### PR TITLE
Fix iterator lifetimes

### DIFF
--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -9,8 +9,8 @@ pub struct BlockIterator<'a> {
     off_off: usize,
 }
 
-impl BlockIterator<'_> {
-    pub fn from_first_key(block: &Block) -> BlockIterator {
+impl <'a> BlockIterator<'a> {
+    pub fn from_first_key(block: &'a Block) -> BlockIterator {
         let mut i = BlockIterator{
             block,
             key: None,
@@ -22,14 +22,14 @@ impl BlockIterator<'_> {
         i
     }
 
-    pub fn key(&self) -> Option<&[u8]> {
+    pub fn key(&self) -> Option<&'a [u8]> {
         if self.off_off < self.block.offsets.len() {
             return self.key;
         }
         None
     }
 
-    pub fn val(&self) -> Option<&[u8]> {
+    pub fn val(&self) -> Option<&'a [u8]> {
         if self.off_off < self.block.offsets.len() {
             return self.val;
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -93,7 +93,7 @@ impl DbInner {
           if val.is_empty() {
             return None;
           }
-          return Some(Bytes::from(val));
+          return Some(Bytes::copy_from_slice(val));
         }
       }
     }
@@ -108,15 +108,13 @@ impl DbInner {
     Some(block_idx)
   }
 
-  fn find_val_in_block(&self, block: &Block, key: &[u8]) -> Option<Vec<u8>> {
+  fn find_val_in_block<'a>(&self, block: &'a Block, key: &[u8]) -> Option<&'a [u8]> {
     let mut iter = BlockIterator::from_first_key(block);
     while let Some(current_key) = iter.key() {
-      if current_key == key {
-        // TODO: there should be some way to do this without copying the buffer, but
-        //       rust won't let me because iter goes out of scope
-        return Some(Vec::from(iter.val().unwrap()))
-      }
-      iter.advance();
+        if current_key == key {
+            return iter.val();
+        }
+        iter.advance();
     }
     None
   }


### PR DESCRIPTION
Note: This still does a memcpy via `copy_from_slice`