### PR TITLE
Remove tokio runtime dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "crossbeam-skiplist",
+ "futures",
  "object_store",
  "parking_lot",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ bytes = "1.6.0"
 crc32fast = "1.4.0"
 crossbeam-channel = "0.5.12"
 crossbeam-skiplist = "0.1.3"
+futures = "0.3.30"
 object_store = "0.9.1"
 parking_lot = "0.12.1"
 tokio = { version = "1.37.0", features = ["sync"] }


### PR DESCRIPTION
Remove `tokio`'s runtime as a library dependency (it's still used for tests). @rodesai and I discussed this back and forth on #3 (https://github.com/criccomini/slatedb/pull/3/#discussion_r1571512755).

Initially, we decided to remove the async/await code entirely. However, after talking with @afeinberg and fiddling around with what a non-async/await API would look like, I opted to just remove the tokio runtime. It seems ugly to fully strip the async/await APIs since the `object_store` crate is still async. We'd need to either integrate our own runtime (e.g. tokio, smol, async-std) or we'd need to have the external client start the flusher tasks themselves. Neither of these seemed very nice.

Instead, I'm using the `futures` crate. It sounds like `futures` is unopinionated about the async/await runtime that's used, which is my preference for the library. (Correct me if I'm wrong on this).