### PR TITLE
Read SsTableInfo without loading entire SST

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -6,7 +6,10 @@ pub enum SlateDBError {
     #[error("Checksum mismatch")]
     ChecksumMismatch,
 
-    #[error("Empty block meta")]
+    #[error("Empty SSTable")]
+    EmptySSTable,
+
+    #[error("Empty block metadata")]
     EmptyBlockMeta,
 
     #[error("Empty block")]


### PR DESCRIPTION
We were reading the entire SST from object storage just to get the SST's metadata. This is inefficient for large SSTs.

The new code is doing 3 round trip fetches:

1. HEAD to get the size of the object in object_storage
2. GET to get the metadata offset location in the object
3. GET to read the metadata from the object

This is good for large SSTs where GETting the entire SST exceeds the length of 3 round trips to object storage. But this the new implementation is not ideal for smaller SSTs.

Given that waiting to download potentially gigs of SST data for larger SSTs (once compaction is implemented), I deem this patch an improvement. Future work could include using user-defined object metadata to store the offset directly in metadata; this would reduce the round trips by one. We might also be able to save SST metadata in the Manifest, thus allowing us to do a single GET for *just* the metadata in the object.

Closes #16