### PR TITLE
make KeyValueIterator::next async

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -83,7 +83,7 @@ impl DbInner {
         for sst in &snapshot.as_ref().l0 {
             if let Some(block_index) = self.find_block_for_key(sst, key) {
                 let block = self.table_store.read_block(sst, block_index).await?;
-                if let Some(val) = self.find_val_in_block(&block, key).await {
+                if let Some(val) = self.find_val_in_block(&block, key).await? {
                     if val.is_empty() {
                         return Ok(None);
                     }
@@ -102,14 +102,18 @@ impl DbInner {
         Some(block_idx)
     }
 
-    async fn find_val_in_block(&self, block: &Block, key: &[u8]) -> Option<Bytes> {
+    async fn find_val_in_block(
+        &self,
+        block: &Block,
+        key: &[u8],
+    ) -> Result<Option<Bytes>, SlateDBError> {
         let mut iter = BlockIterator::from_first_key(block);
-        while let Some(current_key_value) = iter.next().await {
+        while let Some(current_key_value) = iter.next().await? {
             if current_key_value.key == key {
-                return Some(current_key_value.value);
+                return Ok(Some(current_key_value.value));
             }
         }
-        None
+        Ok(None)
     }
 
     /// Put a key-value pair into the database. Key and value must not be empty.

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -17,7 +17,7 @@ impl DbInner {
     async fn flush_imm(&self, imm: Arc<MemTable>, id: usize) -> Result<SsTableInfo, SlateDBError> {
         let mut sst_builder = EncodedSsTableBuilder::new(4096);
         let mut iter = imm.iter();
-        while let Some(kv) = iter.next().await {
+        while let Some(kv) = iter.next().await? {
             sst_builder.add(&kv.key, &kv.value)?;
         }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,5 +1,7 @@
 use bytes::Bytes;
 
+use crate::error::SlateDBError;
+
 #[derive(Debug)]
 pub struct KeyValue {
     pub key: Bytes,
@@ -11,5 +13,5 @@ pub struct KeyValue {
 /// the network.
 /// See: https://github.com/slatedb/slatedb/issues/12
 pub trait KeyValueIterator {
-    async fn next(&mut self) -> Option<KeyValue>;
+    async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError>;
 }

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::error::SlateDBError;
 use crate::iter::{KeyValue, KeyValueIterator};
 use bytes::Bytes;
 use crossbeam_skiplist::map::Iter;
@@ -14,11 +15,11 @@ pub(crate) struct MemTable {
 pub struct MemTableIterator<'a>(Iter<'a, Bytes, Bytes>);
 
 impl<'a> KeyValueIterator for MemTableIterator<'a> {
-    async fn next(&mut self) -> Option<KeyValue> {
-        self.0.next().map(|entry| KeyValue {
+    async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
+        Ok(self.0.next().map(|entry| KeyValue {
             key: entry.key().clone(),
             value: entry.value().clone(),
-        })
+        }))
     }
 }
 


### PR DESCRIPTION
This closes #26. I didn't expect it to be so smooth, but a lot of the calling functions were already async.