### PR TITLE
Add cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 name = "slatedb"
 version = "0.1.0"
 edition = "2021"
+description = "A cloud native embedded storage engine built on object storage."
+repository = "https://github.com/slatedb/slatedb"
+license = "Apache-2.0"
+homepage = "https://github.com/slatedb/slatedb"
+readme = "README.md"
 
 [dependencies]
 bytes = "1.6.0"


### PR DESCRIPTION
There are some `Cargo.toml` fields that are optional for unpublished packages but which become required for a published package, this fills them in (a required prereq for #6)