### PR TITLE
refactor tablestore/sst interfaces

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,0 +1,11 @@
+use crate::error::SlateDBError;
+use bytes::Bytes;
+use std::ops::Range;
+
+pub(crate) trait ReadOnlyBlob {
+    async fn len(&self) -> Result<usize, SlateDBError>;
+
+    async fn read_range(&self, range: Range<usize>) -> Result<Bytes, SlateDBError>;
+
+    async fn read(&self) -> Result<Bytes, SlateDBError>;
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -6,11 +6,12 @@ use std::{
 use crate::{block::Block, error::SlateDBError};
 use crate::{block_iterator::BlockIterator, iter::KeyValueIterator};
 use bytes::Bytes;
+use object_store::ObjectStore;
 use parking_lot::{Mutex, RwLock};
 
 use crate::mem_table::MemTable;
-use crate::sst::SsTableInfo;
-use crate::tablestore::TableStore;
+use crate::sst::SsTableFormat;
+use crate::tablestore::{SSTableHandle, TableStore};
 
 pub struct DbOptions {
     pub flush_ms: usize,
@@ -20,7 +21,7 @@ pub struct DbOptions {
 pub(crate) struct DbState {
     pub(crate) memtable: Arc<MemTable>,
     pub(crate) imm_memtables: Vec<Arc<MemTable>>,
-    pub(crate) l0: Vec<SsTableInfo>,
+    pub(crate) l0: Vec<SSTableHandle>,
     pub(crate) next_sst_id: usize,
 }
 
@@ -93,9 +94,9 @@ impl DbInner {
         Ok(None)
     }
 
-    fn find_block_for_key(&self, sst: &SsTableInfo, key: &[u8]) -> Option<usize> {
-        let block_idx = sst.block_meta.partition_point(|bm| bm.first_key > key);
-        if block_idx == sst.block_meta.len() {
+    fn find_block_for_key(&self, sst: &SSTableHandle, key: &[u8]) -> Option<usize> {
+        let block_idx = sst.info.block_meta.partition_point(|bm| bm.first_key > key);
+        if block_idx == sst.info.block_meta.len() {
             return None;
         }
         Some(block_idx)
@@ -155,8 +156,10 @@ impl Db {
     pub fn open(
         path: impl AsRef<Path>,
         options: DbOptions,
-        table_store: TableStore,
+        object_store: Arc<dyn ObjectStore>,
     ) -> Result<Self, SlateDBError> {
+        let sst_format = SsTableFormat::new(4096);
+        let table_store = TableStore::new(object_store, sst_format);
         let inner = Arc::new(DbInner::new(path, options, table_store)?);
         let (tx, rx) = crossbeam_channel::unbounded();
         let flush_thread = inner.spawn_flush_thread(rx);
@@ -209,11 +212,10 @@ mod tests {
     #[tokio::test]
     async fn test_put_get_delete() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let table_store = TableStore::new(object_store);
         let kv_store = Db::open(
             "/tmp/test_kv_store",
             DbOptions { flush_ms: 100 },
-            table_store,
+            object_store,
         )
         .unwrap();
         let key = b"test_key";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]
 
+mod blob;
 mod block;
 mod block_iterator;
 pub mod db;

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -1,34 +1,86 @@
+use crate::blob::ReadOnlyBlob;
+use crate::block::Block;
 use crate::{
     block::{BlockBuilder, BlockMeta},
     error::SlateDBError,
 };
-use bytes::{BufMut, Bytes};
+use bytes::{Buf, BufMut, Bytes};
+
+pub(crate) struct SsTableFormat {
+    block_size: usize,
+}
+
+impl SsTableFormat {
+    pub fn new(block_size: usize) -> Self {
+        Self { block_size }
+    }
+
+    pub(crate) async fn read_info(
+        &self,
+        obj: &impl ReadOnlyBlob,
+    ) -> Result<SsTableInfo, SlateDBError> {
+        let len = obj.len().await?;
+        if len <= 4 {
+            return Err(SlateDBError::EmptySSTable);
+        }
+        // Get the size of the metadata
+        let sst_metadata_offset_range = (len - 4)..len;
+        let sst_metadata_offset =
+            obj.read_range(sst_metadata_offset_range).await?.get_u32() as usize;
+        // Get the metadata
+        let sst_metadata_range = sst_metadata_offset..len;
+        let mut sst_metadata_bytes = obj.read_range(sst_metadata_range).await?;
+        SsTableInfo::decode(&mut sst_metadata_bytes)
+    }
+
+    pub(crate) async fn read_block(
+        &self,
+        info: &SsTableInfo,
+        block: usize,
+        obj: &impl ReadOnlyBlob,
+    ) -> Result<Block, SlateDBError> {
+        // todo: range read
+        let bytes = obj.read().await?;
+        let block_meta = &info.block_meta[block];
+        let mut end = info.block_meta_offset;
+        if block < info.block_meta.len() - 1 {
+            let next_block_meta = &info.block_meta[block + 1];
+            end = next_block_meta.offset;
+        }
+        // account for checksum
+        end -= 4;
+        let raw_block = bytes.slice(block_meta.offset..end);
+        Ok(Block::decode(raw_block.as_ref()))
+    }
+
+    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder {
+        EncodedSsTableBuilder::new(self.block_size)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct SsTableInfo {
-    pub(crate) id: usize,
     pub(crate) first_key: Bytes,
     // todo: we probably dont want to keep this here, and instead store this in block cache
-    //       and load it from there (ditto for bloom filter when that's implemented)
+    //       and load it from there
     pub(crate) block_meta: Vec<BlockMeta>,
     pub(crate) block_meta_offset: usize,
 }
 
 impl SsTableInfo {
-    pub(crate) fn decode(
-        id: usize,
-        raw_block_meta: &[u8],
-        block_meta_offset: usize,
-    ) -> Result<SsTableInfo, SlateDBError> {
+    fn encode(info: &SsTableInfo, buf: &mut Vec<u8>) {
+        BlockMeta::encode_block_meta(&info.block_meta, buf);
+        buf.put_u32(info.block_meta_offset as u32);
+    }
+
+    pub(crate) fn decode(raw_block_meta: &mut Bytes) -> Result<SsTableInfo, SlateDBError> {
         if raw_block_meta.len() <= 4 {
             return Err(SlateDBError::EmptyBlockMeta);
         }
-
         // Read the block meta
         let block_meta = BlockMeta::decode_block_meta(raw_block_meta)?;
-
+        let block_meta_offset = raw_block_meta.get_u32() as usize;
         Ok(SsTableInfo {
-            id,
             first_key: block_meta
                 .first()
                 .ok_or(SlateDBError::EmptyBlockMeta)?
@@ -40,33 +92,37 @@ impl SsTableInfo {
     }
 }
 
-pub struct EncodedSsTable {
+pub(crate) struct EncodedSsTable {
     pub(crate) info: SsTableInfo,
     pub(crate) raw: Bytes,
 }
 
 /// Builds an SSTable from key-value pairs.
-pub struct EncodedSsTableBuilder {
+pub(crate) struct EncodedSsTableBuilder {
     builder: BlockBuilder,
     first_key: Vec<u8>,
     block_meta: Vec<BlockMeta>,
     data: Vec<u8>,
     block_size: usize,
+    num_keys: u32,
 }
 
 impl EncodedSsTableBuilder {
     /// Create a builder based on target block size.
-    pub fn new(block_size: usize) -> Self {
+    fn new(block_size: usize) -> Self {
         Self {
             data: Vec::new(),
             block_meta: Vec::new(),
             first_key: Vec::new(),
             block_size,
             builder: BlockBuilder::new(block_size),
+            num_keys: 0,
         }
     }
 
     pub fn add(&mut self, key: &[u8], value: &[u8]) -> Result<(), SlateDBError> {
+        self.num_keys += 1;
+
         if self.first_key.is_empty() {
             self.first_key = key.to_vec();
         }
@@ -101,23 +157,23 @@ impl EncodedSsTableBuilder {
         Ok(())
     }
 
-    pub fn build(mut self, id: usize) -> Result<EncodedSsTable, SlateDBError> {
+    pub fn build(mut self) -> Result<EncodedSsTable, SlateDBError> {
         self.finish_block()?;
         let mut buf = self.data;
-        let meta_offset = buf.len();
-        BlockMeta::encode_block_meta(&self.block_meta, &mut buf);
-        buf.put_u32(meta_offset as u32);
         let mut first_key = Bytes::new();
         if let Some(first_block_meta) = self.block_meta.first() {
             first_key = first_block_meta.first_key.clone();
         }
+        let meta_offset = buf.len();
+        let info = SsTableInfo {
+            first_key,
+            block_meta: self.block_meta,
+            block_meta_offset: meta_offset,
+        };
+        // make sure to encode the info at the end so that the block meta offset is last
+        SsTableInfo::encode(&info, &mut buf);
         Ok(EncodedSsTable {
-            info: SsTableInfo {
-                id,
-                first_key,
-                block_meta: self.block_meta,
-                block_meta_offset: meta_offset,
-            },
+            info,
             raw: Bytes::from(buf),
         })
     }
@@ -135,13 +191,15 @@ mod tests {
     #[tokio::test]
     async fn test_sstable() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let table_store = TableStore::new(object_store);
-        let mut builder = EncodedSsTableBuilder::new(4096);
+        let format = SsTableFormat::new(4096);
+        let table_store = TableStore::new(object_store, format);
+        let mut builder = table_store.table_builder();
         builder.add(b"key1", b"value1").unwrap();
         builder.add(b"key2", b"value2").unwrap();
-        let encoded = builder.build(0).unwrap();
-        table_store.write_sst(&encoded).await.unwrap();
-        let sst_info = table_store.open_sst(0).await.unwrap();
-        assert_eq!(encoded.info, sst_info);
+        let encoded = builder.build().unwrap();
+        let encoded_info = encoded.info.clone();
+        table_store.write_sst(0, encoded).await.unwrap();
+        let sst_handle = table_store.open_sst(0).await.unwrap();
+        assert_eq!(encoded_info, sst_handle.info);
     }
 }


### PR DESCRIPTION
Refactor tablestore/sst interfaces a bit for cleaner separation of responsibilities:
- other modules now interact with sst using SstFormat. SstFormat owns the binary layout for ssts. It is parameterized by the sst block size and minimum keys for enabling filters. It has two types of methods:
  - read_x methods take a ref to an object implementing a new trait called ReadOnlyBlob that has interfaces for reading ranges from a blob. These methods extract parts of the SST (like metadata, blocks, and the filter) from the binary form stored in a blob.
  - table_builder() returns the sst builder struct thats used to construct the binary representation of an sst.
- tablestore now owns sst storage and caching. It puts ssts in the object store and caches filters. Currently filters are cached in a handle object that is returned when an sst is opened. The handle is returned in lieu of the metadata, and contains the metadata inside.

I'm deferring setting up proper traits for ssts so we can support different types of  sst formats to a later change. This patch is intended to be a step in the right direction by splitting up responsibilities in a more reasonable way.