### PR TITLE
Add an alternative manifest design document

### DIFF
--- a/docs/0001-manifest.md
+++ b/docs/0001-manifest.md
@@ -4,6 +4,7 @@
 
 * Only one writer client is allowed at a time
 * Multiple reader clients are allowed at the same time
+* Only one compactor client is allowed at a time
 * Compactor, writer, and readers may all be on different machines
 * Writer does not send parallel writes to the object store
 * Manifest on object store requires compare-and-swap (CAS) or transactional store (DynamoDB)
@@ -27,7 +28,7 @@ In the mutable case (2), an object store can't be used to keep reads and writes 
 
 In the immutable case (1), we can emulate CAS if the bucket has versioning enabled. Versioning allows multiple versions of an object to be stored. AWS stores versions [in insertion order](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html#API_ListObjectVersions_Example_3). We can leverage this property as well as AWS's [read-after-write](https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/) to emulate CAS. Many writers can write to the same object path. Writers can then list all versions of the object. The first version (the earliest) is considered the winner. All other writers have failed the CAS operation. This does require a [ListObjectVersions](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectVersions.html) after the write, but if CAS is needed, this is the best we can do.
 
-This document call out whether each CAS operation is immutable CAS and mutable CAS.
+This document calls out whether each CAS operation is immutable CAS and mutable CAS.
 
 ## File Structure
 


### PR DESCRIPTION
Ok, ya'll. I wanted to experiment with an alternative manifest design to what @vigneshc has proposed in https://github.com/slatedb/slatedb/pull/24.

The main motivation for this was to see what the manifest design might look like if we removed `writer_epoch` from the file names, and used CAS or S3 object versioning instead. I felt like this might simplify design a bit since it would give us a single ordered list of L0 SSTs.

During the experiment, I found parallel writes to be extremely problematic. I've removed them from this design. It would mean that #31 could no longer be done. I think this design, in essence, mirrors Kafka producer's [`max.in.flight.requests.per.connection`](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#max-in-flight-requests-per-connection).

_NOTE: The design does not preclude us from allowing parallel writer, it simply means that we might have to retry writing an earlier SST after a later SST, thereby reordering the writes. This is Kafka producer's behavior as well when max in flight > 1._

The design doc is not done to my satisfaction, but I've been working in a vacuum long enough. I want to de-risk my thoughts by sharing it with you all now. Looking forward to your thoughts. 😄 