### PR TITLE
Expose flush() method at DB

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -229,8 +229,8 @@ mod tests {
             kv_store.get(key).await.unwrap(),
             Some(Bytes::from_static(value))
         );
-        kv_store.delete(key).await;        
-        assert!(kv_store.get(key).await.unwrap().is_none()); 
-        kv_store.close().await.unwrap();       
+        kv_store.delete(key).await;
+        assert!(kv_store.get(key).await.unwrap().is_none());
+        kv_store.close().await.unwrap();
     }
 }


### PR DESCRIPTION
Exposes the flush method at Db  #36 
I have updated existing test with a flush and close. Another possible test is to set a large flush_ms, flush() and validate contents of object store. Would like to get feedback on whether we want to have such tests at this point. 
