### PR TITLE
Use VecDequeue for l0 and imm_memtables

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -22,7 +22,7 @@ pub struct DbOptions {
 #[derive(Clone)]
 pub(crate) struct DbState {
     pub(crate) memtable: Arc<MemTable>,
-    pub(crate) imm_memtables: Vec<Arc<MemTable>>,
+    pub(crate) imm_memtables: VecDeque<Arc<MemTable>>,
     pub(crate) l0: VecDeque<SSTableHandle>,
     pub(crate) next_sst_id: usize,
 }
@@ -31,7 +31,7 @@ impl DbState {
     fn create() -> Self {
         Self {
             memtable: Arc::new(MemTable::new()),
-            imm_memtables: Vec::new(),
+            imm_memtables: VecDeque::new(),
             l0: VecDeque::new(),
             next_sst_id: 0,
         }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -36,13 +36,13 @@ impl DbInner {
             let snapshot: DbState = rguard.as_ref().clone();
             snapshot
                 .imm_memtables
-                .last()
+                .back()
                 .map(|imm| (imm.clone(), snapshot.next_sst_id))
         } {
             let sst = self.flush_imm(imm.clone(), id).await?;
             let mut wguard = self.state.write();
             let mut snapshot = wguard.as_ref().clone();
-            snapshot.imm_memtables.pop();
+            snapshot.imm_memtables.pop_back();
             // always put the new sst at the front of l0
             snapshot.l0.push_front(sst);
             snapshot.next_sst_id += 1;
@@ -65,7 +65,7 @@ impl DbInner {
         // Swap the current memtable with a new one.
         let old_memtable = std::mem::replace(&mut snapshot.memtable, Arc::new(MemTable::new()));
         // Add the memtable to the immutable memtables.
-        snapshot.imm_memtables.insert(0, old_memtable.clone());
+        snapshot.imm_memtables.push_front(old_memtable.clone());
         // Update the snapshot.
         *guard = Arc::new(snapshot);
         Some(old_memtable)


### PR DESCRIPTION
This replaces `Vec` for l0 and imm_memtables with [`VecDequeue`](https://doc.rust-lang.org/std/collections/struct.VecDeque.html), a standard library Rust collection with (amortized) O(1) `push_front(X)` as a replacement for `Vec`'s O(n) `insert(0, X)`.