### PR TITLE
Support deletes in iterator

### DIFF
--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -36,7 +36,7 @@ pub struct BlockIterator<B: BlockLike> {
 }
 
 impl<B: BlockLike> KeyValueIterator for BlockIterator<B> {
-    async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
+    async fn next_entry(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
         let Some(key_value) = self.load_at_current_off() else {
             return Ok(None);
         };

--- a/src/db.rs
+++ b/src/db.rs
@@ -119,7 +119,7 @@ impl DbInner {
         key: &[u8],
     ) -> Result<Option<Bytes>, SlateDBError> {
         let mut iter = BlockIterator::from_first_key(block);
-        while let Some(current_key_value) = iter.next().await? {
+        while let Some(current_key_value) = iter.next_entry().await? {
             if current_key_value.key == key {
                 return Ok(Some(current_key_value.value));
             }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -21,7 +21,7 @@ impl DbInner {
     ) -> Result<SSTableHandle, SlateDBError> {
         let mut sst_builder = self.table_store.table_builder();
         let mut iter = imm.iter();
-        while let Some(kv) = iter.next().await? {
+        while let Some(kv) = iter.next_entry().await? {
             sst_builder.add(&kv.key, &kv.value)?;
         }
 

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -25,7 +25,9 @@ impl SstIterator {
 }
 
 impl KeyValueIterator for SstIterator {
-    async fn next(&mut self) -> Result<Option<crate::iter::KeyValue>, crate::error::SlateDBError> {
+    async fn next_entry(
+        &mut self,
+    ) -> Result<Option<crate::iter::KeyValue>, crate::error::SlateDBError> {
         loop {
             let current_iter = if let Some(current_iter) = self.current_iter.as_mut() {
                 current_iter


### PR DESCRIPTION
Currently, the iterator treats deleted entries as a regular k/v pair with an empty value. This exposes two accessors on `KeyValueIterator`: `next_entry` provides the low-level iterator that includes "tombstone" entries, and `next` skips over them.

This will simplify the implementation of a merge iterator (#8)

**Question**: is it a design decision that a deleted value is the same as an empty value, or do we want to have a way to represent an empty but non-deleted value? If the latter (my personal preference), I can take that on next.