### PR TITLE
ensure we write to memtable while holding state lock

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -151,10 +151,12 @@ impl DbInner {
         // Clone memtable to avoid a deadlock with flusher thread.
         let memtable = {
             let guard = self.state.read();
-            Arc::clone(&guard.memtable)
+            let memtable = Arc::clone(&guard.memtable);
+            memtable.put(key, value);
+            memtable
         };
 
-        memtable.put(key, value).await;
+        memtable.await_flush().await;
     }
 
     /// Delete a key from the database. Key must not be empty.
@@ -164,10 +166,12 @@ impl DbInner {
         // Clone memtable to avoid a deadlock with flusher thread.
         let memtable = {
             let guard = self.state.read();
-            Arc::clone(&guard.memtable)
+            let memtable = Arc::clone(&guard.memtable);
+            memtable.delete(key);
+            memtable
         };
 
-        memtable.delete(key).await;
+        memtable.await_flush().await;
     }
 }
 
@@ -307,9 +311,9 @@ mod tests {
             lock.memtable.clone()
         };
 
-        memtable.put_optimistic(b"abc1111", b"value1111");
-        memtable.put_optimistic(b"abc2222", b"value2222");
-        memtable.put_optimistic(b"abc3333", b"value3333");
+        memtable.put(b"abc1111", b"value1111");
+        memtable.put(b"abc2222", b"value2222");
+        memtable.put(b"abc3333", b"value3333");
 
         let mut iter = memtable.iter();
         let kv = iter.next().await.unwrap().unwrap();


### PR DESCRIPTION
This patch changes the write path to ensure that we write to the memtable while holding the read lock on dbstate. This protects against the following race condition:
1. writer selects the current memtable for writing
2. flush thread freezes the current memtable
3. flush thread flushes the current memtable
4. writer writes to the flushed memtable

To acheive this, this change also refactors the memtable api a bit. put and put_optimistic are combined into just put, which does not block on flush. The writer blocks on flush using a call to a new method called await_flush, which waits for the flush notification.