### PR TITLE
Track the size of the data in memtable

### DIFF
--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -85,7 +85,7 @@ impl ManifestV1Owned {
                 writer_epoch: old_manifest.writer_epoch(),
                 compactor_epoch: old_manifest.compactor_epoch(),
                 wal_id_last_compacted: old_manifest.wal_id_last_compacted(),
-                wal_id_last_seen: db_state.next_sst_id - 1,
+                wal_id_last_seen: db_state.compacted.next_sst_id - 1,
                 leveled_ssts: None,
                 snapshots: None,
             },

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -9,8 +9,13 @@ use std::sync::Arc;
 use tokio::sync::Notify;
 
 pub(crate) struct MemTable {
-    pub(crate) map: Arc<SkipMap<Bytes, ValueDeletable>>,
-    pub(crate) flush_notify: Arc<Notify>,
+    map: SkipMap<Bytes, ValueDeletable>,
+    flush_notify: Arc<Notify>,
+}
+
+pub(crate) struct WritableMemTable {
+    table: Arc<MemTable>,
+    size: usize,
 }
 
 type MemTableRange<'a> = Range<'a, Bytes, (Bound<Bytes>, Bound<Bytes>), Bytes, ValueDeletable>;
@@ -26,12 +31,57 @@ impl<'a> KeyValueIterator for MemTableIterator<'a> {
     }
 }
 
-impl MemTable {
+impl WritableMemTable {
     pub(crate) fn new() -> Self {
         Self {
-            map: Arc::new(SkipMap::new()),
+            table: Arc::new(MemTable::new()),
+            size: 0,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn size(&self) -> usize {
+        self.size
+    }
+
+    pub(crate) fn table(&self) -> &Arc<MemTable> {
+        &self.table
+    }
+
+    pub(crate) fn put(&mut self, key: &[u8], value: &[u8]) {
+        self.maybe_subtract_old_val_from_size(key);
+        self.size = self.size + key.len() + value.len();
+        self.table.put(key, value)
+    }
+
+    pub(crate) fn delete(&mut self, key: &[u8]) {
+        self.maybe_subtract_old_val_from_size(key);
+        self.size += key.len();
+        self.table.delete(key);
+    }
+
+    fn maybe_subtract_old_val_from_size(&mut self, key: &[u8]) {
+        if let Some(old_deletable) = self.table.get(key) {
+            self.size = self.size
+                - key.len()
+                - match old_deletable {
+                    ValueDeletable::Tombstone => 0,
+                    ValueDeletable::Value(old) => old.len(),
+                }
+        }
+    }
+}
+
+impl MemTable {
+    fn new() -> Self {
+        Self {
+            map: SkipMap::new(),
             flush_notify: Arc::new(Notify::new()),
         }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.map.is_empty()
     }
 
     /// Get the value for a given key.
@@ -58,22 +108,24 @@ impl MemTable {
 
     /// Puts a value, returning as soon as the value is written to the memtable but before
     /// it is flushed to durable storage.
-    #[allow(dead_code)] // will be used in #8
-    pub(crate) fn put(&self, key: &[u8], value: &[u8]) {
+    fn put(&self, key: &[u8], value: &[u8]) {
         self.map.insert(
             Bytes::copy_from_slice(key),
             ValueDeletable::Value(Bytes::copy_from_slice(value)),
         );
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn delete(&self, key: &[u8]) {
+    fn delete(&self, key: &[u8]) {
         self.map
             .insert(Bytes::copy_from_slice(key), ValueDeletable::Tombstone);
     }
 
     pub(crate) async fn await_flush(&self) {
         self.flush_notify.notified().await;
+    }
+
+    pub(crate) fn notify_flush(&self) {
+        self.flush_notify.notify_waiters()
     }
 }
 
@@ -83,14 +135,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_memtable_iter() {
-        let table = MemTable::new();
+        let mut table = WritableMemTable::new();
         table.put(b"abc333", b"value3");
         table.put(b"abc111", b"value1");
         table.put(b"abc555", b"value5");
         table.put(b"abc444", b"value4");
         table.put(b"abc222", b"value2");
 
-        let mut iter = table.iter();
+        let mut iter = table.table().iter();
         let kv = iter.next().await.unwrap().unwrap();
         assert_eq!(kv.key, b"abc111".as_slice());
         assert_eq!(kv.value, b"value1".as_slice());
@@ -111,14 +163,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_memtable_range_from_existing_key() {
-        let table = MemTable::new();
+        let mut table = WritableMemTable::new();
         table.put(b"abc333", b"value3");
         table.put(b"abc111", b"value1");
         table.put(b"abc555", b"value5");
         table.put(b"abc444", b"value4");
         table.put(b"abc222", b"value2");
 
-        let mut iter = table.range_from(b"abc333");
+        let mut iter = table.table().range_from(b"abc333");
         let kv = iter.next().await.unwrap().unwrap();
         assert_eq!(kv.key, b"abc333".as_slice());
         assert_eq!(kv.value, b"value3".as_slice());
@@ -133,14 +185,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_memtable_range_from_nonexisting_key() {
-        let table = MemTable::new();
+        let mut table = WritableMemTable::new();
         table.put(b"abc333", b"value3");
         table.put(b"abc111", b"value1");
         table.put(b"abc555", b"value5");
         table.put(b"abc444", b"value4");
         table.put(b"abc222", b"value2");
 
-        let mut iter = table.range_from(b"abc345");
+        let mut iter = table.table().range_from(b"abc345");
         let kv = iter.next().await.unwrap().unwrap();
         assert_eq!(kv.key, b"abc444".as_slice());
         assert_eq!(kv.value, b"value4".as_slice());
@@ -152,11 +204,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_memtable_iter_delete() {
-        let table = MemTable::new();
+        let mut table = WritableMemTable::new();
         table.put(b"abc333", b"value3");
         table.delete(b"abc333");
 
-        let mut iter = table.iter();
+        let mut iter = table.table().iter();
         assert!(iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_memtable_track_sz() {
+        let mut table = WritableMemTable::new();
+
+        table.put(b"abc333", b"val1");
+        assert_eq!(table.size(), 10);
+
+        table.put(b"def456", b"blablabla");
+        assert_eq!(table.size(), 25);
+
+        table.put(b"def456", b"blabla");
+        assert_eq!(table.size(), 22);
+
+        table.delete(b"abc333");
+        assert_eq!(table.size(), 18)
     }
 }


### PR DESCRIPTION
This commit adds support to the memtable for tracking the current memtable size in bytes. This actually required a bit of a refactor of dbstate:

Wraps MemTable in WriteableMemTable. All puts/deletes must go through WriteableMemtable, which also tracks size from put/delete. put/delete now require a mutable reference (SkipMap does not require a mutable ref to insert, (I think because its impl uses unsafe)).

Because WriteableMemtable requires a mutable reference to put/del, it can no longer be accessed through an `Arc`. It also doesn't make sense for it to derive `Clone`. Therefore this change refactors the dbstate structure and mutation model as follows:
- `DbState` is split into `DbState` and `CompactedDbState`. `DbState` contains the current mutable memtable and an Arc pointing to `CompactedDbState` which contains immutable memtables and l0.
- When the memtable is frozen, it is pulled out of `WriteableMemTable` and added to the immutable list, and the current memtable is set to a new `WriteableMemtable`. The mutation to the current memtable is made directly to dbstate (no snapshot) while holding the write-lock
- All mutations to compacted dbstate create a clone, mutate it, and reset the Arc.