### PR TITLE
write into the active memtable, and freeze/flush at size threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +503,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +524,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -582,6 +631,7 @@ dependencies = [
  "siphasher",
  "thiserror",
  "tokio",
+ "ulid",
 ]
 
 [[package]]
@@ -725,6 +775,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
+dependencies = [
+ "getrandom",
+ "rand",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +826,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -819,6 +886,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ parking_lot = "0.12.1"
 siphasher = "1"
 thiserror = "1.0.59"
 tokio = { version = "1.37.0", features = ["sync"] }
+ulid = "1.1.2"
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,7 @@
 use crate::flatbuffer_types::ManifestV1Owned;
-use crate::mem_table::{MemTable, WritableMemTable};
+use crate::mem_table::{ImmutableMemtable, ImmutableWal, WritableKVTable};
+use crate::memtable_flush::MemtableFlushThreadMsg;
+use crate::memtable_flush::MemtableFlushThreadMsg::{FlushImmutableMemtables, Shutdown};
 use crate::sst::SsTableFormat;
 use crate::tablestore::{SSTableHandle, SsTableId, TableStore};
 use crate::types::ValueDeletable;
@@ -8,34 +10,41 @@ use crate::{block_iterator::BlockIterator, iter::KeyValueIterator};
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::ObjectStore;
-use parking_lot::{Mutex, RwLock};
+use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use std::{collections::VecDeque, sync::Arc};
 
 pub struct DbOptions {
     pub flush_ms: usize,
     pub min_filter_keys: u32,
+    pub l0_sst_size_bytes: usize,
 }
 
 pub(crate) struct DbState {
-    pub(crate) memtable: WritableMemTable,
+    pub(crate) memtable: WritableKVTable,
+    pub(crate) wal: WritableKVTable,
     pub(crate) compacted: Arc<CompactedDbState>,
 }
 
 #[derive(Clone)]
 pub(crate) struct CompactedDbState {
-    pub(crate) imm_memtables: VecDeque<Arc<MemTable>>,
+    pub(crate) imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
+    pub(crate) imm_wal: VecDeque<Arc<ImmutableWal>>,
     pub(crate) l0: VecDeque<SSTableHandle>,
-    pub(crate) next_sst_id: u64,
+    pub(crate) next_wal_sst_id: u64,
+    pub(crate) last_compacted_wal_sst_id: u64,
 }
 
 impl DbState {
     fn create() -> Self {
         Self {
-            memtable: WritableMemTable::new(),
+            memtable: WritableKVTable::new(),
+            wal: WritableKVTable::new(),
             compacted: Arc::new(CompactedDbState {
-                imm_memtables: VecDeque::new(),
+                imm_memtable: VecDeque::new(),
+                imm_wal: VecDeque::new(),
                 l0: VecDeque::new(),
-                next_sst_id: 1,
+                next_wal_sst_id: 1,
+                last_compacted_wal_sst_id: 0,
             }),
         }
     }
@@ -46,6 +55,7 @@ pub(crate) struct DbInner {
     pub(crate) options: DbOptions,
     pub(crate) table_store: TableStore,
     pub(crate) manifest: Arc<RwLock<ManifestV1Owned>>,
+    pub(crate) memtable_flush_notifier: crossbeam_channel::Sender<MemtableFlushThreadMsg>,
 }
 
 impl DbInner {
@@ -53,12 +63,14 @@ impl DbInner {
         options: DbOptions,
         table_store: TableStore,
         manifest: ManifestV1Owned,
+        memtable_flush_notifier: crossbeam_channel::Sender<MemtableFlushThreadMsg>,
     ) -> Result<Self, SlateDBError> {
         let mut db_inner = Self {
             state: Arc::new(RwLock::new(DbState::create())),
             options,
             table_store,
             manifest: Arc::new(RwLock::new(manifest)),
+            memtable_flush_notifier,
         };
 
         db_inner.load_state().await?;
@@ -70,11 +82,11 @@ impl DbInner {
     pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, SlateDBError> {
         let (memtable, compacted) = {
             let guard = self.state.read();
-            (guard.memtable.table().clone(), Arc::clone(&guard.compacted))
+            (guard.wal.table().clone(), Arc::clone(&guard.compacted))
         };
 
-        let maybe_bytes = std::iter::once(&memtable)
-            .chain(compacted.imm_memtables.iter())
+        let maybe_bytes = std::iter::once(memtable)
+            .chain(compacted.imm_wal.iter().map(|imm| imm.table()))
             .find_map(|memtable| memtable.get(key));
 
         if let Some(val) = maybe_bytes {
@@ -145,19 +157,70 @@ impl DbInner {
         Ok(None)
     }
 
+    fn maybe_freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>) {
+        if guard.memtable.size() < self.options.l0_sst_size_bytes {
+            return;
+        }
+        // If there was no active wal with data, that means the flush thread
+        // will have just frozen it. In that case, check the imm wal list.
+        // If there are no imm wal entries, all wal entries are flushed, so use
+        // the last flushed wal's id
+        let wal_id = match self.freeze_wal(guard) {
+            Some(id) => id,
+            None => match guard.compacted.imm_wal.front() {
+                Some(imm_wal) => imm_wal.id(),
+                None => guard.compacted.next_wal_sst_id - 1,
+            },
+        };
+        self.freeze_memtable(guard, wal_id);
+        self.memtable_flush_notifier
+            .send(FlushImmutableMemtables)
+            .expect("failed to send memtable flush msg");
+    }
+
+    pub(crate) fn freeze_wal(&self, guard: &mut RwLockWriteGuard<DbState>) -> Option<u64> {
+        if guard.wal.table().is_empty() {
+            return None;
+        }
+        let old_wal = std::mem::replace(&mut guard.wal, WritableKVTable::new());
+        let mut compacted_snapshot = guard.compacted.as_ref().clone();
+        let imm_wal = Arc::new(ImmutableWal::new(
+            compacted_snapshot.next_wal_sst_id,
+            old_wal,
+        ));
+        let id = imm_wal.id();
+        compacted_snapshot.imm_wal.push_front(imm_wal);
+        compacted_snapshot.next_wal_sst_id += 1;
+        guard.compacted = Arc::new(compacted_snapshot);
+        Some(id)
+    }
+
+    fn freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>, wal_id: u64) {
+        let old_memtable = std::mem::replace(&mut guard.memtable, WritableKVTable::new());
+        let mut compacted_snapshot = guard.compacted.as_ref().clone();
+        compacted_snapshot
+            .imm_memtable
+            .push_front(Arc::new(ImmutableMemtable::new(old_memtable, wal_id)));
+        guard.compacted = Arc::new(compacted_snapshot);
+    }
+
     /// Put a key-value pair into the database. Key and value must not be empty.
     pub async fn put(&self, key: &[u8], value: &[u8]) {
         assert!(!key.is_empty(), "key cannot be empty");
 
         // Clone memtable to avoid a deadlock with flusher thread.
-        let memtable = {
+        let current_wal_table = {
             let mut guard = self.state.write();
-            let writeable_memtable = &mut guard.memtable;
-            writeable_memtable.put(key, value);
-            writeable_memtable.table().clone()
+            let current_memtable = &mut guard.memtable;
+            current_memtable.put(key, value);
+            let current_wal = &mut guard.wal;
+            current_wal.put(key, value);
+            let current_wal_table = current_wal.table().clone();
+            self.maybe_freeze_memtable(&mut guard);
+            current_wal_table
         };
 
-        memtable.await_flush().await;
+        current_wal_table.await_flush().await;
     }
 
     /// Delete a key from the database. Key must not be empty.
@@ -165,14 +228,18 @@ impl DbInner {
         assert!(!key.is_empty(), "key cannot be empty");
 
         // Clone memtable to avoid a deadlock with flusher thread.
-        let memtable = {
+        let current_wal_table = {
             let mut guard = self.state.write();
-            let writeable_memtable = &mut guard.memtable;
-            writeable_memtable.delete(key);
-            writeable_memtable.table().clone()
+            let current_memtable = &mut guard.memtable;
+            current_memtable.delete(key);
+            let current_wal = &mut guard.wal;
+            current_wal.delete(key);
+            let current_wal_table = current_wal.table().clone();
+            self.maybe_freeze_memtable(&mut guard);
+            current_wal_table
         };
 
-        memtable.await_flush().await;
+        current_wal_table.await_flush().await;
     }
 
     async fn load_state(&mut self) -> Result<(), SlateDBError> {
@@ -187,12 +254,13 @@ impl DbInner {
             rguard_state.compacted.as_ref().clone()
         };
 
+        snapshot.last_compacted_wal_sst_id = wal_id_last_compacted;
         for sst_id in wal_sst_list {
             let sst = self.table_store.open_sst(&SsTableId::Wal(sst_id)).await?;
 
             // always put the new sst at the front of l0
             snapshot.l0.push_front(sst);
-            snapshot.next_sst_id = sst_id + 1;
+            snapshot.next_wal_sst_id = sst_id + 1;
         }
 
         let mut wguard_state = self.state.write();
@@ -208,6 +276,7 @@ pub struct Db {
     flush_notifier: crossbeam_channel::Sender<()>,
     /// The handle for the flush thread.
     flush_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
+    memtable_flush_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
 impl Db {
@@ -228,19 +297,24 @@ impl Db {
             }
         };
 
-        let inner = Arc::new(DbInner::new(options, table_store, manifest).await?);
+        let (memtable_flush_tx, memtable_flush_rx) = crossbeam_channel::unbounded();
+        let inner =
+            Arc::new(DbInner::new(options, table_store, manifest, memtable_flush_tx).await?);
         let (tx, rx) = crossbeam_channel::unbounded();
         let flush_thread = inner.spawn_flush_thread(rx);
+        let memtable_flush_thread = inner.spawn_memtable_flush_thread(memtable_flush_rx);
         Ok(Self {
             inner,
             flush_notifier: tx,
             flush_thread: Mutex::new(flush_thread),
+            memtable_flush_thread: Mutex::new(memtable_flush_thread),
         })
     }
 
     pub async fn close(&self) -> Result<(), SlateDBError> {
         // Tell the notifier thread to shut down.
         self.flush_notifier.send(()).ok();
+        self.inner.memtable_flush_notifier.send(Shutdown).ok();
 
         // Scope the flush_thread lock so its lock isn't held while awaiting the final flush below.
         {
@@ -248,6 +322,15 @@ impl Db {
             let mut flush_thread = self.flush_thread.lock();
             if let Some(flush_thread) = flush_thread.take() {
                 flush_thread.join().expect("Failed to join flush thread");
+            }
+        }
+
+        {
+            let mut memtable_flush_thread = self.memtable_flush_thread.lock();
+            if let Some(memtable_flush_thread) = memtable_flush_thread.take() {
+                memtable_flush_thread
+                    .join()
+                    .expect("Failed to join memtable flush thread");
             }
         }
 
@@ -281,6 +364,8 @@ mod tests {
     use super::*;
     use object_store::memory::InMemory;
     use object_store::ObjectStore;
+    use std::time::{Duration, SystemTime};
+    use tokio::time::sleep;
 
     #[tokio::test]
     async fn test_put_get_delete() {
@@ -290,6 +375,7 @@ mod tests {
             DbOptions {
                 flush_ms: 100,
                 min_filter_keys: 0,
+                l0_sst_size_bytes: 1024,
             },
             object_store,
         )
@@ -310,6 +396,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_put_flushes_memtable() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let kv_store = Db::open(
+            path.clone(),
+            DbOptions {
+                flush_ms: 100,
+                min_filter_keys: 0,
+                l0_sst_size_bytes: 128,
+            },
+            object_store.clone(),
+        )
+        .await
+        .unwrap();
+
+        let sst_format = SsTableFormat::new(4096, 10);
+        let table_store = TableStore::new(object_store.clone(), sst_format, path.clone());
+
+        // Write data a few times such that each loop results in a memtable flush
+        let mut last_compacted = 0;
+        for i in 0..3 {
+            let key = [b'a' + i; 16];
+            let value = [b'b' + i; 50];
+            kv_store.put(&key, &value).await;
+            let key = [b'j' + i; 16];
+            let value = [b'k' + i; 50];
+            kv_store.put(&key, &value).await;
+            let now = SystemTime::now();
+            while now.elapsed().unwrap().as_secs() < 30 {
+                let manifest_owned = table_store.open_latest_manifest().await.unwrap().unwrap();
+                let manifest = manifest_owned.borrow();
+                if manifest.wal_id_last_compacted() > last_compacted {
+                    assert_eq!(manifest.wal_id_last_compacted(), (i as u64) * 2 + 2);
+                    last_compacted = manifest.wal_id_last_compacted();
+                    break;
+                }
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_put_empty_value() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let kv_store = Db::open(
@@ -317,6 +445,7 @@ mod tests {
             DbOptions {
                 flush_ms: 100,
                 min_filter_keys: 0,
+                l0_sst_size_bytes: 1024,
             },
             object_store,
         )
@@ -341,6 +470,7 @@ mod tests {
             DbOptions {
                 flush_ms: 100,
                 min_filter_keys: 0,
+                l0_sst_size_bytes: 1024,
             },
             object_store,
         )
@@ -349,10 +479,10 @@ mod tests {
 
         let memtable = {
             let mut lock = kv_store.inner.state.write();
-            lock.memtable.put(b"abc1111", b"value1111");
-            lock.memtable.put(b"abc2222", b"value2222");
-            lock.memtable.put(b"abc3333", b"value3333");
-            lock.memtable.table().clone()
+            lock.wal.put(b"abc1111", b"value1111");
+            lock.wal.put(b"abc2222", b"value2222");
+            lock.wal.put(b"abc3333", b"value3333");
+            lock.wal.table().clone()
         };
 
         let mut iter = memtable.iter();
@@ -377,6 +507,7 @@ mod tests {
             DbOptions {
                 flush_ms: 100,
                 min_filter_keys: 0,
+                l0_sst_size_bytes: 1024,
             },
             object_store.clone(),
         )
@@ -398,6 +529,7 @@ mod tests {
             DbOptions {
                 flush_ms: 100,
                 min_filter_keys: 0,
+                l0_sst_size_bytes: 1024,
             },
             object_store.clone(),
         )

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -1,4 +1,4 @@
-use crate::db::DbState;
+use crate::db::CompactedDbState;
 use bytes::Bytes;
 use flatbuffers::InvalidFlatbuffer;
 
@@ -74,7 +74,7 @@ impl ManifestV1Owned {
         Self { data }
     }
 
-    pub fn get_updated_manifest(&self, db_state: &DbState) -> ManifestV1Owned {
+    pub fn get_updated_manifest(&self, compacted_db_state: &CompactedDbState) -> ManifestV1Owned {
         let old_manifest = self.borrow();
         let builder = &mut flatbuffers::FlatBufferBuilder::new();
 
@@ -84,8 +84,8 @@ impl ManifestV1Owned {
                 manifest_id: old_manifest.manifest_id() + 1,
                 writer_epoch: old_manifest.writer_epoch(),
                 compactor_epoch: old_manifest.compactor_epoch(),
-                wal_id_last_compacted: old_manifest.wal_id_last_compacted(),
-                wal_id_last_seen: db_state.compacted.next_sst_id - 1,
+                wal_id_last_compacted: compacted_db_state.last_compacted_wal_sst_id,
+                wal_id_last_seen: compacted_db_state.next_wal_sst_id - 1,
                 leveled_ssts: None,
                 snapshots: None,
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod flatbuffer_types;
 mod flush;
 mod iter;
 mod mem_table;
+mod memtable_flush;
 mod sst;
 mod sst_iter;
 mod tablestore;

--- a/src/memtable_flush.rs
+++ b/src/memtable_flush.rs
@@ -1,0 +1,54 @@
+use crate::db::DbInner;
+use crate::error::SlateDBError;
+use crate::tablestore::SsTableId;
+use futures::executor::block_on;
+use std::sync::Arc;
+use ulid::Ulid;
+
+pub(crate) enum MemtableFlushThreadMsg {
+    Shutdown,
+    FlushImmutableMemtables,
+}
+
+impl DbInner {
+    pub(crate) async fn flush_imm_memtables_to_l0(&self) -> Result<(), SlateDBError> {
+        while let Some(imm_memtable) = {
+            let guard = self.state.read();
+            guard.compacted.imm_memtable.back().cloned()
+        } {
+            let id = SsTableId::Compacted(Ulid::new());
+            self.flush_imm_table(&id, imm_memtable.table()).await?;
+            {
+                let mut guard = self.state.write();
+                let mut compacted_snapshot = guard.compacted.as_ref().clone();
+                compacted_snapshot.imm_memtable.pop_back();
+                compacted_snapshot.last_compacted_wal_sst_id = imm_memtable.last_wal_id();
+                guard.compacted = Arc::new(compacted_snapshot);
+            }
+            self.write_manifest().await?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn spawn_memtable_flush_thread(
+        self: &Arc<Self>,
+        rx: crossbeam_channel::Receiver<MemtableFlushThreadMsg>,
+    ) -> Option<std::thread::JoinHandle<()>> {
+        let this = Arc::clone(self);
+        Some(std::thread::spawn(move || loop {
+            let msg = rx.recv();
+            match msg {
+                Ok(MemtableFlushThreadMsg::Shutdown) => return,
+                Ok(MemtableFlushThreadMsg::FlushImmutableMemtables) => {
+                    match block_on(this.flush_imm_memtables_to_l0()) {
+                        Ok(_) => {}
+                        Err(err) => print!("error from memtable flush: {}", err),
+                    }
+                }
+                Err(err) => {
+                    print!("error on memtable flush thread channel: {}", err)
+                }
+            }
+        }))
+    }
+}

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -10,12 +10,14 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use std::ops::Range;
 use std::sync::Arc;
+use ulid::Ulid;
 
 pub struct TableStore {
     object_store: Arc<dyn ObjectStore>,
     sst_format: SsTableFormat,
     root_path: Path,
     wal_path: &'static str,
+    compacted_path: &'static str,
     manifest_path: &'static str,
 }
 
@@ -50,6 +52,7 @@ impl ReadOnlyBlob for ReadOnlyObject {
 #[derive(Clone)]
 pub enum SsTableId {
     Wal(u64),
+    Compacted(Ulid),
 }
 
 #[derive(Clone)]
@@ -74,6 +77,7 @@ impl TableStore {
             sst_format,
             root_path,
             wal_path: "wal",
+            compacted_path: "compacted",
             manifest_path: "manifest",
         }
     }
@@ -227,6 +231,12 @@ impl TableStore {
             SsTableId::Wal(id) => Path::from(format!(
                 "{}/{}/{:020}.sst",
                 &self.root_path, self.wal_path, id
+            )),
+            SsTableId::Compacted(ulid) => Path::from(format!(
+                "{}/{}/{}.sst",
+                &self.root_path,
+                self.compacted_path,
+                ulid.to_string()
             )),
         }
     }


### PR DESCRIPTION
In this patch, slatedb writes to the active memtable in additon to the WAL. Additionally, when the active memtable is full, it freezes it and the WAL and flushes it to l0 from a memtable flush thread:
- Rename MemTable/WritableMemTable to KVTable. We are now using this struct to store the memtable and WAL, so renaming to something more generic.
- Add ImmutableWAL which wraps KVTable and represents a frozen WAL table. This struct also stores the WAL segments' ID.
- Add ImmutableMemtable with wraps KVTable and represents a frozen memtable. This struct stores the ID of the last WAL segment whose contained writes are included in the frozen memtable.
- When executing put/delete check if the memtable has crossed the target specified in `l0_sst_size_bytes`. If it has, then the writer freezes both the memtable and the wal, and adds the frozen memtable and wal onto `imm_memtable` and `imm_wal` respectively. Finally, it notifies the memtable flush thread (see below).
- Start a thread for flushing immutable memtables to l0. This thread waits for flush notifications from put/del. On a notification msg, it flushes every imm memtable to l0. After each flush it updates the manifest document. In a later patch we will limit manifest updates to some interval.
- Adds a test that verifies memtable flushes.
- Note that we don't actually use the memtables or l0 to serve reads yet. This is deferred to a future patch.