### PR TITLE
use l0/imm_memtable instead of wal/imm_wal on read path

### DIFF
--- a/src/flush.rs
+++ b/src/flush.rs
@@ -72,12 +72,10 @@ impl DbInner {
             let snapshot = rguard.compacted.as_ref().clone();
             snapshot.imm_wal.back().cloned()
         } {
-            let sst = self.flush_imm_wal(imm.clone()).await?;
+            self.flush_imm_wal(imm.clone()).await?;
             let mut wguard = self.state.write();
             let mut snapshot = wguard.compacted.as_ref().clone();
             snapshot.imm_wal.pop_back();
-            // always put the new sst at the front of l0
-            snapshot.wal_ssts.push_front(sst);
             wguard.compacted = Arc::new(snapshot);
             imm.table().notify_flush()
         }


### PR DESCRIPTION
Use l0/imm_memtable instead of wal/imm_wal on read path
- Reads now read from l0/imm_memtable instead of the WAL
- When recovering the database, we scan the uncompacted WAL segments and use them to rebuild the memtable and immutable memtables that have not yet been flushed.