### PR TITLE
fix wal to memtable recovery and move writes to flush thread

### DIFF
--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -1,0 +1,27 @@
+use crate::db::DbInner;
+use crate::db::DbState;
+use crate::mem_table::{ImmutableMemtable, WritableKVTable};
+use crate::memtable_flush::MemtableFlushThreadMsg::FlushImmutableMemtables;
+use parking_lot::RwLockWriteGuard;
+use std::sync::Arc;
+
+impl DbInner {
+    pub(crate) fn maybe_freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>, wal_id: u64) {
+        if guard.memtable.size() < self.options.l0_sst_size_bytes {
+            return;
+        }
+        self.freeze_memtable(guard, wal_id);
+    }
+
+    fn freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>, wal_id: u64) {
+        let old_memtable = std::mem::replace(&mut guard.memtable, WritableKVTable::new());
+        let mut compacted_snapshot = guard.compacted.as_ref().clone();
+        compacted_snapshot
+            .imm_memtable
+            .push_front(Arc::new(ImmutableMemtable::new(old_memtable, wal_id)));
+        guard.compacted = Arc::new(compacted_snapshot);
+        self.memtable_flush_notifier
+            .send(FlushImmutableMemtables)
+            .expect("failed to send memtable flush msg");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod blob;
 mod block;
 mod block_iterator;
 pub mod db;
+mod db_common;
 mod error;
 mod filter;
 mod flatbuffer_types;

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -34,10 +34,16 @@ pub struct MemTableIterator<'a>(MemTableRange<'a>);
 
 impl<'a> KeyValueIterator for MemTableIterator<'a> {
     async fn next_entry(&mut self) -> Result<Option<KeyValueDeletable>, SlateDBError> {
-        Ok(self.0.next().map(|entry| KeyValueDeletable {
+        Ok(self.next_entry_sync())
+    }
+}
+
+impl<'a> MemTableIterator<'a> {
+    pub(crate) fn next_entry_sync(&mut self) -> Option<KeyValueDeletable> {
+        self.0.next().map(|entry| KeyValueDeletable {
             key: entry.key().clone(),
             value: entry.value().clone(),
-        }))
+        })
     }
 }
 


### PR DESCRIPTION
fixes a bug in recovery of the imm memtables from the wal on db startup. In particular, we were previously taking a snapshot before replaying the wal, and then we were updating the db state with the snapshot, overriding the changes made from the replay. With this fix we update the dbstate in place as we go along.

this patch also moves memtable writes to the flush thread, after a imm wal segment has been flushed. This way, only committed writes enter the memtable and its straightforward to implement committed vs uncommitted reads by reading from the memtable only or including the unflushed wal, respectively.