### PR TITLE
refactor: reorganize dbstate and codify mutations

### DIFF
--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -1,25 +1,14 @@
 use crate::db::DbInner;
-use crate::db::DbState;
-use crate::mem_table::{ImmutableMemtable, WritableKVTable};
+use crate::db_state::DbState;
 use crate::mem_table_flush::MemtableFlushThreadMsg::FlushImmutableMemtables;
 use parking_lot::RwLockWriteGuard;
-use std::sync::Arc;
 
 impl DbInner {
     pub(crate) fn maybe_freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>, wal_id: u64) {
-        if guard.memtable.size() < self.options.l0_sst_size_bytes {
+        if guard.memtable().size() < self.options.l0_sst_size_bytes {
             return;
         }
-        self.freeze_memtable(guard, wal_id);
-    }
-
-    fn freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>, wal_id: u64) {
-        let old_memtable = std::mem::replace(&mut guard.memtable, WritableKVTable::new());
-        let mut compacted_snapshot = guard.compacted.as_ref().clone();
-        compacted_snapshot
-            .imm_memtable
-            .push_front(Arc::new(ImmutableMemtable::new(old_memtable, wal_id)));
-        guard.compacted = Arc::new(compacted_snapshot);
+        guard.freeze_memtable(wal_id);
         self.memtable_flush_notifier
             .send(FlushImmutableMemtables)
             .expect("failed to send memtable flush msg");

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -1,0 +1,141 @@
+use crate::flatbuffer_types::ManifestV1Owned;
+use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
+use crate::tablestore::SSTableHandle;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+pub(crate) struct DbState {
+    memtable: WritableKVTable,
+    wal: WritableKVTable,
+    state: Arc<COWDbState>,
+}
+
+// represents the state that is mutated by creating a new copy with the mutations
+#[derive(Clone)]
+pub(crate) struct COWDbState {
+    pub(crate) imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
+    pub(crate) imm_wal: VecDeque<Arc<ImmutableWal>>,
+    pub(crate) core: CoreDbState,
+}
+
+// represents the core db state that we persist in the manifest
+#[derive(Clone)]
+pub(crate) struct CoreDbState {
+    pub(crate) l0: VecDeque<SSTableHandle>,
+    pub(crate) next_wal_sst_id: u64,
+    pub(crate) last_compacted_wal_sst_id: u64,
+}
+
+// represents a read-snapshot of the current db state
+#[derive(Clone)]
+pub(crate) struct DbStateSnapshot {
+    pub(crate) memtable: Arc<KVTable>,
+    pub(crate) wal: Arc<KVTable>,
+    pub(crate) state: Arc<COWDbState>,
+}
+
+impl CoreDbState {
+    pub fn load(manifest: &ManifestV1Owned) -> CoreDbState {
+        let manifest = manifest.borrow();
+        CoreDbState {
+            l0: VecDeque::new(),
+            next_wal_sst_id: manifest.wal_id_last_compacted() + 1,
+            last_compacted_wal_sst_id: manifest.wal_id_last_compacted(),
+        }
+    }
+}
+
+impl DbState {
+    pub fn load(manifest: &ManifestV1Owned) -> Self {
+        Self {
+            memtable: WritableKVTable::new(),
+            wal: WritableKVTable::new(),
+            state: Arc::new(COWDbState {
+                imm_memtable: VecDeque::new(),
+                imm_wal: VecDeque::new(),
+                core: CoreDbState::load(manifest),
+            }),
+        }
+    }
+
+    pub fn state(&self) -> Arc<COWDbState> {
+        self.state.clone()
+    }
+
+    pub fn snapshot(&self) -> DbStateSnapshot {
+        DbStateSnapshot {
+            memtable: self.memtable.table().clone(),
+            wal: self.wal.table().clone(),
+            state: self.state.clone(),
+        }
+    }
+
+    // mutations
+
+    pub fn wal(&mut self) -> &mut WritableKVTable {
+        &mut self.wal
+    }
+
+    pub fn memtable(&mut self) -> &mut WritableKVTable {
+        &mut self.memtable
+    }
+
+    fn state_copy(&self) -> COWDbState {
+        self.state.as_ref().clone()
+    }
+
+    fn update_state(&mut self, state: COWDbState) {
+        self.state = Arc::new(state);
+    }
+
+    pub fn freeze_memtable(&mut self, wal_id: u64) {
+        let old_memtable = std::mem::replace(&mut self.memtable, WritableKVTable::new());
+        let mut state = self.state_copy();
+        state
+            .imm_memtable
+            .push_front(Arc::new(ImmutableMemtable::new(old_memtable, wal_id)));
+        self.update_state(state);
+    }
+
+    pub fn freeze_wal(&mut self) -> Option<u64> {
+        if self.wal.table().is_empty() {
+            return None;
+        }
+        let old_wal = std::mem::replace(&mut self.wal, WritableKVTable::new());
+        let mut state = self.state_copy();
+        let imm_wal = Arc::new(ImmutableWal::new(state.core.next_wal_sst_id, old_wal));
+        let id = imm_wal.id();
+        state.imm_wal.push_front(imm_wal);
+        state.core.next_wal_sst_id += 1;
+        self.update_state(state);
+        Some(id)
+    }
+
+    pub fn pop_imm_wal(&mut self) {
+        let mut state = self.state_copy();
+        state.imm_wal.pop_back();
+        self.update_state(state);
+    }
+
+    pub fn move_imm_memtable_to_l0(
+        &mut self,
+        imm_memtable: Arc<ImmutableMemtable>,
+        sst_handle: SSTableHandle,
+    ) {
+        let mut state = self.state_copy();
+        let popped = state
+            .imm_memtable
+            .pop_back()
+            .expect("expected imm memtable");
+        assert!(Arc::ptr_eq(&popped, &imm_memtable));
+        state.core.l0.push_front(sst_handle);
+        state.core.last_compacted_wal_sst_id = imm_memtable.last_wal_id();
+        self.update_state(state);
+    }
+
+    pub fn increment_next_wal_id(&mut self) {
+        let mut state = self.state_copy();
+        state.core.next_wal_sst_id += 1;
+        self.update_state(state);
+    }
+}

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -1,4 +1,4 @@
-use crate::db::CompactedDbState;
+use crate::db_state::CoreDbState;
 use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
 use std::collections::VecDeque;
@@ -80,7 +80,7 @@ impl ManifestV1Owned {
         Self { data }
     }
 
-    pub fn get_updated_manifest(&self, compacted_db_state: &CompactedDbState) -> ManifestV1Owned {
+    pub fn get_updated_manifest(&self, compacted_db_state: &CoreDbState) -> ManifestV1Owned {
         let old_manifest = self.borrow();
         let builder = flatbuffers::FlatBufferBuilder::new();
         let mut manifest_builder = ManifestBuilder::new(builder);
@@ -173,7 +173,7 @@ impl<'b> ManifestBuilder<'b> {
     fn create_from_compacted_dbstate(
         &mut self,
         old_manifest: ManifestV1,
-        compacted_db_state: &CompactedDbState,
+        compacted_db_state: &CoreDbState,
     ) -> Bytes {
         let l0 = self.create_compacted_ssts(&compacted_db_state.l0);
         let manifest = ManifestV1::create(

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -1,46 +1,27 @@
-use crate::db::{DbInner, DbState};
+use crate::db::DbInner;
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::mem_table::{ImmutableWal, KVTable, WritableKVTable};
 use crate::tablestore::{self, SSTableHandle};
 use crate::types::ValueDeletable;
 use futures::executor::block_on;
-use parking_lot::RwLockWriteGuard;
 use std::sync::Arc;
 use std::time::Duration;
 
 impl DbInner {
     pub(crate) async fn flush(&self) -> Result<(), SlateDBError> {
-        self.freeze_wal(&mut self.state.write());
+        self.state.write().freeze_wal();
         self.flush_imm_wals().await?;
         Ok(())
-    }
-
-    fn freeze_wal(&self, guard: &mut RwLockWriteGuard<DbState>) -> Option<u64> {
-        if guard.wal.table().is_empty() {
-            return None;
-        }
-        let old_wal = std::mem::replace(&mut guard.wal, WritableKVTable::new());
-        let mut compacted_snapshot = guard.compacted.as_ref().clone();
-        let imm_wal = Arc::new(ImmutableWal::new(
-            compacted_snapshot.next_wal_sst_id,
-            old_wal,
-        ));
-        let id = imm_wal.id();
-        compacted_snapshot.imm_wal.push_front(imm_wal);
-        compacted_snapshot.next_wal_sst_id += 1;
-        guard.compacted = Arc::new(compacted_snapshot);
-        Some(id)
     }
 
     pub(crate) async fn write_manifest(&self) -> Result<(), SlateDBError> {
         // get the update manifest if there are any updates.
         let updated_manifest: Option<crate::flatbuffer_types::ManifestV1Owned> = {
-            let db_state = self.state.read();
+            let compacted = &self.state.read().state().core;
             let mut wguard_manifest = self.manifest.write();
-            if wguard_manifest.borrow().wal_id_last_seen() != db_state.compacted.next_wal_sst_id - 1
-            {
-                let new_manifest = wguard_manifest.get_updated_manifest(&db_state.compacted);
+            if wguard_manifest.borrow().wal_id_last_seen() != compacted.next_wal_sst_id - 1 {
+                let new_manifest = wguard_manifest.get_updated_manifest(compacted);
                 *wguard_manifest = new_manifest.clone();
                 Some(new_manifest)
             } else {
@@ -101,17 +82,14 @@ impl DbInner {
     async fn flush_imm_wals(&self) -> Result<(), SlateDBError> {
         while let Some(imm) = {
             let rguard = self.state.read();
-            let snapshot = rguard.compacted.as_ref().clone();
-            snapshot.imm_wal.back().cloned()
+            rguard.state().imm_wal.back().cloned()
         } {
             self.flush_imm_wal(imm.clone()).await?;
             let mut wguard = self.state.write();
-            let mut snapshot = wguard.compacted.as_ref().clone();
-            snapshot.imm_wal.pop_back();
-            wguard.compacted = Arc::new(snapshot);
+            wguard.pop_imm_wal();
             // flush to the memtable before notifying so that data is available for reads
             // once we support committed read isolation, reads should read from memtable first
-            self.flush_imm_wal_to_memtable(&mut wguard.memtable, imm.table());
+            self.flush_imm_wal_to_memtable(wguard.memtable(), imm.table());
             self.maybe_freeze_memtable(&mut wguard, imm.id());
             imm.table().notify_flush();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod block;
 mod block_iterator;
 pub mod db;
 mod db_common;
+mod db_state;
 mod error;
 mod failpoints;
 mod filter;


### PR DESCRIPTION
This patch refactors dbstate a bit to hopefully make it easier to follow how the db's internal state is mutated:

1. Reorganizes DbState:
   - DbState: contains all the db's interal state, as before. It contains the active wal, active memtable, and a pointer to the copy-on-write state. Further, i've made the struct fields private to the module so they cannot be mutated directly.
   - Reorganize CompactedDbState into COWDbState and CoreDbState. CoreDbState contains all the state that will be persisted to and read from the manifest stored on durable storage. COWDbState contains all the state that is mutated by making a copy. This includes the core state as well ass the immutable memtables and WALs.

2. Add a DbStateSnapshot that contains everything required for read methods (e.g. get) to get a snapshot for reading the db. This includes an Arc to the cow state, and read-only pointers to the memtable and wal.

3. Move all mutations to the state into &mut self methods in DbState. This will hopefully make it easier to control and follow how exactly the state is mutated.

4. load_state now constructs a DbState rather than updates the db itself. One secondary benefit here is that we don't need to keep locking/unlocking the state when recovering.