### PR TITLE
actually restore l0s when loading state

### DIFF
--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -13,6 +13,8 @@ table SsTableInfo {
     // First key in the SST file.
     first_key: [ubyte];
 
+    // TODO: we should move this index out into its own object
+    //       https://github.com/slatedb/slatedb/issues/88
     // Sequence of block metadata. SST files could have multiple blocks.
     block_meta: [BlockMeta] (required);
 

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -21,7 +21,7 @@ impl DbInner {
             let compacted = &self.state.read().state().core;
             let mut wguard_manifest = self.manifest.write();
             if wguard_manifest.borrow().wal_id_last_seen() != compacted.next_wal_sst_id - 1 {
-                let new_manifest = wguard_manifest.get_updated_manifest(compacted);
+                let new_manifest = wguard_manifest.create_updated_manifest(compacted);
                 *wguard_manifest = new_manifest.clone();
                 Some(new_manifest)
             } else {


### PR DESCRIPTION
Fixes a bug in our restore code where we were not actually loading the l0 SSTs. This patch updates CoreDBState to load l0 ssts when loading the state from the manfiest.