### PR TITLE
compaction: orchestrator for coordinating compaction work

### DIFF
--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -17,6 +17,9 @@ table ManifestV1 {
     // The most recent SST in the WAL at the time manifest was updated.
     wal_id_last_seen: ulong;
 
+    // The last compacted l0
+    l0_last_compacted: CompactedSstId;
+
     // A list of the L0 SSTs that are valid to read in the `compacted` folder.
     l0: [CompactedSsTable];
 

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -1,0 +1,409 @@
+use crate::compactor::CompactorMainMsg::Shutdown;
+use crate::compactor_state::{
+    CompactionWriter, CompactorStateHolder, CompactorStateListener, CompactorStateReader,
+};
+use crate::db_state::SortedRun;
+use crate::error::SlateDBError;
+use crate::size_tiered_compaction::SizeTieredCompactionSchedulerFactory;
+use crate::tablestore::{SSTableHandle, TableStore};
+use crossbeam_channel::{Receiver, Sender};
+use futures::executor::block_on;
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use ulid::Ulid;
+
+const DEFAULT_COMPACTOR_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+pub(crate) trait CompactionSchedulerFactory {
+    /*
+     * Notifies the scheduler that it should start evaluating the db for compaction. This method
+     * receives a channel over which the Executor sends the Scheduler updates about changes
+     * to the database. This includes updates about changes to the database (e.g. arrival of
+     * new L0 files), and completion of compactions.
+     */
+    fn create(
+        &self,
+        state: Rc<dyn CompactorStateReader>,
+        compaction_writer: Rc<dyn CompactionWriter>,
+    ) -> Rc<dyn CompactorStateListener>;
+}
+
+#[derive(Clone)]
+pub struct CompactorOptions {
+    poll_interval: Duration,
+}
+
+impl CompactorOptions {
+    pub fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_COMPACTOR_POLL_INTERVAL,
+        }
+    }
+}
+
+enum CompactorMainMsg {
+    Shutdown,
+}
+
+#[allow(dead_code)]
+enum WorkerToOrchestoratorMsg {
+    CompactionStatus,
+}
+
+pub(crate) struct Compactor {
+    main_tx: Sender<CompactorMainMsg>,
+    main_thread: RefCell<Option<JoinHandle<()>>>,
+}
+
+impl Compactor {
+    pub(crate) fn new(
+        table_store: Arc<TableStore>,
+        options: CompactorOptions,
+    ) -> Result<Self, SlateDBError> {
+        let (external_tx, external_rx) = crossbeam_channel::unbounded();
+        let (err_tx, err_rx) = crossbeam_channel::unbounded();
+        let main_thread = std::thread::spawn(move || {
+            let (_, worker_orch_rx) = crossbeam_channel::unbounded();
+            let load_result = CompactorOrchestrator::new(
+                options,
+                table_store.clone(),
+                external_rx,
+                worker_orch_rx,
+            );
+            let orchestrator = match load_result {
+                Ok(orchestrator) => orchestrator,
+                Err(err) => {
+                    err_tx.send(Err(err)).expect("err channel failure");
+                    return;
+                }
+            };
+            err_tx.send(Ok(())).expect("err channel failure");
+            orchestrator.run();
+        });
+        err_rx.recv().expect("err channel failure")?;
+        Ok(Self {
+            main_thread: RefCell::new(Some(main_thread)),
+            main_tx: external_tx,
+        })
+    }
+
+    pub(crate) fn close(&self) {
+        let mut maybe_main_thread = self.main_thread.borrow_mut();
+        if let Some(main_thread) = maybe_main_thread.take() {
+            self.main_tx.send(Shutdown).expect("main tx disconnected");
+            main_thread
+                .join()
+                .expect("failed to stop main compactor thread");
+        }
+    }
+}
+
+struct CompactorOrchestrator {
+    options: CompactorOptions,
+    table_store: Arc<TableStore>,
+    state: Rc<CompactorStateHolder>,
+    external_rx: Receiver<CompactorMainMsg>,
+    worker_rx: Receiver<WorkerToOrchestoratorMsg>,
+}
+
+impl CompactorOrchestrator {
+    fn new(
+        options: CompactorOptions,
+        table_store: Arc<TableStore>,
+        external_rx: Receiver<CompactorMainMsg>,
+        worker_rx: Receiver<WorkerToOrchestoratorMsg>,
+    ) -> Result<Rc<Self>, SlateDBError> {
+        let state = Self::load_state(table_store.clone())?;
+        let scheduler =
+            Self::load_compaction_scheduler(&options).create(state.clone(), state.clone());
+        let orchestrator = Rc::new(Self {
+            options,
+            table_store,
+            state: state.clone(),
+            external_rx,
+            worker_rx,
+        });
+        state.add_listener(orchestrator.clone());
+        state.add_listener(scheduler);
+        state.add_listener(Rc::new(LoggingCompactorStateListener {
+            state: state.clone(),
+        }));
+        Ok(orchestrator)
+    }
+
+    fn load_compaction_scheduler(
+        _options: &CompactorOptions,
+    ) -> Box<dyn CompactionSchedulerFactory> {
+        // todo: return the right type based on the configured scheduler
+        Box::new(SizeTieredCompactionSchedulerFactory {})
+    }
+
+    fn load_state(table_store: Arc<TableStore>) -> Result<Rc<CompactorStateHolder>, SlateDBError> {
+        let maybe_manifest = block_on(table_store.open_latest_manifest())?;
+        if let Some(manifest) = maybe_manifest {
+            // todo: bump epoch here
+            let state = Rc::new(CompactorStateHolder::new(manifest, table_store.as_ref())?);
+            Ok(state)
+        } else {
+            Err(SlateDBError::InvalidDBState)
+        }
+    }
+
+    fn run(&self) {
+        let ticker = crossbeam_channel::tick(self.options.poll_interval);
+        loop {
+            crossbeam_channel::select! {
+                recv(ticker) -> _ => {
+                    self.load_manifest();
+                }
+                recv(self.worker_rx) -> _ => {
+                    // todo: update compaction status
+                }
+                recv(self.external_rx) -> _ => {
+                    return;
+                }
+            }
+        }
+    }
+
+    fn load_manifest(&self) {
+        let manifest_read_result = block_on(self.table_store.open_latest_manifest());
+        match manifest_read_result {
+            Ok(manifest) => {
+                // todo: check epoch here
+                let merge_result = self.state.merge_writer_update(
+                    manifest.expect("manifest must exist"),
+                    self.table_store.clone(),
+                );
+                if merge_result.is_err() {
+                    println!(
+                        "error merging writer manifest update: {:#?}",
+                        merge_result.err()
+                    )
+                }
+            }
+            Err(err) => {
+                println!("error reading manifest: {:#?}", err)
+            }
+        }
+    }
+
+    fn write_manifest_safely(&self) {
+        // todo: run this in a loop until either the write succeeds or we get fenced
+        // read the manifest first to pull in any writer changes and check for compactor fencing
+        self.load_manifest();
+        self.write_manifest();
+    }
+
+    fn write_manifest(&self) {
+        let manifest = self.state.manifest();
+        let result = block_on(self.table_store.write_manifest(manifest.as_ref()));
+        if result.is_err() {
+            println!("error writing updated manifest: {:#?}", result.err())
+        }
+    }
+}
+
+impl CompactorStateListener for CompactorOrchestrator {
+    fn on_compactor_db_state_update(&self) {
+        self.write_manifest_safely();
+    }
+
+    fn on_compaction_submitted(&self) {
+        // todo: send compactions to the compaction workers instead
+        // just complete the compaction for now by trivially writing a new run with
+        // the l0 SSTs
+        for compaction in self.state.compactions() {
+            let l0s: HashSet<Ulid> = compaction.sources.iter().map(|s| s.unwrap_sst()).collect();
+            let compacted: Vec<SSTableHandle> = self
+                .state
+                .db_state()
+                .l0
+                .iter()
+                .filter(|h| {
+                    let ulid = h.id.unwrap_compacted_id();
+                    l0s.contains(&ulid)
+                })
+                .cloned()
+                .collect();
+            self.state.finish_compaction(SortedRun {
+                id: compaction.destination,
+                ssts: compacted,
+            })
+        }
+    }
+}
+
+struct LoggingCompactorStateListener {
+    state: Rc<dyn CompactorStateReader>,
+}
+
+impl CompactorStateListener for LoggingCompactorStateListener {
+    fn on_writer_db_state_update(&self) {
+        println!("compactor db state merged with writer db state");
+    }
+
+    fn on_compactor_db_state_update(&self) {
+        println!("db state updated by compactor")
+    }
+
+    fn on_compaction_submitted(&self) {
+        println!(
+            "new compaction submitted. currently running compactions: {:#?}",
+            self.state.compactions()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compactor::{CompactorOptions, CompactorOrchestrator};
+    use crate::compactor_state::{CompactionWriter, CompactorStateReader, SourceId};
+    use crate::db::{Db, DbOptions};
+    use crate::sst::SsTableFormat;
+    use crate::tablestore::TableStore;
+    use futures::executor::block_on;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use std::sync::Arc;
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime};
+    use ulid::Ulid;
+
+    const PATH: &str = "/test/db";
+    const DEFAULT_OPTIONS: DbOptions = DbOptions {
+        flush_ms: 100,
+        min_filter_keys: 0,
+        l0_sst_size_bytes: 128,
+        compactor_options: Some(CompactorOptions {
+            poll_interval: Duration::from_millis(100),
+        }),
+    };
+
+    #[test]
+    fn test_compactor_compacts_l0() {
+        // given:
+        let (_, table_store, db) = build_test_db();
+        for i in 0..4 {
+            block_on(db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]));
+            block_on(db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]));
+        }
+
+        // when:
+        let maybe_manifest_owned = run_for(Duration::from_secs(10), || {
+            let manifest = block_on(table_store.open_latest_manifest())
+                .unwrap()
+                .unwrap();
+            if manifest.borrow().l0_last_compacted().is_some() {
+                return Some(manifest);
+            }
+            None
+        });
+
+        // then:
+        let manifest_owned = maybe_manifest_owned.expect("db was not compacted");
+        let manifest = manifest_owned.borrow();
+        assert!(manifest.l0_last_compacted().is_some());
+        assert!(manifest.compacted().is_some());
+        assert_eq!(manifest.compacted().as_ref().unwrap().len(), 1);
+        assert_eq!(
+            manifest
+                .compacted()
+                .as_ref()
+                .unwrap()
+                .get(0)
+                .ssts()
+                .unwrap()
+                .len(),
+            4
+        );
+        // todo: test that the db can read the k/vs (once we implement reading from compacted)
+    }
+
+    #[test]
+    fn test_should_write_manifest_safely() {
+        // given:
+        // write an l0
+        let (os, table_store, db) = build_test_db();
+        block_on(db.put(&[b'a'; 32], &[b'b'; 96]));
+        block_on(db.close()).unwrap();
+        let options = DEFAULT_OPTIONS.clone();
+        let (_, external_rx) = crossbeam_channel::unbounded();
+        let (_, worker_rx) = crossbeam_channel::unbounded();
+        let orchestrator = CompactorOrchestrator::new(
+            options.compactor_options.unwrap(),
+            table_store.clone(),
+            external_rx,
+            worker_rx,
+        )
+        .unwrap();
+        let l0_ids_to_compact: Vec<SourceId> = orchestrator
+            .state
+            .db_state()
+            .l0
+            .iter()
+            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+            .collect();
+        // write another l0
+        let db = block_on(Db::open(Path::from(PATH), DEFAULT_OPTIONS, os.clone())).unwrap();
+        block_on(db.put(&[b'j'; 32], &[b'k'; 96]));
+        block_on(db.close()).unwrap();
+
+        // when:
+        orchestrator
+            .state
+            .submit_compaction(l0_ids_to_compact.clone(), 0)
+            .unwrap();
+
+        // then:
+        let manifest_owned = block_on(table_store.open_latest_manifest())
+            .unwrap()
+            .unwrap();
+        let manifest = manifest_owned.borrow();
+        let manifest_l0 = manifest.l0().unwrap();
+        assert_eq!(manifest_l0.len(), 1);
+        let manifest_compacted = manifest.compacted().unwrap();
+        assert_eq!(manifest_compacted.len(), 1);
+        let l0_id = manifest_l0.get(0).id().unwrap().ulid();
+        let compacted_l0s: Vec<Ulid> = manifest_compacted
+            .get(0)
+            .ssts()
+            .unwrap()
+            .iter()
+            .map(|sst| sst.id().unwrap().ulid())
+            .collect();
+        assert!(!compacted_l0s.contains(&l0_id));
+        assert_eq!(
+            manifest.l0_last_compacted().unwrap().ulid(),
+            compacted_l0s.first().unwrap().clone()
+        );
+    }
+
+    fn run_for<T, F>(duration: Duration, mut f: F) -> Option<T>
+    where
+        F: FnMut() -> Option<T>,
+    {
+        let now = SystemTime::now();
+        while now.elapsed().unwrap() < duration {
+            let maybe_result = f();
+            if maybe_result.is_some() {
+                return maybe_result;
+            }
+            sleep(Duration::from_millis(100));
+        }
+        None
+    }
+
+    fn build_test_db() -> (Arc<dyn ObjectStore>, Arc<TableStore>, Db) {
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = block_on(Db::open(Path::from(PATH), DEFAULT_OPTIONS, os.clone())).unwrap();
+        let sst_format = SsTableFormat::new(4096, 10);
+        let table_store = Arc::new(TableStore::new(os.clone(), sst_format, Path::from(PATH)));
+        (os, table_store, db)
+    }
+}

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -1,0 +1,632 @@
+use crate::db_state::{CoreDbState, SortedRun};
+use crate::error::SlateDBError;
+use crate::flatbuffer_types::{ManifestV1Owned, SsTableInfoOwned};
+use crate::tablestore::SsTableId::Compacted;
+use crate::tablestore::{SSTableHandle, TableStore};
+use futures::executor::block_on;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::rc::Rc;
+use std::sync::Arc;
+use ulid::Ulid;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum SourceId {
+    SortedRun(u32),
+    Sst(Ulid),
+}
+
+impl SourceId {
+    #[allow(dead_code)]
+    pub(crate) fn unwrap_sorted_run(&self) -> u32 {
+        self.maybe_unwrap_sorted_run()
+            .expect("tried to unwrap Sst as Sorted Run")
+    }
+
+    pub(crate) fn maybe_unwrap_sorted_run(&self) -> Option<u32> {
+        match self {
+            SourceId::SortedRun(id) => Some(*id),
+            SourceId::Sst(_) => None,
+        }
+    }
+
+    pub(crate) fn unwrap_sst(&self) -> Ulid {
+        self.maybe_unwrap_sst()
+            .expect("tried to unwrap Sst as Sorted Run")
+    }
+
+    pub(crate) fn maybe_unwrap_sst(&self) -> Option<Ulid> {
+        match self {
+            SourceId::SortedRun(_) => None,
+            SourceId::Sst(ulid) => Some(*ulid),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum CompactionStatus {
+    Submitted,
+    #[allow(dead_code)]
+    InProgress,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Compaction {
+    pub(crate) status: CompactionStatus,
+    pub(crate) sources: Vec<SourceId>,
+    pub(crate) destination: u32,
+}
+
+struct CompactorState {
+    db_state: Rc<CoreDbState>,
+    // TODO: fully specify the manifest in CoreDbState, and then we can drop this and just convert
+    //       back and forth from ManifestSynchronizer. This is also blocked on lazy-loading the
+    //       filters, since its currently too expensive to load the manifest from CoreDbState.
+    manifest: Rc<ManifestV1Owned>,
+    compactions: HashMap<u32, Compaction>,
+}
+
+impl CompactorState {
+    pub(crate) fn new(
+        manifest: ManifestV1Owned,
+        table_store: &TableStore,
+    ) -> Result<Self, SlateDBError> {
+        let db_state = block_on(CoreDbState::load(&manifest, table_store))?;
+        Ok(Self {
+            db_state: Rc::new(db_state),
+            manifest: Rc::new(manifest),
+            compactions: HashMap::<u32, Compaction>::new(),
+        })
+    }
+}
+
+pub(crate) trait CompactorStateListener {
+    fn on_writer_db_state_update(&self) {}
+
+    fn on_compactor_db_state_update(&self) {}
+
+    fn on_compaction_submitted(&self) {}
+}
+
+pub(crate) trait CompactorStateReader {
+    fn db_state(&self) -> Rc<CoreDbState>;
+
+    fn manifest(&self) -> Rc<ManifestV1Owned>;
+
+    fn compactions(&self) -> Vec<Compaction>;
+}
+
+pub(crate) trait CompactionWriter {
+    fn submit_compaction(
+        &self,
+        sources: Vec<SourceId>,
+        destination: u32,
+    ) -> Result<(), SlateDBError>;
+}
+
+pub(crate) struct CompactorStateHolder {
+    state: RefCell<CompactorState>,
+    listeners: RefCell<Vec<Rc<dyn CompactorStateListener>>>,
+}
+
+impl CompactorStateReader for CompactorStateHolder {
+    fn db_state(&self) -> Rc<CoreDbState> {
+        self.state.borrow().db_state.clone()
+    }
+
+    fn manifest(&self) -> Rc<ManifestV1Owned> {
+        self.state.borrow().manifest.clone()
+    }
+
+    fn compactions(&self) -> Vec<Compaction> {
+        self.state.borrow().compactions.values().cloned().collect()
+    }
+}
+
+impl CompactionWriter for CompactorStateHolder {
+    fn submit_compaction(
+        &self,
+        sources: Vec<SourceId>,
+        destination: u32,
+    ) -> Result<(), SlateDBError> {
+        // todo: validate the compaction here
+        {
+            // do the mutable borrow in a contained scope so listeners can access state safely
+            let mut state = self.state.borrow_mut();
+            if state.compactions.contains_key(&destination) {
+                return Err(SlateDBError::InvalidCompaction);
+            }
+            state.compactions.insert(
+                destination,
+                Compaction {
+                    status: CompactionStatus::Submitted,
+                    sources,
+                    destination,
+                },
+            );
+        }
+        for l in &self.clone_listeners() {
+            l.on_compaction_submitted();
+        }
+        Ok(())
+    }
+}
+
+impl CompactorStateHolder {
+    pub(crate) fn merge_writer_update(
+        &self,
+        writer_manifest_owned: ManifestV1Owned,
+        table_store: Arc<TableStore>,
+    ) -> Result<(), SlateDBError> {
+        {
+            // do the mutable borrow in a contained scope so listeners can access state safely
+            let writer_manifest = writer_manifest_owned.borrow();
+            // the writer may have added more l0 SSTs. Add these to our l0 list.
+            let mut state = self.state.borrow_mut();
+            let last_compacted_l0 = &state.db_state.l0_last_compacted;
+            let mut merged_l0s = VecDeque::new();
+            let our_l0s_by_id: HashMap<Ulid, &SSTableHandle> = state
+                .db_state
+                .l0
+                .iter()
+                .map(|h| (h.id.unwrap_compacted_id(), h))
+                .collect();
+            let writer_l0 = writer_manifest.l0().expect("manifest must have l0 list");
+            let mut i = 0;
+            while i < writer_l0.len() {
+                // todo: move to some utility method
+                let writer_l0_sst = writer_l0.get(i);
+                let writer_l0_id = writer_l0_sst.id().expect("l0 sst must have id").ulid();
+                // todo: this is brittle. we are relying on the l0 list always being updated in
+                //       an expected order. We should instead encode the ordering in the l0 SST IDs
+                //       and assert that it follows the order
+                if match &last_compacted_l0 {
+                    None => true,
+                    Some(last_compacted_l0_id) => writer_l0_id != *last_compacted_l0_id,
+                } {
+                    if let Some(&handle_ref) = our_l0s_by_id.get(&writer_l0_id) {
+                        merged_l0s.push_back(handle_ref.clone())
+                    } else {
+                        let writer_l0_info = writer_l0_sst.info().expect("l0 sst must have info");
+                        let handle = block_on(table_store.open_compacted_sst(
+                            Compacted(writer_l0_id),
+                            SsTableInfoOwned::create_copy(&writer_l0_info),
+                        ))?;
+                        merged_l0s.push_back(handle);
+                    }
+                } else {
+                    break;
+                }
+                i += 1;
+            }
+
+            // write out the merged core db state and manifest
+            let mut merged = state.db_state.as_ref().clone();
+            merged.l0 = merged_l0s;
+            merged.last_compacted_wal_sst_id = writer_manifest.wal_id_last_compacted();
+            merged.next_wal_sst_id = writer_manifest.wal_id_last_seen() + 1;
+            state.db_state = Rc::new(merged);
+            state.manifest = Rc::new(state.manifest.create_updated_manifest(&state.db_state));
+        }
+
+        for l in &self.clone_listeners() {
+            l.on_writer_db_state_update();
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn finish_compaction(&self, output_sr: SortedRun) {
+        {
+            // do the mutable borrow in a contained scope so listeners can access state safely
+            let mut state = self.state.borrow_mut();
+            if let Some(compaction) = state.compactions.get(&output_sr.id) {
+                // reconstruct l0
+                let compaction_l0s: HashSet<Ulid> = compaction
+                    .sources
+                    .iter()
+                    .filter_map(|id| id.maybe_unwrap_sst())
+                    .collect();
+                let compaction_srs: HashSet<u32> = compaction
+                    .sources
+                    .iter()
+                    .chain(std::iter::once(&SourceId::SortedRun(
+                        compaction.destination,
+                    )))
+                    .filter_map(|id| id.maybe_unwrap_sorted_run())
+                    .collect();
+                let mut db_state = state.db_state.as_ref().clone();
+                let new_l0: VecDeque<SSTableHandle> = db_state
+                    .l0
+                    .iter()
+                    .filter_map(|l0| {
+                        let l0_id = l0.id.unwrap_compacted_id();
+                        if compaction_l0s.contains(&l0_id) {
+                            return None;
+                        }
+                        Some(l0.clone())
+                    })
+                    .collect();
+                let mut new_compacted = Vec::new();
+                let mut inserted = false;
+                for compacted in db_state.compacted.iter() {
+                    if !inserted && output_sr.id >= compacted.id {
+                        new_compacted.push(output_sr.clone());
+                        inserted = true;
+                    }
+                    if !compaction_srs.contains(&compacted.id) {
+                        new_compacted.push(compacted.clone());
+                    }
+                }
+                if !inserted {
+                    new_compacted.push(output_sr.clone());
+                }
+                let first_source = compaction
+                    .sources
+                    .first()
+                    .expect("illegal: empty compaction");
+                if let Some(compacted_l0) = first_source.maybe_unwrap_sst() {
+                    // if there are l0s, the newest must be the first entry in sources
+                    // TODO: validate that this is the case
+                    db_state.l0_last_compacted = Some(compacted_l0)
+                }
+                db_state.l0 = new_l0;
+                db_state.compacted = new_compacted;
+                state.db_state = Rc::new(db_state);
+                state.manifest = Rc::new(state.manifest.create_updated_manifest(&state.db_state));
+                state.compactions.remove(&output_sr.id);
+            }
+        }
+
+        for l in &self.clone_listeners() {
+            l.on_compactor_db_state_update();
+        }
+    }
+
+    pub(crate) fn add_listener(&self, listener: Rc<dyn CompactorStateListener>) {
+        self.listeners.borrow_mut().push(listener);
+    }
+
+    pub(crate) fn new(
+        manifest: ManifestV1Owned,
+        table_store: &TableStore,
+    ) -> Result<Self, SlateDBError> {
+        let state = CompactorState::new(manifest, table_store)?;
+        Ok(Self {
+            state: RefCell::new(state),
+            listeners: RefCell::new(Vec::new()),
+        })
+    }
+
+    fn clone_listeners(&self) -> Vec<Rc<dyn CompactorStateListener>> {
+        let mut clone = Vec::new();
+        let listeners = self.listeners.borrow();
+        for l in listeners.iter() {
+            clone.push(l.clone())
+        }
+        clone
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compactor_state::CompactionStatus::Submitted;
+    use crate::compactor_state::SourceId::Sst;
+    use crate::db::{Db, DbOptions};
+    use crate::sst::SsTableFormat;
+    use crate::tablestore::SsTableId;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime};
+
+    const PATH: &str = "/test/db";
+    const DEFAULT_OPTIONS: DbOptions = DbOptions {
+        flush_ms: 100,
+        min_filter_keys: 0,
+        l0_sst_size_bytes: 128,
+        compactor_options: None,
+    };
+
+    #[test]
+    fn test_should_register_compaction_as_submitted() {
+        // given:
+        let (_, _, state) = build_test_state();
+        state
+            .submit_compaction(build_l0_compaction(&state.db_state().l0), 0)
+            .unwrap();
+
+        // when/then:
+        assert_eq!(state.compactions().len(), 1);
+        assert_eq!(state.compactions().first().unwrap().status, Submitted);
+    }
+
+    #[test]
+    fn test_should_update_dbstate_when_compaction_finished() {
+        // given:
+        let (_, _, state) = build_test_state();
+        let before_compaction = state.db_state();
+        let sources = build_l0_compaction(&before_compaction.l0);
+        state.submit_compaction(sources, 0).unwrap();
+
+        // when:
+        let compacted_ssts = before_compaction.l0.iter().cloned().collect();
+        let sr = SortedRun {
+            id: 0,
+            ssts: compacted_ssts,
+        };
+        state.finish_compaction(sr.clone());
+
+        // then:
+        assert_eq!(
+            state.db_state().l0_last_compacted,
+            Some(
+                before_compaction
+                    .l0
+                    .front()
+                    .unwrap()
+                    .id
+                    .unwrap_compacted_id()
+            )
+        );
+        assert_eq!(state.db_state().l0.len(), 0);
+        assert_eq!(state.db_state().compacted.len(), 1);
+        assert_eq!(state.db_state().compacted.first().unwrap().id, sr.id);
+        let expected_ids: Vec<SsTableId> = sr.ssts.iter().map(|h| h.id.clone()).collect();
+        let found_ids: Vec<SsTableId> = state
+            .db_state()
+            .compacted
+            .first()
+            .unwrap()
+            .ssts
+            .iter()
+            .map(|h| h.id.clone())
+            .collect();
+        assert_eq!(expected_ids, found_ids);
+    }
+
+    #[test]
+    fn test_should_remove_compaction_when_compaction_finished() {
+        // given:
+        let (_, _, state) = build_test_state();
+        let before_compaction = state.db_state();
+        let sources = build_l0_compaction(&before_compaction.l0);
+        state.submit_compaction(sources, 0).unwrap();
+
+        // when:
+        let compacted_ssts = before_compaction.l0.iter().cloned().collect();
+        let sr = SortedRun {
+            id: 0,
+            ssts: compacted_ssts,
+        };
+        state.finish_compaction(sr.clone());
+
+        // then:
+        assert_eq!(state.compactions().len(), 0)
+    }
+
+    #[test]
+    fn test_should_merge_writer_update_correctly_when_never_compacted() {
+        // given:
+        let (os, table_store, state) = build_test_state();
+        // open a new db and write another l0
+        let db = build_db(os.clone());
+        block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
+        block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        let writer_manifest =
+            wait_for_manifest_with_l0_len(&table_store, state.db_state().l0.len() + 1);
+
+        // when:
+        state
+            .merge_writer_update(writer_manifest.clone(), table_store)
+            .unwrap();
+
+        // then:
+        assert!(state.db_state().l0_last_compacted.is_none());
+        let expected_merged_l0s: Vec<Ulid> = writer_manifest
+            .borrow()
+            .l0()
+            .unwrap()
+            .iter()
+            .map(|t| t.id().unwrap().ulid())
+            .collect();
+        let merged_l0s: Vec<Ulid> = state
+            .db_state()
+            .l0
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        assert_eq!(expected_merged_l0s, merged_l0s);
+    }
+
+    #[test]
+    fn test_should_merge_writer_update_correctly() {
+        // given:
+        let (os, table_store, state) = build_test_state();
+        // compact the last sst
+        let original_l0s = &state.db_state().l0;
+        state
+            .submit_compaction(
+                vec![Sst(original_l0s.back().unwrap().id.unwrap_compacted_id())],
+                0,
+            )
+            .unwrap();
+        state.finish_compaction(SortedRun {
+            id: 0,
+            ssts: vec![original_l0s.back().unwrap().clone()],
+        });
+        // open a new db and write another l0
+        let db = build_db(os.clone());
+        block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
+        block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        let writer_manifest = wait_for_manifest_with_l0_len(&table_store, original_l0s.len() + 1);
+        let db_state_before_merge = state.db_state();
+
+        // when:
+        state
+            .merge_writer_update(writer_manifest.clone(), table_store)
+            .unwrap();
+
+        // then:
+        let db_state = state.db_state();
+        let mut expected_merged_l0s: VecDeque<Ulid> = original_l0s
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        expected_merged_l0s.pop_back();
+        let new_l0 = writer_manifest.borrow().l0().unwrap().get(0).id().unwrap();
+        let new_l0 = Ulid::from((new_l0.high(), new_l0.low()));
+        expected_merged_l0s.push_front(new_l0);
+        let merged_l0: VecDeque<Ulid> = db_state
+            .l0
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        assert_eq!(merged_l0, expected_merged_l0s);
+        assert_eq!(
+            compacted_to_description(&db_state.compacted),
+            compacted_to_description(&db_state_before_merge.compacted)
+        );
+        assert_eq!(
+            db_state.last_compacted_wal_sst_id,
+            writer_manifest.borrow().wal_id_last_compacted()
+        );
+        assert_eq!(
+            db_state.next_wal_sst_id,
+            writer_manifest.borrow().wal_id_last_seen() + 1
+        );
+        let manifest = state.manifest();
+        assert_eq!(
+            manifest.borrow(),
+            writer_manifest
+                .create_updated_manifest(db_state.as_ref())
+                .borrow()
+        )
+    }
+
+    #[test]
+    fn test_should_merge_writer_update_correctly_when_all_l0_compacted() {
+        // given:
+        let (os, table_store, state) = build_test_state();
+        // compact the last sst
+        let original_l0s = &state.db_state().l0;
+        state
+            .submit_compaction(
+                original_l0s
+                    .iter()
+                    .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+                    .collect(),
+                0,
+            )
+            .unwrap();
+        state.finish_compaction(SortedRun {
+            id: 0,
+            ssts: original_l0s.clone().into(),
+        });
+        assert_eq!(state.db_state().l0.len(), 0);
+        // open a new db and write another l0
+        let db = build_db(os.clone());
+        block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
+        block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        let writer_manifest = wait_for_manifest_with_l0_len(&table_store, original_l0s.len() + 1);
+
+        // when:
+        state
+            .merge_writer_update(writer_manifest.clone(), table_store)
+            .unwrap();
+
+        // then:
+        let db_state = state.db_state();
+        let mut expected_merged_l0s = VecDeque::new();
+        let new_l0 = writer_manifest.borrow().l0().unwrap().get(0).id().unwrap();
+        let new_l0 = Ulid::from((new_l0.high(), new_l0.low()));
+        expected_merged_l0s.push_front(new_l0);
+        let merged_l0: VecDeque<Ulid> = db_state
+            .l0
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        assert_eq!(merged_l0, expected_merged_l0s);
+    }
+
+    fn run_for<T, F>(duration: Duration, mut f: F) -> Option<T>
+    where
+        F: FnMut() -> Option<T>,
+    {
+        let now = SystemTime::now();
+        while now.elapsed().unwrap() < duration {
+            let maybe_result = f();
+            if maybe_result.is_some() {
+                return maybe_result;
+            }
+            sleep(Duration::from_millis(100));
+        }
+        None
+    }
+
+    // test helpers
+
+    #[derive(PartialEq, Debug)]
+    struct SortedRunDescription {
+        id: u32,
+        ssts: Vec<SsTableId>,
+    }
+
+    fn compacted_to_description(compacted: &[SortedRun]) -> Vec<SortedRunDescription> {
+        compacted.iter().map(sorted_run_to_description).collect()
+    }
+
+    fn sorted_run_to_description(sr: &SortedRun) -> SortedRunDescription {
+        SortedRunDescription {
+            id: sr.id,
+            ssts: sr.ssts.iter().map(|h| h.id.clone()).collect(),
+        }
+    }
+
+    fn wait_for_manifest_with_l0_len(table_store: &Arc<TableStore>, len: usize) -> ManifestV1Owned {
+        run_for(Duration::from_secs(30), || {
+            let maybe_manifest = block_on(table_store.open_latest_manifest())
+                .unwrap()
+                .unwrap();
+            if maybe_manifest.borrow().l0().unwrap().len() == len {
+                return Some(maybe_manifest);
+            }
+            None
+        })
+        .expect("no manifest found with l0 len")
+    }
+
+    fn build_l0_compaction(ssts: &VecDeque<SSTableHandle>) -> Vec<SourceId> {
+        ssts.iter()
+            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+            .collect()
+    }
+
+    fn build_db(os: Arc<dyn ObjectStore>) -> Db {
+        block_on(Db::open(Path::from(PATH), DEFAULT_OPTIONS, os)).unwrap()
+    }
+
+    fn build_test_state() -> (
+        Arc<dyn ObjectStore>,
+        Arc<TableStore>,
+        Rc<CompactorStateHolder>,
+    ) {
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = build_db(os.clone());
+        let l0_count: u64 = 5;
+        for i in 0..l0_count {
+            block_on(db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]));
+            block_on(db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]));
+        }
+        block_on(db.close()).unwrap();
+        let sst_format = SsTableFormat::new(4096, 10);
+        let table_store = Arc::new(TableStore::new(os.clone(), sst_format, Path::from(PATH)));
+        let manifest = block_on(table_store.open_latest_manifest())
+            .unwrap()
+            .unwrap();
+        let state = CompactorStateHolder::new(manifest, table_store.as_ref()).unwrap();
+        (os, table_store, Rc::new(state))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,4 +23,7 @@ pub enum SlateDBError {
 
     #[error("Invalid DB state error")]
     InvalidDBState,
+
+    #[error("Invalid Compaction")]
+    InvalidCompaction,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 mod blob;
 mod block;
 mod block_iterator;
+mod compactor;
+mod compactor_state;
 pub mod db;
 mod db_common;
 mod db_state;
@@ -17,6 +19,7 @@ mod flush;
 mod iter;
 mod mem_table;
 mod mem_table_flush;
+mod size_tiered_compaction;
 mod sst;
 mod sst_iter;
 mod tablestore;

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -1,0 +1,55 @@
+use crate::compactor::CompactionSchedulerFactory;
+use crate::compactor_state::SourceId::Sst;
+use crate::compactor_state::{
+    CompactionWriter, CompactorStateListener, CompactorStateReader, SourceId,
+};
+use std::rc::Rc;
+
+pub(crate) struct SizeTieredCompactionScheduler {
+    state: Rc<dyn CompactorStateReader>,
+    compaction_writer: Rc<dyn CompactionWriter>,
+}
+
+impl CompactorStateListener for SizeTieredCompactionScheduler {
+    fn on_writer_db_state_update(&self) {
+        self.maybe_schedule_compaction();
+    }
+
+    fn on_compactor_db_state_update(&self) {
+        self.maybe_schedule_compaction();
+    }
+}
+
+impl SizeTieredCompactionScheduler {
+    fn maybe_schedule_compaction(&self) {
+        let db_state = self.state.db_state();
+        // for now, just compact l0 down to a new sorted run each time
+        if db_state.l0.len() >= 4 {
+            let next_sr = db_state.compacted.first().map_or(0, |r| r.id);
+            let sources: Vec<SourceId> = db_state
+                .l0
+                .iter()
+                .map(|h| Sst(h.id.unwrap_compacted_id()))
+                .collect();
+            let result = self.compaction_writer.submit_compaction(sources, next_sr);
+            if result.is_err() {
+                // todo: log me
+            }
+        }
+    }
+}
+
+pub(crate) struct SizeTieredCompactionSchedulerFactory {}
+
+impl CompactionSchedulerFactory for SizeTieredCompactionSchedulerFactory {
+    fn create(
+        &self,
+        state: Rc<dyn CompactorStateReader>,
+        compaction_writer: Rc<dyn CompactionWriter>,
+    ) -> Rc<dyn CompactorStateListener> {
+        Rc::new(SizeTieredCompactionScheduler {
+            state,
+            compaction_writer,
+        })
+    }
+}

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -52,13 +52,23 @@ impl ReadOnlyBlob for ReadOnlyObject {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum SsTableId {
     Wal(u64),
     Compacted(Ulid),
 }
 
-#[derive(Clone)]
+impl SsTableId {
+    #[allow(clippy::panic)]
+    pub(crate) fn unwrap_compacted_id(&self) -> Ulid {
+        match self {
+            SsTableId::Wal(_) => panic!("found WAL id when unwrapping compacted ID"),
+            SsTableId::Compacted(ulid) => *ulid,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct SSTableHandle {
     pub id: SsTableId,
     pub info: SsTableInfoOwned,


### PR DESCRIPTION
This patch adds the compactor thread which orchestrates compaction from l0 to the list of sorted runs:

The core of the compactor is the compactor_state module. This module contains the core compactor state, and provides a wrapping struct for reading and writing this state, called `CompactorStateHolder`. `CompactorStateHolder` executes specific mutations like merging updates from the writer, submitting new compactions, and updating the core db state when a compaction is finished. `CompactorStateHolder` also implements traits that allow restricted access to the state:
- `CompactorStateReader` allows reading compactor state only. All reads are by-value, meaning they return a copy or pointer to immutable data. So new writes will never be reflected in the returned data.
- `CompactionWriter` allows submitting new compactions.

Additionally, `CompactorStateHolder` also allows for registering listeners that are notified whenever the contained state changes. For example, a listener can be notified when a new writer update is merged, the compactor has written new db state, a new compaction was submitted, etc.

Compaction is orchestrated by `CompactionOrchestrator`. It runs in response to timer events (to periodically poll for writer updates) or when messages come in on one of its channels. It has channels for being notified of shutdown and for updates from compaction workers that will actually execute compactions. (note that in this patch we don't actually execute any compactions - the orchestrator just rewrites the same ssts into the target sorted run).

`CompactionOrchestrator` also registers itself as a state listener. When the state is updated, it writes the update to the manifest. When new compactions are submitted it kicks off the compaction work.

This patch also adds a very simple version of the size tiered compaction scheduler. A compaction scheduler accepts a pointer to a `CompactionStateReader` and `CompactionWriter` and uses these to read state and submit compactions, respectively. Currently, it just compacts l0 when it crosses 8 SSTs.

Finally, this patch also contains a change to the manifest schema. I realized we have to include the last compacted l0 sst, because once the compactor has compacted down all l0 SSTs, it needs to know where it left off when merging in a writer's update.