### PR TITLE
run flush and memtable flush as tokio tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,15 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,7 +613,6 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "crc32fast",
- "crossbeam-channel",
  "crossbeam-skiplist",
  "flatbuffers",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ readme = "README.md"
 [dependencies]
 bytes = "1.6.0"
 crc32fast = "1.4.0"
-crossbeam-channel = "0.5.12"
 crossbeam-skiplist = "0.1.3"
 flatbuffers = "24.3.25"
 futures = "0.3.30"
@@ -19,7 +18,7 @@ object_store = "0.9.1"
 parking_lot = "0.12.1"
 siphasher = "1"
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["sync"] }
+tokio = { version = "1.37.0", features = ["sync", "rt"] }
 ulid = "1.1.2"
 rand = "0.8.5"
 log = {  version = "0.4.22", features = ["std"] }

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -4,7 +4,11 @@ use crate::mem_table_flush::MemtableFlushThreadMsg::FlushImmutableMemtables;
 use parking_lot::RwLockWriteGuard;
 
 impl DbInner {
-    pub(crate) fn maybe_freeze_memtable(&self, guard: &mut RwLockWriteGuard<DbState>, wal_id: u64) {
+    pub(crate) fn maybe_freeze_memtable(
+        &self,
+        guard: &mut RwLockWriteGuard<'_, DbState>,
+        wal_id: u64,
+    ) {
         if guard.memtable().size() < self.options.l0_sst_size_bytes {
             return;
         }


### PR DESCRIPTION
This patch changes the flush and memtable threads into tasks that are spawned on the calling tokio runtime. For now, we assume that the user is calling slatedb from a tokio runtime. We can later support using another runtime by accepting a tokio Handle that we spawn the futures onto, but I've deferred this to a later patch as we have a fundamental dependency on tokio anyway due to our usage of reqwest.