### PR TITLE
compaction: orchestrator for coordinating compaction work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -33,14 +33,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.80"
+name = "async-channel"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -51,9 +63,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -72,9 +84,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -84,15 +96,15 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cfg-if"
@@ -113,6 +125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +146,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -160,9 +190,30 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fail-parallel"
@@ -250,7 +301,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -298,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "heck"
@@ -395,15 +446,15 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -429,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -462,6 +513,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -512,9 +569,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -560,11 +617,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -622,8 +679,10 @@ dependencies = [
 name = "slatedb"
 version = "0.1.0"
 dependencies = [
+ "async-channel",
  "bytes",
  "crc32fast",
+ "crossbeam-channel",
  "crossbeam-skiplist",
  "fail-parallel",
  "flatbuffers",
@@ -680,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -691,29 +750,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -726,9 +785,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
@@ -739,13 +798,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -767,7 +826,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -781,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "ulid"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34778c17965aa2a08913b57e1f34db9b4a63f5de31768b55bf20d2795f921259"
+checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
  "getrandom",
  "rand",
@@ -813,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -859,7 +918,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -881,7 +940,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -931,9 +990,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -947,48 +1006,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,10 @@ homepage = "https://github.com/slatedb/slatedb"
 readme = "README.md"
 
 [dependencies]
+async-channel = "2.3.1"
 bytes = "1.6.0"
 crc32fast = "1.4.0"
+crossbeam-channel = "0.5.13"
 crossbeam-skiplist = "0.1.3"
 fail-parallel = "0.5.1"
 flatbuffers = "24.3.25"

--- a/docs/0002-compaction.md
+++ b/docs/0002-compaction.md
@@ -92,6 +92,7 @@ table Compacted {
 
 table Manifest {
     …
+    l0_last_compacted: CompactedSstId  // The last compacted l0
     l0: [SstId];
     compacted: Compacted;
     …
@@ -103,6 +104,8 @@ We propose to augment the manifest by adding the following fields:
 `L0`: Contains a list of SST IDs in L0
 
 `compacted`: Contains a single instance of `Compacted`. `Compacted` contains a list of `SortedRun` instances. A `SortedRun` instance defines a single sorted run. Each Sorted Run contains a list of SST IDs and has a unique ID. The list of SST IDs defines the SSTs that comprise the sorted run. A given SST belongs to at most 1 SR. The ID describes the SR’s position in the list of sorted runs in `compacted`. That is, an SR S with an S.id must occur after SR S’ with ID S’.id if S.id < S’.id (so the sorted run with ID 0 must be last in the list). The last SR in the list must have ID 0. The semantics of the ID will be important when we describe how to define compactions.
+
+`l0_last_compacted`: Contains the ID of the last l0 SST that was compacted to `compacted`. The compactor uses this value to determine which l0 SSTs it needs to consider for compaction when refreshing its view of state with the manifest stored durably.
 
 #### Naming Compacted SSTs (L0 and L1+)
 We will use ULIDs to name compacted SSTs. The ULID is stored in the manifest in the `SstId` table, with the `high` and `low` fields containing the high and low bits of the ULID, respectively.

--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -17,11 +17,14 @@ table ManifestV1 {
     // The most recent SST in the WAL at the time manifest was updated.
     wal_id_last_seen: ulong;
 
+    // The last compacted l0
+    l0_last_compacted: CompactedSstId;
+
     // A list of the L0 SSTs that are valid to read in the `compacted` folder.
-    l0: [CompactedSsTable];
+    l0: [CompactedSsTable] (required);
 
     // A list of the sorted runs that are valid to read in the `compacted` folder.
-    compacted: [SortedRun];
+    compacted: [SortedRun] (required);
 
     // A list of read snapshots that are currently open.
     snapshots: [Snapshot];
@@ -29,7 +32,7 @@ table ManifestV1 {
 
 table SortedRun {
     id: uint32;
-    ssts: [CompactedSsTable];
+    ssts: [CompactedSsTable] (required);
 }
 
 // Snapshot reference to be included in manifest to record active snapshots.

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -1,0 +1,392 @@
+use crate::compactor::CompactorMainMsg::Shutdown;
+use crate::compactor_state::{Compaction, CompactorState};
+use crate::db_state::SortedRun;
+use crate::error::SlateDBError;
+use crate::flatbuffer_types::ManifestV1Owned;
+use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
+use crate::tablestore::{SSTableHandle, TableStore};
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use tokio::runtime::Handle;
+use ulid::Ulid;
+
+const DEFAULT_COMPACTOR_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+pub(crate) trait CompactionScheduler {
+    fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction>;
+}
+
+#[derive(Clone)]
+pub struct CompactorOptions {
+    poll_interval: Duration,
+}
+
+impl CompactorOptions {
+    pub fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_COMPACTOR_POLL_INTERVAL,
+        }
+    }
+}
+
+enum CompactorMainMsg {
+    Shutdown,
+}
+
+#[allow(dead_code)]
+enum WorkerToOrchestoratorMsg {
+    CompactionFinished(SortedRun),
+}
+
+pub(crate) struct Compactor {
+    main_tx: crossbeam_channel::Sender<CompactorMainMsg>,
+    main_thread: Option<JoinHandle<()>>,
+}
+
+impl Compactor {
+    pub(crate) async fn new(
+        table_store: Arc<TableStore>,
+        options: CompactorOptions,
+        tokio_handle: Handle,
+    ) -> Result<Self, SlateDBError> {
+        let (external_tx, external_rx) = crossbeam_channel::unbounded();
+        let (err_tx, err_rx) = tokio::sync::oneshot::channel();
+        let main_thread = thread::spawn(move || {
+            let load_result =
+                CompactorOrchestrator::new(options, table_store.clone(), tokio_handle, external_rx);
+            let mut orchestrator = match load_result {
+                Ok(orchestrator) => orchestrator,
+                Err(err) => {
+                    err_tx.send(Err(err)).expect("err channel failure");
+                    return;
+                }
+            };
+            err_tx.send(Ok(())).expect("err channel failure");
+            orchestrator.run();
+        });
+        err_rx.await.expect("err channel failure")?;
+        Ok(Self {
+            main_thread: Some(main_thread),
+            main_tx: external_tx,
+        })
+    }
+
+    pub(crate) async fn close(mut self) {
+        if let Some(main_thread) = self.main_thread.take() {
+            self.main_tx.send(Shutdown).expect("main tx disconnected");
+            main_thread
+                .join()
+                .expect("failed to stop main compactor thread");
+        }
+    }
+}
+
+struct CompactorOrchestrator {
+    options: CompactorOptions,
+    table_store: Arc<TableStore>,
+    tokio_handle: Handle,
+    state: CompactorState,
+    scheduler: Box<dyn CompactionScheduler>,
+    external_rx: crossbeam_channel::Receiver<CompactorMainMsg>,
+    worker_tx: crossbeam_channel::Sender<WorkerToOrchestoratorMsg>,
+    worker_rx: crossbeam_channel::Receiver<WorkerToOrchestoratorMsg>,
+}
+
+impl CompactorOrchestrator {
+    fn new(
+        options: CompactorOptions,
+        table_store: Arc<TableStore>,
+        tokio_handle: Handle,
+        external_rx: crossbeam_channel::Receiver<CompactorMainMsg>,
+    ) -> Result<Self, SlateDBError> {
+        let state = Self::load_state(table_store.clone(), &tokio_handle)?;
+        let scheduler = Self::load_compaction_scheduler(&options);
+        let (worker_tx, worker_rx) = crossbeam_channel::unbounded();
+        let orchestrator = Self {
+            options,
+            table_store,
+            tokio_handle,
+            state,
+            scheduler,
+            external_rx,
+            worker_tx,
+            worker_rx,
+        };
+        Ok(orchestrator)
+    }
+
+    fn load_compaction_scheduler(_options: &CompactorOptions) -> Box<dyn CompactionScheduler> {
+        // todo: return the right type based on the configured scheduler
+        Box::new(SizeTieredCompactionScheduler {})
+    }
+
+    fn load_state(
+        table_store: Arc<TableStore>,
+        tokio_handle: &Handle,
+    ) -> Result<CompactorState, SlateDBError> {
+        let maybe_manifest = tokio_handle.block_on(table_store.open_latest_manifest())?;
+        if let Some(manifest) = maybe_manifest {
+            // todo: bump epoch here
+            let state = CompactorState::new(manifest, table_store.as_ref(), tokio_handle)?;
+            Ok(state)
+        } else {
+            Err(SlateDBError::InvalidDBState)
+        }
+    }
+
+    fn run(&mut self) {
+        let ticker = crossbeam_channel::tick(self.options.poll_interval);
+        loop {
+            crossbeam_channel::select! {
+                recv(ticker) -> _ => {
+                    self.load_manifest().expect("fatal error loading manifest");
+                }
+                recv(self.worker_rx) -> msg => {
+                    let WorkerToOrchestoratorMsg::CompactionFinished(sr) = msg.expect("fatal error receiving worker msg");
+                    self.finish_compaction(sr).expect("fatal error finishing compaction");
+                }
+                recv(self.external_rx) -> _ => {
+                    return;
+                }
+            }
+        }
+    }
+
+    fn load_manifest(&mut self) -> Result<(), SlateDBError> {
+        let manifest = self
+            .tokio_handle
+            .block_on(self.table_store.open_latest_manifest())?;
+        // todo: check epoch here
+        self.refresh_db_state(manifest.expect("manifest must exist"))?;
+        Ok(())
+    }
+
+    fn write_manifest(&self) -> Result<(), SlateDBError> {
+        let manifest = self.state.manifest();
+        self.tokio_handle
+            .block_on(self.table_store.write_manifest(manifest))
+    }
+
+    fn write_manifest_safely(&mut self) -> Result<(), SlateDBError> {
+        // todo: run this in a loop until either the write succeeds or we get fenced
+        // read the manifest first to pull in any writer changes and check for compactor fencing
+        self.load_manifest()?;
+        self.write_manifest()?;
+        Ok(())
+    }
+
+    fn maybe_schedule_compactions(&mut self) -> Result<(), SlateDBError> {
+        let compactions = self.scheduler.maybe_schedule_compaction(&self.state);
+        for compaction in compactions.iter() {
+            self.submit_compaction(compaction.clone())?;
+        }
+        Ok(())
+    }
+
+    fn start_compaction(&mut self, compaction: Compaction) {
+        // todo: spawn compaction tasks on the runtime instead
+        // just complete the compaction for now by trivially writing a new run with
+        // the l0 SSTs
+        let l0s: HashSet<Ulid> = compaction.sources.iter().map(|s| s.unwrap_sst()).collect();
+        let compacted: Vec<SSTableHandle> = self
+            .state
+            .db_state()
+            .l0
+            .iter()
+            .filter(|h| {
+                let ulid = h.id.unwrap_compacted_id();
+                l0s.contains(&ulid)
+            })
+            .cloned()
+            .collect();
+        self.worker_tx
+            .send(WorkerToOrchestoratorMsg::CompactionFinished(SortedRun {
+                id: compaction.destination,
+                ssts: compacted,
+            }))
+            .expect("failed to send compaction finished msg");
+    }
+
+    // state writers
+
+    fn finish_compaction(&mut self, output_sr: SortedRun) -> Result<(), SlateDBError> {
+        self.state.finish_compaction(output_sr);
+        self.write_manifest_safely()?;
+        self.maybe_schedule_compactions()?;
+        Ok(())
+    }
+
+    fn submit_compaction(&mut self, compaction: Compaction) -> Result<(), SlateDBError> {
+        let result = self.state.submit_compaction(compaction.clone());
+        if result.is_err() {
+            println!("invalid compaction: {:#?}", result);
+            return Ok(());
+        }
+        self.start_compaction(compaction);
+        Ok(())
+    }
+
+    fn refresh_db_state(&mut self, manifest: ManifestV1Owned) -> Result<(), SlateDBError> {
+        let result =
+            self.state
+                .refresh_db_state(manifest, self.table_store.clone(), &self.tokio_handle);
+        if result.is_err() {
+            println!("error merging writer manifest update: {:#?}", result);
+            return Ok(());
+        }
+        self.maybe_schedule_compactions()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compactor::{CompactorOptions, CompactorOrchestrator, WorkerToOrchestoratorMsg};
+    use crate::compactor_state::{Compaction, SourceId};
+    use crate::db::{Db, DbOptions};
+    use crate::sst::SsTableFormat;
+    use crate::tablestore::TableStore;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+    use tokio::runtime::Runtime;
+    use ulid::Ulid;
+
+    const PATH: &str = "/test/db";
+    const DEFAULT_OPTIONS: DbOptions = DbOptions {
+        flush_ms: 100,
+        min_filter_keys: 0,
+        l0_sst_size_bytes: 128,
+        compactor_options: Some(CompactorOptions {
+            poll_interval: Duration::from_millis(100),
+        }),
+    };
+
+    #[tokio::test]
+    async fn test_compactor_compacts_l0() {
+        // given:
+        let (_, table_store, db) = build_test_db().await;
+        for i in 0..4 {
+            db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]).await;
+            db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]).await;
+        }
+
+        // when:
+        let maybe_manifest_owned = run_for(Duration::from_secs(10), || async {
+            let manifest = table_store.open_latest_manifest().await.unwrap().unwrap();
+            if manifest.borrow().l0_last_compacted().is_some() {
+                return Some(manifest);
+            }
+            None
+        })
+        .await;
+
+        // then:
+        let manifest_owned = maybe_manifest_owned.expect("db was not compacted");
+        let manifest = manifest_owned.borrow();
+        assert!(manifest.l0_last_compacted().is_some());
+        assert_eq!(manifest.compacted().len(), 1);
+        assert_eq!(manifest.compacted().get(0).ssts().len(), 4);
+        // todo: test that the db can read the k/vs (once we implement reading from compacted)
+    }
+
+    #[test]
+    fn test_should_write_manifest_safely() {
+        // given:
+        // write an l0
+        let rt = build_runtime();
+        let (os, table_store, db) = rt.block_on(build_test_db());
+        rt.block_on(db.put(&[b'a'; 32], &[b'b'; 96]));
+        rt.block_on(db.close()).unwrap();
+        let options = DEFAULT_OPTIONS.clone();
+        let (_, external_rx) = crossbeam_channel::unbounded();
+        let mut orchestrator = CompactorOrchestrator::new(
+            options.compactor_options.unwrap(),
+            table_store.clone(),
+            rt.handle().clone(),
+            external_rx,
+        )
+        .unwrap();
+        let l0_ids_to_compact: Vec<SourceId> = orchestrator
+            .state
+            .db_state()
+            .l0
+            .iter()
+            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+            .collect();
+        // write another l0
+        let db = rt
+            .block_on(Db::open(Path::from(PATH), DEFAULT_OPTIONS, os.clone()))
+            .unwrap();
+        rt.block_on(db.put(&[b'j'; 32], &[b'k'; 96]));
+        rt.block_on(db.close()).unwrap();
+        orchestrator
+            .submit_compaction(Compaction::new(l0_ids_to_compact.clone(), 0))
+            .unwrap();
+        let msg = orchestrator.worker_rx.recv().unwrap();
+        let WorkerToOrchestoratorMsg::CompactionFinished(sr) = msg;
+
+        // when:
+        orchestrator.finish_compaction(sr).unwrap();
+
+        // then:
+        let manifest_owned = rt
+            .block_on(table_store.open_latest_manifest())
+            .unwrap()
+            .unwrap();
+        let manifest = manifest_owned.borrow();
+        assert_eq!(manifest.l0().len(), 1);
+        assert_eq!(manifest.compacted().len(), 1);
+        let l0_id = manifest.l0().get(0).id().unwrap().ulid();
+        let compacted_l0s: Vec<Ulid> = manifest
+            .compacted()
+            .get(0)
+            .ssts()
+            .iter()
+            .map(|sst| sst.id().unwrap().ulid())
+            .collect();
+        assert!(!compacted_l0s.contains(&l0_id));
+        assert_eq!(
+            manifest.l0_last_compacted().unwrap().ulid(),
+            compacted_l0s.first().unwrap().clone()
+        );
+    }
+
+    fn build_runtime() -> Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    async fn run_for<T, F>(duration: Duration, f: impl Fn() -> F) -> Option<T>
+    where
+        F: Future<Output = Option<T>>,
+    {
+        let now = SystemTime::now();
+        while now.elapsed().unwrap() < duration {
+            let maybe_result = f().await;
+            if maybe_result.is_some() {
+                return maybe_result;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        None
+    }
+
+    async fn build_test_db() -> (Arc<dyn ObjectStore>, Arc<TableStore>, Db) {
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::open(Path::from(PATH), DEFAULT_OPTIONS, os.clone())
+            .await
+            .unwrap();
+        let sst_format = SsTableFormat::new(4096, 10);
+        let table_store = Arc::new(TableStore::new(os.clone(), sst_format, Path::from(PATH)));
+        (os, table_store, db)
+    }
+}

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -1,0 +1,575 @@
+use crate::compactor_state::CompactionStatus::Submitted;
+use crate::db_state::{CoreDbState, SortedRun};
+use crate::error::SlateDBError;
+use crate::flatbuffer_types::{ManifestV1Owned, SsTableInfoOwned};
+use crate::tablestore::SsTableId::Compacted;
+use crate::tablestore::{SSTableHandle, TableStore};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::Arc;
+use tokio::runtime::Handle;
+use ulid::Ulid;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum SourceId {
+    SortedRun(u32),
+    Sst(Ulid),
+}
+
+impl SourceId {
+    #[allow(dead_code)]
+    pub(crate) fn unwrap_sorted_run(&self) -> u32 {
+        self.maybe_unwrap_sorted_run()
+            .expect("tried to unwrap Sst as Sorted Run")
+    }
+
+    pub(crate) fn maybe_unwrap_sorted_run(&self) -> Option<u32> {
+        match self {
+            SourceId::SortedRun(id) => Some(*id),
+            SourceId::Sst(_) => None,
+        }
+    }
+
+    pub(crate) fn unwrap_sst(&self) -> Ulid {
+        self.maybe_unwrap_sst()
+            .expect("tried to unwrap Sst as Sorted Run")
+    }
+
+    pub(crate) fn maybe_unwrap_sst(&self) -> Option<Ulid> {
+        match self {
+            SourceId::SortedRun(_) => None,
+            SourceId::Sst(ulid) => Some(*ulid),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum CompactionStatus {
+    Submitted,
+    #[allow(dead_code)]
+    InProgress,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct Compaction {
+    pub(crate) status: CompactionStatus,
+    pub(crate) sources: Vec<SourceId>,
+    pub(crate) destination: u32,
+}
+
+impl Compaction {
+    pub(crate) fn new(sources: Vec<SourceId>, destination: u32) -> Self {
+        Self {
+            status: Submitted,
+            sources,
+            destination,
+        }
+    }
+}
+
+pub(crate) struct CompactorState {
+    db_state: CoreDbState,
+    // TODO: fully specify the manifest in CoreDbState, and then we can drop this and just convert
+    //       back and forth from ManifestSynchronizer. This is also blocked on lazy-loading the
+    //       filters, since its currently too expensive to load the manifest from CoreDbState.
+    manifest: ManifestV1Owned,
+    compactions: HashMap<u32, Compaction>,
+}
+
+impl CompactorState {
+    pub(crate) fn db_state(&self) -> &CoreDbState {
+        &self.db_state
+    }
+
+    pub(crate) fn manifest(&self) -> &ManifestV1Owned {
+        &self.manifest
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn compactions(&self) -> Vec<Compaction> {
+        self.compactions.values().cloned().collect()
+    }
+
+    pub(crate) fn new(
+        manifest: ManifestV1Owned,
+        table_store: &TableStore,
+        tokio_handle: &Handle,
+    ) -> Result<Self, SlateDBError> {
+        let db_state = tokio_handle.block_on(CoreDbState::load(&manifest, table_store))?;
+        Ok(Self {
+            db_state,
+            manifest,
+            compactions: HashMap::<u32, Compaction>::new(),
+        })
+    }
+
+    pub(crate) fn submit_compaction(&mut self, compaction: Compaction) -> Result<(), SlateDBError> {
+        // todo: validate the compaction here
+        //       https://github.com/slatedb/slatedb/issues/96
+        if self.compactions.contains_key(&compaction.destination) {
+            return Err(SlateDBError::InvalidCompaction);
+        }
+        self.compactions.insert(compaction.destination, compaction);
+        Ok(())
+    }
+
+    pub(crate) fn refresh_db_state(
+        &mut self,
+        writer_manifest_owned: ManifestV1Owned,
+        table_store: Arc<TableStore>,
+        tokio_handle: &Handle,
+    ) -> Result<(), SlateDBError> {
+        let writer_manifest = writer_manifest_owned.borrow();
+        // the writer may have added more l0 SSTs. Add these to our l0 list.
+        let last_compacted_l0 = self.db_state.l0_last_compacted;
+        let mut merged_l0s = VecDeque::new();
+        let our_l0s_by_id: HashMap<Ulid, &SSTableHandle> = self
+            .db_state
+            .l0
+            .iter()
+            .map(|h| (h.id.unwrap_compacted_id(), h))
+            .collect();
+        let writer_l0 = writer_manifest.l0();
+        let mut i = 0;
+        while i < writer_l0.len() {
+            // todo: move to some utility method
+            let writer_l0_sst = writer_l0.get(i);
+            let writer_l0_id = writer_l0_sst.id().expect("l0 sst must have id").ulid();
+            // todo: this is brittle. we are relying on the l0 list always being updated in
+            //       an expected order. We should instead encode the ordering in the l0 SST IDs
+            //       and assert that it follows the order
+            if match &last_compacted_l0 {
+                None => true,
+                Some(last_compacted_l0_id) => writer_l0_id != *last_compacted_l0_id,
+            } {
+                if let Some(&handle_ref) = our_l0s_by_id.get(&writer_l0_id) {
+                    merged_l0s.push_back(handle_ref.clone())
+                } else {
+                    let writer_l0_info = writer_l0_sst.info().expect("l0 sst must have info");
+                    let handle = tokio_handle.block_on(table_store.open_compacted_sst(
+                        Compacted(writer_l0_id),
+                        SsTableInfoOwned::create_copy(&writer_l0_info),
+                    ))?;
+                    merged_l0s.push_back(handle);
+                }
+            } else {
+                break;
+            }
+            i += 1;
+        }
+
+        // write out the merged core db state and manifest
+        let mut merged = self.db_state.clone();
+        merged.l0 = merged_l0s;
+        merged.last_compacted_wal_sst_id = writer_manifest.wal_id_last_compacted();
+        merged.next_wal_sst_id = writer_manifest.wal_id_last_seen() + 1;
+        self.db_state = merged;
+        self.manifest = self.manifest.create_updated_manifest(&self.db_state);
+
+        Ok(())
+    }
+
+    pub(crate) fn finish_compaction(&mut self, output_sr: SortedRun) {
+        if let Some(compaction) = self.compactions.get(&output_sr.id) {
+            // reconstruct l0
+            let compaction_l0s: HashSet<Ulid> = compaction
+                .sources
+                .iter()
+                .filter_map(|id| id.maybe_unwrap_sst())
+                .collect();
+            let compaction_srs: HashSet<u32> = compaction
+                .sources
+                .iter()
+                .chain(std::iter::once(&SourceId::SortedRun(
+                    compaction.destination,
+                )))
+                .filter_map(|id| id.maybe_unwrap_sorted_run())
+                .collect();
+            let mut db_state = self.db_state.clone();
+            let new_l0: VecDeque<SSTableHandle> = db_state
+                .l0
+                .iter()
+                .filter_map(|l0| {
+                    let l0_id = l0.id.unwrap_compacted_id();
+                    if compaction_l0s.contains(&l0_id) {
+                        return None;
+                    }
+                    Some(l0.clone())
+                })
+                .collect();
+            let mut new_compacted = Vec::new();
+            let mut inserted = false;
+            for compacted in db_state.compacted.iter() {
+                if !inserted && output_sr.id >= compacted.id {
+                    new_compacted.push(output_sr.clone());
+                    inserted = true;
+                }
+                if !compaction_srs.contains(&compacted.id) {
+                    new_compacted.push(compacted.clone());
+                }
+            }
+            if !inserted {
+                new_compacted.push(output_sr.clone());
+            }
+            let first_source = compaction
+                .sources
+                .first()
+                .expect("illegal: empty compaction");
+            if let Some(compacted_l0) = first_source.maybe_unwrap_sst() {
+                // if there are l0s, the newest must be the first entry in sources
+                // TODO: validate that this is the case
+                db_state.l0_last_compacted = Some(compacted_l0)
+            }
+            db_state.l0 = new_l0;
+            db_state.compacted = new_compacted;
+            self.db_state = db_state;
+            self.manifest = self.manifest.create_updated_manifest(&self.db_state);
+            self.compactions.remove(&output_sr.id);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compactor_state::CompactionStatus::Submitted;
+    use crate::compactor_state::SourceId::Sst;
+    use crate::db::{Db, DbOptions};
+    use crate::sst::SsTableFormat;
+    use crate::tablestore::SsTableId;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime};
+    use tokio::runtime::Runtime;
+
+    const PATH: &str = "/test/db";
+    const DEFAULT_OPTIONS: DbOptions = DbOptions {
+        flush_ms: 100,
+        min_filter_keys: 0,
+        l0_sst_size_bytes: 128,
+        compactor_options: None,
+    };
+
+    #[test]
+    fn test_should_register_compaction_as_submitted() {
+        // given:
+        let rt = build_runtime();
+        let (_, _, mut state) = build_test_state(rt.handle());
+
+        // when:
+        state
+            .submit_compaction(build_l0_compaction(&state.db_state().l0, 0))
+            .unwrap();
+
+        // then:
+        assert_eq!(state.compactions().len(), 1);
+        assert_eq!(state.compactions().first().unwrap().status, Submitted);
+    }
+
+    #[test]
+    fn test_should_update_dbstate_when_compaction_finished() {
+        // given:
+        let rt = build_runtime();
+        let (_, _, mut state) = build_test_state(rt.handle());
+        let before_compaction = state.db_state().clone();
+        let compaction = build_l0_compaction(&before_compaction.l0, 0);
+        state.submit_compaction(compaction).unwrap();
+
+        // when:
+        let compacted_ssts = before_compaction.l0.iter().cloned().collect();
+        let sr = SortedRun {
+            id: 0,
+            ssts: compacted_ssts,
+        };
+        state.finish_compaction(sr.clone());
+
+        // then:
+        assert_eq!(
+            state.db_state().l0_last_compacted,
+            Some(
+                before_compaction
+                    .l0
+                    .front()
+                    .unwrap()
+                    .id
+                    .unwrap_compacted_id()
+            )
+        );
+        assert_eq!(state.db_state().l0.len(), 0);
+        assert_eq!(state.db_state().compacted.len(), 1);
+        assert_eq!(state.db_state().compacted.first().unwrap().id, sr.id);
+        let expected_ids: Vec<SsTableId> = sr.ssts.iter().map(|h| h.id.clone()).collect();
+        let found_ids: Vec<SsTableId> = state
+            .db_state()
+            .compacted
+            .first()
+            .unwrap()
+            .ssts
+            .iter()
+            .map(|h| h.id.clone())
+            .collect();
+        assert_eq!(expected_ids, found_ids);
+    }
+
+    #[test]
+    fn test_should_remove_compaction_when_compaction_finished() {
+        // given:
+        let rt = build_runtime();
+        let (_, _, mut state) = build_test_state(rt.handle());
+        let before_compaction = state.db_state().clone();
+        let compaction = build_l0_compaction(&before_compaction.l0, 0);
+        state.submit_compaction(compaction).unwrap();
+
+        // when:
+        let compacted_ssts = before_compaction.l0.iter().cloned().collect();
+        let sr = SortedRun {
+            id: 0,
+            ssts: compacted_ssts,
+        };
+        state.finish_compaction(sr.clone());
+
+        // then:
+        assert_eq!(state.compactions().len(), 0)
+    }
+
+    #[test]
+    fn test_should_refresh_db_state_correctly_when_never_compacted() {
+        // given:
+        let rt = build_runtime();
+        let (os, table_store, mut state) = build_test_state(rt.handle());
+        // open a new db and write another l0
+        let db = build_db(os.clone(), rt.handle());
+        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
+        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        let writer_manifest =
+            wait_for_manifest_with_l0_len(&table_store, rt.handle(), state.db_state().l0.len() + 1);
+
+        // when:
+        state
+            .refresh_db_state(writer_manifest.clone(), table_store, rt.handle())
+            .unwrap();
+
+        // then:
+        assert!(state.db_state().l0_last_compacted.is_none());
+        let expected_merged_l0s: Vec<Ulid> = writer_manifest
+            .borrow()
+            .l0()
+            .iter()
+            .map(|t| t.id().unwrap().ulid())
+            .collect();
+        let merged_l0s: Vec<Ulid> = state
+            .db_state()
+            .l0
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        assert_eq!(expected_merged_l0s, merged_l0s);
+    }
+
+    #[test]
+    fn test_should_refresh_db_state_correctly() {
+        // given:
+        let rt = build_runtime();
+        let (os, table_store, mut state) = build_test_state(rt.handle());
+        // compact the last sst
+        let original_l0s = &state.db_state().clone().l0;
+        state
+            .submit_compaction(Compaction::new(
+                vec![Sst(original_l0s.back().unwrap().id.unwrap_compacted_id())],
+                0,
+            ))
+            .unwrap();
+        state.finish_compaction(SortedRun {
+            id: 0,
+            ssts: vec![original_l0s.back().unwrap().clone()],
+        });
+        // open a new db and write another l0
+        let db = build_db(os.clone(), rt.handle());
+        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
+        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        let writer_manifest =
+            wait_for_manifest_with_l0_len(&table_store, rt.handle(), original_l0s.len() + 1);
+        let db_state_before_merge = state.db_state().clone();
+
+        // when:
+        state
+            .refresh_db_state(writer_manifest.clone(), table_store, rt.handle())
+            .unwrap();
+
+        // then:
+        let db_state = state.db_state();
+        let mut expected_merged_l0s: VecDeque<Ulid> = original_l0s
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        expected_merged_l0s.pop_back();
+        let new_l0 = writer_manifest.borrow().l0().get(0).id().unwrap();
+        let new_l0 = Ulid::from((new_l0.high(), new_l0.low()));
+        expected_merged_l0s.push_front(new_l0);
+        let merged_l0: VecDeque<Ulid> = db_state
+            .l0
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        assert_eq!(merged_l0, expected_merged_l0s);
+        assert_eq!(
+            compacted_to_description(&db_state.compacted),
+            compacted_to_description(&db_state_before_merge.compacted)
+        );
+        assert_eq!(
+            db_state.last_compacted_wal_sst_id,
+            writer_manifest.borrow().wal_id_last_compacted()
+        );
+        assert_eq!(
+            db_state.next_wal_sst_id,
+            writer_manifest.borrow().wal_id_last_seen() + 1
+        );
+        let manifest = state.manifest();
+        assert_eq!(
+            manifest.borrow(),
+            writer_manifest.create_updated_manifest(db_state).borrow()
+        )
+    }
+
+    #[test]
+    fn test_should_refresh_db_state_correctly_when_all_l0_compacted() {
+        // given:
+        let rt = build_runtime();
+        let (os, table_store, mut state) = build_test_state(rt.handle());
+        // compact the last sst
+        let original_l0s = &state.db_state().clone().l0;
+        state
+            .submit_compaction(Compaction::new(
+                original_l0s
+                    .iter()
+                    .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+                    .collect(),
+                0,
+            ))
+            .unwrap();
+        state.finish_compaction(SortedRun {
+            id: 0,
+            ssts: original_l0s.clone().into(),
+        });
+        assert_eq!(state.db_state().l0.len(), 0);
+        // open a new db and write another l0
+        let db = build_db(os.clone(), rt.handle());
+        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
+        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        let writer_manifest =
+            wait_for_manifest_with_l0_len(&table_store, rt.handle(), original_l0s.len() + 1);
+
+        // when:
+        state
+            .refresh_db_state(writer_manifest.clone(), table_store, rt.handle())
+            .unwrap();
+
+        // then:
+        let db_state = state.db_state();
+        let mut expected_merged_l0s = VecDeque::new();
+        let new_l0 = writer_manifest.borrow().l0().get(0).id().unwrap();
+        let new_l0 = Ulid::from((new_l0.high(), new_l0.low()));
+        expected_merged_l0s.push_front(new_l0);
+        let merged_l0: VecDeque<Ulid> = db_state
+            .l0
+            .iter()
+            .map(|h| h.id.unwrap_compacted_id())
+            .collect();
+        assert_eq!(merged_l0, expected_merged_l0s);
+    }
+
+    // test helpers
+
+    fn run_for<T, F>(duration: Duration, mut f: F) -> Option<T>
+    where
+        F: FnMut() -> Option<T>,
+    {
+        let now = SystemTime::now();
+        while now.elapsed().unwrap() < duration {
+            let maybe_result = f();
+            if maybe_result.is_some() {
+                return maybe_result;
+            }
+            sleep(Duration::from_millis(100));
+        }
+        None
+    }
+
+    #[derive(PartialEq, Debug)]
+    struct SortedRunDescription {
+        id: u32,
+        ssts: Vec<SsTableId>,
+    }
+
+    fn build_runtime() -> Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+    }
+
+    fn compacted_to_description(compacted: &[SortedRun]) -> Vec<SortedRunDescription> {
+        compacted.iter().map(sorted_run_to_description).collect()
+    }
+
+    fn sorted_run_to_description(sr: &SortedRun) -> SortedRunDescription {
+        SortedRunDescription {
+            id: sr.id,
+            ssts: sr.ssts.iter().map(|h| h.id.clone()).collect(),
+        }
+    }
+
+    fn wait_for_manifest_with_l0_len(
+        table_store: &Arc<TableStore>,
+        tokio_handle: &Handle,
+        len: usize,
+    ) -> ManifestV1Owned {
+        run_for(Duration::from_secs(30), || {
+            let maybe_manifest = tokio_handle
+                .block_on(table_store.open_latest_manifest())
+                .unwrap()
+                .unwrap();
+            if maybe_manifest.borrow().l0().len() == len {
+                return Some(maybe_manifest);
+            }
+            None
+        })
+        .expect("no manifest found with l0 len")
+    }
+
+    fn build_l0_compaction(ssts: &VecDeque<SSTableHandle>, dst: u32) -> Compaction {
+        let sources = ssts
+            .iter()
+            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+            .collect();
+        Compaction::new(sources, dst)
+    }
+
+    fn build_db(os: Arc<dyn ObjectStore>, tokio_handle: &Handle) -> Db {
+        tokio_handle
+            .block_on(Db::open(Path::from(PATH), DEFAULT_OPTIONS, os))
+            .unwrap()
+    }
+
+    fn build_test_state(
+        tokio_handle: &Handle,
+    ) -> (Arc<dyn ObjectStore>, Arc<TableStore>, CompactorState) {
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = build_db(os.clone(), tokio_handle);
+        let l0_count: u64 = 5;
+        for i in 0..l0_count {
+            tokio_handle.block_on(db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]));
+            tokio_handle.block_on(db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]));
+        }
+        tokio_handle.block_on(db.close()).unwrap();
+        let sst_format = SsTableFormat::new(4096, 10);
+        let table_store = Arc::new(TableStore::new(os.clone(), sst_format, Path::from(PATH)));
+        let manifest = tokio_handle
+            .block_on(table_store.open_latest_manifest())
+            .unwrap()
+            .unwrap();
+        let state = CompactorState::new(manifest, table_store.as_ref(), tokio_handle).unwrap();
+        (os, table_store, state)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,4 +23,7 @@ pub enum SlateDBError {
 
     #[error("Invalid DB state error")]
     InvalidDBState,
+
+    #[error("Invalid Compaction")]
+    InvalidCompaction,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 mod blob;
 mod block;
 mod block_iterator;
+mod compactor;
+mod compactor_state;
 pub mod db;
 mod db_common;
 mod db_state;
@@ -16,6 +18,7 @@ mod flush;
 mod iter;
 mod mem_table;
 mod mem_table_flush;
+mod size_tiered_compaction;
 mod sst;
 mod sst_iter;
 mod tablestore;

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -1,0 +1,23 @@
+use crate::compactor::CompactionScheduler;
+use crate::compactor_state::SourceId::Sst;
+use crate::compactor_state::{Compaction, CompactorState, SourceId};
+
+pub(crate) struct SizeTieredCompactionScheduler {}
+
+impl CompactionScheduler for SizeTieredCompactionScheduler {
+    fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction> {
+        let db_state = state.db_state();
+        // for now, just compact l0 down to a new sorted run each time
+        let mut compactions = Vec::new();
+        if db_state.l0.len() >= 4 {
+            let next_sr = db_state.compacted.first().map_or(0, |r| r.id);
+            let sources: Vec<SourceId> = db_state
+                .l0
+                .iter()
+                .map(|h| Sst(h.id.unwrap_compacted_id()))
+                .collect();
+            compactions.push(Compaction::new(sources, next_sr));
+        }
+        compactions
+    }
+}

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -51,13 +51,23 @@ impl ReadOnlyBlob for ReadOnlyObject {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum SsTableId {
     Wal(u64),
     Compacted(Ulid),
 }
 
-#[derive(Clone)]
+impl SsTableId {
+    #[allow(clippy::panic)]
+    pub(crate) fn unwrap_compacted_id(&self) -> Ulid {
+        match self {
+            SsTableId::Wal(_) => panic!("found WAL id when unwrapping compacted ID"),
+            SsTableId::Compacted(ulid) => *ulid,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
 pub struct SSTableHandle {
     pub id: SsTableId,
     pub info: SsTableInfoOwned,


### PR DESCRIPTION
This patch adds the compactor thread which orchestrates compaction from l0 to the list of sorted runs.

The core of the compactor is the compactor_state module. This module contains the core compactor state in CompactorState, and provides methods for reading state and executing specific mutations like merging updates from the writer, submitting new compactions, and updating the core db state when a compaction is finished.

Compaction is orchestrated by CompactionOrchestrator. It runs in response to timer events (to periodically poll for writer updates) or when messages come in on one of its channels. It has channels for being notified of shutdown and for updates from compaction workers that will actually execute compactions. (note that in this patch we don't actually execute any compactions - the orchestrator just rewrites the same ssts into the target sorted run). The orchestrator runs on a thread. It stores a handle to the tokio runtime that it uses to execute async tasks.

Finally, this patch also adds a very simple version of the size tiered compaction scheduler. A compaction scheduler implements a method called `maybe_schedule_compaction` that takes a reference to the current compactor state and returns any compactions that should be executed. Currently, it just compacts l0 when it crosses 8 SSTs.