### PR TITLE
optimize compaction writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +93,15 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -121,7 +136,8 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "windows-targets",
+ "serde",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -131,6 +147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -183,6 +209,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +239,21 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "event-listener"
@@ -235,6 +296,12 @@ dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
@@ -335,6 +402,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +431,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,10 +468,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -405,6 +579,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +602,12 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
@@ -445,10 +641,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -457,6 +669,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -494,13 +717,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8718f8b65fdf67a45108d1548347d4af7d71fb81ce727bbf9e3b2535e079db3"
 dependencies = [
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "futures",
  "humantime",
+ "hyper",
  "itertools",
+ "md-5",
  "parking_lot",
  "percent-encoding",
+ "quick-xml",
+ "rand",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "tracing",
@@ -513,6 +745,12 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "parking"
@@ -540,7 +778,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -574,6 +812,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -616,12 +864,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -640,6 +955,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,16 +1013,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+
+[[package]]
+name = "serde"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.204"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "siphasher"
@@ -692,6 +1141,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "rand",
+ "rand_xorshift",
  "siphasher",
  "thiserror",
  "tokio",
@@ -727,6 +1177,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +1212,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -791,9 +1284,13 @@ checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
 dependencies = [
  "backtrace",
  "bytes",
+ "libc",
+ "mio",
  "num_cpus",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -806,6 +1303,35 @@ dependencies = [
  "quote",
  "syn 2.0.72",
 ]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -837,6 +1363,18 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ulid"
@@ -871,6 +1409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +1426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -889,6 +1439,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -923,6 +1482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,6 +1523,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,7 +1561,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -976,7 +1570,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -985,7 +1588,22 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -994,15 +1612,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1012,9 +1636,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1030,9 +1666,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1042,12 +1690,34 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,21 @@ object_store = "0.9.1"
 parking_lot = "0.12.1"
 siphasher = "1"
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["sync", "rt"] }
+tokio = { version = "1.37.0", features = ["sync", "rt", "rt-multi-thread"] }
 ulid = "1.1.2"
 rand = "0.8.5"
+rand_xorshift = "0.3.0"
 log = {  version = "0.4.22", features = ["std"] }
 once_cell = "1.19.0"
 
 [dev-dependencies]
 tokio = { version = "1.37.0", features = ["rt-multi-thread"] }
 fail-parallel = { version = "0.5.1", features = ["failpoints"] }
+
+[features]
+default = ["aws"]
+aws = ["object_store/aws"]
+
+[[bin]]
+name = "compaction-execute-bench"
+path = "src/compaction_execute_bench/compaction_execute_bench.rs"

--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -101,7 +101,7 @@ mod tests {
     use crate::block::BlockBuilder;
     use crate::block_iterator::BlockIterator;
     use crate::iter::KeyValueIterator;
-    use crate::types::KeyValue;
+    use crate::test_utils;
 
     #[tokio::test]
     async fn test_iterator() {
@@ -112,11 +112,11 @@ mod tests {
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_first_key(&block);
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"donkey", b"kong");
+        test_utils::assert_kv(&kv, b"donkey", b"kong");
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"kratos", b"atreus");
+        test_utils::assert_kv(&kv, b"kratos", b"atreus");
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"super", b"mario");
+        test_utils::assert_kv(&kv, b"super", b"mario");
         assert!(iter.next().await.unwrap().is_none());
     }
 
@@ -129,9 +129,9 @@ mod tests {
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_key(&block, b"kratos".as_ref());
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"kratos", b"atreus");
+        test_utils::assert_kv(&kv, b"kratos", b"atreus");
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"super", b"mario");
+        test_utils::assert_kv(&kv, b"super", b"mario");
         assert!(iter.next().await.unwrap().is_none());
     }
 
@@ -144,9 +144,9 @@ mod tests {
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_key(&block, b"ka".as_ref());
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"kratos", b"atreus");
+        test_utils::assert_kv(&kv, b"kratos", b"atreus");
         let kv = iter.next().await.unwrap().unwrap();
-        assert_kv(&kv, b"super", b"mario");
+        test_utils::assert_kv(&kv, b"super", b"mario");
         assert!(iter.next().await.unwrap().is_none());
     }
 
@@ -159,10 +159,5 @@ mod tests {
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_key(&block, b"zzz".as_ref());
         assert!(iter.next().await.unwrap().is_none());
-    }
-
-    fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
-        assert_eq!(kv.key, key);
-        assert_eq!(kv.value, val);
     }
 }

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -1,0 +1,298 @@
+use crate::compactor::{CompactorOptions, WorkerToOrchestoratorMsg};
+use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
+use crate::error::SlateDBError;
+use crate::sst::SsTableFormat;
+use crate::tablestore::{SsTableId, TableStore};
+use bytes::{BufMut, Bytes, BytesMut};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use rand::{RngCore, SeedableRng};
+use std::mem;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::task::JoinHandle;
+use ulid::Ulid;
+
+#[derive(Debug)]
+struct Options {
+    aws_key: String,
+    aws_secret: String,
+    bucket: String,
+    region: String,
+    path: String,
+    mode: String,
+    sst_bytes: usize,
+    num_ssts: usize,
+    key_bytes: usize,
+    val_bytes: usize,
+}
+
+#[cfg(feature = "aws")]
+fn open_s3(options: &Options) -> Result<Arc<dyn ObjectStore>, SlateDBError> {
+    Ok(Arc::new(
+        object_store::aws::AmazonS3Builder::new()
+            .with_access_key_id(options.aws_key.as_str())
+            .with_secret_access_key(options.aws_secret.as_str())
+            .with_bucket_name(options.bucket.as_str())
+            .with_region(options.region.as_str())
+            .build()?,
+    ))
+}
+
+#[cfg(not(feature = "aws"))]
+fn open_s3(options: &Options) -> Result<Arc<dyn ObjectStore>, SlateDBError> {
+    panic!("compaction bench requires feature s3")
+}
+
+fn open_object_store(options: &Options) -> Result<Arc<dyn ObjectStore>, SlateDBError> {
+    open_s3(options)
+}
+
+#[allow(clippy::panic)]
+pub fn run_compaction_execute_bench() -> Result<(), SlateDBError> {
+    let options = load_options();
+    let s3 = open_object_store(&options)?;
+    let sst_format = SsTableFormat::new(4096, 1);
+    let table_store = Arc::new(TableStore::new(
+        s3.clone(),
+        sst_format,
+        Path::from(options.path.as_str()),
+    ));
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    match options.mode.as_str() {
+        "RUN" => run_bench(&options, runtime.handle().clone(), table_store),
+        "LOAD" => runtime.block_on(run_load(&options, table_store)),
+        "CLEAR" => run_clear(&options, runtime.handle().clone(), s3.clone()),
+        invalid => panic!("invalid mode: {}", invalid),
+    }
+}
+
+fn sst_id(id: u32) -> SsTableId {
+    SsTableId::Compacted(Ulid::from((id as u64, id as u64)))
+}
+
+async fn run_load(options: &Options, table_store: Arc<TableStore>) -> Result<(), SlateDBError> {
+    let num_ssts = options.num_ssts as u32;
+    let sst_bytes = options.sst_bytes;
+    let key_bytes = options.key_bytes;
+    let val_bytes = options.val_bytes;
+    let num_keys = sst_bytes / (val_bytes + key_bytes);
+    let mut key_start = vec![0u8; key_bytes - mem::size_of::<u32>()];
+    let mut rng = rand_xorshift::XorShiftRng::from_entropy();
+    rng.fill_bytes(key_start.as_mut_slice());
+    let mut futures = FuturesUnordered::<JoinHandle<Result<(), SlateDBError>>>::new();
+    for i in 0..num_ssts {
+        while futures.len() >= 4 {
+            futures
+                .next()
+                .await
+                .expect("expected value")
+                .expect("join failed")?;
+        }
+        let ts = table_store.clone();
+        let key_start_copy = key_start.clone();
+        let jh = tokio::spawn(load_sst(i, ts, key_start_copy, num_keys, val_bytes));
+        futures.push(jh)
+    }
+    while !futures.is_empty() {
+        futures
+            .next()
+            .await
+            .expect("expected value")
+            .expect("join failed")?;
+    }
+    Ok(())
+}
+
+async fn load_sst(
+    i: u32,
+    table_store: Arc<TableStore>,
+    key_start: Vec<u8>,
+    num_keys: usize,
+    val_bytes: usize,
+) -> Result<(), SlateDBError> {
+    let mut retries = 0;
+    loop {
+        let result = do_load_sst(
+            i,
+            table_store.clone(),
+            key_start.clone(),
+            num_keys,
+            val_bytes,
+        )
+        .await;
+        match result {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                if retries >= 3 {
+                    return Err(err);
+                } else {
+                    println!("error loading sst: {:#?}", err)
+                }
+            }
+        }
+        retries += 1;
+        tokio::time::sleep(Duration::from_secs(retries + 1)).await;
+    }
+}
+
+async fn do_load_sst(
+    i: u32,
+    table_store: Arc<TableStore>,
+    key_start: Vec<u8>,
+    num_keys: usize,
+    val_bytes: usize,
+) -> Result<(), SlateDBError> {
+    let mut rng = rand_xorshift::XorShiftRng::from_entropy();
+    let start = std::time::Instant::now();
+    let mut key_gen = KeyGenerator::new(i, key_start.as_slice());
+    let mut sst_writer = table_store.table_writer(sst_id(i));
+    for _ in 0..num_keys {
+        let mut val = vec![0u8; val_bytes];
+        rng.fill_bytes(val.as_mut_slice());
+        let key = key_gen.next();
+        sst_writer.add(key.as_ref(), Some(val.as_ref())).await?;
+    }
+    let encoded = sst_writer.close().await?;
+    println!(
+        "wrote sst with id: {:#?} {:#?}",
+        &encoded.id,
+        start.elapsed()
+    );
+    Ok(())
+}
+
+fn run_clear(
+    options: &Options,
+    handle: tokio::runtime::Handle,
+    s3: Arc<dyn ObjectStore>,
+) -> Result<(), SlateDBError> {
+    let mut del_tasks = Vec::new();
+    for i in 0u32..options.num_ssts as u32 {
+        let s3_copy = s3.clone();
+        let path = options.path.clone();
+        del_tasks.push(handle.spawn(async move {
+            let sst_id = sst_id(i);
+            s3_copy.delete(&sst_path(&sst_id, path.as_str())).await
+        }))
+    }
+    while let Some(del_task) = del_tasks.pop() {
+        handle.block_on(del_task).expect("join failed")?;
+    }
+    Ok(())
+}
+
+fn run_bench(
+    options: &Options,
+    handle: tokio::runtime::Handle,
+    table_store: Arc<TableStore>,
+) -> Result<(), SlateDBError> {
+    let (tx, rx) = crossbeam_channel::unbounded();
+    let compactor_options = CompactorOptions::default();
+    let executor = TokioCompactionExecutor::new(
+        handle.clone(),
+        Arc::new(compactor_options),
+        tx,
+        table_store.clone(),
+    );
+    let sst_ids: Vec<SsTableId> = (0u32..options.num_ssts as u32).map(sst_id).collect();
+    let mut ssts = Vec::new();
+    for id in sst_ids.iter() {
+        ssts.push(handle.block_on(table_store.open_sst(id))?);
+    }
+    let job = CompactionJob {
+        destination: 0,
+        ssts,
+        sorted_runs: vec![],
+    };
+    let start = std::time::Instant::now();
+    executor.start_compaction(job);
+    let WorkerToOrchestoratorMsg::CompactionFinished(result) = rx.recv().expect("recv failed");
+    match result {
+        Ok(_) => {
+            println!("compaction finished in {:#?} millis", start.elapsed());
+        }
+        Err(err) => return Err(err),
+    }
+    Ok(())
+}
+
+fn load_options() -> Options {
+    let aws_key = std::env::var("AWS_ACCESS_KEY_ID").expect("must supply AWS access key");
+    let aws_secret = std::env::var("AWS_SECRET_ACCESS_KEY").expect("must supply AWS secret");
+    let bucket = std::env::var("BUCKET").expect("must supply bucket name");
+    let region = std::env::var("REGION")
+        .ok()
+        .unwrap_or(String::from("us-west-2"));
+    let path = std::env::var("SST_BASE_PATH")
+        .ok()
+        .unwrap_or(String::from("/compaction-execute-bench"));
+    let mode = std::env::var("MODE").expect("must specify LOAD, RUN, or CLEAR for MODE");
+    let sst_bytes = std::env::var("SST_BYTES")
+        .ok()
+        .unwrap_or(String::from("1073741824"));
+    let num_ssts = std::env::var("NUM_SSTS").ok().unwrap_or(String::from("4"));
+    let key_bytes = std::env::var("KEY_BYTES")
+        .ok()
+        .unwrap_or(String::from("32"));
+    let val_bytes = std::env::var("VAL_BYTES")
+        .ok()
+        .unwrap_or(String::from("224"));
+    let options = Options {
+        aws_key,
+        aws_secret,
+        bucket,
+        region,
+        path,
+        mode,
+        sst_bytes: sst_bytes.parse::<usize>().expect("invalid sst bytes"),
+        num_ssts: num_ssts.parse::<usize>().expect("invalid num ssts"),
+        key_bytes: key_bytes.parse::<usize>().expect("invalid key bytes"),
+        val_bytes: val_bytes.parse::<usize>().expect("invalid val bytes"),
+    };
+    println!("Options: {:#?}", options);
+    options
+}
+
+struct KeyGenerator {
+    id: u32,
+    bytes: Vec<u8>,
+}
+
+impl KeyGenerator {
+    fn new(id: u32, bytes: &[u8]) -> Self {
+        let bytes = Vec::from(bytes);
+        Self { id, bytes }
+    }
+
+    fn next(&mut self) -> Bytes {
+        let mut result = BytesMut::with_capacity(self.bytes.len() + std::mem::size_of::<u32>());
+        result.put_slice(self.bytes.as_slice());
+        result.put_u32(self.id);
+        self.increment();
+        result.freeze()
+    }
+
+    fn increment(&mut self) {
+        let mut pos = self.bytes.len() - 1;
+        while self.bytes[pos] == u8::MAX {
+            self.bytes[pos] = 0;
+            pos -= 1;
+        }
+        self.bytes[pos] += 1;
+    }
+}
+
+#[allow(clippy::panic)]
+fn sst_path(id: &SsTableId, root_path: &str) -> Path {
+    match id {
+        SsTableId::Compacted(ulid) => {
+            Path::from(format!("{}/compacted/{}.sst", root_path, ulid.to_string()))
+        }
+        _ => panic!("invalid sst type"),
+    }
+}

--- a/src/compaction_execute_bench/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench/compaction_execute_bench.rs
@@ -1,0 +1,4 @@
+use slatedb::compaction_execute_bench::run_compaction_execute_bench;
+fn main() {
+    run_compaction_execute_bench().unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 mod blob;
 mod block;
 mod block_iterator;
+pub mod compaction_execute_bench;
 mod compactor;
 mod compactor_executor;
 mod compactor_state;
@@ -25,4 +26,6 @@ mod sorted_run_iterator;
 mod sst;
 mod sst_iter;
 mod tablestore;
+#[cfg(test)]
+mod test_utils;
 mod types;

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -147,6 +147,7 @@ mod tests {
     use crate::error::SlateDBError;
     use crate::iter::KeyValueIterator;
     use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
+    use crate::test_utils::assert_iterator;
     use crate::types::{KeyValueDeletable, ValueDeletable};
     use bytes::Bytes;
     use std::collections::VecDeque;
@@ -311,20 +312,5 @@ mod tests {
                 Err(err) => Err(err),
             })
         }
-    }
-
-    async fn assert_iterator<T: KeyValueIterator>(
-        iterator: &mut T,
-        entries: &[(&'static [u8], ValueDeletable)],
-    ) {
-        for (expected_k, expected_v) in entries.iter() {
-            if let Some(kv) = iterator.next_entry().await.unwrap() {
-                assert_eq!(kv.key, Bytes::from(*expected_k));
-                assert_eq!(kv.value, *expected_v);
-            } else {
-                panic!("expected next_entry to return a value")
-            }
-        }
-        assert!(iterator.next_entry().await.unwrap().is_none());
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,23 @@
+use crate::iter::KeyValueIterator;
+use crate::types::{KeyValue, ValueDeletable};
+use bytes::Bytes;
+
+pub(crate) async fn assert_iterator<T: KeyValueIterator>(
+    iterator: &mut T,
+    entries: &[(&'static [u8], ValueDeletable)],
+) {
+    for (expected_k, expected_v) in entries.iter() {
+        if let Some(kv) = iterator.next_entry().await.unwrap() {
+            assert_eq!(kv.key, Bytes::from(*expected_k));
+            assert_eq!(kv.value, *expected_v);
+        } else {
+            panic!("expected next_entry to return a value")
+        }
+    }
+    assert!(iterator.next_entry().await.unwrap().is_none());
+}
+
+pub fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
+    assert_eq!(kv.key, key);
+    assert_eq!(kv.value, val);
+}


### PR DESCRIPTION
This patch implements some optimizations to speed up writes for the compactor:
- Adds EncodedSsTableWriter, which writes the SST as records are added, rather than building up the whole encoded SST and then writing it out. Internally, this type uses a BufWriter to write the SST. It calls write_all whenever a new block is encoded. In turn, BufWriter writes data to S3 whenever its accumulated a large enough buffer (1MB). For objects larger than this buffer size, BufWriter uses a multipart upload to parallelize writing the SST.
- Adds the ability to read encoded blocks from EncodedSsTableBuilder by adding a new method called `next_block` which returns the first unconsumed fully- encoded block, if any. Any unconsumed blocks are returned in the EncodedSsTable struct returned by `build`, in lieu of a buffer containing the full sst. The last "block" in the queue includes the SST footer.
- Adds a compaction benchmark tool, which can be used to measure how fast the compaction executor can compact a set of SSTs. Its behaviour is controlled by environment variables. It's run in one of 3 modes (LOAD, RUN, CLEAN), as determined by the MODE environment variable. LOAD writes the ssts to be compacted. RUN compacts the SSTs. CLEAN cleans up SSTs. The other variables determine things like the s3 creds, bucket, sst size, num ssts, etc.
- Adds an s3 feature to the project, which causes it to build with the s3 object_store feature turned on. The benchmark requires this feature to be on.