### PR TITLE
read optimizations for compactor

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -29,8 +29,9 @@ impl Block {
     }
 
     #[rustfmt::skip]
-    pub fn decode(data: &[u8]) -> Self {
+    pub fn decode(bytes: Bytes) -> Self {
         // Get number of elements in the block
+        let data = bytes.as_ref();
         let entry_offsets_len = (&data[data.len() - SIZEOF_U16..]).get_u16() as usize;
         let data_end = data.len()
             - SIZEOF_U16                                            // Entry u16 length
@@ -40,8 +41,8 @@ impl Block {
             .chunks(SIZEOF_U16)
             .map(|mut x| x.get_u16())
             .collect();
-        let data = Bytes::copy_from_slice(data[0..data_end].as_ref());
-        Self { data, offsets }
+        let bytes = bytes.slice(0..data_end);
+        Self { data: bytes, offsets }
     }
 }
 
@@ -123,7 +124,7 @@ mod tests {
         assert!(builder.add(b"key2", Some(b"value2")));
         let block = builder.build().unwrap();
         let encoded = block.encode();
-        let decoded = Block::decode(&encoded);
+        let decoded = Block::decode(encoded);
         assert_eq!(block.data, decoded.data);
         assert_eq!(block.offsets, decoded.offsets);
     }
@@ -136,6 +137,6 @@ mod tests {
         assert!(builder.add(b"key3", Some(b"value3")));
         let block = builder.build().unwrap();
         let encoded = block.encode();
-        let _decoded = Block::decode(&encoded);
+        let _decoded = Block::decode(encoded);
     }
 }

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -324,7 +324,7 @@ mod tests {
             )
             .await
             .unwrap();
-        let mut iter = SstIterator::new(&handle, table_store.as_ref());
+        let mut iter = SstIterator::new(&handle, table_store.clone(), 1, 1);
         for i in 0..4 {
             let kv = iter.next().await.unwrap().unwrap();
             assert_eq!(kv.key.as_ref(), &[b'a' + i as u8; 16]);
@@ -430,7 +430,7 @@ mod tests {
         let db = Db::open(Path::from(PATH), DEFAULT_OPTIONS, os.clone())
             .await
             .unwrap();
-        let sst_format = SsTableFormat::new(4096, 10);
+        let sst_format = SsTableFormat::new(32, 10);
         let table_store = Arc::new(TableStore::new(os.clone(), sst_format, Path::from(PATH)));
         (os, table_store, db)
     }

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -6,22 +6,108 @@ use crate::{
     tablestore::{SSTableHandle, TableStore},
     types::KeyValueDeletable,
 };
+use std::cmp::min;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::task::JoinHandle;
+
+enum FetchTask {
+    InFlight(JoinHandle<Result<VecDeque<Block>, SlateDBError>>),
+    Finished(VecDeque<Block>),
+}
 
 pub(crate) struct SstIterator<'a> {
     table: &'a SSTableHandle,
     current_iter: Option<BlockIterator<Block>>,
-    next_block_idx: usize,
-    table_store: &'a TableStore,
+    next_block_idx_to_fetch: usize,
+    fetch_tasks: VecDeque<FetchTask>,
+    max_fetch_tasks: usize,
+    blocks_to_fetch: usize,
+    table_store: Arc<TableStore>,
 }
 
 impl<'a> SstIterator<'a> {
-    #[allow(dead_code)] // will be used in #8
-    pub(crate) fn new(table: &'a SSTableHandle, table_store: &'a TableStore) -> Self {
+    pub(crate) fn new(
+        table: &'a SSTableHandle,
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
+    ) -> Self {
+        assert!(max_fetch_tasks > 0);
+        assert!(blocks_to_fetch > 0);
         Self {
             table,
             current_iter: None,
-            next_block_idx: 0,
+            next_block_idx_to_fetch: 0,
+            fetch_tasks: VecDeque::new(),
+            max_fetch_tasks,
+            blocks_to_fetch,
             table_store,
+        }
+    }
+
+    pub(crate) fn new_spawn(
+        table: &'a SSTableHandle,
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
+        spawn: bool,
+    ) -> Self {
+        let mut iter = Self::new(table, table_store, max_fetch_tasks, blocks_to_fetch);
+        if spawn {
+            iter.spawn_fetches();
+        }
+        iter
+    }
+
+    fn spawn_fetches(&mut self) {
+        let num_blocks = self.table.info.borrow().block_meta().len();
+        while self.fetch_tasks.len() < self.max_fetch_tasks
+            && self.next_block_idx_to_fetch < num_blocks
+        {
+            let blocks_to_fetch = min(
+                self.blocks_to_fetch,
+                num_blocks - self.next_block_idx_to_fetch,
+            );
+            let table = self.table.clone();
+            let table_store = self.table_store.clone();
+            let blocks_start = self.next_block_idx_to_fetch;
+            let blocks_end = self.next_block_idx_to_fetch + blocks_to_fetch;
+            self.fetch_tasks
+                .push_back(FetchTask::InFlight(tokio::spawn(async move {
+                    table_store
+                        .read_blocks(&table, blocks_start..blocks_end)
+                        .await
+                })));
+            self.next_block_idx_to_fetch = blocks_end;
+        }
+    }
+
+    async fn next_iter(&mut self) -> Result<Option<BlockIterator<Block>>, SlateDBError> {
+        loop {
+            self.spawn_fetches();
+            if let Some(fetch_task) = self.fetch_tasks.front_mut() {
+                match fetch_task {
+                    FetchTask::InFlight(jh) => {
+                        let blocks = jh.await.expect("join task failed")?;
+                        *fetch_task = FetchTask::Finished(blocks);
+                    }
+                    FetchTask::Finished(blocks) => {
+                        if let Some(block) = blocks.pop_front() {
+                            return Ok(Some(BlockIterator::from_first_key(block)));
+                        } else {
+                            self.fetch_tasks.pop_front();
+                        }
+                    }
+                }
+            } else {
+                assert!(self.fetch_tasks.is_empty());
+                assert_eq!(
+                    self.next_block_idx_to_fetch,
+                    self.table.info.borrow().block_meta().len()
+                );
+                return Ok(None);
+            }
         }
     }
 }
@@ -31,19 +117,10 @@ impl<'a> KeyValueIterator for SstIterator<'a> {
         loop {
             let current_iter = if let Some(current_iter) = self.current_iter.as_mut() {
                 current_iter
+            } else if let Some(next_iter) = self.next_iter().await? {
+                self.current_iter.insert(next_iter)
             } else {
-                if self.next_block_idx >= self.table.info.borrow().block_meta().len() {
-                    // No more blocks in the SST.
-                    return Ok(None);
-                }
-
-                let block = self
-                    .table_store
-                    .read_block(self.table, self.next_block_idx)
-                    .await?;
-                self.next_block_idx += 1;
-                self.current_iter
-                    .insert(BlockIterator::from_first_key(block))
+                return Ok(None);
             };
 
             let kv = current_iter.next_entry().await?;
@@ -74,7 +151,7 @@ mod tests {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let format = SsTableFormat::new(4096, 3);
-        let table_store = TableStore::new(object_store, format, root_path.clone());
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
         let mut builder = table_store.table_builder();
         builder.add(b"key1", Some(b"value1")).unwrap();
         builder.add(b"key2", Some(b"value2")).unwrap();
@@ -88,7 +165,7 @@ mod tests {
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         assert_eq!(sst_handle.info.borrow().block_meta().len(), 1);
 
-        let mut iter = SstIterator::new(&sst_handle, &table_store);
+        let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 1, 1);
         let kv = iter.next().await.unwrap().unwrap();
         assert_eq!(kv.key, b"key1".as_slice());
         assert_eq!(kv.value, b"value1".as_slice());
@@ -110,7 +187,7 @@ mod tests {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let format = SsTableFormat::new(4096, 3);
-        let table_store = TableStore::new(object_store, format, root_path.clone());
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
         let mut builder = table_store.table_builder();
 
         for i in 0..1000 {
@@ -130,7 +207,7 @@ mod tests {
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         assert_eq!(sst_handle.info.borrow().block_meta().len(), 6);
 
-        let mut iter = SstIterator::new(&sst_handle, &table_store);
+        let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 3, 3);
         for i in 0..1000 {
             let kv = iter.next().await.unwrap().unwrap();
             assert_eq!(kv.key, format!("key{}", i));


### PR DESCRIPTION
We make 2 main changes to optimize long range reads, as done by the compactor:
1. Support reading multiple blocks in table_store/sst. This is exposed by `read_block` methods that take a range of block ids and return a VecDequeue of the blocks read.
2. SstIterator supports reading multiple ranges of blocks parallel to both other block-range reads and iteration. The iterator now maintains a queue of outstanding fetch tasks. Each fetch task is either in-flight or finished. When the iterator finishes consuming a block, it sees if there are more blocks returned by the current fetch task. If not, it waits for the next fetch task to finish (spawning more fetch tasks if possible), and then pulls the first block from that fetch task. The iterator accepts as parameters the size of fetches it should do, and the max number of un-processed fetch tasks (either in-flight or finished). A task is considered fully processed when all of its blocks have been consumed by the iterator.

This patch also hanges the table store ref to an Arc. Now that the iterator is spawning tasks, the table store ref needs to be Send.

After these changes and the changes in https://github.com/slatedb/slatedb/pull/99 I was able to compact 32 1GB SSTs in ~310 seconds on average on an m5.xlarge, for a compaction rate of just over 800Mbits/second. Compaction was saturated on 1 CPU core, so we can get better throughput by running parallel compactions or implementing subcompaction. I didn't see any other obvious improvements to make when profiling, so subcompactions are probably the most worthwhile thing to implement next. That said, I think what we have here will be good enough for now.