### PR TITLE
read from compacted ssts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ fail-parallel = { version = "0.5.1", features = ["failpoints"] }
 [features]
 default = ["aws"]
 aws = ["object_store/aws"]
+db_bench = ["aws"]
 
 [[bin]]
 name = "compaction-execute-bench"

--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -53,7 +53,6 @@ impl<B: BlockLike> BlockIterator<B> {
 
     /// Construct a BlockIterator that starts at the given key, or at the first
     /// key greater than the given key if the exact key given is not in the block.
-    #[allow(dead_code)] // will be used in #8
     pub fn from_key(block: B, key: &[u8]) -> BlockIterator<B> {
         let idx = block.offsets().partition_point(|offset| {
             let mut cursor = &block.data()[*offset as usize..];

--- a/src/compaction_execute_bench/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench/compaction_execute_bench.rs
@@ -1,4 +1,11 @@
+#[cfg(feature = "db_bench")]
 use slatedb::compaction_execute_bench::run_compaction_execute_bench;
+
+#[cfg(not(feature = "db_bench"))]
+fn run_compaction_execute_bench() -> Result<(), slatedb::error::SlateDBError> {
+    panic!("db_bench feature not enabled!")
+}
+
 fn main() {
     run_compaction_execute_bench().unwrap();
 }

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -74,13 +74,13 @@ impl TokioCompactionExecutorInner {
         let l0_iters: VecDeque<SstIterator> = compaction
             .ssts
             .iter()
-            .map(|l0| SstIterator::new_spawn(l0, self.table_store.clone(), 4, 256, true))
+            .map(|l0| SstIterator::new_spawn(l0, self.table_store.clone(), 4, 256))
             .collect();
         let l0_merge_iter = MergeIterator::new(l0_iters).await?;
         let sr_iters: VecDeque<SortedRunIterator> = compaction
             .sorted_runs
             .iter()
-            .map(|sr| SortedRunIterator::new_spawn(sr, self.table_store.clone(), 4, 256, true))
+            .map(|sr| SortedRunIterator::new_spawn(sr, self.table_store.clone(), 4, 256))
             .collect();
         let sr_merge_iter = MergeIterator::new(sr_iters).await?;
         let mut all_iter = TwoMergeIterator::new(l0_merge_iter, sr_merge_iter).await?;

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -89,7 +89,6 @@ impl DbInner {
             let mut wguard = self.state.write();
             wguard.pop_imm_wal();
             // flush to the memtable before notifying so that data is available for reads
-            // once we support committed read isolation, reads should read from memtable first
             self.flush_imm_wal_to_memtable(wguard.memtable(), imm.table());
             self.maybe_freeze_memtable(&mut wguard, imm.id());
             imm.table().notify_flush();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 mod blob;
 mod block;
 mod block_iterator;
+#[cfg(feature = "db_bench")]
 pub mod compaction_execute_bench;
 mod compactor;
 mod compactor_executor;
@@ -13,7 +14,7 @@ mod compactor_state;
 pub mod db;
 mod db_common;
 mod db_state;
-mod error;
+pub mod error;
 mod filter;
 mod flatbuffer_types;
 mod flush;
@@ -26,6 +27,6 @@ mod sorted_run_iterator;
 mod sst;
 mod sst_iter;
 mod tablestore;
-#[cfg(test)]
+#[cfg(any(test, feature = "db_bench"))]
 mod test_utils;
 mod types;

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -16,17 +16,72 @@ pub(crate) struct SortedRunIterator<'a> {
 }
 
 impl<'a> SortedRunIterator<'a> {
+    pub(crate) fn new_from_key(
+        sorted_run: &'a SortedRun,
+        key: &'a [u8],
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
+    ) -> Self {
+        assert!(!sorted_run.ssts.is_empty());
+        Self::new_opts(
+            sorted_run,
+            Some(key),
+            table_store,
+            max_fetch_tasks,
+            blocks_to_fetch,
+            false,
+        )
+    }
+
     pub(crate) fn new_spawn(
         sorted_run: &'a SortedRun,
         table_store: Arc<TableStore>,
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
+    ) -> Self {
+        Self::new_opts(
+            sorted_run,
+            None,
+            table_store,
+            max_fetch_tasks,
+            blocks_to_fetch,
+            true,
+        )
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        sorted_run: &'a SortedRun,
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
+    ) -> Self {
+        Self::new_opts(
+            sorted_run,
+            None,
+            table_store,
+            max_fetch_tasks,
+            blocks_to_fetch,
+            false,
+        )
+    }
+
+    pub(crate) fn new_opts(
+        sorted_run: &'a SortedRun,
+        from_key: Option<&'a [u8]>,
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
         spawn: bool,
     ) -> Self {
-        let mut sorted_run_iter = sorted_run.ssts.iter();
+        let mut sorted_run_iter = from_key
+            .map(|from_key| Self::find_iter_from_key(from_key, sorted_run))
+            .unwrap_or(sorted_run.ssts.iter());
         let current_iter = sorted_run_iter.next().map(|h| {
-            SstIterator::new_spawn(
+            SstIterator::new_opts(
                 h,
+                from_key,
                 table_store.clone(),
                 max_fetch_tasks,
                 blocks_to_fetch,
@@ -42,20 +97,14 @@ impl<'a> SortedRunIterator<'a> {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn new(
+    pub(crate) fn find_iter_from_key(
+        key: &[u8],
         sorted_run: &'a SortedRun,
-        table_store: Arc<TableStore>,
-        max_fetch_tasks: usize,
-        blocks_to_fetch: usize,
-    ) -> Self {
-        Self::new_spawn(
-            sorted_run,
-            table_store,
-            max_fetch_tasks,
-            blocks_to_fetch,
-            false,
-        )
+    ) -> Iter<'a, SSTableHandle> {
+        match sorted_run.find_sst_with_range_covering_key_idx(key) {
+            None => sorted_run.ssts.iter(),
+            Some(idx) => sorted_run.ssts[idx..].iter(),
+        }
     }
 }
 
@@ -86,6 +135,7 @@ mod tests {
     use super::*;
     use crate::sst::SsTableFormat;
     use crate::tablestore::SsTableId;
+    use crate::test_utils::{assert_kv, OrderedBytesGenerator};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
     use std::sync::Arc;
@@ -159,5 +209,95 @@ mod tests {
         assert_eq!(kv.value, b"value3".as_slice());
         let kv = iter.next().await.unwrap();
         assert!(kv.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_sr_iter_from_key() {
+        let root_path = Path::from("");
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::new(4096, 3);
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
+        let key_gen = OrderedBytesGenerator::new_with_byte_range(&[b'a'; 16], b'a', b'z');
+        let mut test_case_key_gen = key_gen.clone();
+        let val_gen = OrderedBytesGenerator::new_with_byte_range(&[0u8; 16], 0u8, 26u8);
+        let mut test_case_val_gen = val_gen.clone();
+        let sr = build_sr_with_ssts(table_store.clone(), 3, 10, key_gen, val_gen).await;
+
+        for i in 0..30 {
+            let mut expected_key_gen = test_case_key_gen.clone();
+            let mut expected_val_gen = test_case_val_gen.clone();
+            let from_key = test_case_key_gen.next();
+            _ = test_case_val_gen.next();
+            let mut iter =
+                SortedRunIterator::new_from_key(&sr, from_key.as_ref(), table_store.clone(), 1, 1);
+            for _ in 0..30 - i {
+                assert_kv(
+                    &iter.next().await.unwrap().unwrap(),
+                    expected_key_gen.next().as_ref(),
+                    expected_val_gen.next().as_ref(),
+                );
+            }
+            assert!(iter.next().await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sr_iter_from_key_lower_than_range() {
+        let root_path = Path::from("");
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::new(4096, 3);
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
+        let key_gen = OrderedBytesGenerator::new_with_byte_range(&[b'a'; 16], b'a', b'z');
+        let mut expected_key_gen = key_gen.clone();
+        let val_gen = OrderedBytesGenerator::new_with_byte_range(&[0u8; 16], 0u8, 26u8);
+        let mut expected_val_gen = val_gen.clone();
+        let sr = build_sr_with_ssts(table_store.clone(), 3, 10, key_gen, val_gen).await;
+
+        let mut iter = SortedRunIterator::new_from_key(&sr, &[b'a', 10], table_store.clone(), 1, 1);
+
+        for _ in 0..30 {
+            assert_kv(
+                &iter.next().await.unwrap().unwrap(),
+                expected_key_gen.next().as_ref(),
+                expected_val_gen.next().as_ref(),
+            );
+        }
+        assert!(iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_sr_iter_from_key_higher_than_range() {
+        let root_path = Path::from("");
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::new(4096, 3);
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
+        let key_gen = OrderedBytesGenerator::new_with_byte_range(&[b'a'; 16], b'a', b'z');
+        let val_gen = OrderedBytesGenerator::new_with_byte_range(&[0u8; 16], 0u8, 26u8);
+        let sr = build_sr_with_ssts(table_store.clone(), 3, 10, key_gen, val_gen).await;
+
+        let mut iter = SortedRunIterator::new_from_key(&sr, &[b'z', 30], table_store.clone(), 1, 1);
+
+        assert!(iter.next().await.unwrap().is_none());
+    }
+
+    async fn build_sr_with_ssts(
+        table_store: Arc<TableStore>,
+        n: usize,
+        keys_per_sst: usize,
+        mut key_gen: OrderedBytesGenerator,
+        mut val_gen: OrderedBytesGenerator,
+    ) -> SortedRun {
+        let mut ssts = Vec::<SSTableHandle>::new();
+        for _ in 0..n {
+            let mut writer = table_store.table_writer(SsTableId::Compacted(Ulid::new()));
+            for _ in 0..keys_per_sst {
+                writer
+                    .add(key_gen.next().as_ref(), Some(val_gen.next().as_ref()))
+                    .await
+                    .unwrap();
+            }
+            ssts.push(writer.close().await.unwrap());
+        }
+        SortedRun { id: 0, ssts }
     }
 }

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -19,6 +19,7 @@ enum FetchTask {
 pub(crate) struct SstIterator<'a> {
     table: &'a SSTableHandle,
     current_iter: Option<BlockIterator<Block>>,
+    from_key: Option<&'a [u8]>,
     next_block_idx_to_fetch: usize,
     fetch_tasks: VecDeque<FetchTask>,
     max_fetch_tasks: usize,
@@ -27,23 +28,50 @@ pub(crate) struct SstIterator<'a> {
 }
 
 impl<'a> SstIterator<'a> {
-    pub(crate) fn new(
+    fn first_block_with_data_including_or_after_key(sst: &SSTableHandle, key: &[u8]) -> usize {
+        let handle = sst.info.borrow();
+        // search for the block that could contain the key.
+        let mut low = 0;
+        let mut high = handle.block_meta().len() - 1;
+        // if the key is less than all the blocks' first key, scan the whole sst
+        let mut found_block_id = 0;
+
+        while low <= high {
+            let mid = low + (high - low) / 2;
+            let mid_block_first_key = handle.block_meta().get(mid).first_key().bytes();
+            match mid_block_first_key.cmp(key) {
+                std::cmp::Ordering::Less => {
+                    low = mid + 1;
+                    found_block_id = mid;
+                }
+                std::cmp::Ordering::Greater => {
+                    if mid > 0 {
+                        high = mid - 1;
+                    } else {
+                        break;
+                    }
+                }
+                std::cmp::Ordering::Equal => return mid,
+            }
+        }
+        found_block_id
+    }
+
+    pub(crate) fn new_from_key(
         table: &'a SSTableHandle,
         table_store: Arc<TableStore>,
+        from_key: &'a [u8],
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
     ) -> Self {
-        assert!(max_fetch_tasks > 0);
-        assert!(blocks_to_fetch > 0);
-        Self {
+        Self::new_opts(
             table,
-            current_iter: None,
-            next_block_idx_to_fetch: 0,
-            fetch_tasks: VecDeque::new(),
+            Some(from_key),
+            table_store,
             max_fetch_tasks,
             blocks_to_fetch,
-            table_store,
-        }
+            false,
+        )
     }
 
     pub(crate) fn new_spawn(
@@ -51,9 +79,56 @@ impl<'a> SstIterator<'a> {
         table_store: Arc<TableStore>,
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
+    ) -> Self {
+        Self::new_opts(
+            table,
+            None,
+            table_store,
+            max_fetch_tasks,
+            blocks_to_fetch,
+            true,
+        )
+    }
+
+    pub(crate) fn new(
+        table: &'a SSTableHandle,
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
+    ) -> Self {
+        Self::new_opts(
+            table,
+            None,
+            table_store,
+            max_fetch_tasks,
+            blocks_to_fetch,
+            false,
+        )
+    }
+
+    pub(crate) fn new_opts(
+        table: &'a SSTableHandle,
+        from_key: Option<&'a [u8]>,
+        table_store: Arc<TableStore>,
+        max_fetch_tasks: usize,
+        blocks_to_fetch: usize,
         spawn: bool,
     ) -> Self {
-        let mut iter = Self::new(table, table_store, max_fetch_tasks, blocks_to_fetch);
+        assert!(max_fetch_tasks > 0);
+        assert!(blocks_to_fetch > 0);
+        let next_block_idx_to_fetch = from_key
+            .map(|k| Self::first_block_with_data_including_or_after_key(table, k))
+            .unwrap_or(0);
+        let mut iter = Self {
+            table,
+            current_iter: None,
+            next_block_idx_to_fetch,
+            from_key,
+            fetch_tasks: VecDeque::new(),
+            max_fetch_tasks,
+            blocks_to_fetch,
+            table_store,
+        };
         if spawn {
             iter.spawn_fetches();
         }
@@ -94,7 +169,11 @@ impl<'a> SstIterator<'a> {
                     }
                     FetchTask::Finished(blocks) => {
                         if let Some(block) = blocks.pop_front() {
-                            return Ok(Some(BlockIterator::from_first_key(block)));
+                            let first_key = self.from_key.take();
+                            return match first_key {
+                                None => Ok(Some(BlockIterator::from_first_key(block))),
+                                Some(k) => Ok(Some(BlockIterator::from_key(block, k))),
+                            };
                         } else {
                             self.fetch_tasks.pop_front();
                         }
@@ -142,6 +221,7 @@ mod tests {
     use super::*;
     use crate::sst::SsTableFormat;
     use crate::tablestore::SsTableId;
+    use crate::test_utils::{assert_kv, OrderedBytesGenerator};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
     use std::sync::Arc;
@@ -216,5 +296,101 @@ mod tests {
 
         let next = iter.next().await.unwrap();
         assert!(next.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_iter_from_key() {
+        let root_path = Path::from("");
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::new(128, 1);
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
+        let first_key = [b'a'; 16];
+        let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'z');
+        let mut test_case_key_gen = key_gen.clone();
+        let first_val = [1u8; 16];
+        let val_gen = OrderedBytesGenerator::new_with_byte_range(&first_val, 1u8, 26u8);
+        let mut test_case_val_gen = val_gen.clone();
+        let (sst, nkeys) = build_sst_with_n_blocks(3, table_store.clone(), key_gen, val_gen).await;
+
+        // iterate over all keys and make sure we iterate from that key
+        for i in 0..nkeys {
+            let mut expected_key_gen = test_case_key_gen.clone();
+            let mut expected_val_gen = test_case_val_gen.clone();
+            let from_key = test_case_key_gen.next();
+            let _ = test_case_val_gen.next();
+            let mut iter =
+                SstIterator::new_from_key(&sst, table_store.clone(), from_key.as_ref(), 1, 1);
+            for _ in 0..nkeys - i {
+                let e = iter.next().await.unwrap().unwrap();
+                assert_kv(
+                    &e,
+                    expected_key_gen.next().as_ref(),
+                    expected_val_gen.next().as_ref(),
+                );
+            }
+            assert!(iter.next().await.unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_iter_from_key_smaller_than_first() {
+        let root_path = Path::from("");
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::new(128, 1);
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
+        let first_key = [b'b'; 16];
+        let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'y');
+        let mut expected_key_gen = key_gen.clone();
+        let first_val = [2u8; 16];
+        let val_gen = OrderedBytesGenerator::new_with_byte_range(&first_val, 1u8, 26u8);
+        let mut expected_val_gen = val_gen.clone();
+        let (sst, nkeys) = build_sst_with_n_blocks(2, table_store.clone(), key_gen, val_gen).await;
+
+        let mut iter = SstIterator::new_from_key(&sst, table_store.clone(), &[b'a'; 16], 1, 1);
+
+        for _ in 0..nkeys {
+            let e = iter.next().await.unwrap().unwrap();
+            assert_kv(
+                &e,
+                expected_key_gen.next().as_ref(),
+                expected_val_gen.next().as_ref(),
+            );
+        }
+        assert!(iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_iter_from_key_larger_than_last() {
+        let root_path = Path::from("");
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::new(128, 1);
+        let table_store = Arc::new(TableStore::new(object_store, format, root_path.clone()));
+        let first_key = [b'b'; 16];
+        let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'y');
+        let first_val = [2u8; 16];
+        let val_gen = OrderedBytesGenerator::new_with_byte_range(&first_val, 1u8, 26u8);
+        let (sst, _) = build_sst_with_n_blocks(2, table_store.clone(), key_gen, val_gen).await;
+
+        let mut iter = SstIterator::new_from_key(&sst, table_store.clone(), &[b'z'; 16], 1, 1);
+
+        assert!(iter.next().await.unwrap().is_none());
+    }
+
+    async fn build_sst_with_n_blocks(
+        n: usize,
+        ts: Arc<TableStore>,
+        mut key_gen: OrderedBytesGenerator,
+        mut val_gen: OrderedBytesGenerator,
+    ) -> (SSTableHandle, usize) {
+        let mut writer = ts.table_writer(SsTableId::Wal(0));
+        let mut nkeys = 0usize;
+        while writer.blocks_written() < n {
+            writer
+                .add(key_gen.next().as_ref(), Some(val_gen.next().as_ref()))
+                .await
+                .unwrap();
+            nkeys += 1;
+        }
+        (writer.close().await.unwrap(), nkeys)
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,23 +1,129 @@
 use crate::iter::KeyValueIterator;
 use crate::types::{KeyValue, ValueDeletable};
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 
+// this complains because we include these in the db_bench feature but they are only
+// used for cfg(test)
+#[allow(dead_code)]
 pub(crate) async fn assert_iterator<T: KeyValueIterator>(
     iterator: &mut T,
     entries: &[(&'static [u8], ValueDeletable)],
 ) {
     for (expected_k, expected_v) in entries.iter() {
-        if let Some(kv) = iterator.next_entry().await.unwrap() {
-            assert_eq!(kv.key, Bytes::from(*expected_k));
-            assert_eq!(kv.value, *expected_v);
-        } else {
-            panic!("expected next_entry to return a value")
-        }
+        let kv = iterator
+            .next_entry()
+            .await
+            .expect("iterator next_entry failed")
+            .expect("expected iterator to return a value");
+        assert_eq!(kv.key, Bytes::from(*expected_k));
+        assert_eq!(kv.value, *expected_v);
     }
-    assert!(iterator.next_entry().await.unwrap().is_none());
+    assert!(iterator
+        .next_entry()
+        .await
+        .expect("iterator next_entry failed")
+        .is_none());
 }
 
+// this complains because we include these in the db_bench feature but they are only
+// used for cfg(test)
+#[allow(dead_code)]
 pub fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
     assert_eq!(kv.key, key);
     assert_eq!(kv.value, val);
+}
+
+#[derive(Clone)]
+pub(crate) struct OrderedBytesGenerator {
+    suffix: Bytes,
+    bytes: Vec<u8>,
+    min: u8,
+    max: u8,
+}
+
+impl OrderedBytesGenerator {
+    #[allow(dead_code)]
+    pub(crate) fn new_with_suffix(suffix: &[u8], bytes: &[u8]) -> Self {
+        Self::new(suffix, bytes, u8::MIN, u8::MAX)
+    }
+
+    // this complains because we include these in the db_bench feature but they are only
+    // used for cfg(test)
+    #[allow(dead_code)]
+    pub(crate) fn new_with_byte_range(bytes: &[u8], min: u8, max: u8) -> Self {
+        Self::new(&[], bytes, min, max)
+    }
+
+    pub(crate) fn new(suffix: &[u8], bytes: &[u8], min: u8, max: u8) -> Self {
+        let bytes = Vec::from(bytes);
+        Self {
+            suffix: Bytes::copy_from_slice(suffix),
+            bytes,
+            min,
+            max,
+        }
+    }
+
+    pub(crate) fn next(&mut self) -> Bytes {
+        let mut result = BytesMut::with_capacity(self.bytes.len() + std::mem::size_of::<u32>());
+        result.put_slice(self.bytes.as_slice());
+        result.put(self.suffix.as_ref());
+        self.increment();
+        result.freeze()
+    }
+
+    fn increment(&mut self) {
+        let mut pos = self.bytes.len() - 1;
+        while self.bytes[pos] == self.max {
+            self.bytes[pos] = self.min;
+            pos -= 1;
+        }
+        self.bytes[pos] += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::OrderedBytesGenerator;
+    use bytes::{BufMut, Bytes};
+
+    #[test]
+    fn test_should_generate_ordered_bytes() {
+        let mut suffix = Vec::<u8>::new();
+        suffix.put_u32(3735928559);
+        let start = [0u8, 0u8, 0u8];
+        let mut gen = OrderedBytesGenerator::new(suffix.as_ref(), &start, 0, 2);
+
+        let expected = [
+            [0u8, 0u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 0u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 0u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 1u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 1u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 1u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 2u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 2u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [0u8, 2u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 0u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 0u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 0u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 1u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 1u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 1u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 2u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 2u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [1u8, 2u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 0u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 0u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 0u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 1u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 1u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 1u8, 2u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 2u8, 0u8, 0xde, 0xad, 0xbe, 0xef],
+            [2u8, 2u8, 1u8, 0xde, 0xad, 0xbe, 0xef],
+        ];
+        for e in expected.iter() {
+            assert_eq!(gen.next(), Bytes::copy_from_slice(e))
+        }
+    }
 }


### PR DESCRIPTION
This patch adds support for reading from compacted ssts:
- We add new_from_key methods for the sst and sorted run iterators. These methods will start iteration from the next key greater than or equal to the provided key.
- For get, use SstIterator::new_from_key to seek to the key in an sst instead of doing the seek in DbInner.
- If the key is not found in memtables/l0, then look in Compacted by going through all the sorted runs. For each run, if run has an SST that might contain the key, try to read it using an sr iterator.
- I haven't yet added tests for reading from compacted, because the db still doesn't load the manifest periodically. That will come in the next patch