### PR TITLE
refresh db state with compactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ object_store = "0.9.1"
 parking_lot = "0.12.1"
 siphasher = "1"
 thiserror = "1.0.59"
-tokio = { version = "1.37.0", features = ["sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.37.0", features = ["macros", "sync", "rt", "rt-multi-thread"] }
 ulid = "1.1.2"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -282,6 +282,7 @@ mod tests {
     const PATH: &str = "/test/db";
     const DEFAULT_OPTIONS: DbOptions = DbOptions {
         flush_ms: 100,
+        manifest_poll_interval: Duration::from_millis(100),
         min_filter_keys: 0,
         l0_sst_size_bytes: 128,
         compactor_options: Some(CompactorOptions {

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -247,6 +247,7 @@ mod tests {
     const PATH: &str = "/test/db";
     const DEFAULT_OPTIONS: DbOptions = DbOptions {
         flush_ms: 100,
+        manifest_poll_interval: Duration::from_millis(100),
         min_filter_keys: 0,
         l0_sst_size_bytes: 128,
         compactor_options: None,

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -16,28 +16,6 @@ impl DbInner {
         Ok(())
     }
 
-    pub(crate) async fn write_manifest(&self) -> Result<(), SlateDBError> {
-        // get the update manifest if there are any updates.
-        let updated_manifest: Option<crate::flatbuffer_types::ManifestV1Owned> = {
-            let compacted = &self.state.read().state().core;
-            let mut wguard_manifest = self.manifest.write();
-            if wguard_manifest.borrow().wal_id_last_seen() != compacted.next_wal_sst_id - 1 {
-                let new_manifest = wguard_manifest.create_updated_manifest(compacted);
-                *wguard_manifest = new_manifest.clone();
-                Some(new_manifest)
-            } else {
-                None
-            }
-        };
-
-        if let Some(manifest) = updated_manifest {
-            self.table_store.write_manifest(&manifest).await?
-        }
-
-        Ok(())
-    }
-
-    // todo: move me
     pub(crate) async fn flush_imm_table(
         &self,
         id: &tablestore::SsTableId,


### PR DESCRIPTION
This patch refreshes db state with the state written by the compactor. The state is refreshed before any manifest write, and periodically from the mem table flush thread. Also includes a test to verify that we can read data from the compacted ssts