### PR TITLE
refactor: move filters into a cache in tablestore

### DIFF
--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -1,8 +1,9 @@
 use crate::compactor::{CompactorOptions, WorkerToOrchestoratorMsg};
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
+use crate::db_state::{SSTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::sst::SsTableFormat;
-use crate::tablestore::{SSTableHandle, SsTableId, TableStore};
+use crate::tablestore::TableStore;
 use crate::test_utils::OrderedBytesGenerator;
 use bytes::BufMut;
 use futures::stream::FuturesUnordered;

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -1,12 +1,12 @@
 use crate::compactor::WorkerToOrchestoratorMsg::CompactionFinished;
 use crate::compactor::{CompactorOptions, WorkerToOrchestoratorMsg};
-use crate::db_state::SortedRun;
+use crate::db_state::{SSTableHandle, SortedRun, SsTableId};
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::SstIterator;
-use crate::tablestore::{SSTableHandle, SsTableId, TableStore};
+use crate::tablestore::TableStore;
 use parking_lot::Mutex;
 use std::collections::{HashMap, VecDeque};
 use std::mem;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
 use crate::compactor::{Compactor, CompactorOptions};
 use crate::db::ReadLevel::{Commited, Uncommitted};
-use crate::db_state::{DbState, SortedRun};
+use crate::db_state::{DbState, SSTableHandle, SortedRun, SsTableId};
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::ManifestV1Owned;
 use crate::iter::KeyValueIterator;
@@ -9,7 +9,7 @@ use crate::mem_table_flush::MemtableFlushThreadMsg::Shutdown;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst::SsTableFormat;
 use crate::sst_iter::SstIterator;
-use crate::tablestore::{SSTableHandle, SsTableId, TableStore};
+use crate::tablestore::TableStore;
 use crate::types::ValueDeletable;
 use bytes::Bytes;
 use fail_parallel::FailPointRegistry;
@@ -75,7 +75,7 @@ impl DbInner {
         manifest: ManifestV1Owned,
         memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<MemtableFlushThreadMsg>,
     ) -> Result<Self, SlateDBError> {
-        let state = DbState::load(&manifest, &table_store).await?;
+        let state = DbState::load(&manifest);
         let db_inner = Self {
             state: Arc::new(RwLock::new(state)),
             options,

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -1,5 +1,5 @@
 use crate::db_state;
-use crate::db_state::CoreDbState;
+use crate::db_state::{CoreDbState, SSTableHandle};
 use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
 use ulid::Ulid;
@@ -8,11 +8,11 @@ use ulid::Ulid;
 #[allow(warnings)]
 #[rustfmt::skip]
 mod manifest_generated;
+use crate::db_state::SsTableId;
 use crate::flatbuffer_types::manifest_generated::{
     CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, SortedRun,
     SortedRunArgs,
 };
-use crate::tablestore::{SSTableHandle, SsTableId};
 pub use manifest_generated::{
     BlockMeta, BlockMetaArgs, ManifestV1, ManifestV1Args, SsTableInfo, SsTableInfoArgs,
 };

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -1,8 +1,9 @@
 use crate::db::DbInner;
+use crate::db_state;
+use crate::db_state::SSTableHandle;
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::mem_table::{ImmutableWal, KVTable, WritableKVTable};
-use crate::tablestore::{self, SSTableHandle};
 use crate::types::ValueDeletable;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,7 +19,7 @@ impl DbInner {
 
     pub(crate) async fn flush_imm_table(
         &self,
-        id: &tablestore::SsTableId,
+        id: &db_state::SsTableId,
         imm_table: Arc<KVTable>,
     ) -> Result<SSTableHandle, SlateDBError> {
         let mut sst_builder = self.table_store.table_builder();
@@ -40,7 +41,7 @@ impl DbInner {
     }
 
     async fn flush_imm_wal(&self, imm: Arc<ImmutableWal>) -> Result<SSTableHandle, SlateDBError> {
-        let wal_id = tablestore::SsTableId::Wal(imm.id());
+        let wal_id = db_state::SsTableId::Wal(imm.id());
         self.flush_imm_table(&wal_id, imm.table()).await
     }
 

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -1,7 +1,6 @@
 use crate::db::DbInner;
-use crate::db_state::CoreDbState;
+use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
-use crate::tablestore::SsTableId;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use ulid::Ulid;
@@ -18,18 +17,8 @@ impl DbInner {
             .open_latest_manifest()
             .await?
             .expect("manifest must exist");
-        let snapshot = {
-            let state_snapshot = self.state.read().snapshot();
-            state_snapshot.state.clone()
-        };
-        let compacted = CoreDbState::load_srs_from_manifest(
-            &snapshot.core.compacted,
-            &current_manifest.borrow(),
-            self.table_store.as_ref(),
-        )
-        .await?;
         let mut wguard_state = self.state.write();
-        wguard_state.refresh_db_state(current_manifest, compacted);
+        wguard_state.refresh_db_state(current_manifest);
         Ok(())
     }
 

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -1,8 +1,8 @@
-use crate::db_state::SortedRun;
+use crate::db_state::{SSTableHandle, SortedRun};
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::sst_iter::SstIterator;
-use crate::tablestore::{SSTableHandle, TableStore};
+use crate::tablestore::TableStore;
 use crate::types::KeyValueDeletable;
 use std::slice::Iter;
 use std::sync::Arc;
@@ -133,8 +133,8 @@ impl<'a> KeyValueIterator for SortedRunIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db_state::SsTableId;
     use crate::sst::SsTableFormat;
-    use crate::tablestore::SsTableId;
     use crate::test_utils::{assert_kv, OrderedBytesGenerator};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -301,7 +301,8 @@ impl<'a> EncodedSsTableBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use crate::block_iterator::BlockIterator;
-    use crate::tablestore::{SsTableId, TableStore};
+    use crate::db_state::SsTableId;
+    use crate::tablestore::TableStore;
     use crate::test_utils::assert_iterator;
     use crate::types::ValueDeletable;
     use bytes::BytesMut;

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -1,9 +1,7 @@
+use crate::db_state::SSTableHandle;
 use crate::error::SlateDBError;
 use crate::{
-    block::Block,
-    block_iterator::BlockIterator,
-    iter::KeyValueIterator,
-    tablestore::{SSTableHandle, TableStore},
+    block::Block, block_iterator::BlockIterator, iter::KeyValueIterator, tablestore::TableStore,
     types::KeyValueDeletable,
 };
 use std::cmp::min;
@@ -219,8 +217,8 @@ impl<'a> KeyValueIterator for SstIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db_state::SsTableId;
     use crate::sst::SsTableFormat;
-    use crate::tablestore::SsTableId;
     use crate::test_utils::{assert_kv, OrderedBytesGenerator};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};


### PR DESCRIPTION
This patch makes a "refactor" to tablestore that moves the filters from the SsTable descriptor to a "cache" that resides inside tablestore. The cache is not truly a cache, its just a map where we store all the filters we've ever loaded. Filters are cached when SSTs are written, or lazily the first time an SST is loaded. Though its not a true cache, this patch does move us a bit closer to the desired end state, where filters are cached in the db's in-memory/on-disk cache. The benefit of this increment is that we no longer need to do i/o to load up the sst descriptor (SsTableHandle) - it can be loaded from the manifest alone. This really simplifies all the db state code that needs to load descriptors to build up db state.

I've also moved SsTableHandle and SsTableId to the db_state module. I'd like to rename SsTableHandle to SsTable as its really a descriptor rather than a handle that can be closed. But I defer that to a later patch to keep the diff smaller.

I also added a couple unit tests for db_state's refresh_db_state method now that the dbstate is easier to load.