### PR TITLE
use transactional writes for manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,6 +1129,7 @@ name = "slatedb"
 version = "0.1.0"
 dependencies = [
  "async-channel",
+ "async-trait",
  "bytes",
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [dependencies]
 async-channel = "2.3.1"
+async-trait = "0.1.81"
 bytes = "1.6.0"
 crc32fast = "1.4.0"
 crossbeam-channel = "0.5.13"

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,9 @@ pub enum SlateDBError {
     #[error("Object store error")]
     ObjectStoreError(#[from] object_store::Error),
 
+    #[error("Manifest file already exists")]
+    ManifestVersionExists,
+
     #[error("Invalid sst error")]
     InvalidFlatbuffer(#[from] flatbuffers::InvalidFlatbuffer),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod filter;
 mod flatbuffer_types;
 mod flush;
 mod iter;
+mod manifest_store;
 mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
@@ -29,4 +30,5 @@ mod sst_iter;
 mod tablestore;
 #[cfg(any(test, feature = "db_bench"))]
 mod test_utils;
+mod transactional_object_store;
 mod types;

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -1,0 +1,107 @@
+use crate::error::SlateDBError;
+use crate::flatbuffer_types::ManifestV1Owned;
+use crate::transactional_object_store::{
+    DelegatingTransactionalObjectStore, TransactionalObjectStore,
+};
+use bytes::Bytes;
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::Error::AlreadyExists;
+use object_store::ObjectStore;
+use std::sync::Arc;
+
+pub(crate) struct ManifestStore {
+    object_store: Box<dyn TransactionalObjectStore>,
+    manifest_suffix: &'static str,
+}
+
+impl ManifestStore {
+    pub(crate) fn new(root_path: &Path, object_store: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            object_store: Box::new(DelegatingTransactionalObjectStore::new(
+                root_path.child("manifest"),
+                object_store,
+            )),
+            manifest_suffix: "manifest",
+        }
+    }
+    pub(crate) async fn write_manifest(
+        &self,
+        manifest: &ManifestV1Owned,
+    ) -> Result<(), SlateDBError> {
+        let manifest_path = &Path::from(format!(
+            "{:020}.{}",
+            manifest.borrow().manifest_id(),
+            self.manifest_suffix
+        ));
+
+        self.object_store
+            .put_if_not_exists(manifest_path, Bytes::copy_from_slice(manifest.data()))
+            .await
+            .map_err(|err| {
+                if let AlreadyExists { path: _, source: _ } = err {
+                    SlateDBError::ManifestVersionExists
+                } else {
+                    SlateDBError::ObjectStoreError(err)
+                }
+            })?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn read_latest_manifest(
+        &self,
+    ) -> Result<Option<ManifestV1Owned>, SlateDBError> {
+        let manifest_path = &Path::from("/");
+        let mut files_stream = self.object_store.list(Some(manifest_path));
+        let mut id_and_manifest_file_path: Option<(u64, Path)> = None;
+        while let Some(file) = match files_stream.next().await.transpose() {
+            Ok(file) => file,
+            Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
+        } {
+            match self.parse_id(&file.location, "manifest") {
+                Ok(id) => {
+                    id_and_manifest_file_path = match id_and_manifest_file_path {
+                        Some((current_id, current_path)) => Some(if current_id < id {
+                            (id, file.location)
+                        } else {
+                            (current_id, current_path)
+                        }),
+                        None => Some((id, file.location.clone())),
+                    }
+                }
+                Err(_) => continue,
+            }
+        }
+
+        if let Some((_, resolved_manifest_file_path)) = id_and_manifest_file_path {
+            let manifest_bytes = match self.object_store.get(&resolved_manifest_file_path).await {
+                Ok(manifest) => match manifest.bytes().await {
+                    Ok(bytes) => bytes,
+                    Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
+                },
+                Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
+            };
+
+            ManifestV1Owned::new(manifest_bytes.clone())
+                .map(Some)
+                .map_err(SlateDBError::InvalidFlatbuffer)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn parse_id(&self, path: &Path, expected_extension: &str) -> Result<u64, SlateDBError> {
+        match path.extension() {
+            Some(ext) if ext == expected_extension => path
+                .filename()
+                .expect("invalid filename")
+                .split('.')
+                .next()
+                .ok_or_else(|| SlateDBError::InvalidDBState)?
+                .parse()
+                .map_err(|_| SlateDBError::InvalidDBState),
+            _ => Err(SlateDBError::InvalidDBState),
+        }
+    }
+}

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -10,7 +10,7 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
         // for now, just compact l0 down to a new sorted run each time
         let mut compactions = Vec::new();
         if db_state.l0.len() >= 4 {
-            let next_sr = db_state.compacted.first().map_or(0, |r| r.id);
+            let next_sr = db_state.compacted.first().map_or(0, |r| r.id + 1);
             let sources: Vec<SourceId> = db_state
                 .l0
                 .iter()

--- a/src/transactional_object_store.rs
+++ b/src/transactional_object_store.rs
@@ -1,0 +1,222 @@
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::{
+    path, Error, GetResult, ObjectMeta, ObjectStore, PutMode, PutOptions, PutResult,
+};
+use std::sync::Arc;
+
+// Implements transactional object inserts using some safe protocol
+#[async_trait]
+pub(crate) trait TransactionalObjectStore: Send + Sync {
+    async fn put_if_not_exists(&self, path: &Path, data: Bytes) -> Result<PutResult, Error>;
+
+    async fn get(&self, path: &Path) -> Result<GetResult, Error>;
+
+    fn list(&self, path: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta, Error>>;
+}
+
+// An implementation of TransactionalObjectStore that delegates the transactional
+// protocol to the ObjectStore implementation. This implementation is sufficient for
+// object stores that support CAS like Azure and GCP. The object_store S3 impl supports CAS
+// but uses an algorithm that is based on time-expiring locks that are susceptible to either
+// lockout or races, if the lock timeout is set too high or low, respectively. So this type
+// is generally not appropriate for S3.
+pub(crate) struct DelegatingTransactionalObjectStore {
+    root_path: Path,
+    object_store: Arc<dyn ObjectStore>,
+}
+
+impl DelegatingTransactionalObjectStore {
+    pub(crate) fn new(root_path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            root_path,
+            object_store,
+        }
+    }
+
+    fn path(&self, path: &Path) -> Path {
+        Path::from(format!("{}/{}", self.root_path, path))
+    }
+
+    fn strip_root(&self, path: &Path) -> Result<Path, Error> {
+        let root_raw = self.root_path.to_string();
+        let path_raw = path.to_string();
+        // Path ensures there are no empty delimiters, so it should be safe to just do
+        // a raw prefix strip
+        if let Some(stripped) = path_raw.strip_prefix(root_raw.as_str()) {
+            return Ok(Path::from(stripped));
+        }
+        Err(Error::InvalidPath {
+            source: path::Error::PrefixMismatch {
+                path: path.to_string(),
+                prefix: self.root_path.to_string(),
+            },
+        })
+    }
+}
+
+#[async_trait]
+impl TransactionalObjectStore for DelegatingTransactionalObjectStore {
+    async fn put_if_not_exists(&self, path: &Path, data: Bytes) -> Result<PutResult, Error> {
+        let path = self.path(path);
+        self.object_store
+            .put_opts(&path, data, PutOptions::from(PutMode::Create))
+            .await
+    }
+
+    async fn get(&self, path: &Path) -> Result<GetResult, Error> {
+        let path = self.path(path);
+        self.object_store.get(&path).await
+    }
+
+    fn list(&self, path: Option<&Path>) -> BoxStream<'_, Result<ObjectMeta, Error>> {
+        let path = path.map_or(self.root_path.clone(), |p| self.path(p));
+        self.object_store
+            .list(Some(&path))
+            .map(|r| match r {
+                Ok(om) => Ok(ObjectMeta {
+                    location: self.strip_root(&om.location)?,
+                    last_modified: om.last_modified,
+                    size: om.size,
+                    e_tag: om.e_tag,
+                    version: om.version,
+                }),
+                Err(err) => Err(err),
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::transactional_object_store::{
+        DelegatingTransactionalObjectStore, TransactionalObjectStore,
+    };
+    use bytes::Bytes;
+    use futures::StreamExt;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use std::sync::Arc;
+
+    const ROOT_PATH: &str = "/root/path";
+
+    #[tokio::test]
+    async fn test_delegating_should_fail_put_if_exists() {
+        // given:
+        let os = Arc::new(InMemory::new());
+        let txnl_os = DelegatingTransactionalObjectStore::new(Path::from(ROOT_PATH), os.clone());
+        txnl_os
+            .put_if_not_exists(
+                &Path::from("obj"),
+                Bytes::copy_from_slice("data1".as_bytes()),
+            )
+            .await
+            .unwrap();
+
+        // when:
+        let result = txnl_os
+            .put_if_not_exists(
+                &Path::from("obj"),
+                Bytes::copy_from_slice("data2".as_bytes()),
+            )
+            .await;
+
+        // then:
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err().unwrap(),
+            object_store::Error::AlreadyExists { path: _, source: _ }
+        ));
+        let result = txnl_os.get(&Path::from("obj")).await.unwrap();
+        assert_eq!(
+            result.bytes().await.unwrap(),
+            Bytes::copy_from_slice("data1".as_bytes())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delegating_should_get_put() {
+        // given:
+        let os = Arc::new(InMemory::new());
+        let txnl_os = DelegatingTransactionalObjectStore::new(Path::from(ROOT_PATH), os.clone());
+        txnl_os
+            .put_if_not_exists(
+                &Path::from("obj"),
+                Bytes::copy_from_slice("data1".as_bytes()),
+            )
+            .await
+            .unwrap();
+
+        // when:
+        let result = txnl_os.get(&Path::from("obj")).await.unwrap();
+
+        // then:
+        assert_eq!(
+            result.bytes().await.unwrap(),
+            Bytes::copy_from_slice("data1".as_bytes())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delegating_should_list() {
+        // given:
+        let os = Arc::new(InMemory::new());
+        let txnl_os = DelegatingTransactionalObjectStore::new(Path::from(ROOT_PATH), os.clone());
+        txnl_os
+            .put_if_not_exists(
+                &Path::from("obj"),
+                Bytes::copy_from_slice("data1".as_bytes()),
+            )
+            .await
+            .unwrap();
+        txnl_os
+            .put_if_not_exists(
+                &Path::from("foo/bar"),
+                Bytes::copy_from_slice("data1".as_bytes()),
+            )
+            .await
+            .unwrap();
+        os.put(
+            &Path::from("biz/baz"),
+            Bytes::copy_from_slice("data1".as_bytes()),
+        )
+        .await
+        .unwrap();
+
+        // when:
+        let mut listing = txnl_os.list(None);
+
+        let item = listing.next().await.unwrap().unwrap();
+        assert_eq!(item.location, Path::from("foo/bar"));
+        let item = listing.next().await.unwrap().unwrap();
+        assert_eq!(item.location, Path::from("obj"));
+        assert!(listing.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delegating_should_put_with_prefix() {
+        // given:
+        let os = Arc::new(InMemory::new());
+        let txnl_os = DelegatingTransactionalObjectStore::new(Path::from(ROOT_PATH), os.clone());
+        txnl_os
+            .put_if_not_exists(
+                &Path::from("obj"),
+                Bytes::copy_from_slice("data1".as_bytes()),
+            )
+            .await
+            .unwrap();
+
+        // when:
+        let result = os.get(&Path::from("root/path/obj")).await.unwrap();
+
+        // then:
+        assert_eq!(
+            result.bytes().await.unwrap(),
+            Bytes::copy_from_slice("data1".as_bytes())
+        );
+    }
+}


### PR DESCRIPTION
This patch changes manifest read/write to do a transactional if-not-exist write to the object_store. For now, we just use the transaction implementation provided by the object_store crate, which is good enough for testing (and for non-s3 stores):

- Adds a trait called TransactionalObjectStore which is similar to ObjectStore but with an explicit method for put_if_not_exists. I considered just implementing ObjectStore directly, but it has a rather large surface area, so it felt cleaner to just build our own trait with the specific functionality we need. Implementations of the trait should execute transactional puts using one of the CAS protocols from https://github.com/slatedb/slatedb/blob/main/rfcs/0001-manifest.md The parameters and return types just use the ObjectStore crate's types. This should make it easier to remove this trait if/when s3 implements CAS.

- Adds an impl called DelegatingTransactionalObjectStore that just delegates to the ObjectStore crate's api for transactional puts. This type is scoped to a specific path prefix on the underlying object store. I think it makes sense for these impls to be path-scoped because they may write internal objects that should not clobber each other or be visible in listings.

- Adds a type called ManifestStore that executes manifest reads and writes, and moves the corresponding code from TableStore to ManifestStore, and switches it to using the transactional object store.

- Fixes a couple bugs that I uncovered from adding transactional manifest writes:
  - We weren't actually resetting the locally cached manifest after loading it, and so the path being written to was incorrect resulting in AlreadyExist errors.
  - The size-tiered compaction policy was overwriting SR 0 on each compaction.