### PR TITLE
decouple manifest format/writing from db and add fencing

### DIFF
--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -1,4 +1,4 @@
-use crate::flatbuffer_types::{ManifestV1, ManifestV1Owned, SsTableInfoOwned};
+use crate::flatbuffer_types::SsTableInfoOwned;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -93,6 +93,18 @@ pub(crate) struct CoreDbState {
     pub(crate) last_compacted_wal_sst_id: u64,
 }
 
+impl CoreDbState {
+    pub(crate) fn new() -> Self {
+        Self {
+            l0_last_compacted: None,
+            l0: VecDeque::new(),
+            compacted: vec![],
+            next_wal_sst_id: 1,
+            last_compacted_wal_sst_id: 0,
+        }
+    }
+}
+
 // represents a read-snapshot of the current db state
 #[derive(Clone)]
 pub(crate) struct DbStateSnapshot {
@@ -101,61 +113,15 @@ pub(crate) struct DbStateSnapshot {
     pub(crate) state: Arc<COWDbState>,
 }
 
-impl CoreDbState {
-    pub fn load(manifest: &ManifestV1Owned) -> Self {
-        let manifest = manifest.borrow();
-        let l0_last_compacted = manifest
-            .l0_last_compacted()
-            .map(|id| Ulid::from((id.high(), id.low())));
-        let mut l0 = VecDeque::new();
-        for man_sst in manifest.l0().iter() {
-            let man_sst_id = man_sst.id().expect("SSTs in manifest must have IDs");
-            let sst_id = Compacted(Ulid::from((man_sst_id.high(), man_sst_id.low())));
-            let sst_info = SsTableInfoOwned::create_copy(
-                &man_sst.info().expect("SSTs in manifest must have info"),
-            );
-            let l0_sst = SSTableHandle::new(sst_id, sst_info);
-            l0.push_back(l0_sst);
-        }
-        let compacted = Self::load_srs_from_manifest(&manifest);
-        CoreDbState {
-            l0_last_compacted,
-            l0,
-            compacted,
-            next_wal_sst_id: manifest.wal_id_last_compacted() + 1,
-            last_compacted_wal_sst_id: manifest.wal_id_last_compacted(),
-        }
-    }
-
-    fn load_srs_from_manifest(manifest: &ManifestV1<'_>) -> Vec<SortedRun> {
-        let mut new_compacted = Vec::new();
-        for manifest_sr in manifest.compacted().iter() {
-            let mut ssts = Vec::new();
-            for manifest_sst in manifest_sr.ssts().iter() {
-                let id = Compacted(manifest_sst.id().expect("sst must have id").ulid());
-                let info = SsTableInfoOwned::create_copy(
-                    &manifest_sst.info().expect("sst must have info"),
-                );
-                ssts.push(SSTableHandle::new(id, info));
-            }
-            new_compacted.push(SortedRun {
-                id: manifest_sr.id(),
-                ssts,
-            })
-        }
-        new_compacted
-    }
-}
-
 impl DbState {
-    pub fn load(manifest: &ManifestV1Owned) -> Self {
+    pub fn new(core_db_state: CoreDbState) -> Self {
         Self {
             memtable: WritableKVTable::new(),
             wal: WritableKVTable::new(),
             state: Arc::new(COWDbState {
                 imm_memtable: VecDeque::new(),
                 imm_wal: VecDeque::new(),
-                core: CoreDbState::load(manifest),
+                core: core_db_state,
             }),
         }
     }
@@ -241,24 +207,21 @@ impl DbState {
         self.update_state(state);
     }
 
-    pub fn refresh_db_state(&mut self, compactor_manifest_owned: ManifestV1Owned) {
-        let compactor_manifest = compactor_manifest_owned.borrow();
+    pub fn refresh_db_state(&mut self, compactor_state: &CoreDbState) {
         // copy over L0 up to l0_last_compacted
-        let l0_last_compacted = compactor_manifest
-            .l0_last_compacted()
-            .map(|id| Ulid::from((id.high(), id.low())));
+        let l0_last_compacted = &compactor_state.l0_last_compacted;
         let mut new_l0 = VecDeque::new();
         for sst in self.state.core.l0.iter() {
             if let Some(l0_last_compacted) = l0_last_compacted {
-                if sst.id.unwrap_compacted_id() == l0_last_compacted {
+                if sst.id.unwrap_compacted_id() == *l0_last_compacted {
                     break;
                 }
             }
             new_l0.push_back(sst.clone());
         }
-        let compacted = CoreDbState::load_srs_from_manifest(&compactor_manifest);
+        let compacted = compactor_state.compacted.clone();
         let mut state = self.state_copy();
-        state.core.l0_last_compacted = l0_last_compacted;
+        state.core.l0_last_compacted.clone_from(l0_last_compacted);
         state.core.l0 = new_l0;
         state.core.compacted = compacted;
         self.update_state(state);
@@ -267,10 +230,8 @@ impl DbState {
 
 #[cfg(test)]
 mod tests {
-    use crate::db_state::{DbState, SSTableHandle, SsTableId};
-    use crate::flatbuffer_types::{
-        BlockMeta, ManifestV1Owned, SsTableInfo, SsTableInfoArgs, SsTableInfoOwned,
-    };
+    use crate::db_state::{CoreDbState, DbState, SSTableHandle, SsTableId};
+    use crate::flatbuffer_types::{BlockMeta, SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
     use bytes::Bytes;
     use flatbuffers::ForwardsUOffset;
     use ulid::Ulid;
@@ -278,26 +239,18 @@ mod tests {
     #[test]
     fn test_should_refresh_db_state_with_l0s_up_to_last_compacted() {
         // given:
-        let manifest = ManifestV1Owned::create_new();
-        let mut db_state = DbState::load(&manifest);
+        let mut db_state = DbState::new(CoreDbState::new());
         add_l0s_to_dbstate(&mut db_state, 4);
         // mimic the compactor popping off l0s
-        let mut l0s = db_state.state.core.l0.clone();
-        l0s.pop_back();
-        let last_compacted = db_state.state.core.l0.back().unwrap();
-        let manifest = manifest.create_updated_manifest(&db_state.state.core);
-        let mut compacted_db_state = DbState::load(&manifest);
-        let mut cow_state = compacted_db_state.state_copy();
-        cow_state.core.l0_last_compacted = Some(last_compacted.id.unwrap_compacted_id());
-        cow_state.core.l0.clone_from(&l0s);
-        compacted_db_state.update_state(cow_state);
-        let manifest = manifest.create_updated_manifest(&compacted_db_state.state.core);
+        let mut compactor_state = db_state.state.core.clone();
+        let last_compacted = compactor_state.l0.pop_back().unwrap();
+        compactor_state.l0_last_compacted = Some(last_compacted.id.unwrap_compacted_id());
 
         // when:
-        db_state.refresh_db_state(manifest);
+        db_state.refresh_db_state(&compactor_state);
 
         // then:
-        let expected: Vec<SsTableId> = l0s.iter().map(|l0| l0.id.clone()).collect();
+        let expected: Vec<SsTableId> = compactor_state.l0.iter().map(|l0| l0.id.clone()).collect();
         let merged: Vec<SsTableId> = db_state
             .state
             .core
@@ -311,14 +264,12 @@ mod tests {
     #[test]
     fn test_should_refresh_db_state_with_all_l0s_if_none_compacted() {
         // given:
-        let manifest = ManifestV1Owned::create_new();
-        let mut db_state = DbState::load(&manifest);
+        let mut db_state = DbState::new(CoreDbState::new());
         add_l0s_to_dbstate(&mut db_state, 4);
         let l0s = db_state.state.core.l0.clone();
-        assert!(manifest.borrow().l0_last_compacted().is_none());
 
         // when:
-        db_state.refresh_db_state(manifest);
+        db_state.refresh_db_state(&CoreDbState::new());
 
         // then:
         let expected: Vec<SsTableId> = l0s.iter().map(|l0| l0.id.clone()).collect();

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,4 +29,7 @@ pub enum SlateDBError {
 
     #[error("Invalid Compaction")]
     InvalidCompaction,
+
+    #[error("Detected newer DB client")]
+    Fenced,
 }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -91,7 +91,10 @@ impl DbInner {
                     _ = this.flush().await;
                   }
                   // Stop the thread.
-                  _ = rx.recv() => return
+                  _ = rx.recv() => {
+                        _ = this.flush().await;
+                        return
+                  }
                 }
             }
         }))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ mod filter;
 mod flatbuffer_types;
 mod flush;
 mod iter;
+mod manifest;
 mod manifest_store;
 mod mem_table;
 mod mem_table_flush;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,0 +1,16 @@
+use crate::db_state::CoreDbState;
+use crate::error::SlateDBError;
+use bytes::Bytes;
+
+#[derive(Clone)]
+pub(crate) struct Manifest {
+    pub(crate) core: CoreDbState,
+    pub(crate) writer_epoch: u64,
+    pub(crate) compactor_epoch: u64,
+}
+
+pub(crate) trait ManifestCodec: Send + Sync {
+    fn encode(&self, manifest: &Manifest) -> Bytes;
+
+    fn decode(&self, bytes: &Bytes) -> Result<Manifest, SlateDBError>;
+}

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -1,17 +1,168 @@
+use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
-use crate::flatbuffer_types::ManifestV1Owned;
+use crate::error::SlateDBError::InvalidDBState;
+use crate::flatbuffer_types::FlatBufferManifestCodec;
+use crate::manifest::{Manifest, ManifestCodec};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
-use bytes::Bytes;
 use futures::StreamExt;
 use object_store::path::Path;
 use object_store::Error::AlreadyExists;
 use object_store::ObjectStore;
 use std::sync::Arc;
 
+pub(crate) struct FenceableManifest {
+    stored_manifest: StoredManifest,
+    local_epoch: u64,
+    stored_epoch: Box<dyn Fn(&Manifest) -> u64 + Send>,
+}
+
+// This type wraps StoredManifest, and fences other conflicting writers by incrementing
+// the relevant epoch when initialized. It also detects when the current writer has been
+// fenced and fails all operations with SlateDBError::Fenced.
+impl FenceableManifest {
+    pub(crate) async fn init_writer(stored_manifest: StoredManifest) -> Result<Self, SlateDBError> {
+        Self::init(stored_manifest, Box::new(|m| m.writer_epoch), |m, e| {
+            m.writer_epoch = e
+        })
+        .await
+    }
+
+    pub(crate) async fn init_compactor(
+        stored_manifest: StoredManifest,
+    ) -> Result<Self, SlateDBError> {
+        Self::init(stored_manifest, Box::new(|m| m.compactor_epoch), |m, e| {
+            m.compactor_epoch = e
+        })
+        .await
+    }
+
+    async fn init(
+        mut stored_manifest: StoredManifest,
+        stored_epoch: Box<dyn Fn(&Manifest) -> u64 + Send>,
+        set_epoch: impl Fn(&mut Manifest, u64),
+    ) -> Result<Self, SlateDBError> {
+        let mut manifest = stored_manifest.manifest.clone();
+        let local_epoch = stored_epoch(&manifest) + 1;
+        set_epoch(&mut manifest, local_epoch);
+        stored_manifest.update_manifest(manifest).await?;
+        Ok(Self {
+            stored_manifest,
+            local_epoch,
+            stored_epoch,
+        })
+    }
+
+    pub(crate) fn db_state(&self) -> Result<&CoreDbState, SlateDBError> {
+        self.check_epoch()?;
+        Ok(self.stored_manifest.db_state())
+    }
+
+    pub(crate) async fn refresh(&mut self) -> Result<&CoreDbState, SlateDBError> {
+        self.stored_manifest.refresh().await?;
+        self.db_state()
+    }
+
+    pub(crate) async fn update_db_state(
+        &mut self,
+        db_state: CoreDbState,
+    ) -> Result<(), SlateDBError> {
+        self.check_epoch()?;
+        self.stored_manifest.update_db_state(db_state).await
+    }
+
+    #[allow(clippy::panic)]
+    fn check_epoch(&self) -> Result<(), SlateDBError> {
+        let stored_epoch = (self.stored_epoch)(&self.stored_manifest.manifest);
+        if self.local_epoch < stored_epoch {
+            return Err(SlateDBError::Fenced);
+        }
+        if self.local_epoch > stored_epoch {
+            panic!("the stored epoch is lower than the local epoch")
+        }
+        Ok(())
+    }
+}
+
+// Represents the manifest stored in the object store. This type tracks the current
+// contents and id of the stored manifest, and allows callers to read the db state
+// stored therein. Callers can also use this type to update the db state stored in the
+// manifest. The update is done with the next consecutive id, and is conditional on
+// no other writer having made an update to the manifest using that id. Finally, callers
+// can use the `refresh` method to refresh the locally stored manifest+id with the latest
+// manifest stored in the object store.
+pub(crate) struct StoredManifest {
+    id: u64,
+    manifest: Manifest,
+    manifest_store: Arc<ManifestStore>,
+}
+
+impl StoredManifest {
+    pub(crate) async fn init_new_db(
+        store: Arc<ManifestStore>,
+        core: CoreDbState,
+    ) -> Result<Self, SlateDBError> {
+        let manifest = Manifest {
+            core,
+            writer_epoch: 0,
+            compactor_epoch: 0,
+        };
+        store.write_manifest(1, &manifest).await?;
+        Ok(Self {
+            id: 1,
+            manifest,
+            manifest_store: store,
+        })
+    }
+
+    pub(crate) async fn load(store: Arc<ManifestStore>) -> Result<Option<Self>, SlateDBError> {
+        let Some((id, manifest)) = store.read_latest_manifest().await? else {
+            return Ok(None);
+        };
+        Ok(Some(Self {
+            id,
+            manifest,
+            manifest_store: store,
+        }))
+    }
+
+    pub(crate) fn db_state(&self) -> &CoreDbState {
+        &self.manifest.core
+    }
+
+    pub(crate) async fn refresh(&mut self) -> Result<&CoreDbState, SlateDBError> {
+        let Some((id, manifest)) = self.manifest_store.read_latest_manifest().await? else {
+            return Err(InvalidDBState);
+        };
+        self.manifest = manifest;
+        self.id = id;
+        Ok(&self.manifest.core)
+    }
+
+    pub(crate) async fn update_db_state(&mut self, core: CoreDbState) -> Result<(), SlateDBError> {
+        let manifest = Manifest {
+            core,
+            writer_epoch: self.manifest.writer_epoch,
+            compactor_epoch: self.manifest.compactor_epoch,
+        };
+        self.update_manifest(manifest).await
+    }
+
+    async fn update_manifest(&mut self, manifest: Manifest) -> Result<(), SlateDBError> {
+        let new_id = self.id + 1;
+        self.manifest_store
+            .write_manifest(new_id, &manifest)
+            .await?;
+        self.manifest = manifest;
+        self.id = new_id;
+        Ok(())
+    }
+}
+
 pub(crate) struct ManifestStore {
     object_store: Box<dyn TransactionalObjectStore>,
+    codec: Box<dyn ManifestCodec>,
     manifest_suffix: &'static str,
 }
 
@@ -22,21 +173,19 @@ impl ManifestStore {
                 root_path.child("manifest"),
                 object_store,
             )),
+            codec: Box::new(FlatBufferManifestCodec {}),
             manifest_suffix: "manifest",
         }
     }
     pub(crate) async fn write_manifest(
         &self,
-        manifest: &ManifestV1Owned,
+        id: u64,
+        manifest: &Manifest,
     ) -> Result<(), SlateDBError> {
-        let manifest_path = &Path::from(format!(
-            "{:020}.{}",
-            manifest.borrow().manifest_id(),
-            self.manifest_suffix
-        ));
+        let manifest_path = &Path::from(format!("{:020}.{}", id, self.manifest_suffix));
 
         self.object_store
-            .put_if_not_exists(manifest_path, Bytes::copy_from_slice(manifest.data()))
+            .put_if_not_exists(manifest_path, self.codec.encode(manifest))
             .await
             .map_err(|err| {
                 if let AlreadyExists { path: _, source: _ } = err {
@@ -51,7 +200,7 @@ impl ManifestStore {
 
     pub(crate) async fn read_latest_manifest(
         &self,
-    ) -> Result<Option<ManifestV1Owned>, SlateDBError> {
+    ) -> Result<Option<(u64, Manifest)>, SlateDBError> {
         let manifest_path = &Path::from("/");
         let mut files_stream = self.object_store.list(Some(manifest_path));
         let mut id_and_manifest_file_path: Option<(u64, Path)> = None;
@@ -60,21 +209,21 @@ impl ManifestStore {
             Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
         } {
             match self.parse_id(&file.location, "manifest") {
-                Ok(id) => {
+                Ok(found_id) => {
                     id_and_manifest_file_path = match id_and_manifest_file_path {
-                        Some((current_id, current_path)) => Some(if current_id < id {
-                            (id, file.location)
+                        Some((current_id, current_path)) => Some(if current_id < found_id {
+                            (found_id, file.location)
                         } else {
                             (current_id, current_path)
                         }),
-                        None => Some((id, file.location.clone())),
+                        None => Some((found_id, file.location.clone())),
                     }
                 }
                 Err(_) => continue,
             }
         }
 
-        if let Some((_, resolved_manifest_file_path)) = id_and_manifest_file_path {
+        if let Some((id, resolved_manifest_file_path)) = id_and_manifest_file_path {
             let manifest_bytes = match self.object_store.get(&resolved_manifest_file_path).await {
                 Ok(manifest) => match manifest.bytes().await {
                     Ok(bytes) => bytes,
@@ -83,9 +232,7 @@ impl ManifestStore {
                 Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
             };
 
-            ManifestV1Owned::new(manifest_bytes.clone())
-                .map(Some)
-                .map_err(SlateDBError::InvalidFlatbuffer)
+            self.codec.decode(&manifest_bytes).map(|m| Some((id, m)))
         } else {
             Ok(None)
         }
@@ -98,10 +245,164 @@ impl ManifestStore {
                 .expect("invalid filename")
                 .split('.')
                 .next()
-                .ok_or_else(|| SlateDBError::InvalidDBState)?
+                .ok_or_else(|| InvalidDBState)?
                 .parse()
-                .map_err(|_| SlateDBError::InvalidDBState),
-            _ => Err(SlateDBError::InvalidDBState),
+                .map_err(|_| InvalidDBState),
+            _ => Err(InvalidDBState),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db_state::CoreDbState;
+    use crate::error;
+    use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use std::sync::Arc;
+
+    const ROOT: &str = "/root/path";
+
+    #[tokio::test]
+    async fn test_should_fail_write_on_version_conflict() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let state = CoreDbState::new();
+        let mut sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        let mut sm2 = StoredManifest::load(ms.clone()).await.unwrap().unwrap();
+        sm.update_db_state(state.clone()).await.unwrap();
+
+        let result = sm2.update_db_state(state.clone()).await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            error::SlateDBError::ManifestVersionExists
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_should_write_with_new_version() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let state = CoreDbState::new();
+        let mut sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        sm.update_db_state(state.clone()).await.unwrap();
+
+        let (version, _) = ms.read_latest_manifest().await.unwrap().unwrap();
+
+        assert_eq!(version, 2);
+    }
+
+    #[tokio::test]
+    async fn test_should_update_local_state_on_write() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let mut state = CoreDbState::new();
+        let mut sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        state.next_wal_sst_id = 123;
+        sm.update_db_state(state.clone()).await.unwrap();
+
+        assert_eq!(sm.db_state().next_wal_sst_id, 123);
+    }
+
+    #[tokio::test]
+    async fn test_should_refresh() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let mut state = CoreDbState::new();
+        let mut sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        let mut sm2 = StoredManifest::load(ms.clone()).await.unwrap().unwrap();
+        state.next_wal_sst_id = 123;
+        sm.update_db_state(state.clone()).await.unwrap();
+
+        let refreshed = sm2.refresh().await.unwrap();
+
+        assert_eq!(refreshed.next_wal_sst_id, 123);
+        assert_eq!(sm2.db_state().next_wal_sst_id, 123);
+    }
+
+    #[tokio::test]
+    async fn test_should_bump_writer_epoch() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let state = CoreDbState::new();
+        StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        for i in 1..5 {
+            let sm = StoredManifest::load(ms.clone()).await.unwrap().unwrap();
+            FenceableManifest::init_writer(sm).await.unwrap();
+            let (_, manifest) = ms.read_latest_manifest().await.unwrap().unwrap();
+            assert_eq!(manifest.writer_epoch, i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_should_fail_on_writer_fenced() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let mut state = CoreDbState::new();
+        let sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        let mut writer1 = FenceableManifest::init_writer(sm).await.unwrap();
+        let sm2 = StoredManifest::load(ms.clone()).await.unwrap().unwrap();
+
+        let mut writer2 = FenceableManifest::init_writer(sm2).await.unwrap();
+
+        let result = writer1.refresh().await;
+        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+        state.next_wal_sst_id = 123;
+        let result = writer1.update_db_state(state.clone()).await;
+        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+        let refreshed = writer2.refresh().await.unwrap();
+        assert_eq!(refreshed.next_wal_sst_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_should_bump_compactor_epoch() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let state = CoreDbState::new();
+        StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        for i in 1..5 {
+            let sm = StoredManifest::load(ms.clone()).await.unwrap().unwrap();
+            FenceableManifest::init_compactor(sm).await.unwrap();
+            let (_, manifest) = ms.read_latest_manifest().await.unwrap().unwrap();
+            assert_eq!(manifest.compactor_epoch, i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_should_fail_on_compactor_fenced() {
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let mut state = CoreDbState::new();
+        let sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        let mut compactor1 = FenceableManifest::init_compactor(sm).await.unwrap();
+        let sm2 = StoredManifest::load(ms.clone()).await.unwrap().unwrap();
+
+        let mut compactor2 = FenceableManifest::init_compactor(sm2).await.unwrap();
+
+        let result = compactor1.refresh().await;
+        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+        state.next_wal_sst_id = 123;
+        let result = compactor1.update_db_state(state.clone()).await;
+        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+        let refreshed = compactor2.refresh().await.unwrap();
+        assert_eq!(refreshed.next_wal_sst_id, 1);
     }
 }


### PR DESCRIPTION
This patch aims to do a few things:

- Decouple the stored format of the core db state (CoreDbState) from teh main db. The main db now reads and writes updates to CoreDbState rather than dealing with the manifest flatbuffer. This leads to cleaner code (the fb apis are a pain to deal with), and keeps the format as seperated as possible.
- Pull the manifest read/write algorithms out into their own module that can be directly tested.

In detail:
- ManifestStore now reads and writes objects of type Manifest, which contains a CoreDbState and writer+compactor epochs. This type is meant to be our in-memory representation of the manifest (rather than using the fb types).
- ManifestStore contains a pointer to a struct that implements ManifestCodec, which converts Manifest to Bytes and vice-versa. In this patch, this pointer is hard-coded to point to FlatbufferManifestCoded which encodes/decodes using flatbuffers.
- flatbuffer_types is updated to convert back and forth between the Manifest and ManifestV1 flatbuffer type.
- StoredManifest represents a manifest stored persistently in the object store. It tracks the latest known persisted manifest version, and has an update api for attempting to update the stored manifest with the db state. It also has a refresh api for re-syncing its view of the manifest.
- FenceableManifest wraps StoredManifest and guards access to it using our writer/compactor epoch-based fencing protocols.
- Compactor/Db are updated to use FenceableManifest to track the manifest. Db no longer stores the manifest in DbInner. Instead its moved to the memtable flush task so all manifest access is done there.
- Compactor/Db state modules are updated to load/refresh from CoreDbState rather than the flatbuffer types.