### PR TITLE
Minor fixes to enable crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use slatedb::config::{CompactorOptions, DbOptions};
 use std::{sync::Arc, time::Duration};
 
 #[tokio::main]
-fn main() {
+async fn main() {
     // Setup
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let options = DbOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod compaction_execute_bench;
 mod compactor;
 mod compactor_executor;
 mod compactor_state;
-mod config;
+pub mod config;
 pub mod db;
 mod db_common;
 mod db_state;


### PR DESCRIPTION
- Make the config mod public.
- Add `async` to `main`  in example code.