### PR TITLE
Create `DbOptions::default()` and `Db::open_with_opts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ async fn main() {
         l0_sst_size_bytes: 128,
         compactor_options: Some(CompactorOptions::default()),
     };
-    let kv_store = Db::open(
+    let kv_store = Db::open_with_opts(
         Path::from("/tmp/test_kv_store"),
         options,
         object_store,

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -346,7 +346,7 @@ mod tests {
             .collect();
         // write another l0
         let db = rt
-            .block_on(Db::open(Path::from(PATH), options.clone(), os.clone()))
+            .block_on(Db::open_with_opts(Path::from(PATH), options.clone(), os.clone()))
             .unwrap();
         rt.block_on(db.put(&[b'j'; 32], &[b'k'; 96]));
         rt.block_on(db.close()).unwrap();
@@ -412,7 +412,7 @@ mod tests {
         Db,
     ) {
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let db = Db::open(Path::from(PATH), options, os.clone())
+        let db = Db::open_with_opts(Path::from(PATH), options, os.clone())
             .await
             .unwrap();
         let sst_format = SsTableFormat::new(32, 10);

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -225,13 +225,6 @@ mod tests {
     use tokio::runtime::{Handle, Runtime};
 
     const PATH: &str = "/test/db";
-    const DEFAULT_OPTIONS: DbOptions = DbOptions {
-        flush_ms: 100,
-        manifest_poll_interval: Duration::from_millis(100),
-        min_filter_keys: 0,
-        l0_sst_size_bytes: 128,
-        compactor_options: None,
-    };
 
     #[test]
     fn test_should_register_compaction_as_submitted() {
@@ -510,7 +503,7 @@ mod tests {
 
     fn build_db(os: Arc<dyn ObjectStore>, tokio_handle: &Handle) -> Db {
         tokio_handle
-            .block_on(Db::open(Path::from(PATH), DEFAULT_OPTIONS, os))
+            .block_on(Db::open(Path::from(PATH), os))
             .unwrap()
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,10 +124,10 @@ impl DbOptions {
     pub const fn default() -> Self {
         Self {
             flush_ms: 100,
-            manifest_poll_interval: Duration::from_millis(100),
+            manifest_poll_interval: Duration::from_secs(1),
             min_filter_keys: 1000,
             l0_sst_size_bytes: 128,
-            compactor_options: None,
+            compactor_options: Some(CompactorOptions::default()),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 pub const DEFAULT_READ_OPTIONS: &ReadOptions = &ReadOptions::default();
 pub const DEFAULT_WRITE_OPTIONS: &WriteOptions = &WriteOptions::default();
+pub const DEFAULT_DB_OPTIONS: &DbOptions = &DbOptions::default();
 
 #[allow(dead_code)]
 pub const DEFAULT_COMPACTOR_OPTIONS: &CompactorOptions = &CompactorOptions::default();
@@ -73,9 +74,9 @@ pub struct DbOptions {
     /// bytes to object storage.
     pub flush_ms: usize,
 
-    /// How frequently to poll for new manifest files (in milliseconds). Refreshing
-    /// the manifest file allows writers to detect fencing operations and allows
-    /// readers to detect newly compacted data.
+    /// How frequently to poll for new manifest files. Refreshing the manifest file 
+    /// allows writers to detect fencing operations and allows readers to detect newly
+    /// compacted data.
     ///
     /// **NOTE: SlateDB secondary readers (i.e. non-writer clients) do not currently
     /// read from the WAL. Such readers only read from L0+. The manifest poll intervals
@@ -117,6 +118,18 @@ pub struct DbOptions {
 
     /// Configuration options for the compactor.
     pub compactor_options: Option<CompactorOptions>,
+}
+
+impl DbOptions {
+    pub const fn default() -> Self {
+        Self {
+            flush_ms: 100,
+            manifest_poll_interval: Duration::from_millis(100),
+            min_filter_keys: 1000,
+            l0_sst_size_bytes: 128,
+            compactor_options: None,
+        }
+    }
 }
 
 /// Options for the compactor.

--- a/src/db.rs
+++ b/src/db.rs
@@ -215,6 +215,13 @@ pub struct Db {
 impl Db {
     pub async fn open(
         path: Path,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Result<Self, SlateDBError> {
+        Self::open_with_opts(path, DbOptions::default(), object_store).await
+    }
+
+    pub async fn open_with_opts(
+        path: Path,
         options: DbOptions,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Self, SlateDBError> {
@@ -380,7 +387,7 @@ mod tests {
     #[tokio::test]
     async fn test_put_get_delete() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             Path::from("/tmp/test_kv_store"),
             test_db_options(0, 1024, None),
             object_store,
@@ -405,7 +412,7 @@ mod tests {
     async fn test_put_flushes_memtable() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 128, None),
             object_store.clone(),
@@ -464,7 +471,7 @@ mod tests {
     #[tokio::test]
     async fn test_put_empty_value() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             Path::from("/tmp/test_kv_store"),
             test_db_options(0, 1024, None),
             object_store,
@@ -485,7 +492,7 @@ mod tests {
     #[tokio::test]
     async fn test_flush_while_iterating() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             Path::from("/tmp/test_kv_store"),
             test_db_options(0, 1024, None),
             object_store,
@@ -518,7 +525,7 @@ mod tests {
     async fn test_basic_restore() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 128, None),
             object_store.clone(),
@@ -547,7 +554,7 @@ mod tests {
         kv_store.close().await.unwrap();
 
         // recover and validate that sst files are loaded on recovery.
-        let kv_store_restored = Db::open(
+        let kv_store_restored = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 128, None),
             object_store.clone(),
@@ -578,7 +585,7 @@ mod tests {
         let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 1024, None),
             object_store.clone(),
@@ -615,7 +622,7 @@ mod tests {
         let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 1024, None),
             object_store.clone(),
@@ -655,7 +662,7 @@ mod tests {
         let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let kv_store = Db::open(
+        let kv_store = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 1024, None),
             object_store.clone(),
@@ -718,7 +725,7 @@ mod tests {
         db.close().await.unwrap();
 
         // reload the db
-        let db = Db::open(
+        let db = Db::open_with_opts(
             path.clone(),
             test_db_options(0, 128, None),
             object_store.clone(),
@@ -748,7 +755,7 @@ mod tests {
     async fn do_test_should_read_compacted_db(options: DbOptions) {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let db = Db::open(path.clone(), options, object_store.clone())
+        let db = Db::open_with_opts(path.clone(), options, object_store.clone())
             .await
             .unwrap();
         let ms = ManifestStore::new(&path, object_store.clone());


### PR DESCRIPTION
### Changes 
- Addresses #113 
- Created new method `Db::open_with_opts` to simplify `Db::open`. 


Chosen default 
```rust
{
    flush_ms: 100,
    manifest_poll_interval: Duration::from_secs(1),
    min_filter_keys: 1000,
    l0_sst_size_bytes: 128,
    compactor_options: Some(CompactorOptions::default()),
}
```