### PR TITLE
Link to docs.rs and embed readme in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then you can use SlateDB in your Rust code:
 ```rust
 use bytes::Bytes;
 use object_store::{ObjectStore, memory::InMemory, path::Path};
-use slatedb::db:Db;
+use slatedb::db::Db;
 use slatedb::config::{CompactorOptions, DbOptions};
 use std::{sync::Arc, time::Duration};
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ![GitHub License](https://img.shields.io/github/license/slatedb/slatedb?style=flat-square)
 <a href="https://slatedb.io">![slatedb.io](https://img.shields.io/badge/site-slatedb.io-00A1FF?style=flat-square)</a>
 <a href="https://discord.gg/mHYmGy5MgA">![Discord](https://img.shields.io/discord/1232385660460204122?style=flat-square)</a>
+<a href="https://docs.rs/slatedb/latest/slatedb/">![Docs](https://img.shields.io/badge/docs-docs.rs-00A1FF?style=flat-square)</a>
 
 ## Introduction
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 #![warn(clippy::unwrap_used)]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 #![warn(clippy::panic)]


### PR DESCRIPTION
This embeds the readme in the module docstring, so that it appears on docs.rs. Here's what it looks like:

![image](https://github.com/user-attachments/assets/67d7876c-6104-4759-a39e-ac3024a66e16)

It also adds a badge to the readme linking to the docs.