### PR TITLE
Close compactor executor on shutdown

### DIFF
--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -151,8 +151,10 @@ impl CompactorOrchestrator {
                     }
                 }
                 recv(self.external_rx) -> _ => {
+                    // Stop the executor. Don't return because there might
+                    // still be messages in `worker_rx`. Let the loop continue
+                    // to drain them until empty.
                     self.executor.stop();
-                    return;
                 }
             }
         }

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -135,7 +135,10 @@ impl CompactorOrchestrator {
 
     fn run(&mut self) {
         let ticker = crossbeam_channel::tick(self.options.poll_interval);
-        loop {
+
+        // Stop the loop when the executor is shut down *and* all remaining
+        // `worker_rx` messages have been drained.
+        while !(self.executor.is_stopped() && self.worker_rx.is_empty()) {
             crossbeam_channel::select! {
                 recv(ticker) -> _ => {
                     self.load_manifest().expect("fatal error loading manifest");

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -148,6 +148,7 @@ impl CompactorOrchestrator {
                     }
                 }
                 recv(self.external_rx) -> _ => {
+                    self.executor.stop();
                     return;
                 }
             }

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -26,6 +26,7 @@ pub(crate) struct CompactionJob {
 pub(crate) trait CompactionExecutor {
     fn start_compaction(&self, compaction: CompactionJob);
     fn stop(&self);
+    fn is_stopped(&self) -> bool;
 }
 
 pub(crate) struct TokioCompactionExecutor {
@@ -59,6 +60,10 @@ impl CompactionExecutor for TokioCompactionExecutor {
 
     fn stop(&self) {
         self.inner.stop()
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.inner.is_stopped()
     }
 }
 
@@ -165,5 +170,9 @@ impl TokioCompactionExecutorInner {
         });
 
         self.is_stopped.store(true, atomic::Ordering::SeqCst);
+    }
+
+    fn is_stopped(&self) -> bool {
+        self.is_stopped.load(atomic::Ordering::SeqCst)
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -313,7 +313,6 @@ impl Db {
 
         // Tell the notifier thread to shut down.
         self.flush_notifier.send(()).ok();
-        self.inner.memtable_flush_notifier.send(Shutdown).ok();
 
         if let Some(flush_task) = {
             // Scope the flush_thread lock so its lock isn't held while awaiting the join
@@ -324,6 +323,9 @@ impl Db {
         } {
             flush_task.await.expect("Failed to join flush thread");
         }
+
+        // Tell the memtable flush thread to shut down.
+        self.inner.memtable_flush_notifier.send(Shutdown).ok();
 
         if let Some(memtable_flush_task) = {
             let mut memtable_flush_task = self.memtable_flush_task.lock();


### PR DESCRIPTION
The compactor orchestrator was not shutting down the compactor executor when it
received a shutdown message. Instead, it was immediately returning. This
results in spurious error messages when the compactor executor continues trying
to complete compaction jobs after the channel is closed.

I've added code to shutdown the executor and drain the remaining compaction
messages before halting the orchestrator.