### PR TITLE
Skip manifest reload when compactor and memtable flusher are closed

### DIFF
--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -141,7 +141,9 @@ impl CompactorOrchestrator {
         while !(self.executor.is_stopped() && self.worker_rx.is_empty()) {
             crossbeam_channel::select! {
                 recv(ticker) -> _ => {
-                    self.load_manifest().expect("fatal error loading manifest");
+                    if !self.executor.is_stopped() {
+                        self.load_manifest().expect("fatal error loading manifest");
+                    }
                 }
                 recv(self.worker_rx) -> msg => {
                     let WorkerToOrchestoratorMsg::CompactionFinished(result) = msg.expect("fatal error receiving worker msg");


### PR DESCRIPTION
Per #133 discussion, I'm adding closing logic for `load_manifest` calls in the memtable and compactor loops. Previously, ticks that occur in these loops after stopping were still run. Now, the ticks are ignored. There wasn't anything terrible about that, but it could trigger commpactions or flushes after shutdown, which isn't ideal.