### PR TITLE
move sst index into its own data block

### DIFF
--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -13,10 +13,11 @@ table SsTableInfo {
     // First key in the SST file.
     first_key: [ubyte];
 
-    // TODO: we should move this index out into its own object
-    //       https://github.com/slatedb/slatedb/issues/88
-    // Sequence of block metadata. SST files could have multiple blocks.
-    block_meta: [BlockMeta] (required);
+    // Offset of the index block.
+    index_offset: ulong;
+
+    // Length of the index block.
+    index_len: ulong;
 
     // Offset of the bloom filter.
     filter_offset: ulong;
@@ -31,4 +32,8 @@ table BlockMeta {
 
     // First key contained in the block.
     first_key: [ubyte] (required);
+}
+
+table SsTableIndex {
+    block_meta: [BlockMeta] (required);
 }

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -308,7 +308,9 @@ mod tests {
         let compacted = &db_state.compacted.first().unwrap().ssts;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
-        let mut iter = SstIterator::new(handle, table_store.clone(), 1, 1);
+        let mut iter = SstIterator::new(handle, table_store.clone(), 1, 1)
+            .await
+            .unwrap();
         for i in 0..4 {
             let kv = iter.next().await.unwrap().unwrap();
             assert_eq!(kv.key.as_ref(), &[b'a' + i as u8; 16]);

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -231,9 +231,8 @@ impl DbState {
 #[cfg(test)]
 mod tests {
     use crate::db_state::{CoreDbState, DbState, SSTableHandle, SsTableId};
-    use crate::flatbuffer_types::{BlockMeta, SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
+    use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
     use bytes::Bytes;
-    use flatbuffers::ForwardsUOffset;
     use ulid::Ulid;
 
     #[test]
@@ -295,12 +294,12 @@ mod tests {
 
     fn create_sst_info() -> SsTableInfoOwned {
         let mut builder = flatbuffers::FlatBufferBuilder::new();
-        let block_meta_wip = builder.create_vector::<ForwardsUOffset<BlockMeta>>(&[]);
         let wip = SsTableInfo::create(
             &mut builder,
             &SsTableInfoArgs {
                 first_key: None,
-                block_meta: Some(block_meta_wip),
+                index_offset: 0,
+                index_len: 0,
                 filter_offset: 0,
                 filter_len: 0,
             },

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -1,5 +1,6 @@
 use crate::db_state::SSTableHandle;
 use crate::error::SlateDBError;
+use crate::flatbuffer_types::{SsTableIndex, SsTableIndexOwned};
 use crate::{
     block::Block, block_iterator::BlockIterator, iter::KeyValueIterator, tablestore::TableStore,
     types::KeyValueDeletable,
@@ -16,6 +17,7 @@ enum FetchTask {
 
 pub(crate) struct SstIterator<'a> {
     table: &'a SSTableHandle,
+    index: Arc<SsTableIndexOwned>,
     current_iter: Option<BlockIterator<Block>>,
     from_key: Option<&'a [u8]>,
     next_block_idx_to_fetch: usize,
@@ -26,17 +28,16 @@ pub(crate) struct SstIterator<'a> {
 }
 
 impl<'a> SstIterator<'a> {
-    fn first_block_with_data_including_or_after_key(sst: &SSTableHandle, key: &[u8]) -> usize {
-        let handle = sst.info.borrow();
+    fn first_block_with_data_including_or_after_key(index: &SsTableIndex, key: &[u8]) -> usize {
         // search for the block that could contain the key.
         let mut low = 0;
-        let mut high = handle.block_meta().len() - 1;
+        let mut high = index.block_meta().len() - 1;
         // if the key is less than all the blocks' first key, scan the whole sst
         let mut found_block_id = 0;
 
         while low <= high {
             let mid = low + (high - low) / 2;
-            let mid_block_first_key = handle.block_meta().get(mid).first_key().bytes();
+            let mid_block_first_key = index.block_meta().get(mid).first_key().bytes();
             match mid_block_first_key.cmp(key) {
                 std::cmp::Ordering::Less => {
                     low = mid + 1;
@@ -55,13 +56,13 @@ impl<'a> SstIterator<'a> {
         found_block_id
     }
 
-    pub(crate) fn new_from_key(
+    pub(crate) async fn new_from_key(
         table: &'a SSTableHandle,
         table_store: Arc<TableStore>,
         from_key: &'a [u8],
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
-    ) -> Self {
+    ) -> Result<Self, SlateDBError> {
         Self::new_opts(
             table,
             Some(from_key),
@@ -70,14 +71,15 @@ impl<'a> SstIterator<'a> {
             blocks_to_fetch,
             false,
         )
+        .await
     }
 
-    pub(crate) fn new_spawn(
+    pub(crate) async fn new_spawn(
         table: &'a SSTableHandle,
         table_store: Arc<TableStore>,
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
-    ) -> Self {
+    ) -> Result<Self, SlateDBError> {
         Self::new_opts(
             table,
             None,
@@ -86,14 +88,15 @@ impl<'a> SstIterator<'a> {
             blocks_to_fetch,
             true,
         )
+        .await
     }
 
-    pub(crate) fn new(
+    pub(crate) async fn new(
         table: &'a SSTableHandle,
         table_store: Arc<TableStore>,
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
-    ) -> Self {
+    ) -> Result<Self, SlateDBError> {
         Self::new_opts(
             table,
             None,
@@ -102,23 +105,26 @@ impl<'a> SstIterator<'a> {
             blocks_to_fetch,
             false,
         )
+        .await
     }
 
-    pub(crate) fn new_opts(
+    pub(crate) async fn new_opts(
         table: &'a SSTableHandle,
         from_key: Option<&'a [u8]>,
         table_store: Arc<TableStore>,
         max_fetch_tasks: usize,
         blocks_to_fetch: usize,
         spawn: bool,
-    ) -> Self {
+    ) -> Result<Self, SlateDBError> {
         assert!(max_fetch_tasks > 0);
         assert!(blocks_to_fetch > 0);
+        let index = Arc::new(table_store.read_index(table).await?);
         let next_block_idx_to_fetch = from_key
-            .map(|k| Self::first_block_with_data_including_or_after_key(table, k))
+            .map(|k| Self::first_block_with_data_including_or_after_key(&index.borrow(), k))
             .unwrap_or(0);
         let mut iter = Self {
             table,
+            index,
             current_iter: None,
             next_block_idx_to_fetch,
             from_key,
@@ -130,11 +136,11 @@ impl<'a> SstIterator<'a> {
         if spawn {
             iter.spawn_fetches();
         }
-        iter
+        Ok(iter)
     }
 
     fn spawn_fetches(&mut self) {
-        let num_blocks = self.table.info.borrow().block_meta().len();
+        let num_blocks = self.index.borrow().block_meta().len();
         while self.fetch_tasks.len() < self.max_fetch_tasks
             && self.next_block_idx_to_fetch < num_blocks
         {
@@ -146,10 +152,11 @@ impl<'a> SstIterator<'a> {
             let table_store = self.table_store.clone();
             let blocks_start = self.next_block_idx_to_fetch;
             let blocks_end = self.next_block_idx_to_fetch + blocks_to_fetch;
+            let index = self.index.clone();
             self.fetch_tasks
                 .push_back(FetchTask::InFlight(tokio::spawn(async move {
                     table_store
-                        .read_blocks(&table, blocks_start..blocks_end)
+                        .read_blocks_using_index(&table, index, blocks_start..blocks_end)
                         .await
                 })));
             self.next_block_idx_to_fetch = blocks_end;
@@ -181,7 +188,7 @@ impl<'a> SstIterator<'a> {
                 assert!(self.fetch_tasks.is_empty());
                 assert_eq!(
                     self.next_block_idx_to_fetch,
-                    self.table.info.borrow().block_meta().len()
+                    self.index.borrow().block_meta().len()
                 );
                 return Ok(None);
             }
@@ -241,9 +248,12 @@ mod tests {
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
-        assert_eq!(sst_handle.info.borrow().block_meta().len(), 1);
+        let index = table_store.read_index(&sst_handle).await.unwrap();
+        assert_eq!(index.borrow().block_meta().len(), 1);
 
-        let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 1, 1);
+        let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 1, 1)
+            .await
+            .unwrap();
         let kv = iter.next().await.unwrap().unwrap();
         assert_eq!(kv.key, b"key1".as_slice());
         assert_eq!(kv.value, b"value1".as_slice());
@@ -283,9 +293,12 @@ mod tests {
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
-        assert_eq!(sst_handle.info.borrow().block_meta().len(), 6);
+        let index = table_store.read_index(&sst_handle).await.unwrap();
+        assert_eq!(index.borrow().block_meta().len(), 6);
 
-        let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 3, 3);
+        let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 3, 3)
+            .await
+            .unwrap();
         for i in 0..1000 {
             let kv = iter.next().await.unwrap().unwrap();
             assert_eq!(kv.key, format!("key{}", i));
@@ -317,7 +330,9 @@ mod tests {
             let from_key = test_case_key_gen.next();
             let _ = test_case_val_gen.next();
             let mut iter =
-                SstIterator::new_from_key(&sst, table_store.clone(), from_key.as_ref(), 1, 1);
+                SstIterator::new_from_key(&sst, table_store.clone(), from_key.as_ref(), 1, 1)
+                    .await
+                    .unwrap();
             for _ in 0..nkeys - i {
                 let e = iter.next().await.unwrap().unwrap();
                 assert_kv(
@@ -344,7 +359,9 @@ mod tests {
         let mut expected_val_gen = val_gen.clone();
         let (sst, nkeys) = build_sst_with_n_blocks(2, table_store.clone(), key_gen, val_gen).await;
 
-        let mut iter = SstIterator::new_from_key(&sst, table_store.clone(), &[b'a'; 16], 1, 1);
+        let mut iter = SstIterator::new_from_key(&sst, table_store.clone(), &[b'a'; 16], 1, 1)
+            .await
+            .unwrap();
 
         for _ in 0..nkeys {
             let e = iter.next().await.unwrap().unwrap();
@@ -369,7 +386,9 @@ mod tests {
         let val_gen = OrderedBytesGenerator::new_with_byte_range(&first_val, 1u8, 26u8);
         let (sst, _) = build_sst_with_n_blocks(2, table_store.clone(), key_gen, val_gen).await;
 
-        let mut iter = SstIterator::new_from_key(&sst, table_store.clone(), &[b'z'; 16], 1, 1);
+        let mut iter = SstIterator::new_from_key(&sst, table_store.clone(), &[b'z'; 16], 1, 1)
+            .await
+            .unwrap();
 
         assert!(iter.next().await.unwrap().is_none());
     }

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -3,6 +3,7 @@ use crate::block::Block;
 use crate::db_state::{SSTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::filter::BloomFilter;
+use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::sst::{EncodedSsTable, EncodedSsTableBuilder, SsTableFormat};
 use bytes::{BufMut, Bytes};
 use fail_parallel::{fail_point, FailPointRegistry};
@@ -217,6 +218,19 @@ impl TableStore {
         Ok(filter)
     }
 
+    pub(crate) async fn read_index(
+        &self,
+        handle: &SSTableHandle,
+    ) -> Result<SsTableIndexOwned, SlateDBError> {
+        let path = self.path(&handle.id);
+        let obj = ReadOnlyObject {
+            object_store: self.object_store.clone(),
+            path,
+        };
+        self.sst_format.read_index(&handle.info, &obj).await
+    }
+
+    #[allow(dead_code)]
     pub(crate) async fn read_blocks(
         &self,
         handle: &SSTableHandle,
@@ -227,8 +241,26 @@ impl TableStore {
             object_store: self.object_store.clone(),
             path,
         };
+        let index = self.sst_format.read_index(&handle.info, &obj).await?;
         self.sst_format
-            .read_blocks(&handle.info, blocks, &obj)
+            .read_blocks(&handle.info, &index, blocks, &obj)
+            .await
+    }
+
+    // TODO: we probably won't need this once we're caching the index
+    pub(crate) async fn read_blocks_using_index(
+        &self,
+        handle: &SSTableHandle,
+        index: Arc<SsTableIndexOwned>,
+        blocks: Range<usize>,
+    ) -> Result<VecDeque<Block>, SlateDBError> {
+        let path = self.path(&handle.id);
+        let obj = ReadOnlyObject {
+            object_store: self.object_store.clone(),
+            path,
+        };
+        self.sst_format
+            .read_blocks(&handle.info, index.as_ref(), blocks, &obj)
             .await
     }
 
@@ -243,7 +275,10 @@ impl TableStore {
             object_store: self.object_store.clone(),
             path,
         };
-        self.sst_format.read_block(&handle.info, block, &obj).await
+        let index = self.sst_format.read_index(&handle.info, &obj).await?;
+        self.sst_format
+            .read_block(&handle.info, &index, block, &obj)
+            .await
     }
 
     fn path(&self, id: &SsTableId) -> Path {
@@ -350,7 +385,7 @@ mod tests {
         let sst = writer.close().await.unwrap();
 
         // then:
-        let mut iter = SstIterator::new(&sst, ts.clone(), 1, 1);
+        let mut iter = SstIterator::new(&sst, ts.clone(), 1, 1).await.unwrap();
         assert_iterator(
             &mut iter,
             &[


### PR DESCRIPTION
This patch moves the sst index out of the sst info footer and into its own data block that sits just before the footer. The index can grow quite large, and therefore we don't want to require that it be stored in memory, or put it in the manifest. Instead, this patch changes the read path to load the index by reading it from the sst when its needed.