### PR TITLE
Change flush_ms to flush_interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async fn main() {
     // Setup
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let options = DbOptions {
-        flush_ms: 100,
+        flush_interval: Duration::from_millis(100),
         manifest_poll_interval: Duration::from_millis(100),
         min_filter_keys: 10,
         l0_sst_size_bytes: 128,

--- a/docs/0001-manifest.md
+++ b/docs/0001-manifest.md
@@ -69,7 +69,7 @@ SlateDB doesn't have compaction implemented at the moment. We don't have level-1
 
 ### Writes
 
-A `put()` is performed by inserting the key-value pair into `memtable`. Once `flush_ms` (a configuration value) has expired, a flusher thread (in `flush.rs`) locks `DbState` and performs the following operations:
+A `put()` is performed by inserting the key-value pair into `memtable`. Once `flush_interval` (a configuration value) has expired, a flusher thread (in `flush.rs`) locks `DbState` and performs the following operations:
 
 1. Replace `memtable` with a new (empty) MemTable.
 2. Insert the old `memtable` into index 0 of `imm_memtables`.
@@ -341,11 +341,11 @@ Whether this is reasonable or not depends on how frequently manifests are update
 
 SlateDB's WAL is a sequentially ordered contiguous list of SSTs. SST object names are formatted as 20 digit zero-padded numbers to fit u64's maximum integer and to support lexicographical sorting. Each SST contains zero or more sorted key-value pairs. The WAL is used to store writes that have not yet been compacted.
 
-Traditionally, LSMs store WAL data in a different format from the SSTs; this is because each `put()` call results in a single key-value write to the WAL. But SlateDB doesn't write to the WAL on each `put()`. Instead, `put()`'s are batched together based on `flush_ms`, `flush_bytes` ([#30](https://github.com/slatedb/slatedb/issues/30)), or `skip_memtable_bytes` ([#31](https://github.com/slatedb/slatedb/issues/31)). Based on these configurations, multiple key-value pairs are stored in the WAL in a single write. Thus, SlateDB uses SSTs for both the WAL and compacted files.
+Traditionally, LSMs store WAL data in a different format from the SSTs; this is because each `put()` call results in a single key-value write to the WAL. But SlateDB doesn't write to the WAL on each `put()`. Instead, `put()`'s are batched together based on `flush_interval`, `flush_bytes` ([#30](https://github.com/slatedb/slatedb/issues/30)), or `skip_memtable_bytes` ([#31](https://github.com/slatedb/slatedb/issues/31)). Based on these configurations, multiple key-value pairs are stored in the WAL in a single write. Thus, SlateDB uses SSTs for both the WAL and compacted files.
 
 _NOTE: We discussed using a different format for the WAL [here](https://github.com/slatedb/slatedb/pull/39/files#r1590087062), but decided against it._
 
-This design does not use [prefixes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html). AWS allows, "3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per partitioned Amazon S3 prefix." This limits a single writer to 3,500 writes and 5,500 reads per-second. With a `flush_ms` set to 1, a client would write 1,000 writes per-second (not including compactions). Wth caching, the client should be far below the 5,500 reads per-second limit.
+This design does not use [prefixes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html). AWS allows, "3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per partitioned Amazon S3 prefix." This limits a single writer to 3,500 writes and 5,500 reads per-second. With a `flush_interval` set to 1ms, a client would write 1,000 writes per-second (not including compactions). Wth caching, the client should be far below the 5,500 reads per-second limit.
 
 This design also does not expose writer epochs in WAL SST filenames (e.g. `[writer_epoch].[sequence_number].sst`). We discussed this in detail [here](https://github.com/slatedb/slatedb/pull/39/files#r1588892292) and [here](https://github.com/slatedb/slatedb/pull/24/files#r1585569744). Ultimately, we chose "un-namespaced" filenames (i.e. filenames without epoch prefix) because it's simpler to reason about.
 

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -435,7 +435,7 @@ mod tests {
 
     fn db_options(compactor_options: Option<CompactorOptions>) -> DbOptions {
         DbOptions {
-            flush_ms: 100,
+            flush_interval: Duration::from_millis(100),
             manifest_poll_interval: Duration::from_millis(100),
             min_filter_keys: 0,
             l0_sst_size_bytes: 128,

--- a/src/config.rs
+++ b/src/config.rs
@@ -56,8 +56,7 @@ impl WriteOptions {
 /// Configuration options for the database. These options are set on client startup.
 #[derive(Clone)]
 pub struct DbOptions {
-    /// How frequently to flush the write-ahead log to object storage (in
-    /// milliseconds).
+    /// How frequently to flush the write-ahead log to object storage.
     ///
     /// When setting this configuration, users must consider:
     ///
@@ -74,7 +73,7 @@ pub struct DbOptions {
     /// Keep in mind that the flush interval does not include the network latency. A
     /// 100ms flush interval will result in a 100ms + the time it takes to send the
     /// bytes to object storage.
-    pub flush_ms: usize,
+    pub flush_interval: Duration,
 
     /// How frequently to poll for new manifest files. Refreshing the manifest file
     /// allows writers to detect fencing operations and allows readers to detect newly
@@ -92,8 +91,8 @@ pub struct DbOptions {
 
     /// The minimum size a memtable needs to be before it is frozen and flushed to
     /// L0 object storage. Writes will still be flushed to the object storage WAL
-    /// (based on flush_ms) regardless of this value. Memtable sizes are checked
-    /// every `flush_ms` milliseconds.
+    /// (based on flush_interval) regardless of this value. Memtable sizes are checked
+    /// every `flush_interval`.
     ///
     /// When setting this configuration, users must consider:
     ///
@@ -126,7 +125,7 @@ pub struct DbOptions {
 impl DbOptions {
     pub const fn default() -> Self {
         Self {
-            flush_ms: 100,
+            flush_interval: Duration::from_millis(100),
             manifest_poll_interval: Duration::from_secs(1),
             min_filter_keys: 1000,
             l0_sst_size_bytes: 128,

--- a/src/db.rs
+++ b/src/db.rs
@@ -873,7 +873,7 @@ mod tests {
         compactor_options: Option<CompactorOptions>,
     ) -> DbOptions {
         DbOptions {
-            flush_ms: 100,
+            flush_interval: Duration::from_millis(100),
             manifest_poll_interval: Duration::from_millis(100),
             min_filter_keys,
             l0_sst_size_bytes,

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -6,7 +6,6 @@ use crate::iter::KeyValueIterator;
 use crate::mem_table::{ImmutableWal, KVTable, WritableKVTable};
 use crate::types::ValueDeletable;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::select;
 
@@ -83,7 +82,7 @@ impl DbInner {
         let this = Arc::clone(self);
         Some(tokio_handle.spawn(async move {
             let mut ticker =
-                tokio::time::interval(Duration::from_millis(this.options.flush_ms as u64));
+                tokio::time::interval(this.options.flush_interval);
             loop {
                 select! {
                   // Tick to freeze and flush the memtable

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -81,8 +81,7 @@ impl DbInner {
     ) -> Option<tokio::task::JoinHandle<()>> {
         let this = Arc::clone(self);
         Some(tokio_handle.spawn(async move {
-            let mut ticker =
-                tokio::time::interval(this.options.flush_interval);
+            let mut ticker = tokio::time::interval(this.options.flush_interval);
             loop {
                 select! {
                   // Tick to freeze and flush the memtable


### PR DESCRIPTION
Given we already use `Duration` for other interval fields, this one looked out of place. 
Change `flush_ms` to `flush_interval` to make it uniform. 