### PR TITLE
Implement metrics for `Db`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +123,12 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytemuck"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 
 [[package]]
 name = "bytes"
@@ -1268,6 +1283,8 @@ version = "0.1.4"
 dependencies = [
  "async-channel",
  "async-trait",
+ "atomic",
+ "bytemuck",
  "bytes",
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 [dependencies]
 async-channel = "2.3.1"
 async-trait = "0.1.81"
+atomic = "0.6.0"
+bytemuck = "1.17.0"
 bytes = "1.6.0"
 crc32fast = "1.4.0"
 crossbeam-channel = "0.5.13"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::compactor::Compactor;
 use crate::config::ReadLevel::Uncommitted;
 use crate::config::{
@@ -11,6 +9,7 @@ use crate::iter::KeyValueIterator;
 use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
 use crate::mem_table_flush::MemtableFlushThreadMsg;
 use crate::mem_table_flush::MemtableFlushThreadMsg::Shutdown;
+use crate::metrics::DbStats;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst::SsTableFormat;
 use crate::sst_iter::SstIterator;
@@ -21,6 +20,7 @@ use fail_parallel::FailPointRegistry;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use parking_lot::{Mutex, RwLock};
+use std::sync::Arc;
 use tokio::runtime::Handle;
 
 pub(crate) struct DbInner {
@@ -28,6 +28,7 @@ pub(crate) struct DbInner {
     pub(crate) options: DbOptions,
     pub(crate) table_store: Arc<TableStore>,
     pub(crate) memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<MemtableFlushThreadMsg>,
+    pub(crate) db_stats: Arc<DbStats>,
 }
 
 impl DbInner {
@@ -43,6 +44,7 @@ impl DbInner {
             options,
             table_store,
             memtable_flush_notifier,
+            db_stats: Arc::new(DbStats::new()),
         };
         db_inner.replay_wal().await?;
         Ok(db_inner)
@@ -309,6 +311,7 @@ impl Db {
                     table_store.clone(),
                     compactor_options.clone(),
                     Handle::current(),
+                    inner.db_stats.clone(),
                 )
                 .await?,
             )
@@ -411,6 +414,10 @@ impl Db {
 
     pub async fn flush(&self) -> Result<(), SlateDBError> {
         self.inner.flush().await
+    }
+
+    pub fn metrics(&self) -> Arc<DbStats> {
+        self.inner.db_stats.clone()
     }
 }
 
@@ -604,6 +611,7 @@ mod tests {
             let kv = iter.next().await.unwrap();
             assert!(kv.is_none());
         }
+        assert!(kv_store.metrics().immutable_memtable_flushes.get() > 0);
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ mod manifest_store;
 mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
+mod metrics;
 mod size_tiered_compaction;
 mod sorted_run_iterator;
 mod sst;

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -102,7 +102,7 @@ impl DbInner {
                             },
                             MemtableFlushThreadMsg::FlushImmutableMemtables => {
                                 match flusher.flush_imm_memtables_to_l0().await {
-                                    Ok(_) => {}
+                                    Ok(_) => { this.db_stats.immutable_memtable_flushes.inc(); }
                                     Err(err) => print!("error from memtable flush: {}", err),
                                 }
                             }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,97 @@
+use atomic::{Atomic, Ordering};
+use bytemuck::NoUninit;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct Counter {
+    pub value: Arc<Atomic<u64>>,
+}
+
+impl Counter {
+    pub fn get(&self) -> u64 {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    pub fn inc(&self) -> u64 {
+        self.value.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl Default for Counter {
+    fn default() -> Self {
+        Self {
+            value: Arc::new(Atomic::<u64>::default()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Gauge<T> {
+    value: Arc<Atomic<T>>,
+}
+
+impl<T: NoUninit> Gauge<T> {
+    pub fn get(&self) -> T {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    pub fn set(&self, value: T) -> T {
+        self.value.swap(value, Ordering::Relaxed)
+    }
+}
+
+impl<T: Default> Default for Gauge<T> {
+    fn default() -> Self {
+        Self {
+            value: Arc::new(Atomic::<T>::default()),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DbStats {
+    pub immutable_memtable_flushes: Counter,
+    pub last_compaction_ts: Gauge<u64>,
+}
+
+impl DbStats {
+    pub(crate) fn new() -> Self {
+        Self {
+            immutable_memtable_flushes: Counter::default(),
+            last_compaction_ts: Gauge::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_counter() {
+        let counter = Counter::default();
+        counter.inc();
+        assert_eq!(counter.get(), 1);
+        counter.inc();
+        assert_eq!(counter.get(), 2);
+    }
+
+    #[test]
+    fn test_gauge() {
+        let gauge = Gauge::default();
+        gauge.set(42);
+        assert_eq!(gauge.get(), 42);
+        gauge.set(24);
+        assert_eq!(gauge.get(), 24);
+    }
+
+    #[test]
+    fn test_gauge_bool() {
+        let gauge = Gauge::<bool>::default();
+        assert_eq!(gauge.get(), bool::default());
+        gauge.set(true);
+        assert!(gauge.get());
+        gauge.set(false);
+        assert!(!gauge.get());
+    }
+}


### PR DESCRIPTION
Lay out the backbone of `DbStats`, which provides counters and gauges.