### PR TITLE
Support changing the compression codec on an initialized db

### DIFF
--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -8,6 +8,14 @@ table CompactedSsTable {
     info: SsTableInfo;
 }
 
+enum CompressionFormat: byte {
+    None,
+    Snappy,
+    Zlib,
+    Lz4,
+    Zstd
+}
+
 // Has metadata about a SST file.
 table SsTableInfo {
     // First key in the SST file.
@@ -24,6 +32,9 @@ table SsTableInfo {
 
     // Length of bloom filter. Length will be zero if filter is not present.
     filter_len: ulong;
+
+    // type of compression algorithm used.
+    compression_format: CompressionFormat;
 }
 
 table BlockMeta {

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -33,7 +33,7 @@ table SsTableInfo {
     // Length of bloom filter. Length will be zero if filter is not present.
     filter_len: ulong;
 
-    // type of compression algorithm used.
+    // Type of compression algorithm used.
     compression_format: CompressionFormat;
 }
 

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -302,7 +302,7 @@ mod tests {
                 index_len: 0,
                 filter_offset: 0,
                 filter_len: 0,
-                compression_format: None.into()
+                compression_format: None.into(),
             },
         );
         builder.finish(wip, None);

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -302,6 +302,7 @@ mod tests {
                 index_len: 0,
                 filter_offset: 0,
                 filter_len: 0,
+                compression_format: None.into()
             },
         );
         builder.finish(wip, None);

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -9,16 +9,19 @@ use ulid::Ulid;
 #[allow(warnings)]
 #[rustfmt::skip]
 mod manifest_generated;
+use crate::config::CompressionCodec;
 use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::Compacted;
 use crate::error::SlateDBError;
-use crate::flatbuffer_types::manifest_generated::{CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat, SortedRun, SortedRunArgs};
+use crate::flatbuffer_types::manifest_generated::{
+    CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat,
+    SortedRun, SortedRunArgs,
+};
 use crate::manifest::{Manifest, ManifestCodec};
 pub use manifest_generated::{
     BlockMeta, BlockMetaArgs, ManifestV1, ManifestV1Args, SsTableIndex, SsTableIndexArgs,
     SsTableInfo, SsTableInfoArgs,
 };
-use crate::config::CompressionCodec;
 
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct SsTableInfoOwned {
@@ -159,7 +162,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 index_len: info.index_len(),
                 filter_offset: info.filter_offset(),
                 filter_len: info.filter_len(),
-                compression_format: info.compression_format()
+                compression_format: info.compression_format(),
             },
         )
     }
@@ -262,9 +265,9 @@ impl<'b> DbFlatBufferBuilder<'b> {
     }
 }
 
-impl Into<CompressionFormat> for Option<CompressionCodec> {
-    fn into(self) -> CompressionFormat {
-        match self {
+impl From<Option<CompressionCodec>> for CompressionFormat {
+    fn from(value: Option<CompressionCodec>) -> Self {
+        match value {
             None => CompressionFormat::None,
             Some(codec) => match codec {
                 #[cfg(feature = "snappy")]
@@ -274,25 +277,24 @@ impl Into<CompressionFormat> for Option<CompressionCodec> {
                 #[cfg(feature = "lz4")]
                 CompressionCodec::Zlib => CompressionFormat::Zlib,
                 #[cfg(feature = "zstd")]
-                CompressionCodec::Zstd => CompressionFormat::Zstd
-            }
+                CompressionCodec::Zstd => CompressionFormat::Zstd,
+            },
         }
     }
 }
 
 impl From<CompressionFormat> for Option<CompressionCodec> {
     fn from(value: CompressionFormat) -> Self {
-       match value {
-           #[cfg(feature = "snappy")]
-           CompressionFormat::Snappy => Some(CompressionCodec::Snappy),
-           #[cfg(feature = "zlib")]
-           CompressionFormat::Lz4 => Some(CompressionCodec::Lz4),
-           #[cfg(feature = "lz4")]
-           CompressionFormat::Zlib => Some(CompressionCodec::Zlib),
-           #[cfg(feature = "zstd")]
-           CompressionFormat::Zstd => Some(CompressionCodec::Zstd),
-           _ => None
-       }
-
+        match value {
+            #[cfg(feature = "snappy")]
+            CompressionFormat::Snappy => Some(CompressionCodec::Snappy),
+            #[cfg(feature = "zlib")]
+            CompressionFormat::Lz4 => Some(CompressionCodec::Lz4),
+            #[cfg(feature = "lz4")]
+            CompressionFormat::Zlib => Some(CompressionCodec::Zlib),
+            #[cfg(feature = "zstd")]
+            CompressionFormat::Zstd => Some(CompressionCodec::Zstd),
+            _ => None,
+        }
     }
 }

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -12,15 +12,13 @@ mod manifest_generated;
 use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::Compacted;
 use crate::error::SlateDBError;
-use crate::flatbuffer_types::manifest_generated::{
-    CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, SortedRun,
-    SortedRunArgs,
-};
+use crate::flatbuffer_types::manifest_generated::{CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat, SortedRun, SortedRunArgs};
 use crate::manifest::{Manifest, ManifestCodec};
 pub use manifest_generated::{
     BlockMeta, BlockMetaArgs, ManifestV1, ManifestV1Args, SsTableIndex, SsTableIndexArgs,
     SsTableInfo, SsTableInfoArgs,
 };
+use crate::config::CompressionCodec;
 
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct SsTableInfoOwned {
@@ -161,6 +159,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 index_len: info.index_len(),
                 filter_offset: info.filter_offset(),
                 filter_len: info.filter_len(),
+                compression_format: info.compression_format()
             },
         )
     }
@@ -260,5 +259,40 @@ impl<'b> DbFlatBufferBuilder<'b> {
         let copy = self.add_sst_info_copy(sst_info);
         self.builder.finish(copy, None);
         Bytes::copy_from_slice(self.builder.finished_data())
+    }
+}
+
+impl Into<CompressionFormat> for Option<CompressionCodec> {
+    fn into(self) -> CompressionFormat {
+        match self {
+            None => CompressionFormat::None,
+            Some(codec) => match codec {
+                #[cfg(feature = "snappy")]
+                CompressionCodec::Snappy => CompressionFormat::Snappy,
+                #[cfg(feature = "zlib")]
+                CompressionCodec::Lz4 => CompressionFormat::Lz4,
+                #[cfg(feature = "lz4")]
+                CompressionCodec::Zlib => CompressionFormat::Zlib,
+                #[cfg(feature = "zstd")]
+                CompressionCodec::Zstd => CompressionFormat::Zstd
+            }
+        }
+    }
+}
+
+impl From<CompressionFormat> for Option<CompressionCodec> {
+    fn from(value: CompressionFormat) -> Self {
+       match value {
+           #[cfg(feature = "snappy")]
+           CompressionFormat::Snappy => Some(CompressionCodec::Snappy),
+           #[cfg(feature = "zlib")]
+           CompressionFormat::Lz4 => Some(CompressionCodec::Lz4),
+           #[cfg(feature = "lz4")]
+           CompressionFormat::Zlib => Some(CompressionCodec::Zlib),
+           #[cfg(feature = "zstd")]
+           CompressionFormat::Zstd => Some(CompressionCodec::Zstd),
+           _ => None
+       }
+
     }
 }

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -272,9 +272,9 @@ impl From<Option<CompressionCodec>> for CompressionFormat {
             Some(codec) => match codec {
                 #[cfg(feature = "snappy")]
                 CompressionCodec::Snappy => CompressionFormat::Snappy,
-                #[cfg(feature = "zlib")]
-                CompressionCodec::Lz4 => CompressionFormat::Lz4,
                 #[cfg(feature = "lz4")]
+                CompressionCodec::Lz4 => CompressionFormat::Lz4,
+                #[cfg(feature = "zlib")]
                 CompressionCodec::Zlib => CompressionFormat::Zlib,
                 #[cfg(feature = "zstd")]
                 CompressionCodec::Zstd => CompressionFormat::Zstd,
@@ -288,9 +288,9 @@ impl From<CompressionFormat> for Option<CompressionCodec> {
         match value {
             #[cfg(feature = "snappy")]
             CompressionFormat::Snappy => Some(CompressionCodec::Snappy),
-            #[cfg(feature = "zlib")]
-            CompressionFormat::Lz4 => Some(CompressionCodec::Lz4),
             #[cfg(feature = "lz4")]
+            CompressionFormat::Lz4 => Some(CompressionCodec::Lz4),
+            #[cfg(feature = "zlib")]
             CompressionFormat::Zlib => Some(CompressionCodec::Zlib),
             #[cfg(feature = "zstd")]
             CompressionFormat::Zstd => Some(CompressionCodec::Zstd),

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -99,7 +99,11 @@ impl SsTableFormat {
         self.decode_index(index_bytes, compression_codec.into())
     }
 
-    fn decode_index(&self, index_bytes: Bytes, compression_codec: Option<CompressionCodec>) -> Result<SsTableIndexOwned, SlateDBError> {
+    fn decode_index(
+        &self,
+        index_bytes: Bytes,
+        compression_codec: Option<CompressionCodec>,
+    ) -> Result<SsTableIndexOwned, SlateDBError> {
         let index_bytes = match compression_codec {
             Some(c) => Self::decompress(index_bytes, c)?,
             None => index_bytes,
@@ -456,7 +460,7 @@ impl<'a> EncodedSsTableBuilder<'a> {
                 index_len: index_len as u64,
                 filter_offset: filter_offset as u64,
                 filter_len: filter_len as u64,
-                compression_format: self.compression_codec.into()
+                compression_format: self.compression_codec.into(),
             },
         );
 


### PR DESCRIPTION
Based on ##141

Storing the Compression Codec in sst-info file for every SST created in db. Using sst-info to decompress the SST block. 