### PR TITLE
implement compaction policy with backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ async fn main() {
         #[cfg(feature = "wal_disable")] wal_enabled: true,
         min_filter_keys: 10,
         l0_sst_size_bytes: 128,
+        l0_max_ssts: 8,
+        max_unflushed_memtable: 2,
         compactor_options: Some(CompactorOptions::default()),
         compression_codec: None,
     };

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -6,18 +6,18 @@ use crate::db_state::{SSTableHandle, SortedRun};
 use crate::error::SlateDBError;
 use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
 use crate::metrics::DbStats;
-use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
 use crate::tablestore::TableStore;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::thread;
 use std::thread::JoinHandle;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Handle;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use ulid::Ulid;
 
-pub(crate) trait CompactionScheduler {
+pub trait CompactionScheduler {
     fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction>;
 }
 
@@ -131,9 +131,8 @@ impl CompactorOrchestrator {
         Ok(orchestrator)
     }
 
-    fn load_compaction_scheduler(_options: &CompactorOptions) -> Box<dyn CompactionScheduler> {
-        // todo: return the right type based on the configured scheduler
-        Box::new(SizeTieredCompactionScheduler {})
+    fn load_compaction_scheduler(options: &CompactorOptions) -> Box<dyn CompactionScheduler> {
+        options.compaction_scheduler.compaction_scheduler()
     }
 
     fn load_state(stored_manifest: &FenceableManifest) -> Result<CompactorState, SlateDBError> {
@@ -143,11 +142,15 @@ impl CompactorOrchestrator {
 
     fn run(&mut self) {
         let ticker = crossbeam_channel::tick(self.options.poll_interval);
+        let db_runs_log_ticker = crossbeam_channel::tick(Duration::from_secs(10));
 
         // Stop the loop when the executor is shut down *and* all remaining
         // `worker_rx` messages have been drained.
         while !(self.executor.is_stopped() && self.worker_rx.is_empty()) {
             crossbeam_channel::select! {
+                recv(db_runs_log_ticker) -> _ => {
+                    self.log_compaction_state();
+                }
                 recv(ticker) -> _ => {
                     if !self.executor.is_stopped() {
                         self.load_manifest().expect("fatal error loading manifest");
@@ -188,7 +191,7 @@ impl CompactorOrchestrator {
             match self.write_manifest() {
                 Ok(_) => return Ok(()),
                 Err(SlateDBError::ManifestVersionExists) => {
-                    print!("conflicting manifest version. retry write");
+                    warn!("conflicting manifest version. retry write");
                 }
                 Err(err) => return Err(err),
             }
@@ -198,12 +201,22 @@ impl CompactorOrchestrator {
     fn maybe_schedule_compactions(&mut self) -> Result<(), SlateDBError> {
         let compactions = self.scheduler.maybe_schedule_compaction(&self.state);
         for compaction in compactions.iter() {
+            if self.state.num_compactions() >= self.options.max_concurrent_compactions {
+                println!(
+                    "already running {} compactions, which is at the max {}. Won't run compaction {:?}",
+                    self.state.num_compactions(),
+                    self.options.max_concurrent_compactions,
+                    compaction
+                );
+                break;
+            }
             self.submit_compaction(compaction.clone())?;
         }
         Ok(())
     }
 
     fn start_compaction(&mut self, compaction: Compaction) {
+        self.log_compaction_state();
         let db_state = self.state.db_state();
         let compacted_sst_iter = db_state.compacted.iter().flat_map(|sr| sr.ssts.iter());
         let ssts_by_id: HashMap<Ulid, &SSTableHandle> = db_state
@@ -237,6 +250,7 @@ impl CompactorOrchestrator {
 
     fn finish_compaction(&mut self, output_sr: SortedRun) -> Result<(), SlateDBError> {
         self.state.finish_compaction(output_sr);
+        self.log_compaction_state();
         self.write_manifest_safely()?;
         self.maybe_schedule_compactions()?;
         self.db_stats.last_compaction_ts.set(
@@ -263,16 +277,25 @@ impl CompactorOrchestrator {
         self.maybe_schedule_compactions()?;
         Ok(())
     }
+
+    fn log_compaction_state(&self) {
+        self.state.db_state().log_db_runs();
+        let compactions = self.state.compactions();
+        for compaction in compactions.iter() {
+            info!("in-flight compaction: {}", compaction);
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::compactor::{CompactorOptions, CompactorOrchestrator, WorkerToOrchestratorMsg};
     use crate::compactor_state::{Compaction, SourceId};
-    use crate::config::DbOptions;
+    use crate::config::{DbOptions, SizeTieredCompactionSchedulerOptions};
     use crate::db::Db;
     use crate::iter::KeyValueIterator;
     use crate::manifest_store::{ManifestStore, StoredManifest};
+    use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
     use crate::sst::SsTableFormat;
     use crate::sst_iter::SstIterator;
     use crate::tablestore::TableStore;
@@ -286,15 +309,11 @@ mod tests {
     use ulid::Ulid;
 
     const PATH: &str = "/test/db";
-    const COMPACTOR_OPTIONS: CompactorOptions = CompactorOptions {
-        poll_interval: Duration::from_millis(100),
-        max_sst_size: 1024 * 1024 * 1024,
-    };
 
     #[tokio::test]
     async fn test_compactor_compacts_l0() {
         // given:
-        let options = db_options(Some(COMPACTOR_OPTIONS.clone()));
+        let options = db_options(Some(compactor_options()));
         let (_, manifest_store, table_store, db) = build_test_db(options).await;
         for i in 0..4 {
             db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]).await;
@@ -354,7 +373,7 @@ mod tests {
         rt.block_on(db.close()).unwrap();
         let (_, external_rx) = crossbeam_channel::unbounded();
         let mut orchestrator = CompactorOrchestrator::new(
-            COMPACTOR_OPTIONS.clone(),
+            compactor_options(),
             manifest_store.clone(),
             table_store.clone(),
             rt.handle().clone(),
@@ -458,8 +477,21 @@ mod tests {
             manifest_poll_interval: Duration::from_millis(100),
             min_filter_keys: 0,
             l0_sst_size_bytes: 128,
+            max_unflushed_memtable: 2,
+            l0_max_ssts: 8,
             compactor_options,
             compression_codec: None,
+        }
+    }
+
+    fn compactor_options() -> CompactorOptions {
+        CompactorOptions {
+            poll_interval: Duration::from_millis(100),
+            max_sst_size: 1024 * 1024 * 1024,
+            compaction_scheduler: Arc::new(SizeTieredCompactionSchedulerSupplier::new(
+                SizeTieredCompactionSchedulerOptions::default(),
+            )),
+            max_concurrent_compactions: 1,
         }
     }
 }

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -96,7 +96,7 @@ impl TokioCompactionExecutorInner {
         let l0_merge_iter = MergeIterator::new(l0_iters).await?;
         let mut sr_iters = VecDeque::new();
         for sr in compaction.sorted_runs.iter() {
-            let iter = SortedRunIterator::new_spawn(sr, self.table_store.clone(), 4, 256).await?;
+            let iter = SortedRunIterator::new_spawn(sr, self.table_store.clone(), 16, 256).await?;
             sr_iters.push_back(iter);
         }
         let sr_merge_iter = MergeIterator::new(sr_iters).await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,12 @@
+use crate::compactor::CompactionScheduler;
+use std::sync::Arc;
 use std::{str::FromStr, time::Duration};
 
 use crate::error::SlateDBError;
+use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
 
 pub const DEFAULT_READ_OPTIONS: &ReadOptions = &ReadOptions::default();
 pub const DEFAULT_WRITE_OPTIONS: &WriteOptions = &WriteOptions::default();
-pub const DEFAULT_DB_OPTIONS: &DbOptions = &DbOptions::default();
-
-#[allow(dead_code)]
-pub const DEFAULT_COMPACTOR_OPTIONS: &CompactorOptions = &CompactorOptions::default();
 
 /// Whether reads see only writes that have been committed durably to the DB.  A
 /// write is considered durably committed if all future calls to read are guaranteed
@@ -44,13 +43,15 @@ impl ReadOptions {
 pub struct WriteOptions {
     /// Whether `put` calls should block until the write has been durably committed
     /// to the DB.
-    pub await_flush: bool,
+    pub await_durable: bool,
 }
 
 impl WriteOptions {
-    /// Create a new `WriteOptions`` with `await_flush` set to `true`.
+    /// Create a new `WriteOptions`` with `await_durable` set to `true`.
     const fn default() -> Self {
-        Self { await_flush: true }
+        Self {
+            await_durable: true,
+        }
     }
 }
 
@@ -122,13 +123,21 @@ pub struct DbOptions {
     ///   secondary readers to see new data.
     pub l0_sst_size_bytes: usize,
 
+    /// Defines the max number of SSTs in l0. Memtables will not be flushed if there are more
+    /// l0 ssts than this value, until compaction can compact the ssts into compacted.
+    pub l0_max_ssts: usize,
+
+    /// Defines the max number of unflushed memtables. Writes will be paused if there
+    /// are more unflushed memtables than this value
+    pub max_unflushed_memtable: usize,
+
     /// Configuration options for the compactor.
     pub compactor_options: Option<CompactorOptions>,
     pub compression_codec: Option<CompressionCodec>,
 }
 
-impl DbOptions {
-    pub const fn default() -> Self {
+impl Default for DbOptions {
+    fn default() -> Self {
         Self {
             flush_interval: Duration::from_millis(100),
             #[cfg(feature = "wal_disable")]
@@ -136,23 +145,12 @@ impl DbOptions {
             manifest_poll_interval: Duration::from_secs(1),
             min_filter_keys: 1000,
             l0_sst_size_bytes: 128,
+            max_unflushed_memtable: 2,
+            l0_max_ssts: 8,
             compactor_options: Some(CompactorOptions::default()),
             compression_codec: None,
         }
     }
-}
-
-/// Options for the compactor.
-#[derive(Clone)]
-pub struct CompactorOptions {
-    /// The interval at which the compactor checks for a new manifest and decides
-    /// if a compaction must be scheduled
-    pub(crate) poll_interval: Duration,
-
-    /// A compacted SSTable's maximum size (in bytes). If more data needs to be
-    /// written to a Sorted Run during a compaction, a new SSTable will be created
-    /// in the Sorted Run when this size is exceeded.
-    pub(crate) max_sst_size: usize,
 }
 
 /// The compression algorithm to use for SSTables.
@@ -190,15 +188,67 @@ impl FromStr for CompressionCodec {
     }
 }
 
+pub trait CompactionSchedulerSupplier: Send + Sync {
+    fn compaction_scheduler(&self) -> Box<dyn CompactionScheduler>;
+}
+
+/// Options for the compactor.
+#[derive(Clone)]
+pub struct CompactorOptions {
+    /// The interval at which the compactor checks for a new manifest and decides
+    /// if a compaction must be scheduled
+    pub poll_interval: Duration,
+
+    /// A compacted SSTable's maximum size (in bytes). If more data needs to be
+    /// written to a Sorted Run during a compaction, a new SSTable will be created
+    /// in the Sorted Run when this size is exceeded.
+    pub max_sst_size: usize,
+
+    /// Supplies the compaction scheduler to use to select the compactions that should be
+    /// scheduled. Currently, the only provided implementation is
+    /// SizeTieredCompactionSchedulerSupplier
+    pub compaction_scheduler: Arc<dyn CompactionSchedulerSupplier>,
+
+    /// The maximum number of concurrent compactions to execute at once
+    pub max_concurrent_compactions: usize,
+}
+
 /// Default options for the compactor. Currently, only a
 /// `SizeTieredCompactionScheduler` compaction strategy is implemented.
-impl CompactorOptions {
+impl Default for CompactorOptions {
     /// Returns a `CompactorOptions` with a 5 second poll interval and a 1GB max
     /// SSTable size.
-    pub const fn default() -> Self {
+    fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(5),
             max_sst_size: 1024 * 1024 * 1024,
+            compaction_scheduler: Arc::new(SizeTieredCompactionSchedulerSupplier::new(
+                SizeTieredCompactionSchedulerOptions::default(),
+            )),
+            max_concurrent_compactions: 4,
+        }
+    }
+}
+
+#[derive(Clone)]
+/// Options for the Size-Tiered Compaction Scheduler
+pub struct SizeTieredCompactionSchedulerOptions {
+    /// The minimum number of sources to include together in a single compaction step.
+    pub min_compaction_sources: usize,
+    /// The maximum number of sources to include together in a single compaction step.
+    pub max_compaction_sources: usize,
+    /// The size threshold that the scheduler will use to determine if a sorted run should
+    /// be included in a given compaction. A sorted run S will be added to a compaction C if S's
+    /// size is less than this value times the min size of the runs currently included in C.
+    pub include_size_threshold: f32,
+}
+
+impl SizeTieredCompactionSchedulerOptions {
+    pub const fn default() -> Self {
+        Self {
+            min_compaction_sources: 4,
+            max_compaction_sources: 8,
+            include_size_threshold: 4.0,
         }
     }
 }

--- a/src/db_bench/args.rs
+++ b/src/db_bench/args.rs
@@ -48,7 +48,7 @@ pub(crate) struct WriteArgs {
     #[arg(long)]
     key_len: usize,
     #[arg(long, default_value_t = false)]
-    await_flush: bool,
+    await_durable: bool,
     #[arg(long)]
     pub(crate) write_rate: Option<u32>,
     #[arg(long, default_value_t = 4)]
@@ -72,7 +72,7 @@ impl WriteArgs {
 
     pub(crate) fn write_options(&self) -> WriteOptions {
         WriteOptions {
-            await_flush: self.await_flush,
+            await_durable: self.await_durable,
         }
     }
 }

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -14,7 +14,7 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id);
         self.memtable_flush_notifier
-            .send(FlushImmutableMemtables)
+            .send(FlushImmutableMemtables(None))
             .expect("failed to send memtable flush msg");
     }
 }

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -2,6 +2,7 @@ use crate::flatbuffer_types::SsTableInfoOwned;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 use std::collections::VecDeque;
 use std::sync::Arc;
+use tracing::info;
 use ulid::Ulid;
 use SsTableId::Compacted;
 
@@ -22,6 +23,15 @@ impl SSTableHandle {
         }
         false
     }
+
+    pub(crate) fn estimate_size(&self) -> u64 {
+        let info = self.info.borrow();
+        // this is a hacky estimate of the sst size since we don't have it stored anywhere
+        // right now. Just use the index's offset and add the index length. Since the index
+        // is the last thing we put in the SST before the info footer, this should be a good
+        // estimate for now.
+        info.index_offset() + info.index_len()
+    }
 }
 
 #[derive(Clone, PartialEq, Debug, Hash, Eq)]
@@ -41,12 +51,16 @@ impl SsTableId {
 }
 
 #[derive(Clone, PartialEq)]
-pub(crate) struct SortedRun {
+pub struct SortedRun {
     pub(crate) id: u32,
     pub(crate) ssts: Vec<SSTableHandle>,
 }
 
 impl SortedRun {
+    pub(crate) fn estimate_size(&self) -> u64 {
+        self.ssts.iter().map(|sst| sst.estimate_size()).sum()
+    }
+
     pub(crate) fn find_sst_with_range_covering_key_idx(&self, key: &[u8]) -> Option<usize> {
         // returns the sst after the one whose range includes the key
         let first_sst = self.ssts.partition_point(|sst| {
@@ -85,7 +99,7 @@ pub(crate) struct COWDbState {
 }
 // represents the core db state that we persist in the manifest
 #[derive(Clone, PartialEq)]
-pub(crate) struct CoreDbState {
+pub struct CoreDbState {
     pub(crate) l0_last_compacted: Option<Ulid>,
     pub(crate) l0: VecDeque<SSTableHandle>,
     pub(crate) compacted: Vec<SortedRun>,
@@ -102,6 +116,20 @@ impl CoreDbState {
             next_wal_sst_id: 1,
             last_compacted_wal_sst_id: 0,
         }
+    }
+
+    pub(crate) fn log_db_runs(&self) {
+        let l0s: Vec<_> = self.l0.iter().map(|l0| l0.estimate_size()).collect();
+        let compacted: Vec<_> = self
+            .compacted
+            .iter()
+            .map(|sr| (sr.id, sr.estimate_size()))
+            .collect();
+        info!("DB Levels:");
+        info!("-----------------");
+        info!("{:?}", l0s);
+        info!("{:?}", compacted);
+        info!("-----------------");
     }
 }
 

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -69,7 +69,7 @@ impl DbInner {
             // flush to the memtable before notifying so that data is available for reads
             self.flush_imm_wal_to_memtable(wguard.memtable(), imm.table());
             self.maybe_freeze_memtable(&mut wguard, imm.id());
-            imm.table().notify_flush();
+            imm.table().notify_durable();
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
 mod metrics;
-mod size_tiered_compaction;
+pub mod size_tiered_compaction;
 mod sorted_run_iterator;
 mod sst;
 mod sst_iter;

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -1,23 +1,688 @@
 use crate::compactor::CompactionScheduler;
-use crate::compactor_state::SourceId::Sst;
 use crate::compactor_state::{Compaction, CompactorState, SourceId};
+use crate::config::{CompactionSchedulerSupplier, SizeTieredCompactionSchedulerOptions};
+use crate::db_state::CoreDbState;
+use std::cmp::min;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::iter::Peekable;
+use std::slice::Iter;
 
-pub(crate) struct SizeTieredCompactionScheduler {}
+const MAX_IN_FLIGHT_COMPACTIONS: usize = 4;
+
+#[derive(Clone)]
+struct CompactionSource {
+    source: SourceId,
+    size: u64,
+}
+
+/// Checks a candidate compaction to make sure that it does not conflict
+/// with any other ongoing compactions. A compaction conflict if it uses a
+/// source (SST or SR) that is already in use by a running compaction.
+pub(crate) struct ConflictChecker {
+    sources_used: HashSet<SourceId>,
+}
+
+impl ConflictChecker {
+    fn new(compactions: &[Compaction]) -> Self {
+        let mut checker = Self {
+            sources_used: HashSet::new(),
+        };
+        for compaction in compactions.iter() {
+            checker.add_compaction(compaction);
+        }
+        checker
+    }
+
+    fn check_compaction(&self, sources: &VecDeque<CompactionSource>, dst: u32) -> bool {
+        for source in sources.iter() {
+            if self.sources_used.contains(&source.source) {
+                return false;
+            }
+        }
+        let dst = SourceId::SortedRun(dst);
+        if self.sources_used.contains(&dst) {
+            return false;
+        }
+        true
+    }
+
+    fn add_compaction(&mut self, compaction: &Compaction) {
+        for source in compaction.sources.iter() {
+            self.sources_used.insert(source.clone());
+        }
+        self.sources_used
+            .insert(SourceId::SortedRun(compaction.destination));
+    }
+}
+
+/// Checks a candidate compaction to ensure that the db is not compacting smaller
+/// ssts too quickly. First, the checker estimates the size of the output of a candidate compaction.
+/// Then, it sees whether there are already lots of sorted runs that are sized similarly to the
+/// output of the candidate compaction. If there are, then it rejects the compaction. To estimate
+/// the size of the output, the checker simply sums up the sizes of the sources. To look for
+/// similarly sized runs, the db uses the same include_size_threshold as the compaction scheduler.
+/// It rejects a compaction if there are more than max_compaction_sources that are <= output
+/// size * include_size_threshold.
+struct BackpressureChecker {
+    include_size_threshold: f32,
+    max_compaction_sources: usize,
+    longest_compactable_runs_by_sr: HashMap<u32, VecDeque<CompactionSource>>,
+}
+
+impl BackpressureChecker {
+    fn new(
+        include_size_threshold: f32,
+        max_compaction_sources: usize,
+        srs: &[CompactionSource],
+    ) -> Self {
+        let mut longest_compactable_runs_by_sr = HashMap::new();
+        let mut srs_iter = srs.iter().peekable();
+        while let Some(sr) = srs_iter.peek() {
+            let sr = sr.source.unwrap_sorted_run();
+            let compactable_run = SizeTieredCompactionScheduler::build_compactable_run(
+                include_size_threshold,
+                srs_iter.clone(),
+                None,
+            );
+            longest_compactable_runs_by_sr.insert(sr, compactable_run);
+            srs_iter.next();
+        }
+        Self {
+            include_size_threshold,
+            max_compaction_sources,
+            longest_compactable_runs_by_sr,
+        }
+    }
+
+    fn check_compaction(
+        &self,
+        sources: &VecDeque<CompactionSource>,
+        next_sr: Option<&CompactionSource>,
+    ) -> bool {
+        // checks that we are not creating a run that itself needs to be compacted
+        // with lots of runs. If we are, we should wait till those runs are compacted
+        let estimated_result_size: u64 = sources.iter().map(|src| src.size).sum();
+        if let Some(next_sr) = next_sr {
+            let estimated_result_sz = estimated_result_size;
+            if next_sr.size <= ((estimated_result_sz as f32) * self.include_size_threshold) as u64 {
+                // the result of this compaction can be compacted with the next sr. Check to see
+                // if there's already a max sized list of compactable runs there
+                if self
+                    .longest_compactable_runs_by_sr
+                    .get(&next_sr.source.unwrap_sorted_run())
+                    .map(|r| r.len())
+                    .unwrap_or(0)
+                    >= self.max_compaction_sources
+                {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+struct CompactionChecker {
+    conflict_checker: ConflictChecker,
+    backpressure_checker: BackpressureChecker,
+}
+
+impl CompactionChecker {
+    fn new(conflict_checker: ConflictChecker, backpressure_checker: BackpressureChecker) -> Self {
+        Self {
+            conflict_checker,
+            backpressure_checker,
+        }
+    }
+
+    fn check_compaction(
+        &self,
+        sources: &VecDeque<CompactionSource>,
+        dst: u32,
+        next_sr: Option<&CompactionSource>,
+    ) -> bool {
+        if !self.conflict_checker.check_compaction(sources, dst) {
+            return false;
+        }
+        if !self.backpressure_checker.check_compaction(sources, next_sr) {
+            return false;
+        }
+        true
+    }
+}
+
+/// Implements a size-tiered compaction scheduler. The scheduler works by scheduling compaction for
+/// one of:
+/// - options.min_compaction_sources L0 SSTs
+/// - A series of at least options.min_compaction_sources sorted runs where the size of the largest
+///   run <= options.include_size_threshold * size of the smallest run.
+///
+/// The scheduler ensures that a compaction has at most options.max_compaction_sources. The scheduler
+/// rejects compactions that violate one of the compaction checkers defined above.
+pub(crate) struct SizeTieredCompactionScheduler {
+    options: SizeTieredCompactionSchedulerOptions,
+}
 
 impl CompactionScheduler for SizeTieredCompactionScheduler {
     fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction> {
-        let db_state = state.db_state();
-        // for now, just compact l0 down to a new sorted run each time
         let mut compactions = Vec::new();
-        if db_state.l0.len() >= 4 {
-            let next_sr = db_state.compacted.first().map_or(0, |r| r.id + 1);
-            let sources: Vec<SourceId> = db_state
+
+        let (l0, srs) = self.compaction_sources(state.db_state());
+
+        let conflict_checker = ConflictChecker::new(&state.compactions());
+        let backpressure_checker = BackpressureChecker::new(
+            self.options.include_size_threshold,
+            self.options.max_compaction_sources,
+            &srs,
+        );
+        let mut checker = CompactionChecker::new(conflict_checker, backpressure_checker);
+
+        while state.compactions().len() + compactions.len() < MAX_IN_FLIGHT_COMPACTIONS {
+            let Some(compaction) = self.pick_next_compaction(&l0, &srs, &checker) else {
+                break;
+            };
+            checker.conflict_checker.add_compaction(&compaction);
+            compactions.push(compaction);
+        }
+
+        compactions
+    }
+}
+
+impl SizeTieredCompactionScheduler {
+    pub(crate) fn new(options: SizeTieredCompactionSchedulerOptions) -> Self {
+        Self { options }
+    }
+
+    fn pick_next_compaction(
+        &self,
+        l0: &[CompactionSource],
+        srs: &[CompactionSource],
+        checker: &CompactionChecker,
+    ) -> Option<Compaction> {
+        // compact l0s if required
+        let l0_candidates: VecDeque<_> = l0.iter().cloned().collect();
+        if let Some(mut l0_candidates) = self.clamp_min(l0_candidates) {
+            l0_candidates = self.clamp_max(l0_candidates);
+            let dst = srs
+                .first()
+                .map_or(0, |sr| sr.source.unwrap_sorted_run() + 1);
+            let next_sr = srs.first();
+            if checker.check_compaction(&l0_candidates, dst, next_sr) {
+                return Some(self.create_compaction(l0_candidates, dst));
+            }
+        }
+
+        // try to compact the lower levels
+        let mut srs_iter = srs.iter().peekable();
+        while srs_iter.peek().is_some() {
+            let compactable_run = Self::build_compactable_run(
+                self.options.include_size_threshold,
+                srs_iter.clone(),
+                Some(checker),
+            );
+            let compactable_run = self.clamp_min(compactable_run);
+            if let Some(mut compactable_run) = compactable_run {
+                compactable_run = self.clamp_max(compactable_run);
+                let dst = compactable_run
+                    .back()
+                    .expect("expected non-empty compactable run")
+                    .source
+                    .unwrap_sorted_run();
+                return Some(self.create_compaction(compactable_run, dst));
+            }
+            srs_iter.next();
+        }
+        None
+    }
+
+    fn clamp_min(&self, sources: VecDeque<CompactionSource>) -> Option<VecDeque<CompactionSource>> {
+        if sources.len() < self.options.min_compaction_sources {
+            return None;
+        }
+        Some(sources)
+    }
+
+    fn clamp_max(&self, mut sources: VecDeque<CompactionSource>) -> VecDeque<CompactionSource> {
+        while sources.len() > self.options.max_compaction_sources {
+            sources.pop_front();
+        }
+        sources
+    }
+
+    fn create_compaction(&self, sources: VecDeque<CompactionSource>, dst: u32) -> Compaction {
+        let sources: Vec<SourceId> = sources.iter().map(|src| src.source.clone()).collect();
+        Compaction::new(sources, dst)
+    }
+
+    // looks for a series of sorted runs with similar sizes and assemble to a vecdequeue,
+    // optionally validating the resulting series
+    fn build_compactable_run(
+        size_threshold: f32,
+        mut sources: Peekable<Iter<CompactionSource>>,
+        checker: Option<&CompactionChecker>,
+    ) -> VecDeque<CompactionSource> {
+        let mut compactable_runs = VecDeque::new();
+        let mut maybe_min_sz = None;
+        while let Some(src) = sources.next() {
+            if let Some(min_sz) = maybe_min_sz {
+                if src.size > ((min_sz as f32) * size_threshold) as u64 {
+                    break;
+                }
+                maybe_min_sz = Some(min(min_sz, src.size));
+            } else {
+                maybe_min_sz = Some(src.size);
+            }
+            compactable_runs.push_back(src.clone());
+            if let Some(checker) = checker {
+                let dst = src.source.unwrap_sorted_run();
+                let next_sr = sources.peek().cloned().cloned();
+                if !checker.check_compaction(&compactable_runs, dst, next_sr.as_ref()) {
+                    compactable_runs.pop_back();
+                    break;
+                }
+            }
+        }
+        compactable_runs
+    }
+
+    fn compaction_sources(
+        &self,
+        db_state: &CoreDbState,
+    ) -> (Vec<CompactionSource>, Vec<CompactionSource>) {
+        (
+            db_state
                 .l0
                 .iter()
-                .map(|h| Sst(h.id.unwrap_compacted_id()))
-                .collect();
-            compactions.push(Compaction::new(sources, next_sr));
+                .map(|l0| CompactionSource {
+                    source: SourceId::Sst(l0.id.unwrap_compacted_id()),
+                    size: l0.estimate_size(),
+                })
+                .collect(),
+            db_state
+                .compacted
+                .iter()
+                .map(|sr| CompactionSource {
+                    source: SourceId::SortedRun(sr.id),
+                    size: sr.estimate_size(),
+                })
+                .collect(),
+        )
+    }
+}
+
+pub struct SizeTieredCompactionSchedulerSupplier {
+    options: SizeTieredCompactionSchedulerOptions,
+}
+
+impl SizeTieredCompactionSchedulerSupplier {
+    pub const fn new(options: SizeTieredCompactionSchedulerOptions) -> Self {
+        Self { options }
+    }
+}
+
+impl CompactionSchedulerSupplier for SizeTieredCompactionSchedulerSupplier {
+    fn compaction_scheduler(&self) -> Box<dyn CompactionScheduler> {
+        Box::new(SizeTieredCompactionScheduler::new(self.options.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::compactor::CompactionScheduler;
+    use crate::compactor_state::{Compaction, CompactorState, SourceId};
+    use crate::config::SizeTieredCompactionSchedulerOptions;
+    use crate::db_state::{CoreDbState, SSTableHandle, SortedRun, SsTableId};
+    use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
+    use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
+    use bytes::Bytes;
+    use std::collections::VecDeque;
+
+    #[test]
+    fn test_should_compact_l0s_to_first_sr() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let l0 = vec![create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let state =
+            create_compactor_state(create_db_state(l0.iter().cloned().collect(), Vec::new()));
+
+        // when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 1);
+        let compaction = compactions.first().unwrap();
+        let expected_sources: Vec<SourceId> = l0
+            .iter()
+            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+            .collect();
+        assert_eq!(compaction.sources, expected_sources);
+        assert_eq!(compaction.destination, 0);
+    }
+
+    #[test]
+    fn test_should_compact_l0s_to_new_sr() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let l0 = vec![create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let state = create_compactor_state(create_db_state(
+            l0.iter().cloned().collect(),
+            vec![create_sr2(10, 2), create_sr2(0, 2)],
+        ));
+
+        // when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 1);
+        let compaction = compactions.first().unwrap();
+        assert_eq!(compaction.destination, 11);
+    }
+
+    #[test]
+    fn test_should_not_compact_l0s_if_fewer_than_min_threshold() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let l0 = [create_sst(1), create_sst(1), create_sst(1)];
+        let state = create_compactor_state(create_db_state(l0.iter().cloned().collect(), vec![]));
+
+        // when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 0);
+    }
+
+    #[test]
+    fn test_should_compact_srs_if_enough_with_similar_size() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let state = create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![
+                create_sr2(4, 2),
+                create_sr2(3, 2),
+                create_sr2(2, 2),
+                create_sr2(1, 2),
+                create_sr2(0, 2),
+            ],
+        ));
+
+        // when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 1);
+        let compaction = compactions.first().unwrap();
+        assert_eq!(
+            compaction.clone(),
+            create_sr_compaction(vec![4, 3, 2, 1, 0])
+        )
+    }
+
+    #[test]
+    fn test_should_only_include_srs_if_with_similar_size() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let state = create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![
+                create_sr2(4, 2),
+                create_sr2(3, 2),
+                create_sr2(2, 2),
+                create_sr2(1, 2),
+                create_sr2(0, 10),
+            ],
+        ));
+
+        // when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 1);
+        let compaction = compactions.first().unwrap();
+        assert_eq!(compaction.clone(), create_sr_compaction(vec![4, 3, 2, 1]))
+    }
+
+    #[test]
+    fn test_should_not_schedule_compaction_for_source_that_is_already_compacting() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let mut state = create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![
+                create_sr2(4, 2),
+                create_sr2(3, 2),
+                create_sr2(2, 2),
+                create_sr2(1, 2),
+                create_sr2(0, 2),
+            ],
+        ));
+        state
+            .submit_compaction(create_sr_compaction(vec![3, 2, 1, 0]))
+            .unwrap();
+
+        // when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 0);
+    }
+
+    #[test]
+    fn test_should_not_compact_srs_if_fewer_than_min_threshold() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let state = create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![create_sr2(2, 2), create_sr2(1, 2), create_sr4(0, 2)],
+        ));
+
+        //when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert!(compactions.is_empty());
+    }
+
+    #[test]
+    fn test_should_clamp_compaction_size() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let state = create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![
+                create_sr2(11, 2),
+                create_sr2(10, 2),
+                create_sr2(9, 2),
+                create_sr2(8, 2),
+                create_sr2(7, 2),
+                create_sr2(6, 2),
+                create_sr2(5, 2),
+                create_sr2(4, 2),
+                create_sr2(3, 2),
+                create_sr2(2, 2),
+                create_sr2(1, 2),
+                create_sr4(0, 2),
+            ],
+        ));
+
+        //when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 1);
+        assert_eq!(
+            compactions.first().unwrap(),
+            &create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0])
+        );
+    }
+
+    #[test]
+    fn test_should_apply_backpressure() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let mut state = create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![
+                create_sr2(11, 2),
+                create_sr2(10, 2),
+                create_sr2(9, 2),
+                create_sr2(8, 2),
+                create_sr2(7, 2),
+                create_sr2(6, 2),
+                create_sr2(5, 2),
+                create_sr2(4, 2),
+                create_sr2(3, 2),
+                create_sr2(2, 2),
+                create_sr2(1, 2),
+                create_sr4(0, 2),
+            ],
+        ));
+        state
+            .submit_compaction(create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
+            .unwrap();
+
+        //when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert!(compactions.is_empty());
+    }
+
+    #[test]
+    fn test_should_apply_backpressure_for_l0s() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let l0 = vec![create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let mut state = create_compactor_state(create_db_state(
+            l0.iter().cloned().collect(),
+            vec![
+                create_sr2(7, 2),
+                create_sr2(6, 2),
+                create_sr2(5, 2),
+                create_sr2(4, 2),
+                create_sr2(3, 2),
+                create_sr2(2, 2),
+                create_sr2(1, 2),
+                create_sr4(0, 2),
+            ],
+        ));
+        state
+            .submit_compaction(create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
+            .unwrap();
+
+        //when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert!(compactions.is_empty());
+    }
+
+    #[test]
+    fn test_should_return_multiple_compactions() {
+        // given:
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default());
+        let l0 = vec![create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let state = create_compactor_state(create_db_state(
+            l0.iter().cloned().collect(),
+            vec![
+                create_sr2(10, 2),
+                create_sr2(9, 2),
+                create_sr2(8, 2),
+                create_sr2(7, 2),
+                create_sr4(3, 16),
+                create_sr4(2, 16),
+                create_sr4(1, 16),
+                create_sr4(0, 16),
+            ],
+        ));
+
+        //when:
+        let compactions = scheduler.maybe_schedule_compaction(&state);
+
+        // then:
+        assert_eq!(compactions.len(), 3);
+        let compaction = compactions.first().unwrap();
+        assert_eq!(compaction, &create_l0_compaction(&l0, 11));
+        let compaction = compactions.get(1).unwrap();
+        assert_eq!(compaction, &create_sr_compaction(vec![10, 9, 8, 7]));
+        let compaction = compactions.get(2).unwrap();
+        assert_eq!(compaction, &create_sr_compaction(vec![3, 2, 1, 0]));
+    }
+
+    fn create_sst(size: u64) -> SSTableHandle {
+        let mut builder = flatbuffers::FlatBufferBuilder::new();
+        let wip = SsTableInfo::create(
+            &mut builder,
+            &SsTableInfoArgs {
+                first_key: None,
+                index_offset: size,
+                index_len: 0,
+                filter_offset: 0,
+                filter_len: 0,
+                compression_format: None.into(),
+            },
+        );
+        builder.finish(wip, None);
+        let info = SsTableInfoOwned::new(Bytes::copy_from_slice(builder.finished_data())).unwrap();
+        SSTableHandle {
+            id: SsTableId::Compacted(ulid::Ulid::new()),
+            info,
         }
-        compactions
+    }
+
+    fn create_sr2(id: u32, size: u64) -> SortedRun {
+        create_sr(id, size / 2, 2)
+    }
+
+    fn create_sr4(id: u32, size: u64) -> SortedRun {
+        create_sr(id, size / 4, 4)
+    }
+
+    fn create_sr(id: u32, sst_size: u64, num_ssts: usize) -> SortedRun {
+        let ssts: Vec<SSTableHandle> = (0..num_ssts).map(|_| create_sst(sst_size)).collect();
+        SortedRun { id, ssts }
+    }
+
+    fn create_db_state(l0: VecDeque<SSTableHandle>, srs: Vec<SortedRun>) -> CoreDbState {
+        CoreDbState {
+            l0_last_compacted: None,
+            l0,
+            compacted: srs,
+            next_wal_sst_id: 0,
+            last_compacted_wal_sst_id: 0,
+        }
+    }
+
+    fn create_compactor_state(db_state: CoreDbState) -> CompactorState {
+        CompactorState::new(db_state)
+    }
+
+    fn create_l0_compaction(l0: &[SSTableHandle], dst: u32) -> Compaction {
+        Compaction::new(
+            l0.iter()
+                .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+                .collect(),
+            dst,
+        )
+    }
+
+    fn create_sr_compaction(srs: Vec<u32>) -> Compaction {
+        Compaction::new(
+            srs.iter().map(|sr| SourceId::SortedRun(*sr)).collect(),
+            *srs.last().unwrap(),
+        )
     }
 }


### PR DESCRIPTION
this patch fills in the size-tiered compaction policy and adds a crude backpressure mechanism to throttle writes if they are arriving faster than the db can compact:

Updates SizeTieredCompactionPolicy so that it compacts sorted runs under compacted. The policy works by looking for sequences of runs that are all similarly sized. Similarly sized is determined by an option to the policy called include_size_threshold. A SR is included in a given sequence if it's size is less than include_size_threshold multiplied by the size of the smallest run that is already in the sequence.

The policy eliminates sequences that violate the following constraints:
- conflicts: A compaction is eliminated if it includes a source for which there is already a compaction running.
- backpressure: A compaction is eliminated if it produces a run that is adjacent to lots of other runs that are also of similar size to the produced run (estimated using the sum of the sizes of the runs in the compaction). The threshold for the number of similarly-sized runs is the size of the max compaction (defaults to 8). This way, we won't schedule this compaction until those larger runs are compacted.

This patch also includes a mechanism for applying backpressure to writes. The compaction policy applies backpressure by waiting to compact when there are too many larger runs. The writer then applies backpressure by pausing memtable flushes and writes, based on the following options:
- l0_max_ssts: if there are more l0 SSTs than this value, the writer won't flush immutable memtables.
- max_unflushed_memtable: if there are more immutable memtables than this value, the writer pauses writes until the memtables are flushed.

Currently writes block until the backpressure condition is no longer met. In the future we could opt to instead simply slow down the writes to some rate limit, or return an error and let the client back off.

With this patch, using the db bench tool in #148, I was able to load ~500GB into a database on an m5.xlarge (4 cores, 16GB memory) with 32-byte keys + 256-byte values at a rate of ~70K writes/second. The number of runs in the database was always under 15 runs, so we should be able to get pretty reasonable read performance (I'll measure that next).