### PR TITLE
add db bench tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +45,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -52,7 +116,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -86,7 +150,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -126,24 +190,31 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12916984aab3fa6e39d655a33e09c0071eb36d6ab3aea5c2d78551f1df6d952"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -162,8 +233,54 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "concurrent-queue"
@@ -186,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -266,6 +383,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,12 +455,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -394,7 +534,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -458,9 +598,9 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -486,6 +626,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -632,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "93ead53efc7ea8ed3cfb0c79fc8023fbb782a5432b52830b6518941cebe6505c"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -645,6 +791,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -672,18 +824,29 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.155"
+name = "leaky-bucket"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "0a396bb213c2d09ed6c5495fd082c991b6ab39c9daf4fff59e6727f85c73e4c5"
+dependencies = [
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.158"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "lock_api"
@@ -742,14 +905,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -762,20 +935,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -848,7 +1011,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -874,7 +1037,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -897,9 +1060,12 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -970,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1026,10 +1192,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.5"
+name = "regex"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "reqwest"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64",
  "bytes",
@@ -1067,7 +1262,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -1122,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile",
@@ -1151,9 +1346,9 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1221,31 +1416,32 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1261,6 +1457,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siphasher"
@@ -1286,13 +1488,16 @@ dependencies = [
  "atomic",
  "bytemuck",
  "bytes",
+ "clap",
  "crc32fast",
  "crossbeam-channel",
  "crossbeam-skiplist",
+ "env_logger",
  "fail-parallel",
  "flatbuffers",
  "flate2",
  "futures",
+ "leaky-bucket",
  "log",
  "lz4_flex",
  "object_store",
@@ -1331,7 +1536,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1366,6 +1571,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1398,6 +1609,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "thiserror"
@@ -1416,7 +1630,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1436,30 +1650,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1509,9 +1722,9 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1533,7 +1746,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1617,10 +1830,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
+name = "utf8parse"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1649,34 +1868,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1686,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1696,22 +1916,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
@@ -1728,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1748,11 +1968,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1761,16 +1981,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1779,22 +2020,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1803,21 +2038,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1827,21 +2056,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1857,21 +2074,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1881,21 +2086,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1904,13 +2097,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
+name = "zerocopy"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,15 @@ async-trait = "0.1.81"
 atomic = "0.6.0"
 bytemuck = "1.17.0"
 bytes = "1.6.0"
+clap = { version = "4.5", optional = true, features = ["derive"] }
 crc32fast = "1.4.0"
 crossbeam-channel = "0.5.13"
 crossbeam-skiplist = "0.1.3"
+env_logger = { version = "0.11", optional = true }
 fail-parallel = "0.5.1"
 flatbuffers = "24.3.25"
 futures = "0.3.30"
+leaky-bucket = {  version = "1.1", optional = true }
 object_store = "0.10.2"
 parking_lot = "0.12.1"
 siphasher = "1"
@@ -43,7 +46,7 @@ fail-parallel = { version = "0.5.1", features = ["failpoints"] }
 [features]
 default = ["aws"]
 aws = ["object_store/aws"]
-db_bench = ["aws"]
+db_bench = ["aws", "env_logger", "leaky-bucket", "clap", "clap/derive", "wal_disable"]
 compression = ["snappy"]
 snappy = ["dep:snap"]
 zlib = ["dep:flate2"]
@@ -54,3 +57,9 @@ wal_disable = []
 [[bin]]
 name = "compaction-execute-bench"
 path = "src/compaction_execute_bench/compaction_execute_bench.rs"
+required-features = ["db_bench"]
+
+[[bin]]
+name = "db-bench"
+path = "src/db_bench/main.rs"
+required-features = ["db_bench"]

--- a/src/compaction_execute_bench/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench/compaction_execute_bench.rs
@@ -1,11 +1,6 @@
-#[cfg(feature = "db_bench")]
 use slatedb::compaction_execute_bench::run_compaction_execute_bench;
 
-#[cfg(not(feature = "db_bench"))]
-fn run_compaction_execute_bench() -> Result<(), slatedb::error::SlateDBError> {
-    panic!("db_bench feature not enabled!")
-}
-
 fn main() {
+    env_logger::init();
     run_compaction_execute_bench().unwrap();
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ impl ReadOptions {
 
 /// Configuration for client write operations. `WriteOptions` is supplied for each
 /// write call and controls the behavior of the write.
+#[derive(Clone)]
 pub struct WriteOptions {
     /// Whether `put` calls should block until the write has been durably committed
     /// to the DB.

--- a/src/db_bench/args.rs
+++ b/src/db_bench/args.rs
@@ -1,0 +1,144 @@
+use crate::db_bench::{KeyGenerator, RandomKeyGenerator};
+use clap::builder::PossibleValue;
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use slatedb::config::WriteOptions;
+use std::fmt::{Display, Formatter};
+
+#[derive(Parser, Clone)]
+#[command(version, about, long_about=None)]
+pub(crate) struct DbBenchArgs {
+    #[arg(short, long)]
+    pub(crate) bucket: Option<String>,
+    #[arg(short, long)]
+    pub(crate) region: Option<String>,
+    #[arg(short = 'c', long)]
+    pub(crate) provider: Provider,
+    #[arg(long)]
+    pub(crate) dynamodb_table: Option<String>,
+    #[arg(short, long)]
+    pub(crate) path: String,
+    #[arg(long)]
+    pub(crate) flush_ms: Option<u32>,
+    #[arg(long)]
+    pub(crate) disable_wal: Option<bool>,
+    #[arg(long)]
+    pub(crate) l0_sst_size_bytes: Option<usize>,
+    #[command(subcommand)]
+    pub(crate) command: DbBenchCommand,
+}
+
+pub(crate) fn parse_args() -> DbBenchArgs {
+    DbBenchArgs::parse()
+}
+
+#[derive(Subcommand, Clone)]
+pub(crate) enum DbBenchCommand {
+    Write(WriteArgs),
+}
+
+#[derive(Args, Clone)]
+pub(crate) struct WriteArgs {
+    #[arg(long)]
+    pub(crate) duration: Option<u32>,
+    #[arg(
+        long,
+        default_value_t = KeyDistribution::Random,
+    )]
+    key_distribution: KeyDistribution,
+    #[arg(long)]
+    key_len: usize,
+    #[arg(long, default_value_t = false)]
+    await_flush: bool,
+    #[arg(long)]
+    pub(crate) write_rate: Option<u32>,
+    #[arg(long, default_value_t = 4)]
+    pub(crate) write_tasks: u32,
+    #[arg(long)]
+    pub(crate) num_rows: Option<u64>,
+    #[arg(long)]
+    pub(crate) val_len: usize,
+}
+
+impl WriteArgs {
+    pub(crate) fn key_gen_supplier(&self) -> Box<dyn Fn() -> Box<dyn KeyGenerator>> {
+        let supplier = match self.key_distribution {
+            KeyDistribution::Random => {
+                let key_len = self.key_len;
+                move || Box::new(RandomKeyGenerator::new(key_len)) as Box<dyn KeyGenerator>
+            }
+        };
+        Box::new(supplier)
+    }
+
+    pub(crate) fn write_options(&self) -> WriteOptions {
+        WriteOptions {
+            await_flush: self.await_flush,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum Provider {
+    Aws,
+    InMemory,
+}
+
+const PROVIDER_AWS: &str = "aws";
+const PROVIDER_MEMORY: &str = "memory";
+
+impl ValueEnum for Provider {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Provider::Aws, Provider::InMemory]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            Provider::Aws => Some(PossibleValue::new(PROVIDER_AWS)),
+            Provider::InMemory => Some(PossibleValue::new(PROVIDER_MEMORY)),
+        }
+    }
+}
+
+impl Display for Provider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Provider::Aws => PROVIDER_AWS,
+                Provider::InMemory => PROVIDER_MEMORY,
+            }
+        )
+    }
+}
+
+#[derive(Clone)]
+pub(crate) enum KeyDistribution {
+    Random,
+}
+
+const KEY_DISTRIBUTION_RANDOM: &str = "Random";
+
+impl ValueEnum for KeyDistribution {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[KeyDistribution::Random]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        match self {
+            KeyDistribution::Random => Some(PossibleValue::new(KEY_DISTRIBUTION_RANDOM)),
+        }
+    }
+}
+
+impl Display for KeyDistribution {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                KeyDistribution::Random => KEY_DISTRIBUTION_RANDOM,
+            }
+        )
+    }
+}

--- a/src/db_bench/db_bench.rs
+++ b/src/db_bench/db_bench.rs
@@ -1,0 +1,303 @@
+use bytes::Bytes;
+use leaky_bucket::RateLimiter;
+use rand::{RngCore, SeedableRng};
+use rand_xorshift::XorShiftRng;
+use slatedb::config::WriteOptions;
+use slatedb::db::Db;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::time::Instant;
+
+pub trait KeyGenerator: Send {
+    fn next_key(&mut self) -> Bytes;
+}
+
+// TODO: implement other distributions
+
+pub struct RandomKeyGenerator {
+    key_len_bytes: usize,
+    rng: XorShiftRng,
+}
+
+impl RandomKeyGenerator {
+    pub fn new(key_bytes: usize) -> Self {
+        Self {
+            key_len_bytes: key_bytes,
+            rng: rand_xorshift::XorShiftRng::from_entropy(),
+        }
+    }
+}
+
+impl KeyGenerator for RandomKeyGenerator {
+    fn next_key(&mut self) -> Bytes {
+        let mut bytes = vec![0u8; self.key_len_bytes];
+        self.rng.fill_bytes(bytes.as_mut_slice());
+        Bytes::copy_from_slice(bytes.as_slice())
+    }
+}
+
+pub struct DbBench {
+    key_gen_supplier: Box<dyn Fn() -> Box<dyn KeyGenerator>>,
+    val_size: usize,
+    write_options: WriteOptions,
+    write_rate: Option<u32>,
+    #[allow(dead_code)]
+    read_rate: Option<u32>,
+    write_tasks: u32,
+    #[allow(dead_code)]
+    read_tasks: u32,
+    num_rows: Option<u64>,
+    duration: Option<Duration>,
+    db: Arc<Db>,
+}
+
+impl DbBench {
+    #[allow(clippy::too_many_arguments)]
+    pub fn write(
+        key_gen_supplier: Box<dyn Fn() -> Box<dyn KeyGenerator>>,
+        val_size: usize,
+        write_options: WriteOptions,
+        write_rate: Option<u32>,
+        write_tasks: u32,
+        num_rows: Option<u64>,
+        duration: Option<Duration>,
+        db: Arc<Db>,
+    ) -> Self {
+        Self {
+            key_gen_supplier,
+            val_size,
+            write_options,
+            write_rate,
+            read_rate: None,
+            write_tasks,
+            read_tasks: 0,
+            num_rows,
+            duration,
+            db,
+        }
+    }
+
+    pub async fn run(&self) {
+        let rate_limiter = self.write_rate.map(|r| {
+            Arc::new(
+                RateLimiter::builder()
+                    .initial(r as usize)
+                    .max(r as usize)
+                    .interval(Duration::from_millis(1))
+                    .refill((r / 1000) as usize)
+                    .build(),
+            )
+        });
+        let stats_recorder = Arc::new(StatsRecorder::new());
+        let mut write_tasks = Vec::new();
+        for _ in 0..self.write_tasks {
+            let mut write_task = WriteTask::new(
+                (*self.key_gen_supplier)(),
+                self.val_size,
+                self.write_options.clone(),
+                self.num_rows,
+                self.duration,
+                rate_limiter.clone(),
+                stats_recorder.clone(),
+                self.db.clone(),
+            );
+            write_tasks.push(tokio::spawn(async move { write_task.run().await }));
+        }
+        tokio::spawn(async move { dump_stats(stats_recorder).await });
+        for write_task in write_tasks {
+            write_task.await.unwrap();
+        }
+    }
+}
+
+struct WriteTask {
+    key_generator: Box<dyn KeyGenerator>,
+    val_size: usize,
+    write_options: WriteOptions,
+    num_keys: Option<u64>,
+    duration: Option<Duration>,
+    rate_limiter: Option<Arc<RateLimiter>>,
+    stats_recorder: Arc<StatsRecorder>,
+    db: Arc<Db>,
+}
+
+impl WriteTask {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        key_generator: Box<dyn KeyGenerator>,
+        val_size: usize,
+        write_options: WriteOptions,
+        num_keys: Option<u64>,
+        duration: Option<Duration>,
+        rate_limiter: Option<Arc<RateLimiter>>,
+        stats_recorder: Arc<StatsRecorder>,
+        db: Arc<Db>,
+    ) -> Self {
+        Self {
+            key_generator,
+            val_size,
+            write_options,
+            num_keys,
+            duration,
+            rate_limiter,
+            stats_recorder,
+            db,
+        }
+    }
+
+    async fn run(&mut self) {
+        let start = std::time::Instant::now();
+        let mut keys_written = 0u64;
+        let write_batch = 4;
+        let mut val_rng = rand_xorshift::XorShiftRng::from_entropy();
+        loop {
+            if start.elapsed() >= self.duration.unwrap_or(Duration::MAX) {
+                break;
+            }
+            if keys_written >= self.num_keys.unwrap_or(u64::MAX) {
+                break;
+            }
+            if let Some(rate_limiter) = &self.rate_limiter {
+                rate_limiter.acquire(write_batch).await;
+            }
+            for _ in 0..write_batch {
+                let key = self.key_generator.next_key();
+                let mut value = vec![0; self.val_size];
+                val_rng.fill_bytes(value.as_mut_slice());
+                self.db
+                    .put_with_options(key.as_ref(), value.as_ref(), &self.write_options)
+                    .await;
+            }
+            self.stats_recorder
+                .record_records_written(write_batch as u64);
+            keys_written += write_batch as u64;
+        }
+    }
+}
+
+const WINDOW_SIZE: Duration = Duration::from_secs(10);
+
+struct Window {
+    start: Instant,
+    last: Instant,
+    value: f32,
+}
+
+struct StatsRecorderInner {
+    records_written: u64,
+    records_written_windows: VecDeque<Window>,
+}
+
+impl StatsRecorderInner {
+    fn maybe_roll_window(now: Instant, windows: &mut VecDeque<Window>) {
+        let Some(front) = windows.front() else {
+            windows.push_front(Window {
+                start: now,
+                value: 0f32,
+                last: now,
+            });
+            return;
+        };
+        let mut front_start = front.start;
+        while now.duration_since(front_start) > WINDOW_SIZE {
+            windows.push_front(Window {
+                start: front_start + WINDOW_SIZE,
+                value: 0f32,
+                last: now,
+            });
+            front_start = windows.front().unwrap().start;
+            while windows.len() > 180 {
+                windows.pop_back();
+            }
+        }
+    }
+
+    fn record_records_written(&mut self, now: Instant, records: u64) {
+        Self::maybe_roll_window(now, &mut self.records_written_windows);
+        if let Some(front) = self.records_written_windows.front_mut() {
+            front.value += records as f32;
+            front.last = now;
+        }
+        self.records_written += records;
+    }
+
+    fn records_written(&self) -> u64 {
+        self.records_written
+    }
+
+    fn sum_windows(windows: &VecDeque<Window>, since: Instant) -> Option<(Instant, Instant, f32)> {
+        let sum: f32 = windows
+            .iter()
+            .filter(|w| w.start > since)
+            .map(|w| w.value)
+            .sum();
+        let start = windows
+            .iter()
+            .filter(|w| w.start > since)
+            .map(|w| w.start)
+            .min();
+        if let Some(start) = start {
+            return windows.front().map(|w| (w.start, start, sum));
+        }
+        None
+    }
+
+    fn records_written_since(&self, since: Instant) -> Option<(Instant, Instant, u64)> {
+        Self::sum_windows(&self.records_written_windows, since).map(|r| (r.0, r.1, r.2 as u64))
+    }
+}
+
+struct StatsRecorder {
+    inner: Mutex<StatsRecorderInner>,
+}
+
+impl StatsRecorder {
+    fn new() -> Self {
+        Self {
+            inner: Mutex::new(StatsRecorderInner {
+                records_written: 0,
+                records_written_windows: VecDeque::new(),
+            }),
+        }
+    }
+
+    fn record_records_written(&self, records: u64) {
+        let now = Instant::now();
+        let mut guard = self.inner.lock().expect("lock failed");
+        guard.record_records_written(now, records);
+    }
+
+    fn records_written(&self) -> u64 {
+        let guard = self.inner.lock().expect("lock failed");
+        guard.records_written()
+    }
+
+    fn records_written_since(&self, since: Instant) -> Option<(Instant, Instant, u64)> {
+        let guard = self.inner.lock().expect("lock failed");
+        guard.records_written_since(since)
+    }
+}
+
+const STAT_DUMP_INTERVAL: Duration = Duration::from_secs(10);
+
+async fn dump_stats(stats: Arc<StatsRecorder>) {
+    loop {
+        let records_written = stats.records_written();
+        let records_written_since =
+            stats.records_written_since(Instant::now() - Duration::from_secs(60));
+        let (write_rate, interval) =
+            if let Some((last, start, records_written)) = records_written_since {
+                let interval = last - start;
+                (records_written as f32 / interval.as_secs() as f32, interval)
+            } else {
+                (0f32, Duration::from_secs(0))
+            };
+        println!("Stats Dump:");
+        println!("---------------------------------------");
+        println!("records written: {}", records_written);
+        println!("write rate: {}/second over {:?}", write_rate, interval);
+        println!();
+        tokio::time::sleep(STAT_DUMP_INTERVAL).await;
+    }
+}

--- a/src/db_bench/main.rs
+++ b/src/db_bench/main.rs
@@ -1,0 +1,91 @@
+use crate::args::{parse_args, DbBenchArgs, DbBenchCommand, Provider};
+use crate::db_bench::DbBench;
+use object_store::aws::{DynamoCommit, S3ConditionalPut};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use s3::load_aws_creds;
+use slatedb::config::DbOptions;
+use slatedb::db::Db;
+use slatedb::error::SlateDBError;
+use std::sync::Arc;
+use std::time::Duration;
+
+mod args;
+mod db_bench;
+#[cfg(feature = "aws")]
+mod s3;
+
+fn load_object_store(args: &DbBenchArgs) -> Result<Arc<dyn ObjectStore>, SlateDBError> {
+    let os = match args.provider {
+        Provider::Aws => {
+            #[cfg(feature = "aws")]
+            {
+                let (aws_key, aws_secret) = load_aws_creds();
+                Arc::new(
+                    object_store::aws::AmazonS3Builder::new()
+                        .with_access_key_id(aws_key.as_str())
+                        .with_secret_access_key(aws_secret.as_str())
+                        .with_bucket_name(args.bucket.as_ref().unwrap().as_str())
+                        .with_region(args.region.as_ref().unwrap().as_str())
+                        .with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new(
+                            String::from(
+                                args.dynamodb_table
+                                    .as_ref()
+                                    .expect("must provide dynamodb table when using s3"),
+                            ),
+                        )))
+                        .build()?,
+                ) as Arc<dyn ObjectStore>
+            }
+            #[cfg(not(feature = "aws"))]
+            {
+                panic!("feature aws must be enabled to run db bench")
+            }
+        }
+        Provider::InMemory => {
+            Arc::new(object_store::memory::InMemory::new()) as Arc<dyn ObjectStore>
+        }
+    };
+    Ok(os)
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let args: DbBenchArgs = parse_args();
+    let mut db_options = DbOptions::default();
+    db_options.wal_enabled = !args.disable_wal.unwrap_or(false);
+    db_options.flush_interval = args
+        .flush_ms
+        .map(|i| Duration::from_millis(i as u64))
+        .unwrap_or(db_options.flush_interval);
+    db_options.l0_sst_size_bytes = args
+        .l0_sst_size_bytes
+        .unwrap_or(db_options.l0_sst_size_bytes);
+    let path = Path::from(args.path.as_str());
+    let os = load_object_store(&args).expect("failed to open object store");
+    let db = Arc::new(
+        Db::open_with_opts(path.clone(), db_options, os.clone())
+            .await
+            .expect("failed to open db"),
+    );
+
+    let bench = match args.command {
+        DbBenchCommand::Write(write) => {
+            let key_gen_supplier = write.key_gen_supplier();
+            let write_options = write.write_options();
+            DbBench::write(
+                key_gen_supplier,
+                write.val_len,
+                write_options,
+                write.write_rate,
+                write.write_tasks,
+                write.num_rows,
+                write.duration.map(|d| Duration::from_millis(d as u64)),
+                db.clone(),
+            )
+        }
+    };
+
+    bench.run().await;
+}

--- a/src/db_bench/s3.rs
+++ b/src/db_bench/s3.rs
@@ -1,0 +1,5 @@
+pub(crate) fn load_aws_creds() -> (String, String) {
+    let aws_key = std::env::var("AWS_ACCESS_KEY_ID").expect("must supply AWS access key");
+    let aws_secret = std::env::var("AWS_SECRET_ACCESS_KEY").expect("must supply AWS secret");
+    (aws_key, aws_secret)
+}


### PR DESCRIPTION
This patch adds a tool for load testing SlateDB. The tool is configured using command-line args. Currently, it only supports write-only workloads over a random keyspace.

The general syntax for the command line looks like: `db_bench <db opts> COMMAND <command opts>`

`<db opts>` let you configure database options.
`<command opts>` let you configure the bench command

Currently the only command that is supported is write, which generates a pure write workload.

for example:
```bash
$ db-bench -c aws -r us-west-2 -b rohan-test-slatedb -p test-2 --disable-wal true \
    --flush-ms 100 --l0-sst-size-bytes 67108864 \
    write \
    --key-distribution Random --key-len 32 --val-len 256
```