### PR TITLE
fix a couple bugs in the wal_disable feature

### DIFF
--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -138,6 +138,11 @@ impl DbState {
         }
     }
 
+    pub fn last_written_wal_id(&self) -> u64 {
+        assert!(self.state.core.next_wal_sst_id > 0);
+        self.state.core.next_wal_sst_id - 1
+    }
+
     // mutations
 
     pub fn wal(&mut self) -> &mut WritableKVTable {

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -60,6 +60,7 @@ impl MemtableFlusher {
                 guard.move_imm_memtable_to_l0(imm_memtable.clone(), sst_handle);
             }
             self.write_manifest_safely().await?;
+            imm_memtable.table().notify_flush();
         }
         Ok(())
     }


### PR DESCRIPTION
- Set the wal id associated with a memtable to the last wal id rather than the last compacted wal id. This ensures we avoid replaying wal entries on a restart.
- Notify waiters after flushing an imm memtable