### PR TITLE
support configuring the filter bits per key

### DIFF
--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -66,7 +66,10 @@ fn open_object_store(options: &Options) -> Result<Arc<dyn ObjectStore>, SlateDBE
 pub fn run_compaction_execute_bench() -> Result<(), SlateDBError> {
     let options = load_options();
     let s3 = open_object_store(&options)?;
-    let sst_format = SsTableFormat::new(4096, 1, options.compression_codec);
+    let sst_format = SsTableFormat {
+        compression_codec: options.compression_codec,
+        ..SsTableFormat::default()
+    };
     let table_store = Arc::new(TableStore::new(
         s3.clone(),
         sst_format,

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -468,7 +468,12 @@ mod tests {
         let db = Db::open_with_opts(Path::from(PATH), options.clone(), os.clone())
             .await
             .unwrap();
-        let sst_format = SsTableFormat::new(32, 10, options.compression_codec);
+        let sst_format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 10,
+            compression_codec: options.compression_codec,
+            ..SsTableFormat::default()
+        };
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let table_store = Arc::new(TableStore::new(
             os.clone(),
@@ -486,6 +491,7 @@ mod tests {
             wal_enabled: true,
             manifest_poll_interval: Duration::from_millis(100),
             min_filter_keys: 0,
+            filter_bits_per_key: 10,
             l0_sst_size_bytes: 128,
             max_unflushed_memtable: 2,
             l0_max_ssts: 8,

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,13 @@ pub struct DbOptions {
     /// faster without a bloom filter.
     pub min_filter_keys: u32,
 
+    /// The number of bits to use per key for bloom filters. We recommend setting this
+    /// to the default value of 10, which yields a filter with an expected fpp of ~.0082
+    /// Note that this is evaluated per-sorted-run, so the expected number of false positives
+    /// per request is the fpp * number of sorted runs. So for large dbs with lots of runs,
+    /// you may benefit from setting this higher (if you have enough memory available)
+    pub filter_bits_per_key: u32,
+
     /// The minimum size a memtable needs to be before it is frozen and flushed to
     /// L0 object storage. Writes will still be flushed to the object storage WAL
     /// (based on flush_interval) regardless of this value. Memtable sizes are checked
@@ -167,6 +174,7 @@ impl Default for DbOptions {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             block_cache_options: Some(InMemoryCacheOptions::default()),
             garbage_collector_options: Some(GarbageCollectorOptions::default()),
+            filter_bits_per_key: 10,
         }
     }
 }

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -733,7 +733,7 @@ mod tests {
         );
         let path = Path::from("/");
         let manifest_store = Arc::new(ManifestStore::new(&path, local_object_store.clone()));
-        let sst_format = SsTableFormat::new(4096, 10, None);
+        let sst_format = SsTableFormat::default();
         let table_store = Arc::new(TableStore::new(
             local_object_store.clone(),
             sst_format,

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -170,7 +170,10 @@ mod tests {
     async fn test_one_sst_sr_iter() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -210,7 +213,10 @@ mod tests {
     async fn test_many_sst_sr_iter() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -254,7 +260,10 @@ mod tests {
     async fn test_sr_iter_from_key() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -297,7 +306,10 @@ mod tests {
     async fn test_sr_iter_from_key_lower_than_range() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -329,7 +341,10 @@ mod tests {
     async fn test_sr_iter_from_key_higher_than_range() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -254,7 +254,10 @@ mod tests {
     async fn test_one_block_sst_iter() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -298,7 +301,10 @@ mod tests {
     async fn test_many_block_sst_iter() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(4096, 3, None);
+        let format = SsTableFormat {
+            min_filter_keys: 3,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -342,7 +348,11 @@ mod tests {
     async fn test_iter_from_key() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(128, 1, None);
+        let format = SsTableFormat {
+            block_size: 128,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -389,7 +399,11 @@ mod tests {
     async fn test_iter_from_key_smaller_than_first() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(128, 1, None);
+        let format = SsTableFormat {
+            block_size: 128,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,
@@ -424,7 +438,11 @@ mod tests {
     async fn test_iter_from_key_larger_than_last() {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(128, 1, None);
+        let format = SsTableFormat {
+            block_size: 128,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             object_store,
             format,

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -546,6 +546,8 @@ mod tests {
     use object_store::{memory::InMemory, path::Path, ObjectStore};
     use ulid::Ulid;
 
+    use crate::inmemory_cache::{InMemoryCacheOptions, MokaCache};
+    use crate::sst::SsTableFormat;
     use crate::sst_iter::SstIterator;
     use crate::tablestore::TableStore;
     use crate::test_utils::assert_iterator;
@@ -554,10 +556,6 @@ mod tests {
         block::Block, block_iterator::BlockIterator, db_state::SsTableId, iter::KeyValueIterator,
     };
     use crate::{error, tablestore::InMemoryCache};
-    use crate::{
-        inmemory_cache::{InMemoryCacheOptions, MokaCache},
-        sst::SsTableFormat,
-    };
 
     const ROOT: &str = "/root";
 
@@ -586,7 +584,11 @@ mod tests {
     async fn test_sst_writer_should_write_sst() {
         // given:
         let os = Arc::new(object_store::memory::InMemory::new());
-        let format = SsTableFormat::new(32, 1, None);
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let ts = Arc::new(TableStore::new(os.clone(), format, Path::from(ROOT), None));
         let id = SsTableId::Compacted(Ulid::new());
 
@@ -626,7 +628,11 @@ mod tests {
     #[tokio::test]
     async fn test_wal_write_should_fail_when_fenced() {
         let os = Arc::new(object_store::memory::InMemory::new());
-        let format = SsTableFormat::new(32, 1, None);
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let ts = Arc::new(TableStore::new(os.clone(), format, Path::from(ROOT), None));
         let wal_id = SsTableId::Wal(1);
 
@@ -649,7 +655,10 @@ mod tests {
     async fn test_tablestore_sst_and_partial_cache_hits() {
         // Setup
         let os = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(32, 1, None);
+        let format = SsTableFormat {
+            block_size: 32,
+            ..SsTableFormat::default()
+        };
         let block_cache = Arc::new(MokaCache::new(InMemoryCacheOptions::default()));
         let ts = Arc::new(TableStore::new(
             os.clone(),
@@ -769,7 +778,11 @@ mod tests {
     #[tokio::test]
     async fn test_list_compacted_ssts() {
         let os = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(32, 1, None);
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let ts = Arc::new(TableStore::new(os.clone(), format, Path::from(ROOT), None));
 
         // Create id1, id2, and i3 as three random UUIDs that have been sorted ascending.
@@ -824,7 +837,11 @@ mod tests {
     #[tokio::test]
     async fn test_list_wal_ssts() {
         let os = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(32, 1, None);
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let ts = Arc::new(TableStore::new(os.clone(), format, Path::from(ROOT), None));
 
         let id1 = SsTableId::Wal(1);
@@ -866,7 +883,11 @@ mod tests {
     #[tokio::test]
     async fn test_delete_sst() {
         let os = Arc::new(InMemory::new());
-        let format = SsTableFormat::new(32, 1, None);
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
         let ts = Arc::new(TableStore::new(os.clone(), format, Path::from(ROOT), None));
 
         let id1 = SsTableId::Compacted(Ulid::new());


### PR DESCRIPTION
adds a new db opt named filter_bits_per_key which lets the user specify the number of filter bits to use per key for each bloom filter.

also changes the way that SsTableFormat is built to use a builder rather than a new() method with a bunch of parameters. This will let us add new format parameters without having to change all the places where we create a format