### PR TITLE
make compactor tokio handle configurable

### DIFF
--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -44,7 +44,7 @@ impl Compactor {
     ) -> Result<Self, SlateDBError> {
         let (external_tx, external_rx) = crossbeam_channel::unbounded();
         let (err_tx, err_rx) = tokio::sync::oneshot::channel();
-        let tokio_handle = options.compaction_runtime.as_ref().map(|h| h.clone()).unwrap_or(tokio_handle);
+        let tokio_handle = options.compaction_runtime.clone().unwrap_or(tokio_handle);
         let main_thread = thread::spawn(move || {
             let load_result = CompactorOrchestrator::new(
                 options,

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -44,6 +44,7 @@ impl Compactor {
     ) -> Result<Self, SlateDBError> {
         let (external_tx, external_rx) = crossbeam_channel::unbounded();
         let (err_tx, err_rx) = tokio::sync::oneshot::channel();
+        let tokio_handle = options.compaction_runtime.as_ref().map(|h| h.clone()).unwrap_or(tokio_handle);
         let main_thread = thread::spawn(move || {
             let load_result = CompactorOrchestrator::new(
                 options,
@@ -492,6 +493,7 @@ mod tests {
                 SizeTieredCompactionSchedulerOptions::default(),
             )),
             max_concurrent_compactions: 1,
+            compaction_runtime: None,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::compactor::CompactionScheduler;
 use std::sync::Arc;
 use std::{str::FromStr, time::Duration};
+use tokio::runtime::Handle;
 
 use crate::error::SlateDBError;
 use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
@@ -211,6 +212,10 @@ pub struct CompactorOptions {
 
     /// The maximum number of concurrent compactions to execute at once
     pub max_concurrent_compactions: usize,
+
+    /// An optional tokio runtime handle to use for scheduling compaction work. You can use
+    /// this to isolate compactions to a dedicated thread pool.
+    pub compaction_runtime: Option<Handle>,
 }
 
 /// Default options for the compactor. Currently, only a
@@ -226,6 +231,7 @@ impl Default for CompactorOptions {
                 SizeTieredCompactionSchedulerOptions::default(),
             )),
             max_concurrent_compactions: 4,
+            compaction_runtime: None,
         }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1111,6 +1111,7 @@ mod tests {
                     SizeTieredCompactionSchedulerOptions::default(),
                 )),
                 max_concurrent_compactions: 1,
+                compaction_runtime: None,
             }),
         ))
         .await;
@@ -1128,6 +1129,7 @@ mod tests {
                     SizeTieredCompactionSchedulerOptions::default(),
                 )),
                 max_concurrent_compactions: 1,
+                compaction_runtime: None,
             }),
         ))
         .await


### PR DESCRIPTION
This patch makes the tokio handle for the compactor configurable. This way the client can isolate the compactor to its own worker pool so that it doesn't compete for access to the thread pool used by the main runtime which serves reads/writes.