### PR TITLE
Improved SsTable size estimations using SsTableFormat

### DIFF
--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -9,7 +9,14 @@ impl DbInner {
         guard: &mut RwLockWriteGuard<'_, DbState>,
         wal_id: u64,
     ) {
-        if guard.memtable().size() < self.options.l0_sst_size_bytes {
+        let (total_size_bytes, num_keys) = {
+            let memtable = guard.memtable();
+            (memtable.total_size_bytes(), memtable.num_entries())
+        };
+        let estimated_sst_size = self
+            .sst_format
+            .estimate_sst_size(num_keys, total_size_bytes);
+        if estimated_sst_size < self.options.l0_sst_size_bytes {
             return;
         }
         guard.freeze_memtable(wal_id);

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -99,9 +99,12 @@ impl WritableKVTable {
         }
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn size(&self) -> usize {
+    pub(crate) fn total_size_bytes(&self) -> usize {
         self.size
+    }
+
+    pub(crate) fn num_entries(&self) -> usize {
+        self.table.map.len()
     }
 
     pub(crate) fn table(&self) -> &Arc<KVTable> {
@@ -277,15 +280,15 @@ mod tests {
         let mut table = WritableKVTable::new();
 
         table.put(b"abc333", b"val1");
-        assert_eq!(table.size(), 10);
+        assert_eq!(table.total_size_bytes(), 10);
 
         table.put(b"def456", b"blablabla");
-        assert_eq!(table.size(), 25);
+        assert_eq!(table.total_size_bytes(), 25);
 
         table.put(b"def456", b"blabla");
-        assert_eq!(table.size(), 22);
+        assert_eq!(table.total_size_bytes(), 22);
 
         table.delete(b"abc333");
-        assert_eq!(table.size(), 18)
+        assert_eq!(table.total_size_bytes(), 18)
     }
 }

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -901,6 +901,42 @@ mod tests {
         assert!(blocks.is_empty())
     }
 
+    #[test]
+    fn test_estimate_sst_size() {
+        let format = SsTableFormat::new(4096, 0, None);
+        let per_entry_overhead = std::mem::size_of::<u16>() + std::mem::size_of::<u32>();
+
+        // Test case 1: Empty SSTable
+        assert_eq!(format.estimate_sst_size(0, 0), 0);
+
+        // Test case 2: Single small entry
+        let num_entries = 1;
+        let total_entry_size = 10;
+        let expected_size = 10 + per_entry_overhead;
+        assert_eq!(
+            format.estimate_sst_size(num_entries, total_entry_size),
+            expected_size
+        );
+
+        // Test case 3: Multiple entries
+        let num_entries = 100;
+        let total_entry_size = 1000;
+        let expected_size = 1000 + 100 * per_entry_overhead;
+        assert_eq!(
+            format.estimate_sst_size(num_entries, total_entry_size),
+            expected_size
+        );
+
+        // Test case 4: Large entries
+        let num_entries = 10000;
+        let total_entry_size = 1_000_000;
+        let expected_size = 1_000_000 + 10000 * per_entry_overhead;
+        assert_eq!(
+            format.estimate_sst_size(num_entries, total_entry_size),
+            expected_size
+        );
+    }
+
     struct BytesBlob {
         bytes: Bytes,
     }

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -1,4 +1,4 @@
-use crate::block::Block;
+use crate::block::{Block, SIZEOF_U16, SIZEOF_U32};
 use crate::filter::{BloomFilter, BloomFilterBuilder};
 use crate::flatbuffer_types::{
     BlockMeta, BlockMetaArgs, SsTableIndex, SsTableIndexArgs, SsTableIndexOwned, SsTableInfo,
@@ -260,7 +260,9 @@ impl SsTableFormat {
         total_entry_size_bytes: usize,
     ) -> usize {
         // u16 for key size, u32 for value size
-        let per_entry_overhead = std::mem::size_of::<u16>() + std::mem::size_of::<u32>();
+        let entry_key_and_val_size_header_offset = SIZEOF_U16 + SIZEOF_U32;
+        let entry_offset_overhead = SIZEOF_U16;
+        let per_entry_overhead = entry_key_and_val_size_header_offset + entry_offset_overhead;
 
         total_entry_size_bytes + per_entry_overhead * num_entries
     }

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -253,6 +253,17 @@ impl SsTableFormat {
             self.compression_codec,
         )
     }
+
+    pub(crate) fn estimate_sst_size(
+        &self,
+        num_entries: usize,
+        total_entry_size_bytes: usize,
+    ) -> usize {
+        // u16 for key size, u32 for value size
+        let per_entry_overhead = std::mem::size_of::<u16>() + std::mem::size_of::<u32>();
+
+        total_entry_size_bytes + per_entry_overhead * num_entries
+    }
 }
 
 impl SsTableInfoOwned {


### PR DESCRIPTION
Starts work on  #77

This PR adds a new function to `SsTableFormat` to estimate the size of an sstable given a memtable and uses it to determine whether to freeze a memtable. Main changes  are in `SsTableFormat` and `maybe_freeze_memtable` in db_common.rs.

An instance of `SsTableFormat` is now plumbed through to `DbInner` which may or may not be correst.

Some caveats:

1. this duplicates some estimation logic in block.rs
2. The size estimate doesn't include the bloom filter size, which  @rodesai [mentioned](https://github.com/slatedb/slatedb/pull/72#discussion_r1651742468) should probably be included.
3. Some functions return `usize` which denote element counts, while others use it to communicate sizes in bytes. Maybe they could use `bytesize` to make this distinction clearer?