### PR TITLE
Simplify BloomFilterBuilder.filter_bytes

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -25,7 +25,9 @@ impl BloomFilterBuilder {
         self.key_hashes.push(filter_hash(key))
     }
 
-    fn filter_bytes(&self, num_keys: u32, bits_per_key: u32) -> usize {
+    fn filter_size_bytes(&self) -> usize {
+        let num_keys = self.key_hashes.len() as u32;
+        let bits_per_key = self.bits_per_key;
         let filter_bits = num_keys * bits_per_key;
         // compute filter bytes rounded up to the number of bytes required to fit the filter
         ((filter_bits + 7) / 8) as usize
@@ -33,7 +35,7 @@ impl BloomFilterBuilder {
 
     pub(crate) fn build(&self) -> BloomFilter {
         let num_probes = optimal_num_probes(self.bits_per_key);
-        let filter_bytes = self.filter_bytes(self.key_hashes.len() as u32, self.bits_per_key);
+        let filter_bytes = self.filter_size_bytes();
         let filter_bits = (filter_bytes * 8) as u32;
         let mut buffer = vec![0x00; filter_bytes];
         for k in self.key_hashes.iter() {


### PR DESCRIPTION
It looks like the only call-site only provides values from `self` that the function `filter_size_bytes` itself has access to.