### PR TITLE
chore: add rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+reorder_imports = true
+group_imports = "StdExternalCrate"
+normalize_comments = true

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,6 +1,8 @@
-use crate::error::SlateDBError;
-use bytes::Bytes;
 use std::ops::Range;
+
+use bytes::Bytes;
+
+use crate::error::SlateDBError;
 
 pub(crate) trait ReadOnlyBlob {
     async fn len(&self) -> Result<usize, SlateDBError>;

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,5 +1,6 @@
-use crate::error::SlateDBError;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use crate::error::SlateDBError;
 
 pub(crate) const SIZEOF_U16: usize = std::mem::size_of::<u16>();
 pub(crate) const SIZEOF_U32: usize = std::mem::size_of::<u32>();

--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -1,10 +1,11 @@
+use bytes::{Buf, Bytes};
+
 use crate::{
     block::{Block, TOMBSTONE},
     error::SlateDBError,
     iter::KeyValueIterator,
     types::{KeyValueDeletable, ValueDeletable},
 };
-use bytes::{Buf, Bytes};
 
 pub trait BlockLike {
     fn data(&self) -> &Bytes;

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -1,3 +1,19 @@
+use std::collections::HashMap;
+use std::mem;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::BufMut;
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use rand::{RngCore, SeedableRng};
+use tokio::runtime::Handle;
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+use ulid::Ulid;
+
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
 use crate::config::CompactorOptions;
@@ -8,20 +24,6 @@ use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use crate::test_utils::OrderedBytesGenerator;
 use crate::{compactor::WorkerToOrchestratorMsg, config::CompressionCodec};
-use bytes::BufMut;
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
-use object_store::path::Path;
-use object_store::ObjectStore;
-use rand::{RngCore, SeedableRng};
-use std::collections::HashMap;
-use std::mem;
-use std::sync::Arc;
-use std::time::Duration;
-use tokio::runtime::Handle;
-use tokio::task::JoinHandle;
-use tracing::{error, info};
-use ulid::Ulid;
 
 #[derive(Debug)]
 struct Options {

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -1,3 +1,14 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use tokio::runtime::Handle;
+use tracing::{error, info, warn};
+use ulid::Ulid;
+
 use crate::compactor::CompactorMainMsg::Shutdown;
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, CompactorState};
@@ -7,15 +18,6 @@ use crate::error::SlateDBError;
 use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
 use crate::metrics::DbStats;
 use crate::tablestore::TableStore;
-use std::collections::HashMap;
-use std::sync::Arc;
-use std::thread;
-use std::thread::JoinHandle;
-use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::runtime::Handle;
-use tracing::{error, info, warn};
-use ulid::Ulid;
 
 pub trait CompactionScheduler {
     fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction>;
@@ -290,6 +292,16 @@ impl CompactorOrchestrator {
 
 #[cfg(test)]
 mod tests {
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use tokio::runtime::Runtime;
+    use ulid::Ulid;
+
     use crate::compactor::{CompactorOptions, CompactorOrchestrator, WorkerToOrchestratorMsg};
     use crate::compactor_state::{Compaction, SourceId};
     use crate::config::{DbOptions, SizeTieredCompactionSchedulerOptions};
@@ -300,14 +312,6 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::sst_iter::SstIterator;
     use crate::tablestore::TableStore;
-    use object_store::memory::InMemory;
-    use object_store::path::Path;
-    use object_store::ObjectStore;
-    use std::future::Future;
-    use std::sync::Arc;
-    use std::time::{Duration, SystemTime};
-    use tokio::runtime::Runtime;
-    use ulid::Ulid;
 
     const PATH: &str = "/test/db";
 

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -1,3 +1,13 @@
+use std::collections::{HashMap, VecDeque};
+use std::mem;
+use std::sync::atomic::{self, AtomicBool};
+use std::sync::Arc;
+
+use futures::future::join_all;
+use parking_lot::Mutex;
+use tokio::task::JoinHandle;
+use ulid::Ulid;
+
 use crate::compactor::WorkerToOrchestratorMsg;
 use crate::compactor::WorkerToOrchestratorMsg::CompactionFinished;
 use crate::config::CompactorOptions;
@@ -8,14 +18,6 @@ use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::SstIterator;
 use crate::tablestore::TableStore;
-use futures::future::join_all;
-use parking_lot::Mutex;
-use std::collections::{HashMap, VecDeque};
-use std::mem;
-use std::sync::atomic::{self, AtomicBool};
-use std::sync::Arc;
-use tokio::task::JoinHandle;
-use ulid::Ulid;
 
 pub(crate) struct CompactionJob {
     pub(crate) destination: u32,

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -1,10 +1,12 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt::{Display, Formatter};
+
+use tracing::info;
+use ulid::Ulid;
+
 use crate::compactor_state::CompactionStatus::Submitted;
 use crate::db_state::{CoreDbState, SSTableHandle, SortedRun};
 use crate::error::SlateDBError;
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::fmt::{Display, Formatter};
-use tracing::info;
-use ulid::Ulid;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) enum SourceId {
@@ -240,6 +242,15 @@ impl CompactorState {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::thread::sleep;
+    use std::time::{Duration, SystemTime};
+
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use tokio::runtime::{Handle, Runtime};
+
     use super::*;
     use crate::compactor_state::CompactionStatus::Submitted;
     use crate::compactor_state::SourceId::Sst;
@@ -247,13 +258,6 @@ mod tests {
     use crate::db::Db;
     use crate::db_state::SsTableId;
     use crate::manifest_store::{ManifestStore, StoredManifest};
-    use object_store::memory::InMemory;
-    use object_store::path::Path;
-    use object_store::ObjectStore;
-    use std::sync::Arc;
-    use std::thread::sleep;
-    use std::time::{Duration, SystemTime};
-    use tokio::runtime::{Handle, Runtime};
 
     const PATH: &str = "/test/db";
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
-use crate::compactor::CompactionScheduler;
 use std::sync::Arc;
 use std::{str::FromStr, time::Duration};
+
 use tokio::runtime::Handle;
 
+use crate::compactor::CompactionScheduler;
 use crate::error::SlateDBError;
 use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,13 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use fail_parallel::FailPointRegistry;
+use log::warn;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use parking_lot::{Mutex, RwLock};
+use tokio::runtime::Handle;
+
 use crate::compactor::Compactor;
 use crate::config::ReadLevel::Uncommitted;
 use crate::config::{
@@ -16,14 +26,6 @@ use crate::sst::SsTableFormat;
 use crate::sst_iter::SstIterator;
 use crate::tablestore::TableStore;
 use crate::types::ValueDeletable;
-use bytes::Bytes;
-use fail_parallel::FailPointRegistry;
-use log::warn;
-use object_store::path::Path;
-use object_store::ObjectStore;
-use parking_lot::{Mutex, RwLock};
-use std::sync::Arc;
-use tokio::runtime::Handle;
 
 pub(crate) struct DbInner {
     pub(crate) state: Arc<RwLock<DbState>>,
@@ -496,16 +498,18 @@ impl Db {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use object_store::memory::InMemory;
+    use object_store::ObjectStore;
+    use tracing::info;
+
     use super::*;
     use crate::config::{CompactorOptions, SizeTieredCompactionSchedulerOptions};
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
     use crate::sst_iter::SstIterator;
     #[cfg(feature = "wal_disable")]
     use crate::test_utils::assert_iterator;
-    use object_store::memory::InMemory;
-    use object_store::ObjectStore;
-    use std::time::Duration;
-    use tracing::info;
 
     #[tokio::test]
     async fn test_put_get_delete() {

--- a/src/db_bench/args.rs
+++ b/src/db_bench/args.rs
@@ -1,8 +1,10 @@
-use crate::db_bench::{KeyGenerator, RandomKeyGenerator};
+use std::fmt::{Display, Formatter};
+
 use clap::builder::PossibleValue;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 use slatedb::config::WriteOptions;
-use std::fmt::{Display, Formatter};
+
+use crate::db_bench::{KeyGenerator, RandomKeyGenerator};
 
 #[derive(Parser, Clone)]
 #[command(version, about, long_about=None)]

--- a/src/db_bench/db_bench.rs
+++ b/src/db_bench/db_bench.rs
@@ -1,12 +1,13 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
 use bytes::Bytes;
 use leaky_bucket::RateLimiter;
 use rand::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use slatedb::config::WriteOptions;
 use slatedb::db::Db;
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
 use tokio::time::Instant;
 
 pub trait KeyGenerator: Send {

--- a/src/db_bench/main.rs
+++ b/src/db_bench/main.rs
@@ -1,5 +1,6 @@
-use crate::args::{parse_args, DbBenchArgs, DbBenchCommand, Provider};
-use crate::db_bench::DbBench;
+use std::sync::Arc;
+use std::time::Duration;
+
 use object_store::aws::{DynamoCommit, S3ConditionalPut};
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -7,8 +8,9 @@ use s3::load_aws_creds;
 use slatedb::config::DbOptions;
 use slatedb::db::Db;
 use slatedb::error::SlateDBError;
-use std::sync::Arc;
-use std::time::Duration;
+
+use crate::args::{parse_args, DbBenchArgs, DbBenchCommand, Provider};
+use crate::db_bench::DbBench;
 
 mod args;
 mod db_bench;

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -1,7 +1,8 @@
+use parking_lot::RwLockWriteGuard;
+
 use crate::db::DbInner;
 use crate::db_state::DbState;
 use crate::mem_table_flush::MemtableFlushThreadMsg::FlushImmutableMemtables;
-use parking_lot::RwLockWriteGuard;
 
 impl DbInner {
     pub(crate) fn maybe_freeze_memtable(

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -1,10 +1,12 @@
-use crate::flatbuffer_types::SsTableInfoOwned;
-use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 use std::collections::VecDeque;
 use std::sync::Arc;
+
 use tracing::info;
 use ulid::Ulid;
 use SsTableId::Compacted;
+
+use crate::flatbuffer_types::SsTableInfoOwned;
+use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 
 #[derive(Clone, PartialEq)]
 pub struct SSTableHandle {
@@ -263,10 +265,11 @@ impl DbState {
 
 #[cfg(test)]
 mod tests {
-    use crate::db_state::{CoreDbState, DbState, SSTableHandle, SsTableId};
-    use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
     use bytes::Bytes;
     use ulid::Ulid;
+
+    use crate::db_state::{CoreDbState, DbState, SSTableHandle, SsTableId};
+    use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
 
     #[test]
     fn test_should_refresh_db_state_with_l0s_up_to_last_compacted() {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,6 +1,7 @@
+use std::mem::size_of;
+
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use siphasher::sip::SipHasher13;
-use std::mem::size_of;
 
 pub(crate) struct BloomFilterBuilder {
     bits_per_key: u32,

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -1,14 +1,21 @@
-use crate::db_state;
-use crate::db_state::{CoreDbState, SSTableHandle};
+use std::collections::VecDeque;
+
 use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
-use std::collections::VecDeque;
 use ulid::Ulid;
+
+use crate::db_state;
+use crate::db_state::{CoreDbState, SSTableHandle};
 
 #[path = "./generated/manifest_generated.rs"]
 #[allow(warnings)]
 #[rustfmt::skip]
 mod manifest_generated;
+pub use manifest_generated::{
+    BlockMeta, BlockMetaArgs, ManifestV1, ManifestV1Args, SsTableIndex, SsTableIndexArgs,
+    SsTableInfo, SsTableInfoArgs,
+};
+
 use crate::config::CompressionCodec;
 use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::Compacted;
@@ -18,10 +25,6 @@ use crate::flatbuffer_types::manifest_generated::{
     SortedRun, SortedRunArgs,
 };
 use crate::manifest::{Manifest, ManifestCodec};
-pub use manifest_generated::{
-    BlockMeta, BlockMetaArgs, ManifestV1, ManifestV1Args, SsTableIndex, SsTableIndexArgs,
-    SsTableInfo, SsTableInfoArgs,
-};
 
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct SsTableInfoOwned {

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -1,3 +1,8 @@
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+use tokio::select;
+
 use crate::db::DbInner;
 use crate::db_state;
 use crate::db_state::SSTableHandle;
@@ -5,9 +10,6 @@ use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::mem_table::{ImmutableWal, KVTable, WritableKVTable};
 use crate::types::ValueDeletable;
-use std::sync::Arc;
-use tokio::runtime::Handle;
-use tokio::select;
 
 impl DbInner {
     pub(crate) async fn flush(&self) -> Result<(), SlateDBError> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,6 +1,7 @@
+use bytes::Bytes;
+
 use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
-use bytes::Bytes;
 
 #[derive(Clone)]
 pub(crate) struct Manifest {

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -1,3 +1,10 @@
+use std::sync::Arc;
+
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::Error::AlreadyExists;
+use object_store::ObjectStore;
+
 use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::InvalidDBState;
@@ -6,11 +13,6 @@ use crate::manifest::{Manifest, ManifestCodec};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
-use futures::StreamExt;
-use object_store::path::Path;
-use object_store::Error::AlreadyExists;
-use object_store::ObjectStore;
-use std::sync::Arc;
 
 pub(crate) struct FenceableManifest {
     stored_manifest: StoredManifest,
@@ -255,12 +257,14 @@ impl ManifestStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+
     use crate::db_state::CoreDbState;
     use crate::error;
     use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
-    use object_store::memory::InMemory;
-    use object_store::path::Path;
-    use std::sync::Arc;
 
     const ROOT: &str = "/root/path";
 

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -1,12 +1,14 @@
-use crate::error::SlateDBError;
-use crate::iter::KeyValueIterator;
-use crate::types::{KeyValueDeletable, ValueDeletable};
+use std::ops::Bound;
+use std::sync::Arc;
+
 use bytes::Bytes;
 use crossbeam_skiplist::map::Range;
 use crossbeam_skiplist::SkipMap;
-use std::ops::Bound;
-use std::sync::Arc;
 use tokio::sync::Notify;
+
+use crate::error::SlateDBError;
+use crate::iter::KeyValueIterator;
+use crate::types::{KeyValueDeletable, ValueDeletable};
 
 pub(crate) struct KVTable {
     map: SkipMap<Bytes, ValueDeletable>,

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -1,11 +1,13 @@
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+use tracing::{error, warn};
+use ulid::Ulid;
+
 use crate::db::DbInner;
 use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
 use crate::manifest_store::FenceableManifest;
-use std::sync::Arc;
-use tokio::runtime::Handle;
-use tracing::{error, warn};
-use ulid::Ulid;
 
 pub(crate) enum MemtableFlushThreadMsg {
     Shutdown,

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -1,8 +1,9 @@
+use std::cmp::{Ordering, Reverse};
+use std::collections::{BinaryHeap, VecDeque};
+
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::types::KeyValueDeletable;
-use std::cmp::{Ordering, Reverse};
-use std::collections::{BinaryHeap, VecDeque};
 
 pub(crate) struct TwoMergeIterator<T1: KeyValueIterator, T2: KeyValueIterator> {
     iterator1: (T1, Option<KeyValueDeletable>),
@@ -144,13 +145,15 @@ impl<T: KeyValueIterator> KeyValueIterator for MergeIterator<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
+    use bytes::Bytes;
+
     use crate::error::SlateDBError;
     use crate::iter::KeyValueIterator;
     use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
     use crate::test_utils::assert_iterator;
     use crate::types::{KeyValueDeletable, ValueDeletable};
-    use bytes::Bytes;
-    use std::collections::VecDeque;
 
     #[tokio::test]
     async fn test_merge_iterator_should_include_entries_in_order() {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,7 @@
+use std::sync::Arc;
+
 use atomic::{Atomic, Ordering};
 use bytemuck::NoUninit;
-use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Counter {

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -1,11 +1,12 @@
-use crate::compactor::CompactionScheduler;
-use crate::compactor_state::{Compaction, CompactorState, SourceId};
-use crate::config::{CompactionSchedulerSupplier, SizeTieredCompactionSchedulerOptions};
-use crate::db_state::CoreDbState;
 use std::cmp::min;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::iter::Peekable;
 use std::slice::Iter;
+
+use crate::compactor::CompactionScheduler;
+use crate::compactor_state::{Compaction, CompactorState, SourceId};
+use crate::config::{CompactionSchedulerSupplier, SizeTieredCompactionSchedulerOptions};
+use crate::db_state::CoreDbState;
 
 const MAX_IN_FLIGHT_COMPACTIONS: usize = 4;
 
@@ -329,14 +330,16 @@ impl CompactionSchedulerSupplier for SizeTieredCompactionSchedulerSupplier {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
+    use bytes::Bytes;
+
     use crate::compactor::CompactionScheduler;
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
     use crate::config::SizeTieredCompactionSchedulerOptions;
     use crate::db_state::{CoreDbState, SSTableHandle, SortedRun, SsTableId};
     use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
     use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
-    use bytes::Bytes;
-    use std::collections::VecDeque;
 
     #[test]
     fn test_should_compact_l0s_to_first_sr() {
@@ -485,7 +488,7 @@ mod tests {
             vec![create_sr2(2, 2), create_sr2(1, 2), create_sr4(0, 2)],
         ));
 
-        //when:
+        // when:
         let compactions = scheduler.maybe_schedule_compaction(&state);
 
         // then:
@@ -515,7 +518,7 @@ mod tests {
             ],
         ));
 
-        //when:
+        // when:
         let compactions = scheduler.maybe_schedule_compaction(&state);
 
         // then:
@@ -552,7 +555,7 @@ mod tests {
             .submit_compaction(create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
             .unwrap();
 
-        //when:
+        // when:
         let compactions = scheduler.maybe_schedule_compaction(&state);
 
         // then:
@@ -582,7 +585,7 @@ mod tests {
             .submit_compaction(create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
             .unwrap();
 
-        //when:
+        // when:
         let compactions = scheduler.maybe_schedule_compaction(&state);
 
         // then:
@@ -609,7 +612,7 @@ mod tests {
             ],
         ));
 
-        //when:
+        // when:
         let compactions = scheduler.maybe_schedule_compaction(&state);
 
         // then:

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -1,11 +1,12 @@
+use std::slice::Iter;
+use std::sync::Arc;
+
 use crate::db_state::{SSTableHandle, SortedRun};
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::sst_iter::SstIterator;
 use crate::tablestore::TableStore;
 use crate::types::KeyValueDeletable;
-use std::slice::Iter;
-use std::sync::Arc;
 
 pub(crate) struct SortedRunIterator<'a> {
     current_iter: Option<SstIterator<'a>>,
@@ -143,14 +144,16 @@ impl<'a> KeyValueIterator for SortedRunIterator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use object_store::path::Path;
+    use object_store::{memory::InMemory, ObjectStore};
+    use ulid::Ulid;
+
     use super::*;
     use crate::db_state::SsTableId;
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, OrderedBytesGenerator};
-    use object_store::path::Path;
-    use object_store::{memory::InMemory, ObjectStore};
-    use std::sync::Arc;
-    use ulid::Ulid;
 
     #[tokio::test]
     async fn test_one_sst_sr_iter() {

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -1,3 +1,14 @@
+use std::collections::VecDeque;
+#[cfg(feature = "snappy")]
+use std::io::Read;
+#[cfg(feature = "lz4")]
+use std::io::Write;
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::{Buf, BufMut, Bytes};
+use flatbuffers::DefaultAllocator;
+
 use crate::block::Block;
 use crate::filter::{BloomFilter, BloomFilterBuilder};
 use crate::flatbuffer_types::{
@@ -6,17 +17,6 @@ use crate::flatbuffer_types::{
 };
 use crate::{blob::ReadOnlyBlob, config::CompressionCodec};
 use crate::{block::BlockBuilder, error::SlateDBError};
-use bytes::{Buf, BufMut, Bytes};
-use flatbuffers::DefaultAllocator;
-use std::collections::VecDeque;
-use std::ops::Range;
-use std::sync::Arc;
-
-#[cfg(feature = "snappy")]
-use std::io::Read;
-
-#[cfg(feature = "lz4")]
-use std::io::Write;
 
 #[derive(Clone)]
 pub(crate) struct SsTableFormat {
@@ -507,18 +507,19 @@ impl<'a> EncodedSsTableBuilder<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes::BytesMut;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+
+    use super::*;
     use crate::block_iterator::BlockIterator;
     use crate::db_state::SsTableId;
     use crate::tablestore::TableStore;
     use crate::test_utils::assert_iterator;
     use crate::types::ValueDeletable;
-    use bytes::BytesMut;
-    use object_store::memory::InMemory;
-    use object_store::path::Path;
-    use object_store::ObjectStore;
-    use std::sync::Arc;
-
-    use super::*;
 
     fn next_block_to_iter(builder: &mut EncodedSsTableBuilder) -> BlockIterator<Block> {
         let block = builder.next_block();

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -1,3 +1,9 @@
+use std::cmp::min;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+
 use crate::db_state::SSTableHandle;
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::{SsTableIndex, SsTableIndexOwned};
@@ -5,10 +11,6 @@ use crate::{
     block::Block, block_iterator::BlockIterator, iter::KeyValueIterator, tablestore::TableStore,
     types::KeyValueDeletable,
 };
-use std::cmp::min;
-use std::collections::VecDeque;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
 
 enum FetchTask {
     InFlight(JoinHandle<Result<VecDeque<Block>, SlateDBError>>),
@@ -223,13 +225,15 @@ impl<'a> KeyValueIterator for SstIterator<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use object_store::path::Path;
+    use object_store::{memory::InMemory, ObjectStore};
+
     use super::*;
     use crate::db_state::SsTableId;
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, OrderedBytesGenerator};
-    use object_store::path::Path;
-    use object_store::{memory::InMemory, ObjectStore};
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_one_block_sst_iter() {

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -1,3 +1,16 @@
+use std::collections::{HashMap, VecDeque};
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::{BufMut, Bytes};
+use fail_parallel::{fail_point, FailPointRegistry};
+use futures::StreamExt;
+use object_store::buffered::BufWriter;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use parking_lot::RwLock;
+use tokio::io::AsyncWriteExt;
+
 use crate::blob::ReadOnlyBlob;
 use crate::block::Block;
 use crate::db_state::{SSTableHandle, SsTableId};
@@ -8,17 +21,6 @@ use crate::sst::{EncodedSsTable, EncodedSsTableBuilder, SsTableFormat};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
-use bytes::{BufMut, Bytes};
-use fail_parallel::{fail_point, FailPointRegistry};
-use futures::StreamExt;
-use object_store::buffered::BufWriter;
-use object_store::path::Path;
-use object_store::ObjectStore;
-use parking_lot::RwLock;
-use std::collections::{HashMap, VecDeque};
-use std::ops::Range;
-use std::sync::Arc;
-use tokio::io::AsyncWriteExt;
 
 pub struct TableStore {
     object_store: Arc<dyn ObjectStore>,
@@ -372,6 +374,12 @@ impl<'a> EncodedSsTableWriter<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use object_store::path::Path;
+    use ulid::Ulid;
+
     use crate::db_state::SsTableId;
     use crate::error;
     use crate::sst::SsTableFormat;
@@ -379,10 +387,6 @@ mod tests {
     use crate::tablestore::TableStore;
     use crate::test_utils::assert_iterator;
     use crate::types::ValueDeletable;
-    use bytes::Bytes;
-    use object_store::path::Path;
-    use std::sync::Arc;
-    use ulid::Ulid;
 
     const ROOT: &str = "/root";
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,7 @@
+use bytes::{BufMut, Bytes, BytesMut};
+
 use crate::iter::KeyValueIterator;
 use crate::types::{KeyValue, ValueDeletable};
-use bytes::{BufMut, Bytes, BytesMut};
 
 // this complains because we include these in the db_bench feature but they are only
 // used for cfg(test)
@@ -84,8 +85,9 @@ impl OrderedBytesGenerator {
 
 #[cfg(test)]
 mod tests {
-    use crate::test_utils::OrderedBytesGenerator;
     use bytes::{BufMut, Bytes};
+
+    use crate::test_utils::OrderedBytesGenerator;
 
     #[test]
     fn test_should_generate_ordered_bytes() {

--- a/src/transactional_object_store.rs
+++ b/src/transactional_object_store.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
@@ -6,7 +8,6 @@ use object_store::path::Path;
 use object_store::{
     path, Error, GetResult, ObjectMeta, ObjectStore, PutMode, PutOptions, PutPayload, PutResult,
 };
-use std::sync::Arc;
 
 // Implements transactional object inserts using some safe protocol
 #[async_trait]
@@ -96,15 +97,17 @@ impl TransactionalObjectStore for DelegatingTransactionalObjectStore {
 
 #[cfg(test)]
 mod tests {
-    use crate::transactional_object_store::{
-        DelegatingTransactionalObjectStore, TransactionalObjectStore,
-    };
+    use std::sync::Arc;
+
     use bytes::Bytes;
     use futures::StreamExt;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{ObjectStore, PutPayload};
-    use std::sync::Arc;
+
+    use crate::transactional_object_store::{
+        DelegatingTransactionalObjectStore, TransactionalObjectStore,
+    };
 
     const ROOT_PATH: &str = "/root/path";
 


### PR DESCRIPTION
this PR adds a simple config for rustfmt.toml which helps automatically format the imports.