### PR TITLE
fix: use stable in rustfmt.toml 

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,2 @@
 edition = "2021"
 reorder_imports = true
-group_imports = "StdExternalCrate"
-normalize_comments = true


### PR DESCRIPTION
sadly it turns out `group_imports = StdExternalCrate` is still in nightly, we can not use the merge import format rule with stable rust.

```
Warning: can't set `normalize_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `normalize_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `normalize_comments = true`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
```

we can add these back when https://github.com/rust-lang/rustfmt/issues/5083 get resolved.
