### PR TITLE
manifest: make fields required

### DIFF
--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -4,8 +4,8 @@ table CompactedSstId {
 }
 
 table CompactedSsTable {
-    id: CompactedSstId;
-    info: SsTableInfo;
+    id: CompactedSstId (required);
+    info: SsTableInfo (required);
 }
 
 enum CompressionFormat: byte {

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -93,11 +93,9 @@ impl FlatBufferManifestCodec {
             .map(|id| Ulid::from((id.high(), id.low())));
         let mut l0 = VecDeque::new();
         for man_sst in manifest.l0().iter() {
-            let man_sst_id = man_sst.id().expect("SSTs in manifest must have IDs");
+            let man_sst_id = man_sst.id();
             let sst_id = Compacted(Ulid::from((man_sst_id.high(), man_sst_id.low())));
-            let sst_info = SsTableInfoOwned::create_copy(
-                &man_sst.info().expect("SSTs in manifest must have info"),
-            );
+            let sst_info = SsTableInfoOwned::create_copy(&man_sst.info());
             let l0_sst = SSTableHandle::new(sst_id, sst_info);
             l0.push_back(l0_sst);
         }
@@ -105,10 +103,8 @@ impl FlatBufferManifestCodec {
         for manifest_sr in manifest.compacted().iter() {
             let mut ssts = Vec::new();
             for manifest_sst in manifest_sr.ssts().iter() {
-                let id = Compacted(manifest_sst.id().expect("sst must have id").ulid());
-                let info = SsTableInfoOwned::create_copy(
-                    &manifest_sst.info().expect("sst must have info"),
-                );
+                let id = Compacted(manifest_sst.id().ulid());
+                let info = SsTableInfoOwned::create_copy(&manifest_sst.info());
                 ssts.push(SSTableHandle::new(id, info));
             }
             compacted.push(db_state::SortedRun {

--- a/src/generated/manifest_generated.rs
+++ b/src/generated/manifest_generated.rs
@@ -256,18 +256,18 @@ impl<'a> CompactedSsTable<'a> {
 
 
   #[inline]
-  pub fn id(&self) -> Option<CompactedSstId<'a>> {
+  pub fn id(&self) -> CompactedSstId<'a> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<CompactedSstId>>(CompactedSsTable::VT_ID, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<CompactedSstId>>(CompactedSsTable::VT_ID, None).unwrap()}
   }
   #[inline]
-  pub fn info(&self) -> Option<SsTableInfo<'a>> {
+  pub fn info(&self) -> SsTableInfo<'a> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<SsTableInfo>>(CompactedSsTable::VT_INFO, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<SsTableInfo>>(CompactedSsTable::VT_INFO, None).unwrap()}
   }
 }
 
@@ -278,8 +278,8 @@ impl flatbuffers::Verifiable for CompactedSsTable<'_> {
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
-     .visit_field::<flatbuffers::ForwardsUOffset<CompactedSstId>>("id", Self::VT_ID, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<SsTableInfo>>("info", Self::VT_INFO, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<CompactedSstId>>("id", Self::VT_ID, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<SsTableInfo>>("info", Self::VT_INFO, true)?
      .finish();
     Ok(())
   }
@@ -292,8 +292,8 @@ impl<'a> Default for CompactedSsTableArgs<'a> {
   #[inline]
   fn default() -> Self {
     CompactedSsTableArgs {
-      id: None,
-      info: None,
+      id: None, // required field
+      info: None, // required field
     }
   }
 }
@@ -322,6 +322,8 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> CompactedSsTableBuilder<'a, 'b,
   #[inline]
   pub fn finish(self) -> flatbuffers::WIPOffset<CompactedSsTable<'a>> {
     let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, CompactedSsTable::VT_ID,"id");
+    self.fbb_.required(o, CompactedSsTable::VT_INFO,"info");
     flatbuffers::WIPOffset::new(o.value())
   }
 }


### PR DESCRIPTION
Fixes: #97

This PR makes the following two fields `CompactedSstId` and `SsTableInfo` required.

Rest of the fields can't be changed to required as they are scalars

The following fields have been left as optional in line with this comment  https://github.com/slatedb/slatedb/issues/97#issuecomment-2308542303
- `ManifestV1.snapshots`
- `ManifestV1.l0_last_compacted`
- `SsTableInfo.first_key`