### PR TITLE
fix: fsync after write to avoid too many dirty pages

### DIFF
--- a/src/cached_object_store.rs
+++ b/src/cached_object_store.rs
@@ -574,6 +574,7 @@ impl FsCacheEntry {
             .await
             .map_err(wrap_io_err)?;
         file.write_all(&buf).await.map_err(wrap_io_err)?;
+        file.sync_all().await.map_err(wrap_io_err)?;
         fs::rename(tmp_path, path).await.map_err(wrap_io_err)
     }
 


### PR DESCRIPTION
related issue: https://github.com/slatedb/slatedb/issues/192#issuecomment-2346036581

> Apparently object cache is also leaking memory and got Killed by OS. With block cache only, the throughput is 100-150 op/s and it can run for long time without memory leaks.

> I guess it might be because the page cache did not get flushed in time during writes, making the dirty page cache accumulated too much. let me fix it

this pr add a `fsync` after the files were written to disk. this may help reduce the dirty pages floating in the system during many writes.
