### PR TITLE
Add some steps to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ SlateDB is an open source project and we welcome contributions. Please open Gith
 
 Join our [Discord server](https://discord.gg/mHYmGy5MgA) to chat with the developers.
 
+Please follow the instructions below before making a PR:
+- Run `cargo clippy --all-targets --all-features` and `cargo fmt` on your patch to fix lints and formatting issues
+- Run `cargo test --all-features` to check that your patch doesn't break any tests
+
+
 ## Contributor License Agreement
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ SlateDB is an open source project and we welcome contributions. Please open Gith
 Join our [Discord server](https://discord.gg/mHYmGy5MgA) to chat with the developers.
 
 Please follow the instructions below before making a PR:
-- Run `cargo clippy --all-targets --all-features` and `cargo fmt` on your patch to fix lints and formatting issues
-- Run `cargo test --all-features` to check that your patch doesn't break any tests
 
+- Run `cargo clippy --all-targets --all-features` and `cargo fmt` on your patch to fix lints and formatting issues.
+- Run `cargo test --all-features` to check that your patch doesn't break any tests.
 
 ## Contributor License Agreement
 


### PR DESCRIPTION
i saw a bunch of new PRs with red CI so I thought we should explicitly mention all these steps for new contributors and rustaceans to make their first PR experience smoother.

I also think we should move the schema generation instructions out of the generated folder into the Contributing.md so that all the development steps are available in one document and not scattered. Let me know if you would like me to make that change in this PR too.