### PR TITLE
Close `db` in `db-bench` tool to prevent `JoinError::Cancelled` messages

### DIFF
--- a/src/db_bench/main.rs
+++ b/src/db_bench/main.rs
@@ -90,4 +90,5 @@ async fn main() {
     };
 
     bench.run().await;
+    db.close().await.expect("failed to close db");
 }


### PR DESCRIPTION
Fixes #192

We were seeing `JoinError::Cancelled` errors when running `db-bench`. Oddly, it was only with the release binary. I eventually realized it's becasue we're just breaking the main loop in `db_bench.rs`'s `run()` method. When the loop breaks, the process returns almost immediately. The code never shuts down the `db` object. If the compactor executor is running, it'll throw these cancellation messages.