### PR TITLE
Fetch WALs in parallel on recovery

### DIFF
--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -37,6 +37,12 @@ impl SsTableHandle {
     }
 }
 
+impl AsRef<SsTableHandle> for SsTableHandle {
+    fn as_ref(&self) -> &SsTableHandle {
+        self
+    }
+}
+
 #[derive(Clone, PartialEq, Debug, Hash, Eq, Copy, Serialize)]
 pub(crate) enum SsTableId {
     Wal(u64),


### PR DESCRIPTION
Fixes: #185

I come from a Go background haven't written much async Rust so please let me know if anything is non-idiomatic.

I only tried to parallelize the part which reads and buffers the wal items, left the memtable building part out of the tokio task as that was acquiring a lock and I thought it might get complicated and lead to deadlocks, etc. I am also assuming that the intent of the issue was also to simply parallelize the wal fetch part excluding memtable building. Let me know if I got that wrong.

In a nutshell does the following:
- ~Extracts the logic which opens SST and iterates over WAL entries to a seperate method `fetch_wall`~
- ~wraps the aforementioned method as a tokio task~
- ~Runs all the tasks in parallel using `join_all`~
- ~Iterates over the results of all the tasks and inserts them into a `BTreeMap` using `sst_id` as the key to ensure that order is preserved, it also collects errors and propogates them to the caller if any errors occur~
- ~The memtable part  is more or less the same it simply iterates over this BTreeMap to build memtable in the same order as before~

I didn't get time to benchmark this against main to see if we are getting any perf gains at all, I just wanted everyone to take a look at this initial draft and confirm if I am headed in the right direction. Just to check the correctness of the code I ran tests and  none of the existing ones broke