### PR TITLE
first pass at slatedb read-manifest CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/target
+**/target
 .DS_Store
+.idea
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +566,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "downcast-rs"
@@ -2123,6 +2150,8 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "crossbeam-skiplist",
+ "derive_more",
+ "dotenv",
  "env_logger",
  "fail-parallel",
  "flatbuffers",
@@ -2552,6 +2581,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,27 +537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
- "unicode-xid",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,10 +547,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast-rs"
@@ -2150,8 +2129,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-channel",
  "crossbeam-skiplist",
- "derive_more",
- "dotenv",
+ "dotenvy",
  "env_logger",
  "fail-parallel",
  "flatbuffers",
@@ -2558,6 +2536,7 @@ checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
  "web-time",
 ]
 
@@ -2581,12 +2560,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ clap = { version = "4.5", optional = true, features = ["derive"] }
 crc32fast = "1.4.2"
 crossbeam-channel = "0.5.13"
 crossbeam-skiplist = "0.1.3"
-derive_more = { version = "1.0.0", features = ["display"] }
-dotenv = "0.15.0"
+dotenvy = { version = "0.15.7", optional = true }
 env_logger = { version = "0.11", optional = true }
 fail-parallel = "0.5.1"
 flatbuffers = "24.3.25"
@@ -30,7 +29,7 @@ parking_lot = "0.12.3"
 siphasher = "1"
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["macros", "sync", "rt", "rt-multi-thread"] }
-ulid = "1.1.3"
+ulid = { version = "1.1.3", features = ["serde"] }
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
 log = {  version = "0.4.22", features = ["std"] }
@@ -54,7 +53,7 @@ tempfile = "3.3"
 [features]
 default = ["aws"]
 aws = ["object_store/aws"]
-cli = ["clap", "clap/derive"]
+cli = ["clap", "clap/derive", "dotenvy"]
 db_bench = ["aws", "env_logger", "leaky-bucket", "clap", "clap/derive", "wal_disable"]
 compression = ["snappy"]
 snappy = ["dep:snap"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ clap = { version = "4.5", optional = true, features = ["derive"] }
 crc32fast = "1.4.2"
 crossbeam-channel = "0.5.13"
 crossbeam-skiplist = "0.1.3"
+derive_more = { version = "1.0.0", features = ["display"] }
+dotenv = "0.15.0"
 env_logger = { version = "0.11", optional = true }
 fail-parallel = "0.5.1"
 flatbuffers = "24.3.25"
@@ -52,6 +54,7 @@ tempfile = "3.3"
 [features]
 default = ["aws"]
 aws = ["object_store/aws"]
+cli = ["clap", "clap/derive"]
 db_bench = ["aws", "env_logger", "leaky-bucket", "clap", "clap/derive", "wal_disable"]
 compression = ["snappy"]
 snappy = ["dep:snap"]
@@ -69,3 +72,9 @@ required-features = ["db_bench"]
 name = "db-bench"
 path = "src/db_bench/main.rs"
 required-features = ["db_bench"]
+
+[[bin]]
+name = "slatedb"
+path = "src/cli/main.rs"
+required-features = ["cli"]
+

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,68 @@
+use crate::manifest_store::ManifestStore;
+use object_store::path::Path;
+use object_store::ObjectStore;
+use std::env;
+use std::error::Error;
+use std::sync::Arc;
+
+/// read-only access to the latest manifest file
+pub async fn read_manifest(
+    path: &Path,
+    object_store: Arc<dyn ObjectStore>,
+) -> Result<Option<String>, Box<dyn Error>> {
+    let manifest_store = ManifestStore::new(path, object_store);
+    match manifest_store.read_latest_manifest().await? {
+        None => Ok(None),
+        Some(id_manifest) => Ok(Some(serde_json::to_string(&id_manifest)?)),
+    }
+}
+
+/// Loads an object store from configured environment variables.
+/// The provider is specified using the CLOUD_PROVIDER variable.
+/// For specific provider configurations, see the corresponding
+/// method documentation:
+///
+/// | Provider | Value | Documentation |
+/// |----------|-------|---------------|
+/// | AWS | `aws` | [load_aws] |
+pub fn load_object_store_from_env(
+    env_file: Option<String>,
+) -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
+    dotenvy::from_filename(env_file.unwrap_or(String::from(".env"))).ok();
+
+    let provider = &*env::var("CLOUD_PROVIDER")
+        .expect("CLOUD_PROVIDER must be set")
+        .to_lowercase();
+    match provider {
+        "aws" => load_aws(),
+        _ => Err(format!("Unknown OS_PROVIDER: '{}'", provider).into()),
+    }
+}
+
+/// Loads an AWS S3 Object store instance.
+///
+/// | Env Variable | Doc | Required |
+/// |--------------|-----|----------|
+/// | AWS_ACCESS_KEY_ID | The access key for a role with permissions to access the store | Yes |
+/// | AWS_SECRET_ACCESS_KEY | The access key secret for the above ID | Yes |
+/// | AWS_BUCKET | The bucket to use within S3 | Yes |
+/// | AWS_REGION | The AWS region to use | Yes |
+pub fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
+    #[cfg(not(feature = "aws"))]
+    panic!("feature 'aws' must be enabled to use OS_PROVIDER=aws");
+
+    let key = env::var("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID must be set");
+    let secret =
+        env::var("AWS_SECRET_ACCESS_KEY").expect("Expected AWS_SECRET_ACCESS_KEY must be set");
+    let bucket = env::var("AWS_BUCKET").expect("AWS_BUCKET must be set");
+    let region = env::var("AWS_REGION").expect("AWS_REGION must be set");
+
+    Ok(Arc::new(
+        object_store::aws::AmazonS3Builder::new()
+            .with_access_key_id(key)
+            .with_secret_access_key(secret)
+            .with_bucket_name(bucket)
+            .with_region(region)
+            .build()?,
+    ) as Arc<dyn ObjectStore>)
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -14,7 +14,7 @@ pub(crate) struct CliArgs {
     #[arg(
         short,
         long,
-        help = "The path in the object store to the root directory"
+        help = "The path in the object store to the root directory, starting from within the object store bucket (specified when configuring the object store provider)"
     )]
     pub(crate) path: String,
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,0 +1,34 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(name = "slatedb")]
+#[command(version = "0.1.0")]
+#[command(about, long_about = None)]
+pub(crate) struct CliArgs {
+    #[arg(
+        short,
+        long,
+        help = "A .env file to use to supply environment variables"
+    )]
+    pub(crate) env_file: Option<String>,
+    #[arg(
+        short,
+        long,
+        help = "The path in the object store to the root directory"
+    )]
+    pub(crate) path: String,
+
+    #[command(subcommand)]
+    pub(crate) command: CliCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum CliCommands {
+    /// Reads the latest manifest file and outputs a readable
+    /// String representation
+    ReadManifest,
+}
+
+pub(crate) fn parse_args() -> CliArgs {
+    CliArgs::parse()
+}

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,8 +1,8 @@
 use crate::args::{parse_args, CliArgs, CliCommands};
 use object_store::path::Path;
 use object_store::ObjectStore;
-use slatedb::manifest_store::read_manifest;
-use std::env;
+use slatedb::admin;
+use slatedb::admin::read_manifest;
 use std::error::Error;
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ mod args;
 async fn main() -> Result<(), Box<dyn Error>> {
     let args: CliArgs = parse_args();
     let path = Path::from(args.path.as_str());
-    let object_store = load_object_store_from_env(args.env_file)?;
+    let object_store = admin::load_object_store_from_env(args.env_file)?;
     match args.command {
         CliCommands::ReadManifest => exec_read_manifest(&path, object_store).await?,
     }
@@ -33,38 +33,4 @@ async fn exec_read_manifest(
         }
     }
     Ok(())
-}
-
-fn load_object_store_from_env(
-    env_file: Option<String>,
-) -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
-    dotenv::from_filename(env_file.unwrap_or(String::from(".env"))).ok();
-
-    let provider = &*env::var("OS_PROVIDER")
-        .expect("OS_PROVIDER must be set")
-        .to_lowercase();
-    match provider {
-        "aws" => load_aws(),
-        _ => Err(format!("Unknown OS_PROVIDER: '{}'", provider).into()),
-    }
-}
-
-fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
-    #[cfg(not(feature = "aws"))]
-    panic!("feature 'aws' must be enabled to use OS_PROVIDER=aws");
-
-    let key = env::var("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID must be set");
-    let secret =
-        env::var("AWS_SECRET_ACCESS_KEY").expect("Expected AWS_SECRET_ACCESS_KEY must be set");
-    let bucket = env::var("AWS_BUCKET").expect("AWS_BUCKET must be set");
-    let region = env::var("AWS_REGION").expect("AWS_REGION must be set");
-
-    Ok(Arc::new(
-        object_store::aws::AmazonS3Builder::new()
-            .with_access_key_id(key)
-            .with_secret_access_key(secret)
-            .with_bucket_name(bucket)
-            .with_region(region)
-            .build()?,
-    ) as Arc<dyn ObjectStore>)
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,0 +1,70 @@
+use crate::args::{parse_args, CliArgs, CliCommands};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use slatedb::manifest_store::read_manifest;
+use std::env;
+use std::error::Error;
+use std::sync::Arc;
+
+mod args;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args: CliArgs = parse_args();
+    let path = Path::from(args.path.as_str());
+    let object_store = load_object_store_from_env(args.env_file)?;
+    match args.command {
+        CliCommands::ReadManifest => exec_read_manifest(&path, object_store).await?,
+    }
+
+    Ok(())
+}
+
+async fn exec_read_manifest(
+    path: &Path,
+    object_store: Arc<dyn ObjectStore>,
+) -> Result<(), Box<dyn Error>> {
+    match read_manifest(path, object_store).await? {
+        None => {
+            println!("No manifest file found.")
+        }
+        Some(manifest) => {
+            println!("{}", manifest);
+        }
+    }
+    Ok(())
+}
+
+fn load_object_store_from_env(
+    env_file: Option<String>,
+) -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
+    dotenv::from_filename(env_file.unwrap_or(String::from(".env"))).ok();
+
+    let provider = &*env::var("OS_PROVIDER")
+        .expect("OS_PROVIDER must be set")
+        .to_lowercase();
+    match provider {
+        "aws" => load_aws(),
+        _ => Err(format!("Unknown OS_PROVIDER: '{}'", provider).into()),
+    }
+}
+
+fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
+    #[cfg(not(feature = "aws"))]
+    panic!("feature 'aws' must be enabled to use OS_PROVIDER=aws");
+
+    let key = env::var("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID must be set");
+    let secret =
+        env::var("AWS_SECRET_ACCESS_KEY").expect("Expected AWS_SECRET_ACCESS_KEY must be set");
+    let bucket = env::var("AWS_BUCKET").expect("AWS_BUCKET must be set");
+    let region = env::var("AWS_REGION").expect("AWS_REGION must be set");
+
+    Ok(Arc::new(
+        object_store::aws::AmazonS3Builder::new()
+            .with_access_key_id(key)
+            .with_secret_access_key(secret)
+            .with_bucket_name(bucket)
+            .with_region(region)
+            .build()?,
+    ) as Arc<dyn ObjectStore>)
+}

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -1,6 +1,8 @@
+use derive_more::Display;
 use std::collections::VecDeque;
+use std::fmt;
+use std::fmt::Formatter;
 use std::sync::Arc;
-
 use tracing::info;
 use ulid::Ulid;
 use SsTableId::{Compacted, Wal};
@@ -8,7 +10,8 @@ use SsTableId::{Compacted, Wal};
 use crate::flatbuffer_types::SsTableInfoOwned;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Display)]
+#[display("{}", id)]
 pub struct SsTableHandle {
     pub id: SsTableId,
     pub info: SsTableInfoOwned,
@@ -36,7 +39,8 @@ impl SsTableHandle {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Hash, Eq, Copy)]
+#[derive(Clone, PartialEq, Debug, Hash, Eq, Copy, Display)]
+#[display("SST(id: {_variant})")]
 pub enum SsTableId {
     Wal(u64),
     Compacted(Ulid),
@@ -60,7 +64,8 @@ impl SsTableId {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Display)]
+#[display("SR(id: {})", id)]
 pub struct SortedRun {
     pub(crate) id: u32,
     pub(crate) ssts: Vec<SsTableHandle>,
@@ -115,6 +120,26 @@ pub struct CoreDbState {
     pub(crate) compacted: Vec<SortedRun>,
     pub(crate) next_wal_sst_id: u64,
     pub(crate) last_compacted_wal_sst_id: u64,
+}
+
+impl fmt::Display for CoreDbState {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let l0_ids = self
+            .l0
+            .iter()
+            .map(|sst| sst.id.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let compacted_ids = self
+            .compacted
+            .iter()
+            .map(|sr| format!("{}", sr))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        write!(f, "{{\n\tLast Compacted L0: {:?},\n\tL0: {},\n\tCompacted: {},\n\tNext WAL SST: {},\n\tLast Compacted WAL SST: {}\n}}", self.l0_last_compacted, l0_ids, compacted_ids, self.next_wal_sst_id, self.last_compacted_wal_sst_id)
+    }
 }
 
 impl CoreDbState {

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -2,6 +2,8 @@ use std::collections::VecDeque;
 
 use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use ulid::Ulid;
 
 use crate::db_state;
@@ -29,6 +31,17 @@ use crate::manifest::{Manifest, ManifestCodec};
 #[derive(Clone, PartialEq, Debug)]
 pub(crate) struct SsTableInfoOwned {
     data: Bytes,
+}
+
+impl Serialize for SsTableInfoOwned {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("SsTableInfoOwned", 2)?;
+        s.serialize_field("data_length", &self.data.len())?;
+        s.end()
+    }
 }
 
 impl SsTableInfoOwned {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]
 
+pub mod admin;
 mod blob;
 mod block;
 mod block_iterator;
@@ -25,7 +26,7 @@ mod garbage_collector;
 pub mod inmemory_cache;
 mod iter;
 mod manifest;
-pub mod manifest_store;
+mod manifest_store;
 mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ mod garbage_collector;
 pub mod inmemory_cache;
 mod iter;
 mod manifest;
-mod manifest_store;
+pub mod manifest_store;
 mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,34 +1,13 @@
 use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
 use bytes::Bytes;
-use std::fmt;
-use std::fmt::Formatter;
+use serde::Serialize;
 
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub(crate) struct Manifest {
     pub(crate) core: CoreDbState,
     pub(crate) writer_epoch: u64,
     pub(crate) compactor_epoch: u64,
-}
-
-impl fmt::Display for Manifest {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let core_indented = self
-            .core
-            .to_string()
-            .lines()
-            .map(|line| format!("\t{}", line))
-            .collect::<Vec<String>>()
-            .join("\n");
-
-        write!(
-            f,
-            "{{\n\tCore: {},\n\tWriter Epoch: {},\n\tCompactor Epoch: {}\n}}",
-            core_indented.trim(),
-            self.writer_epoch,
-            self.compactor_epoch
-        )
-    }
 }
 
 pub(crate) trait ManifestCodec: Send + Sync {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,13 +1,34 @@
-use bytes::Bytes;
-
 use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
+use bytes::Bytes;
+use std::fmt;
+use std::fmt::Formatter;
 
 #[derive(Clone)]
 pub(crate) struct Manifest {
     pub(crate) core: CoreDbState,
     pub(crate) writer_epoch: u64,
     pub(crate) compactor_epoch: u64,
+}
+
+impl fmt::Display for Manifest {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let core_indented = self
+            .core
+            .to_string()
+            .lines()
+            .map(|line| format!("\t{}", line))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        write!(
+            f,
+            "{{\n\tCore: {},\n\tWriter Epoch: {},\n\tCompactor Epoch: {}\n}}",
+            core_indented.trim(),
+            self.writer_epoch,
+            self.compactor_epoch
+        )
+    }
 }
 
 pub(crate) trait ManifestCodec: Send + Sync {

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -17,18 +17,6 @@ use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
 
-/// read-only access to the latest manifest file
-pub async fn read_manifest(
-    path: &Path,
-    object_store: Arc<dyn ObjectStore>,
-) -> Result<Option<String>, SlateDBError> {
-    let manifest_store = ManifestStore::new(path, object_store);
-    match manifest_store.read_latest_manifest().await? {
-        None => Ok(None),
-        Some((_, manifest)) => Ok(Some(manifest.to_string())),
-    }
-}
-
 pub(crate) struct FenceableManifest {
     stored_manifest: StoredManifest,
     local_epoch: u64,

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -17,6 +17,18 @@ use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
 
+/// read-only access to the latest manifest file
+pub async fn read_manifest(
+    path: &Path,
+    object_store: Arc<dyn ObjectStore>,
+) -> Result<Option<String>, SlateDBError> {
+    let manifest_store = ManifestStore::new(path, object_store);
+    match manifest_store.read_latest_manifest().await? {
+        None => Ok(None),
+        Some((_, manifest)) => Ok(Some(manifest.to_string())),
+    }
+}
+
 pub(crate) struct FenceableManifest {
     stored_manifest: StoredManifest,
     local_epoch: u64,


### PR DESCRIPTION
This is the first step to implementing and Admin CLI, as the result of the discussion on #151 and the discord channel. Note that this specific PR does not spin up an entire embedded SlateDB instance and instead just directly leverages the ability to read the manifest, this makes it really fast!

```
$ target/release/slatedb --path store2375 read-manifest | jq .
[
  36,
  {
    "core": {
      "l0_last_compacted": "01J7M9NRAGXPV967CK920R7EFT",
      "l0": [
        {
          "id": {
            "Compacted": "01J7MDQE553EWN2MV7JM2JJ13Z"
          },
          "info": {
            "data_length": 72
          }
        },
        {
          "id": {
            "Compacted": "01J7MDP1AFRMF7KGK9H3D64K1Q"
          },
          "info": {
            "data_length": 72
          }
        }
      ],
      "compacted": [
        {
          "id": 0,
          "ssts": [
            {
              "id": {
                "Compacted": "01J7M9NWFP9BMW733J4BH5VRV4"
              },
              "info": {
                "data_length": 72
              }
            }
          ]
        }
      ],
      "next_wal_sst_id": 1,
      "last_compacted_wal_sst_id": 0
    },
    "writer_epoch": 14,
    "compactor_epoch": 14
  }
]
```

```
$target/release/slatedb --env-file .env2 --path store2375 --help
A cloud native embedded storage engine built on object storage.

Usage: slatedb [OPTIONS] --path <PATH> <COMMAND>

Commands:
  read-manifest  Reads the latest manifest file and outputs a readable String representation
  help           Print this message or the help of the given subcommand(s)

Options:
  -e, --env-file <ENV_FILE>  A .env file to use to supply environment variables
  -p, --path <PATH>          The path in the object store to the root directory
  -h, --help                 Print help
  -V, --version              Print version
```