### PR TITLE
cache indexes and bloom filters in memory

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 edition = "2021"
 reorder_imports = true
+required_version = "1.8.1"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,2 @@
 edition = "2021"
 reorder_imports = true
-required_version = "1.8.1"

--- a/src/inmemory_cache.rs
+++ b/src/inmemory_cache.rs
@@ -42,16 +42,16 @@ impl Default for InMemoryCacheOptions {
 
 #[async_trait]
 pub(crate) trait InMemoryCache: Send + Sync + 'static {
-    async fn get(&self, key: (SsTableId, usize)) -> CachedBlockOption;
-    async fn insert(&self, key: (SsTableId, usize), value: CachedBlock);
+    async fn get(&self, key: (SsTableId, u64)) -> CachedBlockOption;
+    async fn insert(&self, key: (SsTableId, u64), value: CachedBlock);
     #[allow(dead_code)]
-    async fn remove(&self, key: (SsTableId, usize));
+    async fn remove(&self, key: (SsTableId, u64));
     #[allow(dead_code)]
     fn entry_count(&self) -> u64;
 }
 
 pub(crate) struct MokaCache {
-    inner: moka::future::Cache<(SsTableId, usize), CachedBlock>,
+    inner: moka::future::Cache<(SsTableId, u64), CachedBlock>,
 }
 
 impl MokaCache {
@@ -76,15 +76,15 @@ impl MokaCache {
 
 #[async_trait]
 impl InMemoryCache for MokaCache {
-    async fn get(&self, key: (SsTableId, usize)) -> CachedBlockOption {
+    async fn get(&self, key: (SsTableId, u64)) -> CachedBlockOption {
         CachedBlockOption::Moka(self.inner.get(&key).await)
     }
 
-    async fn insert(&self, key: (SsTableId, usize), value: CachedBlock) {
+    async fn insert(&self, key: (SsTableId, u64), value: CachedBlock) {
         self.inner.insert(key, value).await;
     }
 
-    async fn remove(&self, key: (SsTableId, usize)) {
+    async fn remove(&self, key: (SsTableId, u64)) {
         self.inner.remove(&key).await;
     }
 
@@ -94,7 +94,7 @@ impl InMemoryCache for MokaCache {
 }
 
 pub(crate) struct FoyerCache {
-    inner: foyer::Cache<(SsTableId, usize), CachedBlock>,
+    inner: foyer::Cache<(SsTableId, u64), CachedBlock>,
 }
 
 impl FoyerCache {
@@ -118,15 +118,15 @@ impl FoyerCache {
 
 #[async_trait]
 impl InMemoryCache for FoyerCache {
-    async fn get(&self, key: (SsTableId, usize)) -> CachedBlockOption {
+    async fn get(&self, key: (SsTableId, u64)) -> CachedBlockOption {
         CachedBlockOption::Foyer(self.inner.get(&key))
     }
 
-    async fn insert(&self, key: (SsTableId, usize), value: CachedBlock) {
+    async fn insert(&self, key: (SsTableId, u64), value: CachedBlock) {
         self.inner.insert(key, value);
     }
 
-    async fn remove(&self, key: (SsTableId, usize)) {
+    async fn remove(&self, key: (SsTableId, u64)) {
         self.inner.remove(&key);
     }
 
@@ -152,7 +152,7 @@ pub(crate) fn create_block_cache(
 /// wrapper around Option<CachedBlock> to provide helper functions
 pub(crate) enum CachedBlockOption {
     Moka(Option<CachedBlock>),
-    Foyer(Option<foyer::CacheEntry<(SsTableId, usize), CachedBlock>>),
+    Foyer(Option<foyer::CacheEntry<(SsTableId, u64), CachedBlock>>),
 }
 
 impl CachedBlockOption {

--- a/src/inmemory_cache.rs
+++ b/src/inmemory_cache.rs
@@ -9,9 +9,7 @@ use crate::{
 #[derive(Clone)]
 pub(crate) enum CachedBlock {
     Block(Arc<Block>),
-    #[allow(dead_code)]
     Index(Arc<SsTableIndexOwned>),
-    #[allow(dead_code)]
     Filter(Arc<BloomFilter>),
 }
 
@@ -169,7 +167,6 @@ impl CachedBlockOption {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn sst_index(&self) -> Option<Arc<SsTableIndexOwned>> {
         match self {
             CachedBlockOption::Moka(Some(CachedBlock::Index(index))) => Some(index.clone()),
@@ -181,7 +178,6 @@ impl CachedBlockOption {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn bloom_filter(&self) -> Option<Arc<BloomFilter>> {
         match self {
             CachedBlockOption::Moka(Some(CachedBlock::Filter(filter))) => Some(filter.clone()),

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -128,7 +128,7 @@ impl<'a> SstIterator<'a> {
     ) -> Result<Self, SlateDBError> {
         assert!(max_fetch_tasks > 0);
         assert!(blocks_to_fetch > 0);
-        let index = Arc::new(table_store.read_index(table).await?);
+        let index = table_store.read_index(table).await?;
         let next_block_idx_to_fetch = from_key
             .map(|k| Self::first_block_with_data_including_or_after_key(&index.borrow(), k))
             .unwrap_or(0);


### PR DESCRIPTION
This PR introduces in-memory cache for Bloom filters and Sst Indexes and removes the filter map in TableStore