### PR TITLE
Use `dotenvy` crate for all binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.5", optional = true, features = ["derive"] }
 crc32fast = "1.4.2"
 crossbeam-channel = "0.5.13"
 crossbeam-skiplist = "0.1.3"
-dotenvy = { version = "0.15.7", optional = true }
+dotenvy = { version = "0.15.7" }
 env_logger = { version = "0.11", optional = true }
 fail-parallel = "0.5.1"
 flatbuffers = "24.3.25"
@@ -53,7 +53,7 @@ tempfile = "3.3"
 [features]
 default = ["aws"]
 aws = ["object_store/aws"]
-cli = ["clap", "clap/derive", "dotenvy"]
+cli = ["clap", "clap/derive"]
 db_bench = ["aws", "env_logger", "leaky-bucket", "clap", "clap/derive", "wal_disable"]
 compression = ["snappy"]
 snappy = ["dep:snap"]


### PR DESCRIPTION
The `admin.rs` file is using `dotenvy` for `load_object_store_from_env`. Since the admin package is meant to be used outside of the `cli` feature, I opted to include `dotenvy` as a dependency in all binaries rather than introduce another `admin` feature or wrap the `dotenvy` usage in the `cli` feature..