### PR TITLE
Use ulid, no crash protection, single flush thread

### DIFF
--- a/specs/kvstore/KeyValueStore.fizz
+++ b/specs/kvstore/KeyValueStore.fizz
@@ -2,9 +2,13 @@
 deadlock_detection: false
 options:
     max_actions: 100
+    crash_on_yield: false
+    max_concurrent_actions: 2
 action_options:
     SlateDb.Put:
         max_actions: 2
+    SlateDb.FlushMemtable:
+        max_concurrent_actions: 1
 
 ---
 
@@ -30,11 +34,6 @@ role SlateDb:
     # For now, modeling only a single writer that maintains its own count
     self.wal_index = 0
 
-    # A way to version, the design doc seems to use some hash, but hash algorithms are not supported in fizzbee
-    # so using a workaround. The memtable_wal_index represents the high watermark of the wal index written whose
-    # data are included in this memtable version.
-    self.memtable_wal_index = -1
-
   atomic action Put:
     require (self.MODE == 'RW')
     kv = any [ (k,v) for k in KEYS for v in VALUES ]
@@ -47,6 +46,7 @@ role SlateDb:
   #   return v
 
   fair action FlushWal:
+    require len(self.wal) > 0 or len(self.immutable_wal) > 0
     self.freeze_wal()
     self.write_wal()
     self.update_memtable()
@@ -54,6 +54,7 @@ role SlateDb:
     
 
   fair action FlushMemtable:
+    require len(self.memtable) > 0 or len(self.immutable_memtable) > 0
     self.freeze_memtable()
     self.write_l0()
     self.immutable_memtable.clear()
@@ -76,7 +77,6 @@ role SlateDb:
         content = store.Read(l0)
         if content and content.get(k):
             return content.get(k)
-            
  
     return NOT_FOUND
 
@@ -93,9 +93,6 @@ role SlateDb:
 
 
   atomic func update_memtable():
-    if self.memtable_wal_index >= self.wal_index:
-        return
-    self.memtable_wal_index = self.wal_index
     for kv in self.immutable_wal:
         self.memtable[kv[0]] = kv[1]
     
@@ -103,22 +100,21 @@ role SlateDb:
   atomic func freeze_memtable():
     if len(self.immutable_memtable) > 0 or len(self.memtable) == 0:
         return
-    name = "compacted/hash-" + str(self.memtable_wal_index) + ".sst"
-    if name in self.l0:
-        return
+
     self.immutable_memtable = dict(self.memtable)
     self.memtable.clear()
-    self.l0.append(name)
 
   atomic func write_l0():
     if len(self.immutable_memtable) == 0:
         return
-    name = self.l0[-1]
+    name = "compacted/ulid-" + str(next_ulid) + ".sst"
+    next_ulid += 1
     store.Write(name, dict(self.immutable_memtable))
     
 
   atomic func clear_immutable_memtable():
     self.immutable_memtable.clear()
+
 
 role ObjectStore:
   action Init:
@@ -134,6 +130,8 @@ role ObjectStore:
 action Init:
   writer = SlateDb(MODE="RW")
   store = ObjectStore()  
+  # Slatedb uses ULID, that is a sortable unique id. We can model it with just a counter
+  next_ulid = 1
 
 
 always assertion NoEmptyL0s:
@@ -142,7 +140,6 @@ always assertion NoEmptyL0s:
             return False
     return True
         
-
 always eventually assertion ConsistentRead:
     reader = SlateDb(mode="RO")
     reader.l0 = writer.l0
@@ -153,6 +150,9 @@ always eventually assertion ConsistentRead:
             return False
     return True
         
+always assertion MaxObjects:
+    return len(store.objects) <= 6
+
 always eventually assertion WalFlushed:
     return len(writer.wal) == 0 and len(writer.immutable_wal) == 0
 

--- a/specs/kvstore/KeyValueStore.fizz
+++ b/specs/kvstore/KeyValueStore.fizz
@@ -3,10 +3,11 @@ deadlock_detection: false
 options:
     max_actions: 100
     crash_on_yield: false
-    max_concurrent_actions: 2
 action_options:
     SlateDb.Put:
         max_actions: 2
+    SlateDb.FlushWal:
+        max_concurrent_actions: 1
     SlateDb.FlushMemtable:
         max_concurrent_actions: 1
 
@@ -37,7 +38,8 @@ role SlateDb:
   atomic action Put:
     require (self.MODE == 'RW')
     kv = any [ (k,v) for k in KEYS for v in VALUES ]
-    writer.put(kv[0], kv[1])
+    self.put(kv[0], kv[1])
+    _last_puts[kv[0]] = kv[1]
 
   # atomic action Get:
   #   k = any KEYS
@@ -59,7 +61,7 @@ role SlateDb:
     self.write_l0()
     self.immutable_memtable.clear()
     
-  func put(k, v):
+  atomic func put(k, v):
     self.wal.append( (k, v) )
 
   atomic func get(k, read_level):
@@ -68,16 +70,16 @@ role SlateDb:
             if kv[0] == k:
                 return kv[1]
 
-    if self.immutable_memtable.get(k):
-        return self.immutable_memtable.get(k)
     if self.memtable.get(k):
         return self.memtable.get(k)
+    if self.immutable_memtable.get(k):
+        return self.immutable_memtable.get(k)
 
     for l0 in reversed(self.l0):
         content = store.Read(l0)
         if content and content.get(k):
             return content.get(k)
- 
+
     return NOT_FOUND
 
   atomic func freeze_wal():
@@ -110,6 +112,7 @@ role SlateDb:
     name = "compacted/ulid-" + str(next_ulid) + ".sst"
     next_ulid += 1
     store.Write(name, dict(self.immutable_memtable))
+    self.l0.append(name)
     
 
   atomic func clear_immutable_memtable():
@@ -133,13 +136,34 @@ action Init:
   # Slatedb uses ULID, that is a sortable unique id. We can model it with just a counter
   next_ulid = 1
 
+  # As a convention, variables starting with _ are not part of the system modelled, but
+  # useful for assertions
+  _last_puts = {}
+
 
 always assertion NoEmptyL0s:
     for l0 in writer.l0:
         if store.objects.get(l0) != None and len(store.objects.get(l0)) == 0:
             return False
     return True
-        
+
+always assertion UncommittedRead:
+    for k in KEYS:
+        v0 = writer.get(k, ReadLevel.Uncommitted)
+        v1 = _last_puts.get(k, NOT_FOUND)
+        if v0 != v1:
+            return False
+    return True
+
+always eventually assertion CommittedRead:
+    for k in KEYS:
+        v0 = writer.get(k, ReadLevel.Uncommitted)
+        v1 = writer.get(k, ReadLevel.Committed)
+        v2 = _last_puts.get(k, NOT_FOUND)
+        if v0 != v1 or v0 != v2:
+            return False
+    return True
+
 always eventually assertion ConsistentRead:
     reader = SlateDb(mode="RO")
     reader.l0 = writer.l0


### PR DESCRIPTION
Making some changes to actually reflect the design.

1.  Use chronologically sortable id for L0 names (to model ULID)
2.  Does not handle flush thread crashes (`crash_on_yield: false`)
3.  Support only a single flush thread (`max_concurrent_actions: 1`)
4.  Add assertion that uncommitted read always returns last put value
5.  Add assertion that committed read eventually returns the last put value
6.  Add an assertion MaxObjects as safety check. 
    -  The MaxObjects in the ObjectStore should be at most 2*number of Puts.
    -  Violating 2 and 3 above will fail MaxObjects check

There is a small bit that deviates from the actual design. The FlushWal and FlushMemtable are modeled as separate actions, instead of FlushWal triggering FlushMemtable as an option. One implication is there could be two threads one flushing wal and one flushing memtable at a time.