### PR TITLE
support list-manifests and read specific manifest for slatedb CLI

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -26,7 +26,23 @@ pub(crate) struct CliArgs {
 pub(crate) enum CliCommands {
     /// Reads the latest manifest file and outputs a readable
     /// String representation
-    ReadManifest,
+    ReadManifest {
+        /// Specify a specific manifest ULID to read, if this is
+        /// not specified the latest manifest will be returned
+        #[arg(short, long)]
+        id: Option<u64>,
+    },
+
+    /// Lists all available manifests
+    ListManifests {
+        /// Optionally specify a start id for the range of manifests to lookup
+        #[arg(short, long)]
+        start: Option<u64>,
+
+        /// Optionally specify an end id for the range of manifests to lookup
+        #[arg(short, long)]
+        end: Option<u64>,
+    },
 }
 
 pub(crate) fn parse_args() -> CliArgs {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -2,7 +2,7 @@ use crate::args::{parse_args, CliArgs, CliCommands};
 use object_store::path::Path;
 use object_store::ObjectStore;
 use slatedb::admin;
-use slatedb::admin::read_manifest;
+use slatedb::admin::{list_manifests, read_manifest};
 use std::error::Error;
 use std::sync::Arc;
 
@@ -14,7 +14,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let path = Path::from(args.path.as_str());
     let object_store = admin::load_object_store_from_env(args.env_file)?;
     match args.command {
-        CliCommands::ReadManifest => exec_read_manifest(&path, object_store).await?,
+        CliCommands::ReadManifest { id } => exec_read_manifest(&path, object_store, id).await?,
+        CliCommands::ListManifests { start, end } => {
+            exec_list_manifest(&path, object_store, start, end).await?
+        }
     }
 
     Ok(())
@@ -23,8 +26,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn exec_read_manifest(
     path: &Path,
     object_store: Arc<dyn ObjectStore>,
+    id: Option<u64>,
 ) -> Result<(), Box<dyn Error>> {
-    match read_manifest(path, object_store).await? {
+    match read_manifest(path, object_store, id).await? {
         None => {
             println!("No manifest file found.")
         }
@@ -33,4 +37,23 @@ async fn exec_read_manifest(
         }
     }
     Ok(())
+}
+
+async fn exec_list_manifest(
+    path: &Path,
+    object_store: Arc<dyn ObjectStore>,
+    start: Option<u64>,
+    end: Option<u64>,
+) -> Result<(), Box<dyn Error>> {
+    let range = match (start, end) {
+        (Some(s), Some(e)) => s..e,
+        (Some(s), None) => s..u64::MAX,
+        (None, Some(e)) => u64::MIN..e,
+        _ => u64::MIN..u64::MAX,
+    };
+
+    Ok(println!(
+        "{}",
+        list_manifests(path, object_store, range).await?
+    ))
 }

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -5,7 +5,8 @@ use chrono::Utc;
 use futures::StreamExt;
 use object_store::path::Path;
 use object_store::Error::AlreadyExists;
-use object_store::ObjectStore;
+use object_store::{Error, ObjectStore};
+use serde::Serialize;
 use tracing::warn;
 
 use crate::db_state::CoreDbState;
@@ -166,12 +167,21 @@ impl StoredManifest {
 }
 
 /// Represents the metadata of a manifest file stored in the object store.
+#[derive(Serialize)]
 pub(crate) struct ManifestFileMetadata {
     pub(crate) id: u64,
+    #[serde(serialize_with = "serialize_path")]
     pub(crate) location: Path,
     pub(crate) last_modified: chrono::DateTime<Utc>,
     #[allow(dead_code)]
     pub(crate) size: usize,
+}
+
+fn serialize_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&*path.to_string())
 }
 
 pub(crate) struct ManifestStore {
@@ -253,7 +263,7 @@ impl ManifestStore {
                         size: file.size,
                     });
                 }
-                Err(_) => warn!("Unknwon file in manifest directory: {:?}", file.location),
+                Err(_) => warn!("Unknown file in manifest directory: {:?}", file.location),
                 _ => {}
             }
         }
@@ -266,23 +276,31 @@ impl ManifestStore {
         &self,
     ) -> Result<Option<(u64, Manifest)>, SlateDBError> {
         let manifest_metadatas_list = self.list_manifests(..).await?;
-
         match manifest_metadatas_list.last() {
-            Some(metadata) => {
-                let manifest_bytes = match self.object_store.get(&metadata.location).await {
-                    Ok(manifest) => match manifest.bytes().await {
-                        Ok(bytes) => bytes,
-                        Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
-                    },
-                    Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
-                };
-
-                self.codec
-                    .decode(&manifest_bytes)
-                    .map(|m| Some((metadata.id, m)))
-            }
             None => Ok(None),
+            Some(metadata) => Ok(self.read_manifest(metadata.id).await?),
         }
+    }
+
+    pub(crate) async fn read_manifest(
+        &self,
+        id: u64,
+    ) -> Result<Option<(u64, Manifest)>, SlateDBError> {
+        let manifest_path = &self.get_manifest_path(id);
+        let manifest_bytes = match self.object_store.get(manifest_path).await {
+            Ok(manifest) => match manifest.bytes().await {
+                Ok(bytes) => bytes,
+                Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
+            },
+            Err(e) => {
+                return match e {
+                    Error::NotFound { .. } => Ok(None),
+                    _ => Err(SlateDBError::ObjectStoreError(e)),
+                }
+            }
+        };
+
+        self.codec.decode(&manifest_bytes).map(|m| Some((id, m)))
     }
 
     fn parse_id(&self, path: &Path, expected_extension: &str) -> Result<u64, SlateDBError> {
@@ -457,6 +475,24 @@ mod tests {
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
         let refreshed = compactor2.refresh().await.unwrap();
         assert_eq!(refreshed.next_wal_sst_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_should_read_specific_manifest() {
+        // Given
+        let os = Arc::new(InMemory::new());
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let state = CoreDbState::new();
+        let mut sm = StoredManifest::init_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        sm.update_db_state(state.clone()).await.unwrap();
+
+        // When
+        let (id, _) = ms.read_manifest(2).await.unwrap().unwrap();
+
+        // Then:
+        assert_eq!(id, 2);
     }
 
     #[tokio::test]

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -181,7 +181,7 @@ fn serialize_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(&*path.to_string())
+    serializer.serialize_str(path.as_ref())
 }
 
 pub(crate) struct ManifestStore {


### PR DESCRIPTION
This adds more of the functionality requested in #151. See below for behavior:

### Read Specific Manifest

```
$ target/release/slatedb --path store2375 read-manifest -i 32 | jq .
[
  32,
  {
    "core": {
      "l0_last_compacted": "01J7M9NRAGXPV967CK920R7EFT",
      "l0": [
        {...
  }
]
```
```
$ target/release/slatedb --path store2375 read-manifest -i 37
No manifest file found.
```

### List Manifests (all)

```
$ target/release/slatedb --path store2375 list-manifests | jq .
[
  {
    "id": 1,
    "location": "00000000000000000001.manifest",
    "last_modified": "2024-09-12T23:38:34Z",
    "size": 44
  },
  {
    "id": 2,
    "location": "00000000000000000002.manifest",
    "last_modified": "2024-09-12T23:38:35Z",
    "size": 56
  },
  {
    "id": 3,
    "location": "00000000000000000003.manifest",
    "last_modified": "2024-09-12T23:38:35Z",
    "size": 64
  },
```

### List Manifest (range)

```
$ target/release/slatedb --path store2375 list-manifests --start 2 --end 4 | jq .
[
  {
    "id": 2,
    "location": "00000000000000000002.manifest",
    "last_modified": "2024-09-12T23:38:35Z",
    "size": 56
  },
  {
    "id": 3,
    "location": "00000000000000000003.manifest",
    "last_modified": "2024-09-12T23:38:35Z",
    "size": 64
  }
]
```

```
$ target/release/slatedb --path store2375 list-manifests --end 4 | jq .
[
  {
    "id": 1,
    "location": "00000000000000000001.manifest",
    "last_modified": "2024-09-12T23:38:34Z",
    "size": 44
  },
  {
    "id": 2,
    "location": "00000000000000000002.manifest",
    "last_modified": "2024-09-12T23:38:35Z",
    "size": 56
  },
  {
    "id": 3,
    "location": "00000000000000000003.manifest",
    "last_modified": "2024-09-12T23:38:35Z",
    "size": 64
  }
]
```