### PR TITLE
Remove `SsTableInfoOwned` and add `SsTableInfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,9 @@ name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ async-channel = "2.3.1"
 async-trait = "0.1.82"
 atomic = "0.6.0"
 bytemuck = "1.18.0"
-bytes = "1.7.1"
+bytes = { version = "1.7.1", features = ["serde"] }
 clap = { version = "4.5", optional = true, features = ["derive"] }
 crc32fast = "1.4.2"
 crossbeam-channel = "0.5.13"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::{str::FromStr, time::Duration};
 
+use serde::Serialize;
 use tokio::runtime::Handle;
 
 use crate::compactor::CompactionScheduler;
@@ -171,7 +172,7 @@ impl Default for DbOptions {
 }
 
 /// The compression algorithm to use for SSTables.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug, Serialize)]
 pub enum CompressionCodec {
     #[cfg(feature = "snappy")]
     /// Snappy compression algorithm.

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use serde::Serialize;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -5,34 +6,34 @@ use tracing::info;
 use ulid::Ulid;
 use SsTableId::{Compacted, Wal};
 
-use crate::flatbuffer_types::SsTableInfoOwned;
+use crate::config::CompressionCodec;
+use crate::error::SlateDBError;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 
 #[derive(Clone, PartialEq, Serialize)]
 pub struct SsTableHandle {
     pub id: SsTableId,
-    pub info: SsTableInfoOwned,
+    pub info: SsTableInfo,
 }
 
 impl SsTableHandle {
-    pub(crate) fn new(id: SsTableId, info: SsTableInfoOwned) -> Self {
+    pub(crate) fn new(id: SsTableId, info: SsTableInfo) -> Self {
         SsTableHandle { id, info }
     }
 
     pub(crate) fn range_covers_key(&self, key: &[u8]) -> bool {
-        if let Some(first_key) = self.info.borrow().first_key() {
-            return key >= first_key.bytes();
+        if let Some(first_key) = self.info.first_key.as_ref() {
+            return key >= first_key;
         }
         false
     }
 
     pub(crate) fn estimate_size(&self) -> u64 {
-        let info = self.info.borrow();
         // this is a hacky estimate of the sst size since we don't have it stored anywhere
         // right now. Just use the index's offset and add the index length. Since the index
         // is the last thing we put in the SST before the info footer, this should be a good
         // estimate for now.
-        info.index_offset() + info.index_len()
+        self.info.index_offset + self.info.index_len
     }
 }
 
@@ -60,6 +61,33 @@ impl SsTableId {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct SsTableInfo {
+    pub(crate) first_key: Option<Bytes>,
+    pub(crate) index_offset: u64,
+    pub(crate) index_len: u64,
+    pub(crate) filter_offset: u64,
+    pub(crate) filter_len: u64,
+    pub(crate) compression_codec: Option<CompressionCodec>,
+}
+
+pub(crate) trait SsTableInfoCodec: Send + Sync {
+    fn encode(&self, manifest: &SsTableInfo) -> Bytes;
+
+    fn decode(&self, bytes: &Bytes) -> Result<SsTableInfo, SlateDBError>;
+
+    fn clone_box(&self) -> Box<dyn SsTableInfoCodec>;
+}
+
+/// Implement Clone for Box<dyn SsTableInfoCodec> by delegating to the clone_box method.
+/// This is the idiomatic way to clone trait objects in Rust. It is also the only way to
+/// clone trait objects without knowing the concrete type.
+impl Clone for Box<dyn SsTableInfoCodec> {
+    fn clone(&self) -> Self {
+        self.as_ref().clone_box()
+    }
+}
+
 #[derive(Clone, PartialEq, Serialize)]
 pub struct SortedRun {
     pub(crate) id: u32,
@@ -75,10 +103,9 @@ impl SortedRun {
         // returns the sst after the one whose range includes the key
         let first_sst = self.ssts.partition_point(|sst| {
             sst.info
-                .borrow()
-                .first_key()
+                .first_key
+                .as_ref()
                 .expect("sst must have first key")
-                .bytes()
                 <= key
         });
         if first_sst > 0 {
@@ -274,11 +301,9 @@ impl DbState {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
     use ulid::Ulid;
 
-    use crate::db_state::{CoreDbState, DbState, SsTableHandle, SsTableId};
-    use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
+    use crate::db_state::{CoreDbState, DbState, SsTableHandle, SsTableId, SsTableInfo};
 
     #[test]
     fn test_should_refresh_db_state_with_l0s_up_to_last_compacted() {
@@ -325,20 +350,14 @@ mod tests {
         }
     }
 
-    fn create_sst_info() -> SsTableInfoOwned {
-        let mut builder = flatbuffers::FlatBufferBuilder::new();
-        let wip = SsTableInfo::create(
-            &mut builder,
-            &SsTableInfoArgs {
-                first_key: None,
-                index_offset: 0,
-                index_len: 0,
-                filter_offset: 0,
-                filter_len: 0,
-                compression_format: None.into(),
-            },
-        );
-        builder.finish(wip, None);
-        SsTableInfoOwned::new(Bytes::copy_from_slice(builder.finished_data())).unwrap()
+    fn create_sst_info() -> SsTableInfo {
+        SsTableInfo {
+            first_key: None,
+            index_offset: 0,
+            index_len: 0,
+            filter_offset: 0,
+            filter_len: 0,
+            compression_codec: None,
+        }
     }
 }

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -2,11 +2,9 @@ use std::collections::VecDeque;
 
 use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
-use serde::ser::SerializeStruct;
-use serde::{Serialize, Serializer};
 use ulid::Ulid;
 
-use crate::db_state;
+use crate::db_state::{self, SsTableInfo, SsTableInfoCodec};
 use crate::db_state::{CoreDbState, SsTableHandle};
 
 #[path = "./generated/manifest_generated.rs"]
@@ -15,7 +13,7 @@ use crate::db_state::{CoreDbState, SsTableHandle};
 mod manifest_generated;
 pub use manifest_generated::{
     BlockMeta, BlockMetaArgs, ManifestV1, ManifestV1Args, SsTableIndex, SsTableIndexArgs,
-    SsTableInfo, SsTableInfoArgs,
+    SsTableInfo as FbSsTableInfo, SsTableInfoArgs,
 };
 
 use crate::config::CompressionCodec;
@@ -27,48 +25,6 @@ use crate::flatbuffer_types::manifest_generated::{
     SortedRun, SortedRunArgs,
 };
 use crate::manifest::{Manifest, ManifestCodec};
-
-#[derive(Clone, PartialEq, Debug)]
-pub(crate) struct SsTableInfoOwned {
-    data: Bytes,
-}
-
-impl Serialize for SsTableInfoOwned {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut s = serializer.serialize_struct("SsTableInfoOwned", 2)?;
-        s.serialize_field("data_length", &self.data.len())?;
-        s.end()
-    }
-}
-
-impl SsTableInfoOwned {
-    pub fn new(data: Bytes) -> Result<Self, InvalidFlatbuffer> {
-        flatbuffers::root::<SsTableInfo>(&data)?;
-        Ok(Self { data })
-    }
-
-    pub fn data(&self) -> &[u8] {
-        &self.data
-    }
-
-    pub fn borrow(&self) -> SsTableInfo<'_> {
-        let raw = &self.data;
-        // This is safe, because we validated the flatbuffer on construction and the
-        // memory is immutable once we construct the handle.
-        unsafe { flatbuffers::root_unchecked::<SsTableInfo>(raw) }
-    }
-
-    pub fn create_copy(sst_info: &SsTableInfo) -> Self {
-        let builder = flatbuffers::FlatBufferBuilder::new();
-        let mut db_fb_builder = DbFlatBufferBuilder::new(builder);
-        Self {
-            data: db_fb_builder.create_sst_info_copy(sst_info),
-        }
-    }
-}
 
 pub(crate) struct SsTableIndexOwned {
     data: Bytes,
@@ -86,21 +42,61 @@ impl SsTableIndexOwned {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct FlatBufferSsTableInfoCodec {}
+
+impl SsTableInfoCodec for FlatBufferSsTableInfoCodec {
+    fn encode(&self, info: &SsTableInfo) -> Bytes {
+        Self::create_from_sst_info(info)
+    }
+
+    fn decode(&self, bytes: &Bytes) -> Result<SsTableInfo, SlateDBError> {
+        let info = flatbuffers::root::<FbSsTableInfo>(bytes)?;
+        Ok(Self::sst_info(&info))
+    }
+
+    fn clone_box(&self) -> Box<dyn SsTableInfoCodec> {
+        Box::new(Self {})
+    }
+}
+
+impl FlatBufferSsTableInfoCodec {
+    pub fn sst_info(info: &FbSsTableInfo) -> SsTableInfo {
+        let first_key: Option<Bytes> = info
+            .first_key()
+            .map(|key| Bytes::copy_from_slice(key.bytes()));
+        SsTableInfo {
+            first_key,
+            index_offset: info.index_offset(),
+            index_len: info.index_len(),
+            filter_offset: info.filter_offset(),
+            filter_len: info.filter_len(),
+            compression_codec: info.compression_format().into(),
+        }
+    }
+
+    pub fn create_from_sst_info(info: &SsTableInfo) -> Bytes {
+        let builder = FlatBufferBuilder::new();
+        let mut db_fb_builder = DbFlatBufferBuilder::new(builder);
+        db_fb_builder.create_sst_info(info)
+    }
+}
+
 pub(crate) struct FlatBufferManifestCodec {}
 
 impl ManifestCodec for FlatBufferManifestCodec {
     fn encode(&self, manifest: &Manifest) -> Bytes {
-        self.create_from_manifest(manifest)
+        Self::create_from_manifest(manifest)
     }
 
     fn decode(&self, bytes: &Bytes) -> Result<Manifest, SlateDBError> {
         let manifest = flatbuffers::root::<ManifestV1>(bytes)?;
-        Ok(self.manifest(&manifest))
+        Ok(Self::manifest(&manifest))
     }
 }
 
 impl FlatBufferManifestCodec {
-    pub fn manifest(&self, manifest: &ManifestV1) -> Manifest {
+    pub fn manifest(manifest: &ManifestV1) -> Manifest {
         let l0_last_compacted = manifest
             .l0_last_compacted()
             .map(|id| Ulid::from((id.high(), id.low())));
@@ -108,7 +104,8 @@ impl FlatBufferManifestCodec {
         for man_sst in manifest.l0().iter() {
             let man_sst_id = man_sst.id();
             let sst_id = Compacted(Ulid::from((man_sst_id.high(), man_sst_id.low())));
-            let sst_info = SsTableInfoOwned::create_copy(&man_sst.info());
+
+            let sst_info = FlatBufferSsTableInfoCodec::sst_info(&man_sst.info());
             let l0_sst = SsTableHandle::new(sst_id, sst_info);
             l0.push_back(l0_sst);
         }
@@ -117,7 +114,7 @@ impl FlatBufferManifestCodec {
             let mut ssts = Vec::new();
             for manifest_sst in manifest_sr.ssts().iter() {
                 let id = Compacted(manifest_sst.id().ulid());
-                let info = SsTableInfoOwned::create_copy(&manifest_sst.info());
+                let info = FlatBufferSsTableInfoCodec::sst_info(&manifest_sst.info());
                 ssts.push(SsTableHandle::new(id, info));
             }
             compacted.push(db_state::SortedRun {
@@ -139,7 +136,7 @@ impl FlatBufferManifestCodec {
         }
     }
 
-    pub fn create_from_manifest(&self, manifest: &Manifest) -> Bytes {
+    pub fn create_from_manifest(manifest: &Manifest) -> Bytes {
         let builder = FlatBufferBuilder::new();
         let mut db_fb_builder = DbFlatBufferBuilder::new(builder);
         db_fb_builder.create_manifest(manifest)
@@ -161,20 +158,20 @@ impl<'b> DbFlatBufferBuilder<'b> {
         Self { builder }
     }
 
-    fn add_sst_info_copy(&mut self, info: &SsTableInfo) -> WIPOffset<SsTableInfo<'b>> {
-        let first_key = match info.first_key() {
+    fn add_sst_info(&mut self, info: &SsTableInfo) -> WIPOffset<FbSsTableInfo<'b>> {
+        let first_key = match info.first_key.as_ref() {
             None => None,
-            Some(first_key_vector) => Some(self.builder.create_vector(first_key_vector.bytes())),
+            Some(first_key_vector) => Some(self.builder.create_vector(first_key_vector)),
         };
-        SsTableInfo::create(
+        FbSsTableInfo::create(
             &mut self.builder,
             &SsTableInfoArgs {
                 first_key,
-                index_offset: info.index_offset(),
-                index_len: info.index_len(),
-                filter_offset: info.filter_offset(),
-                filter_len: info.filter_len(),
-                compression_format: info.compression_format(),
+                index_offset: info.index_offset,
+                index_len: info.index_len,
+                filter_offset: info.filter_offset,
+                filter_len: info.filter_len,
+                compression_format: info.compression_codec.into(),
             },
         )
     }
@@ -190,7 +187,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
     fn add_compacted_sst(
         &mut self,
         id: &SsTableId,
-        info: &SsTableInfoOwned,
+        info: &SsTableInfo,
     ) -> WIPOffset<CompactedSsTable<'b>> {
         let ulid = match id {
             SsTableId::Wal(_) => {
@@ -199,7 +196,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
             SsTableId::Compacted(ulid) => *ulid,
         };
         let compacted_sst_id = self.add_compacted_sst_id(&ulid);
-        let compacted_sst_info = self.add_sst_info_copy(&info.borrow());
+        let compacted_sst_info = self.add_sst_info(info);
         CompactedSsTable::create(
             &mut self.builder,
             &CompactedSsTableArgs {
@@ -270,8 +267,8 @@ impl<'b> DbFlatBufferBuilder<'b> {
         Bytes::copy_from_slice(self.builder.finished_data())
     }
 
-    fn create_sst_info_copy(&mut self, sst_info: &SsTableInfo) -> Bytes {
-        let copy = self.add_sst_info_copy(sst_info);
+    fn create_sst_info(&mut self, info: &SsTableInfo) -> Bytes {
+        let copy = self.add_sst_info(info);
         self.builder.finish(copy, None);
         Bytes::copy_from_slice(self.builder.finished_data())
     }

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -332,13 +332,10 @@ impl CompactionSchedulerSupplier for SizeTieredCompactionSchedulerSupplier {
 mod tests {
     use std::collections::VecDeque;
 
-    use bytes::Bytes;
-
     use crate::compactor::CompactionScheduler;
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
     use crate::config::SizeTieredCompactionSchedulerOptions;
-    use crate::db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId};
-    use crate::flatbuffer_types::{SsTableInfo, SsTableInfoArgs, SsTableInfoOwned};
+    use crate::db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
 
     #[test]
@@ -626,20 +623,14 @@ mod tests {
     }
 
     fn create_sst(size: u64) -> SsTableHandle {
-        let mut builder = flatbuffers::FlatBufferBuilder::new();
-        let wip = SsTableInfo::create(
-            &mut builder,
-            &SsTableInfoArgs {
-                first_key: None,
-                index_offset: size,
-                index_len: 0,
-                filter_offset: 0,
-                filter_len: 0,
-                compression_format: None.into(),
-            },
-        );
-        builder.finish(wip, None);
-        let info = SsTableInfoOwned::new(Bytes::copy_from_slice(builder.finished_data())).unwrap();
+        let info = SsTableInfo {
+            first_key: None,
+            index_offset: size,
+            index_len: 0,
+            filter_offset: 0,
+            filter_len: 0,
+            compression_codec: None,
+        };
         SsTableHandle {
             id: SsTableId::Compacted(ulid::Ulid::new()),
             info,

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -271,9 +271,9 @@ impl SsTableFormat {
 
 impl SsTableInfo {
     pub(crate) fn encode(info: &SsTableInfo, buf: &mut Vec<u8>, sst_codec: &dyn SsTableInfoCodec) {
-        let data = sst_codec.encode(info);
-        buf.extend_from_slice(data.as_ref());
-        buf.put_u32(crc32fast::hash(data.as_ref()));
+        let data = &sst_codec.encode(info);
+        buf.extend_from_slice(data);
+        buf.put_u32(crc32fast::hash(data));
     }
 
     pub(crate) fn decode(

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -10,10 +10,11 @@ use bytes::{Buf, BufMut, Bytes};
 use flatbuffers::DefaultAllocator;
 
 use crate::block::Block;
+use crate::db_state::{SsTableInfo, SsTableInfoCodec};
 use crate::filter::{BloomFilter, BloomFilterBuilder};
 use crate::flatbuffer_types::{
-    BlockMeta, BlockMetaArgs, SsTableIndex, SsTableIndexArgs, SsTableIndexOwned, SsTableInfo,
-    SsTableInfoArgs, SsTableInfoOwned,
+    BlockMeta, BlockMetaArgs, FlatBufferSsTableInfoCodec, SsTableIndex, SsTableIndexArgs,
+    SsTableIndexOwned,
 };
 use crate::{blob::ReadOnlyBlob, config::CompressionCodec};
 use crate::{block::BlockBuilder, error::SlateDBError};
@@ -22,6 +23,7 @@ use crate::{block::BlockBuilder, error::SlateDBError};
 pub(crate) struct SsTableFormat {
     block_size: usize,
     min_filter_keys: u32,
+    sst_codec: Box<dyn SsTableInfoCodec>,
     compression_codec: Option<CompressionCodec>,
 }
 
@@ -34,6 +36,7 @@ impl SsTableFormat {
         Self {
             block_size,
             min_filter_keys,
+            sst_codec: Box::new(FlatBufferSsTableInfoCodec {}),
             compression_codec,
         }
     }
@@ -41,7 +44,7 @@ impl SsTableFormat {
     pub(crate) async fn read_info(
         &self,
         obj: &impl ReadOnlyBlob,
-    ) -> Result<SsTableInfoOwned, SlateDBError> {
+    ) -> Result<SsTableInfo, SlateDBError> {
         let len = obj.len().await?;
         if len <= 4 {
             return Err(SlateDBError::EmptySSTable);
@@ -53,23 +56,22 @@ impl SsTableFormat {
         // Get the metadata. Last 4 bytes are the offset of SsTableInfo
         let sst_metadata_range = sst_metadata_offset..len - 4;
         let sst_metadata_bytes = obj.read_range(sst_metadata_range).await?;
-        SsTableInfoOwned::decode(sst_metadata_bytes)
+        SsTableInfo::decode(sst_metadata_bytes, &*self.sst_codec)
     }
 
     pub(crate) async fn read_filter(
         &self,
-        info: &SsTableInfoOwned,
+        info: &SsTableInfo,
         obj: &impl ReadOnlyBlob,
     ) -> Result<Option<Arc<BloomFilter>>, SlateDBError> {
         let mut filter = None;
-        let handle = info.borrow();
-        if handle.filter_len() > 0 {
-            let filter_end = handle.filter_offset() + handle.filter_len();
-            let filter_offset_range = handle.filter_offset() as usize..filter_end as usize;
+        if info.filter_len > 0 {
+            let filter_end = info.filter_offset + info.filter_len;
+            let filter_offset_range = info.filter_offset as usize..filter_end as usize;
             let filter_bytes = obj.read_range(filter_offset_range).await?;
-            let compression_codec = handle.compression_format();
+            let compression_codec = info.compression_codec;
             filter = Some(Arc::new(
-                self.decode_filter(filter_bytes, compression_codec.into())?,
+                self.decode_filter(filter_bytes, compression_codec)?,
             ));
         }
         Ok(filter)
@@ -89,29 +91,27 @@ impl SsTableFormat {
 
     pub(crate) async fn read_index(
         &self,
-        info_owned: &SsTableInfoOwned,
+        info: &SsTableInfo,
         obj: &impl ReadOnlyBlob,
     ) -> Result<SsTableIndexOwned, SlateDBError> {
-        let info = info_owned.borrow();
-        let index_off = info.index_offset() as usize;
-        let index_end = index_off + info.index_len() as usize;
+        let index_off = info.index_offset as usize;
+        let index_end = index_off + info.index_len as usize;
         let index_bytes = obj.read_range(index_off..index_end).await?;
-        let compression_codec = info.compression_format();
-        self.decode_index(index_bytes, compression_codec.into())
+        let compression_codec = info.compression_codec;
+        self.decode_index(index_bytes, compression_codec)
     }
 
     #[allow(dead_code)]
     pub(crate) fn read_index_raw(
         &self,
-        info_owned: &SsTableInfoOwned,
+        info: &SsTableInfo,
         sst_bytes: &Bytes,
     ) -> Result<SsTableIndexOwned, SlateDBError> {
-        let info = info_owned.borrow();
-        let index_off = info.index_offset() as usize;
-        let index_end = index_off + info.index_len() as usize;
+        let index_off = info.index_offset as usize;
+        let index_end = index_off + info.index_len as usize;
         let index_bytes: Bytes = sst_bytes.slice(index_off..index_end);
-        let compression_codec = info.compression_format();
-        self.decode_index(index_bytes, compression_codec.into())
+        let compression_codec = info.compression_codec;
+        self.decode_index(index_bytes, compression_codec)
     }
 
     fn decode_index(
@@ -165,10 +165,10 @@ impl SsTableFormat {
     fn block_range(
         &self,
         blocks: Range<usize>,
-        handle: &SsTableInfo,
+        info: &SsTableInfo,
         index: &SsTableIndex,
     ) -> Range<usize> {
-        let mut end_offset = handle.filter_offset() as usize;
+        let mut end_offset = info.filter_offset as usize;
         if blocks.end < index.block_meta().len() {
             let next_block_meta = index.block_meta().get(blocks.end);
             end_offset = next_block_meta.offset() as usize;
@@ -179,23 +179,22 @@ impl SsTableFormat {
 
     pub(crate) async fn read_blocks(
         &self,
-        info: &SsTableInfoOwned,
+        info: &SsTableInfo,
         index_owned: &SsTableIndexOwned,
         blocks: Range<usize>,
         obj: &impl ReadOnlyBlob,
     ) -> Result<VecDeque<Block>, SlateDBError> {
-        let handle = &info.borrow();
         let index = index_owned.borrow();
         assert!(blocks.start <= blocks.end);
         assert!(blocks.end <= index.block_meta().len());
         if blocks.start == blocks.end {
             return Ok(VecDeque::new());
         }
-        let range = self.block_range(blocks.clone(), handle, &index);
+        let range = self.block_range(blocks.clone(), info, &index);
         let start_offset = range.start;
         let bytes: Bytes = obj.read_range(range).await?;
         let mut decoded_blocks = VecDeque::new();
-        let compression_codec = handle.compression_format();
+        let compression_codec = info.compression_codec;
         for block in blocks {
             let block_meta = index.block_meta().get(block);
             let block_bytes_start = block_meta.offset() as usize - start_offset;
@@ -206,7 +205,7 @@ impl SsTableFormat {
                 let block_bytes_end = next_block_meta.offset() as usize - start_offset;
                 bytes.slice(block_bytes_start..block_bytes_end)
             };
-            decoded_blocks.push_back(self.decode_block(block_bytes, compression_codec.into())?);
+            decoded_blocks.push_back(self.decode_block(block_bytes, compression_codec)?);
         }
         Ok(decoded_blocks)
     }
@@ -237,7 +236,7 @@ impl SsTableFormat {
 
     pub(crate) async fn read_block(
         &self,
-        info: &SsTableInfoOwned,
+        info: &SsTableInfo,
         index: &SsTableIndexOwned,
         block: usize,
         obj: &impl ReadOnlyBlob,
@@ -249,34 +248,38 @@ impl SsTableFormat {
     #[allow(dead_code)]
     pub(crate) fn read_block_raw(
         &self,
-        info: &SsTableInfoOwned,
+        info: &SsTableInfo,
         index_owned: &SsTableIndexOwned,
         block: usize,
         sst_bytes: &Bytes,
     ) -> Result<Block, SlateDBError> {
-        let handle = &info.borrow();
         let index = index_owned.borrow();
-        let bytes: Bytes = sst_bytes.slice(self.block_range(block..block + 1, handle, &index));
-        let compression_codec = handle.compression_format();
-        self.decode_block(bytes, compression_codec.into())
+        let bytes: Bytes = sst_bytes.slice(self.block_range(block..block + 1, info, &index));
+        let compression_codec = info.compression_codec;
+        self.decode_block(bytes, compression_codec)
     }
 
     pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder {
         EncodedSsTableBuilder::new(
             self.block_size,
             self.min_filter_keys,
+            self.sst_codec.clone(),
             self.compression_codec,
         )
     }
 }
 
-impl SsTableInfoOwned {
-    fn encode(info: &SsTableInfoOwned, buf: &mut Vec<u8>) {
-        buf.extend_from_slice(info.data());
-        buf.put_u32(crc32fast::hash(info.data()));
+impl SsTableInfo {
+    pub(crate) fn encode(info: &SsTableInfo, buf: &mut Vec<u8>, sst_codec: &dyn SsTableInfoCodec) {
+        let data = sst_codec.encode(info);
+        buf.extend_from_slice(data.as_ref());
+        buf.put_u32(crc32fast::hash(data.as_ref()));
     }
 
-    pub(crate) fn decode(raw_info: Bytes) -> Result<SsTableInfoOwned, SlateDBError> {
+    pub(crate) fn decode(
+        raw_info: Bytes,
+        sst_codec: &dyn SsTableInfoCodec,
+    ) -> Result<SsTableInfo, SlateDBError> {
         if raw_info.len() <= 4 {
             return Err(SlateDBError::EmptyBlockMeta);
         }
@@ -286,13 +289,13 @@ impl SsTableInfoOwned {
             return Err(SlateDBError::ChecksumMismatch);
         }
 
-        let info = SsTableInfoOwned::new(data)?;
+        let info = sst_codec.decode(&data)?;
         Ok(info)
     }
 }
 
 pub(crate) struct EncodedSsTable {
-    pub(crate) info: SsTableInfoOwned,
+    pub(crate) info: SsTableInfo,
     pub(crate) filter: Option<Arc<BloomFilter>>,
     pub(crate) unconsumed_blocks: VecDeque<Bytes>,
 }
@@ -310,6 +313,7 @@ pub(crate) struct EncodedSsTableBuilder<'a> {
     min_filter_keys: u32,
     num_keys: u32,
     filter_builder: BloomFilterBuilder,
+    sst_codec: Box<dyn SsTableInfoCodec>,
     compression_codec: Option<CompressionCodec>,
 }
 
@@ -318,6 +322,7 @@ impl<'a> EncodedSsTableBuilder<'a> {
     fn new(
         block_size: usize,
         min_filter_keys: u32,
+        sst_codec: Box<dyn SsTableInfoCodec>,
         compression_codec: Option<CompressionCodec>,
     ) -> Self {
         Self {
@@ -332,6 +337,7 @@ impl<'a> EncodedSsTableBuilder<'a> {
             num_keys: 0,
             filter_builder: BloomFilterBuilder::new(10),
             index_builder: flatbuffers::FlatBufferBuilder::new(),
+            sst_codec,
             compression_codec,
         }
     }
@@ -472,29 +478,19 @@ impl<'a> EncodedSsTableBuilder<'a> {
         let index_len = index_block.len();
         buf.put(index_block);
 
-        let mut sst_info_builder = flatbuffers::FlatBufferBuilder::new();
-        let first_key = self
-            .sst_first_key
-            .map(|k| sst_info_builder.create_vector(k.as_ref()));
         let meta_offset = self.current_len + buf.len();
-        let info_wip_offset = SsTableInfo::create(
-            &mut sst_info_builder,
-            &SsTableInfoArgs {
-                first_key,
-                index_offset: index_offset as u64,
-                index_len: index_len as u64,
-                filter_offset: filter_offset as u64,
-                filter_len: filter_len as u64,
-                compression_format: self.compression_codec.into(),
-            },
-        );
+        let info = SsTableInfo {
+            first_key: self.sst_first_key,
+            index_offset: index_offset as u64,
+            index_len: index_len as u64,
+            filter_offset: filter_offset as u64,
+            filter_len: filter_len as u64,
+            compression_codec: self.compression_codec,
+        };
+        SsTableInfo::encode(&info, &mut buf, &*self.sst_codec);
 
-        sst_info_builder.finish(info_wip_offset, None);
-        let info = SsTableInfoOwned::new(Bytes::from(sst_info_builder.finished_data().to_vec()))?;
-
-        SsTableInfoOwned::encode(&info, &mut buf);
-
-        // write the metadata offset at the end of the file. FlatBuffer internal representation is not intended to be used directly.
+        // write the metadata offset at the end of the file. FlatBuffer internal
+        // representation is not intended to be used directly.
         buf.put_u32(meta_offset as u32);
         self.blocks.push_back(Bytes::from(buf));
         Ok(EncodedSsTable {
@@ -651,10 +647,10 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(encoded_info, sst_handle.info);
-        let sst_info = sst_handle.info.borrow();
+        let sst_info = sst_handle.info;
         assert_eq!(
             b"key1",
-            sst_info.first_key().unwrap().bytes(),
+            sst_info.first_key.unwrap().as_ref(),
             "first key in sst info should be correct"
         );
 
@@ -665,11 +661,11 @@ mod tests {
             .read_index(&sst_handle_from_store)
             .await
             .unwrap();
-        let sst_info_from_store = sst_handle_from_store.info.borrow();
+        let sst_info_from_store = sst_handle_from_store.info;
         assert_eq!(1, index.borrow().block_meta().len());
         assert_eq!(
             b"key1",
-            sst_info_from_store.first_key().unwrap().bytes(),
+            sst_info_from_store.first_key.unwrap().as_ref(),
             "first key in sst info should be correct after reading from store"
         );
         assert_eq!(
@@ -696,8 +692,7 @@ mod tests {
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         assert_eq!(encoded_info, sst_handle.info);
-        let handle = sst_handle.info.borrow();
-        assert_eq!(handle.filter_len(), 0);
+        assert_eq!(sst_handle.info.filter_len, 0);
     }
 
     #[tokio::test]
@@ -724,11 +719,10 @@ mod tests {
             assert!(filter.has_key(b"key1"));
             assert!(filter.has_key(b"key2"));
             assert_eq!(encoded_info, sst_handle.info);
-            let sst_info = sst_handle.info.borrow();
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(
                 b"key1",
-                sst_info.first_key().unwrap().bytes(),
+                sst_handle.info.first_key.unwrap().as_ref(),
                 "first key in sst info should be correct"
             );
         }
@@ -763,11 +757,10 @@ mod tests {
             assert!(filter.has_key(b"key1"));
             assert!(filter.has_key(b"key2"));
             assert_eq!(encoded_info, sst_handle.info);
-            let sst_info = sst_handle.info.borrow();
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(
                 b"key1",
-                sst_info.first_key().unwrap().bytes(),
+                sst_handle.info.first_key.unwrap().as_ref(),
                 "first key in sst info should be correct"
             );
         }


### PR DESCRIPTION
We've been passing FlatBuffer objects around for SST info data. We've been wrapping these objects in `SsTableInfoOwned` because FlatBuffer's code generated structs don't allow borrwing easily. This leads to some annoying side effects:

- We're using FlatBuffer APIs all over the place
- We're using `.borrow()` everywhere

The Manifest doesn't work this way. Instead, we have a normal Rust struct for Manifest and we have a codec to convert back and forth between the FlatBuffer Manifest and our own. This PR makes SsTableInfo behave like Manifest.

The drawback to our new approach is that we don't lazy decode the FlatBuffer like we used to. This could impact performance in some cases. In practice, I suspect it'll be negligible. Still, we should run some tests to verify.

Fixes #213