### PR TITLE
feat(filter): implement hash sharing to reduce filter cost

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -72,8 +72,8 @@ impl BloomFilter {
         (self.buffer.len() * 8) as u32
     }
 
-    pub(crate) fn has_key(&self, key_hash: u64) -> bool {
-        for p in probes_for_key(key_hash, self.num_probes, self.filter_bits()) {
+    pub(crate) fn may_contains(&self, hash: u64) -> bool {
+        for p in probes_for_key(hash, self.num_probes, self.filter_bits()) {
             if !check_bit(p as usize, &self.buffer) {
                 return false;
             }
@@ -231,7 +231,7 @@ mod tests {
             bytes.reserve(key_sz);
             bytes.put_u32(i);
             let hash = filter_hash(bytes.freeze().as_ref());
-            assert!(filter.has_key(hash));
+            assert!(filter.may_contains(hash));
         }
 
         // check false positives
@@ -241,7 +241,7 @@ mod tests {
             bytes.reserve(key_sz);
             bytes.put_u32(i);
             let hash = filter_hash(bytes.freeze().as_ref());
-            if filter.has_key(hash) {
+            if filter.may_contains(hash) {
                 fp += 1;
             }
         }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -72,7 +72,7 @@ impl BloomFilter {
         (self.buffer.len() * 8) as u32
     }
 
-    pub(crate) fn may_contains(&self, hash: u64) -> bool {
+    pub(crate) fn might_contain(&self, hash: u64) -> bool {
         for p in probes_for_key(hash, self.num_probes, self.filter_bits()) {
             if !check_bit(p as usize, &self.buffer) {
                 return false;
@@ -231,7 +231,7 @@ mod tests {
             bytes.reserve(key_sz);
             bytes.put_u32(i);
             let hash = filter_hash(bytes.freeze().as_ref());
-            assert!(filter.may_contains(hash));
+            assert!(filter.might_contain(hash));
         }
 
         // check false positives
@@ -241,7 +241,7 @@ mod tests {
             bytes.reserve(key_sz);
             bytes.put_u32(i);
             let hash = filter_hash(bytes.freeze().as_ref());
-            if filter.may_contains(hash) {
+            if filter.might_contain(hash) {
                 fp += 1;
             }
         }

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -717,8 +717,8 @@ mod tests {
             let index = table_store.read_index(&sst_handle).await.unwrap();
             let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
 
-            assert!(filter.may_contains(filter_hash(b"key1")));
-            assert!(filter.may_contains(filter_hash(b"key2")));
+            assert!(filter.might_contain(filter_hash(b"key1")));
+            assert!(filter.might_contain(filter_hash(b"key2")));
             assert_eq!(encoded_info, sst_handle.info);
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(
@@ -755,8 +755,8 @@ mod tests {
             let index = table_store.read_index(&sst_handle).await.unwrap();
             let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
 
-            assert!(filter.may_contains(filter_hash(b"key1")));
-            assert!(filter.may_contains(filter_hash(b"key2")));
+            assert!(filter.might_contain(filter_hash(b"key1")));
+            assert!(filter.might_contain(filter_hash(b"key2")));
             assert_eq!(encoded_info, sst_handle.info);
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -717,8 +717,8 @@ mod tests {
             let index = table_store.read_index(&sst_handle).await.unwrap();
             let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
 
-            assert!(filter.has_key(filter_hash(b"key1")));
-            assert!(filter.has_key(filter_hash(b"key2")));
+            assert!(filter.may_contains(filter_hash(b"key1")));
+            assert!(filter.may_contains(filter_hash(b"key2")));
             assert_eq!(encoded_info, sst_handle.info);
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(
@@ -755,8 +755,8 @@ mod tests {
             let index = table_store.read_index(&sst_handle).await.unwrap();
             let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
 
-            assert!(filter.has_key(filter_hash(b"key1")));
-            assert!(filter.has_key(filter_hash(b"key2")));
+            assert!(filter.may_contains(filter_hash(b"key1")));
+            assert!(filter.may_contains(filter_hash(b"key2")));
             assert_eq!(encoded_info, sst_handle.info);
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -513,6 +513,7 @@ mod tests {
     use super::*;
     use crate::block_iterator::BlockIterator;
     use crate::db_state::SsTableId;
+    use crate::filter::filter_hash;
     use crate::tablestore::TableStore;
     use crate::test_utils::assert_iterator;
     use crate::types::ValueDeletable;
@@ -716,8 +717,8 @@ mod tests {
             let index = table_store.read_index(&sst_handle).await.unwrap();
             let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
 
-            assert!(filter.has_key(b"key1"));
-            assert!(filter.has_key(b"key2"));
+            assert!(filter.has_key(filter_hash(b"key1")));
+            assert!(filter.has_key(filter_hash(b"key2")));
             assert_eq!(encoded_info, sst_handle.info);
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(
@@ -754,8 +755,8 @@ mod tests {
             let index = table_store.read_index(&sst_handle).await.unwrap();
             let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
 
-            assert!(filter.has_key(b"key1"));
-            assert!(filter.has_key(b"key2"));
+            assert!(filter.has_key(filter_hash(b"key1")));
+            assert!(filter.has_key(filter_hash(b"key2")));
             assert_eq!(encoded_info, sst_handle.info);
             assert_eq!(1, index.borrow().block_meta().len());
             assert_eq!(


### PR DESCRIPTION
Implement _hash sharing_ in [Reducing Bloom Filter CPU Overhead in LSM-Trees on Modern Storage Devices](https://dl.acm.org/doi/10.1145/3465998.3466002)

The idea is very simple and intuitive. In the point query of LSM, we need to probe the filter. Since the key remains unchanged, we only need to calculate the hash value once and pass the hash value to filter. So we can reduce the hash overhead of the filter during each point query.
![屏幕截图 2024-09-21 164154](https://github.com/user-attachments/assets/387ce8be-02a0-4784-9e78-db317884dfdb)


In addition, we may be able to implement hash sharing during the construction process of SSTable. For example, in levels below L0, the same key may be arranged together with different values. In SSTable Builder we can use a field named `last_key_hash`, and every time a new key is added, we compare it with `last_key`. If it is the same, we can avoid the hash cost required to build the filter during compaction.

We can also use a BTreeMap to save the existing key and its hash value since the block size is fixed, we can estimate the space overhead it brings(use BTreeMap instead of `last_key_hash`). But I'm not sure if slateDB welcomes this idea, if allowed I'd be happy to experiment with it. At least I think it's worth using a `last_key_hash` field and only paying for a u64 field and simple comparison to avoid unnecessary hash costs.


