### PR TITLE
feat(block): support prefix key encoding

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -54,6 +54,22 @@ pub struct BlockBuilder {
     offsets: Vec<u16>,
     data: Vec<u8>,
     block_size: usize,
+    first_key: Bytes,
+}
+
+// Details can be found: https://users.rust-lang.org/t/how-to-find-common-prefix-of-two-byte-slices-effectively/25815/4
+fn compute_prefix(lhs: &[u8], rhs: &[u8]) -> usize {
+    compute_prefix_chunks::<128>(lhs, rhs)
+}
+
+fn compute_prefix_chunks<const N: usize>(lhs: &[u8], rhs: &[u8]) -> usize {
+    let off = std::iter::zip(lhs.chunks_exact(N), rhs.chunks_exact(N))
+        .take_while(|(a, b)| a == b)
+        .count()
+        * N;
+    off + std::iter::zip(&lhs[off..], &rhs[off..])
+        .take_while(|(a, b)| a == b)
+        .count()
 }
 
 impl BlockBuilder {
@@ -62,10 +78,12 @@ impl BlockBuilder {
             offsets: Vec::new(),
             data: Vec::new(),
             block_size,
+            first_key: Bytes::new(),
         }
     }
 
     #[rustfmt::skip]
+    #[inline]
     fn estimated_size(&self) -> usize {
         SIZEOF_U16           // number of key-value pairs in the block
         + self.offsets.len() // offsets
@@ -75,13 +93,15 @@ impl BlockBuilder {
     #[must_use]
     pub fn add(&mut self, key: &[u8], value: Option<&[u8]>) -> bool {
         assert!(!key.is_empty(), "key must not be empty");
+        let overlap_len = compute_prefix(&self.first_key, key);
+        let rest_key = &key[overlap_len..];
 
         // If adding the key-value pair would exceed the block size limit, don't add it.
         // (Unless the block is empty, in which case, allow the block to exceed the limit.)
         if self.estimated_size()
-                + key.len()
+                + rest_key.len()
                 + value.map(|v| v.len()).unwrap_or_default() // None takes no space (besides u32)
-                + SIZEOF_U16 * 2 // key size and offset size
+                + SIZEOF_U16 * 3 // overlap key size + rest key size + offset size
                 + SIZEOF_U32 // value size
                 > self.block_size
             && !self.is_empty()
@@ -90,13 +110,18 @@ impl BlockBuilder {
         }
 
         self.offsets.push(self.data.len() as u16);
-        self.data.put_u16(key.len() as u16);
-        self.data.put(key);
+        self.data.put_u16(overlap_len as u16);
+        self.data.put_u16(rest_key.len() as u16);
+        self.data.put(rest_key);
         if let Some(value) = value {
             self.data.put_u32(value.len() as u32);
             self.data.put(value);
         } else {
             self.data.put_u32(TOMBSTONE);
+        }
+
+        if self.first_key.is_empty() {
+            self.first_key = Bytes::copy_from_slice(key);
         }
 
         true

--- a/src/block.rs
+++ b/src/block.rs
@@ -179,7 +179,7 @@ mod tests {
         assert!(builder.add(b"key1", Some(b"value1")));
         assert!(builder.add(b"key2", Some(b"value2")));
         let block = builder.build().unwrap();
-        assert_eq!(38, block.size());
+        assert_eq!(39, block.size());
     }
 
     #[test]

--- a/src/block.rs
+++ b/src/block.rs
@@ -90,7 +90,7 @@ impl BlockBuilder {
     #[inline]
     fn estimated_size(&self) -> usize {
         SIZEOF_U16           // number of key-value pairs in the block
-        + self.offsets.len() // offsets
+        + self.offsets.len() * SIZEOF_U16 // offsets
         + self.data.len()    // key-value pairs
     }
 
@@ -180,5 +180,12 @@ mod tests {
         assert!(builder.add(b"key2", Some(b"value2")));
         let block = builder.build().unwrap();
         assert_eq!(38, block.size());
+    }
+
+    #[test]
+    fn test_prefix_computing() {
+        assert_eq!(compute_prefix(b"1", b"11"), 1);
+        assert_eq!(compute_prefix(b"222", b"111"), 0);
+        assert_eq!(compute_prefix(b"1234567", b"123456789"), 7);
     }
 }

--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -81,7 +81,8 @@ impl<B: BlockLike> BlockIterator<B> {
             let overlap_len = cursor.get_u16() as usize;
             let rest_len = cursor.get_u16() as usize;
             let rest_key = &cursor[..rest_len];
-            let mut cursor_key = BytesMut::from(&first_key[..overlap_len]);
+            let mut cursor_key = BytesMut::with_capacity(overlap_len + rest_len);
+            cursor_key.extend_from_slice(&first_key[..overlap_len]);
             cursor_key.extend_from_slice(rest_key);
             cursor_key < key
         });
@@ -118,7 +119,8 @@ impl<B: BlockLike> BlockIterator<B> {
             ValueDeletable::Value(value)
         };
 
-        let mut key = BytesMut::from(&self.first_key[..overlap_len]);
+        let mut key = BytesMut::with_capacity(overlap_len + rest_len);
+        key.extend_from_slice(&self.first_key[..overlap_len]);
         key.extend_from_slice(&rest_key);
 
         Some(KeyValueDeletable {

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -329,7 +329,7 @@ mod tests {
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         let index = table_store.read_index(&sst_handle).await.unwrap();
-        assert_eq!(index.borrow().block_meta().len(), 6);
+        assert_eq!(index.borrow().block_meta().len(), 5);
 
         let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 3, 3, true)
             .await


### PR DESCRIPTION
Solve #237.

Adding prefix key encoding for slateDB.

