### PR TITLE
Adding missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ Checkout [slatedb.io](https://slatedb.io) to learn more.
 
 ## Get Started
 
-Add the following to your `Cargo.toml` to use SlateDB:
+Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
 slatedb = "*"
+bytes = "*"
+object_store = "*"
+tokio = "*"
 ```
 
 Then you can use SlateDB in your Rust code:


### PR DESCRIPTION
Without those, I'd get build errors due to the unresolveable imports in the hello world example:

```
error[E0432]: unresolved import `bytes`
 --> src/main.rs:1:5
  |
1 | use bytes::Bytes;
  |     ^^^^^ use of undeclared crate or module `bytes`

error[E0433]: failed to resolve: use of undeclared crate or module `object_store`
 --> src/main.rs:2:5
  |
2 | use object_store::{ObjectStore, memory::InMemory, path::Path};
  |     ^^^^^^^^^^^^ use of undeclared crate or module `object_store`

error[E0432]: unresolved import `object_store`
 --> src/main.rs:2:5
  |
2 | use object_store::{ObjectStore, memory::InMemory, path::Path};
  |     ^^^^^^^^^^^^ use of undeclared crate or module `object_store`

error[E0433]: failed to resolve: use of undeclared crate or module `tokio`
 --> src/main.rs:7:3
  |
7 | #[tokio::main]
  |   ^^^^^ use of undeclared crate or module `tokio`

error: could not compile `hello-rust` (bin "hello-rust") due to 4 previous errors
```

Adding these dependencies makes the example work for me. I am literally ten min into my Rust journey, so maybe there is alternatively a way for buidling and running the example so that any transitive dependencies of SlateDB are resolved automatically? If so, I also can adjust the README with the right instructions for doing so.