### PR TITLE
fix(cache): Use the cached entries size as weights to calculate the size of the cache

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -16,11 +16,7 @@ pub(crate) struct Block {
 impl Block {
     #[rustfmt::skip]
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(
-            self.data.len()                   // data byte length
-            + self.offsets.len() * SIZEOF_U16 // offsets as u16's
-            + SIZEOF_U16, // number of offsets in the block
-        );
+        let mut buf = BytesMut::with_capacity(self.size());
         buf.put_slice(&self.data);
         for offset in &self.offsets {
             buf.put_u16(*offset);
@@ -47,6 +43,14 @@ impl Block {
             data: bytes,
             offsets,
         }
+    }
+
+    /// Returns the size of the block in bytes.
+    #[rustfmt::skip]
+    pub(crate) fn size(&self) -> usize {
+        self.data.len()                   // data byte length
+        + self.offsets.len() * SIZEOF_U16 // offsets as u16's
+        + SIZEOF_U16 // number of offsets in the block
     }
 }
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -147,4 +147,13 @@ mod tests {
         let encoded = block.encode();
         let _decoded = Block::decode(encoded);
     }
+
+    #[test]
+    fn test_block_size() {
+        let mut builder = BlockBuilder::new(4096);
+        assert!(builder.add(b"key1", Some(b"value1")));
+        assert!(builder.add(b"key2", Some(b"value2")));
+        let block = builder.build().unwrap();
+        assert_eq!(38, block.size());
+    }
 }

--- a/src/db_cache.rs
+++ b/src/db_cache.rs
@@ -21,8 +21,6 @@ use crate::{
 
 /// The default max capacity for the cache. (64MB)
 pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
-/// The default cached block size for the cache. (32 bytes)
-pub const DEFAULT_CACHED_BLOCK_SIZE: u32 = 32;
 
 #[cfg(feature = "foyer")]
 pub mod foyer;
@@ -167,6 +165,18 @@ impl CachedEntry {
         match &self.item {
             CachedItem::BloomFilter(bloom_filter) => Some(bloom_filter.clone()),
             _ => None,
+        }
+    }
+
+    /// Returns the size of the cached entry in bytes.
+    ///
+    /// This method is public to allow external cache implementations
+    /// to use it to implement custom weighers.
+    pub fn size(&self) -> usize {
+        match &self.item {
+            CachedItem::Block(block) => block.size(),
+            CachedItem::SsTableIndex(sst_index) => sst_index.size(),
+            CachedItem::BloomFilter(bloom_filter) => bloom_filter.size(),
         }
     }
 }

--- a/src/db_cache/foyer.rs
+++ b/src/db_cache/foyer.rs
@@ -30,23 +30,19 @@
 //! }
 //! ```
 //!
-use crate::db_cache::{
-    CachedEntry, CachedKey, DbCache, DEFAULT_CACHED_BLOCK_SIZE, DEFAULT_MAX_CAPACITY,
-};
+use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
 
 /// The options for the Foyer cache.
 #[derive(Clone, Copy, Debug)]
 pub struct FoyerCacheOptions {
     pub max_capacity: u64,
-    pub cached_block_size: u32,
 }
 
 impl Default for FoyerCacheOptions {
     fn default() -> Self {
         Self {
             max_capacity: DEFAULT_MAX_CAPACITY,
-            cached_block_size: DEFAULT_CACHED_BLOCK_SIZE,
         }
     }
 }
@@ -77,7 +73,7 @@ impl FoyerCache {
 
     pub fn new_with_opts(options: FoyerCacheOptions) -> Self {
         let builder = foyer::CacheBuilder::new(options.max_capacity as _)
-            .with_weighter(move |_, _| options.cached_block_size as _);
+            .with_weighter(|_, v: &CachedEntry| v.size());
 
         let cache = builder.build();
 

--- a/src/db_cache/moka.rs
+++ b/src/db_cache/moka.rs
@@ -30,9 +30,7 @@
 //! }
 //! ```
 //!
-use crate::db_cache::{
-    CachedEntry, CachedKey, DbCache, DEFAULT_CACHED_BLOCK_SIZE, DEFAULT_MAX_CAPACITY,
-};
+use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
 use std::time::Duration;
 
@@ -40,7 +38,6 @@ use std::time::Duration;
 #[derive(Clone, Copy, Debug)]
 pub struct MokaCacheOptions {
     pub max_capacity: u64,
-    pub cached_block_size: u32,
     pub time_to_live: Option<Duration>,
     pub time_to_idle: Option<Duration>,
 }
@@ -49,7 +46,6 @@ impl Default for MokaCacheOptions {
     fn default() -> Self {
         Self {
             max_capacity: DEFAULT_MAX_CAPACITY,
-            cached_block_size: DEFAULT_CACHED_BLOCK_SIZE,
             time_to_live: None,
             time_to_idle: None,
         }
@@ -82,7 +78,7 @@ impl MokaCache {
 
     pub fn new_with_opts(options: MokaCacheOptions) -> Self {
         let mut builder = moka::future::Cache::builder()
-            .weigher(move |_, _| options.cached_block_size)
+            .weigher(|_, v: &CachedEntry| v.size() as u32)
             .max_capacity(options.max_capacity);
 
         if let Some(ttl) = options.time_to_live {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -254,4 +254,24 @@ mod tests {
         // observed fp is .0087
         assert!((fp as f32 / keys_to_test as f32) < 0.01);
     }
+
+    #[test]
+    fn test_bloom_filter_size() {
+        let mut builder = BloomFilterBuilder::new(10);
+        builder.add_key(b"test_key");
+        let filter = builder.build();
+
+        // The exact size may vary, so we'll check if it's greater than zero
+        assert!(
+            filter.size() > 0,
+            "Bloom filter size should be greater than zero"
+        );
+
+        // We can also check if the size matches the buffer length
+        assert_eq!(
+            filter.size(),
+            filter.buffer.len(),
+            "Size should match buffer length"
+        );
+    }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -80,6 +80,11 @@ impl BloomFilter {
         }
         true
     }
+
+    /// Returns the size of the bloom filter in bytes.
+    pub(crate) fn size(&self) -> usize {
+        self.buffer.len()
+    }
 }
 
 pub fn filter_hash(key: &[u8]) -> u64 {

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -41,6 +41,11 @@ impl SsTableIndexOwned {
         let raw = &self.data;
         unsafe { flatbuffers::root_unchecked::<SsTableIndex>(raw) }
     }
+
+    /// Returns the size of the SSTable index in bytes.
+    pub(crate) fn size(&self) -> usize {
+        self.data.len()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Calculate the size of each cached item based on their content. Since other cache implementations might use similar weights mechanisms, the CachedEntry::size method is declared public.

Fixes #241