### PR TITLE
Allow AWS session token for admin/testing

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -75,6 +75,7 @@ pub fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
     let key = env::var("AWS_ACCESS_KEY_ID").expect("AWS_ACCESS_KEY_ID must be set");
     let secret =
         env::var("AWS_SECRET_ACCESS_KEY").expect("Expected AWS_SECRET_ACCESS_KEY must be set");
+    let session_token = env::var("AWS_SESSION_TOKEN").ok();
     let bucket = env::var("AWS_BUCKET").expect("AWS_BUCKET must be set");
     let region = env::var("AWS_REGION").expect("AWS_REGION must be set");
     let endpoint = env::var("AWS_ENDPOINT").ok();
@@ -85,6 +86,13 @@ pub fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
         .with_bucket_name(bucket)
         .with_region(region)
         .with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new(dynamodb_table)));
+
+    let builder = if let Some(token) = session_token {
+        builder.with_token(token)
+    } else {
+        builder
+    };
+
     let builder = if let Some(endpoint) = endpoint {
         builder.with_allow_http(true).with_endpoint(endpoint)
     } else {

--- a/src/bencher/README.md
+++ b/src/bencher/README.md
@@ -56,11 +56,12 @@ Make sure to set up the following environment variables before benchmarking:
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`
-- `AWS_S3_BUCKET`
+- `AWS_BUCKET`
 - `AWS_DYNAMODB_TABLE`, see
   [DynamoCommit](https://docs.rs/object_store/latest/object_store/aws/struct.DynamoCommit.html)
   for more details.
 - `AWS_ENDPOINT` (optional), if you are using a custom S3 endpoint.
+- `AWS_SESSION_TOKEN` (optional), if you are using temporary credentials. 
 
 ### Plotting Results
 


### PR DESCRIPTION
It is useful for running admin commands or for testing to support the AWS session token