### PR TITLE
[3/N] RFC-3: add timestamps

### DIFF
--- a/rfcs/0003-timestamps-and-ttl.md
+++ b/rfcs/0003-timestamps-and-ttl.md
@@ -166,7 +166,7 @@ Currently, SlateDB does not have a mechanism for backwards-compatibility of the 
 We will first introduce the following fields to the flatbuffer definitions:
 
 - `format_version`: field that specifies the codec version that encoded this SST
-- `row_attributes`: an enumeration of metadata fields that are available with each encoded row. This
+- `row_features`: an enumeration of metadata fields that are available with each encoded row. This
   makes it possible in the future to save space per row by disabling row attributes, but that is
   out of scope for this RFC
 - `creation_timestamp`: the time at which this SST file was written. For this RFC this timestamp is
@@ -176,7 +176,7 @@ We will first introduce the following fields to the flatbuffer definitions:
 ```fbs
 /// the metadata encoded with each row, note that the ordering of this enum is 
 /// sensitive and must be maintained
-enum RowAttributes: byte {
+enum RowFeature: byte {
     RowFlags,
     Timestamp,
     TimeToLive,
@@ -190,7 +190,7 @@ table SsTableInfo {
     
     // The metadata attributes that are encoded with each row. These attributes will be encoded
     // in order that they are declared in the RowAttributes enum
-    row_attributes: [RowAttributes];
+    row_features: [RowFeature];
     
     // The time at which this SST was created, based on the configured Clock in
     // DbOptions
@@ -225,7 +225,7 @@ The `format_version` will be bumped to 1 and will be modified to have the follow
 |---------|-----|------|-----------|-------|
 ```
 
-The newly introduced `attr` field will be decoded using the `row_attributes` array specified for
+The newly introduced `attr` field will be decoded using the `row_features` array specified for
 this SST. Which row attributes are included depend on the data that is being written. If
 any row in the SST has a `ttl`, the `TimeToLive` feature will be enabled.
 
@@ -287,7 +287,7 @@ a tombstone is added, the TTL (`expire_ts`) for the row will be cleared, indicat
 run of this filter should not remove the tombstone.
 
 Since this RFC does not cover the public API for compaction filters, this filter will simply run
-on any SST that specifies `row_attributes: [Timestamp && TimeToLive]`.
+on any SST that specifies `row_features: [Timestamp && TimeToLive]`.
 
 #### Periodic Compaction
 

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -16,7 +16,7 @@ enum CompressionFormat: byte {
     Zstd
 }
 
-enum SstRowAttribute: byte {
+enum SstRowFeature: byte {
     Flags,
     Timestamp
 }
@@ -41,8 +41,8 @@ table SsTableInfo {
     // Type of compression algorithm used.
     compression_format: CompressionFormat;
 
-    // The row level attributes enabled for this SST
-    row_attributes: [SstRowAttribute];
+    // The row level features enabled for this SST
+    row_features: [SstRowFeature];
 }
 
 table BlockMeta {

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -17,7 +17,8 @@ enum CompressionFormat: byte {
 }
 
 enum SstRowAttribute: byte {
-    Flags
+    Flags,
+    Timestamp
 }
 
 // Has metadata about a SST file.

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -37,6 +37,7 @@ use crate::{
     error::SlateDBError,
     mem_table::KVTable,
 };
+use crate::types::RowAttributes;
 
 pub(crate) enum WriteBatchMsg {
     Shutdown,
@@ -59,10 +60,10 @@ impl DbInner {
             for op in batch.ops {
                 match op {
                     WriteOp::Put(key, value) => {
-                        current_wal.put(key, value);
+                        current_wal.put(key, value, RowAttributes { ts: Some(self.options.clock.now()) });
                     }
                     WriteOp::Delete(key) => {
-                        current_wal.delete(key);
+                        current_wal.delete(key, RowAttributes { ts: Some(self.options.clock.now()) });
                     }
                 }
             }
@@ -76,10 +77,10 @@ impl DbInner {
             for op in batch.ops {
                 match op {
                     WriteOp::Put(key, value) => {
-                        current_memtable.put(key, value);
+                        current_memtable.put(key, value, RowAttributes { ts: Some(self.options.clock.now()) });
                     }
                     WriteOp::Delete(key) => {
-                        current_memtable.delete(key);
+                        current_memtable.delete(key,  RowAttributes { ts: Some(self.options.clock.now()) });
                     }
                 }
             }

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -31,13 +31,13 @@ use std::sync::Arc;
 use log::warn;
 use tokio::runtime::Handle;
 
+use crate::types::RowAttributes;
 use crate::{
     batch::{WriteBatch, WriteOp},
     db::DbInner,
     error::SlateDBError,
     mem_table::KVTable,
 };
-use crate::types::RowAttributes;
 
 pub(crate) enum WriteBatchMsg {
     Shutdown,
@@ -60,10 +60,21 @@ impl DbInner {
             for op in batch.ops {
                 match op {
                     WriteOp::Put(key, value) => {
-                        current_wal.put(key, value, RowAttributes { ts: Some(self.options.clock.now()) });
+                        current_wal.put(
+                            key,
+                            value,
+                            RowAttributes {
+                                ts: Some(self.options.clock.now()),
+                            },
+                        );
                     }
                     WriteOp::Delete(key) => {
-                        current_wal.delete(key, RowAttributes { ts: Some(self.options.clock.now()) });
+                        current_wal.delete(
+                            key,
+                            RowAttributes {
+                                ts: Some(self.options.clock.now()),
+                            },
+                        );
                     }
                 }
             }
@@ -77,10 +88,21 @@ impl DbInner {
             for op in batch.ops {
                 match op {
                     WriteOp::Put(key, value) => {
-                        current_memtable.put(key, value, RowAttributes { ts: Some(self.options.clock.now()) });
+                        current_memtable.put(
+                            key,
+                            value,
+                            RowAttributes {
+                                ts: Some(self.options.clock.now()),
+                            },
+                        );
                     }
                     WriteOp::Delete(key) => {
-                        current_memtable.delete(key,  RowAttributes { ts: Some(self.options.clock.now()) });
+                        current_memtable.delete(
+                            key,
+                            RowAttributes {
+                                ts: Some(self.options.clock.now()),
+                            },
+                        );
                     }
                 }
             }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,6 +1,7 @@
 use crate::db_state::RowAttribute;
 use crate::error::SlateDBError;
 use crate::row_codec::encode_row_v0;
+use crate::types::RowAttributes;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 pub(crate) const SIZEOF_U16: usize = std::mem::size_of::<u16>();
@@ -105,7 +106,7 @@ impl BlockBuilder {
     }
 
     #[must_use]
-    pub fn add(&mut self, key: &[u8], value: Option<&[u8]>) -> bool {
+    pub fn add(&mut self, key: &[u8], value: Option<&[u8]>, attrs: RowAttributes) -> bool {
         assert!(!key.is_empty(), "key must not be empty");
         let key_prefix_len = compute_prefix(&self.first_key, key);
         let key_suffix = &key[key_prefix_len..];
@@ -130,6 +131,7 @@ impl BlockBuilder {
             key_suffix,
             value,
             &self.row_attributes,
+            attrs.ts,
         );
 
         if self.first_key.is_empty() {
@@ -157,12 +159,13 @@ impl BlockBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::gen_attrs;
 
     #[test]
     fn test_block() {
         let mut builder = BlockBuilder::new(4096, vec![RowAttribute::Flags]);
-        assert!(builder.add(b"key1", Some(b"value1")));
-        assert!(builder.add(b"key2", Some(b"value2")));
+        assert!(builder.add(b"key1", Some(b"value1"), gen_attrs(0)));
+        assert!(builder.add(b"key2", Some(b"value2"), gen_attrs(1)));
         let block = builder.build().unwrap();
         let encoded = block.encode();
         let decoded = Block::decode(encoded);
@@ -173,9 +176,9 @@ mod tests {
     #[test]
     fn test_block_with_tombstone() {
         let mut builder = BlockBuilder::new(4096, vec![RowAttribute::Flags]);
-        assert!(builder.add(b"key1", Some(b"value1")));
-        assert!(builder.add(b"key2", None));
-        assert!(builder.add(b"key3", Some(b"value3")));
+        assert!(builder.add(b"key1", Some(b"value1"), gen_attrs(0)));
+        assert!(builder.add(b"key2", None, gen_attrs(1)));
+        assert!(builder.add(b"key3", Some(b"value3"), gen_attrs(2)));
         let block = builder.build().unwrap();
         let encoded = block.encode();
         let _decoded = Block::decode(encoded);
@@ -184,8 +187,8 @@ mod tests {
     #[test]
     fn test_block_size() {
         let mut builder = BlockBuilder::new(4096, vec![RowAttribute::Flags]);
-        assert!(builder.add(b"key1", Some(b"value1")));
-        assert!(builder.add(b"key2", Some(b"value2")));
+        assert!(builder.add(b"key1", Some(b"value1"), gen_attrs(1)));
+        assert!(builder.add(b"key2", Some(b"value2"), gen_attrs(2)));
         let block = builder.build().unwrap();
         assert_eq!(41, block.size());
     }

--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -135,6 +135,7 @@ mod tests {
     use crate::db_state::RowAttribute;
     use crate::iter::KeyValueIterator;
     use crate::test_utils;
+    use crate::test_utils::gen_attrs;
 
     fn attributes() -> Vec<RowAttribute> {
         vec![RowAttribute::Flags]
@@ -143,9 +144,9 @@ mod tests {
     #[tokio::test]
     async fn test_iterator() {
         let mut block_builder = BlockBuilder::new(1024, attributes());
-        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref())));
-        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref())));
-        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref())));
+        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
+        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
+        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_first_key(&block, attributes());
         let kv = iter.next().await.unwrap().unwrap();
@@ -160,9 +161,9 @@ mod tests {
     #[tokio::test]
     async fn test_iter_from_existing_key() {
         let mut block_builder = BlockBuilder::new(1024, attributes());
-        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref())));
-        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref())));
-        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref())));
+        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
+        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
+        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_key(&block, b"kratos".as_ref(), attributes());
         let kv = iter.next().await.unwrap().unwrap();
@@ -175,9 +176,9 @@ mod tests {
     #[tokio::test]
     async fn test_iter_from_nonexisting_key() {
         let mut block_builder = BlockBuilder::new(1024, attributes());
-        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref())));
-        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref())));
-        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref())));
+        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
+        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
+        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_key(&block, b"ka".as_ref(), attributes());
         let kv = iter.next().await.unwrap().unwrap();
@@ -190,9 +191,9 @@ mod tests {
     #[tokio::test]
     async fn test_iter_from_end() {
         let mut block_builder = BlockBuilder::new(1024, attributes());
-        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref())));
-        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref())));
-        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref())));
+        assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
+        assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
+        assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
         let mut iter = BlockIterator::from_key(&block, b"zzz".as_ref(), attributes());
         assert!(iter.next().await.unwrap().is_none());

--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bytes::{Buf, Bytes, BytesMut};
 
-use crate::db_state::RowAttribute;
+use crate::db_state::RowFeature;
 use crate::row_codec::decode_row_v0;
 use crate::{block::Block, error::SlateDBError, iter::KeyValueIterator, types::KeyValueDeletable};
 
@@ -47,7 +47,7 @@ pub struct BlockIterator<B: BlockLike> {
     // first key in the block, because slateDB does not support multi version of keys
     // so we use `Bytes` temporarily
     first_key: Bytes,
-    row_attributes: Vec<RowAttribute>,
+    row_features: Vec<RowFeature>,
 }
 
 impl<B: BlockLike> KeyValueIterator for BlockIterator<B> {
@@ -65,18 +65,18 @@ impl<B: BlockLike> KeyValueIterator for BlockIterator<B> {
 }
 
 impl<B: BlockLike> BlockIterator<B> {
-    pub fn from_first_key(block: B, row_attributes: Vec<RowAttribute>) -> BlockIterator<B> {
+    pub fn from_first_key(block: B, row_features: Vec<RowFeature>) -> BlockIterator<B> {
         BlockIterator {
             first_key: BlockIterator::decode_first_key(&block),
             block,
             off_off: 0,
-            row_attributes,
+            row_features,
         }
     }
 
     /// Construct a BlockIterator that starts at the given key, or at the first
     /// key greater than the given key if the exact key given is not in the block.
-    pub fn from_key(block: B, key: &[u8], row_attributes: Vec<RowAttribute>) -> BlockIterator<B> {
+    pub fn from_key(block: B, key: &[u8], row_features: Vec<RowFeature>) -> BlockIterator<B> {
         let first_key = BlockIterator::decode_first_key(&block);
 
         let idx = block.offsets().partition_point(|offset| {
@@ -94,7 +94,7 @@ impl<B: BlockLike> BlockIterator<B> {
             block,
             off_off: idx,
             first_key,
-            row_attributes,
+            row_features,
         }
     }
 
@@ -113,7 +113,7 @@ impl<B: BlockLike> BlockIterator<B> {
 
         Ok(Some(decode_row_v0(
             &self.first_key,
-            &self.row_attributes,
+            &self.row_features,
             &mut cursor,
         )?))
     }
@@ -132,23 +132,23 @@ impl<B: BlockLike> BlockIterator<B> {
 mod tests {
     use crate::block::BlockBuilder;
     use crate::block_iterator::BlockIterator;
-    use crate::db_state::RowAttribute;
+    use crate::db_state::RowFeature;
     use crate::iter::KeyValueIterator;
     use crate::test_utils;
     use crate::test_utils::gen_attrs;
 
-    fn attributes() -> Vec<RowAttribute> {
-        vec![RowAttribute::Flags]
+    fn features() -> Vec<RowFeature> {
+        vec![RowFeature::Flags]
     }
 
     #[tokio::test]
     async fn test_iterator() {
-        let mut block_builder = BlockBuilder::new(1024, attributes());
+        let mut block_builder = BlockBuilder::new(1024, features());
         assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
         assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
         assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
-        let mut iter = BlockIterator::from_first_key(&block, attributes());
+        let mut iter = BlockIterator::from_first_key(&block, features());
         let kv = iter.next().await.unwrap().unwrap();
         test_utils::assert_kv(&kv, b"donkey", b"kong");
         let kv = iter.next().await.unwrap().unwrap();
@@ -160,12 +160,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_iter_from_existing_key() {
-        let mut block_builder = BlockBuilder::new(1024, attributes());
+        let mut block_builder = BlockBuilder::new(1024, features());
         assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
         assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
         assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
-        let mut iter = BlockIterator::from_key(&block, b"kratos".as_ref(), attributes());
+        let mut iter = BlockIterator::from_key(&block, b"kratos".as_ref(), features());
         let kv = iter.next().await.unwrap().unwrap();
         test_utils::assert_kv(&kv, b"kratos", b"atreus");
         let kv = iter.next().await.unwrap().unwrap();
@@ -175,12 +175,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_iter_from_nonexisting_key() {
-        let mut block_builder = BlockBuilder::new(1024, attributes());
+        let mut block_builder = BlockBuilder::new(1024, features());
         assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
         assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
         assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
-        let mut iter = BlockIterator::from_key(&block, b"ka".as_ref(), attributes());
+        let mut iter = BlockIterator::from_key(&block, b"ka".as_ref(), features());
         let kv = iter.next().await.unwrap().unwrap();
         test_utils::assert_kv(&kv, b"kratos", b"atreus");
         let kv = iter.next().await.unwrap().unwrap();
@@ -190,12 +190,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_iter_from_end() {
-        let mut block_builder = BlockBuilder::new(1024, attributes());
+        let mut block_builder = BlockBuilder::new(1024, features());
         assert!(block_builder.add("donkey".as_ref(), Some("kong".as_ref()), gen_attrs(1)));
         assert!(block_builder.add("kratos".as_ref(), Some("atreus".as_ref()), gen_attrs(2)));
         assert!(block_builder.add("super".as_ref(), Some("mario".as_ref()), gen_attrs(3)));
         let block = block_builder.build().unwrap();
-        let mut iter = BlockIterator::from_key(&block, b"zzz".as_ref(), attributes());
+        let mut iter = BlockIterator::from_key(&block, b"zzz".as_ref(), features());
         assert!(iter.next().await.unwrap().is_none());
     }
 }

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -23,6 +23,7 @@ use crate::manifest_store::{ManifestStore, StoredManifest};
 use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use crate::test_utils::OrderedBytesGenerator;
+use crate::types::RowAttributes;
 use crate::{compactor::WorkerToOrchestratorMsg, config::CompressionCodec};
 
 pub struct CompactionExecuteBench {
@@ -142,7 +143,9 @@ impl CompactionExecuteBench {
             let mut val = vec![0u8; val_bytes];
             rng.fill_bytes(val.as_mut_slice());
             let key = key_gen.next();
-            sst_writer.add(key.as_ref(), Some(val.as_ref())).await?;
+            sst_writer
+                .add(key.as_ref(), Some(val.as_ref()), RowAttributes { ts: None })
+                .await?;
         }
         let encoded = sst_writer.close().await?;
         info!("wrote sst with id: {:?} {:?}", &encoded.id, start.elapsed());

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -312,6 +312,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::sst_iter::SstIterator;
     use crate::tablestore::TableStore;
+    use crate::test_utils::TestClock;
 
     const PATH: &str = "/test/db";
 
@@ -500,6 +501,7 @@ mod tests {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             block_cache: None,
             garbage_collector_options: None,
+            clock: Arc::new(TestClock::new()),
         }
     }
 

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -123,7 +123,11 @@ impl TokioCompactionExecutorInner {
             // Add to SST
             let value = kv.value.into_option();
             current_writer
-                .add(kv.key.as_ref(), value.as_ref().map(|b| b.as_ref()))
+                .add(
+                    kv.key.as_ref(),
+                    value.as_ref().map(|b| b.as_ref()),
+                    kv.attributes,
+                )
                 .await?;
             current_size += kv.key.len() + value.map_or(0, |b| b.len());
             if current_size > self.options.max_sst_size {

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,7 +249,9 @@ impl Clock for SystemClock {
 }
 
 fn default_clock() -> Arc<dyn Clock + Send + Sync> {
-    Arc::new(SystemClock {last_tick: AtomicI64::new(i64::MIN)})
+    Arc::new(SystemClock {
+        last_tick: AtomicI64::new(i64::MIN),
+    })
 }
 
 /// Configuration options for the database. These options are set on client startup.

--- a/src/db.rs
+++ b/src/db.rs
@@ -705,7 +705,7 @@ impl Db {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     use futures::{future::join_all, StreamExt};
     use object_store::memory::InMemory;
@@ -715,13 +715,12 @@ mod tests {
     use super::*;
     use crate::config::{
         CompactorOptions, ObjectStoreCacheOptions, SizeTieredCompactionSchedulerOptions,
-        SystemClock,
     };
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
     use crate::sst_iter::SstIterator;
     #[cfg(feature = "wal_disable")]
     use crate::test_utils::assert_iterator;
-    use crate::test_utils::gen_attrs;
+    use crate::test_utils::{gen_attrs, TestClock};
 
     #[tokio::test]
     async fn test_put_get_delete() {
@@ -1142,13 +1141,13 @@ mod tests {
                 (
                     vec![b'a'; 32],
                     ValueDeletable::Value(Bytes::copy_from_slice(&[b'j'; 32])),
-                    gen_attrs(1),
+                    gen_attrs(0),
                 ),
-                (vec![b'b'; 32], ValueDeletable::Tombstone, gen_attrs(2)),
+                (vec![b'b'; 32], ValueDeletable::Tombstone, gen_attrs(1)),
                 (
                     vec![b'c'; 32],
                     ValueDeletable::Value(Bytes::copy_from_slice(&[b'l'; 32])),
-                    gen_attrs(3),
+                    gen_attrs(2),
                 ),
             ],
         )
@@ -1785,9 +1784,7 @@ mod tests {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             block_cache: None,
             garbage_collector_options: None,
-            clock: Arc::new(SystemClock {
-                system_time: SystemTime::now(),
-            }),
+            clock: Arc::new(TestClock::new()),
         }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -75,18 +75,18 @@ impl DbInner {
         let snapshot = self.state.read().snapshot();
 
         if matches!(options.read_level, Uncommitted) {
-            let maybe_bytes = std::iter::once(snapshot.wal)
+            let maybe_val = std::iter::once(snapshot.wal)
                 .chain(snapshot.state.imm_wal.iter().map(|imm| imm.table()))
                 .find_map(|memtable| memtable.get(key));
-            if let Some(val) = maybe_bytes {
+            if let Some(val) = maybe_val {
                 return Ok(val.value.into_option());
             }
         }
 
-        let maybe_bytes = std::iter::once(snapshot.memtable)
+        let maybe_val = std::iter::once(snapshot.memtable)
             .chain(snapshot.state.imm_memtable.iter().map(|imm| imm.table()))
             .find_map(|memtable| memtable.get(key));
-        if let Some(val) = maybe_bytes {
+        if let Some(val) = maybe_val {
             return Ok(val.value.into_option());
         }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -394,9 +394,15 @@ impl DbInner {
                 for kv in wal_replay_buf.iter() {
                     match &kv.value {
                         ValueDeletable::Value(value) => {
-                            guard.memtable().put(kv.key.clone(), value.clone(), kv.attributes.clone());
+                            guard.memtable().put(
+                                kv.key.clone(),
+                                value.clone(),
+                                kv.attributes.clone(),
+                            );
                         }
-                        ValueDeletable::Tombstone => guard.memtable().delete(kv.key.clone(), kv.attributes.clone()),
+                        ValueDeletable::Tombstone => guard
+                            .memtable()
+                            .delete(kv.key.clone(), kv.attributes.clone()),
                     }
                 }
                 self.maybe_freeze_memtable(&mut guard, sst_id);
@@ -1280,17 +1286,17 @@ mod tests {
             lock.wal().put(
                 Bytes::copy_from_slice(b"abc1111"),
                 Bytes::copy_from_slice(b"value1111"),
-                gen_attrs(1)
+                gen_attrs(1),
             );
             lock.wal().put(
                 Bytes::copy_from_slice(b"abc2222"),
                 Bytes::copy_from_slice(b"value2222"),
-                gen_attrs(2)
+                gen_attrs(2),
             );
             lock.wal().put(
                 Bytes::copy_from_slice(b"abc3333"),
                 Bytes::copy_from_slice(b"value3333"),
-                gen_attrs(3)
+                gen_attrs(3),
             );
             lock.wal().table().clone()
         };

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -68,7 +68,7 @@ impl SsTableId {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
-pub(crate) enum RowAttribute {
+pub(crate) enum RowFeature {
     Flags,
     Timestamp,
 }
@@ -81,7 +81,7 @@ pub(crate) struct SsTableInfo {
     pub(crate) filter_offset: u64,
     pub(crate) filter_len: u64,
     pub(crate) compression_codec: Option<CompressionCodec>,
-    pub(crate) row_attributes: Vec<RowAttribute>,
+    pub(crate) row_features: Vec<RowFeature>,
 }
 
 pub(crate) trait SsTableInfoCodec: Send + Sync {
@@ -317,7 +317,7 @@ mod tests {
     use ulid::Ulid;
 
     use crate::db_state::{
-        CoreDbState, DbState, RowAttribute, SsTableHandle, SsTableId, SsTableInfo,
+        CoreDbState, DbState, RowFeature, SsTableHandle, SsTableId, SsTableInfo,
     };
 
     #[test]
@@ -373,7 +373,7 @@ mod tests {
             filter_offset: 0,
             filter_len: 0,
             compression_codec: None,
-            row_attributes: vec![RowAttribute::Flags],
+            row_features: vec![RowFeature::Flags],
         }
     }
 }

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -70,6 +70,7 @@ impl SsTableId {
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub(crate) enum RowAttribute {
     Flags,
+    Timestamp,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -335,6 +335,7 @@ impl From<RowAttribute> for SstRowAttribute {
     fn from(value: RowAttribute) -> Self {
         match value {
             RowAttribute::Flags => SstRowAttribute::Flags,
+            RowAttribute::Timestamp => SstRowAttribute::Timestamp,
         }
     }
 }
@@ -344,6 +345,7 @@ impl From<SstRowAttribute> for RowAttribute {
     fn from(value: SstRowAttribute) -> Self {
         match value {
             SstRowAttribute::Flags => RowAttribute::Flags,
+            SstRowAttribute::Timestamp => RowAttribute::Timestamp,
             _ => panic!(
                 "Attempted to read SST written with unknown SstRowAttribute. Are you \
             running an older version of SlateDB than was used to write the SST?"

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -20,7 +20,10 @@ use crate::config::CompressionCodec;
 use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::Compacted;
 use crate::error::SlateDBError;
-use crate::flatbuffer_types::manifest_generated::{CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat, SortedRun, SortedRunArgs, SstRowFeature};
+use crate::flatbuffer_types::manifest_generated::{
+    CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat,
+    SortedRun, SortedRunArgs, SstRowFeature,
+};
 use crate::manifest::{Manifest, ManifestCodec};
 
 /// A wrapper around a `Bytes` buffer containing a FlatBuffer-encoded `SsTableIndex`.

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
 use ulid::Ulid;
 
-use crate::db_state::{self, RowAttribute, SsTableInfo, SsTableInfoCodec};
+use crate::db_state::{self, RowFeature, SsTableInfo, SsTableInfoCodec};
 use crate::db_state::{CoreDbState, SsTableHandle};
 
 #[path = "./generated/manifest_generated.rs"]
@@ -20,10 +20,7 @@ use crate::config::CompressionCodec;
 use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::Compacted;
 use crate::error::SlateDBError;
-use crate::flatbuffer_types::manifest_generated::{
-    CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat,
-    SortedRun, SortedRunArgs, SstRowAttribute,
-};
+use crate::flatbuffer_types::manifest_generated::{CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat, SortedRun, SortedRunArgs, SstRowFeature};
 use crate::manifest::{Manifest, ManifestCodec};
 
 /// A wrapper around a `Bytes` buffer containing a FlatBuffer-encoded `SsTableIndex`.
@@ -72,7 +69,7 @@ impl FlatBufferSsTableInfoCodec {
             .first_key()
             .map(|key| Bytes::copy_from_slice(key.bytes()));
 
-        let row_attributes: Vec<RowAttribute> = match info.row_attributes() {
+        let row_features: Vec<RowFeature> = match info.row_features() {
             Some(vec) => vec.into_iter().map(|attr| attr.into()).collect(),
             None => Vec::new(),
         };
@@ -84,7 +81,7 @@ impl FlatBufferSsTableInfoCodec {
             filter_offset: info.filter_offset(),
             filter_len: info.filter_len(),
             compression_codec: info.compression_format().into(),
-            row_attributes,
+            row_features,
         }
     }
 
@@ -177,13 +174,13 @@ impl<'b> DbFlatBufferBuilder<'b> {
             Some(first_key_vector) => Some(self.builder.create_vector(first_key_vector)),
         };
 
-        let sst_row_attributes: Vec<SstRowAttribute> = info
-            .row_attributes
+        let sst_row_features: Vec<SstRowFeature> = info
+            .row_features
             .clone()
             .into_iter()
             .map(|attr| attr.into())
             .collect();
-        let row_attributes = Some(self.builder.create_vector(&sst_row_attributes));
+        let row_features = Some(self.builder.create_vector(&sst_row_features));
 
         FbSsTableInfo::create(
             &mut self.builder,
@@ -194,7 +191,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 filter_offset: info.filter_offset,
                 filter_len: info.filter_len,
                 compression_format: info.compression_codec.into(),
-                row_attributes,
+                row_features,
             },
         )
     }
@@ -331,21 +328,21 @@ impl From<CompressionFormat> for Option<CompressionCodec> {
     }
 }
 
-impl From<RowAttribute> for SstRowAttribute {
-    fn from(value: RowAttribute) -> Self {
+impl From<RowFeature> for SstRowFeature {
+    fn from(value: RowFeature) -> Self {
         match value {
-            RowAttribute::Flags => SstRowAttribute::Flags,
-            RowAttribute::Timestamp => SstRowAttribute::Timestamp,
+            RowFeature::Flags => SstRowFeature::Flags,
+            RowFeature::Timestamp => SstRowFeature::Timestamp,
         }
     }
 }
 
 #[allow(clippy::panic)]
-impl From<SstRowAttribute> for RowAttribute {
-    fn from(value: SstRowAttribute) -> Self {
+impl From<SstRowFeature> for RowFeature {
+    fn from(value: SstRowFeature) -> Self {
         match value {
-            SstRowAttribute::Flags => RowAttribute::Flags,
-            SstRowAttribute::Timestamp => RowAttribute::Timestamp,
+            SstRowFeature::Flags => RowFeature::Flags,
+            SstRowFeature::Timestamp => RowFeature::Timestamp,
             _ => panic!(
                 "Attempted to read SST written with unknown SstRowAttribute. Are you \
             running an older version of SlateDB than was used to write the SST?"

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -33,10 +33,10 @@ impl DbInner {
         while let Some(kv) = iter.next_entry().await? {
             match kv.value {
                 ValueDeletable::Value(v) => {
-                    sst_builder.add(&kv.key, Some(&v))?;
+                    sst_builder.add(&kv.key, Some(&v), kv.attributes)?;
                 }
                 ValueDeletable::Tombstone => {
-                    sst_builder.add(&kv.key, None)?;
+                    sst_builder.add(&kv.key, None, kv.attributes)?;
                 }
             }
         }
@@ -56,10 +56,10 @@ impl DbInner {
         while let Some(kv) = iter.next_entry_sync() {
             match kv.value {
                 ValueDeletable::Value(v) => {
-                    mem_table.put(kv.key, v);
+                    mem_table.put(kv.key, v, kv.attributes);
                 }
                 ValueDeletable::Tombstone => {
-                    mem_table.delete(kv.key);
+                    mem_table.delete(kv.key, kv.attributes);
                 }
             }
         }

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -265,6 +265,7 @@ mod tests {
     use object_store::{local::LocalFileSystem, path::Path};
     use ulid::Ulid;
 
+    use crate::test_utils::gen_attrs;
     use crate::{
         db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId},
         garbage_collector::GarbageCollector,
@@ -431,13 +432,13 @@ mod tests {
         // write a wal sst
         let id1 = SsTableId::Wal(1);
         let mut sst1 = table_store.table_builder();
-        sst1.add(b"key", Some(b"value")).unwrap();
+        sst1.add(b"key", Some(b"value"), gen_attrs(1)).unwrap();
         let table1 = sst1.build().unwrap();
         table_store.write_sst(&id1, table1).await.unwrap();
 
         let id2 = SsTableId::Wal(2);
         let mut sst2 = table_store.table_builder();
-        sst2.add(b"key", Some(b"value")).unwrap();
+        sst2.add(b"key", Some(b"value"), gen_attrs(2)).unwrap();
         let table2 = sst2.build().unwrap();
         table_store.write_sst(&id2, table2).await.unwrap();
 
@@ -500,13 +501,13 @@ mod tests {
         // write a wal sst
         let id1 = SsTableId::Wal(1);
         let mut sst1 = table_store.table_builder();
-        sst1.add(b"key", Some(b"value")).unwrap();
+        sst1.add(b"key", Some(b"value"), gen_attrs(1)).unwrap();
         let table1 = sst1.build().unwrap();
         table_store.write_sst(&id1, table1).await.unwrap();
 
         let id2 = SsTableId::Wal(2);
         let mut sst2 = table_store.table_builder();
-        sst2.add(b"key", Some(b"value")).unwrap();
+        sst2.add(b"key", Some(b"value"), gen_attrs(2)).unwrap();
         let table2 = sst2.build().unwrap();
         table_store.write_sst(&id2, table2).await.unwrap();
 
@@ -794,7 +795,7 @@ mod tests {
 
         let sst_id = SsTableId::Compacted(Ulid::new());
         let mut sst = table_store.table_builder();
-        sst.add(b"key", Some(b"value")).unwrap();
+        sst.add(b"key", Some(b"value"), gen_attrs(1)).unwrap();
         let table = sst.build().unwrap();
         table_store.write_sst(&sst_id, table).await.unwrap()
     }

--- a/src/generated/manifest_generated.rs
+++ b/src/generated/manifest_generated.rs
@@ -109,11 +109,12 @@ impl flatbuffers::SimpleToVerifyInSlice for CompressionFormat {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_SST_ROW_ATTRIBUTE: i8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_SST_ROW_ATTRIBUTE: i8 = 0;
+pub const ENUM_MAX_SST_ROW_ATTRIBUTE: i8 = 1;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_SST_ROW_ATTRIBUTE: [SstRowAttribute; 1] = [
+pub const ENUM_VALUES_SST_ROW_ATTRIBUTE: [SstRowAttribute; 2] = [
   SstRowAttribute::Flags,
+  SstRowAttribute::Timestamp,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -122,16 +123,19 @@ pub struct SstRowAttribute(pub i8);
 #[allow(non_upper_case_globals)]
 impl SstRowAttribute {
   pub const Flags: Self = Self(0);
+  pub const Timestamp: Self = Self(1);
 
   pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 0;
+  pub const ENUM_MAX: i8 = 1;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::Flags,
+    Self::Timestamp,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
     match self {
       Self::Flags => Some("Flags"),
+      Self::Timestamp => Some("Timestamp"),
       _ => None,
     }
   }

--- a/src/generated/manifest_generated.rs
+++ b/src/generated/manifest_generated.rs
@@ -107,21 +107,21 @@ impl<'a> flatbuffers::Verifiable for CompressionFormat {
 
 impl flatbuffers::SimpleToVerifyInSlice for CompressionFormat {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MIN_SST_ROW_ATTRIBUTE: i8 = 0;
+pub const ENUM_MIN_SST_ROW_FEATURE: i8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_SST_ROW_ATTRIBUTE: i8 = 1;
+pub const ENUM_MAX_SST_ROW_FEATURE: i8 = 1;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_SST_ROW_ATTRIBUTE: [SstRowAttribute; 2] = [
-  SstRowAttribute::Flags,
-  SstRowAttribute::Timestamp,
+pub const ENUM_VALUES_SST_ROW_FEATURE: [SstRowFeature; 2] = [
+  SstRowFeature::Flags,
+  SstRowFeature::Timestamp,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[repr(transparent)]
-pub struct SstRowAttribute(pub i8);
+pub struct SstRowFeature(pub i8);
 #[allow(non_upper_case_globals)]
-impl SstRowAttribute {
+impl SstRowFeature {
   pub const Flags: Self = Self(0);
   pub const Timestamp: Self = Self(1);
 
@@ -140,7 +140,7 @@ impl SstRowAttribute {
     }
   }
 }
-impl core::fmt::Debug for SstRowAttribute {
+impl core::fmt::Debug for SstRowFeature {
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     if let Some(name) = self.variant_name() {
       f.write_str(name)
@@ -149,7 +149,7 @@ impl core::fmt::Debug for SstRowAttribute {
     }
   }
 }
-impl<'a> flatbuffers::Follow<'a> for SstRowAttribute {
+impl<'a> flatbuffers::Follow<'a> for SstRowFeature {
   type Inner = Self;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
@@ -158,15 +158,15 @@ impl<'a> flatbuffers::Follow<'a> for SstRowAttribute {
   }
 }
 
-impl flatbuffers::Push for SstRowAttribute {
-    type Output = SstRowAttribute;
+impl flatbuffers::Push for SstRowFeature {
+    type Output = SstRowFeature;
     #[inline]
     unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
         flatbuffers::emplace_scalar::<i8>(dst, self.0);
     }
 }
 
-impl flatbuffers::EndianScalar for SstRowAttribute {
+impl flatbuffers::EndianScalar for SstRowFeature {
   type Scalar = i8;
   #[inline]
   fn to_little_endian(self) -> i8 {
@@ -180,7 +180,7 @@ impl flatbuffers::EndianScalar for SstRowAttribute {
   }
 }
 
-impl<'a> flatbuffers::Verifiable for SstRowAttribute {
+impl<'a> flatbuffers::Verifiable for SstRowFeature {
   #[inline]
   fn run_verifier(
     v: &mut flatbuffers::Verifier, pos: usize
@@ -190,7 +190,7 @@ impl<'a> flatbuffers::Verifiable for SstRowAttribute {
   }
 }
 
-impl flatbuffers::SimpleToVerifyInSlice for SstRowAttribute {}
+impl flatbuffers::SimpleToVerifyInSlice for SstRowFeature {}
 pub enum CompactedSstIdOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -443,7 +443,7 @@ impl<'a> SsTableInfo<'a> {
   pub const VT_FILTER_OFFSET: flatbuffers::VOffsetT = 10;
   pub const VT_FILTER_LEN: flatbuffers::VOffsetT = 12;
   pub const VT_COMPRESSION_FORMAT: flatbuffers::VOffsetT = 14;
-  pub const VT_ROW_ATTRIBUTES: flatbuffers::VOffsetT = 16;
+  pub const VT_ROW_FEATURES: flatbuffers::VOffsetT = 16;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -459,7 +459,7 @@ impl<'a> SsTableInfo<'a> {
     builder.add_filter_offset(args.filter_offset);
     builder.add_index_len(args.index_len);
     builder.add_index_offset(args.index_offset);
-    if let Some(x) = args.row_attributes { builder.add_row_attributes(x); }
+    if let Some(x) = args.row_features { builder.add_row_features(x); }
     if let Some(x) = args.first_key { builder.add_first_key(x); }
     builder.add_compression_format(args.compression_format);
     builder.finish()
@@ -509,11 +509,11 @@ impl<'a> SsTableInfo<'a> {
     unsafe { self._tab.get::<CompressionFormat>(SsTableInfo::VT_COMPRESSION_FORMAT, Some(CompressionFormat::None)).unwrap()}
   }
   #[inline]
-  pub fn row_attributes(&self) -> Option<flatbuffers::Vector<'a, SstRowAttribute>> {
+  pub fn row_features(&self) -> Option<flatbuffers::Vector<'a, SstRowFeature>> {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, SstRowAttribute>>>(SsTableInfo::VT_ROW_ATTRIBUTES, None)}
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, SstRowFeature>>>(SsTableInfo::VT_ROW_FEATURES, None)}
   }
 }
 
@@ -530,7 +530,7 @@ impl flatbuffers::Verifiable for SsTableInfo<'_> {
      .visit_field::<u64>("filter_offset", Self::VT_FILTER_OFFSET, false)?
      .visit_field::<u64>("filter_len", Self::VT_FILTER_LEN, false)?
      .visit_field::<CompressionFormat>("compression_format", Self::VT_COMPRESSION_FORMAT, false)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, SstRowAttribute>>>("row_attributes", Self::VT_ROW_ATTRIBUTES, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, SstRowFeature>>>("row_features", Self::VT_ROW_FEATURES, false)?
      .finish();
     Ok(())
   }
@@ -542,7 +542,7 @@ pub struct SsTableInfoArgs<'a> {
     pub filter_offset: u64,
     pub filter_len: u64,
     pub compression_format: CompressionFormat,
-    pub row_attributes: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, SstRowAttribute>>>,
+    pub row_features: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, SstRowFeature>>>,
 }
 impl<'a> Default for SsTableInfoArgs<'a> {
   #[inline]
@@ -554,7 +554,7 @@ impl<'a> Default for SsTableInfoArgs<'a> {
       filter_offset: 0,
       filter_len: 0,
       compression_format: CompressionFormat::None,
-      row_attributes: None,
+      row_features: None,
     }
   }
 }
@@ -589,8 +589,8 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SsTableInfoBuilder<'a, 'b, A> {
     self.fbb_.push_slot::<CompressionFormat>(SsTableInfo::VT_COMPRESSION_FORMAT, compression_format, CompressionFormat::None);
   }
   #[inline]
-  pub fn add_row_attributes(&mut self, row_attributes: flatbuffers::WIPOffset<flatbuffers::Vector<'b , SstRowAttribute>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(SsTableInfo::VT_ROW_ATTRIBUTES, row_attributes);
+  pub fn add_row_features(&mut self, row_features: flatbuffers::WIPOffset<flatbuffers::Vector<'b , SstRowFeature>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(SsTableInfo::VT_ROW_FEATURES, row_features);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SsTableInfoBuilder<'a, 'b, A> {
@@ -616,7 +616,7 @@ impl core::fmt::Debug for SsTableInfo<'_> {
       ds.field("filter_offset", &self.filter_offset());
       ds.field("filter_len", &self.filter_len());
       ds.field("compression_format", &self.compression_format());
-      ds.field("row_attributes", &self.row_attributes());
+      ds.field("row_features", &self.row_features());
       ds.finish()
   }
 }

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -228,11 +228,31 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_iter() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
-        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"), gen_attrs(3));
-        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"), gen_attrs(4));
-        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"), gen_attrs(5));
+        table.put(
+            Bytes::from_static(b"abc333"),
+            Bytes::from_static(b"value3"),
+            gen_attrs(1),
+        );
+        table.put(
+            Bytes::from_static(b"abc111"),
+            Bytes::from_static(b"value1"),
+            gen_attrs(2),
+        );
+        table.put(
+            Bytes::from_static(b"abc555"),
+            Bytes::from_static(b"value5"),
+            gen_attrs(3),
+        );
+        table.put(
+            Bytes::from_static(b"abc444"),
+            Bytes::from_static(b"value4"),
+            gen_attrs(4),
+        );
+        table.put(
+            Bytes::from_static(b"abc222"),
+            Bytes::from_static(b"value2"),
+            gen_attrs(5),
+        );
 
         let mut iter = table.table().iter();
         let kv = iter.next().await.unwrap().unwrap();
@@ -256,8 +276,16 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_iter_entry_attrs() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
+        table.put(
+            Bytes::from_static(b"abc333"),
+            Bytes::from_static(b"value3"),
+            gen_attrs(1),
+        );
+        table.put(
+            Bytes::from_static(b"abc111"),
+            Bytes::from_static(b"value1"),
+            gen_attrs(2),
+        );
 
         let mut iter = table.table().iter();
         let kv = iter.next_entry().await.unwrap().unwrap();
@@ -272,11 +300,31 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_range_from_existing_key() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
-        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"), gen_attrs(3));
-        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"), gen_attrs(4));
-        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"), gen_attrs(5));
+        table.put(
+            Bytes::from_static(b"abc333"),
+            Bytes::from_static(b"value3"),
+            gen_attrs(1),
+        );
+        table.put(
+            Bytes::from_static(b"abc111"),
+            Bytes::from_static(b"value1"),
+            gen_attrs(2),
+        );
+        table.put(
+            Bytes::from_static(b"abc555"),
+            Bytes::from_static(b"value5"),
+            gen_attrs(3),
+        );
+        table.put(
+            Bytes::from_static(b"abc444"),
+            Bytes::from_static(b"value4"),
+            gen_attrs(4),
+        );
+        table.put(
+            Bytes::from_static(b"abc222"),
+            Bytes::from_static(b"value2"),
+            gen_attrs(5),
+        );
 
         let mut iter = table.table().range_from(Bytes::from_static(b"abc333"));
         let kv = iter.next().await.unwrap().unwrap();
@@ -294,11 +342,31 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_range_from_nonexisting_key() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
-        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"), gen_attrs(3));
-        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"), gen_attrs(4));
-        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"), gen_attrs(5));
+        table.put(
+            Bytes::from_static(b"abc333"),
+            Bytes::from_static(b"value3"),
+            gen_attrs(1),
+        );
+        table.put(
+            Bytes::from_static(b"abc111"),
+            Bytes::from_static(b"value1"),
+            gen_attrs(2),
+        );
+        table.put(
+            Bytes::from_static(b"abc555"),
+            Bytes::from_static(b"value5"),
+            gen_attrs(3),
+        );
+        table.put(
+            Bytes::from_static(b"abc444"),
+            Bytes::from_static(b"value4"),
+            gen_attrs(4),
+        );
+        table.put(
+            Bytes::from_static(b"abc222"),
+            Bytes::from_static(b"value2"),
+            gen_attrs(5),
+        );
 
         let mut iter = table.table().range_from(Bytes::from_static(b"abc345"));
         let kv = iter.next().await.unwrap().unwrap();
@@ -313,7 +381,11 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_iter_delete() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
+        table.put(
+            Bytes::from_static(b"abc333"),
+            Bytes::from_static(b"value3"),
+            gen_attrs(1),
+        );
         table.delete(Bytes::from_static(b"abc333"), gen_attrs(2));
 
         let mut iter = table.table().iter();
@@ -324,13 +396,25 @@ mod tests {
     async fn test_memtable_track_sz() {
         let mut table = WritableKVTable::new();
 
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"val1"), gen_attrs(1));
+        table.put(
+            Bytes::from_static(b"abc333"),
+            Bytes::from_static(b"val1"),
+            gen_attrs(1),
+        );
         assert_eq!(table.size(), 18);
 
-        table.put(Bytes::from_static(b"def456"), Bytes::from_static(b"blablabla"), RowAttributes { ts: None });
+        table.put(
+            Bytes::from_static(b"def456"),
+            Bytes::from_static(b"blablabla"),
+            RowAttributes { ts: None },
+        );
         assert_eq!(table.size(), 33);
 
-        table.put(Bytes::from_static(b"def456"), Bytes::from_static(b"blabla"), gen_attrs(3));
+        table.put(
+            Bytes::from_static(b"def456"),
+            Bytes::from_static(b"blabla"),
+            gen_attrs(3),
+        );
         assert_eq!(table.size(), 38);
 
         table.delete(Bytes::from_static(b"abc333"), gen_attrs(4));

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -8,10 +8,10 @@ use tokio::sync::watch;
 
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
-use crate::types::{KeyValueDeletable, ValueDeletable};
+use crate::types::{KeyValueDeletable, RowAttributes, ValueDeletable};
 
 pub(crate) struct KVTable {
-    map: SkipMap<Bytes, ValueDeletable>,
+    map: SkipMap<Bytes, MemValue>,
     is_durable_tx: watch::Sender<bool>,
     is_durable_rx: watch::Receiver<bool>,
 }
@@ -33,9 +33,15 @@ pub(crate) struct ImmutableWal {
     table: Arc<KVTable>,
 }
 
-type MemTableRange<'a> = Range<'a, Bytes, (Bound<Bytes>, Bound<Bytes>), Bytes, ValueDeletable>;
+type MemTableRange<'a> = Range<'a, Bytes, (Bound<Bytes>, Bound<Bytes>), Bytes, MemValue>;
 
 pub struct MemTableIterator<'a>(MemTableRange<'a>);
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct MemValue {
+    pub(crate) value: ValueDeletable,
+    pub(crate) attrs: RowAttributes,
+}
 
 impl<'a> KeyValueIterator for MemTableIterator<'a> {
     async fn next_entry(&mut self) -> Result<Option<KeyValueDeletable>, SlateDBError> {
@@ -47,7 +53,8 @@ impl<'a> MemTableIterator<'a> {
     pub(crate) fn next_entry_sync(&mut self) -> Option<KeyValueDeletable> {
         self.0.next().map(|entry| KeyValueDeletable {
             key: entry.key().clone(),
-            value: entry.value().clone(),
+            value: entry.value().value.clone(),
+            attributes: entry.value().attrs.clone(),
         })
     }
 }
@@ -117,26 +124,27 @@ impl WritableKVTable {
         &self.table
     }
 
-    pub(crate) fn put(&mut self, key: Bytes, value: Bytes) {
+    pub(crate) fn put(&mut self, key: Bytes, value: Bytes, attrs: RowAttributes) {
         self.maybe_subtract_old_val_from_size(key.clone());
-        self.size = self.size + key.len() + value.len();
-        self.table.put(key, value)
+        self.size = self.size + key.len() + value.len() + sizeof_attributes(&attrs);
+        self.table.put(key, value, attrs)
     }
 
-    pub(crate) fn delete(&mut self, key: Bytes) {
+    pub(crate) fn delete(&mut self, key: Bytes, attrs: RowAttributes) {
         self.maybe_subtract_old_val_from_size(key.clone());
         self.size += key.len();
-        self.table.delete(key);
+        self.table.delete(key, attrs);
     }
 
     fn maybe_subtract_old_val_from_size(&mut self, key: Bytes) {
         if let Some(old_deletable) = self.table.get(&key) {
             self.size = self.size
                 - key.len()
-                - match old_deletable {
+                - match old_deletable.value {
                     ValueDeletable::Tombstone => 0,
                     ValueDeletable::Value(old) => old.len(),
                 }
+                - sizeof_attributes(&old_deletable.attrs)
         }
     }
 }
@@ -159,7 +167,7 @@ impl KVTable {
     /// Returns None if the key is not in the memtable at all,
     /// Some(None) if the key is in the memtable but has a tombstone value,
     /// Some(Some(value)) if the key is in the memtable with a non-tombstone value.
-    pub(crate) fn get(&self, key: &[u8]) -> Option<ValueDeletable> {
+    pub(crate) fn get(&self, key: &[u8]) -> Option<MemValue> {
         self.map.get(key).map(|entry| entry.value().clone())
     }
 
@@ -176,12 +184,24 @@ impl KVTable {
 
     /// Puts a value, returning as soon as the value is written to the memtable but before
     /// it is flushed to durable storage.
-    fn put(&self, key: Bytes, value: Bytes) {
-        self.map.insert(key, ValueDeletable::Value(value));
+    fn put(&self, key: Bytes, value: Bytes, attrs: RowAttributes) {
+        self.map.insert(
+            key,
+            MemValue {
+                value: ValueDeletable::Value(value),
+                attrs,
+            },
+        );
     }
 
-    fn delete(&self, key: Bytes) {
-        self.map.insert(key, ValueDeletable::Tombstone);
+    fn delete(&self, key: Bytes, attrs: RowAttributes) {
+        self.map.insert(
+            key,
+            MemValue {
+                value: ValueDeletable::Tombstone,
+                attrs,
+            },
+        );
     }
 
     pub(crate) async fn await_durable(&self) {
@@ -196,18 +216,23 @@ impl KVTable {
     }
 }
 
+fn sizeof_attributes(attrs: &RowAttributes) -> usize {
+    attrs.ts.map(|_| 8).unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::gen_attrs;
 
     #[tokio::test]
     async fn test_memtable_iter() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"));
-        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"));
-        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"));
-        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"));
+        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
+        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
+        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"), gen_attrs(3));
+        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"), gen_attrs(4));
+        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"), gen_attrs(5));
 
         let mut iter = table.table().iter();
         let kv = iter.next().await.unwrap().unwrap();
@@ -229,13 +254,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_memtable_iter_entry_attrs() {
+        let mut table = WritableKVTable::new();
+        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
+        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
+
+        let mut iter = table.table().iter();
+        let kv = iter.next_entry().await.unwrap().unwrap();
+        assert_eq!(kv.key, b"abc111".as_slice());
+        assert_eq!(kv.attributes.ts, Some(2));
+        let kv = iter.next_entry().await.unwrap().unwrap();
+        assert_eq!(kv.key, b"abc333".as_slice());
+        assert_eq!(kv.attributes.ts, Some(1));
+        assert!(iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn test_memtable_range_from_existing_key() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"));
-        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"));
-        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"));
-        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"));
+        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
+        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
+        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"), gen_attrs(3));
+        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"), gen_attrs(4));
+        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"), gen_attrs(5));
 
         let mut iter = table.table().range_from(Bytes::from_static(b"abc333"));
         let kv = iter.next().await.unwrap().unwrap();
@@ -253,11 +294,11 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_range_from_nonexisting_key() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"));
-        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"));
-        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"));
-        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"));
-        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"));
+        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
+        table.put(Bytes::from_static(b"abc111"), Bytes::from_static(b"value1"), gen_attrs(2));
+        table.put(Bytes::from_static(b"abc555"), Bytes::from_static(b"value5"), gen_attrs(3));
+        table.put(Bytes::from_static(b"abc444"), Bytes::from_static(b"value4"), gen_attrs(4));
+        table.put(Bytes::from_static(b"abc222"), Bytes::from_static(b"value2"), gen_attrs(5));
 
         let mut iter = table.table().range_from(Bytes::from_static(b"abc345"));
         let kv = iter.next().await.unwrap().unwrap();
@@ -272,8 +313,8 @@ mod tests {
     #[tokio::test]
     async fn test_memtable_iter_delete() {
         let mut table = WritableKVTable::new();
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"));
-        table.delete(Bytes::from_static(b"abc333"));
+        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"value3"), gen_attrs(1));
+        table.delete(Bytes::from_static(b"abc333"), gen_attrs(2));
 
         let mut iter = table.table().iter();
         assert!(iter.next().await.unwrap().is_none());
@@ -283,19 +324,16 @@ mod tests {
     async fn test_memtable_track_sz() {
         let mut table = WritableKVTable::new();
 
-        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"val1"));
-        assert_eq!(table.size(), 10);
+        table.put(Bytes::from_static(b"abc333"), Bytes::from_static(b"val1"), gen_attrs(1));
+        assert_eq!(table.size(), 18);
 
-        table.put(
-            Bytes::from_static(b"def456"),
-            Bytes::from_static(b"blablabla"),
-        );
-        assert_eq!(table.size(), 25);
+        table.put(Bytes::from_static(b"def456"), Bytes::from_static(b"blablabla"), RowAttributes { ts: None });
+        assert_eq!(table.size(), 33);
 
-        table.put(Bytes::from_static(b"def456"), Bytes::from_static(b"blabla"));
-        assert_eq!(table.size(), 22);
+        table.put(Bytes::from_static(b"def456"), Bytes::from_static(b"blabla"), gen_attrs(3));
+        assert_eq!(table.size(), 38);
 
-        table.delete(Bytes::from_static(b"abc333"));
-        assert_eq!(table.size(), 18)
+        table.delete(Bytes::from_static(b"abc333"), gen_attrs(4));
+        assert_eq!(table.size(), 26)
     }
 }

--- a/src/row_codec.rs
+++ b/src/row_codec.rs
@@ -60,11 +60,7 @@ pub(crate) fn encode_row_v0(
     }
 }
 
-fn encode_meta(
-    row_features: &[RowFeature],
-    is_tombstone: bool,
-    timestamp: Option<i64>,
-) -> Bytes {
+fn encode_meta(row_features: &[RowFeature], is_tombstone: bool, timestamp: Option<i64>) -> Bytes {
     let mut meta = BytesMut::new();
 
     for attr in row_features {
@@ -124,10 +120,7 @@ struct RowMetadata {
     timestamp: Option<i64>,
 }
 
-fn decode_meta(
-    row_features: &[RowFeature],
-    data: &mut Bytes,
-) -> Result<RowMetadata, SlateDBError> {
+fn decode_meta(row_features: &[RowFeature], data: &mut Bytes) -> Result<RowMetadata, SlateDBError> {
     let mut meta = RowMetadata {
         flags: RowFlags::empty(),
         timestamp: None,
@@ -179,8 +172,7 @@ mod tests {
 
         let first_key = Bytes::from(b"prefixdata".as_ref());
         let mut data = Bytes::from(encoded_data);
-        let decoded =
-            decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
+        let decoded = decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
 
         // Expected key: first_key[..3] + "key" = "prekey"
         let expected_key = Bytes::from(b"prekey" as &[u8]);
@@ -211,8 +203,7 @@ mod tests {
 
         let first_key = Bytes::from(b"".as_ref());
         let mut data = Bytes::from(encoded_data);
-        let decoded =
-            decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
+        let decoded = decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
 
         assert_eq!(decoded.attributes.ts, None);
     }
@@ -237,8 +228,7 @@ mod tests {
 
         let first_key = Bytes::from(b"deadbeefdata".as_ref());
         let mut data = Bytes::from(encoded_data);
-        let decoded =
-            decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
+        let decoded = decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
 
         // Expected key: first_key[..4] + "tomb" = "deadtomb"
         let expected_key = Bytes::from(b"deadtomb" as &[u8]);
@@ -296,8 +286,7 @@ mod tests {
 
         let first_key = Bytes::from(b"keyprefixdata".as_slice());
         let mut data = Bytes::from(encoded_data);
-        let decoded =
-            decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
+        let decoded = decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
 
         // Expected key: first_key[..4] + "" = "keyp"
         let expected_key = Bytes::from(b"keyp" as &[u8]);

--- a/src/row_codec.rs
+++ b/src/row_codec.rs
@@ -1,6 +1,6 @@
 use crate::db_state::RowAttribute;
 use crate::error::SlateDBError;
-use crate::types::{KeyValueDeletable, ValueDeletable};
+use crate::types::{KeyValueDeletable, RowAttributes, ValueDeletable};
 use bitflags::bitflags;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
@@ -46,12 +46,13 @@ pub(crate) fn encode_row_v0(
     key_suffix: &[u8],
     value: Option<&[u8]>,
     row_attributes: &Vec<RowAttribute>,
+    timestamp: Option<i64>,
 ) {
     data.put_u16(key_prefix_len as u16);
     data.put_u16(key_suffix.len() as u16);
     data.put(key_suffix);
 
-    data.put(encode_meta(row_attributes, value.is_none()));
+    data.put(encode_meta(row_attributes, value.is_none(), timestamp));
 
     if let Some(value) = value {
         data.put_u32(value.len() as u32);
@@ -59,12 +60,17 @@ pub(crate) fn encode_row_v0(
     }
 }
 
-fn encode_meta(row_attributes: &Vec<RowAttribute>, is_tombstone: bool) -> Bytes {
+fn encode_meta(
+    row_attributes: &Vec<RowAttribute>,
+    is_tombstone: bool,
+    timestamp: Option<i64>,
+) -> Bytes {
     let mut meta = BytesMut::new();
 
     for attr in row_attributes {
         match attr {
             RowAttribute::Flags => meta.put_u8(encode_row_flags(is_tombstone)),
+            RowAttribute::Timestamp => meta.put_i64(timestamp.expect("Timestamp RowAttribute was enabled for SST but attempted to insert a row with no timestamp.")),
         }
     }
 
@@ -109,11 +115,13 @@ pub(crate) fn decode_row_v0(
     Ok(KeyValueDeletable {
         key: key.into(),
         value,
+        attributes: RowAttributes { ts: meta.timestamp },
     })
 }
 
 struct RowMetadata {
     flags: RowFlags,
+    timestamp: Option<i64>,
 }
 
 fn decode_meta(
@@ -122,6 +130,7 @@ fn decode_meta(
 ) -> Result<RowMetadata, SlateDBError> {
     let mut meta = RowMetadata {
         flags: RowFlags::empty(),
+        timestamp: None,
     };
     for attr in row_attributes {
         match attr {
@@ -131,6 +140,7 @@ fn decode_meta(
                 }
                 Err(e) => return Err(e),
             },
+            RowAttribute::Timestamp => meta.timestamp = Some(data.get_i64()),
         }
     }
     Ok(meta)
@@ -155,7 +165,7 @@ mod tests {
         let key_prefix_len = 3;
         let key_suffix = b"key";
         let value = Some(b"value".as_slice());
-        let row_attributes = vec![RowAttribute::Flags];
+        let row_attributes = vec![RowAttribute::Flags, RowAttribute::Timestamp];
 
         // Encode the row
         encode_row_v0(
@@ -164,6 +174,7 @@ mod tests {
             key_suffix,
             value,
             &row_attributes,
+            Some(1),
         );
 
         let first_key = Bytes::from(b"prefixdata".as_ref());
@@ -177,6 +188,33 @@ mod tests {
 
         assert_eq!(decoded.key, expected_key);
         assert_eq!(decoded.value, expected_value);
+        assert_eq!(decoded.attributes.ts, Some(1));
+    }
+
+    #[test]
+    fn test_encode_decode_row_with_disabled_row_attr_flag() {
+        let mut encoded_data = Vec::new();
+        let key_prefix_len = 0;
+        let key_suffix = b"";
+        let value = Some(b"value".as_slice());
+        let row_attributes = vec![RowAttribute::Flags];
+
+        // Encode the row
+        encode_row_v0(
+            &mut encoded_data,
+            key_prefix_len,
+            key_suffix,
+            value,
+            &row_attributes,
+            Some(1), // pass in a timestamp, but it should not be encoded because flag is disabled
+        );
+
+        let first_key = Bytes::from(b"".as_ref());
+        let mut data = Bytes::from(encoded_data);
+        let decoded =
+            decode_row_v0(&first_key, &row_attributes, &mut data).expect("Decoding failed");
+
+        assert_eq!(decoded.attributes.ts, None);
     }
 
     #[test]
@@ -194,6 +232,7 @@ mod tests {
             key_suffix,
             value,
             &row_attributes,
+            Some(1),
         );
 
         let first_key = Bytes::from(b"deadbeefdata".as_ref());
@@ -252,6 +291,7 @@ mod tests {
             key_suffix,
             value,
             &row_attributes,
+            Some(1),
         );
 
         let first_key = Bytes::from(b"keyprefixdata".as_slice());

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -337,7 +337,7 @@ mod tests {
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
     use crate::config::SizeTieredCompactionSchedulerOptions;
     use crate::db_state::{
-        CoreDbState, RowAttribute, SortedRun, SsTableHandle, SsTableId, SsTableInfo,
+        CoreDbState, RowFeature, SortedRun, SsTableHandle, SsTableId, SsTableInfo,
     };
     use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
 
@@ -633,7 +633,7 @@ mod tests {
             filter_offset: 0,
             filter_len: 0,
             compression_codec: None,
-            row_attributes: vec![RowAttribute::Flags],
+            row_features: vec![RowFeature::Flags],
         };
         SsTableHandle {
             id: SsTableId::Compacted(ulid::Ulid::new()),

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -200,12 +200,12 @@ impl<'a, H: AsRef<SsTableHandle>> SstIterator<'a, H> {
                             return match first_key {
                                 None => Ok(Some(BlockIterator::from_first_key(
                                     block,
-                                    self.table.as_ref().info.row_attributes.clone(),
+                                    self.table.as_ref().info.row_features.clone(),
                                 ))),
                                 Some(k) => Ok(Some(BlockIterator::from_key(
                                     block,
                                     k,
-                                    self.table.as_ref().info.row_attributes.clone(),
+                                    self.table.as_ref().info.row_features.clone(),
                                 ))),
                             };
                         } else {

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -838,7 +838,7 @@ mod tests {
 
         while let (Some(block), Some(expected_item)) = (block_iter.next(), expected_iter.next()) {
             let mut iter =
-                BlockIterator::from_first_key(block.clone(), handle.info.row_attributes.clone());
+                BlockIterator::from_first_key(block.clone(), handle.info.row_features.clone());
             let kv = iter.next().await.unwrap().unwrap();
             assert_eq!(kv.key, expected_item.0);
             assert_eq!(ValueDeletable::Value(kv.value), expected_item.1);

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -22,6 +22,7 @@ use crate::sst::{EncodedSsTable, EncodedSsTableBuilder, SsTableFormat};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
+use crate::types::RowAttributes;
 use crate::{blob::ReadOnlyBlob, block::Block, db_cache::DbCache};
 
 pub struct TableStore {
@@ -532,8 +533,13 @@ pub(crate) struct EncodedSsTableWriter<'a> {
 }
 
 impl<'a> EncodedSsTableWriter<'a> {
-    pub async fn add(&mut self, key: &[u8], value: Option<&[u8]>) -> Result<(), SlateDBError> {
-        self.builder.add(key, value)?;
+    pub async fn add(
+        &mut self,
+        key: &[u8],
+        value: Option<&[u8]>,
+        attrs: RowAttributes,
+    ) -> Result<(), SlateDBError> {
+        self.builder.add(key, value, attrs)?;
         self.drain_blocks().await
     }
 
@@ -582,7 +588,7 @@ mod tests {
     #[cfg(feature = "moka")]
     use crate::tablestore::DbCache;
     use crate::tablestore::TableStore;
-    use crate::test_utils::assert_iterator;
+    use crate::test_utils::{assert_iterator, gen_attrs};
     use crate::types::ValueDeletable;
     use crate::{
         block::Block, block_iterator::BlockIterator, db_state::SsTableId, iter::KeyValueIterator,
@@ -625,10 +631,19 @@ mod tests {
 
         // when:
         let mut writer = ts.table_writer(id);
-        writer.add(&[b'a'; 16], Some(&[1u8; 16])).await.unwrap();
-        writer.add(&[b'b'; 16], Some(&[2u8; 16])).await.unwrap();
-        writer.add(&[b'c'; 16], None).await.unwrap();
-        writer.add(&[b'd'; 16], Some(&[4u8; 16])).await.unwrap();
+        writer
+            .add(&[b'a'; 16], Some(&[1u8; 16]), gen_attrs(1))
+            .await
+            .unwrap();
+        writer
+            .add(&[b'b'; 16], Some(&[2u8; 16]), gen_attrs(2))
+            .await
+            .unwrap();
+        writer.add(&[b'c'; 16], None, gen_attrs(3)).await.unwrap();
+        writer
+            .add(&[b'd'; 16], Some(&[4u8; 16]), gen_attrs(4))
+            .await
+            .unwrap();
         let sst = writer.close().await.unwrap();
 
         // then:
@@ -641,15 +656,18 @@ mod tests {
                 (
                     vec![b'a'; 16],
                     ValueDeletable::Value(Bytes::copy_from_slice(&[1u8; 16])),
+                    gen_attrs(1),
                 ),
                 (
                     vec![b'b'; 16],
                     ValueDeletable::Value(Bytes::copy_from_slice(&[2u8; 16])),
+                    gen_attrs(2),
                 ),
-                (vec![b'c'; 16], ValueDeletable::Tombstone),
+                (vec![b'c'; 16], ValueDeletable::Tombstone, gen_attrs(3)),
                 (
                     vec![b'd'; 16],
                     ValueDeletable::Value(Bytes::copy_from_slice(&[4u8; 16])),
+                    gen_attrs(4),
                 ),
             ],
         )
@@ -669,12 +687,12 @@ mod tests {
 
         // write a wal sst
         let mut sst1 = ts.table_builder();
-        sst1.add(b"key", Some(b"value")).unwrap();
+        sst1.add(b"key", Some(b"value"), gen_attrs(1)).unwrap();
         let table = sst1.build().unwrap();
         ts.write_sst(&wal_id, table).await.unwrap();
 
         let mut sst2 = ts.table_builder();
-        sst2.add(b"key", Some(b"value")).unwrap();
+        sst2.add(b"key", Some(b"value"), gen_attrs(2)).unwrap();
         let table2 = sst2.build().unwrap();
 
         // write another wal sst with the same id.
@@ -713,7 +731,7 @@ mod tests {
                 Vec::from(key.as_slice()),
                 ValueDeletable::Value(Bytes::copy_from_slice(&value)),
             ));
-            writer.add(&key, Some(&value)).await.unwrap();
+            writer.add(&key, Some(&value), gen_attrs(i)).await.unwrap();
         }
         let handle = writer.close().await.unwrap();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,6 +14,13 @@ pub struct KeyValue {
 pub struct KeyValueDeletable {
     pub key: Bytes,
     pub value: ValueDeletable,
+    pub attributes: RowAttributes,
+}
+
+/// The metadata associated with a `KeyValueDeletable`
+#[derive(Debug, Clone, PartialEq)]
+pub struct RowAttributes {
+    pub ts: Option<i64>,
 }
 
 /// Represents a value that may be a tombstone.


### PR DESCRIPTION
### Overview

This is the third PR in the sequence to implement #228. It adds timestamps into the row format and encodes them into the SSTs using a custom-defined clock.

### Review Guide

1. check `config.rs` for the `Clock` trait definition and default implementations
2. look at `db.rs` which uses the clock to seed the timestamp
3. follow the plumbing all the way through to `row_codec.rs`, where the values are encoded/decoded
4. confirm size computations in `mem_table.rs` are valid
5. look at test changes, starting with `test_utils.rs` which defines a test clock and confirms timestamps during iteration

### Follow Ups:

- [ ] Enforce monotonically increasing clock across restarts
- [ ] Make including timestamps optional (this PR hardcodes them into the SST row attributes)