### PR TITLE
feat(db): Allow loading DbOptions from a configuration file or environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,6 +531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +560,19 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "duration-str"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709d653e7c92498eb29fb86a2a6f0f3502b97530f33aedb32ef848d4d28b31a3"
+dependencies = [
+ "rust_decimal",
+ "serde",
+ "thiserror",
+ "time",
+ "winnow",
+]
 
 [[package]]
 name = "either"
@@ -644,6 +666,24 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "filetime"
@@ -1120,6 +1160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1425,6 +1471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1532,6 +1584,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1657,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,6 +1702,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -1848,6 +1942,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f94e84c073f3b85d4012b44722fa8842b9986d741590d4f2636ad0a5b14143"
 
 [[package]]
+name = "rust_decimal"
+version = "1.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b082d80e3e3cc52b2ed634388d436fe1f4de6af5786cc2de9ba9737527bdf555"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2171,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,7 +2238,9 @@ dependencies = [
  "crossbeam-channel",
  "crossbeam-skiplist",
  "dotenvy",
+ "duration-str",
  "fail-parallel",
+ "figment",
  "filetime",
  "flatbuffers",
  "flate2",
@@ -2306,6 +2425,24 @@ dependencies = [
  "cfg-if",
  "once_cell",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "tinyvec"
@@ -2535,6 +2672,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2554,6 +2700,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2884,6 +3036,12 @@ checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,15 @@ chrono = { version = "0.4.38", features = ["serde"] }
 foyer = { version = "0.11.2", optional = true }
 walkdir = "2.3.3"
 radix_trie = "0.2.1"
+figment = { version = "0.10.19", features = ["env", "json", "toml", "yaml"] }
+duration-str = { version = "0.11.2", features = ["serde", "time"], default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 fail-parallel = { version = "0.5.1", features = ["failpoints"] }
 tempfile = "3.3"
 filetime = "0.2"
+figment = { version = "0.10.19", features = ["test"] }
 
 [features]
 default = ["aws", "moka"]

--- a/src/bencher/README.md
+++ b/src/bencher/README.md
@@ -13,18 +13,10 @@ arguments:
 Usage: bencher db [OPTIONS]
 
 Options:
-      --disable-wal
-          Whether to disable the write-ahead log.
-      --flush-ms <FLUSH_MS>
-          The interval in milliseconds to flush the write-ahead log.
-      --l0-sst-size-bytes <L0_SST_SIZE_BYTES>
-          The size in bytes of the L0 SSTables.
+      --db-options-path <FILE_PATH>
+          Options path to a file with options for DbOptions, `SlateDb.toml` is used if this flag is not set.
       --block-cache-size <BLOCK_CACHE_SIZE>
           The size in bytes of the block cache.
-      --object-cache-path <OBJECT_CACHE_PATH>
-          The path where object store cache part files are stored.
-      --object-cache-part-size <OBJECT_CACHE_PART_SIZE>
-          The size in bytes of the object store cache part files.
       --duration <DURATION>
           The duration in seconds to run the benchmark for.
       --key-generator <KEY_GENERATOR>
@@ -41,7 +33,7 @@ Options:
           The length of the values to generate. [default: 1024]
       --put-percentage <PUT_PERCENTAGE>
           The percentage of writes to perform in each task. [default: 20]
-  -h, --help
+      -h, --help
           Print help
 ```
 

--- a/src/bencher/SlateDb.toml
+++ b/src/bencher/SlateDb.toml
@@ -1,0 +1,5 @@
+wal_enabled = false
+flush_interval = "100ms"
+
+[object_store_cache_options]
+root_folder = "/tmp/slatedb-cache"

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -13,9 +13,7 @@ gnuplot -V # just to make sure gnuplot is present
 BENCH="cargo run -r --bin bencher --features=bencher -- --path /slatedb-bencher db \
   --duration 60 \
   --val-len 8192 \
-  --disable-wal \
   --block-cache-size 134217728 \
-  --object-cache-path /tmp/slatedb-cache \
 "
 
 parse_stats() {

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 async fn exec_benchmark_db(path: Path, object_store: Arc<dyn ObjectStore>, args: BenchmarkDbArgs) {
-    let config = args.db_args.config();
+    let config = args.db_args.config().unwrap();
     let write_options = WriteOptions {
         await_durable: args.await_durable,
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,8 +4,7 @@ use std::{str::FromStr, time::Duration};
 
 use duration_str::{deserialize_duration, deserialize_option_duration};
 use figment::providers::{Env, Format, Json, Toml, Yaml};
-pub use figment::Provider as DbOptionsProvider;
-use figment::{Figment, Metadata};
+use figment::{Figment, Metadata, Provider};
 use serde::{Deserialize, Serialize, Serializer};
 use tokio::runtime::Handle;
 
@@ -287,7 +286,7 @@ impl DbOptions {
     }
 }
 
-impl DbOptionsProvider for DbOptions {
+impl Provider for DbOptions {
     fn metadata(&self) -> figment::Metadata {
         Metadata::named("SlateDb configuration options")
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,155 @@
+//! Configuration options for SlateDB.
+//!
+//! This module provides structures and functions to manage database configuration options,
+//! including reading from files and environment variables.
+//!
+//! # Examples
+//!
+//! Loading the default configuration for `DbOptions`:
+//!
+//! ```rust
+//! use slatedb::config::DbOptions;
+//! let config = DbOptions::default();
+//! ```
+//!
+//! Loading `DbOptions` from a specific file:
+//!
+//! ```rust
+//! use slatedb::config::DbOptions;
+//! let config = DbOptions::from_file("config.toml").expect("Failed to load options from file");
+//! ```
+//!
+//! Loading `DbOptions` from environment variables:
+//!
+//! ```rust
+//! use slatedb::config::DbOptions;
+//! let config = DbOptions::from_env("SLATEDB_").expect("Failed to load options from env");
+//! ```
+//!
+//! Loading `DbOptions` from predefined files, SlateDb.toml, SlateDb.json, SlateDb.yaml, or SlateDb.yml.
+//! This method also merges any environment variable that starts with `SLATEDB_` to the final `DbOptions` struct:
+//!
+//! ```rust
+//! use slatedb::config::DbOptions;
+//! let config = DbOptions::load().expect("Failed to load options");
+//! ```
+//!
+//! # Configuration formats
+//!
+//! SlateDB supports three configuration formats: TOML, JSON, and YAML.
+//! Duration options in the configuration are represented as human-friendly strings,
+//! allowing you to specify time intervals in a more intuitive way, such as "100ms" or "1s".
+//!
+//! Representing `DbOptions` with TOML:
+//!
+//! ```toml
+//! flush_interval = "100ms"
+//! wal_enabled = false
+//! manifest_poll_interval = "1s"
+//! min_filter_keys = 1000
+//! filter_bits_per_key = 10
+//! l0_sst_size_bytes = 67108864
+//! l0_max_ssts = 8
+//! max_unflushed_memtable = 2
+//!
+//! [compactor_options]
+//! poll_interval = "5s"
+//! max_sst_size = 1073741824
+//! max_concurrent_compactions = 4
+//!
+//! [object_store_cache_options]
+//! root_folder = "/tmp/slatedb-cache"
+//! max_cache_size_bytes = 17179869184
+//! part_size_bytes = 4194304
+//! scan_interval = "3600s"
+//!
+//! [garbage_collector_options.manifest_options]
+//! poll_interval = "300s"
+//! min_age = "86400s"
+//!
+//! [garbage_collector_options.wal_options]
+//! poll_interval = "60s"
+//! min_age = "60s"
+//!
+//! [garbage_collector_options.compacted_options]
+//! poll_interval = "300s"
+//! min_age = "86400s"
+//! ```
+//!
+//! Representing `DbOptions` with JSON:
+//!
+//! ```json
+//!{
+//!  "flush_interval": "100ms",
+//!  "wal_enabled": false,
+//!  "manifest_poll_interval": "1s",
+//!  "min_filter_keys": 1000,
+//!  "filter_bits_per_key": 10,
+//!  "l0_sst_size_bytes": 67108864,
+//!  "l0_max_ssts": 8,
+//!  "max_unflushed_memtable": 2,
+//!  "compactor_options": {
+//!    "poll_interval": "5s",
+//!    "max_sst_size": 1073741824,
+//!    "max_concurrent_compactions": 4
+//!  },
+//!  "compression_codec": null,
+//!  "object_store_cache_options": {
+//!    "root_folder": "/tmp/slatedb-cache",
+//!    "max_cache_size_bytes": 17179869184,
+//!    "part_size_bytes": 4194304,
+//!    "scan_interval": "3600s"
+//!  },
+//!  "garbage_collector_options": {
+//!    "manifest_options": {
+//!      "poll_interval": "300s",
+//!      "min_age": "86400s"
+//!    },
+//!    "wal_options": {
+//!      "poll_interval": "60s",
+//!      "min_age": "60s"
+//!    },
+//!    "compacted_options": {
+//!      "poll_interval": "300s",
+//!      "min_age": "86400s"
+//!    }
+//!  }
+//!}
+//!```
+//!
+//! Representing `DbOptions` with YAML:
+//!
+//! ```yaml
+//! flush_interval: '100ms'
+//! wal_enabled: false
+//! manifest_poll_interval: '1s'
+//! min_filter_keys: 1000
+//! filter_bits_per_key: 10
+//! l0_sst_size_bytes: 67108864
+//! l0_max_ssts: 8
+//! max_unflushed_memtable: 2
+//! compactor_options:
+//!   poll_interval: '5s'
+//!   max_sst_size: 1073741824
+//!   max_concurrent_compactions: 4
+//! compression_codec: null
+//! object_store_cache_options:
+//!   root_folder: /tmp/slatedb-cache
+//!   max_cache_size_bytes: 17179869184
+//!   part_size_bytes: 4194304
+//!   scan_interval: '3600s'
+//! garbage_collector_options:
+//!   manifest_options:
+//!     poll_interval: '300s'
+//!     min_age: '86400s'
+//!   wal_options:
+//!     poll_interval: '60s'
+//!     min_age: '60s'
+//!   compacted_options:
+//!     poll_interval: '300s'
+//!     min_age: '86400s'
+//! ```
+//!
 use std::path::Path;
 use std::sync::Arc;
 use std::{str::FromStr, time::Duration};

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 #[derive(thiserror::Error, Debug)]
 pub enum SlateDBError {
     #[error("IO error")]
@@ -53,4 +55,17 @@ pub enum SlateDBError {
 
     #[error("Unknown RowFlags -- this may be caused by reading data encoded with a newer codec")]
     InvalidRowFlags,
+}
+
+/// Represents errors that can occur during the database configuration.
+///
+/// This enum encapsulates various error conditions that may arise
+/// when parsing or processing database configuration options.
+#[derive(thiserror::Error, Debug)]
+pub enum DbOptionsError {
+    #[error("Unknown configuration file format: {0}")]
+    UnknownFormat(PathBuf),
+
+    #[error("Invalid configuration format")]
+    InvalidFormat(#[from] figment::Error),
 }

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -312,6 +312,7 @@ impl SizeTieredCompactionScheduler {
     }
 }
 
+#[derive(Default)]
 pub struct SizeTieredCompactionSchedulerSupplier {
     options: SizeTieredCompactionSchedulerOptions,
 }


### PR DESCRIPTION
This change adds these functions to allow loading DbOptions from configuration files or environment variables:

`from_file`: loads the options from a specific file.
`from_env`: loads the options from environment variables with a specific prefix.
`load`: loads the options with some default file locations and `SLATEDB_` as a default prefix. This option is accumulative. If a config file exists, and environment variables also exist, both are combined. Environment variables override settings in the configuration file.

I was going to document all this and provide additional configuration examples, but I could not find a good place to do it. Let me know where I should add that @criccomini. If this repo doesn't include the documentation, I'll be happy to open a new PR in a different repository for the documentation.

PS: Most of the changes are in `src/config.rs` which GitHub collapses 🤷 

Fixes #263 