### PR TITLE
Fix race condition in writer fencing  that could result in two writers being open at the same time.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -118,8 +118,8 @@ impl DbInner {
         Ok(None)
     }
 
-    async fn fence_writers(&self, manifest: &mut FenceableManifest) -> Result<(), SlateDBError> {
-        let mut empty_wal_id = self.state.read().state().core.next_wal_sst_id;
+    async fn fence_writers(&self, manifest: &mut FenceableManifest, next_wal_id: u64) -> Result<(), SlateDBError> {
+        let mut empty_wal_id = next_wal_id;
 
         loop {
             let empty_wal = WritableKVTable::new();
@@ -451,7 +451,16 @@ impl Db {
         ));
 
         let manifest_store = Arc::new(ManifestStore::new(&path, maybe_cached_object_store.clone()));
-        let mut manifest = Self::init_db(&manifest_store, &table_store).await?;
+        let latest_manifest = StoredManifest::load(manifest_store.clone()).await?;
+
+        // get the next wal id before writing manifest.
+        let wal_id_last_compacted = match &latest_manifest {
+            Some(latest_stored_manifest) => latest_stored_manifest.db_state().last_compacted_wal_sst_id,
+            None => 0
+        };
+        let next_wal_id = table_store.next_wal_sst_id(wal_id_last_compacted).await?;
+
+        let mut manifest = Self::init_db(&manifest_store, latest_manifest).await?;
         let (memtable_flush_tx, memtable_flush_rx) = tokio::sync::mpsc::unbounded_channel();
         let (wal_flush_tx, wal_flush_rx) = tokio::sync::mpsc::unbounded_channel();
         let inner = Arc::new(
@@ -466,7 +475,7 @@ impl Db {
             .await?,
         );
         if inner.wal_enabled() {
-            inner.fence_writers(&mut manifest).await?;
+            inner.fence_writers(&mut manifest, next_wal_id).await?;
         }
         inner.replay_wal().await?;
         let tokio_handle = Handle::current();
@@ -522,24 +531,13 @@ impl Db {
 
     async fn init_db(
         manifest_store: &Arc<ManifestStore>,
-        table_store: &Arc<TableStore>,
+        latest_stored_manifest: Option<StoredManifest>
     ) -> Result<FenceableManifest, SlateDBError> {
-        let stored_manifest = Self::init_stored_manifest(manifest_store).await?;
-        let mut state = stored_manifest.db_state().clone();
-        state.next_wal_sst_id = table_store
-            .clone()
-            .next_wal_sst_id(state.last_compacted_wal_sst_id)
-            .await?;
+        let stored_manifest = match latest_stored_manifest {
+            Some(manifest) => manifest,
+            None => StoredManifest::init_new_db(manifest_store.clone(), CoreDbState::new()).await?
+        };
         FenceableManifest::init_writer(stored_manifest).await
-    }
-
-    async fn init_stored_manifest(
-        manifest_store: &Arc<ManifestStore>,
-    ) -> Result<StoredManifest, SlateDBError> {
-        if let Some(stored_manifest) = StoredManifest::load(manifest_store.clone()).await? {
-            return Ok(stored_manifest);
-        }
-        StoredManifest::init_new_db(manifest_store.clone(), CoreDbState::new()).await
     }
 
     pub async fn close(&self) -> Result<(), SlateDBError> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -118,7 +118,11 @@ impl DbInner {
         Ok(None)
     }
 
-    async fn fence_writers(&self, manifest: &mut FenceableManifest, next_wal_id: u64) -> Result<(), SlateDBError> {
+    async fn fence_writers(
+        &self,
+        manifest: &mut FenceableManifest,
+        next_wal_id: u64,
+    ) -> Result<(), SlateDBError> {
         let mut empty_wal_id = next_wal_id;
 
         loop {
@@ -455,8 +459,10 @@ impl Db {
 
         // get the next wal id before writing manifest.
         let wal_id_last_compacted = match &latest_manifest {
-            Some(latest_stored_manifest) => latest_stored_manifest.db_state().last_compacted_wal_sst_id,
-            None => 0
+            Some(latest_stored_manifest) => {
+                latest_stored_manifest.db_state().last_compacted_wal_sst_id
+            }
+            None => 0,
         };
         let next_wal_id = table_store.next_wal_sst_id(wal_id_last_compacted).await?;
 
@@ -531,11 +537,11 @@ impl Db {
 
     async fn init_db(
         manifest_store: &Arc<ManifestStore>,
-        latest_stored_manifest: Option<StoredManifest>
+        latest_stored_manifest: Option<StoredManifest>,
     ) -> Result<FenceableManifest, SlateDBError> {
         let stored_manifest = match latest_stored_manifest {
             Some(manifest) => manifest,
-            None => StoredManifest::init_new_db(manifest_store.clone(), CoreDbState::new()).await?
+            None => StoredManifest::init_new_db(manifest_store.clone(), CoreDbState::new()).await?,
         };
         FenceableManifest::init_writer(stored_manifest).await
     }

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -141,9 +141,14 @@ impl TableStore {
         Ok(wal_list)
     }
 
-    pub(crate) async  fn next_wal_sst_id(&self, wal_id_last_compacted: u64) -> Result<u64, SlateDBError> {
-        Ok(self.list_wal_ssts(wal_id_last_compacted..).await?
-           .into_iter()
+    pub(crate) async fn next_wal_sst_id(
+        &self,
+        wal_id_last_compacted: u64,
+    ) -> Result<u64, SlateDBError> {
+        Ok(self
+            .list_wal_ssts(wal_id_last_compacted..)
+            .await?
+            .into_iter()
             .map(|wal_sst| wal_sst.id.unwrap_wal_id())
             .max()
             .unwrap_or(wal_id_last_compacted + 1))

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -151,7 +151,7 @@ impl TableStore {
             .into_iter()
             .map(|wal_sst| wal_sst.id.unwrap_wal_id())
             .max()
-            .unwrap_or(wal_id_last_compacted + 1))
+            .unwrap_or(wal_id_last_compacted) + 1)
     }
 
     pub(crate) fn table_writer(&self, id: SsTableId) -> EncodedSsTableWriter {

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -141,6 +141,14 @@ impl TableStore {
         Ok(wal_list)
     }
 
+    pub(crate) async  fn next_wal_sst_id(&self, wal_id_last_compacted: u64) -> Result<u64, SlateDBError> {
+        Ok(self.list_wal_ssts(wal_id_last_compacted..).await?
+           .into_iter()
+            .map(|wal_sst| wal_sst.id.unwrap_wal_id())
+            .max()
+            .unwrap_or(wal_id_last_compacted + 1))
+    }
+
     pub(crate) fn table_writer(&self, id: SsTableId) -> EncodedSsTableWriter {
         let path = self.path(&id);
         EncodedSsTableWriter {

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -151,7 +151,8 @@ impl TableStore {
             .into_iter()
             .map(|wal_sst| wal_sst.id.unwrap_wal_id())
             .max()
-            .unwrap_or(wal_id_last_compacted) + 1)
+            .unwrap_or(wal_id_last_compacted)
+            + 1)
     }
 
     pub(crate) fn table_writer(&self, id: SsTableId) -> EncodedSsTableWriter {


### PR DESCRIPTION
Addresses the bug reported by [Writer Fencing Fizzbee spec](https://github.com/slatedb/slatedb/pull/266)

* Read the latest manifest and next WAL ID before writing the updated writer manifest and fencing WAL.
