### PR TITLE
Include timestamp when loading tables for compaction bench

### DIFF
--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -16,7 +16,7 @@ use ulid::Ulid;
 
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
-use crate::config::{Clock, CompactorOptions, CompressionCodec, default_clock};
+use crate::config::{Clock, CompactorOptions, CompressionCodec, DbOptions};
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::manifest_store::{ManifestStore, StoredManifest};
@@ -58,7 +58,7 @@ impl CompactionExecuteBench {
             self.path.clone(),
             None,
         ));
-        let clock = default_clock();
+        let clock = DbOptions::default().clock;
 
         let num_keys = sst_bytes / (val_bytes + key_bytes);
         let mut key_start = vec![0u8; key_bytes - mem::size_of::<u32>()];

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info};
 use ulid::Ulid;
 
+use crate::compactor::WorkerToOrchestratorMsg;
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
 use crate::config::{Clock, CompactorOptions, CompressionCodec, DbOptions};
@@ -24,7 +25,6 @@ use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use crate::test_utils::OrderedBytesGenerator;
 use crate::types::RowAttributes;
-use crate::compactor::WorkerToOrchestratorMsg;
 
 pub struct CompactionExecuteBench {
     path: Path,
@@ -150,7 +150,13 @@ impl CompactionExecuteBench {
             let key = key_gen.next();
             let timestamp = clock.now();
             sst_writer
-                .add(key.as_ref(), Some(val.as_ref()), RowAttributes { ts: Some(timestamp) })
+                .add(
+                    key.as_ref(),
+                    Some(val.as_ref()),
+                    RowAttributes {
+                        ts: Some(timestamp),
+                    },
+                )
                 .await?;
         }
         let encoded = sst_writer.close().await?;

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -16,6 +16,7 @@ use ulid::Ulid;
 
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
+use crate::config::Clock;
 use crate::config::CompactorOptions;
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
@@ -24,7 +25,7 @@ use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use crate::test_utils::OrderedBytesGenerator;
 use crate::types::RowAttributes;
-use crate::{compactor::WorkerToOrchestratorMsg, config::CompressionCodec};
+use crate::{compactor::WorkerToOrchestratorMsg, config, config::CompressionCodec};
 
 pub struct CompactionExecuteBench {
     path: Path,
@@ -58,6 +59,7 @@ impl CompactionExecuteBench {
             self.path.clone(),
             None,
         ));
+        let clock = config::default_clock();
 
         let num_keys = sst_bytes / (val_bytes + key_bytes);
         let mut key_start = vec![0u8; key_bytes - mem::size_of::<u32>()];
@@ -80,6 +82,7 @@ impl CompactionExecuteBench {
                 key_start_copy,
                 num_keys,
                 val_bytes,
+                clock.clone(),
             ));
             futures.push(jh)
         }
@@ -99,6 +102,7 @@ impl CompactionExecuteBench {
         key_start: Vec<u8>,
         num_keys: usize,
         val_bytes: usize,
+        clock: Arc<dyn Clock + Send + Sync>,
     ) -> Result<(), SlateDBError> {
         let mut retries = 0;
         loop {
@@ -108,6 +112,7 @@ impl CompactionExecuteBench {
                 key_start.clone(),
                 num_keys,
                 val_bytes,
+                clock.clone(),
             )
             .await;
             match result {
@@ -131,6 +136,7 @@ impl CompactionExecuteBench {
         key_start: Vec<u8>,
         num_keys: usize,
         val_bytes: usize,
+        clock: Arc<dyn Clock + Send + Sync>,
     ) -> Result<(), SlateDBError> {
         let mut rng = rand_xorshift::XorShiftRng::from_entropy();
         let start = std::time::Instant::now();
@@ -143,8 +149,9 @@ impl CompactionExecuteBench {
             let mut val = vec![0u8; val_bytes];
             rng.fill_bytes(val.as_mut_slice());
             let key = key_gen.next();
+            let timestamp = clock.now();
             sst_writer
-                .add(key.as_ref(), Some(val.as_ref()), RowAttributes { ts: None })
+                .add(key.as_ref(), Some(val.as_ref()), RowAttributes { ts: Some(timestamp) })
                 .await?;
         }
         let encoded = sst_writer.close().await?;

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -16,8 +16,7 @@ use ulid::Ulid;
 
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
-use crate::config::Clock;
-use crate::config::CompactorOptions;
+use crate::config::{Clock, CompactorOptions, CompressionCodec, default_clock};
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::manifest_store::{ManifestStore, StoredManifest};
@@ -25,7 +24,7 @@ use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use crate::test_utils::OrderedBytesGenerator;
 use crate::types::RowAttributes;
-use crate::{compactor::WorkerToOrchestratorMsg, config, config::CompressionCodec};
+use crate::compactor::WorkerToOrchestratorMsg;
 
 pub struct CompactionExecuteBench {
     path: Path,
@@ -59,7 +58,7 @@ impl CompactionExecuteBench {
             self.path.clone(),
             None,
         ));
-        let clock = config::default_clock();
+        let clock = default_clock();
 
         let num_keys = sst_bytes / (val_bytes + key_bytes);
         let mut key_start = vec![0u8; key_bytes - mem::size_of::<u32>()];

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,7 +248,7 @@ impl Clock for SystemClock {
     }
 }
 
-fn default_clock() -> Arc<dyn Clock + Send + Sync> {
+pub(crate) fn default_clock() -> Arc<dyn Clock + Send + Sync> {
     Arc::new(SystemClock {
         last_tick: AtomicI64::new(i64::MIN),
     })

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,7 +248,7 @@ impl Clock for SystemClock {
     }
 }
 
-pub(crate) fn default_clock() -> Arc<dyn Clock + Send + Sync> {
+fn default_clock() -> Arc<dyn Clock + Send + Sync> {
     Arc::new(SystemClock {
         last_tick: AtomicI64::new(i64::MIN),
     })


### PR DESCRIPTION
Currently run the `bencher compaction load` fails with the following error:
```
thread 'main' panicked at /Users/jason/Code/slatedb/src/compaction_execute_bench.rs:91:18:
join failed: JoinError::Panic(Id(14), "Timestamp RowAttribute was enabled for SST but attempted to insert a row with no timestamp.", ...)
```
This patch just uses current time to provide the missing timestamp. We could alternatively disable it in the row attributes or provide some other way to seed the values, but this seemed like the simplest thing for now.