### PR TITLE
[4/N] RFC-3: add support for ttl expiry during compaction

### DIFF
--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -18,7 +18,8 @@ enum CompressionFormat: byte {
 
 enum SstRowFeature: byte {
     Flags,
-    Timestamp
+    Timestamp,
+    ExpireAtTs,
 }
 
 // Has metadata about a SST file.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -4,6 +4,7 @@
 //! collection of write operations (puts and/or deletes) that are applied
 //! atomically to the database.
 
+use crate::config::PutOptions;
 use bytes::Bytes;
 
 /// A batch of write operations (puts and/or deletes). All operations in the
@@ -40,7 +41,7 @@ impl Default for WriteBatch {
 }
 
 pub enum WriteOp {
-    Put(Bytes, Bytes),
+    Put(Bytes, Bytes, PutOptions),
     Delete(Bytes),
 }
 
@@ -51,10 +52,16 @@ impl WriteBatch {
 
     /// Put a key-value pair into the batch. Keys must not be empty.
     pub fn put(&mut self, key: &[u8], value: &[u8]) {
+        self.put_with_options(key, value, &PutOptions::default())
+    }
+
+    /// Put a key-value pair into the batch. Keys must not be empty.
+    pub fn put_with_options(&mut self, key: &[u8], value: &[u8], options: &PutOptions) {
         assert!(!key.is_empty(), "key cannot be empty");
         self.ops.push(WriteOp::Put(
             Bytes::copy_from_slice(key),
             Bytes::copy_from_slice(value),
+            options.clone(),
         ));
     }
 

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -66,12 +66,7 @@ impl DbInner {
                             value,
                             RowAttributes {
                                 ts: Some(now),
-                                expire_ts: opts.ttl.map(|ttl| {
-                                    now + i64::try_from(ttl.as_millis()).expect(
-                                        "Duration could not be converted into an i64 timestamp. \
-            Perhaps the duration in millis exceeds the maximum i64?",
-                                    )
-                                }),
+                                expire_ts: opts.expire_ts_from(now),
                             },
                         );
                     }
@@ -79,7 +74,7 @@ impl DbInner {
                         current_wal.delete(
                             key,
                             RowAttributes {
-                                ts: Some(self.options.clock.now()),
+                                ts: Some(now),
                                 expire_ts: None,
                             },
                         );
@@ -100,13 +95,8 @@ impl DbInner {
                             key,
                             value,
                             RowAttributes {
-                                ts: Some(self.options.clock.now()),
-                                expire_ts: opts.ttl.map(|ttl| {
-                                    now + i64::try_from(ttl.as_millis()).expect(
-                                        "Duration could not be converted into an i64 timestamp. \
-            Perhaps the duration in millis exceeds the maximum i64?",
-                                    )
-                                }),
+                                ts: Some(now),
+                                expire_ts: opts.expire_ts_from(now),
                             },
                         );
                     }
@@ -114,7 +104,7 @@ impl DbInner {
                         current_memtable.delete(
                             key,
                             RowAttributes {
-                                ts: Some(self.options.clock.now()),
+                                ts: Some(now),
                                 expire_ts: None,
                             },
                         );

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -66,7 +66,7 @@ impl DbInner {
                             value,
                             RowAttributes {
                                 ts: Some(now),
-                                expire_ts: opts.expire_ts_from(now),
+                                expire_ts: opts.expire_ts_from(self.options.default_ttl, now),
                             },
                         );
                     }
@@ -96,7 +96,7 @@ impl DbInner {
                             value,
                             RowAttributes {
                                 ts: Some(now),
-                                expire_ts: opts.expire_ts_from(now),
+                                expire_ts: opts.expire_ts_from(self.options.default_ttl, now),
                             },
                         );
                     }

--- a/src/bencher/db.rs
+++ b/src/bencher/db.rs
@@ -42,7 +42,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use rand::{Rng, RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
-use slatedb::config::WriteOptions;
+use slatedb::config::{PutOptions, WriteOptions};
 use slatedb::db::Db;
 use tokio::time::Instant;
 use tracing::info;
@@ -232,7 +232,12 @@ impl Task {
                 let mut value = vec![0; self.val_len];
                 random.fill_bytes(value.as_mut_slice());
                 self.db
-                    .put_with_options(key, value.as_ref(), &self.write_options)
+                    .put_with_options(
+                        key,
+                        value.as_ref(),
+                        &self.write_options,
+                        &PutOptions::default(),
+                    )
                     .await;
                 puts += 1;
             } else {

--- a/src/bencher/db.rs
+++ b/src/bencher/db.rs
@@ -235,8 +235,8 @@ impl Task {
                     .put_with_options(
                         key,
                         value.as_ref(),
-                        &self.write_options,
                         &PutOptions::default(),
+                        &self.write_options,
                     )
                     .await;
                 puts += 1;

--- a/src/block.rs
+++ b/src/block.rs
@@ -132,6 +132,7 @@ impl BlockBuilder {
             value,
             &self.row_features,
             attrs.ts,
+            attrs.expire_ts,
         );
 
         if self.first_key.is_empty() {

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -156,6 +156,7 @@ impl CompactionExecuteBench {
                     Some(val.as_ref()),
                     RowAttributes {
                         ts: Some(timestamp),
+                        expire_ts: None,
                     },
                 )
                 .await?;

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -305,8 +305,12 @@ mod tests {
 
     use crate::compactor::{CompactorOptions, CompactorOrchestrator, WorkerToOrchestratorMsg};
     use crate::compactor_state::{Compaction, SourceId};
-    use crate::config::{DbOptions, ObjectStoreCacheOptions, SizeTieredCompactionSchedulerOptions};
+    use crate::config::{
+        DbOptions, ObjectStoreCacheOptions, PutOptions, SizeTieredCompactionSchedulerOptions,
+        WriteOptions,
+    };
     use crate::db::Db;
+    use crate::db_state::CoreDbState;
     use crate::iter::KeyValueIterator;
     use crate::manifest_store::{ManifestStore, StoredManifest};
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
@@ -320,7 +324,8 @@ mod tests {
     #[tokio::test]
     async fn test_compactor_compacts_l0() {
         // given:
-        let options = db_options(Some(compactor_options()));
+        let clock = Arc::new(TestClock::new());
+        let options = db_options(Some(compactor_options(clock.clone())), clock.clone());
         let (_, manifest_store, table_store, db) = build_test_db(options).await;
         for i in 0..4 {
             db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]).await;
@@ -328,18 +333,7 @@ mod tests {
         }
 
         // when:
-        let db_state = run_for(Duration::from_secs(10), || async {
-            let stored_manifest = StoredManifest::load(manifest_store.clone())
-                .await
-                .unwrap()
-                .unwrap();
-            let db_state = stored_manifest.db_state();
-            if db_state.l0_last_compacted.is_some() {
-                return Some(db_state.clone());
-            }
-            None
-        })
-        .await;
+        let db_state = await_compaction(manifest_store).await;
 
         // then:
         let db_state = db_state.expect("db was not compacted");
@@ -365,11 +359,115 @@ mod tests {
         // todo: test that the db can read the k/vs (once we implement reading from compacted)
     }
 
+    #[tokio::test]
+    async fn test_should_compact_expired_entries() {
+        // given:
+        let insert_clock = Arc::new(TestClock::new());
+        let compaction_clock = Arc::new(TestClock::new());
+
+        let compactor_opts = CompactorOptions {
+            compaction_scheduler: Arc::new(SizeTieredCompactionSchedulerSupplier::new(
+                SizeTieredCompactionSchedulerOptions {
+                    // compact as soon as we have data
+                    min_compaction_sources: 1,
+                    max_compaction_sources: 10,
+                    include_size_threshold: 4.0,
+                },
+            )),
+            ..compactor_options(compaction_clock.clone())
+        };
+        let options = db_options(Some(compactor_opts), insert_clock.clone());
+        let (_, manifest_store, table_store, db) = build_test_db(options).await;
+
+        // ticker time = 0, expire time = 10
+        insert_clock.ticker.store(0, atomic::Ordering::SeqCst);
+        db.put_with_options(
+            &[1; 16],
+            &[b'a'; 64],
+            &WriteOptions::default(),
+            &PutOptions {
+                ttl: Some(Duration::from_millis(100)),
+            },
+        )
+        .await;
+
+        // ticker time = 10, expire time = 60
+        insert_clock.ticker.store(10, atomic::Ordering::SeqCst);
+        db.put_with_options(
+            &[2; 16],
+            &[b'a'; 64],
+            &WriteOptions::default(),
+            &PutOptions {
+                ttl: Some(Duration::from_millis(50)),
+            },
+        )
+        .await;
+
+        db.flush().await.unwrap();
+
+        // ticker time = 30, no expire time
+        insert_clock.ticker.store(30, atomic::Ordering::SeqCst);
+        db.put_with_options(
+            &[3; 16],
+            &[b'a'; 64],
+            &WriteOptions::default(),
+            &PutOptions { ttl: None },
+        )
+        .await;
+
+        // this revives key 1
+        // ticker time = 40, expire time 80
+        insert_clock.ticker.store(40, atomic::Ordering::SeqCst);
+        db.put_with_options(
+            &[1; 16],
+            &[b'a'; 64],
+            &WriteOptions::default(),
+            &PutOptions {
+                ttl: Some(Duration::from_millis(40)),
+            },
+        )
+        .await;
+
+        db.flush().await.unwrap();
+
+        // when:
+        // advance time to 70
+        compaction_clock.ticker.store(70, atomic::Ordering::SeqCst);
+        let db_state = await_compaction(manifest_store).await;
+
+        // then:
+        let db_state = db_state.expect("db was not compacted");
+        assert!(db_state.l0_last_compacted.is_some());
+        assert_eq!(db_state.compacted.len(), 1);
+        let compacted = &db_state.compacted.first().unwrap().ssts;
+        assert_eq!(compacted.len(), 1);
+        let handle = compacted.first().unwrap();
+        let mut iter = SstIterator::new(handle, table_store.clone(), 1, 1, false)
+            .await
+            .unwrap();
+
+        let kv = iter.next().await.unwrap().unwrap();
+        assert_eq!(kv.key.as_ref(), &[1; 16]);
+
+        // skip k2 because its expired
+
+        let kv = iter.next().await.unwrap().unwrap();
+        assert_eq!(kv.key.as_ref(), &[3; 16]);
+
+        let maybe_kv = iter.next().await.unwrap();
+        assert!(
+            maybe_kv.is_none(),
+            "Expected no more entries, but got: {:?}",
+            maybe_kv
+        );
+    }
+
     #[test]
     fn test_should_write_manifest_safely() {
         // given:
         // write an l0
-        let options = db_options(None);
+        let clock = Arc::new(TestClock::new());
+        let options = db_options(None, clock.clone());
         let rt = build_runtime();
         let (os, manifest_store, table_store, db) = rt.block_on(build_test_db(options.clone()));
         let mut stored_manifest = rt
@@ -380,7 +478,7 @@ mod tests {
         rt.block_on(db.close()).unwrap();
         let (_, external_rx) = crossbeam_channel::unbounded();
         let mut orchestrator = CompactorOrchestrator::new(
-            compactor_options(),
+            compactor_options(clock.clone()),
             manifest_store.clone(),
             table_store.clone(),
             rt.handle().clone(),
@@ -486,7 +584,22 @@ mod tests {
         (os, manifest_store, table_store, db)
     }
 
-    fn db_options(compactor_options: Option<CompactorOptions>) -> DbOptions {
+    async fn await_compaction(manifest_store: Arc<ManifestStore>) -> Option<CoreDbState> {
+        run_for(Duration::from_secs(10), || async {
+            let stored_manifest = StoredManifest::load(manifest_store.clone())
+                .await
+                .unwrap()
+                .unwrap();
+            let db_state = stored_manifest.db_state();
+            if db_state.l0_last_compacted.is_some() {
+                return Some(db_state.clone());
+            }
+            None
+        })
+        .await
+    }
+
+    fn db_options(compactor_options: Option<CompactorOptions>, clock: Arc<TestClock>) -> DbOptions {
         DbOptions {
             flush_interval: Duration::from_millis(100),
             #[cfg(feature = "wal_disable")]
@@ -502,11 +615,11 @@ mod tests {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             block_cache: None,
             garbage_collector_options: None,
-            clock: Arc::new(TestClock::new()),
+            clock,
         }
     }
 
-    fn compactor_options() -> CompactorOptions {
+    fn compactor_options(clock: Arc<TestClock>) -> CompactorOptions {
         CompactorOptions {
             poll_interval: Duration::from_millis(100),
             max_sst_size: 1024 * 1024 * 1024,
@@ -515,6 +628,7 @@ mod tests {
             )),
             max_concurrent_compactions: 1,
             compaction_runtime: None,
+            clock,
         }
     }
 }

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -399,9 +399,7 @@ mod tests {
         db.put_with_options(
             &[2; 16],
             &[b'a'; 64],
-            &PutOptions {
-                ttl: Ttl::Default,
-            },
+            &PutOptions { ttl: Ttl::Default },
             &WriteOptions::default(),
         )
         .await;

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -145,7 +145,7 @@ impl TokioCompactionExecutorInner {
                             expire_ts: None,
                         },
                     }
-                },
+                }
                 _ => raw_kv,
             };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,6 +235,12 @@ impl PutOptions {
     const fn default() -> Self {
         Self { ttl: None }
     }
+
+    pub(crate) fn expire_ts_from(&self, now: i64) -> Option<i64> {
+        self.ttl.map(|ttl| now + i64::try_from(ttl.as_millis()).expect(
+            "Duration could not be converted into an i64 timestamp. \
+             Perhaps the duration in millis exceeds the maximum i64?"))
+    }
 }
 
 /// defines the clock that SlateDB will use during this session

--- a/src/config.rs
+++ b/src/config.rs
@@ -237,9 +237,12 @@ impl PutOptions {
     }
 
     pub(crate) fn expire_ts_from(&self, now: i64) -> Option<i64> {
-        self.ttl.map(|ttl| now + i64::try_from(ttl.as_millis()).expect(
-            "Duration could not be converted into an i64 timestamp. \
-             Perhaps the duration in millis exceeds the maximum i64?"))
+        self.ttl.map(|ttl| {
+            now + i64::try_from(ttl.as_millis()).expect(
+                "Duration could not be converted into an i64 timestamp. \
+             Perhaps the duration in millis exceeds the maximum i64?",
+            )
+        })
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,7 +14,8 @@ use crate::cached_object_store::CachedObjectStore;
 use crate::compactor::Compactor;
 use crate::config::ReadLevel::Uncommitted;
 use crate::config::{
-    DbOptions, ReadOptions, WriteOptions, DEFAULT_READ_OPTIONS, DEFAULT_WRITE_OPTIONS,
+    DbOptions, PutOptions, ReadOptions, WriteOptions, DEFAULT_PUT_OPTIONS, DEFAULT_READ_OPTIONS,
+    DEFAULT_WRITE_OPTIONS,
 };
 use crate::db_state::{CoreDbState, DbState, SortedRun, SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
@@ -204,13 +205,26 @@ impl DbInner {
 
     /// Put a key-value pair into the database. Key must not be empty.
     #[allow(clippy::panic)]
-    pub async fn put_with_options(&self, key: &[u8], value: &[u8], options: &WriteOptions) {
+    pub async fn put_with_options(
+        &self,
+        key: &[u8],
+        value: &[u8],
+        write_opts: &WriteOptions,
+        put_opts: &PutOptions,
+    ) {
         assert!(!key.is_empty(), "key cannot be empty");
 
         self.maybe_apply_backpressure().await;
 
         let key = Bytes::copy_from_slice(key);
         let value = Bytes::copy_from_slice(value);
+        let now = self.options.clock.now();
+        let expire_ts = put_opts.ttl.map(|ttl| {
+            now + i64::try_from(ttl.as_millis()).expect(
+                "Duration could not be converted into an i64 timestamp. \
+            Perhaps the duration in millis exceeds the maximum i64?",
+            )
+        });
 
         // Clone memtable to avoid a deadlock with flusher thread.
         let current_table = if self.wal_enabled() {
@@ -220,7 +234,8 @@ impl DbInner {
                 key,
                 value,
                 RowAttributes {
-                    ts: Some(self.options.clock.now()),
+                    ts: Some(now),
+                    expire_ts,
                 },
             );
             current_wal.table().clone()
@@ -235,6 +250,7 @@ impl DbInner {
                 value,
                 RowAttributes {
                     ts: Some(self.options.clock.now()),
+                    expire_ts,
                 },
             );
             let table = current_memtable.table().clone();
@@ -243,7 +259,7 @@ impl DbInner {
             table
         };
 
-        if options.await_durable {
+        if write_opts.await_durable {
             current_table.await_durable().await;
         }
     }
@@ -265,6 +281,7 @@ impl DbInner {
                 key,
                 RowAttributes {
                     ts: Some(self.options.clock.now()),
+                    expire_ts: None,
                 },
             );
             current_wal.table().clone()
@@ -278,6 +295,7 @@ impl DbInner {
                 key,
                 RowAttributes {
                     ts: Some(self.options.clock.now()),
+                    expire_ts: None,
                 },
             );
             let table = current_memtable.table().clone();
@@ -659,12 +677,20 @@ impl Db {
     pub async fn put(&self, key: &[u8], value: &[u8]) {
         // TODO move the put into an async block by blocking on the memtable flush
         self.inner
-            .put_with_options(key, value, DEFAULT_WRITE_OPTIONS)
+            .put_with_options(key, value, DEFAULT_WRITE_OPTIONS, DEFAULT_PUT_OPTIONS)
             .await;
     }
 
-    pub async fn put_with_options(&self, key: &[u8], value: &[u8], options: &WriteOptions) {
-        self.inner.put_with_options(key, value, options).await;
+    pub async fn put_with_options(
+        &self,
+        key: &[u8],
+        value: &[u8],
+        write_opts: &WriteOptions,
+        put_opts: &PutOptions,
+    ) {
+        self.inner
+            .put_with_options(key, value, write_opts, put_opts)
+            .await;
     }
 
     pub async fn delete(&self, key: &[u8]) {
@@ -712,6 +738,7 @@ impl Db {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use futures::{future::join_all, StreamExt};
@@ -990,6 +1017,7 @@ mod tests {
                         )),
                         max_concurrent_compactions: 1,
                         compaction_runtime: None,
+                        clock: Arc::new(TestClock::new()),
                     }),
                 ),
                 object_store.clone(),
@@ -1098,7 +1126,8 @@ mod tests {
     #[cfg(feature = "wal_disable")]
     #[tokio::test]
     async fn test_wal_disabled() {
-        let mut options = test_db_options(0, 128, None);
+        let clock = Arc::new(TestClock::new());
+        let mut options = test_db_options_with_clock(0, 128, None, clock.clone());
         options.wal_enabled = false;
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
@@ -1121,14 +1150,25 @@ mod tests {
             await_durable: false,
         };
 
-        db.put_with_options(&[b'a'; 32], &[b'j'; 32], &write_options)
-            .await;
+        db.put_with_options(
+            &[b'a'; 32],
+            &[b'j'; 32],
+            &write_options,
+            DEFAULT_PUT_OPTIONS,
+        )
+        .await;
         db.delete_with_options(&[b'b'; 32], &write_options).await;
         let write_options = WriteOptions {
             await_durable: true,
         };
-        db.put_with_options(&[b'c'; 32], &[b'l'; 32], &write_options)
-            .await;
+        clock.ticker.store(10, Ordering::SeqCst);
+        db.put_with_options(
+            &[b'c'; 32],
+            &[b'l'; 32],
+            &write_options,
+            DEFAULT_PUT_OPTIONS,
+        )
+        .await;
 
         let state = wait_for_manifest_condition(
             &mut stored_manifest,
@@ -1150,11 +1190,11 @@ mod tests {
                     ValueDeletable::Value(Bytes::copy_from_slice(&[b'j'; 32])),
                     gen_attrs(0),
                 ),
-                (vec![b'b'; 32], ValueDeletable::Tombstone, gen_attrs(1)),
+                (vec![b'b'; 32], ValueDeletable::Tombstone, gen_attrs(0)),
                 (
                     vec![b'c'; 32],
                     ValueDeletable::Value(Bytes::copy_from_slice(&[b'l'; 32])),
-                    gen_attrs(2),
+                    gen_attrs(10),
                 ),
             ],
         )
@@ -1403,6 +1443,7 @@ mod tests {
                 &WriteOptions {
                     await_durable: false,
                 },
+                DEFAULT_PUT_OPTIONS,
             )
             .await;
 
@@ -1443,6 +1484,7 @@ mod tests {
                 &WriteOptions {
                     await_durable: false,
                 },
+                DEFAULT_PUT_OPTIONS,
             )
             .await;
 
@@ -1655,6 +1697,7 @@ mod tests {
                 )),
                 max_concurrent_compactions: 1,
                 compaction_runtime: None,
+                clock: Arc::new(TestClock::new()),
             }),
         ))
         .await;
@@ -1673,6 +1716,7 @@ mod tests {
                 )),
                 max_concurrent_compactions: 1,
                 compaction_runtime: None,
+                clock: Arc::new(TestClock::new()),
             }),
         ))
         .await
@@ -1722,6 +1766,7 @@ mod tests {
             &WriteOptions {
                 await_durable: false,
             },
+            DEFAULT_PUT_OPTIONS,
         )
         .await;
         db1.flush().await.unwrap();
@@ -1740,6 +1785,7 @@ mod tests {
             &WriteOptions {
                 await_durable: false,
             },
+            DEFAULT_PUT_OPTIONS,
         )
         .await;
         assert!(matches!(db1.flush().await, Err(SlateDBError::Fenced)));
@@ -1749,6 +1795,7 @@ mod tests {
             &WriteOptions {
                 await_durable: false,
             },
+            DEFAULT_PUT_OPTIONS,
         )
         .await;
         db2.flush().await.unwrap();
@@ -1776,6 +1823,20 @@ mod tests {
         l0_sst_size_bytes: usize,
         compactor_options: Option<CompactorOptions>,
     ) -> DbOptions {
+        test_db_options_with_clock(
+            min_filter_keys,
+            l0_sst_size_bytes,
+            compactor_options,
+            Arc::new(TestClock::new()),
+        )
+    }
+
+    fn test_db_options_with_clock(
+        min_filter_keys: u32,
+        l0_sst_size_bytes: usize,
+        compactor_options: Option<CompactorOptions>,
+        clock: Arc<TestClock>,
+    ) -> DbOptions {
         DbOptions {
             flush_interval: Duration::from_millis(100),
             #[cfg(feature = "wal_disable")]
@@ -1791,7 +1852,7 @@ mod tests {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             block_cache: None,
             garbage_collector_options: None,
-            clock: Arc::new(TestClock::new()),
+            clock,
         }
     }
 }

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -71,6 +71,7 @@ impl SsTableId {
 pub(crate) enum RowFeature {
     Flags,
     Timestamp,
+    ExpireAtTs,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -336,6 +336,7 @@ impl From<RowFeature> for SstRowFeature {
         match value {
             RowFeature::Flags => SstRowFeature::Flags,
             RowFeature::Timestamp => SstRowFeature::Timestamp,
+            RowFeature::ExpireAtTs => SstRowFeature::ExpireAtTs,
         }
     }
 }
@@ -346,6 +347,7 @@ impl From<SstRowFeature> for RowFeature {
         match value {
             SstRowFeature::Flags => RowFeature::Flags,
             SstRowFeature::Timestamp => RowFeature::Timestamp,
+            SstRowFeature::ExpireAtTs => RowFeature::ExpireAtTs,
             _ => panic!(
                 "Attempted to read SST written with unknown SstRowAttribute. Are you \
             running an older version of SlateDB than was used to write the SST?"

--- a/src/generated/manifest_generated.rs
+++ b/src/generated/manifest_generated.rs
@@ -109,12 +109,13 @@ impl flatbuffers::SimpleToVerifyInSlice for CompressionFormat {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_SST_ROW_FEATURE: i8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_SST_ROW_FEATURE: i8 = 1;
+pub const ENUM_MAX_SST_ROW_FEATURE: i8 = 2;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_SST_ROW_FEATURE: [SstRowFeature; 2] = [
+pub const ENUM_VALUES_SST_ROW_FEATURE: [SstRowFeature; 3] = [
   SstRowFeature::Flags,
   SstRowFeature::Timestamp,
+  SstRowFeature::ExpireAtTs,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -124,18 +125,21 @@ pub struct SstRowFeature(pub i8);
 impl SstRowFeature {
   pub const Flags: Self = Self(0);
   pub const Timestamp: Self = Self(1);
+  pub const ExpireAtTs: Self = Self(2);
 
   pub const ENUM_MIN: i8 = 0;
-  pub const ENUM_MAX: i8 = 1;
+  pub const ENUM_MAX: i8 = 2;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::Flags,
     Self::Timestamp,
+    Self::ExpireAtTs,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
     match self {
       Self::Flags => Some("Flags"),
       Self::Timestamp => Some("Timestamp"),
+      Self::ExpireAtTs => Some("ExpireAtTs"),
       _ => None,
     }
   }

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -406,7 +406,10 @@ mod tests {
         table.put(
             Bytes::from_static(b"def456"),
             Bytes::from_static(b"blablabla"),
-            RowAttributes { ts: None },
+            RowAttributes {
+                ts: None,
+                expire_ts: None,
+            },
         );
         assert_eq!(table.size(), 33);
 

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -145,15 +145,14 @@ impl<T: KeyValueIterator> KeyValueIterator for MergeIterator<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-
-    use crate::config::Clock;
     use crate::error::SlateDBError;
     use crate::iter::KeyValueIterator;
     use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
     use crate::test_utils::{assert_iterator, gen_attrs, TestClock};
     use crate::types::{KeyValueDeletable, ValueDeletable};
     use bytes::Bytes;
+    use std::collections::VecDeque;
+    use std::sync::atomic::Ordering::SeqCst;
 
     #[tokio::test]
     async fn test_merge_iterator_should_include_entries_in_order() {
@@ -388,7 +387,7 @@ mod tests {
             self.entries.push_back(Ok(KeyValueDeletable {
                 key: Bytes::from(key),
                 value: ValueDeletable::Value(Bytes::from(val)),
-                attributes: gen_attrs(self.clock.now()),
+                attributes: gen_attrs(self.clock.ticker.fetch_add(1, SeqCst)),
             }));
             self
         }

--- a/src/row_codec.rs
+++ b/src/row_codec.rs
@@ -10,7 +10,7 @@ bitflags! {
     }
 }
 
-const NO_EXPIRE_TS: i64 = i64::MAX;
+const NO_EXPIRE_TS: i64 = i64::MIN;
 
 /// Encodes key and value using the binary codec for SlateDB row representation
 /// using the `v0` encoding scheme.

--- a/src/row_codec.rs
+++ b/src/row_codec.rs
@@ -10,6 +10,8 @@ bitflags! {
     }
 }
 
+const NO_EXPIRE_TS: i64 = i64::MAX;
+
 /// Encodes key and value using the binary codec for SlateDB row representation
 /// using the `v0` encoding scheme.
 ///
@@ -47,12 +49,18 @@ pub(crate) fn encode_row_v0(
     value: Option<&[u8]>,
     row_features: &[RowFeature],
     timestamp: Option<i64>,
+    expire_at: Option<i64>,
 ) {
     data.put_u16(key_prefix_len as u16);
     data.put_u16(key_suffix.len() as u16);
     data.put(key_suffix);
 
-    data.put(encode_meta(row_features, value.is_none(), timestamp));
+    data.put(encode_meta(
+        row_features,
+        value.is_none(),
+        timestamp,
+        expire_at,
+    ));
 
     if let Some(value) = value {
         data.put_u32(value.len() as u32);
@@ -60,13 +68,19 @@ pub(crate) fn encode_row_v0(
     }
 }
 
-fn encode_meta(row_features: &[RowFeature], is_tombstone: bool, timestamp: Option<i64>) -> Bytes {
+fn encode_meta(
+    row_features: &[RowFeature],
+    is_tombstone: bool,
+    timestamp: Option<i64>,
+    expire_at: Option<i64>,
+) -> Bytes {
     let mut meta = BytesMut::new();
 
     for attr in row_features {
         match attr {
             RowFeature::Flags => meta.put_u8(encode_row_flags(is_tombstone)),
             RowFeature::Timestamp => meta.put_i64(timestamp.expect("Timestamp RowAttribute was enabled for SST but attempted to insert a row with no timestamp.")),
+            RowFeature::ExpireAtTs => meta.put_i64(expire_at.unwrap_or(NO_EXPIRE_TS))
         }
     }
 
@@ -111,19 +125,24 @@ pub(crate) fn decode_row_v0(
     Ok(KeyValueDeletable {
         key: key.into(),
         value,
-        attributes: RowAttributes { ts: meta.timestamp },
+        attributes: RowAttributes {
+            ts: meta.timestamp,
+            expire_ts: meta.expire_ts,
+        },
     })
 }
 
 struct RowMetadata {
     flags: RowFlags,
     timestamp: Option<i64>,
+    expire_ts: Option<i64>,
 }
 
 fn decode_meta(row_features: &[RowFeature], data: &mut Bytes) -> Result<RowMetadata, SlateDBError> {
     let mut meta = RowMetadata {
         flags: RowFlags::empty(),
         timestamp: None,
+        expire_ts: None,
     };
     for attr in row_features {
         match attr {
@@ -134,6 +153,14 @@ fn decode_meta(row_features: &[RowFeature], data: &mut Bytes) -> Result<RowMetad
                 Err(e) => return Err(e),
             },
             RowFeature::Timestamp => meta.timestamp = Some(data.get_i64()),
+            RowFeature::ExpireAtTs => {
+                let expire_ts = data.get_i64();
+                meta.expire_ts = if expire_ts == NO_EXPIRE_TS {
+                    None
+                } else {
+                    Some(expire_ts)
+                };
+            }
         }
     }
     Ok(meta)
@@ -158,7 +185,11 @@ mod tests {
         let key_prefix_len = 3;
         let key_suffix = b"key";
         let value = Some(b"value".as_slice());
-        let row_features = vec![RowFeature::Flags, RowFeature::Timestamp];
+        let row_features = vec![
+            RowFeature::Flags,
+            RowFeature::Timestamp,
+            RowFeature::ExpireAtTs,
+        ];
 
         // Encode the row
         encode_row_v0(
@@ -168,6 +199,7 @@ mod tests {
             value,
             &row_features,
             Some(1),
+            Some(10),
         );
 
         let first_key = Bytes::from(b"prefixdata".as_ref());
@@ -181,6 +213,37 @@ mod tests {
         assert_eq!(decoded.key, expected_key);
         assert_eq!(decoded.value, expected_value);
         assert_eq!(decoded.attributes.ts, Some(1));
+        assert_eq!(decoded.attributes.expire_ts, Some(10));
+    }
+
+    #[test]
+    fn test_encode_decode_normal_row_no_expire_ts() {
+        let mut encoded_data = Vec::new();
+        let key_prefix_len = 3;
+        let key_suffix = b"key";
+        let value = Some(b"value".as_slice());
+        let row_features = vec![
+            RowFeature::Flags,
+            RowFeature::Timestamp,
+            RowFeature::ExpireAtTs,
+        ];
+
+        // Encode the row
+        encode_row_v0(
+            &mut encoded_data,
+            key_prefix_len,
+            key_suffix,
+            value,
+            &row_features,
+            Some(1),
+            None,
+        );
+
+        let first_key = Bytes::from(b"prefixdata".as_ref());
+        let mut data = Bytes::from(encoded_data);
+        let decoded = decode_row_v0(&first_key, &row_features, &mut data).expect("Decoding failed");
+
+        assert_eq!(decoded.attributes.expire_ts, None);
     }
 
     #[test]
@@ -199,6 +262,7 @@ mod tests {
             value,
             &row_features,
             Some(1), // pass in a timestamp, but it should not be encoded because flag is disabled
+            Some(10),
         );
 
         let first_key = Bytes::from(b"".as_ref());
@@ -224,6 +288,7 @@ mod tests {
             value,
             &row_features,
             Some(1),
+            Some(10),
         );
 
         let first_key = Bytes::from(b"deadbeefdata".as_ref());
@@ -282,6 +347,7 @@ mod tests {
             value,
             &row_features,
             Some(1),
+            Some(10),
         );
 
         let first_key = Bytes::from(b"keyprefixdata".as_slice());

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -36,7 +36,11 @@ impl Default for SsTableFormat {
             sst_codec: Box::new(FlatBufferSsTableInfoCodec {}),
             filter_bits_per_key: 10,
             compression_codec: None,
-            row_features: vec![RowFeature::Flags, RowFeature::Timestamp],
+            row_features: vec![
+                RowFeature::Flags,
+                RowFeature::Timestamp,
+                RowFeature::ExpireAtTs,
+            ],
         }
     }
 }
@@ -878,7 +882,7 @@ mod tests {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let format = SsTableFormat {
-            block_size: 40,
+            block_size: 48,
             min_filter_keys: 1,
             ..SsTableFormat::default()
         };
@@ -954,7 +958,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let format = SsTableFormat {
             min_filter_keys: 1,
-            block_size: 40,
+            block_size: 48,
             ..SsTableFormat::default()
         };
         let row_features = format.row_features.clone();

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -341,7 +341,7 @@ mod tests {
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         let index = table_store.read_index(&sst_handle).await.unwrap();
-        assert_eq!(index.borrow().block_meta().len(), 8);
+        assert_eq!(index.borrow().block_meta().len(), 10);
 
         let mut iter = SstIterator::new(&sst_handle, table_store.clone(), 3, 3, true)
             .await

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -57,20 +57,20 @@ pub fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
 }
 
 #[allow(dead_code)]
-pub fn gen_attrs(ts: i64) -> RowAttributes {
+pub(crate) fn gen_attrs(ts: i64) -> RowAttributes {
     RowAttributes {
         ts: Some(ts),
         expire_ts: None,
     }
 }
 
-pub struct TestClock {
-    pub ticker: AtomicI64,
+pub(crate) struct TestClock {
+    pub(crate) ticker: AtomicI64,
 }
 
 #[allow(dead_code)]
 impl TestClock {
-    pub fn new() -> TestClock {
+    pub(crate) fn new() -> TestClock {
         TestClock {
             ticker: AtomicI64::new(0),
         }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -58,11 +58,14 @@ pub fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
 
 #[allow(dead_code)]
 pub fn gen_attrs(ts: i64) -> RowAttributes {
-    RowAttributes { ts: Some(ts) }
+    RowAttributes {
+        ts: Some(ts),
+        expire_ts: None,
+    }
 }
 
 pub struct TestClock {
-    ticker: AtomicI64,
+    pub ticker: AtomicI64,
 }
 
 #[allow(dead_code)]
@@ -76,7 +79,7 @@ impl TestClock {
 
 impl Clock for TestClock {
     fn now(&self) -> i64 {
-        self.ticker.fetch_add(1, Ordering::SeqCst)
+        self.ticker.load(Ordering::SeqCst)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -21,6 +21,7 @@ pub struct KeyValueDeletable {
 #[derive(Debug, Clone, PartialEq)]
 pub struct RowAttributes {
     pub ts: Option<i64>,
+    pub expire_ts: Option<i64>,
 }
 
 /// Represents a value that may be a tombstone.


### PR DESCRIPTION
This PR adds the physical component of TTL in accordance to RFC-3 (#228). It functions by encoding an `expire_ts` in the row as its written to the SST and then filters out rows during compaction that have already expired. Some intricacies:

- added `PutOption` to the public API to have something that is applied per-row (compared to `WriteOption` that is only applied per-write, which may contain multiple rows)
- added a clock to the `CompactorOptions` so that the timestamp of compaction can be set (this determines the "now" timestamp for expiration)

See the PR sequence for more background:
- #251 
- #258 
- #265 

Follow-Ups:

- [ ] Don't encode `expire_ts` in the SST if no row in the SST has an `expire_ts` set
- [ ] Filter out values on retrieval if they're already expired and compaction hasn't kicked in yet
- [x] Support default TTLs when opening a db connection