### PR TITLE
Unify write commit pipe

### DIFF
--- a/src/bencher/db.rs
+++ b/src/bencher/db.rs
@@ -238,7 +238,8 @@ impl Task {
                         &PutOptions::default(),
                         &self.write_options,
                     )
-                    .await;
+                    .await
+                    .unwrap();
                 puts += 1;
             } else {
                 self.db.get(key).await.unwrap();

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -328,8 +328,12 @@ mod tests {
         let options = db_options(Some(compactor_options(clock.clone())), clock.clone());
         let (_, manifest_store, table_store, db) = build_test_db(options).await;
         for i in 0..4 {
-            db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]).await;
-            db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]).await;
+            db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48])
+                .await
+                .unwrap();
+            db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48])
+                .await
+                .unwrap();
         }
 
         // when:
@@ -392,7 +396,8 @@ mod tests {
             },
             &WriteOptions::default(),
         )
-        .await;
+        .await
+        .unwrap();
 
         // ticker time = 10, expire time = 60 (using default TTL)
         insert_clock.ticker.store(10, atomic::Ordering::SeqCst);
@@ -402,7 +407,8 @@ mod tests {
             &PutOptions { ttl: Ttl::Default },
             &WriteOptions::default(),
         )
-        .await;
+        .await
+        .unwrap();
 
         db.flush().await.unwrap();
 
@@ -414,7 +420,8 @@ mod tests {
             &PutOptions { ttl: Ttl::NoExpiry },
             &WriteOptions::default(),
         )
-        .await;
+        .await
+        .unwrap();
 
         // this revives key 1
         // ticker time = 40, expire time 80
@@ -427,7 +434,8 @@ mod tests {
             },
             &WriteOptions::default(),
         )
-        .await;
+        .await
+        .unwrap();
 
         db.flush().await.unwrap();
 
@@ -475,7 +483,7 @@ mod tests {
             .block_on(StoredManifest::load(manifest_store.clone()))
             .unwrap()
             .unwrap();
-        rt.block_on(db.put(&[b'a'; 32], &[b'b'; 96]));
+        rt.block_on(db.put(&[b'a'; 32], &[b'b'; 96])).unwrap();
         rt.block_on(db.close()).unwrap();
         let (_, external_rx) = crossbeam_channel::unbounded();
         let mut orchestrator = CompactorOrchestrator::new(
@@ -502,7 +510,7 @@ mod tests {
                 os.clone(),
             ))
             .unwrap();
-        rt.block_on(db.put(&[b'j'; 32], &[b'k'; 96]));
+        rt.block_on(db.put(&[b'j'; 32], &[b'k'; 96])).unwrap();
         rt.block_on(db.close()).unwrap();
         orchestrator
             .submit_compaction(Compaction::new(l0_ids_to_compact.clone(), 0))

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -350,8 +350,8 @@ mod tests {
         let (os, mut sm, mut state) = build_test_state(rt.handle());
         // open a new db and write another l0
         let db = build_db(os.clone(), rt.handle());
-        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
-        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48])).unwrap();
+        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48])).unwrap();
         let writer_db_state =
             wait_for_manifest_with_l0_len(&mut sm, rt.handle(), state.db_state().l0.len() + 1);
 
@@ -393,8 +393,8 @@ mod tests {
         });
         // open a new db and write another l0
         let db = build_db(os.clone(), rt.handle());
-        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
-        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48])).unwrap();
+        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48])).unwrap();
         let writer_db_state =
             wait_for_manifest_with_l0_len(&mut sm, rt.handle(), original_l0s.len() + 1);
         let db_state_before_merge = state.db_state().clone();
@@ -451,8 +451,8 @@ mod tests {
         assert_eq!(state.db_state().l0.len(), 0);
         // open a new db and write another l0
         let db = build_db(os.clone(), rt.handle());
-        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48]));
-        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48]));
+        rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48])).unwrap();
+        rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48])).unwrap();
         let writer_db_state =
             wait_for_manifest_with_l0_len(&mut sm, rt.handle(), original_l0s.len() + 1);
 
@@ -553,8 +553,12 @@ mod tests {
         let db = build_db(os.clone(), tokio_handle);
         let l0_count: u64 = 5;
         for i in 0..l0_count {
-            tokio_handle.block_on(db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]));
-            tokio_handle.block_on(db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]));
+            tokio_handle
+                .block_on(db.put(&[b'a' + i as u8; 16], &[b'b' + i as u8; 48]))
+                .unwrap();
+            tokio_handle
+                .block_on(db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]))
+                .unwrap();
         }
         tokio_handle.block_on(db.close()).unwrap();
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));


### PR DESCRIPTION
This PR migrates all put/delete calls to use write batches (and thus, the commit
pipeline). For single row operations, a batch with one row is created under the
hood. The PR also includes two other changes:

### Return results for put/delete

The `write_with_options` method returns a `Result<(), SlateDbError>`. Now that
we use this method for puts and deletes, they need to unwrap or forward the
results. I opted to forward them, as this lays the groundwork for #111. Note
that, though we now return a `Result`, it only returns `Ok` right now in the
commit pipeline. #111 must forward actual errors as they occur.

### Move backpressure into the synchronous call path

I noticed that I moved backpressure into the commit pipeline (batch write loop)
in a separate thread in #264. This works fine for tasks that have `WriteOptions`
where `await_durable` is true, but for `await_durable` set to false, it causes a
problem. Because `write()` calls simply put the WriteBatch into an
`UnboundedSender`, if an `await_durable` writer outpaces the commit pipeline, it
will eventually overrun memory. I moved the backpressure check back into
`write_with_options` in `DbInner`, so this won't happen.