### PR TITLE
Close DB in bencher

### DIFF
--- a/src/bencher/args.rs
+++ b/src/bencher/args.rs
@@ -53,6 +53,7 @@ pub(crate) struct DbArgs {
         help = "Optional path to load the DbOptions configuration from. `Slatedb.toml` is used by default if this option is not present"
     )]
     db_options_path: Option<PathBuf>,
+
     #[arg(long, help = "The size in bytes of the block cache.")]
     pub(crate) block_cache_size: Option<u64>,
 }

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -54,9 +54,10 @@ async fn exec_benchmark_db(path: Path, object_store: Arc<dyn ObjectStore>, args:
         args.num_rows,
         args.duration.map(|d| Duration::from_secs(d as u64)),
         args.put_percentage,
-        db,
+        db.clone(),
     );
     bencher.run().await;
+    db.close().await.expect("Failed to close db");
 }
 
 async fn exec_benchmark_compaction(


### PR DESCRIPTION
The bencher was sometimes failing with an object store error. It turns out, we weren't closing the DB after running bencher. This could sometimes cause threads to try and flush after the runtime was shutdown but before the process was halted.

The PR also adds a run_bench method so we can include put/concurrency args into the object store paths. Previously, all benchmarks were writing into the same directory.

Fixes #291