### PR TITLE
chore(db): Propagate errors to the client.

### DIFF
--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -111,7 +111,7 @@ impl DbInner {
             }
             let table = current_memtable.table().clone();
             let last_wal_id = guard.last_written_wal_id();
-            self.maybe_freeze_memtable(&mut guard, last_wal_id);
+            self.maybe_freeze_memtable(&mut guard, last_wal_id)?;
             table
         };
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -20,12 +20,11 @@ use crate::config::{
 use crate::db_state::{CoreDbState, DbState, SortedRun, SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::filter;
-use crate::flush::WalFlushThreadMsg;
+use crate::flush::FlushThreadMsg;
 use crate::garbage_collector::GarbageCollector;
 use crate::iter::KeyValueIterator;
 use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
 use crate::mem_table::WritableKVTable;
-use crate::mem_table_flush::MemtableFlushThreadMsg;
 use crate::metrics::DbStats;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst::SsTableFormat;
@@ -38,8 +37,8 @@ pub(crate) struct DbInner {
     pub(crate) state: Arc<RwLock<DbState>>,
     pub(crate) options: DbOptions,
     pub(crate) table_store: Arc<TableStore>,
-    pub(crate) wal_flush_notifier: tokio::sync::mpsc::UnboundedSender<WalFlushThreadMsg>,
-    pub(crate) memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<MemtableFlushThreadMsg>,
+    pub(crate) wal_flush_notifier: tokio::sync::mpsc::UnboundedSender<FlushThreadMsg>,
+    pub(crate) memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<FlushThreadMsg>,
     pub(crate) write_notifier: tokio::sync::mpsc::UnboundedSender<WriteBatchMsg>,
     pub(crate) db_stats: Arc<DbStats>,
 }
@@ -49,8 +48,8 @@ impl DbInner {
         options: DbOptions,
         table_store: Arc<TableStore>,
         core_db_state: CoreDbState,
-        wal_flush_notifier: tokio::sync::mpsc::UnboundedSender<WalFlushThreadMsg>,
-        memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<MemtableFlushThreadMsg>,
+        wal_flush_notifier: tokio::sync::mpsc::UnboundedSender<FlushThreadMsg>,
+        memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<FlushThreadMsg>,
         write_notifier: tokio::sync::mpsc::UnboundedSender<WriteBatchMsg>,
         db_stats: Arc<DbStats>,
     ) -> Result<Self, SlateDBError> {
@@ -218,7 +217,7 @@ impl DbInner {
         self.maybe_apply_backpressure().await;
         self.write_notifier.send(batch_msg).ok();
 
-        let current_table = rx.await.expect("write batch failed")?;
+        let current_table = rx.await??;
 
         if options.await_durable {
             current_table.await_durable().await;
@@ -252,18 +251,16 @@ impl DbInner {
     async fn flush_wals(&self) -> Result<(), SlateDBError> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.wal_flush_notifier
-            .send(WalFlushThreadMsg::FlushImmutableWals(Some(tx)))
-            .expect("wal flush hung up");
-        rx.await.expect("received error on wal flush")
+            .send(FlushThreadMsg::Flush(Some(tx)))?;
+        rx.await?
     }
 
     // use to manually flush memtables
     async fn flush_memtables(&self) -> Result<(), SlateDBError> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.memtable_flush_notifier
-            .send(MemtableFlushThreadMsg::FlushImmutableMemtables(Some(tx)))
-            .expect("memtable flush hung up");
-        rx.await.expect("receive error on memtable flush")
+            .send(FlushThreadMsg::Flush(Some(tx)))?;
+        rx.await?
     }
 
     async fn replay_wal(&self) -> Result<(), SlateDBError> {
@@ -335,7 +332,7 @@ impl DbInner {
                             .delete(kv.key.clone(), kv.attributes.clone()),
                     }
                 }
-                self.maybe_freeze_memtable(&mut guard, sst_id);
+                self.maybe_freeze_memtable(&mut guard, sst_id)?;
                 if guard.state().core.next_wal_sst_id == sst_id {
                     guard.increment_next_wal_id();
                 }
@@ -551,7 +548,7 @@ impl Db {
         // Shutdown the WAL flush thread.
         self.inner
             .wal_flush_notifier
-            .send(WalFlushThreadMsg::Shutdown)
+            .send(FlushThreadMsg::Shutdown)
             .ok();
 
         if let Some(flush_task) = {
@@ -564,7 +561,7 @@ impl Db {
         // Shutdown the memtable flush thread.
         self.inner
             .memtable_flush_notifier
-            .send(MemtableFlushThreadMsg::Shutdown)
+            .send(FlushThreadMsg::Shutdown)
             .ok();
 
         if let Some(memtable_flush_task) = {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use crate::flush::FlushThreadMsg;
+
 #[derive(thiserror::Error, Debug)]
 pub enum SlateDBError {
     #[error("IO error: {0}")]
@@ -55,6 +57,12 @@ pub enum SlateDBError {
 
     #[error("Unknown RowFlags -- this may be caused by reading data encoded with a newer codec")]
     InvalidRowFlags,
+
+    #[error("Flush channel error: {0}")]
+    FlushChannelError(#[from] tokio::sync::mpsc::error::SendError<FlushThreadMsg>),
+
+    #[error("Read channel error: {0}")]
+    ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
 }
 
 /// Represents errors that can occur during the database configuration.


### PR DESCRIPTION
This change propagates write errors to the application using SlateDB.

I've removed the calls to `expect` that cause the process to panic on error, and wrapped a few missing errors into SlateDbError. I've also unified `MemtableFlushThreadMsg` and `WallFlushThreadMsg` into a single structure because the looked redundant.

@criccomini the only panic that I was not sure about is this code below introduced in https://github.com/slatedb/slatedb/pull/264/files#diff-51529babecd6e4018b78a49622df5b5d2c480476389ec07c0b4943d8bdbaa35eR71. To me, it looks like that code is never going to be reachable because the `if` clause always returns true if the feature flag `wal_disable` is not enabled. It makes me wonder if this feature flag is even useful for people. It doesn't look like it adds any additional dependencies or code. I would propose removing the feature flag all together, but maybe it's a discussion for an issue instead.

```
let current_table = if self.wal_enabled() {
...
} else {
            if cfg!(not(feature = "wal_disable")) {
                panic!("wal_disabled feature must be enabled");
            }
```

I think when this is merged, #111 can be closed.

