### PR TITLE
chore(db): Improve DB initialization and docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Then you can use SlateDB in your Rust code:
 
 ```rust
 use bytes::Bytes;
-use object_store::{ObjectStore, memory::InMemory, path::Path};
 use slatedb::db::Db;
 use slatedb::config::DbOptions;
+use slatedb::object_store::{ObjectStore, memory::InMemory};
 use std::sync::Arc;
 
 #[tokio::main]
@@ -47,7 +47,7 @@ async fn main() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let options = DbOptions::default();
     let kv_store = Db::open_with_opts(
-        Path::from("/tmp/test_kv_store"),
+        "/tmp/test_kv_store",
         options,
         object_store,
     )
@@ -74,7 +74,7 @@ async fn main() {
 }
 ```
 
-SlateDB uses the [`object_store`](https://docs.rs/object_store/latest/object_store/) crate to interact with object storage, and therefore supports any object storage that implements the `ObjectStore` trait.
+SlateDB uses the [`object_store`](https://docs.rs/object_store/latest/object_store/) crate to interact with object storage, and therefore supports any object storage that implements the `ObjectStore` trait. You can use the crate in your project to interact with any object storage that implements the `ObjectStore` trait. SlateDB also re-exports the [`object_store`](https://docs.rs/object_store/latest/object_store/) crate for your convenience.
 
 ## Documentation
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,8 +176,10 @@ pub const DEFAULT_PUT_OPTIONS: &PutOptions = &PutOptions::default();
 /// write is considered durably committed if all future calls to read are guaranteed
 /// to serve the data written by the write, until some later durably committed write
 /// updates the same key.
+#[derive(Clone, Default)]
 pub enum ReadLevel {
     /// Client reads will only see data that's been committed durably to the DB.
+    #[default]
     Commited,
 
     /// Clients will see all writes, including those not yet durably committed to the
@@ -187,13 +189,14 @@ pub enum ReadLevel {
 
 /// Configuration for client read operations. `ReadOptions` is supplied for each
 /// read call and controls the behavior of the read.
+#[derive(Clone, Default)]
 pub struct ReadOptions {
     /// The read commit level for read operations.
     pub read_level: ReadLevel,
 }
 
 impl ReadOptions {
-    /// Create a new ReadOptions with `read_level` set to `Commited`.
+    /// Create a new `ReadOptions` with `read_level` set to `Commited`.
     const fn default() -> Self {
         Self {
             read_level: ReadLevel::Commited,

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,24 @@
+//! This module provides the core database functionality for SlateDB.
+//! It provides methods for reading and writing to the database, as well as for flushing the database to disk.
+//!
+//! The `Db` struct represents a database.
+//!
+//! # Examples
+//!
+//! Basic usage of the `Db` struct:
+//!
+//! ```
+//! use slatedb::{db::Db, error::SlateDBError};
+//! use slatedb::object_store::{ObjectStore, memory::InMemory};
+//! use std::sync::Arc;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), SlateDBError> {
+//!     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+//!     let db = Db::open("test_db", object_store).await?;
+//!     Ok(())
+//! }
+//! ```
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -368,15 +389,68 @@ pub struct Db {
 }
 
 impl Db {
-    pub async fn open(
-        path: Path,
+    /// Open a new database with default options.
+    ///
+    /// ## Arguments
+    /// - `path`: the path to the database
+    /// - `object_store`: the object store to use for the database
+    ///
+    /// ## Returns
+    /// - `Db`: the database
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error opening the database
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn open<P: Into<Path>>(
+        path: P,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Self, SlateDBError> {
         Self::open_with_opts(path, DbOptions::default(), object_store).await
     }
 
-    pub async fn open_with_opts(
-        path: Path,
+    /// Open a new database with custom `DbOptions`.
+    ///
+    /// ## Arguments
+    /// - `path`: the path to the database
+    /// - `options`: the options to use for the database
+    /// - `object_store`: the object store to use for the database
+    ///
+    /// ## Returns
+    /// - `Db`: the database
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error opening the database
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, config::DbOptions, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open_with_opts("test_db", DbOptions::default(), object_store).await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn open_with_opts<P: Into<Path>>(
+        path: P,
         options: DbOptions,
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Self, SlateDBError> {
@@ -389,12 +463,43 @@ impl Db {
         .await
     }
 
-    pub async fn open_with_fp_registry(
-        path: Path,
+    /// Open a new database with a custom `FailPointRegistry`.
+    ///
+    /// ## Arguments
+    /// - `path`: the path to the database
+    /// - `options`: the options to use for the database
+    /// - `object_store`: the object store to use for the database
+    /// - `fp_registry`: the failpoint registry to use for the database
+    ///
+    /// ## Returns
+    /// - `Db`: the database
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error opening the database
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, config::DbOptions, error::SlateDBError};
+    /// use slatedb::fail_parallel::FailPointRegistry;
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let fp_registry = Arc::new(FailPointRegistry::new());
+    ///     let db = Db::open_with_fp_registry("test_db", DbOptions::default(), object_store, fp_registry).await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn open_with_fp_registry<P: Into<Path>>(
+        path: P,
         options: DbOptions,
         object_store: Arc<dyn ObjectStore>,
         fp_registry: Arc<FailPointRegistry>,
     ) -> Result<Self, SlateDBError> {
+        let path = path.into();
         let db_stats = Arc::new(DbStats::new());
         let sst_format = SsTableFormat {
             min_filter_keys: options.min_filter_keys,
@@ -523,6 +628,26 @@ impl Db {
         FenceableManifest::init_writer(stored_manifest).await
     }
 
+    /// Close the database.
+    ///
+    /// ## Returns
+    /// - `Result<(), SlateDBError>`: if there was an error closing the database
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.close().await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn close(&self) -> Result<(), SlateDBError> {
         if let Some(compactor) = {
             let mut maybe_compactor = self.compactor.lock();
@@ -579,10 +704,71 @@ impl Db {
         Ok(())
     }
 
+    /// Get a value from the database with default read options.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to get
+    ///
+    /// ## Returns
+    /// - `Result<Option<Bytes>, SlateDBError>`:
+    ///     - `Some(Bytes)`: the value if it exists
+    ///     - `None`: if the value does not exist
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error getting the value
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use bytes::Bytes;
+    /// use slatedb::{db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.put(b"key", b"value").await?;
+    ///     assert_eq!(db.get(b"key").await?, Some(Bytes::from_static(b"value")));
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn get(&self, key: &[u8]) -> Result<Option<Bytes>, SlateDBError> {
         self.inner.get_with_options(key, DEFAULT_READ_OPTIONS).await
     }
 
+    /// Get a value from the database with custom read options.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to get
+    /// - `options`: the read options to use
+    ///
+    /// ## Returns
+    /// - `Result<Option<Bytes>, SlateDBError>`:
+    ///     - `Some(Bytes)`: the value if it exists
+    ///     - `None`: if the value does not exist
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error getting the value
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use bytes::Bytes;
+    /// use slatedb::{db::Db, config::ReadOptions, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.put(b"key", b"value").await?;
+    ///     assert_eq!(db.get_with_options(b"key", &ReadOptions::default()).await?, Some(Bytes::from_static(b"value")));
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn get_with_options(
         &self,
         key: &[u8],
@@ -591,12 +777,62 @@ impl Db {
         self.inner.get_with_options(key, options).await
     }
 
+    /// Write a value into the database with default `WriteOptions`.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to write
+    /// - `value`: the value to write
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error writing the value
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.put(b"key", b"value").await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn put(&self, key: &[u8], value: &[u8]) -> Result<(), SlateDBError> {
         let mut batch = WriteBatch::new();
         batch.put(key, value);
         self.write(batch).await
     }
 
+    /// Write a value into the database with custom `PutOptions` and `WriteOptions`.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to write
+    /// - `value`: the value to write
+    /// - `put_opts`: the put options to use
+    /// - `write_opts`: the write options to use
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error writing the value
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, config::{PutOptions, WriteOptions}, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.put_with_options(b"key", b"value", &PutOptions::default(), &WriteOptions::default()).await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn put_with_options(
         &self,
         key: &[u8],
@@ -609,12 +845,59 @@ impl Db {
         self.write_with_options(batch, write_opts).await
     }
 
+    /// Delete a key from the database with default `WriteOptions`.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to delete
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error deleting the key
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.delete(b"key").await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn delete(&self, key: &[u8]) -> Result<(), SlateDBError> {
         let mut batch = WriteBatch::new();
         batch.delete(key);
         self.write(batch).await
     }
 
+    /// Delete a key from the database with custom `WriteOptions`.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to delete
+    /// - `options`: the write options to use
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error deleting the key
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, config::WriteOptions, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.delete_with_options(b"key", &WriteOptions::default()).await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn delete_with_options(
         &self,
         key: &[u8],
@@ -628,6 +911,34 @@ impl Db {
     /// Write a batch of put/delete operations atomically to the database. Batch writes
     /// block other gets and writes until the batch is written to the WAL (or memtable if
     /// WAL is disabled).
+    ///
+    /// ## Arguments
+    /// - `batch`: the batch of put/delete operations to write
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error writing the batch
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{batch::WriteBatch, db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///
+    ///     let mut batch = WriteBatch::new();
+    ///     batch.put(b"key1", b"value1");
+    ///     batch.put(b"key2", b"value2");
+    ///     batch.delete(b"key1");
+    ///     db.write(batch).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn write(&self, batch: WriteBatch) -> Result<(), SlateDBError> {
         self.write_with_options(batch, DEFAULT_WRITE_OPTIONS).await
     }
@@ -635,6 +946,35 @@ impl Db {
     /// Write a batch of put/delete operations atomically to the database. Batch writes
     /// block other gets and writes until the batch is written to the WAL (or memtable if
     /// WAL is disabled).
+    ///
+    /// ## Arguments
+    /// - `batch`: the batch of put/delete operations to write
+    /// - `options`: the write options to use
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error writing the batch
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{batch::WriteBatch, db::Db, config::WriteOptions, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///
+    ///     let mut batch = WriteBatch::new();
+    ///     batch.put(b"key1", b"value1");
+    ///     batch.put(b"key2", b"value2");
+    ///     batch.delete(b"key1");
+    ///     db.write_with_options(batch, &WriteOptions::default()).await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn write_with_options(
         &self,
         batch: WriteBatch,
@@ -643,6 +983,28 @@ impl Db {
         self.inner.write_with_options(batch, options).await
     }
 
+    /// Flush the database to disk.
+    /// If WAL is enabled, flushes the WAL to disk.
+    /// If WAL is disabled, flushes the memtables to disk.
+    ///
+    /// ## Errors
+    /// - `SlateDBError`: if there was an error flushing the database
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{db::Db, error::SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     db.flush().await?;
+    ///     Ok(())
+    /// }
+    /// ```
     pub async fn flush(&self) -> Result<(), SlateDBError> {
         if self.inner.wal_enabled() {
             self.inner.flush_wals().await

--- a/src/db_cache/foyer.rs
+++ b/src/db_cache/foyer.rs
@@ -26,7 +26,7 @@
 //!         block_cache: Some(Arc::new(FoyerCache::new())),
 //!         ..Default::default()
 //!     };
-//!     let db = Db::open_with_opts("path/to/db".into(), options, object_store).await;
+//!     let db = Db::open_with_opts("path/to/db", options, object_store).await;
 //! }
 //! ```
 //!

--- a/src/db_cache/moka.rs
+++ b/src/db_cache/moka.rs
@@ -26,7 +26,7 @@
 //!         block_cache: Some(Arc::new(MokaCache::new())),
 //!         ..Default::default()
 //!     };
-//!     let db = Db::open_with_opts("path/to/db".into(), options, object_store).await;
+//!     let db = Db::open_with_opts("path/to/db", options, object_store).await;
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,3 +43,15 @@ mod tablestore;
 mod test_utils;
 mod transactional_object_store;
 mod types;
+
+/// Re-export the object store crate.
+///
+/// This is useful for users of the crate who want to use SlateDB
+/// without having to depend on the object store crate directly.
+pub use object_store;
+
+/// Re-export the fail-parallel crate.
+///
+/// This is useful for users of the crate who want to use SlateDB
+/// with failpoints in their tests without having to depend on the fail-parallel crate directly.
+pub use fail_parallel;

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -78,10 +78,10 @@ pub(crate) struct SstFileMetadata {
 
 impl TableStore {
     #[allow(dead_code)]
-    pub fn new(
+    pub fn new<P: Into<Path>>(
         object_store: Arc<dyn ObjectStore>,
         sst_format: SsTableFormat,
-        root_path: Path,
+        root_path: P,
         block_cache: Option<Arc<dyn DbCache>>,
     ) -> Self {
         Self::new_with_fp_registry(
@@ -93,17 +93,17 @@ impl TableStore {
         )
     }
 
-    pub fn new_with_fp_registry(
+    pub fn new_with_fp_registry<P: Into<Path>>(
         object_store: Arc<dyn ObjectStore>,
         sst_format: SsTableFormat,
-        root_path: Path,
+        root_path: P,
         fp_registry: Arc<FailPointRegistry>,
         block_cache: Option<Arc<dyn DbCache>>,
     ) -> Self {
         Self {
             object_store: object_store.clone(),
             sst_format,
-            root_path: root_path.clone(),
+            root_path: root_path.into(),
             wal_path: "wal",
             compacted_path: "compacted",
             fp_registry,


### PR DESCRIPTION
SlateDB uses a `Path` struct from `object_store`, this is not always evident when you start using the crate, and it can be confusing because `Path` is pretty well known from the standard library.

To make it easy to start with a new database, the `open` operations take now a generic that can be converted to a `object_store::path::Path`, which removes the direct dependency from the structure in the caller.

This change also re-exports `object_store` and `fail_parallel` so SlateDB provides all the main dependencies without having to fiddle with additional crates in the project directly.

Since the `db` module was not very well documented, and it's the core of the project, I decided to document all the public functions that users regularly interact with.

The main changes are in `src/db.rs` which GitHub collapses 🤷 