### PR TITLE
[1/N] checkpoints: api and manifest model for creating checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,6 +2266,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ulid",
+ "uuid",
  "walkdir",
  "zstd",
 ]
@@ -2732,11 +2733,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ siphasher = "1"
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 ulid = { version = "1.1.3", features = ["serde"] }
+uuid = { version = "1.11.0", features = ["v4", "serde"] }
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
 log = {  version = "0.4.22", features = ["std"] }

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -176,6 +176,14 @@ struct CheckpointOptions {
     source: Option<UUID>
 }
 
+#[derive(Debug)]
+pub struct CheckpointCreateResult {
+    /// The id of the created checkpoint.
+    id: uuid::Uuid,
+    /// The manifest id referenced by the created checkpoint.
+    manifest_id: u64,
+}
+
 impl Db {
     /// Opens a Db from a checkpoint. If no db already exists at the specified path, then this will create
     /// a new db under the path that is a clone of the db at parent_path. A clone is a shallow copy of the
@@ -196,7 +204,7 @@ impl Db {
 
     /// Creates a checkpoint of an opened db using the provided options. Returns the ID of the created
     /// checkpoint and the id of the referenced manifest.
-    pub async fn create_checkpoint(&self, options: &CheckpointOptions) -> Result<(uuid::UUID, u64), SlateDBError> {
+    pub async fn create_checkpoint(&self, options: &CheckpointOptions) -> Result<CheckpointCreateResult, SlateDBError> {
         …
     }
 
@@ -207,7 +215,7 @@ impl Db {
        path: Path,
        object_store: Arc<dyn ObjectStore>,
        options: &CheckpointOptions,
-    ) -> Result<(uuid::UUID, u64), SlateDBError> {}
+    ) -> Result<CheckpointCreateResult, SlateDBError> {}
        ...
     )
 

--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -1,9 +1,20 @@
 include "sst.fbs";
 
+table Uuid {
+   high: uint64;
+   low: uint64;
+}
+
 // Manifest to persist state of DB.
 table ManifestV1 {
     // Id of manifest. Manifest file name will be derived from this id.
     manifest_id: ulong;
+
+    // Flag to indicate whether initialization has finished. When creating the initial manifest for
+    // a root db (one that is not a clone), this flag will be set to true. When creating the initial
+    // manifest for a clone db, this flag will be set to false and then updated to true once clone
+    // initialization has completed.
+    initialized: bool;
 
     // The current writer's epoch.
     writer_epoch: ulong;
@@ -26,11 +37,11 @@ table ManifestV1 {
     // A list of the sorted runs that are valid to read in the `compacted` folder.
     compacted: [SortedRun] (required);
 
-    // A list of read snapshots that are currently open.
-    snapshots: [Snapshot];
-
     // The last clock tick
     last_clock_tick: long;
+
+    // A list of checkpoints that are currently open.
+    checkpoints: [Checkpoint] (required);
 }
 
 table SortedRun {
@@ -38,16 +49,29 @@ table SortedRun {
     ssts: [CompactedSsTable] (required);
 }
 
-// Snapshot reference to be included in manifest to record active snapshots.
-table Snapshot {
-    // Id that must be unique across all open snapshots.
-    id: ulong;
+table WriterCheckpoint {
+   epoch: uint64;
+}
 
-    // The manifest ID that this snapshot is using as its `DbState`.
+union CheckpointMetadata { WriterCheckpoint }
+
+// Checkpoint reference to be included in manifest to record active checkpoints.
+table Checkpoint {
+    // Id that must be unique across all open checkpoints.
+    id: Uuid (required);
+
+    // The manifest ID that this checkpoint is using as its `DbState`.
     manifest_id: ulong;
 
-    // The UTC unix timestamp seconds that a snapshot expires at. Clients may update this value.
-    // If `snapshot_expire_time_s` is older than now(), the snapshot is considered expired.
-    // If `snapshot_expire_time_s` is 0, the snapshot will never expire.
-    snapshot_expire_time_s: uint;
+    // The UTC unix timestamp seconds that a checkpoint expires at. Clients may update this value.
+    // If `checkpoint_expire_time_s` is older than now(), the checkpoint is considered expired.
+    // If `checkpoint_expire_time_s` is 0, the checkpoint will never expire.
+    checkpoint_expire_time_s: uint;
+
+    // The unix timestamp seconds that the checkpoint was created
+    checkpoint_create_time_s: uint;
+
+    // Optional metadata associated with the checkpoint. For example, the writer can use this to
+    // clean up checkpoints from older writers.
+    metadata: CheckpointMetadata;
 }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,0 +1,228 @@
+use crate::config::CheckpointOptions;
+use crate::db::Db;
+use crate::db_state::Checkpoint;
+use crate::error::SlateDBError;
+use crate::manifest_store::{apply_db_state_update, ManifestStore, StoredManifest};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+impl Db {
+    /// Creates a checkpoint of the db stored in the object store at the specified path using the
+    /// provided options. Note that the scope option does not impact the behaviour of this method.
+    /// The checkpoint will reference the current active manifest of the db.
+    pub async fn create_checkpoint(
+        path: Path,
+        object_store: Arc<dyn ObjectStore>,
+        options: &CheckpointOptions,
+    ) -> Result<(uuid::Uuid, u64), SlateDBError> {
+        let manifest_store = Arc::new(ManifestStore::new(&path, object_store));
+        let Some(mut stored_manifest) = StoredManifest::load(manifest_store).await? else {
+            return Err(SlateDBError::ManifestMissing);
+        };
+        let id = uuid::Uuid::new_v4();
+        apply_db_state_update(&mut stored_manifest, |stored_manifest| {
+            let expire_time = options.lifetime.map(|l| SystemTime::now() + l);
+            let db_state = stored_manifest.db_state();
+            let manifest_id = match options.source {
+                Some(source_checkpoint_id) => {
+                    let Some(source_checkpoint) = db_state
+                        .checkpoints
+                        .iter()
+                        .find(|c| c.id == source_checkpoint_id)
+                    else {
+                        return Err(SlateDBError::InvalidDBState);
+                    };
+                    source_checkpoint.manifest_id
+                }
+                None => {
+                    if !db_state.initialized {
+                        return Err(SlateDBError::InvalidDBState);
+                    }
+                    stored_manifest.id()
+                }
+            };
+            let checkpoint = Checkpoint {
+                id,
+                manifest_id,
+                expire_time,
+                create_time: SystemTime::now(),
+            };
+            let mut updated_db_state = db_state.clone();
+            updated_db_state.checkpoints.push(checkpoint);
+            Ok(updated_db_state)
+        })
+        .await?;
+        let checkpoint = stored_manifest
+            .db_state()
+            .checkpoints
+            .iter()
+            .find(|c| c.id == id)
+            .expect("update applied but checkpoint not found");
+        Ok((id, checkpoint.manifest_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::{CheckpointOptions, DbOptions};
+    use crate::db::Db;
+    use crate::error::SlateDBError;
+    use crate::manifest_store::ManifestStore;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
+
+    #[tokio::test]
+    async fn test_should_create_checkpoint() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        // open and close the db to init the manifest and trigger another write
+        let db = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+        db.close().await.unwrap();
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let (manifest_id, before_checkpoint) = manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .unwrap();
+
+        let (checkpoint_id, checkpoint_manifest_id) = Db::create_checkpoint(
+            path.clone(),
+            object_store.clone(),
+            &CheckpointOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let (_, manifest) = manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(manifest_id, checkpoint_manifest_id);
+        let checkpoints = &manifest.core.checkpoints;
+        assert_eq!(
+            before_checkpoint.core.checkpoints.len() + 1,
+            checkpoints.len()
+        );
+        let checkpoint = checkpoints.iter().find(|c| c.id == checkpoint_id).unwrap();
+        assert_eq!(checkpoint.manifest_id, manifest_id);
+        assert_eq!(checkpoint.expire_time, None);
+    }
+
+    #[tokio::test]
+    async fn test_should_create_checkpoint_with_expiry() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        // open and close the db to init the manifest and trigger another write
+        let db = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+        db.close().await.unwrap();
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let checkpoint_time = SystemTime::now();
+
+        let (checkpoint_id, _) = Db::create_checkpoint(
+            path.clone(),
+            object_store.clone(),
+            &CheckpointOptions {
+                lifetime: Some(Duration::from_secs(3600)),
+                ..CheckpointOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let (_, manifest) = manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .unwrap();
+        let checkpoints = &manifest.core.checkpoints;
+        let checkpoint = checkpoints.iter().find(|c| c.id == checkpoint_id).unwrap();
+        assert!(checkpoint.expire_time.is_some());
+        let expire_time = checkpoint.expire_time.unwrap();
+        let expected = checkpoint_time + Duration::from_secs(3600);
+        // check that expire time is close to the expected value (account for delay/time adjustment)
+        if expire_time >= expected {
+            assert!(expire_time.duration_since(expected).unwrap() < Duration::from_secs(5))
+        } else {
+            assert!(expected.duration_since(expire_time).unwrap() < Duration::from_secs(5))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_should_create_checkpoint_from_checkpoint() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let db = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+        db.close().await.unwrap();
+        let (source_checkpoint_id, source_checkpoint_manifest_id) = Db::create_checkpoint(
+            path.clone(),
+            object_store.clone(),
+            &CheckpointOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let (_, checkpoint_manifest_id) = Db::create_checkpoint(
+            path.clone(),
+            object_store.clone(),
+            &CheckpointOptions {
+                source: Some(source_checkpoint_id),
+                ..CheckpointOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(checkpoint_manifest_id, source_checkpoint_manifest_id);
+    }
+
+    #[tokio::test]
+    async fn test_should_fail_create_checkpoint_from_missing_checkpoint() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        // open and close the db to init the manifest and trigger another write
+        let _ = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+
+        let result = Db::create_checkpoint(
+            path.clone(),
+            object_store.clone(),
+            &CheckpointOptions {
+                source: Some(uuid::Uuid::new_v4()),
+                ..CheckpointOptions::default()
+            },
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), SlateDBError::InvalidDBState));
+    }
+
+    #[tokio::test]
+    async fn test_should_fail_create_checkpoint_no_manifest() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+
+        let result = Db::create_checkpoint(
+            path.clone(),
+            object_store.clone(),
+            &CheckpointOptions::default(),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), SlateDBError::ManifestMissing));
+    }
+}

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -11,9 +11,9 @@ use std::time::SystemTime;
 #[derive(Debug)]
 pub struct CheckpointCreateResult {
     /// The id of the created checkpoint.
-    id: uuid::Uuid,
+    pub id: uuid::Uuid,
     /// The manifest id referenced by the created checkpoint.
-    manifest_id: u64,
+    pub manifest_id: u64,
 }
 
 impl Db {

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -13,7 +13,7 @@ impl Db {
     /// provided options. Note that the scope option does not impact the behaviour of this method.
     /// The checkpoint will reference the current active manifest of the db.
     pub async fn create_checkpoint(
-        path: Path,
+        path: &Path,
         object_store: Arc<dyn ObjectStore>,
         options: &CheckpointOptions,
     ) -> Result<(uuid::Uuid, u64), SlateDBError> {
@@ -92,13 +92,10 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        let (checkpoint_id, checkpoint_manifest_id) = Db::create_checkpoint(
-            path.clone(),
-            object_store.clone(),
-            &CheckpointOptions::default(),
-        )
-        .await
-        .unwrap();
+        let (checkpoint_id, checkpoint_manifest_id) =
+            Db::create_checkpoint(&path, object_store.clone(), &CheckpointOptions::default())
+                .await
+                .unwrap();
 
         let (_, manifest) = manifest_store
             .read_latest_manifest()
@@ -129,7 +126,7 @@ mod tests {
         let checkpoint_time = SystemTime::now();
 
         let (checkpoint_id, _) = Db::create_checkpoint(
-            path.clone(),
+            &path,
             object_store.clone(),
             &CheckpointOptions {
                 lifetime: Some(Duration::from_secs(3600)),
@@ -165,16 +162,13 @@ mod tests {
             .await
             .unwrap();
         db.close().await.unwrap();
-        let (source_checkpoint_id, source_checkpoint_manifest_id) = Db::create_checkpoint(
-            path.clone(),
-            object_store.clone(),
-            &CheckpointOptions::default(),
-        )
-        .await
-        .unwrap();
+        let (source_checkpoint_id, source_checkpoint_manifest_id) =
+            Db::create_checkpoint(&path, object_store.clone(), &CheckpointOptions::default())
+                .await
+                .unwrap();
 
         let (_, checkpoint_manifest_id) = Db::create_checkpoint(
-            path.clone(),
+            &path,
             object_store.clone(),
             &CheckpointOptions {
                 source: Some(source_checkpoint_id),
@@ -197,7 +191,7 @@ mod tests {
             .unwrap();
 
         let result = Db::create_checkpoint(
-            path.clone(),
+            &path,
             object_store.clone(),
             &CheckpointOptions {
                 source: Some(uuid::Uuid::new_v4()),
@@ -215,12 +209,8 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
 
-        let result = Db::create_checkpoint(
-            path.clone(),
-            object_store.clone(),
-            &CheckpointOptions::default(),
-        )
-        .await;
+        let result =
+            Db::create_checkpoint(&path, object_store.clone(), &CheckpointOptions::default()).await;
 
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), SlateDBError::ManifestMissing));

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,7 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{str::FromStr, time::Duration};
 use tokio::runtime::Handle;
+use uuid::Uuid;
 
 use crate::compactor::CompactionScheduler;
 use crate::error::{DbOptionsError, SlateDBError};
@@ -306,6 +307,44 @@ fn default_clock() -> Arc<dyn Clock + Send + Sync> {
     Arc::new(SystemClock {
         last_tick: AtomicI64::new(i64::MIN),
     })
+}
+
+/// Defines the scope targeted by a given checkpoint. If set to All, then the checkpoint will
+/// include all writes that were issued at the time that create_checkpoint is called. If force_flush
+/// is true, then SlateDB will force the current wal, or memtable if wal_enabled is false, to flush
+/// its data. Otherwise, the database will wait for the current wal or memtable to be flushed due to
+/// flush_interval or reaching l0_sst_size_bytes, respectively. If set to Durable, then the
+/// checkpoint includes only writes that were durable at the time of the call. This will be faster,
+/// but may not include data from recent writes.
+pub enum CheckpointScope {
+    All { force_flush: bool },
+    Durable,
+}
+
+/// Specify options to provide when creating a checkpoint.
+pub struct CheckpointOptions {
+    /// Specifies the scope targeted by the checkpoint (see above)
+    pub scope: CheckpointScope,
+
+    /// Optionally specifies the lifetime of the checkpoint to create. The expire time will be
+    /// set to the current wallclock time plus the specified lifetime. If lifetime is None, then
+    /// the checkpoint is created without an expiry time.
+    pub lifetime: Option<Duration>,
+
+    /// Optionally specifies an existing checkpoint to use as the source for this checkpoint. This
+    /// is useful for users to establish checkpoints from existing checkpoints, but with a different
+    /// lifecycle and/or metadata.
+    pub source: Option<Uuid>,
+}
+
+impl Default for CheckpointOptions {
+    fn default() -> Self {
+        Self {
+            scope: CheckpointScope::Durable,
+            lifetime: None,
+            source: None,
+        }
+    }
 }
 
 /// Configuration options for the database. These options are set on client startup.

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
@@ -21,8 +22,9 @@ use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::Compacted;
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::manifest_generated::{
-    CompactedSsTable, CompactedSsTableArgs, CompactedSstId, CompactedSstIdArgs, CompressionFormat,
-    SortedRun, SortedRunArgs, SstRowFeature,
+    Checkpoint, CheckpointArgs, CheckpointMetadata, CompactedSsTable, CompactedSsTableArgs,
+    CompactedSstId, CompactedSstIdArgs, CompressionFormat, SortedRun, SortedRunArgs, SstRowFeature,
+    Uuid, UuidArgs,
 };
 use crate::manifest::{Manifest, ManifestCodec};
 
@@ -109,6 +111,18 @@ impl ManifestCodec for FlatBufferManifestCodec {
 }
 
 impl FlatBufferManifestCodec {
+    fn unix_ts_to_time(unix_ts: u32) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(unix_ts as u64)
+    }
+
+    fn maybe_unix_ts_to_time(unix_ts: u32) -> Option<SystemTime> {
+        if unix_ts == 0 {
+            None
+        } else {
+            Some(Self::unix_ts_to_time(unix_ts))
+        }
+    }
+
     pub fn manifest(manifest: &ManifestV1) -> Manifest {
         let l0_last_compacted = manifest
             .l0_last_compacted()
@@ -135,13 +149,25 @@ impl FlatBufferManifestCodec {
                 ssts,
             })
         }
+        let checkpoints: Vec<db_state::Checkpoint> = manifest
+            .checkpoints()
+            .iter()
+            .map(|cp| db_state::Checkpoint {
+                id: uuid::Uuid::from_u64_pair(cp.id().high(), cp.id().low()),
+                manifest_id: cp.manifest_id(),
+                expire_time: Self::maybe_unix_ts_to_time(cp.checkpoint_expire_time_s()),
+                create_time: Self::unix_ts_to_time(cp.checkpoint_create_time_s()),
+            })
+            .collect();
         let core = CoreDbState {
+            initialized: manifest.initialized(),
             l0_last_compacted,
             l0,
             compacted,
             next_wal_sst_id: manifest.wal_id_last_seen() + 1,
             last_compacted_wal_sst_id: manifest.wal_id_last_compacted(),
             last_clock_tick: manifest.last_clock_tick(),
+            checkpoints,
         };
         Manifest {
             core,
@@ -265,6 +291,47 @@ impl<'b> DbFlatBufferBuilder<'b> {
         self.builder.create_vector(sorted_runs_fbs.as_ref())
     }
 
+    fn add_uuid(&mut self, uuid: uuid::Uuid) -> WIPOffset<Uuid<'b>> {
+        let (high, low) = uuid.as_u64_pair();
+        Uuid::create(&mut self.builder, &UuidArgs { high, low })
+    }
+
+    fn time_to_unix_ts(time: &SystemTime) -> u32 {
+        time.duration_since(UNIX_EPOCH)
+            .expect("manifest expire time cannot be earlier than epoch")
+            .as_secs() as u32 // TODO: check bounds
+    }
+
+    fn maybe_time_to_unix_ts(time: Option<&SystemTime>) -> u32 {
+        time.map(Self::time_to_unix_ts).unwrap_or(0)
+    }
+
+    fn add_checkpoint(&mut self, checkpoint: &db_state::Checkpoint) -> WIPOffset<Checkpoint<'b>> {
+        let id = self.add_uuid(checkpoint.id);
+        let checkpoint_expire_time_s = Self::maybe_time_to_unix_ts(checkpoint.expire_time.as_ref());
+        let checkpoint_create_time_s = Self::time_to_unix_ts(&checkpoint.create_time);
+        Checkpoint::create(
+            &mut self.builder,
+            &CheckpointArgs {
+                id: Some(id),
+                manifest_id: checkpoint.manifest_id,
+                checkpoint_expire_time_s,
+                checkpoint_create_time_s,
+                metadata: None,
+                metadata_type: CheckpointMetadata::NONE,
+            },
+        )
+    }
+
+    fn add_checkpoints(
+        &mut self,
+        checkpoints: &[db_state::Checkpoint],
+    ) -> WIPOffset<Vector<'b, ForwardsUOffset<Checkpoint<'b>>>> {
+        let checkpoints_fb_vec: Vec<WIPOffset<Checkpoint>> =
+            checkpoints.iter().map(|c| self.add_checkpoint(c)).collect();
+        self.builder.create_vector(checkpoints_fb_vec.as_ref())
+    }
+
     fn create_manifest(&mut self, manifest: &Manifest) -> Bytes {
         let core = &manifest.core;
         let l0 = self.add_compacted_ssts(core.l0.iter());
@@ -273,10 +340,12 @@ impl<'b> DbFlatBufferBuilder<'b> {
             l0_last_compacted = Some(self.add_compacted_sst_id(ulid))
         }
         let compacted = self.add_sorted_runs(&core.compacted);
+        let checkpoints = self.add_checkpoints(&core.checkpoints);
         let manifest = ManifestV1::create(
             &mut self.builder,
             &ManifestV1Args {
                 manifest_id: 0, // todo: get rid of me
+                initialized: core.initialized,
                 writer_epoch: manifest.writer_epoch,
                 compactor_epoch: manifest.compactor_epoch,
                 wal_id_last_compacted: core.last_compacted_wal_sst_id,
@@ -284,8 +353,8 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 l0_last_compacted,
                 l0: Some(l0),
                 compacted: Some(compacted),
-                snapshots: None,
                 last_clock_tick: core.last_clock_tick,
+                checkpoints: Some(checkpoints),
             },
         );
         self.builder.finish(manifest, None);
@@ -355,5 +424,47 @@ impl From<SstRowFeature> for RowFeature {
             running an older version of SlateDB than was used to write the SST?"
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db_state;
+    use crate::db_state::CoreDbState;
+    use crate::flatbuffer_types::FlatBufferManifestCodec;
+    use crate::manifest::{Manifest, ManifestCodec};
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn test_should_encode_decode_manifest_checkpoints() {
+        // given:
+        let mut core = CoreDbState::new();
+        core.checkpoints = vec![
+            db_state::Checkpoint {
+                id: uuid::Uuid::new_v4(),
+                manifest_id: 1,
+                expire_time: None,
+                create_time: SystemTime::UNIX_EPOCH + Duration::from_secs(100),
+            },
+            db_state::Checkpoint {
+                id: uuid::Uuid::new_v4(),
+                manifest_id: 2,
+                expire_time: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1000)),
+                create_time: SystemTime::UNIX_EPOCH + Duration::from_secs(200),
+            },
+        ];
+        let manifest = Manifest {
+            core,
+            writer_epoch: 0,
+            compactor_epoch: 0,
+        };
+        let codec = FlatBufferManifestCodec {};
+
+        // when:
+        let bytes = codec.encode(&manifest);
+        let decoded = codec.decode(&bytes).expect("failed to decode manifest");
+
+        // then:
+        assert_eq!(manifest, decoded);
     }
 }

--- a/src/generated/manifest_generated.rs
+++ b/src/generated/manifest_generated.rs
@@ -195,6 +195,93 @@ impl<'a> flatbuffers::Verifiable for SstRowFeature {
 }
 
 impl flatbuffers::SimpleToVerifyInSlice for SstRowFeature {}
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MIN_CHECKPOINT_METADATA: u8 = 0;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+pub const ENUM_MAX_CHECKPOINT_METADATA: u8 = 1;
+#[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
+#[allow(non_camel_case_types)]
+pub const ENUM_VALUES_CHECKPOINT_METADATA: [CheckpointMetadata; 2] = [
+  CheckpointMetadata::NONE,
+  CheckpointMetadata::WriterCheckpoint,
+];
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[repr(transparent)]
+pub struct CheckpointMetadata(pub u8);
+#[allow(non_upper_case_globals)]
+impl CheckpointMetadata {
+  pub const NONE: Self = Self(0);
+  pub const WriterCheckpoint: Self = Self(1);
+
+  pub const ENUM_MIN: u8 = 0;
+  pub const ENUM_MAX: u8 = 1;
+  pub const ENUM_VALUES: &'static [Self] = &[
+    Self::NONE,
+    Self::WriterCheckpoint,
+  ];
+  /// Returns the variant's name or "" if unknown.
+  pub fn variant_name(self) -> Option<&'static str> {
+    match self {
+      Self::NONE => Some("NONE"),
+      Self::WriterCheckpoint => Some("WriterCheckpoint"),
+      _ => None,
+    }
+  }
+}
+impl core::fmt::Debug for CheckpointMetadata {
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    if let Some(name) = self.variant_name() {
+      f.write_str(name)
+    } else {
+      f.write_fmt(format_args!("<UNKNOWN {:?}>", self.0))
+    }
+  }
+}
+impl<'a> flatbuffers::Follow<'a> for CheckpointMetadata {
+  type Inner = Self;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    let b = flatbuffers::read_scalar_at::<u8>(buf, loc);
+    Self(b)
+  }
+}
+
+impl flatbuffers::Push for CheckpointMetadata {
+    type Output = CheckpointMetadata;
+    #[inline]
+    unsafe fn push(&self, dst: &mut [u8], _written_len: usize) {
+        flatbuffers::emplace_scalar::<u8>(dst, self.0);
+    }
+}
+
+impl flatbuffers::EndianScalar for CheckpointMetadata {
+  type Scalar = u8;
+  #[inline]
+  fn to_little_endian(self) -> u8 {
+    self.0.to_le()
+  }
+  #[inline]
+  #[allow(clippy::wrong_self_convention)]
+  fn from_little_endian(v: u8) -> Self {
+    let b = u8::from_le(v);
+    Self(b)
+  }
+}
+
+impl<'a> flatbuffers::Verifiable for CheckpointMetadata {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    u8::run_verifier(v, pos)
+  }
+}
+
+impl flatbuffers::SimpleToVerifyInSlice for CheckpointMetadata {}
+pub struct CheckpointMetadataUnionTableOffset {}
+
 pub enum CompactedSstIdOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -837,6 +924,120 @@ impl core::fmt::Debug for SsTableIndex<'_> {
       ds.finish()
   }
 }
+pub enum UuidOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Uuid<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Uuid<'a> {
+  type Inner = Uuid<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> Uuid<'a> {
+  pub const VT_HIGH: flatbuffers::VOffsetT = 4;
+  pub const VT_LOW: flatbuffers::VOffsetT = 6;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    Uuid { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args UuidArgs
+  ) -> flatbuffers::WIPOffset<Uuid<'bldr>> {
+    let mut builder = UuidBuilder::new(_fbb);
+    builder.add_low(args.low);
+    builder.add_high(args.high);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn high(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(Uuid::VT_HIGH, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn low(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(Uuid::VT_LOW, Some(0)).unwrap()}
+  }
+}
+
+impl flatbuffers::Verifiable for Uuid<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u64>("high", Self::VT_HIGH, false)?
+     .visit_field::<u64>("low", Self::VT_LOW, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct UuidArgs {
+    pub high: u64,
+    pub low: u64,
+}
+impl<'a> Default for UuidArgs {
+  #[inline]
+  fn default() -> Self {
+    UuidArgs {
+      high: 0,
+      low: 0,
+    }
+  }
+}
+
+pub struct UuidBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> UuidBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_high(&mut self, high: u64) {
+    self.fbb_.push_slot::<u64>(Uuid::VT_HIGH, high, 0);
+  }
+  #[inline]
+  pub fn add_low(&mut self, low: u64) {
+    self.fbb_.push_slot::<u64>(Uuid::VT_LOW, low, 0);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> UuidBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    UuidBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Uuid<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for Uuid<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("Uuid");
+      ds.field("high", &self.high());
+      ds.field("low", &self.low());
+      ds.finish()
+  }
+}
 pub enum ManifestV1Offset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -854,15 +1055,16 @@ impl<'a> flatbuffers::Follow<'a> for ManifestV1<'a> {
 
 impl<'a> ManifestV1<'a> {
   pub const VT_MANIFEST_ID: flatbuffers::VOffsetT = 4;
-  pub const VT_WRITER_EPOCH: flatbuffers::VOffsetT = 6;
-  pub const VT_COMPACTOR_EPOCH: flatbuffers::VOffsetT = 8;
-  pub const VT_WAL_ID_LAST_COMPACTED: flatbuffers::VOffsetT = 10;
-  pub const VT_WAL_ID_LAST_SEEN: flatbuffers::VOffsetT = 12;
-  pub const VT_L0_LAST_COMPACTED: flatbuffers::VOffsetT = 14;
-  pub const VT_L0: flatbuffers::VOffsetT = 16;
-  pub const VT_COMPACTED: flatbuffers::VOffsetT = 18;
-  pub const VT_SNAPSHOTS: flatbuffers::VOffsetT = 20;
+  pub const VT_INITIALIZED: flatbuffers::VOffsetT = 6;
+  pub const VT_WRITER_EPOCH: flatbuffers::VOffsetT = 8;
+  pub const VT_COMPACTOR_EPOCH: flatbuffers::VOffsetT = 10;
+  pub const VT_WAL_ID_LAST_COMPACTED: flatbuffers::VOffsetT = 12;
+  pub const VT_WAL_ID_LAST_SEEN: flatbuffers::VOffsetT = 14;
+  pub const VT_L0_LAST_COMPACTED: flatbuffers::VOffsetT = 16;
+  pub const VT_L0: flatbuffers::VOffsetT = 18;
+  pub const VT_COMPACTED: flatbuffers::VOffsetT = 20;
   pub const VT_LAST_CLOCK_TICK: flatbuffers::VOffsetT = 22;
+  pub const VT_CHECKPOINTS: flatbuffers::VOffsetT = 24;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -880,10 +1082,11 @@ impl<'a> ManifestV1<'a> {
     builder.add_compactor_epoch(args.compactor_epoch);
     builder.add_writer_epoch(args.writer_epoch);
     builder.add_manifest_id(args.manifest_id);
-    if let Some(x) = args.snapshots { builder.add_snapshots(x); }
+    if let Some(x) = args.checkpoints { builder.add_checkpoints(x); }
     if let Some(x) = args.compacted { builder.add_compacted(x); }
     if let Some(x) = args.l0 { builder.add_l0(x); }
     if let Some(x) = args.l0_last_compacted { builder.add_l0_last_compacted(x); }
+    builder.add_initialized(args.initialized);
     builder.finish()
   }
 
@@ -894,6 +1097,13 @@ impl<'a> ManifestV1<'a> {
     // Created from valid Table for this object
     // which contains a valid value in this slot
     unsafe { self._tab.get::<u64>(ManifestV1::VT_MANIFEST_ID, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn initialized(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(ManifestV1::VT_INITIALIZED, Some(false)).unwrap()}
   }
   #[inline]
   pub fn writer_epoch(&self) -> u64 {
@@ -945,18 +1155,18 @@ impl<'a> ManifestV1<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRun>>>>(ManifestV1::VT_COMPACTED, None).unwrap()}
   }
   #[inline]
-  pub fn snapshots(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Snapshot<'a>>>> {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Snapshot>>>>(ManifestV1::VT_SNAPSHOTS, None)}
-  }
-  #[inline]
   pub fn last_clock_tick(&self) -> i64 {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
     unsafe { self._tab.get::<i64>(ManifestV1::VT_LAST_CLOCK_TICK, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn checkpoints(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint>>>>(ManifestV1::VT_CHECKPOINTS, None).unwrap()}
   }
 }
 
@@ -968,6 +1178,7 @@ impl flatbuffers::Verifiable for ManifestV1<'_> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
      .visit_field::<u64>("manifest_id", Self::VT_MANIFEST_ID, false)?
+     .visit_field::<bool>("initialized", Self::VT_INITIALIZED, false)?
      .visit_field::<u64>("writer_epoch", Self::VT_WRITER_EPOCH, false)?
      .visit_field::<u64>("compactor_epoch", Self::VT_COMPACTOR_EPOCH, false)?
      .visit_field::<u64>("wal_id_last_compacted", Self::VT_WAL_ID_LAST_COMPACTED, false)?
@@ -975,14 +1186,15 @@ impl flatbuffers::Verifiable for ManifestV1<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<CompactedSstId>>("l0_last_compacted", Self::VT_L0_LAST_COMPACTED, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTable>>>>("l0", Self::VT_L0, true)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SortedRun>>>>("compacted", Self::VT_COMPACTED, true)?
-     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Snapshot>>>>("snapshots", Self::VT_SNAPSHOTS, false)?
      .visit_field::<i64>("last_clock_tick", Self::VT_LAST_CLOCK_TICK, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Checkpoint>>>>("checkpoints", Self::VT_CHECKPOINTS, true)?
      .finish();
     Ok(())
   }
 }
 pub struct ManifestV1Args<'a> {
     pub manifest_id: u64,
+    pub initialized: bool,
     pub writer_epoch: u64,
     pub compactor_epoch: u64,
     pub wal_id_last_compacted: u64,
@@ -990,14 +1202,15 @@ pub struct ManifestV1Args<'a> {
     pub l0_last_compacted: Option<flatbuffers::WIPOffset<CompactedSstId<'a>>>,
     pub l0: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTable<'a>>>>>,
     pub compacted: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRun<'a>>>>>,
-    pub snapshots: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Snapshot<'a>>>>>,
     pub last_clock_tick: i64,
+    pub checkpoints: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>>>>,
 }
 impl<'a> Default for ManifestV1Args<'a> {
   #[inline]
   fn default() -> Self {
     ManifestV1Args {
       manifest_id: 0,
+      initialized: false,
       writer_epoch: 0,
       compactor_epoch: 0,
       wal_id_last_compacted: 0,
@@ -1005,8 +1218,8 @@ impl<'a> Default for ManifestV1Args<'a> {
       l0_last_compacted: None,
       l0: None, // required field
       compacted: None, // required field
-      snapshots: None,
       last_clock_tick: 0,
+      checkpoints: None, // required field
     }
   }
 }
@@ -1019,6 +1232,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV1Builder<'a, 'b, A> {
   #[inline]
   pub fn add_manifest_id(&mut self, manifest_id: u64) {
     self.fbb_.push_slot::<u64>(ManifestV1::VT_MANIFEST_ID, manifest_id, 0);
+  }
+  #[inline]
+  pub fn add_initialized(&mut self, initialized: bool) {
+    self.fbb_.push_slot::<bool>(ManifestV1::VT_INITIALIZED, initialized, false);
   }
   #[inline]
   pub fn add_writer_epoch(&mut self, writer_epoch: u64) {
@@ -1049,12 +1266,12 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV1Builder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV1::VT_COMPACTED, compacted);
   }
   #[inline]
-  pub fn add_snapshots(&mut self, snapshots: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Snapshot<'b >>>>) {
-    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV1::VT_SNAPSHOTS, snapshots);
-  }
-  #[inline]
   pub fn add_last_clock_tick(&mut self, last_clock_tick: i64) {
     self.fbb_.push_slot::<i64>(ManifestV1::VT_LAST_CLOCK_TICK, last_clock_tick, 0);
+  }
+  #[inline]
+  pub fn add_checkpoints(&mut self, checkpoints: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Checkpoint<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV1::VT_CHECKPOINTS, checkpoints);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ManifestV1Builder<'a, 'b, A> {
@@ -1069,6 +1286,7 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV1Builder<'a, 'b, A> {
     let o = self.fbb_.end_table(self.start_);
     self.fbb_.required(o, ManifestV1::VT_L0,"l0");
     self.fbb_.required(o, ManifestV1::VT_COMPACTED,"compacted");
+    self.fbb_.required(o, ManifestV1::VT_CHECKPOINTS,"checkpoints");
     flatbuffers::WIPOffset::new(o.value())
   }
 }
@@ -1077,6 +1295,7 @@ impl core::fmt::Debug for ManifestV1<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
     let mut ds = f.debug_struct("ManifestV1");
       ds.field("manifest_id", &self.manifest_id());
+      ds.field("initialized", &self.initialized());
       ds.field("writer_epoch", &self.writer_epoch());
       ds.field("compactor_epoch", &self.compactor_epoch());
       ds.field("wal_id_last_compacted", &self.wal_id_last_compacted());
@@ -1084,8 +1303,8 @@ impl core::fmt::Debug for ManifestV1<'_> {
       ds.field("l0_last_compacted", &self.l0_last_compacted());
       ds.field("l0", &self.l0());
       ds.field("compacted", &self.compacted());
-      ds.field("snapshots", &self.snapshots());
       ds.field("last_clock_tick", &self.last_clock_tick());
+      ds.field("checkpoints", &self.checkpoints());
       ds.finish()
   }
 }
@@ -1204,134 +1423,314 @@ impl core::fmt::Debug for SortedRun<'_> {
       ds.finish()
   }
 }
-pub enum SnapshotOffset {}
+pub enum WriterCheckpointOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
-pub struct Snapshot<'a> {
+pub struct WriterCheckpoint<'a> {
   pub _tab: flatbuffers::Table<'a>,
 }
 
-impl<'a> flatbuffers::Follow<'a> for Snapshot<'a> {
-  type Inner = Snapshot<'a>;
+impl<'a> flatbuffers::Follow<'a> for WriterCheckpoint<'a> {
+  type Inner = WriterCheckpoint<'a>;
   #[inline]
   unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
     Self { _tab: flatbuffers::Table::new(buf, loc) }
   }
 }
 
-impl<'a> Snapshot<'a> {
-  pub const VT_ID: flatbuffers::VOffsetT = 4;
-  pub const VT_MANIFEST_ID: flatbuffers::VOffsetT = 6;
-  pub const VT_SNAPSHOT_EXPIRE_TIME_S: flatbuffers::VOffsetT = 8;
+impl<'a> WriterCheckpoint<'a> {
+  pub const VT_EPOCH: flatbuffers::VOffsetT = 4;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
-    Snapshot { _tab: table }
+    WriterCheckpoint { _tab: table }
   }
   #[allow(unused_mut)]
   pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
     _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
-    args: &'args SnapshotArgs
-  ) -> flatbuffers::WIPOffset<Snapshot<'bldr>> {
-    let mut builder = SnapshotBuilder::new(_fbb);
-    builder.add_manifest_id(args.manifest_id);
-    builder.add_id(args.id);
-    builder.add_snapshot_expire_time_s(args.snapshot_expire_time_s);
+    args: &'args WriterCheckpointArgs
+  ) -> flatbuffers::WIPOffset<WriterCheckpoint<'bldr>> {
+    let mut builder = WriterCheckpointBuilder::new(_fbb);
+    builder.add_epoch(args.epoch);
     builder.finish()
   }
 
 
   #[inline]
-  pub fn id(&self) -> u64 {
+  pub fn epoch(&self) -> u64 {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<u64>(Snapshot::VT_ID, Some(0)).unwrap()}
-  }
-  #[inline]
-  pub fn manifest_id(&self) -> u64 {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<u64>(Snapshot::VT_MANIFEST_ID, Some(0)).unwrap()}
-  }
-  #[inline]
-  pub fn snapshot_expire_time_s(&self) -> u32 {
-    // Safety:
-    // Created from valid Table for this object
-    // which contains a valid value in this slot
-    unsafe { self._tab.get::<u32>(Snapshot::VT_SNAPSHOT_EXPIRE_TIME_S, Some(0)).unwrap()}
+    unsafe { self._tab.get::<u64>(WriterCheckpoint::VT_EPOCH, Some(0)).unwrap()}
   }
 }
 
-impl flatbuffers::Verifiable for Snapshot<'_> {
+impl flatbuffers::Verifiable for WriterCheckpoint<'_> {
   #[inline]
   fn run_verifier(
     v: &mut flatbuffers::Verifier, pos: usize
   ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
     use self::flatbuffers::Verifiable;
     v.visit_table(pos)?
-     .visit_field::<u64>("id", Self::VT_ID, false)?
-     .visit_field::<u64>("manifest_id", Self::VT_MANIFEST_ID, false)?
-     .visit_field::<u32>("snapshot_expire_time_s", Self::VT_SNAPSHOT_EXPIRE_TIME_S, false)?
+     .visit_field::<u64>("epoch", Self::VT_EPOCH, false)?
      .finish();
     Ok(())
   }
 }
-pub struct SnapshotArgs {
-    pub id: u64,
-    pub manifest_id: u64,
-    pub snapshot_expire_time_s: u32,
+pub struct WriterCheckpointArgs {
+    pub epoch: u64,
 }
-impl<'a> Default for SnapshotArgs {
+impl<'a> Default for WriterCheckpointArgs {
   #[inline]
   fn default() -> Self {
-    SnapshotArgs {
-      id: 0,
-      manifest_id: 0,
-      snapshot_expire_time_s: 0,
+    WriterCheckpointArgs {
+      epoch: 0,
     }
   }
 }
 
-pub struct SnapshotBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+pub struct WriterCheckpointBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
   fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
   start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
 }
-impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SnapshotBuilder<'a, 'b, A> {
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> WriterCheckpointBuilder<'a, 'b, A> {
   #[inline]
-  pub fn add_id(&mut self, id: u64) {
-    self.fbb_.push_slot::<u64>(Snapshot::VT_ID, id, 0);
+  pub fn add_epoch(&mut self, epoch: u64) {
+    self.fbb_.push_slot::<u64>(WriterCheckpoint::VT_EPOCH, epoch, 0);
   }
   #[inline]
-  pub fn add_manifest_id(&mut self, manifest_id: u64) {
-    self.fbb_.push_slot::<u64>(Snapshot::VT_MANIFEST_ID, manifest_id, 0);
-  }
-  #[inline]
-  pub fn add_snapshot_expire_time_s(&mut self, snapshot_expire_time_s: u32) {
-    self.fbb_.push_slot::<u32>(Snapshot::VT_SNAPSHOT_EXPIRE_TIME_S, snapshot_expire_time_s, 0);
-  }
-  #[inline]
-  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SnapshotBuilder<'a, 'b, A> {
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> WriterCheckpointBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
-    SnapshotBuilder {
+    WriterCheckpointBuilder {
       fbb_: _fbb,
       start_: start,
     }
   }
   #[inline]
-  pub fn finish(self) -> flatbuffers::WIPOffset<Snapshot<'a>> {
+  pub fn finish(self) -> flatbuffers::WIPOffset<WriterCheckpoint<'a>> {
     let o = self.fbb_.end_table(self.start_);
     flatbuffers::WIPOffset::new(o.value())
   }
 }
 
-impl core::fmt::Debug for Snapshot<'_> {
+impl core::fmt::Debug for WriterCheckpoint<'_> {
   fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-    let mut ds = f.debug_struct("Snapshot");
+    let mut ds = f.debug_struct("WriterCheckpoint");
+      ds.field("epoch", &self.epoch());
+      ds.finish()
+  }
+}
+pub enum CheckpointOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Checkpoint<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Checkpoint<'a> {
+  type Inner = Checkpoint<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> Checkpoint<'a> {
+  pub const VT_ID: flatbuffers::VOffsetT = 4;
+  pub const VT_MANIFEST_ID: flatbuffers::VOffsetT = 6;
+  pub const VT_CHECKPOINT_EXPIRE_TIME_S: flatbuffers::VOffsetT = 8;
+  pub const VT_CHECKPOINT_CREATE_TIME_S: flatbuffers::VOffsetT = 10;
+  pub const VT_METADATA_TYPE: flatbuffers::VOffsetT = 12;
+  pub const VT_METADATA: flatbuffers::VOffsetT = 14;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    Checkpoint { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args CheckpointArgs<'args>
+  ) -> flatbuffers::WIPOffset<Checkpoint<'bldr>> {
+    let mut builder = CheckpointBuilder::new(_fbb);
+    builder.add_manifest_id(args.manifest_id);
+    if let Some(x) = args.metadata { builder.add_metadata(x); }
+    builder.add_checkpoint_create_time_s(args.checkpoint_create_time_s);
+    builder.add_checkpoint_expire_time_s(args.checkpoint_expire_time_s);
+    if let Some(x) = args.id { builder.add_id(x); }
+    builder.add_metadata_type(args.metadata_type);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn id(&self) -> Uuid<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Uuid>>(Checkpoint::VT_ID, None).unwrap()}
+  }
+  #[inline]
+  pub fn manifest_id(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(Checkpoint::VT_MANIFEST_ID, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn checkpoint_expire_time_s(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(Checkpoint::VT_CHECKPOINT_EXPIRE_TIME_S, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn checkpoint_create_time_s(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(Checkpoint::VT_CHECKPOINT_CREATE_TIME_S, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn metadata_type(&self) -> CheckpointMetadata {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<CheckpointMetadata>(Checkpoint::VT_METADATA_TYPE, Some(CheckpointMetadata::NONE)).unwrap()}
+  }
+  #[inline]
+  pub fn metadata(&self) -> Option<flatbuffers::Table<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Table<'a>>>(Checkpoint::VT_METADATA, None)}
+  }
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn metadata_as_writer_checkpoint(&self) -> Option<WriterCheckpoint<'a>> {
+    if self.metadata_type() == CheckpointMetadata::WriterCheckpoint {
+      self.metadata().map(|t| {
+       // Safety:
+       // Created from a valid Table for this object
+       // Which contains a valid union in this slot
+       unsafe { WriterCheckpoint::init_from_table(t) }
+     })
+    } else {
+      None
+    }
+  }
+
+}
+
+impl flatbuffers::Verifiable for Checkpoint<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Uuid>>("id", Self::VT_ID, true)?
+     .visit_field::<u64>("manifest_id", Self::VT_MANIFEST_ID, false)?
+     .visit_field::<u32>("checkpoint_expire_time_s", Self::VT_CHECKPOINT_EXPIRE_TIME_S, false)?
+     .visit_field::<u32>("checkpoint_create_time_s", Self::VT_CHECKPOINT_CREATE_TIME_S, false)?
+     .visit_union::<CheckpointMetadata, _>("metadata_type", Self::VT_METADATA_TYPE, "metadata", Self::VT_METADATA, false, |key, v, pos| {
+        match key {
+          CheckpointMetadata::WriterCheckpoint => v.verify_union_variant::<flatbuffers::ForwardsUOffset<WriterCheckpoint>>("CheckpointMetadata::WriterCheckpoint", pos),
+          _ => Ok(()),
+        }
+     })?
+     .finish();
+    Ok(())
+  }
+}
+pub struct CheckpointArgs<'a> {
+    pub id: Option<flatbuffers::WIPOffset<Uuid<'a>>>,
+    pub manifest_id: u64,
+    pub checkpoint_expire_time_s: u32,
+    pub checkpoint_create_time_s: u32,
+    pub metadata_type: CheckpointMetadata,
+    pub metadata: Option<flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>>,
+}
+impl<'a> Default for CheckpointArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    CheckpointArgs {
+      id: None, // required field
+      manifest_id: 0,
+      checkpoint_expire_time_s: 0,
+      checkpoint_create_time_s: 0,
+      metadata_type: CheckpointMetadata::NONE,
+      metadata: None,
+    }
+  }
+}
+
+pub struct CheckpointBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> CheckpointBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_id(&mut self, id: flatbuffers::WIPOffset<Uuid<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Uuid>>(Checkpoint::VT_ID, id);
+  }
+  #[inline]
+  pub fn add_manifest_id(&mut self, manifest_id: u64) {
+    self.fbb_.push_slot::<u64>(Checkpoint::VT_MANIFEST_ID, manifest_id, 0);
+  }
+  #[inline]
+  pub fn add_checkpoint_expire_time_s(&mut self, checkpoint_expire_time_s: u32) {
+    self.fbb_.push_slot::<u32>(Checkpoint::VT_CHECKPOINT_EXPIRE_TIME_S, checkpoint_expire_time_s, 0);
+  }
+  #[inline]
+  pub fn add_checkpoint_create_time_s(&mut self, checkpoint_create_time_s: u32) {
+    self.fbb_.push_slot::<u32>(Checkpoint::VT_CHECKPOINT_CREATE_TIME_S, checkpoint_create_time_s, 0);
+  }
+  #[inline]
+  pub fn add_metadata_type(&mut self, metadata_type: CheckpointMetadata) {
+    self.fbb_.push_slot::<CheckpointMetadata>(Checkpoint::VT_METADATA_TYPE, metadata_type, CheckpointMetadata::NONE);
+  }
+  #[inline]
+  pub fn add_metadata(&mut self, metadata: flatbuffers::WIPOffset<flatbuffers::UnionWIPOffset>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Checkpoint::VT_METADATA, metadata);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> CheckpointBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    CheckpointBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Checkpoint<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, Checkpoint::VT_ID,"id");
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for Checkpoint<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("Checkpoint");
       ds.field("id", &self.id());
       ds.field("manifest_id", &self.manifest_id());
-      ds.field("snapshot_expire_time_s", &self.snapshot_expire_time_s());
+      ds.field("checkpoint_expire_time_s", &self.checkpoint_expire_time_s());
+      ds.field("checkpoint_create_time_s", &self.checkpoint_create_time_s());
+      ds.field("metadata_type", &self.metadata_type());
+      match self.metadata_type() {
+        CheckpointMetadata::WriterCheckpoint => {
+          if let Some(x) = self.metadata_as_writer_checkpoint() {
+            ds.field("metadata", &x)
+          } else {
+            ds.field("metadata", &"InvalidFlatbuffer: Union discriminant does not match value.")
+          }
+        },
+        _ => {
+          let x: Option<()> = None;
+          ds.field("metadata", &x)
+        },
+      };
       ds.finish()
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod blob;
 mod block;
 mod block_iterator;
 mod cached_object_store;
-mod checkpoint;
+pub mod checkpoint;
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
 mod compactor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod blob;
 mod block;
 mod block_iterator;
 mod cached_object_store;
+mod checkpoint;
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
 mod compactor;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,7 +3,7 @@ use crate::error::SlateDBError;
 use bytes::Bytes;
 use serde::Serialize;
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Serialize, PartialEq, Debug)]
 pub(crate) struct Manifest {
     pub(crate) core: CoreDbState,
     pub(crate) writer_epoch: u64,

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -18,6 +18,31 @@ use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
 
+/// Helper function that applies an update to a stored manifest, and retries the update
+/// if the write fails due to a manifest version conflict caused by another client
+/// updating the manifest at the same time. The update to be applied is specified by
+/// the mutator parameter, which is a function that takes a &StoredManifest and returns
+/// the updated CoreDbState.
+pub(crate) async fn apply_db_state_update<F>(
+    manifest: &mut StoredManifest,
+    mutator: F,
+) -> Result<(), SlateDBError>
+where
+    F: Fn(&StoredManifest) -> Result<CoreDbState, SlateDBError>,
+{
+    loop {
+        let mutated_db_state = mutator(manifest)?;
+        return match manifest.update_db_state(mutated_db_state).await {
+            Err(SlateDBError::ManifestVersionExists) => {
+                manifest.refresh().await?;
+                continue;
+            }
+            Err(e) => Err(e),
+            Ok(()) => Ok(()),
+        };
+    }
+}
+
 pub(crate) struct FenceableManifest {
     stored_manifest: StoredManifest,
     local_epoch: u64,
@@ -122,6 +147,9 @@ impl StoredManifest {
         })
     }
 
+    /// Load the current manifest from the supplied manifest store. If there is no db at the
+    /// manifest store's path then this fn returns None. Otherwise, on success it returns a
+    /// Result with an instance of StoredManifest.
     pub(crate) async fn load(store: Arc<ManifestStore>) -> Result<Option<Self>, SlateDBError> {
         let Some((id, manifest)) = store.read_latest_manifest().await? else {
             return Ok(None);
@@ -131,6 +159,10 @@ impl StoredManifest {
             manifest,
             manifest_store: store,
         }))
+    }
+
+    pub(crate) fn id(&self) -> u64 {
+        self.id
     }
 
     pub(crate) fn db_state(&self) -> &CoreDbState {

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -656,12 +656,14 @@ mod tests {
 
     fn create_db_state(l0: VecDeque<SsTableHandle>, srs: Vec<SortedRun>) -> CoreDbState {
         CoreDbState {
+            initialized: true,
             l0_last_compacted: None,
             l0,
             compacted: srs,
             next_wal_sst_id: 0,
             last_compacted_wal_sst_id: 0,
             last_clock_tick: 0,
+            checkpoints: vec![],
         }
     }
 


### PR DESCRIPTION
This patch adds the manifest model for checkpoints
- Changes usage of the term "snapshot" to "checkpoint" in the manifest schema.
- adds the checkpoint_create_time_s, id, and metadata fields to checkpoint table
- adds the initialized field to the manifest (this is always set to true for now)
- plumbing for storing checkpoints in CoreDbState and encoding/decoding to/from the manifest bytes.

Also adds the initial API for creating checkpoints (from arbitrary clients and not the main db writer - this will be added in a later commit)

Review Guide:
- Review the changes to manifest.fbs
- Review the changes to `CoreDbState` that adds checkpoints and the plumbing to encode/decode these in the manifest
- Review the new API for checkpoint creation (the `create_checkpoint` API and the associated options)

Fixes https://github.com/slatedb/slatedb/issues/309

Changes for this feature: https://github.com/slatedb/slatedb/milestone/6