### PR TITLE
chore: Separate WAL and MemTable flushing mechanisms.

### DIFF
--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -3,8 +3,7 @@ use parking_lot::RwLockWriteGuard;
 use crate::db::DbInner;
 use crate::db_state::DbState;
 use crate::error::SlateDBError;
-use crate::flush::FlushThreadMsg;
-
+use crate::mem_table_flush::MemtableFlushThreadMsg;
 impl DbInner {
     pub(crate) fn maybe_freeze_memtable(
         &self,
@@ -16,7 +15,7 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id);
         self.memtable_flush_notifier
-            .send(FlushThreadMsg::Flush(None))?;
+            .send(MemtableFlushThreadMsg::FlushImmutableMemtables(None))?;
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::flush::FlushThreadMsg;
+use crate::{flush::WalFlushThreadMsg, mem_table_flush::MemtableFlushThreadMsg};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SlateDBError {
@@ -58,8 +58,11 @@ pub enum SlateDBError {
     #[error("Unknown RowFlags -- this may be caused by reading data encoded with a newer codec")]
     InvalidRowFlags,
 
-    #[error("Flush channel error: {0}")]
-    FlushChannelError(#[from] tokio::sync::mpsc::error::SendError<FlushThreadMsg>),
+    #[error("Error flushing immutable wals: {0}")]
+    FlushChannelError(#[from] tokio::sync::mpsc::error::SendError<WalFlushThreadMsg>),
+
+    #[error("Error flushing memtables: {0}")]
+    MemtableFlushError(#[from] tokio::sync::mpsc::error::SendError<MemtableFlushThreadMsg>),
 
     #[error("Read channel error: {0}")]
     ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),


### PR DESCRIPTION
Use two different enums to represent flushing both structures since they can have different semantics.

/cc @rodesai 