### PR TITLE
fix(compaction): filter tombstones out when compacting into the last sorted run

### DIFF
--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -301,11 +301,16 @@ impl CompactionExecuteBench {
         let job = match &compaction {
             Some(compaction) => {
                 info!("load job from existing compaction");
-                CompactionExecuteBench::load_compaction_as_job(&manifest, compaction)
+                CompactionExecuteBench::load_compaction_as_job(&manifest, compaction, false)
             }
             None => {
-                CompactionExecuteBench::load_compaction_job(&manifest, num_ssts, &table_store)
-                    .await?
+                CompactionExecuteBench::load_compaction_job(
+                    &manifest,
+                    num_ssts,
+                    &table_store,
+                    false,
+                )
+                .await?
             }
         };
         let start = std::time::Instant::now();

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -181,6 +181,7 @@ impl CompactionExecuteBench {
         manifest: &StoredManifest,
         num_ssts: usize,
         table_store: &Arc<TableStore>,
+        is_dest_last_run: bool,
     ) -> Result<CompactionJob, SlateDBError> {
         let sst_ids: Vec<SsTableId> = (0u32..num_ssts as u32)
             .map(CompactionExecuteBench::sst_id)
@@ -222,10 +223,15 @@ impl CompactionExecuteBench {
             ssts,
             sorted_runs: vec![],
             compaction_ts: manifest.db_state().last_l0_clock_tick,
+            is_dest_last_run,
         })
     }
 
-    fn load_compaction_as_job(manifest: &StoredManifest, compaction: &Compaction) -> CompactionJob {
+    fn load_compaction_as_job(
+        manifest: &StoredManifest,
+        compaction: &Compaction,
+        is_dest_last_run: bool,
+    ) -> CompactionJob {
         let state = manifest.db_state();
         let srs_by_id: HashMap<_, _> = state
             .compacted
@@ -249,6 +255,7 @@ impl CompactionExecuteBench {
             ssts: vec![],
             sorted_runs: srs,
             compaction_ts: state.last_l0_clock_tick,
+            is_dest_last_run,
         }
     }
 

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -341,12 +341,19 @@ impl CompactorEventHandler {
             .filter_map(|s| s.maybe_unwrap_sorted_run())
             .filter_map(|id| srs_by_id.get(&id).map(|t| (*t).clone()))
             .collect();
+        // if there are no SRs when we compact L0 then the resulting SR is the last sorted run.
+        let is_dest_last_run = db_state.compacted.is_empty()
+            || db_state
+                .compacted
+                .last()
+                .is_some_and(|sr| compaction.destination == sr.id);
         self.executor.start_compaction(CompactionJob {
             id,
             destination: compaction.destination,
             ssts,
             sorted_runs,
             compaction_ts: db_state.last_l0_clock_tick,
+            is_dest_last_run,
         });
     }
 

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -347,13 +347,6 @@ impl CompactorEventHandler {
                 .compacted
                 .last()
                 .is_some_and(|sr| compaction.destination == sr.id);
-        info!(
-            "Compaction destination run determination: is_dest_last_run={}, compacted_empty={}, last_sr_id={:?}, compaction_destination={}",
-            is_dest_last_run,
-            db_state.compacted.is_empty(),
-            db_state.compacted.last().map(|sr| sr.id),
-            compaction.destination
-        );
         self.executor.start_compaction(CompactionJob {
             id,
             destination: compaction.destination,

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -1033,6 +1033,7 @@ mod tests {
         .await
     }
 
+    #[allow(unused)] // only used with feature(wal_disable)
     async fn await_compacted_compaction(
         manifest_store: Arc<ManifestStore>,
         old_compacted: Vec<SortedRun>,
@@ -1138,11 +1139,13 @@ mod tests {
         }
     }
 
+    #[allow(unused)] // only used with feature(wal_disable)
     #[derive(Clone)]
     struct OnDemandCompactionScheduler {
         should_compact: Arc<AtomicBool>,
     }
 
+    #[allow(unused)] // only used with feature(wal_disable)
     impl OnDemandCompactionScheduler {
         fn new() -> Self {
             Self {
@@ -1185,10 +1188,12 @@ mod tests {
         }
     }
 
+    #[allow(unused)] // only used with feature(wal_disable)
     struct OnDemandCompactionSchedulerSupplier {
         scheduler: OnDemandCompactionScheduler,
     }
 
+    #[allow(unused)] // only used with feature(wal_disable)
     impl OnDemandCompactionSchedulerSupplier {
         fn new() -> Self {
             Self {

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -347,6 +347,13 @@ impl CompactorEventHandler {
                 .compacted
                 .last()
                 .is_some_and(|sr| compaction.destination == sr.id);
+        info!(
+            "Compaction destination run determination: is_dest_last_run={}, compacted_empty={}, last_sr_id={:?}, compaction_destination={}",
+            is_dest_last_run,
+            db_state.compacted.is_empty(),
+            db_state.compacted.last().map(|sr| sr.id),
+            compaction.destination
+        );
         self.executor.start_compaction(CompactionJob {
             id,
             destination: compaction.destination,
@@ -440,6 +447,8 @@ pub mod stats {
 #[cfg(test)]
 mod tests {
     use std::future::Future;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering::SeqCst;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
 
@@ -459,10 +468,11 @@ mod tests {
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
     use crate::compactor_stats::LAST_COMPACTION_TS_SEC;
     use crate::config::{
-        DbOptions, PutOptions, SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
+        CompactionSchedulerSupplier, DbOptions, PutOptions, SizeTieredCompactionSchedulerOptions,
+        Ttl, WriteOptions,
     };
     use crate::db::Db;
-    use crate::db_state::CoreDbState;
+    use crate::db_state::{CoreDbState, SortedRun};
     use crate::iter::KeyValueIterator;
     use crate::manifest::store::{ManifestStore, StoredManifest};
 
@@ -525,6 +535,80 @@ mod tests {
         }
         assert!(iter.next().await.unwrap().is_none());
         // todo: test that the db can read the k/vs (once we implement reading from compacted)
+    }
+
+    #[cfg(feature = "wal_disable")]
+    #[tokio::test]
+    async fn test_should_tombstones_in_l0() {
+        let clock = Arc::new(TestClock::new());
+        let mut compactor_opts = compactor_options();
+        let scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new());
+        compactor_opts.compaction_scheduler = scheduler.clone();
+        let mut options = db_options(Some(compactor_opts), clock.clone());
+        options.wal_enabled = false;
+        options.l0_sst_size_bytes = 128;
+        let (_, manifest_store, table_store, db) = build_test_db(options).await;
+
+        // put key 'a' into L1 (and key 'b' so that when we delete 'a' the SST is non-empty)
+        db.put(&[b'a'; 16], &[b'a'; 32]).await.unwrap();
+        db.put(&[b'b'; 16], &[b'a'; 32]).await.unwrap();
+        db.flush().await.unwrap();
+        scheduler.scheduler.should_compact.store(true, SeqCst);
+        let db_state = await_compaction(manifest_store.clone()).await.unwrap();
+        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.l0.len(), 0, "{}", format!("{:?}", db_state.l0));
+
+        // put tombstone for key a into L0
+        db.delete_with_options(
+            &[b'a'; 16],
+            &WriteOptions {
+                await_durable: false,
+            },
+        )
+        .await
+        .unwrap();
+        db.flush().await.unwrap();
+
+        // Then:
+        // we should now have a tombstone in L0 and a value in L1
+        let db_state = get_db_state(manifest_store.clone()).await;
+        assert_eq!(db_state.l0.len(), 1, "{}", format!("{:?}", db_state.l0));
+        assert_eq!(db_state.compacted.len(), 1);
+
+        let l0 = db_state.l0.front().unwrap();
+        let mut iter =
+            SstIterator::new_borrowed(.., l0, table_store.clone(), SstIteratorOptions::default())
+                .await
+                .unwrap();
+
+        let tombstone = iter.next_entry().await.unwrap();
+        assert!(tombstone.unwrap().value.is_tombstone());
+
+        scheduler.scheduler.should_compact.store(true, SeqCst);
+        let db_state = await_compacted_compaction(manifest_store.clone(), db_state.compacted)
+            .await
+            .unwrap();
+        assert_eq!(db_state.compacted.len(), 1);
+
+        let compacted = &db_state.compacted.first().unwrap().ssts;
+        assert_eq!(compacted.len(), 1);
+        let handle = compacted.first().unwrap();
+
+        let mut iter = SstIterator::new_borrowed(
+            ..,
+            handle,
+            table_store.clone(),
+            SstIteratorOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        // should be no tombstone for key 'a' because it was filtered
+        // out of the last run
+        let next = iter.next().await.unwrap();
+        assert_eq!(next.unwrap().key.as_ref(), &[b'b'; 16]);
+        let next = iter.next().await.unwrap();
+        assert!(next.is_none());
     }
 
     #[tokio::test]
@@ -630,7 +714,7 @@ mod tests {
                 RowEntry::new_value(&[1; 16], value, 4)
                     .with_create_ts(70)
                     .with_expire_ts(150),
-                RowEntry::new_tombstone(&[2; 16], 2).with_create_ts(10),
+                // no tombstone for &[2; 16] because this is the last layer of the tree,
                 RowEntry::new_value(&[3; 16], value, 3).with_create_ts(30),
             ],
         )
@@ -947,14 +1031,32 @@ mod tests {
 
     async fn await_compaction(manifest_store: Arc<ManifestStore>) -> Option<CoreDbState> {
         run_for(Duration::from_secs(10), || async {
-            let stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
-            let db_state = stored_manifest.db_state();
+            let db_state = get_db_state(manifest_store.clone()).await;
             if db_state.l0_last_compacted.is_some() {
-                return Some(db_state.clone());
+                return Some(db_state);
             }
             None
         })
         .await
+    }
+
+    async fn await_compacted_compaction(
+        manifest_store: Arc<ManifestStore>,
+        old_compacted: Vec<SortedRun>,
+    ) -> Option<CoreDbState> {
+        run_for(Duration::from_secs(10), || async {
+            let db_state = get_db_state(manifest_store.clone()).await;
+            if !db_state.compacted.eq(&old_compacted) {
+                return Some(db_state);
+            }
+            None
+        })
+        .await
+    }
+
+    async fn get_db_state(manifest_store: Arc<ManifestStore>) -> CoreDbState {
+        let stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
+        stored_manifest.db_state().clone()
     }
 
     fn db_options(compactor_options: Option<CompactorOptions>, clock: Arc<TestClock>) -> DbOptions {
@@ -1040,6 +1142,71 @@ mod tests {
 
         fn is_stopped(&self) -> bool {
             false
+        }
+    }
+
+    #[derive(Clone)]
+    struct OnDemandCompactionScheduler {
+        should_compact: Arc<AtomicBool>,
+    }
+
+    impl OnDemandCompactionScheduler {
+        fn new() -> Self {
+            Self {
+                should_compact: Arc::new(AtomicBool::new(false)),
+            }
+        }
+    }
+
+    impl CompactionScheduler for OnDemandCompactionScheduler {
+        fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction> {
+            if !self.should_compact.load(SeqCst) {
+                return vec![];
+            }
+
+            // this compactor will only compact if there are L0s,
+            // it won't compact only lower levels for simplicity
+            let db_state = state.db_state();
+            if db_state.l0.is_empty() {
+                return vec![];
+            }
+
+            self.should_compact.store(false, SeqCst);
+
+            // always compact into sorted run 0
+            let next_sr_id = 0;
+
+            // Create a compaction of all SSTs from L0 and all sorted runs
+            let mut sources: Vec<SourceId> = db_state
+                .l0
+                .iter()
+                .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+                .collect();
+
+            // Add SSTs from all sorted runs
+            for sr in &db_state.compacted {
+                sources.push(SourceId::SortedRun(sr.id));
+            }
+
+            vec![Compaction::new(sources, next_sr_id)]
+        }
+    }
+
+    struct OnDemandCompactionSchedulerSupplier {
+        scheduler: OnDemandCompactionScheduler,
+    }
+
+    impl OnDemandCompactionSchedulerSupplier {
+        fn new() -> Self {
+            Self {
+                scheduler: OnDemandCompactionScheduler::new(),
+            }
+        }
+    }
+
+    impl CompactionSchedulerSupplier for OnDemandCompactionSchedulerSupplier {
+        fn compaction_scheduler(&self) -> Box<dyn CompactionScheduler> {
+            Box::new(self.scheduler.clone())
         }
     }
 }

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -32,6 +32,7 @@ pub(crate) struct CompactionJob {
     pub(crate) ssts: Vec<SsTableHandle>,
     pub(crate) sorted_runs: Vec<SortedRun>,
     pub(crate) compaction_ts: i64,
+    pub(crate) is_dest_last_run: bool,
 }
 
 pub(crate) trait CompactionExecutor {
@@ -157,6 +158,10 @@ impl TokioCompactionExecutorInner {
                 }
                 _ => raw_kv,
             };
+
+            if compaction.is_dest_last_run && kv.value.is_tombstone() {
+                continue;
+            }
 
             // Add to SST
             let key_len = kv.key.len();

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,4 +155,11 @@ impl ValueDeletable {
             ValueDeletable::Tombstone => None,
         }
     }
+
+    pub fn is_tombstone(&self) -> bool {
+        match self {
+            ValueDeletable::Value(_) => false,
+            ValueDeletable::Tombstone => true,
+        }
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -159,6 +159,7 @@ impl ValueDeletable {
     pub fn is_tombstone(&self) -> bool {
         match self {
             ValueDeletable::Value(_) => false,
+            ValueDeletable::Merge(_) => false,
             ValueDeletable::Tombstone => true,
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -157,10 +157,6 @@ impl ValueDeletable {
     }
 
     pub fn is_tombstone(&self) -> bool {
-        match self {
-            ValueDeletable::Value(_) => false,
-            ValueDeletable::Merge(_) => false,
-            ValueDeletable::Tombstone => true,
-        }
+        matches!(self, ValueDeletable::Tombstone)
     }
 }


### PR DESCRIPTION
This PR will close #285

Unfortunately I didn't come up with a good way to add unit tests, because tombstones behave the same when accessed via the `Get` operation regardless of whether they're physically removed or not.

I followed @rodesai suggestion of letting the orchestrator decide whether the dest sorted run is the last sorted run or not.