### PR TITLE
fix(flush): Handle background flush errors.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -97,7 +97,7 @@ impl DbInner {
         key: &[u8],
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, SlateDBError> {
-        let _ = self.check_error()?;
+        self.check_error()?;
         let snapshot = self.state.read().snapshot();
 
         if matches!(options.read_level, Uncommitted) {
@@ -233,7 +233,7 @@ impl DbInner {
         batch: WriteBatch,
         options: &WriteOptions,
     ) -> Result<(), SlateDBError> {
-        let _ = self.check_error()?;
+        self.check_error()?;
 
         if batch.ops.is_empty() {
             return Ok(());

--- a/src/db.rs
+++ b/src/db.rs
@@ -64,6 +64,7 @@ pub(crate) struct DbInner {
     pub(crate) memtable_flush_notifier: tokio::sync::mpsc::UnboundedSender<MemtableFlushThreadMsg>,
     pub(crate) write_notifier: tokio::sync::mpsc::UnboundedSender<WriteBatchMsg>,
     pub(crate) db_stats: Arc<DbStats>,
+    pub(crate) error: RwLock<Option<SlateDBError>>,
 }
 
 impl DbInner {
@@ -85,6 +86,7 @@ impl DbInner {
             memtable_flush_notifier,
             write_notifier,
             db_stats,
+            error: RwLock::new(None),
         };
         Ok(db_inner)
     }
@@ -95,13 +97,10 @@ impl DbInner {
         key: &[u8],
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, SlateDBError> {
-        let snapshot = {
-            let state = self.state.read();
-            if let Some(err) = state.error() {
-                return Err(err);
-            }
-            state.snapshot()
-        };
+        if let Some(err) = self.error() {
+            return Err(err);
+        }
+        let snapshot = self.state.read().snapshot();
 
         if matches!(options.read_level, Uncommitted) {
             let maybe_val = std::iter::once(snapshot.wal)
@@ -236,11 +235,8 @@ impl DbInner {
         batch: WriteBatch,
         options: &WriteOptions,
     ) -> Result<(), SlateDBError> {
-        {
-            let state = self.state.read();
-            if let Some(err) = state.error() {
-                return Err(err);
-            }
+        if let Some(err) = self.error() {
+            return Err(err);
         }
 
         if batch.ops.is_empty() {
@@ -436,6 +432,24 @@ impl DbInner {
         );
 
         Ok(())
+    }
+
+    /// Return an error if the state has encountered
+    /// an unrecoverable error.
+    pub(crate) fn error(&self) -> Option<SlateDBError> {
+        self.error.read().clone()
+    }
+
+    /// Set the state error if it is not already set.
+    ///
+    /// We only care about the first error because
+    /// subsequent errors are likely to be the result of
+    /// the first error.
+    pub(crate) fn set_error_if_none(&self, new_error: SlateDBError) {
+        let mut error = self.error.write();
+        if error.is_none() {
+            *error = Some(new_error);
+        }
     }
 }
 
@@ -1978,6 +1992,70 @@ mod tests {
         kv_store.close().await.unwrap();
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_should_recover_imm_from_wal() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "pause").unwrap();
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let mut next_wal_id = 1;
+        let db = Db::open_with_fp_registry(
+            path.clone(),
+            test_db_options(0, 128, None),
+            object_store.clone(),
+            fp_registry.clone(),
+        )
+        .await
+        .unwrap();
+        next_wal_id += 1;
+
+        // write a few keys that will result in memtable flushes
+        let key1 = [b'a'; 32];
+        let value1 = [b'b'; 96];
+        db.put(&key1, &value1).await.unwrap();
+        next_wal_id += 1;
+        let key2 = [b'c'; 32];
+        let value2 = [b'd'; 96];
+        db.put(&key2, &value2).await.unwrap();
+        next_wal_id += 1;
+
+        let reader = Db::open_with_opts(
+            path.clone(),
+            test_db_options(0, 128, None),
+            object_store.clone(),
+        )
+        .await
+        .unwrap();
+
+        // increment wal id for the empty wal
+        next_wal_id += 1;
+
+        // verify that we reload imm
+        let snapshot = reader.inner.state.read().snapshot();
+        assert_eq!(snapshot.state.imm_memtable.len(), 2);
+
+        // one empty wal and two wals for the puts
+        assert_eq!(
+            snapshot.state.imm_memtable.front().unwrap().last_wal_id(),
+            1 + 2
+        );
+        assert_eq!(snapshot.state.imm_memtable.get(1).unwrap().last_wal_id(), 2);
+        assert_eq!(snapshot.state.core.next_wal_sst_id, next_wal_id);
+        assert_eq!(
+            db.get(&key1).await.unwrap(),
+            Some(Bytes::copy_from_slice(&value1))
+        );
+        assert_eq!(
+            db.get(&key2).await.unwrap(),
+            Some(Bytes::copy_from_slice(&value2))
+        );
+
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
+        db.close().await.unwrap();
+        reader.close().await.unwrap();
+    }
+
     #[tokio::test]
     async fn test_should_recover_imm_from_wal_after_flush_error() {
         let fp_registry = Arc::new(FailPointRegistry::new());
@@ -2023,8 +2101,6 @@ mod tests {
         )
         .await
         .unwrap();
-        // // increment wal id for the empty wal
-        // next_wal_id += 1;
 
         // verify that we reload imm
         let snapshot = db.inner.state.read().snapshot();

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -17,7 +17,8 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id);
         self.memtable_flush_notifier
-            .send(MemtableFlushThreadMsg::FlushImmutableMemtables(None))?;
+            .send(MemtableFlushThreadMsg::FlushImmutableMemtables(None))
+            .map_err(|_| SlateDBError::MemtableFlushChannelError)?;
         Ok(())
     }
 
@@ -34,7 +35,8 @@ impl DbInner {
         }
         guard.freeze_wal();
         self.wal_flush_notifier
-            .send(WalFlushThreadMsg::FlushImmutableWals(None))?;
+            .send(WalFlushThreadMsg::FlushImmutableWals(None))
+            .map_err(|_| SlateDBError::WalFlushChannelError)?;
         Ok(())
     }
 }

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -156,7 +156,6 @@ pub(crate) struct COWDbState {
     pub(crate) imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
     pub(crate) imm_wal: VecDeque<Arc<ImmutableWal>>,
     pub(crate) core: CoreDbState,
-    pub(crate) error: Option<SlateDBError>,
 }
 
 // represents the core db state that we persist in the manifest
@@ -218,7 +217,6 @@ impl DbState {
                 imm_memtable: VecDeque::new(),
                 imm_wal: VecDeque::new(),
                 core: core_db_state,
-                error: None,
             }),
         }
     }
@@ -238,12 +236,6 @@ impl DbState {
     pub fn last_written_wal_id(&self) -> u64 {
         assert!(self.state.core.next_wal_sst_id > 0);
         self.state.core.next_wal_sst_id - 1
-    }
-
-    /// Return an error if the state has encountered
-    /// an unrecoverable error.
-    pub fn error(&self) -> Option<SlateDBError> {
-        self.state.error.clone()
     }
 
     // mutations
@@ -347,19 +339,6 @@ impl DbState {
         state.core.l0 = new_l0;
         state.core.compacted = compacted;
         self.update_state(state);
-    }
-
-    /// Set the state error if it is not already set.
-    ///
-    /// We only care about the first error because
-    /// subsequent errors are likely to be the result of
-    /// the first error.
-    pub fn set_error_if_none(&mut self, error: SlateDBError) {
-        let mut state = self.state_copy();
-        if state.error.is_none() {
-            state.error = Some(error);
-            self.update_state(state);
-        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,10 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, sync::Arc};
+use thiserror::Error;
 
-use crate::{flush::WalFlushThreadMsg, mem_table_flush::MemtableFlushThreadMsg};
-
-#[derive(thiserror::Error, Debug)]
+#[derive(Clone, Debug, Error)]
 pub enum SlateDBError {
     #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    IoError(#[from] Arc<std::io::Error>),
 
     #[error("Checksum mismatch")]
     ChecksumMismatch,
@@ -20,7 +19,7 @@ pub enum SlateDBError {
     EmptyBlock,
 
     #[error("Object store error: {0}")]
-    ObjectStoreError(#[from] object_store::Error),
+    ObjectStoreError(#[from] Arc<object_store::Error>),
 
     #[error("Manifest file already exists")]
     ManifestVersionExists,
@@ -65,14 +64,26 @@ pub enum SlateDBError {
     #[error("Unknown RowFlags -- this may be caused by reading data encoded with a newer codec")]
     InvalidRowFlags,
 
-    #[error("Error flushing immutable wals: {0}")]
-    FlushChannelError(#[from] tokio::sync::mpsc::error::SendError<WalFlushThreadMsg>),
+    #[error("Error flushing immutable wals: channel closed")]
+    WalFlushChannelError,
 
-    #[error("Error flushing memtables: {0}")]
-    MemtableFlushError(#[from] tokio::sync::mpsc::error::SendError<MemtableFlushThreadMsg>),
+    #[error("Error flushing memtables: channel closed")]
+    MemtableFlushChannelError,
 
     #[error("Read channel error: {0}")]
     ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
+}
+
+impl From<std::io::Error> for SlateDBError {
+    fn from(value: std::io::Error) -> Self {
+        Self::IoError(Arc::new(value))
+    }
+}
+
+impl From<object_store::Error> for SlateDBError {
+    fn from(value: object_store::Error) -> Self {
+        Self::ObjectStoreError(Arc::new(value))
+    }
 }
 
 /// Represents errors that can occur during the database configuration.

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -103,7 +103,7 @@ impl DbInner {
                      let result = this.flush().await;
                      if let Err(err) = result {
                         error!("error from wal flush: {err}");
-                        this.state.write().set_error_if_none(err);
+                        this.set_error_if_none(err);
                      }
                   }
                   msg = rx.recv() => {
@@ -118,14 +118,14 @@ impl DbInner {
                                 let result = this.flush().await;
                                 if let Err(err) = &result {
                                     error!("error from wal flush: {err}");
-                                    this.state.write().set_error_if_none(err.clone());
+                                    this.set_error_if_none(err.clone());
                                 }
 
                                 if let Some(rsp) = rsp {
                                     let res = rsp.send(result);
                                     if let Err(Err(err)) = res {
                                         error!("error sending flush response: {err}");
-                                        this.state.write().set_error_if_none(err);
+                                        this.set_error_if_none(err);
                                     }
                                 }
                             },

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -98,15 +98,15 @@ impl DbInner {
             let mut ticker = tokio::time::interval(this.options.flush_interval);
             loop {
                 select! {
-                  // Tick to freeze and flush the memtable
-                  _ = ticker.tick() => {
-                     let result = this.flush().await;
-                     if let Err(err) = result {
-                        error!("error from wal flush: {err}");
-                        this.set_error_if_none(err);
-                     }
-                  }
-                  msg = rx.recv() => {
+                    // Tick to freeze and flush the memtable
+                    _ = ticker.tick() => {
+                        let result = this.flush().await;
+                        if let Err(err) = result {
+                            error!("error from wal flush: {err}");
+                            this.set_error_if_none(err);
+                        }
+                    }
+                    msg = rx.recv() => {
                         let msg = msg.expect("channel unexpectedly closed");
                         match msg {
                             WalFlushThreadMsg::Shutdown => {
@@ -130,7 +130,7 @@ impl DbInner {
                                 }
                             },
                         }
-                  }
+                    }
                 }
             }
         }))

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use tokio::runtime::Handle;
 use tokio::select;
+use tracing::error;
 
 use crate::db::DbInner;
 use crate::db_state;
@@ -93,7 +94,11 @@ impl DbInner {
                 select! {
                   // Tick to freeze and flush the memtable
                   _ = ticker.tick() => {
-                    _ = this.flush().await;
+                     let result = this.flush().await;
+                     if let Err(err) = result {
+                        error!("error from wal flush: {err}");
+                        this.state.write().set_error_if_none(err);
+                     }
                   }
                   msg = rx.recv() => {
                         let msg = msg.expect("channel unexpectedly closed");
@@ -105,8 +110,17 @@ impl DbInner {
                             },
                             WalFlushThreadMsg::FlushImmutableWals(rsp) => {
                                 let result = this.flush().await;
+                                if let Err(err) = &result {
+                                    error!("error from wal flush: {err}");
+                                    this.state.write().set_error_if_none(err.clone());
+                                }
+
                                 if let Some(rsp) = rsp {
-                                    rsp.send(result).expect("send flush result");
+                                    let res = rsp.send(result);
+                                    if let Err(Err(err)) = res {
+                                        error!("error sending flush response: {err}");
+                                        this.state.write().set_error_if_none(err);
+                                    }
                                 }
                             },
                         }

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -248,7 +248,7 @@ impl ManifestStore {
                 if let AlreadyExists { path: _, source: _ } = err {
                     SlateDBError::ManifestVersionExists
                 } else {
-                    SlateDBError::ObjectStoreError(err)
+                    SlateDBError::from(err)
                 }
             })?;
 
@@ -284,7 +284,7 @@ impl ManifestStore {
 
         while let Some(file) = match files_stream.next().await.transpose() {
             Ok(file) => file,
-            Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
+            Err(e) => return Err(SlateDBError::from(e)),
         } {
             match self.parse_id(&file.location, "manifest") {
                 Ok(id) if id_range.contains(&id) => {
@@ -322,12 +322,12 @@ impl ManifestStore {
         let manifest_bytes = match self.object_store.get(manifest_path).await {
             Ok(manifest) => match manifest.bytes().await {
                 Ok(bytes) => bytes,
-                Err(e) => return Err(SlateDBError::ObjectStoreError(e)),
+                Err(e) => return Err(SlateDBError::from(e)),
             },
             Err(e) => {
                 return match e {
                     Error::NotFound { .. } => Ok(None),
-                    _ => Err(SlateDBError::ObjectStoreError(e)),
+                    _ => Err(SlateDBError::from(e)),
                 }
             }
         };

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -104,13 +104,17 @@ impl DbInner {
                     _ = manifest_poll_interval.tick() => {
                         if !is_stopped {
                             if let Err(err) = flusher.load_manifest().await {
-                                error!("error loading manifest: {}", err);
+                                error!("error loading manifest: {err}");
+                                this.state.write().set_error_if_none(err);
                             }
                             match flusher.flush_imm_memtables_to_l0().await {
                                 Ok(_) => {
                                     this.db_stats.immutable_memtable_flushes.inc();
                                 }
-                                Err(err) => error!("error from memtable flush: {}", err),
+                                Err(err) => {
+                                    error!("error from memtable flush: {err}");
+                                    this.state.write().set_error_if_none(err);
+                                }
                             }
                         }
                     }
@@ -126,10 +130,17 @@ impl DbInner {
                                     Ok(_) => {
                                         this.db_stats.immutable_memtable_flushes.inc();
                                     }
-                                    Err(err) => error!("error from memtable flush: {}", err),
+                                    Err(err) => {
+                                        error!("error from memtable flush: {err}");
+                                        this.state.write().set_error_if_none(err.clone());
+                                    }
                                 }
                                 if let Some(rsp) = rsp {
-                                    _ = rsp.send(result)
+                                    let res = rsp.send(result);
+                                    if let Err(Err(err)) = res {
+                                        error!("error sending flush response: {err}");
+                                        this.state.write().set_error_if_none(err);
+                                    }
                                 }
                             }
                         }

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -105,7 +105,7 @@ impl DbInner {
                         if !is_stopped {
                             if let Err(err) = flusher.load_manifest().await {
                                 error!("error loading manifest: {err}");
-                                this.state.write().set_error_if_none(err);
+                                this.set_error_if_none(err);
                             }
                             match flusher.flush_imm_memtables_to_l0().await {
                                 Ok(_) => {
@@ -113,7 +113,7 @@ impl DbInner {
                                 }
                                 Err(err) => {
                                     error!("error from memtable flush: {err}");
-                                    this.state.write().set_error_if_none(err);
+                                    this.set_error_if_none(err);
                                 }
                             }
                         }
@@ -132,14 +132,14 @@ impl DbInner {
                                     }
                                     Err(err) => {
                                         error!("error from memtable flush: {err}");
-                                        this.state.write().set_error_if_none(err.clone());
+                                        this.set_error_if_none(err.clone());
                                     }
                                 }
                                 if let Some(rsp) = rsp {
                                     let res = rsp.send(result);
                                     if let Err(Err(err)) = res {
                                         error!("error sending flush response: {err}");
-                                        this.state.write().set_error_if_none(err);
+                                        this.set_error_if_none(err);
                                     }
                                 }
                             }

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -45,24 +45,19 @@ struct ReadOnlyObject {
 
 impl ReadOnlyBlob for ReadOnlyObject {
     async fn len(&self) -> Result<usize, SlateDBError> {
-        let object_metadata = self
-            .object_store
-            .head(&self.path)
-            .await
-            .map_err(SlateDBError::ObjectStoreError)?;
+        let object_metadata = self.object_store.head(&self.path).await?;
         Ok(object_metadata.size)
     }
 
     async fn read_range(&self, range: Range<usize>) -> Result<Bytes, SlateDBError> {
-        self.object_store
-            .get_range(&self.path, range)
-            .await
-            .map_err(SlateDBError::ObjectStoreError)
+        let bytes = self.object_store.get_range(&self.path, range).await?;
+        Ok(bytes)
     }
 
     async fn read(&self) -> Result<Bytes, SlateDBError> {
         let file = self.object_store.get(&self.path).await?;
-        file.bytes().await.map_err(SlateDBError::ObjectStoreError)
+        let bytes = file.bytes().await?;
+        Ok(bytes)
     }
 }
 
@@ -180,19 +175,13 @@ impl TableStore {
             self.fp_registry.clone(),
             "write-wal-sst-io-error",
             matches!(id, SsTableId::Wal(_)),
-            |_| Result::Err(SlateDBError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "oops"
-            )))
+            |_| Result::Err(slatedb_io_error())
         );
         fail_point!(
             self.fp_registry.clone(),
             "write-compacted-sst-io-error",
             matches!(id, SsTableId::Compacted(_)),
-            |_| Result::Err(SlateDBError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "oops"
-            )))
+            |_| Result::Err(slatedb_io_error())
         );
 
         let total_size = encoded_sst
@@ -212,9 +201,9 @@ impl TableStore {
             .map_err(|e| match e {
                 object_store::Error::AlreadyExists { path: _, source: _ } => match id {
                     SsTableId::Wal(_) => SlateDBError::Fenced,
-                    SsTableId::Compacted(_) => SlateDBError::ObjectStoreError(e),
+                    SsTableId::Compacted(_) => SlateDBError::from(e),
                 },
-                _ => SlateDBError::ObjectStoreError(e),
+                _ => SlateDBError::from(e),
             })?;
 
         self.cache_filter(*id, encoded_sst.info.filter_offset, encoded_sst.filter)
@@ -242,7 +231,7 @@ impl TableStore {
         self.object_store
             .delete(&path)
             .await
-            .map_err(SlateDBError::ObjectStoreError)
+            .map_err(SlateDBError::from)
     }
 
     /// List all SSTables in the compacted directory.
@@ -584,6 +573,11 @@ impl<'a> EncodedSsTableWriter<'a> {
     pub(crate) fn blocks_written(&self) -> usize {
         self.blocks_written
     }
+}
+
+#[allow(dead_code)]
+fn slatedb_io_error() -> SlateDBError {
+    SlateDBError::from(std::io::Error::new(std::io::ErrorKind::Other, "oops"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When a flush operation fails in the background, an error is populated in the COWDbState structure that handles the state of the database. Foreground operations check this error and returns it when the user tries to read or write from the database.

This is another improvement to handle errors described in #111.