### PR TITLE
[2/N] checkpoints: add CLI commands for managing checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,6 +2246,7 @@ dependencies = [
  "flate2",
  "foyer",
  "futures",
+ "humantime",
  "leaky-bucket",
  "log",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ dotenvy = { version = "0.15.7" }
 fail-parallel = "0.5.1"
 flatbuffers = "24.3.25"
 futures = "0.3.30"
+humantime = {  version = "2.1.0", optional = true }
 leaky-bucket = {  version = "1.1", optional = true }
 object_store = "0.11.0"
 parking_lot = "0.12.3"
@@ -62,7 +63,7 @@ figment = { version = "0.10.19", features = ["test"] }
 default = ["aws", "moka"]
 aws = ["object_store/aws"]
 azure = ["object_store/azure"]
-cli = ["clap", "clap/derive"]
+cli = ["clap", "clap/derive", "humantime"]
 bencher = ["aws", "azure", "wal_disable", "clap", "clap/derive", "moka"]
 compression = ["snappy"]
 snappy = ["dep:snap"]

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -212,12 +212,28 @@ impl Db {
     /// Note that the scope option does not impact the behaviour of this method. The checkpoint will reference
     /// the current active manifest of the db.
     pub async fn create_checkpoint(
-       path: Path,
+       path: &Path,
        object_store: Arc<dyn ObjectStore>,
        options: &CheckpointOptions,
     ) -> Result<CheckpointCreateResult, SlateDBError> {}
-       ...
-    )
+
+    /// Refresh the lifetime of an existing checkpoint. Takes the id of an existing checkpoint
+    /// and a lifetime, and sets the lifetime of the checkpoint to the specified lifetime. If
+    /// there is no checkpoint with the specified id, then this fn fails with
+    /// SlateDBError::InvalidDbState
+    pub async fn refresh_checkpoint(
+        path: &Path,
+        object_store: Arc<dyn ObjectStore>,
+        id: Uuid,
+        lifetime: Option<Duration>,
+    ) -> Result<(), SlateDBError> {}
+    
+    /// Deletes the checkpoint with the specified id.
+    pub async fn delete_checkpoint(
+        path: &Path,
+        object_store: Arc<dyn ObjectStore>,
+        id: Uuid,
+    ) -> Result<(), SlateDBError> {}
 
     /// Called to destroy the database at the given path. If `soft` is true, This method will
     /// set the destroyed_at_s field in the manifest. The GC will clean up the db after some

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,3 +1,4 @@
+use crate::checkpoint::Checkpoint;
 use crate::error::SlateDBError;
 use crate::manifest_store::ManifestStore;
 #[cfg(feature = "aws")]
@@ -40,12 +41,12 @@ pub async fn list_manifests<R: RangeBounds<u64>>(
 pub async fn list_checkpoints(
     path: &Path,
     object_store: Arc<dyn ObjectStore>,
-) -> Result<String, Box<dyn Error>> {
+) -> Result<Vec<Checkpoint>, Box<dyn Error>> {
     let manifest_store = ManifestStore::new(path, object_store);
     let Some((_, manifest)) = manifest_store.read_latest_manifest().await? else {
         return Err(Box::new(SlateDBError::ManifestMissing));
     };
-    Ok(serde_json::to_string(&manifest.core.checkpoints)?)
+    Ok(manifest.core.checkpoints)
 }
 
 /// Loads an object store from configured environment variables.

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -1,13 +1,21 @@
 use crate::config::CheckpointOptions;
 use crate::db::Db;
-use crate::db_state::Checkpoint;
 use crate::error::SlateDBError;
 use crate::manifest_store::{apply_db_state_update, ManifestStore, StoredManifest};
 use object_store::path::Path;
 use object_store::ObjectStore;
+use serde::Serialize;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
+
+#[derive(Clone, PartialEq, Serialize, Debug)]
+pub struct Checkpoint {
+    pub id: Uuid,
+    pub manifest_id: u64,
+    pub expire_time: Option<SystemTime>,
+    pub create_time: SystemTime,
+}
 
 #[derive(Debug)]
 pub struct CheckpointCreateResult {
@@ -133,10 +141,10 @@ impl Db {
 
 #[cfg(test)]
 mod tests {
+    use crate::checkpoint::Checkpoint;
     use crate::checkpoint::CheckpointCreateResult;
     use crate::config::{CheckpointOptions, DbOptions};
     use crate::db::Db;
-    use crate::db_state::Checkpoint;
     use crate::error::SlateDBError;
     use crate::manifest_store::ManifestStore;
     use object_store::memory::InMemory;

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -6,7 +6,8 @@ use crate::manifest_store::{apply_db_state_update, ManifestStore, StoredManifest
 use object_store::path::Path;
 use object_store::ObjectStore;
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
+use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct CheckpointCreateResult {
@@ -73,6 +74,61 @@ impl Db {
             manifest_id: checkpoint.manifest_id,
         })
     }
+
+    /// Refresh the lifetime of an existing checkpoint. Takes the id of an existing checkpoint
+    /// and a lifetime, and sets the lifetime of the checkpoint to the specified lifetime. If
+    /// there is no checkpoint with the specified id, then this fn fails with
+    /// SlateDBError::InvalidDbState
+    pub async fn refresh_checkpoint(
+        path: &Path,
+        object_store: Arc<dyn ObjectStore>,
+        id: Uuid,
+        lifetime: Option<Duration>,
+    ) -> Result<(), SlateDBError> {
+        let manifest_store = Arc::new(ManifestStore::new(path, object_store));
+        let Some(mut stored_manifest) = StoredManifest::load(manifest_store).await? else {
+            return Err(SlateDBError::ManifestMissing);
+        };
+        apply_db_state_update(&mut stored_manifest, |stored_manifest| {
+            let mut db_state = stored_manifest.db_state().clone();
+            let expire_time = lifetime.map(|l| SystemTime::now() + l);
+            let Some(_) = db_state.checkpoints.iter_mut().find_map(|c| {
+                if c.id == id {
+                    c.expire_time = expire_time;
+                    return Some(());
+                }
+                None
+            }) else {
+                return Err(SlateDBError::InvalidDBState);
+            };
+            Ok(db_state)
+        })
+        .await
+    }
+
+    /// Deletes the checkpoint with the specified id.
+    pub async fn delete_checkpoint(
+        path: &Path,
+        object_store: Arc<dyn ObjectStore>,
+        id: Uuid,
+    ) -> Result<(), SlateDBError> {
+        let manifest_store = Arc::new(ManifestStore::new(path, object_store));
+        let Some(mut stored_manifest) = StoredManifest::load(manifest_store).await? else {
+            return Err(SlateDBError::ManifestMissing);
+        };
+        apply_db_state_update(&mut stored_manifest, |stored_manifest| {
+            let mut db_state = stored_manifest.db_state().clone();
+            let checkpoints: Vec<Checkpoint> = db_state
+                .checkpoints
+                .iter()
+                .filter(|c| c.id != id)
+                .cloned()
+                .collect();
+            db_state.checkpoints = checkpoints;
+            Ok(db_state)
+        })
+        .await
+    }
 }
 
 #[cfg(test)]
@@ -80,6 +136,7 @@ mod tests {
     use crate::checkpoint::CheckpointCreateResult;
     use crate::config::{CheckpointOptions, DbOptions};
     use crate::db::Db;
+    use crate::db_state::Checkpoint;
     use crate::error::SlateDBError;
     use crate::manifest_store::ManifestStore;
     use object_store::memory::InMemory;
@@ -236,5 +293,105 @@ mod tests {
 
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), SlateDBError::ManifestMissing));
+    }
+
+    #[tokio::test]
+    async fn test_should_refresh_checkpoint() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let _ = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+        let CheckpointCreateResult { id, manifest_id: _ } = Db::create_checkpoint(
+            &path,
+            object_store.clone(),
+            &CheckpointOptions {
+                lifetime: Some(Duration::from_secs(100)),
+                ..CheckpointOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let (_, manifest) = manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .unwrap();
+        let checkpoint = manifest
+            .core
+            .checkpoints
+            .iter()
+            .find(|c| c.id == id)
+            .unwrap();
+        let expire_time = checkpoint.expire_time.unwrap();
+
+        Db::refresh_checkpoint(
+            &path,
+            object_store.clone(),
+            id,
+            Some(Duration::from_secs(1000)),
+        )
+        .await
+        .unwrap();
+
+        let (_, manifest) = manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .unwrap();
+        let found: Vec<&Checkpoint> = manifest
+            .core
+            .checkpoints
+            .iter()
+            .filter(|c| c.id == id)
+            .collect();
+        assert_eq!(1, found.len());
+        let refreshed_expire_time = found.first().unwrap().expire_time.unwrap();
+        assert!(refreshed_expire_time > expire_time);
+    }
+
+    #[tokio::test]
+    async fn test_should_fail_refresh_checkpoint_if_checkpoint_missing() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let _ = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+
+        let result = Db::refresh_checkpoint(
+            &path,
+            object_store.clone(),
+            uuid::Uuid::new_v4(),
+            Some(Duration::from_secs(1000)),
+        )
+        .await;
+
+        assert!(matches!(result, Err(SlateDBError::InvalidDBState)));
+    }
+
+    #[tokio::test]
+    async fn test_should_delete_checkpoint() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let _ = Db::open_with_opts(path.clone(), DbOptions::default(), object_store.clone())
+            .await
+            .unwrap();
+        let CheckpointCreateResult { id, manifest_id: _ } =
+            Db::create_checkpoint(&path, object_store.clone(), &CheckpointOptions::default())
+                .await
+                .unwrap();
+
+        Db::delete_checkpoint(&path, object_store.clone(), id)
+            .await
+            .unwrap();
+
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let (_, manifest) = manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!manifest.core.checkpoints.iter().any(|c| c.id == id));
     }
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -120,5 +120,7 @@ async fn exec_list_checkpoints(
     path: &Path,
     object_store: Arc<dyn ObjectStore>,
 ) -> Result<(), Box<dyn Error>> {
-    Ok(println!("{}", list_checkpoints(path, object_store).await?))
+    let checkpoint = list_checkpoints(path, object_store).await?;
+    let checkpoint_json = serde_json::to_string(&checkpoint)?;
+    Ok(println!("{}", checkpoint_json))
 }

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -1,12 +1,11 @@
+use crate::checkpoint::Checkpoint;
 use bytes::Bytes;
 use serde::Serialize;
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use std::time::SystemTime;
 use tracing::debug;
 use ulid::Ulid;
-use uuid::Uuid;
 use SsTableId::{Compacted, Wal};
 
 use crate::config::CompressionCodec;
@@ -134,14 +133,6 @@ impl SortedRun {
         self.find_sst_with_range_covering_key_idx(key)
             .map(|idx| &self.ssts[idx])
     }
-}
-
-#[derive(Clone, PartialEq, Serialize, Debug)]
-pub(crate) struct Checkpoint {
-    pub(crate) id: Uuid,
-    pub(crate) manifest_id: u64,
-    pub(crate) expire_time: Option<SystemTime>,
-    pub(crate) create_time: SystemTime,
 }
 
 pub(crate) struct DbState {


### PR DESCRIPTION
This patch adds CLI commands for creating, refreshing, deleting, and listing checkpoints:
- Adds public APIs for refreshing and deleting checkpoints.
- Adds CLI commands that are implemented by calling these public APIs.
- Updates the RFC with the public APIs for refreshing/deleting checkpoints.

Fixes #310

Checkpoints Milestone: https://github.com/slatedb/slatedb/issues/310