### PR TITLE
Add release.yaml and RELEASE.md

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,59 @@
+name: Publish Release
+
+on:
+  # Allow manual triggering of the workflow
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of the release (e.g., 1.0.0)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release SlateDB
+    runs-on: ubuntu-latest
+
+    steps:
+      # Verify the version is a valid SemVer version
+      - name: Verify version
+        id: semver
+        uses: matt-usurp/validate-semver@v2
+        with:
+          version: ${{ github.event.inputs.version }}
+
+      # Checkout repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Set up Rust stable
+      - name: Set up Rust stable
+        run: rustup default stable
+
+      # Set Cargo.toml version using cargo-edit
+      - name: Set version
+        run: cargo set-version ${{ github.event.inputs.version }}
+
+      # Commit changes
+      - name: Commit version bump
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Bump version to ${{ github.event.inputs.version }}"
+          push: true
+
+      # Publish a git release that creates a new "vX.Y.Z" release tag and includes generated notes
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: v${{ github.event.inputs.version }}
+          name: v${{ github.event.inputs.version }}
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Publish the crate to crates.io
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,7 +2,7 @@
 
 SlateDB releases are published using a Github release action defined in `.github/workflows/release.yml`. To create a new release:
 
-1. Go to the [release action page](https://github.com/slatedb/slatedb/actions/workflows/pr.yaml)
+1. Go to the [release action page](https://github.com/slatedb/slatedb/actions/workflows/release.yaml)
 2. Input a version value in the format `X.Y.Z` and click `Run workflow`.
 
 The release action will do the following:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+# Releasing SlateDB
+
+SlateDB releases are published using a Github release action defined in `.github/workflows/release.yml`. To create a new release:
+
+1. Go to the [release action page](https://github.com/slatedb/slatedb/actions/workflows/pr.yaml)
+2. Input a version value in the format `X.Y.Z` and click `Run workflow`.
+
+The release action will do the following:
+
+1. Verify that the version adheres to the semantic versioning format.
+2. Check out the latest code from the `main` branch.
+3. Update the version in Cargo.toml to the specified version.
+4. Commit the changes and push to the `main` branch.
+5. Create a Github release with the specified version and auto-generated release notes.
+6. Publish a release to crates.io.


### PR DESCRIPTION
This PR adds a release.yaml Github action to make it easier to publish SlateDB releases. The action is triggered through the Github actions page. To run it, SlateDB committers input a version number and click "run workflow". The workflow will:

1. Verify that the version adheres to the semantic versioning format.
2. Check out the latest code from the `main` branch.
3. Update the version in Cargo.toml to the specified version.
4. Commit the changes and push to the `main` branch.
5. Create a Github release with the specified version and auto-generated release notes.
6. Publish a release to crates.io.

I've also added a RELEASE.md to describe this process.