### PR TITLE
refactor(flush): Split flush structures

### DIFF
--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -17,7 +17,7 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id);
         self.memtable_flush_notifier
-            .send(MemtableFlushThreadMsg::FlushImmutableMemtables(None))
+            .send((None, MemtableFlushThreadMsg::FlushImmutableMemtables))
             .map_err(|_| SlateDBError::MemtableFlushChannelError)?;
         Ok(())
     }
@@ -35,7 +35,7 @@ impl DbInner {
         }
         guard.freeze_wal();
         self.wal_flush_notifier
-            .send(WalFlushThreadMsg::FlushImmutableWals(None))
+            .send((None, WalFlushThreadMsg::FlushImmutableWals))
             .map_err(|_| SlateDBError::WalFlushChannelError)?;
         Ok(())
     }

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -1,17 +1,19 @@
 use std::sync::Arc;
 
 use tokio::runtime::Handle;
+use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, warn};
 use ulid::Ulid;
 
-use crate::db::DbInner;
+use crate::db::{DbInner, FlushMsg};
 use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
 use crate::manifest_store::FenceableManifest;
 
+#[derive(Debug)]
 pub enum MemtableFlushThreadMsg {
     Shutdown,
-    FlushImmutableMemtables(Option<tokio::sync::oneshot::Sender<Result<(), SlateDBError>>>),
+    FlushImmutableMemtables,
 }
 
 pub(crate) struct MemtableFlusher {
@@ -84,7 +86,7 @@ impl DbInner {
     pub(crate) fn spawn_memtable_flush_task(
         self: &Arc<Self>,
         manifest: FenceableManifest,
-        mut rx: tokio::sync::mpsc::UnboundedReceiver<MemtableFlushThreadMsg>,
+        mut rx: UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>,
         tokio_handle: &Handle,
     ) -> Option<tokio::task::JoinHandle<()>> {
         let this = Arc::clone(self);
@@ -119,12 +121,12 @@ impl DbInner {
                         }
                     }
                     msg = rx.recv() => {
-                        let msg = msg.expect("channel unexpectedly closed");
+                        let (rsp_sender, msg) = msg.expect("channel unexpectedly closed");
                         match msg {
                             MemtableFlushThreadMsg::Shutdown => {
                                 is_stopped = true
                             },
-                            MemtableFlushThreadMsg::FlushImmutableMemtables(rsp) => {
+                            MemtableFlushThreadMsg::FlushImmutableMemtables => {
                                 let result = flusher.flush_imm_memtables_to_l0().await;
                                 match &result {
                                     Ok(_) => {
@@ -135,8 +137,8 @@ impl DbInner {
                                         this.set_error_if_none(err.clone());
                                     }
                                 }
-                                if let Some(rsp) = rsp {
-                                    let res = rsp.send(result);
+                                if let Some(rsp_sender) = rsp_sender {
+                                    let res = rsp_sender.send(result);
                                     if let Err(Err(err)) = res {
                                         error!("error sending flush response: {err}");
                                         this.set_error_if_none(err);


### PR DESCRIPTION
While working on #321, I struggled with the semantics of the flush messages because they optionally carry a `Sender` struct that comes from a dependency. This for example, didn't allow me to make the flush messages clonable.

This change decouples the response sender and the messages sent in those responses. This way, the Flush enums are independent from the channels they are sent through, and it's easier to work with them. This change should not change how flush operates.

/cc @rodesai, @criccomini 