### PR TITLE
support running GC from the admin CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,9 +2829,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ object_store = "0.11.0"
 parking_lot = "0.12.3"
 siphasher = "1"
 thiserror = "1.0.63"
-tokio = { version = "1.40.0", features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.40.0", features = ["fs", "macros", "sync", "rt", "rt-multi-thread", "signal"] }
 ulid = { version = "1.1.3", features = ["serde"] }
 uuid = { version = "1.11.0", features = ["v4", "serde"] }
 rand = "0.8.5"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -87,7 +87,7 @@ pub async fn run_gc_instance(
     path: &Path,
     object_store: Arc<dyn ObjectStore>,
     gc_opts: GarbageCollectorOptions,
-) -> Result<(Arc<DbStats>, GarbageCollector), Box<dyn Error>> {
+) -> Result<(), Box<dyn Error>> {
     let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
     let sst_format = SsTableFormat::default(); // read only SSTs, can use default
     let fp_registry = Arc::new(FailPointRegistry::new());
@@ -110,7 +110,8 @@ pub async fn run_gc_instance(
     )
     .await;
 
-    Ok((stats, collector))
+    collector.shutdown_notified().await;
+    Ok(())
 }
 
 /// Loads a local object store instance.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,6 +1,12 @@
 use crate::checkpoint::Checkpoint;
+use crate::config::GarbageCollectorOptions;
 use crate::error::SlateDBError;
+use crate::garbage_collector::GarbageCollector;
 use crate::manifest_store::ManifestStore;
+use crate::metrics::DbStats;
+use crate::sst::SsTableFormat;
+use crate::tablestore::TableStore;
+use fail_parallel::FailPointRegistry;
 #[cfg(feature = "aws")]
 use log::warn;
 use object_store::path::Path;
@@ -9,6 +15,7 @@ use std::env;
 use std::error::Error;
 use std::ops::RangeBounds;
 use std::sync::Arc;
+use tokio::runtime::Handle;
 
 /// read-only access to the latest manifest file
 pub async fn read_manifest(
@@ -74,6 +81,36 @@ pub fn load_object_store_from_env(
         "azure" => load_azure(),
         _ => Err(format!("Unknown CLOUD_PROVIDER: '{}'", provider).into()),
     }
+}
+
+pub async fn run_gc_instance(
+    path: &Path,
+    object_store: Arc<dyn ObjectStore>,
+    gc_opts: GarbageCollectorOptions,
+) -> Result<(Arc<DbStats>, GarbageCollector), Box<dyn Error>> {
+    let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
+    let sst_format = SsTableFormat::default(); // read only SSTs, can use default
+    let fp_registry = Arc::new(FailPointRegistry::new());
+    let table_store = Arc::new(TableStore::new_with_fp_registry(
+        object_store.clone(),
+        sst_format.clone(),
+        path.clone(),
+        fp_registry.clone(),
+        None, // no need for cache in GC
+    ));
+
+    let tokio_handle = Handle::current();
+    let stats = Arc::new(DbStats::new());
+    let collector = GarbageCollector::new(
+        manifest_store,
+        table_store,
+        gc_opts,
+        tokio_handle,
+        stats.clone(),
+    )
+    .await;
+
+    Ok((stats, collector))
 }
 
 /// Loads a local object store instance.

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -60,8 +60,8 @@ generate_plot() {
     '$input_file' skip $warmup using 1:3 with linespoints linewidth 2 title 'Gets/s';"
 }
 
-for put_percentage in 20 ; do
-  for concurrency in 1; do
+for put_percentage in 20 40 60 80 100; do
+  for concurrency in 1 4; do
     log_file="$OUT/logs/${put_percentage}_${concurrency}.log"
     dat_file="$OUT/dats/${put_percentage}_${concurrency}.dat"
     svg_file="$OUT/plots/${put_percentage}_${concurrency}.svg"

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -60,8 +60,8 @@ generate_plot() {
     '$input_file' skip $warmup using 1:3 with linespoints linewidth 2 title 'Gets/s';"
 }
 
-for put_percentage in 20 40 60 80 100; do
-  for concurrency in 1 4; do
+for put_percentage in 20 ; do
+  for concurrency in 1; do
     log_file="$OUT/logs/${put_percentage}_${concurrency}.log"
     dat_file="$OUT/dats/${put_percentage}_${concurrency}.dat"
     svg_file="$OUT/plots/${put_percentage}_${concurrency}.svg"

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -97,11 +97,11 @@ pub(crate) enum CliCommands {
 
     /// Runs a garbage collection for a specific resource type once
     RunGarbageCollection {
-        /// If specified, the minimum age of manifests to collect
+        /// the type of resource to clean up (manifest, wal, compacted)
         #[arg(short, long)]
         resource: GcResource,
 
-        /// If specified, the minimum age of manifests to collect
+        /// the minimum age of the resource before considering it for GC
         #[arg(short, long)]
         #[clap(value_parser = humantime::parse_duration)]
         min_age: Duration,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,4 +1,5 @@
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
+use std::collections::HashMap;
 use std::time::Duration;
 use uuid::Uuid;
 
@@ -93,8 +94,159 @@ pub(crate) enum CliCommands {
 
     /// List the current checkpoints of the db.
     ListCheckpoints {},
+
+    /// Runs a garbage collection for a specific resource type once
+    RunGarbageCollection {
+        /// If specified, the minimum age of manifests to collect
+        #[arg(short, long)]
+        resource: GcResource,
+
+        /// If specified, the minimum age of manifests to collect
+        #[arg(short, long)]
+        #[clap(value_parser = humantime::parse_duration)]
+        min_age: Duration,
+    },
+
+    /// Schedules a period garbage collection job
+    #[command(group(
+    ArgGroup::new("gc_config")
+        .args(["manifest", "wal", "compacted"])
+        .multiple(true)
+        .required(true)
+    ))]
+    ScheduleGarbageCollection {
+        /// Configuration for manifest garbage collection should be set in the
+        /// format min_age=<duration>,period=<duration> -- the min_age is the
+        /// minimum manifest age that should be considered for collection and
+        /// the period is how often to attempt a GC
+        #[arg(long, value_parser = parse_gc_schedule)]
+        manifest: Option<GcSchedule>,
+
+        /// Configuration for WAL garbage collection should be set in the
+        /// format min_age=<duration>,period=<duration> -- the min_age is the
+        /// minimum WAL age that should be considered for collection and
+        /// the period is how often to attempt a GC
+        #[arg(long, value_parser = parse_gc_schedule)]
+        wal: Option<GcSchedule>,
+
+        /// Configuration for compacted SST garbage collection should be set in the
+        /// format min_age=<duration>,period=<duration> -- the min_age is the
+        /// minimum SST age that should be considered for collection and
+        /// the period is how often to attempt a GC
+        #[arg(long, value_parser = parse_gc_schedule)]
+        compacted: Option<GcSchedule>,
+    },
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+pub(crate) enum GcResource {
+    Manifest,
+    Wal,
+    Compacted,
+}
+
+fn parse_gc_schedule(s: &str) -> Result<GcSchedule, String> {
+    let parts: HashMap<String, String> = s
+        .split(',')
+        .filter_map(|kv| {
+            let mut parts = kv.splitn(2, '=');
+            match (parts.next(), parts.next()) {
+                (Some(key), Some(value)) => Some((key.to_string(), value.to_string())),
+                _ => None,
+            }
+        })
+        .collect();
+
+    let min_age = parts
+        .get("min_age")
+        .ok_or_else(|| "Missing or invalid 'min_age'".to_string())
+        .and_then(|v| {
+            humantime::parse_duration(v).map_err(|e| {
+                "Could not parse min_age as duration: "
+                    .to_string()
+                    .to_owned()
+                    + e.to_string().as_str()
+            })
+        })?;
+    let period = parts
+        .get("period")
+        .ok_or_else(|| "Missing or invalid 'period'".to_string())
+        .and_then(|v| humantime::parse_duration(v).map_err(|e| e.to_string()))?;
+
+    Ok(GcSchedule { min_age, period })
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GcSchedule {
+    /// Minimum age of resources to collect
+    pub(crate) min_age: Duration,
+
+    /// How often to run the garbage collection
+    pub(crate) period: Duration,
 }
 
 pub(crate) fn parse_args() -> CliArgs {
     CliArgs::parse()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::args::parse_gc_schedule;
+    use rstest::rstest;
+    use std::time::Duration;
+
+    #[rstest]
+    #[case(
+        "min_age=10m,period=1m",
+        Some(Duration::from_secs(600)),
+        Some(Duration::from_secs(60)),
+        None
+    )]
+    #[case(
+        "min_age=10m,period=1m,ignored=5m",
+        Some(Duration::from_secs(600)),
+        Some(Duration::from_secs(60)),
+        None
+    )]
+    #[case("period=1m", None, None, Some("Missing or invalid 'min_age'"))]
+    #[case("min_age=10m", None, None, Some("Missing or invalid 'period'"))]
+    #[case(
+        "min_age=invalid,period=1m",
+        None,
+        None,
+        Some("Could not parse min_age as duration")
+    )]
+    #[case(
+        "min_age=,period=1m",
+        None,
+        None,
+        Some("Could not parse min_age as duration: value was empty")
+    )]
+    fn parse_gc_schedule_tests(
+        #[case] input: &str,
+        #[case] expected_min_age: Option<Duration>,
+        #[case] expected_period: Option<Duration>,
+        #[case] expected_error: Option<&str>,
+    ) {
+        let result = parse_gc_schedule(input);
+
+        match (result, expected_min_age, expected_period, expected_error) {
+            // Valid case: min_age and period are parsed correctly
+            (Ok(schedule), Some(min_age), Some(period), None) => {
+                assert_eq!(schedule.min_age, min_age);
+                assert_eq!(schedule.period, period);
+            }
+            // Error case: check if the error message matches
+            (Err(err), None, None, Some(expected_msg)) => {
+                assert!(
+                    err.contains(expected_msg),
+                    "Expected error to contain '{}', got '{}'",
+                    expected_msg,
+                    err
+                );
+            }
+            // Any unexpected combination fails the test
+            result => panic!("Unexpected test case result. {:?}", result),
+        }
+    }
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -210,9 +210,9 @@ async fn schedule_gc(
         })
     }
     let gc_opts = GarbageCollectorOptions {
-        manifest_options: manifest_schedule.map_or(None, |sched| create_gc_dir_opts(sched)),
-        wal_options: wal_schedule.map_or(None, |sched| create_gc_dir_opts(sched)),
-        compacted_options: compacted_schedule.map_or(None, |sched| create_gc_dir_opts(sched)),
+        manifest_options: manifest_schedule.and_then(create_gc_dir_opts),
+        wal_options: wal_schedule.and_then(create_gc_dir_opts),
+        compacted_options: compacted_schedule.and_then(create_gc_dir_opts),
         ..GarbageCollectorOptions::default()
     };
     let (stats, _collector) = run_gc_instance(path, object_store, gc_opts).await?;

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -67,7 +67,7 @@ impl GarbageCollector {
             // !important: make sure that this is always the last thing that this
             // thread does, otherwise we risk notifying waiters and leaving this
             // thread around after shutdown
-            if let Err(_) = shutdown_tx.send(true) {
+            if shutdown_tx.send(true).is_err() {
                 error!("Could not send shutdown signal to threads blocked on await_shutdown");
             }
         });
@@ -91,7 +91,7 @@ impl GarbageCollector {
 
     /// Triggers the main garbage collection thread to terminate
     fn trigger_shutdown(&self) {
-        if let Err(_) = self.main_tx.send(Shutdown) {
+        if self.main_tx.send(Shutdown).is_err() {
             error!("Could not send shutdown signal to threads blocked on await_shutdown");
         }
     }

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -78,7 +78,10 @@ impl GarbageCollector {
                 break;
             }
 
-            self.shutdown_rx.changed().await.expect("Shutdown rx disconnected.");
+            self.shutdown_rx
+                .changed()
+                .await
+                .expect("Shutdown rx disconnected.");
         }
     }
 


### PR DESCRIPTION
fixes #286

This PR introduces the ability to run GC on-demand and wires that mechanism into the admin CLI. The following changes were made to the public API:

- Changes the public API for `GarbageCollectorDirectoryOptions` by encapsulating the `poll_interval` in an enum
- Exposes two CLI methods. One to run a single one-off GC for a single resource type (Manifest/WAL/Compacted) and another to schedule a periodic GC job.

```
Runs a garbage collection for a specific resource type once

Usage: slatedb --path <PATH> run-garbage-collection --resource <RESOURCE> --min-age <MIN_AGE>

Options:
  -r, --resource <RESOURCE>  If specified, the minimum age of manifests to collect [possible values: manifest, wal, compacted]
  -m, --min-age <MIN_AGE>    If specified, the minimum age of manifests to collect
  -h, --help                 Print help
```

```
Schedules a period garbage collection job

Usage: slatedb --path <PATH> schedule-garbage-collection <--manifest <MANIFEST>|--wal <WAL>|--compacted <COMPACTED>>

Options:
      --manifest <MANIFEST>    Configuration for manifest garbage collection should be set in the format min_age=<duration>,period=<duration> -- the min_age is the minimum manifest age that should be considered for collection and the period is how often to attempt a GC
      --wal <WAL>              Configuration for WAL garbage collection should be set in the format min_age=<duration>,period=<duration> -- the min_age is the minimum WAL age that should be considered for collection and the period is how often to attempt a GC
      --compacted <COMPACTED>  Configuration for compacted SST garbage collection should be set in the format min_age=<duration>,period=<duration> -- the min_age is the minimum SST age that should be considered for collection and the period is how often to attempt a GC
  -h, --help                   Print help
```

An example of this is `schedule-garbage-collection --manifest min_age=20s,period=10s`

-----

### Sample Runs

```
$ RUST_LOG=debug cargo run --features=cli --bin slatedb -- --env-file .env --path 'slatedb-bencher_20_1'  schedule-garbage-collection --manifest min_age=20s,period=10s
   Compiling slatedb v0.3.0 (/Users/agavra/dev/slatedb)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.06s
     Running `target/debug/slatedb --env-file .env --path slatedb-bencher_20_1 schedule-garbage-collection --manifest min_age=20s,period=10s`
2024-11-21T17:44:43.010944Z  INFO slatedb::garbage_collector: Starting Garbage Collector with [manifest: Run Every 10s], [wal: Done], [compacted: Done]
2024-11-21T17:44:53.012817Z DEBUG slatedb::garbage_collector: Scheduled garbage collection attempt for Manifests.
...
2024-11-21T17:45:43.015694Z  INFO slatedb::garbage_collector: GC has collected 23 Manifests, 0 WAL SSTs and 0 Compacted SSTs.
```

```
$ RUST_LOG=debug cargo run --features=cli --bin slatedb -- --env-file .env --path 'slatedb-bencher_20_1'  run-garbage-collection --resource compacted --min-age 10s
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/slatedb --env-file .env --path slatedb-bencher_20_1 run-garbage-collection --resource compacted --min-age 10s`
2024-11-21T17:46:32.722464Z  INFO slatedb::garbage_collector: Starting Garbage Collector with [manifest: Done], [wal: Done], [compacted: Run Once]
2024-11-21T17:46:32.722601Z DEBUG slatedb::garbage_collector: Scheduled garbage collection attempt for Compacted SSTs.
2024-11-21T17:46:33.283995Z  INFO slatedb::garbage_collector: Garbage Collector is done - exiting main thread.
2024-11-21T17:46:33.284016Z  INFO slatedb::garbage_collector: GC shutdown after collecting 0 Manifests, 0 WAL SSTs and 51 Compacted SSTs.
2024-11-21T17:46:33.284129Z DEBUG slatedb::garbage_collector: Garbage collector dropped - external_tx will be disconnected.
```