### PR TITLE
Add a GOVERNANCE.md document

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,30 +12,35 @@ leads to better decisions. We seek to resolve disagreement by reaching
 consensus based on the merit of technical arguments, with no regard to status or
 formal role. This almost always works.
 
+_This document does not apply to https://github.com/slatedb/slatedb-go._
+
 # SlateDB Roles
 
 There are two formal roles in SlateDB:
 
-* __SlateDB Committers__ have the right to merge pull requests into the SlateDB repo.
+* __SlateDB Committers__ have the right to merge pull requests into the SlateDB repo,
+  publish releases, and approve requests for comments (RFCs).
 * __The SlateDB Board__ has final authority over all decisions made on the project.
 
 # SlateDB Committers
 
 A __SlateDB Committer__ is able to merge pull requests into the SlateDB repositories under
-[https://github.com/slatedb](https://github.com/slatedb), including into
-the master branch that is released to production.
+[https://github.com/slatedb](https://github.com/slatedb), including into the master branch
+that is released to production. Committers are also able to publish SlateDB releases and
+approve RFCs. Approval requirements for these activities depends on the nature of the change:
 
-To become a SlateDB Committer, start making PRs that are approved. When a sufficient
-trust is built through working on SlateDB this way, any current SlateDB Committer can nominate
+- RFCs and release proposals must be approved by two committers.
+- Committers may merge small, low-risk, uncontroversial PRs without any approval.
+- All other PRs must be approved by a SlateDB committer other than the author of the request.
+
+Approval is indicated by clicking "approve" on a PR, by making a comment indicating approval,
+or by simply merging a PR.
+
+To become a SlateDB committer, start making PRs that are approved. When a sufficient
+trust is built through working on SlateDB this way, any current SlateDB committer can nominate
 you to the board for the committer role.
 
-Every pull request should be approved by a SlateDB Committer other than the author of the
-request by clicking "approve", by making a comment indicating agreement, or by simply
-merging it. SlateDB Committers may merge their own PRs without approval from another committer
-if the PR is small, low-risk, and uncontroversial. This is left to the discretion of the
-committer.
-
-The SlateDB committers are listed in [slatedb-pulumi](https://github.com/slatedb/slatedb-pulumi/blob/main/__main__.py).
+SlateDB's committers are listed in [slatedb-pulumi](https://github.com/slatedb/slatedb-pulumi/blob/main/__main__.py).
 
 # The SlateDB Board
 
@@ -46,9 +51,14 @@ including:
 * who should be committers and who should be members of the board, and
 * whether to make any changes to the governance policy (this document).
 
-Board members need not be committers, but they can be. Similarly, committers need not be board
-members, but they can be.
+SlateDB's board members are:
 
-Currently, the board consists of each of the SlateDB committers.
-[Chris Riccomini](https://github.com/criccomini) is the board leader. On a tie, the leader of
-the board has a double vote.
+* Vignesh Chandramohan (vigneshc)
+* Rohan Desai (rodesai)
+* Chris Riccomini (criccomini) - leader
+* Li Yazhou (flaneur2020)
+
+Board votes must be conducted on a Github issue or Github pull request. Votes are represented
+as -1 and +1, with '-1' meaning 'no' and '+1' meaning 'yes.' Voting must be open for at least
+1 week or until all members have voted, whichever comes first. A vote passes if a majority of
+the votes placed are in favor. On a tie, the leader of the board has a double vote.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,15 +18,15 @@ _This document does not apply to https://github.com/slatedb/slatedb-go._
 
 There are two formal roles in SlateDB:
 
-* __SlateDB Committers__ have the right to merge pull requests into the SlateDB repo,
+* __SlateDB Committers__ have the right to merge pull requests into SlateDB repositories,
   publish releases, and approve requests for comments (RFCs).
 * __The SlateDB Board__ has final authority over all decisions made on the project.
 
 # SlateDB Committers
 
-A __SlateDB Committer__ is able to merge pull requests into the SlateDB repositories under
-[https://github.com/slatedb](https://github.com/slatedb), including into the master branch
-that is released to production. Committers are also able to publish SlateDB releases and
+A __SlateDB Committer__ is able to merge pull requests into SlateDB repositories under
+[https://github.com/slatedb](https://github.com/slatedb), including into the main branches
+that are released to production. Committers are also able to publish SlateDB releases and
 approve RFCs. Approval requirements for these activities depends on the nature of the change:
 
 - RFCs and release proposals must be approved by two committers other than the author of the
@@ -59,7 +59,7 @@ SlateDB's board members are:
 * Chris Riccomini (criccomini) - leader
 * Li Yazhou (flaneur2020)
 
-Board votes must be conducted on a Github issue or Github pull request. Votes are represented
-as -1 and +1, with '-1' meaning 'no' and '+1' meaning 'yes.' Voting must be open for at least
-1 week or until all members have voted, whichever comes first. A vote passes if a majority of
-the votes placed are in favor. On a tie, the leader of the board has a double vote.
+Board votes must be conducted on a Github issue, Github pull request, or Discord post. Votes
+are represented as -1 and +1, with '-1' meaning 'no' and '+1' meaning 'yes.' Voting must be open
+for at least 1 week or until all members have voted, whichever comes first. A vote passes if a
+majority of the votes placed are in favor. On a tie, the leader of the board has a double vote.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,54 @@
+# SlateDB Governance
+
+Anyone is welcome to contribute to SlateDB by [creating pull requests](CONTRIBUTING.md)
+or taking part in discussions about features, e.g. in [GitHub issues](https://github.com/slatedb/slatedb/issues).
+
+This document defines who has authority to do what on the SlateDB open-source project.
+
+While a formal assignment of authority is necessary as a fallback mechanism, it is
+not the way decisions regarding SlateDB are usually made, or expected to be made.
+The community sees disagreement as good as a diversity of perspectives having influence
+leads to better decisions. We seek to resolve disagreement by reaching 
+consensus based on the merit of technical arguments, with no regard to status or
+formal role. This almost always works.
+
+# SlateDB Roles
+
+There are two formal roles in SlateDB:
+
+* __SlateDB Committers__ have the right to merge pull requests into the SlateDB repo.
+* __The SlateDB Board__ has final authority over all decisions made on the project.
+
+# SlateDB Committers
+
+A __SlateDB Committer__ is able to merge pull requests into the SlateDB repositories under
+[https://github.com/slatedb](https://github.com/slatedb), including into
+the master branch that is released to production.
+
+To become a SlateDB Committer, start making PRs that are approved. When a sufficient
+trust is built through working on SlateDB this way, any current SlateDB Committer can nominate
+you to the board for the committer role.
+
+Every pull request should be approved by a SlateDB Committer other than the author of the
+request by clicking "approve", by making a comment indicating agreement, or by simply
+merging it. SlateDB Committers may merge their own PRs without approval from another committer
+if the PR is small, low-risk, and uncontroversial. This is left to the discretion of the
+committer.
+
+The SlateDB committers are listed in [slatedb-pulumi](https://github.com/slatedb/slatedb-pulumi/blob/main/__main__.py).
+
+# The SlateDB Board
+
+The __SlateDB Board__ has final authority over all decisions regarding the SlateDB project,
+including:
+
+* whether to merge (or keep) a PR in the event of any dispute, 
+* who should be committers and who should be members of the board, and
+* whether to make any changes to the governance policy (this document).
+
+Board members need not be committers, but they can be. Similarly, committers need not be board
+members, but they can be.
+
+Currently, the board consists of each of the SlateDB committers.
+[Chris Riccomini](https://github.com/criccomini) is the board leader. On a tie, the leader of
+the board has a double vote.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -29,7 +29,8 @@ A __SlateDB Committer__ is able to merge pull requests into the SlateDB reposito
 that is released to production. Committers are also able to publish SlateDB releases and
 approve RFCs. Approval requirements for these activities depends on the nature of the change:
 
-- RFCs and release proposals must be approved by two committers.
+- RFCs and release proposals must be approved by two committers other than the author of the
+  request.
 - Committers may merge small, low-risk, uncontroversial PRs without any approval.
 - All other PRs must be approved by a SlateDB committer other than the author of the request.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,7 +1,0 @@
-# SlateDB Maintainers
-
-- [Chris Riccomini](https://github.com/criccomini)
-- [Rohan Desai](https://github.com/rodesai), [Responsive](https://www.responsive.dev)
-- [Vignesh Chandramohan](https://github.com/vigneshc), [Microsoft](https://www.microsoft.com)
-- [Paul Butler](https://github.com/paulgb), [Jamsocket](https://jamsocket.com)
-- [Li Yazhou](https://github.com/flaneur2020), [Databend Labs](https://www.databend.com)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,19 @@
 # Releasing SlateDB
 
+## Cadence
+
+We aim to release a new version of SlateDB every 2 months. This is a guideline, not a strict rule. The actual cadence may vary based on the amount of work that has been completed.
+
+## Proposal
+
+Anyone may propose a new SlateDB release by opening a Github issue.
+
+## Approval
+
+[GOVERNANCE.md](GOVERNANCE.md) defines how a release is approved.
+
+## Publication
+
 SlateDB releases are published using a Github release action defined in `.github/workflows/release.yml`. To create a new release:
 
 1. Go to the [release action page](https://github.com/slatedb/slatedb/actions/workflows/release.yaml)


### PR DESCRIPTION
Adding a governance document based on [Vespa's](https://github.com/vespa-engine/vespa/blob/master/GOVERNANCE.md).

I tweaked the following things:

- Make all committers board members for now.
- Add reference to slatedb-pulumi for the official committer list.
- Cleaned some grammar.
- Added a carveout to allow committers to merge small PRs without approval.