### PR TITLE
Use cargo-nextest to run tests in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci]
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,5 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.84
       - name: Run Tests
-        run: cargo test --all-features --verbose
+        run: cargo nextest run --all-features --profile ci
+


### PR DESCRIPTION
The immediate motivation is configuring a per-test timeout in CI, but see https://nexte.st for the long list of improvements that cargo-nextest makes over cargo test.