### PR TITLE
tighten up error handling to prevent writer clients from blocking indefinitely

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -124,6 +124,7 @@ pub async fn run_gc_instance(
         gc_opts,
         tokio_handle,
         stats.clone(),
+        |_| {},
     )
     .await;
 

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -26,19 +26,19 @@
 //! be contention between `get`s, which holds a lock, and the write loop._
 
 use core::panic;
-use std::sync::Arc;
 use log::warn;
+use std::sync::Arc;
 
 use tokio::runtime::Handle;
 
 use crate::types::RowAttributes;
+use crate::utils::spawn_bg_task;
 use crate::{
     batch::{WriteBatch, WriteOp},
     db::DbInner,
     error::SlateDBError,
     mem_table::KVTable,
 };
-use crate::utils::spawn_bg_task;
 
 pub(crate) enum WriteBatchMsg {
     Shutdown,
@@ -152,14 +152,14 @@ impl DbInner {
 
         let this = Arc::clone(self);
         Some(spawn_bg_task(
-            &tokio_handle,
+            tokio_handle,
             move |err| {
                 warn!("write task exited with {:?}", err);
                 // notify any waiters about the failure
                 let mut state = this.state.write();
                 state.record_fatal_error(err.clone());
             },
-            fut
+            fut,
         ))
     }
 }

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -53,8 +53,6 @@ pub(crate) struct WriteBatchRequest {
 impl DbInner {
     #[allow(clippy::panic)]
     async fn write_batch(&self, batch: WriteBatch) -> Result<Arc<KVTable>, SlateDBError> {
-        self.check_error()?;
-
         let now = self.options.clock.now();
 
         let current_table = if self.wal_enabled() {

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -48,7 +48,7 @@ impl Compactor {
         let (external_tx, external_rx) = crossbeam_channel::unbounded();
         let (err_tx, err_rx) = tokio::sync::oneshot::channel();
         let tokio_handle = options.compaction_runtime.clone().unwrap_or(tokio_handle);
-        let main_thread = spawn_bg_thread("compactor", cleanup_fn, move || {
+        let main_thread = spawn_bg_thread("slatedb-compactor", cleanup_fn, move || {
             let load_result = CompactorOrchestrator::new(
                 options,
                 manifest_store.clone(),

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -18,6 +17,7 @@ use crate::error::SlateDBError;
 use crate::manifest_store::{FenceableManifest, ManifestStore, StoredManifest};
 use crate::metrics::DbStats;
 use crate::tablestore::TableStore;
+use crate::utils::spawn_bg_thread;
 
 pub trait CompactionScheduler {
     fn maybe_schedule_compaction(&self, state: &CompactorState) -> Vec<Compaction>;
@@ -33,7 +33,7 @@ pub(crate) enum WorkerToOrchestratorMsg {
 
 pub(crate) struct Compactor {
     main_tx: crossbeam_channel::Sender<CompactorMainMsg>,
-    main_thread: Option<JoinHandle<()>>,
+    main_thread: Option<JoinHandle<Result<(), SlateDBError>>>,
 }
 
 impl Compactor {
@@ -43,11 +43,12 @@ impl Compactor {
         options: CompactorOptions,
         tokio_handle: Handle,
         db_stats: Arc<DbStats>,
+        cleanup_fn: impl FnOnce(&SlateDBError) + Send + 'static,
     ) -> Result<Self, SlateDBError> {
         let (external_tx, external_rx) = crossbeam_channel::unbounded();
         let (err_tx, err_rx) = tokio::sync::oneshot::channel();
         let tokio_handle = options.compaction_runtime.clone().unwrap_or(tokio_handle);
-        let main_thread = thread::spawn(move || {
+        let main_thread = spawn_bg_thread("compactor", cleanup_fn, move || {
             let load_result = CompactorOrchestrator::new(
                 options,
                 manifest_store.clone(),
@@ -60,11 +61,11 @@ impl Compactor {
                 Ok(orchestrator) => orchestrator,
                 Err(err) => {
                     err_tx.send(Err(err)).expect("err channel failure");
-                    return;
+                    return Ok(());
                 }
             };
             err_tx.send(Ok(())).expect("err channel failure");
-            orchestrator.run();
+            orchestrator.run()
         });
         err_rx.await.expect("err channel failure")?;
         Ok(Self {
@@ -76,9 +77,10 @@ impl Compactor {
     pub(crate) async fn close(mut self) {
         if let Some(main_thread) = self.main_thread.take() {
             self.main_tx.send(Shutdown).expect("main tx disconnected");
-            main_thread
+            let result = main_thread
                 .join()
                 .expect("failed to stop main compactor thread");
+            info!("compactor thread exited with: {:?}", result)
         }
     }
 }
@@ -141,7 +143,7 @@ impl CompactorOrchestrator {
         Ok(CompactorState::new(db_state.clone()))
     }
 
-    fn run(&mut self) {
+    fn run(&mut self) -> Result<(), SlateDBError> {
         let ticker = crossbeam_channel::tick(self.options.poll_interval);
         let db_runs_log_ticker = crossbeam_channel::tick(Duration::from_secs(10));
 
@@ -172,6 +174,7 @@ impl CompactorOrchestrator {
                 }
             }
         }
+        Ok(())
     }
 
     fn load_manifest(&mut self) -> Result<(), SlateDBError> {

--- a/src/db.rs
+++ b/src/db.rs
@@ -2155,7 +2155,7 @@ mod tests {
 
         fail_parallel::cfg(fp_registry.clone(), "write-wal-sst-io-error", "panic").unwrap();
         let result = db.put(b"foo", b"bar").await;
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskFailed)));
+        assert!(matches!(result, Err(SlateDBError::BackgroundTaskPanic(_))));
     }
 
     async fn do_test_should_read_compacted_db(options: DbOptions) {

--- a/src/db.rs
+++ b/src/db.rs
@@ -471,7 +471,7 @@ pub struct Db {
     /// The handle for the flush thread.
     wal_flush_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
     memtable_flush_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
-    write_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
+    write_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
     compactor: Mutex<Option<Compactor>>,
     garbage_collector: Mutex<Option<GarbageCollector>>,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2104,10 +2104,7 @@ mod tests {
         assert!(result.is_ok(), "Failed to write key1");
 
         let flush_result = db.inner.flush_memtables().await;
-        match flush_result {
-            Err(e) => assert!(matches!(e, SlateDBError::IoError(_))),
-            _ => panic!("Expected flush error"),
-        }
+        assert!(flush_result.is_err());
         db.close().await.unwrap();
 
         // reload the db

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -15,7 +15,7 @@ impl DbInner {
         if guard.memtable().size() < self.options.l0_sst_size_bytes {
             return Ok(());
         }
-        guard.freeze_memtable(wal_id);
+        guard.freeze_memtable(wal_id)?;
         self.memtable_flush_notifier
             .send((None, MemtableFlushThreadMsg::FlushImmutableMemtables))
             .map_err(|_| SlateDBError::MemtableFlushChannelError)?;
@@ -33,7 +33,7 @@ impl DbInner {
         if guard.wal().size() < self.options.l0_sst_size_bytes {
             return Ok(());
         }
-        guard.freeze_wal();
+        guard.freeze_wal()?;
         self.wal_flush_notifier
             .send((None, WalFlushThreadMsg::FlushImmutableWals))
             .map_err(|_| SlateDBError::WalFlushChannelError)?;

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -11,7 +11,7 @@ use SsTableId::{Compacted, Wal};
 use crate::config::CompressionCodec;
 use crate::error::SlateDBError;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
-use crate::utils::{WriteOnceRegister, WriteOnceRegisterReader};
+use crate::utils::{WatchableOnceCell, WatchableOnceCellReader};
 
 #[derive(Clone, PartialEq, Serialize)]
 pub(crate) struct SsTableHandle {
@@ -140,7 +140,7 @@ pub(crate) struct DbState {
     memtable: WritableKVTable,
     wal: WritableKVTable,
     state: Arc<COWDbState>,
-    error: WriteOnceRegister<SlateDBError>,
+    error: WatchableOnceCell<SlateDBError>,
 }
 
 // represents the state that is mutated by creating a new copy with the mutations
@@ -211,7 +211,7 @@ impl DbState {
                 imm_wal: VecDeque::new(),
                 core: core_db_state,
             }),
-            error: WriteOnceRegister::new(),
+            error: WatchableOnceCell::new(),
         }
     }
 
@@ -232,7 +232,7 @@ impl DbState {
         self.state.core.next_wal_sst_id - 1
     }
 
-    pub fn error_reader(&self) -> WriteOnceRegisterReader<SlateDBError> {
+    pub fn error_reader(&self) -> WatchableOnceCellReader<SlateDBError> {
         self.error.reader()
     }
 

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -11,6 +11,7 @@ use SsTableId::{Compacted, Wal};
 use crate::config::CompressionCodec;
 use crate::error::SlateDBError;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
+use crate::utils::{WriteOnceRegister, WriteOnceRegisterReader};
 
 #[derive(Clone, PartialEq, Serialize)]
 pub(crate) struct SsTableHandle {
@@ -139,6 +140,7 @@ pub(crate) struct DbState {
     memtable: WritableKVTable,
     wal: WritableKVTable,
     state: Arc<COWDbState>,
+    error: WriteOnceRegister<SlateDBError>,
 }
 
 // represents the state that is mutated by creating a new copy with the mutations
@@ -209,6 +211,7 @@ impl DbState {
                 imm_wal: VecDeque::new(),
                 core: core_db_state,
             }),
+            error: WriteOnceRegister::new(),
         }
     }
 
@@ -229,7 +232,14 @@ impl DbState {
         self.state.core.next_wal_sst_id - 1
     }
 
+    pub fn error_reader(&self) -> WriteOnceRegisterReader<SlateDBError> {
+        self.error.reader()
+    }
+
     // mutations
+    pub fn record_fatal_error(&mut self, error: SlateDBError) {
+        self.error.write(error);
+    }
 
     pub fn wal(&mut self) -> &mut WritableKVTable {
         &mut self.wal
@@ -247,18 +257,25 @@ impl DbState {
         self.state = Arc::new(state);
     }
 
-    pub fn freeze_memtable(&mut self, wal_id: u64) {
+    pub fn freeze_memtable(&mut self, wal_id: u64) -> Result<(), SlateDBError> {
+        if let Some(err) = self.error.reader().read() {
+            return Err(err.clone());
+        }
         let old_memtable = std::mem::replace(&mut self.memtable, WritableKVTable::new());
         let mut state = self.state_copy();
         state
             .imm_memtable
             .push_front(Arc::new(ImmutableMemtable::new(old_memtable, wal_id)));
         self.update_state(state);
+        Ok(())
     }
 
-    pub fn freeze_wal(&mut self) -> Option<u64> {
+    pub fn freeze_wal(&mut self) -> Result<Option<u64>, SlateDBError> {
+        if let Some(err) = self.error.reader().read() {
+            return Err(err.clone());
+        }
         if self.wal.table().is_empty() {
-            return None;
+            return Ok(None);
         }
         let old_wal = std::mem::replace(&mut self.wal, WritableKVTable::new());
         let mut state = self.state_copy();
@@ -267,7 +284,7 @@ impl DbState {
         state.imm_wal.push_front(imm_wal);
         state.core.next_wal_sst_id += 1;
         self.update_state(state);
-        Some(id)
+        Ok(Some(id))
     }
 
     pub fn pop_imm_wal(&mut self) {
@@ -377,7 +394,9 @@ mod tests {
     fn add_l0s_to_dbstate(db_state: &mut DbState, n: u32) {
         let dummy_info = create_sst_info();
         for i in 0..n {
-            db_state.freeze_memtable(i as u64);
+            db_state
+                .freeze_memtable(i as u64)
+                .expect("db in error state");
             let imm = db_state.state.imm_memtable.back().unwrap().clone();
             let handle = SsTableHandle::new(SsTableId::Compacted(Ulid::new()), dummy_info.clone());
             db_state.move_imm_memtable_to_l0(imm, handle);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use std::any::Any;
+use std::sync::Mutex;
 use std::{path::PathBuf, sync::Arc};
 use thiserror::Error;
 
@@ -80,8 +82,10 @@ pub enum SlateDBError {
     #[error("Read channel error: {0}")]
     ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
 
-    #[error("background task failed")]
-    BackgroundTaskFailed,
+    #[error("background task panic'd")]
+    // we need to wrap the panic args in an Arc so SlateDbError is Clone
+    // we need to wrap the panic args in a mutex so that SlateDbError is Sync
+    BackgroundTaskPanic(Arc<Mutex<Box<dyn Any + Send>>>),
 
     #[error("background task shutdown")]
     BackgroundTaskShutdown,

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,6 +79,12 @@ pub enum SlateDBError {
 
     #[error("Read channel error: {0}")]
     ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
+
+    #[error("background task failed")]
+    BackgroundTaskFailed,
+
+    #[error("background task shutdown")]
+    BackgroundTaskShutdown,
 }
 
 impl From<std::io::Error> for SlateDBError {

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use log::warn;
+use std::sync::Arc;
 
 use tokio::runtime::Handle;
 use tokio::select;
@@ -104,7 +104,7 @@ impl DbInner {
         let this = Arc::clone(self);
         async fn core_flush_loop(
             this: &Arc<DbInner>,
-            rx: &mut UnboundedReceiver<FlushMsg<WalFlushThreadMsg>>
+            rx: &mut UnboundedReceiver<FlushMsg<WalFlushThreadMsg>>,
         ) -> Result<(), SlateDBError> {
             let mut ticker = tokio::time::interval(this.options.flush_interval);
             let mut err_reader = this.state.read().error_reader();

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -74,7 +74,7 @@ impl GarbageCollector {
             }
             Ok(())
         };
-        spawn_bg_thread("gc", cleanup_fn, gc_main);
+        spawn_bg_thread("slatedb-gc", cleanup_fn, gc_main);
         Self {
             main_tx: Arc::new(external_tx),
             shutdown_rx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ mod tablestore;
 mod test_utils;
 mod transactional_object_store;
 mod types;
+mod utils;
 
 /// Re-export the object store crate.
 ///

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -10,11 +10,11 @@ use crossbeam_skiplist::SkipMap;
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::types::{RowAttributes, RowEntry, ValueDeletable};
-use crate::utils::WriteOnceRegister;
+use crate::utils::WatchableOnceCell;
 
 pub(crate) struct KVTable {
     map: SkipMap<Bytes, ValueWithAttributes>,
-    durable: WriteOnceRegister<Result<(), SlateDBError>>,
+    durable: WatchableOnceCell<Result<(), SlateDBError>>,
     size: AtomicUsize,
 }
 
@@ -25,7 +25,7 @@ pub(crate) struct WritableKVTable {
 pub(crate) struct ImmutableMemtable {
     last_wal_id: u64,
     table: Arc<KVTable>,
-    flushed: WriteOnceRegister<Result<(), SlateDBError>>,
+    flushed: WatchableOnceCell<Result<(), SlateDBError>>,
 }
 
 pub(crate) struct ImmutableWal {
@@ -66,7 +66,7 @@ impl ImmutableMemtable {
         Self {
             table: table.table,
             last_wal_id,
-            flushed: WriteOnceRegister::new(),
+            flushed: WatchableOnceCell::new(),
         }
     }
 
@@ -135,7 +135,7 @@ impl KVTable {
         Self {
             map: SkipMap::new(),
             size: AtomicUsize::new(0),
-            durable: WriteOnceRegister::new(),
+            durable: WatchableOnceCell::new(),
         }
     }
 

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -96,7 +96,7 @@ impl DbInner {
         async fn core_flush_loop(
             this: &Arc<DbInner>,
             flusher: &mut MemtableFlusher,
-            rx: &mut UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>
+            rx: &mut UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>,
         ) -> Result<(), SlateDBError> {
             let mut manifest_poll_interval =
                 tokio::time::interval(this.options.manifest_poll_interval);
@@ -151,7 +151,7 @@ impl DbInner {
                         }
                     }
                 }
-            };
+            }
         }
 
         let fut = async move {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,38 @@
+pub(crate) struct WriteOnceRegister<T: Clone> {
+    pub(crate) rx: tokio::sync::watch::Receiver<Option<T>>,
+    pub(crate) tx: tokio::sync::watch::Sender<Option<T>>
+}
+
+impl <T: Clone> WriteOnceRegister<T> {
+    pub(crate) fn new() -> Self {
+        let (tx, rx) = tokio::sync::watch::channel(None);
+        Self{
+            rx,
+            tx,
+        }
+    }
+
+    pub(crate) fn write(&self, val: T) {
+        self.tx.send_if_modified(|v| {
+            if v.is_some() {
+                return false;
+            }
+            v.replace(val);
+            true
+        });
+    }
+
+    pub(crate) fn read(&self) -> Option<T> {
+        self.rx.borrow().clone()
+    }
+
+    pub(crate) async fn await_value(&self) -> T {
+        let mut rx = self.rx.clone();
+        loop {
+            if let Some(maybe_value) = rx.borrow_and_update().clone() {
+                return maybe_value;
+            }
+            rx.changed().await.expect("watch channel closed")
+        }
+    }
+}


### PR DESCRIPTION
This patch tries to tighten up error handling to prevent writer clients from blocking indefinitely. Previously we could see:
- a writer could pass the initial error check and then write to the in memory table, and then block until the table is durable. meanwhile, the flush task could panic or become fenced and the writer would never be notified.
- a writer could block in the backpressure loop, which never clears because the compactor failed.

The approach here consists of the following changes:

First, we add some utility types/fns:
- `WriteOnceRegister` which represents a value that can be written once. Later writes are dropped. The type also supports waiting for a value to be written to the register.
- Utility methods for spawning monitored tasks and threads. A monitored task or thread is spawned by another task/thread which waits on the result of the monitored task/thread. Then, the monitor task/thread calls a cleanup fn with the result.

The error field in DbImpl is removed and replaced with an error field of type WriteOnceRegister<SlateDBError> in DbState. We had to move this to DbState so that we could get mutual exclusion between setting the error and creating a new writable table.

The flushed/durable notifications in the memtables are replaced with WriteOnceRegister.

The wal flush task, memtable flush task, and compactor all spawn using the utitlity spawn methods, and also monitor the global error register. They signal status to the monitor task/thread by returning their status. The cleanup fn for the wal flush task sets the global error register, and the register in every wal table. The cleanup fn for the memtable flush task sets the global error register, and the register in every mem table. The cleanup fn for the comapctor sets the global error register.