### PR TITLE
Add ID to ManifestMissing error

### DIFF
--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -35,9 +35,7 @@ impl Db {
         options: &CheckpointOptions,
     ) -> Result<CheckpointCreateResult, SlateDBError> {
         let manifest_store = Arc::new(ManifestStore::new(path, object_store));
-        let Some(mut stored_manifest) = StoredManifest::load(manifest_store).await? else {
-            return Err(SlateDBError::ManifestMissing);
-        };
+        let mut stored_manifest = StoredManifest::load(manifest_store).await?;
         let id = Uuid::new_v4();
         stored_manifest
             .maybe_apply_db_state_update(|stored_manifest| {
@@ -95,9 +93,7 @@ impl Db {
         lifetime: Option<Duration>,
     ) -> Result<(), SlateDBError> {
         let manifest_store = Arc::new(ManifestStore::new(path, object_store));
-        let Some(mut stored_manifest) = StoredManifest::load(manifest_store).await? else {
-            return Err(SlateDBError::ManifestMissing);
-        };
+        let mut stored_manifest = StoredManifest::load(manifest_store).await?;
         stored_manifest
             .maybe_apply_db_state_update(|stored_manifest| {
                 let mut db_state = stored_manifest.db_state().clone();
@@ -123,9 +119,7 @@ impl Db {
         id: Uuid,
     ) -> Result<(), SlateDBError> {
         let manifest_store = Arc::new(ManifestStore::new(path, object_store));
-        let Some(mut stored_manifest) = StoredManifest::load(manifest_store).await? else {
-            return Err(SlateDBError::ManifestMissing);
-        };
+        let mut stored_manifest = StoredManifest::load(manifest_store).await?;
         stored_manifest
             .maybe_apply_db_state_update(|stored_manifest| {
                 let mut db_state = stored_manifest.db_state().clone();
@@ -166,11 +160,7 @@ mod tests {
             .unwrap();
         db.close().await.unwrap();
         let manifest_store = ManifestStore::new(&path, object_store.clone());
-        let (manifest_id, before_checkpoint) = manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap()
-            .unwrap();
+        let (manifest_id, before_checkpoint) = manifest_store.read_latest_manifest().await.unwrap();
 
         let CheckpointCreateResult {
             id: checkpoint_id,
@@ -179,11 +169,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (_, manifest) = manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap()
-            .unwrap();
+        let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         assert_eq!(manifest_id, checkpoint_manifest_id);
         let checkpoints = &manifest.core.checkpoints;
         assert_eq!(
@@ -221,11 +207,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (_, manifest) = manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap()
-            .unwrap();
+        let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         let checkpoints = &manifest.core.checkpoints;
         let checkpoint = checkpoints.iter().find(|c| c.id == checkpoint_id).unwrap();
         assert!(checkpoint.expire_time.is_some());
@@ -303,7 +285,10 @@ mod tests {
             Db::create_checkpoint(&path, object_store.clone(), &CheckpointOptions::default()).await;
 
         assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), SlateDBError::ManifestMissing));
+        assert!(matches!(
+            result.unwrap_err(),
+            SlateDBError::LatestManifestMissing
+        ));
     }
 
     #[tokio::test]
@@ -324,11 +309,7 @@ mod tests {
         .await
         .unwrap();
         let manifest_store = ManifestStore::new(&path, object_store.clone());
-        let (_, manifest) = manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap()
-            .unwrap();
+        let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         let checkpoint = manifest
             .core
             .checkpoints
@@ -346,11 +327,7 @@ mod tests {
         .await
         .unwrap();
 
-        let (_, manifest) = manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap()
-            .unwrap();
+        let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         let found: Vec<&Checkpoint> = manifest
             .core
             .checkpoints
@@ -398,11 +375,7 @@ mod tests {
             .unwrap();
 
         let manifest_store = ManifestStore::new(&path, object_store.clone());
-        let (_, manifest) = manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap()
-            .unwrap();
+        let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         assert!(!manifest.core.checkpoints.iter().any(|c| c.id == id));
     }
 }

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -283,7 +283,7 @@ impl CompactionExecuteBench {
         let os = self.object_store.clone();
         info!("load compaction job");
         let manifest_store = Arc::new(ManifestStore::new(&self.path, os.clone()));
-        let manifest = StoredManifest::load(manifest_store)
+        let manifest = StoredManifest::try_load(manifest_store)
             .await?
             .expect("expected manifest");
         let job = match &compaction {

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -283,9 +283,8 @@ impl CompactionExecuteBench {
         let os = self.object_store.clone();
         info!("load compaction job");
         let manifest_store = Arc::new(ManifestStore::new(&self.path, os.clone()));
-        let manifest = StoredManifest::try_load(manifest_store)
-            .await?
-            .expect("expected manifest");
+        let manifest = StoredManifest::load(manifest_store).await?;
+
         let job = match &compaction {
             Some(compaction) => {
                 info!("load job from existing compaction");

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -106,10 +106,7 @@ impl CompactorOrchestrator {
     ) -> Result<Self, SlateDBError> {
         let options = Arc::new(options);
         let stored_manifest =
-            tokio_handle.block_on(StoredManifest::try_load(manifest_store.clone()))?;
-        let Some(stored_manifest) = stored_manifest else {
-            return Err(SlateDBError::InvalidDBState);
-        };
+            tokio_handle.block_on(StoredManifest::load(manifest_store.clone()))?;
         let manifest = tokio_handle.block_on(FenceableManifest::init_compactor(stored_manifest))?;
         let state = Self::load_state(&manifest)?;
         let scheduler = Self::load_compaction_scheduler(options.as_ref());

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -106,7 +106,7 @@ impl CompactorOrchestrator {
     ) -> Result<Self, SlateDBError> {
         let options = Arc::new(options);
         let stored_manifest =
-            tokio_handle.block_on(StoredManifest::load(manifest_store.clone()))?;
+            tokio_handle.block_on(StoredManifest::try_load(manifest_store.clone()))?;
         let Some(stored_manifest) = stored_manifest else {
             return Err(SlateDBError::InvalidDBState);
         };
@@ -479,7 +479,7 @@ mod tests {
         let rt = build_runtime();
         let (os, manifest_store, table_store, db) = rt.block_on(build_test_db(options.clone()));
         let mut stored_manifest = rt
-            .block_on(StoredManifest::load(manifest_store.clone()))
+            .block_on(StoredManifest::try_load(manifest_store.clone()))
             .unwrap()
             .unwrap();
         rt.block_on(db.put(&[b'a'; 32], &[b'b'; 96])).unwrap();
@@ -594,7 +594,7 @@ mod tests {
 
     async fn await_compaction(manifest_store: Arc<ManifestStore>) -> Option<CoreDbState> {
         run_for(Duration::from_secs(10), || async {
-            let stored_manifest = StoredManifest::load(manifest_store.clone())
+            let stored_manifest = StoredManifest::try_load(manifest_store.clone())
                 .await
                 .unwrap()
                 .unwrap();

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -479,8 +479,7 @@ mod tests {
         let rt = build_runtime();
         let (os, manifest_store, table_store, db) = rt.block_on(build_test_db(options.clone()));
         let mut stored_manifest = rt
-            .block_on(StoredManifest::try_load(manifest_store.clone()))
-            .unwrap()
+            .block_on(StoredManifest::load(manifest_store.clone()))
             .unwrap();
         rt.block_on(db.put(&[b'a'; 32], &[b'b'; 96])).unwrap();
         rt.block_on(db.close()).unwrap();
@@ -594,10 +593,7 @@ mod tests {
 
     async fn await_compaction(manifest_store: Arc<ManifestStore>) -> Option<CoreDbState> {
         run_for(Duration::from_secs(10), || async {
-            let stored_manifest = StoredManifest::try_load(manifest_store.clone())
-                .await
-                .unwrap()
-                .unwrap();
+            let stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
             let db_state = stored_manifest.db_state();
             if db_state.l0_last_compacted.is_some() {
                 return Some(db_state.clone());

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -564,7 +564,7 @@ mod tests {
         tokio_handle.block_on(db.close()).unwrap();
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let stored_manifest = tokio_handle
-            .block_on(StoredManifest::load(manifest_store))
+            .block_on(StoredManifest::try_load(manifest_store))
             .unwrap()
             .unwrap();
         let state = CompactorState::new(stored_manifest.db_state().clone());

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -564,8 +564,7 @@ mod tests {
         tokio_handle.block_on(db.close()).unwrap();
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let stored_manifest = tokio_handle
-            .block_on(StoredManifest::try_load(manifest_store))
-            .unwrap()
+            .block_on(StoredManifest::load(manifest_store))
             .unwrap();
         let state = CompactorState::new(stored_manifest.db_state().clone());
         (os, stored_manifest, state)

--- a/src/db.rs
+++ b/src/db.rs
@@ -1532,10 +1532,7 @@ mod tests {
             .await
             .unwrap();
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
-        let mut stored_manifest = StoredManifest::try_load(manifest_store.clone())
-            .await
-            .unwrap()
-            .unwrap();
+        let mut stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
         let write_options = WriteOptions {
             await_durable: false,
         };
@@ -1608,10 +1605,7 @@ mod tests {
         .unwrap();
 
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
-        let mut stored_manifest = StoredManifest::try_load(manifest_store.clone())
-            .await
-            .unwrap()
-            .unwrap();
+        let mut stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
         let sst_format = SsTableFormat {
             min_filter_keys: 10,
             ..SsTableFormat::default()
@@ -1856,10 +1850,7 @@ mod tests {
 
         // validate that the manifest file exists.
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
-        let stored_manifest = StoredManifest::try_load(manifest_store)
-            .await
-            .unwrap()
-            .unwrap();
+        let stored_manifest = StoredManifest::load(manifest_store).await.unwrap();
         let db_state = stored_manifest.db_state();
         assert_eq!(db_state.next_wal_sst_id, next_wal_id);
     }
@@ -2137,10 +2128,7 @@ mod tests {
             .await
             .unwrap();
         let ms = ManifestStore::new(&path, object_store.clone());
-        let mut sm = StoredManifest::try_load(Arc::new(ms))
-            .await
-            .unwrap()
-            .unwrap();
+        let mut sm = StoredManifest::load(Arc::new(ms)).await.unwrap();
 
         // write enough to fill up a few l0 SSTs
         for i in 0..4 {

--- a/src/db.rs
+++ b/src/db.rs
@@ -622,7 +622,7 @@ impl Db {
         ));
 
         let manifest_store = Arc::new(ManifestStore::new(&path, maybe_cached_object_store.clone()));
-        let latest_manifest = StoredManifest::load(manifest_store.clone()).await?;
+        let latest_manifest = StoredManifest::try_load(manifest_store.clone()).await?;
 
         // get the next wal id before writing manifest.
         let wal_id_last_compacted = match &latest_manifest {
@@ -1532,7 +1532,7 @@ mod tests {
             .await
             .unwrap();
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
-        let mut stored_manifest = StoredManifest::load(manifest_store.clone())
+        let mut stored_manifest = StoredManifest::try_load(manifest_store.clone())
             .await
             .unwrap()
             .unwrap();
@@ -1608,7 +1608,7 @@ mod tests {
         .unwrap();
 
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
-        let mut stored_manifest = StoredManifest::load(manifest_store.clone())
+        let mut stored_manifest = StoredManifest::try_load(manifest_store.clone())
             .await
             .unwrap()
             .unwrap();
@@ -1856,7 +1856,10 @@ mod tests {
 
         // validate that the manifest file exists.
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
-        let stored_manifest = StoredManifest::load(manifest_store).await.unwrap().unwrap();
+        let stored_manifest = StoredManifest::try_load(manifest_store)
+            .await
+            .unwrap()
+            .unwrap();
         let db_state = stored_manifest.db_state();
         assert_eq!(db_state.next_wal_sst_id, next_wal_id);
     }
@@ -2134,7 +2137,10 @@ mod tests {
             .await
             .unwrap();
         let ms = ManifestStore::new(&path, object_store.clone());
-        let mut sm = StoredManifest::load(Arc::new(ms)).await.unwrap().unwrap();
+        let mut sm = StoredManifest::try_load(Arc::new(ms))
+            .await
+            .unwrap()
+            .unwrap();
 
         // write enough to fill up a few l0 SSTs
         for i in 0..4 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,8 +24,11 @@ pub enum SlateDBError {
     #[error("Manifest file already exists")]
     ManifestVersionExists,
 
-    #[error("Manifest missing")]
-    ManifestMissing,
+    #[error("Failed to find manifest with id {0}")]
+    ManifestMissing(u64),
+
+    #[error("Failed to find latest manifest")]
+    LatestManifestMissing,
 
     #[error("Invalid deletion")]
     InvalidDeletion,
@@ -90,7 +93,7 @@ impl From<object_store::Error> for SlateDBError {
 ///
 /// This enum encapsulates various error conditions that may arise
 /// when parsing or processing database configuration options.
-#[derive(thiserror::Error, Debug)]
+#[derive(Error, Debug)]
 pub enum DbOptionsError {
     #[error("Unknown configuration file format: {0}")]
     UnknownFormat(PathBuf),

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -137,6 +137,9 @@ impl StoredManifest {
         }))
     }
 
+    /// Load the current manifest from the supplied manifest store. If successful,
+    /// this method returns a [`Result`] with an instance of [`StoredManifest`].
+    /// If no manifests could be found, the error [`LatestManifestMissing`] is returned.
     pub(crate) async fn load(store: Arc<ManifestStore>) -> Result<Self, SlateDBError> {
         Self::try_load(store).await?.ok_or(LatestManifestMissing)
     }


### PR DESCRIPTION
Fixes #366. In addition to adding ID to `ManifestMissing`, this patch creates a separate error `LatestManifestMissing` when we are trying to find the latest and do not have a specific ID. This patch also adds a couple helpers for the common case when we expect either the latest manifest or a specific manifest to exist.