### PR TITLE
Remove unused lifetimes and use div_ceil in object storage cache

### DIFF
--- a/src/cached_object_store/object_store.rs
+++ b/src/cached_object_store/object_store.rs
@@ -325,7 +325,7 @@ impl CachedObjectStore {
 
     fn align_range(&self, range: &Range<usize>, alignment: usize) -> Range<usize> {
         let start_aligned = range.start - range.start % alignment;
-        let end_aligned = ((range.end + alignment - 1) / alignment) * alignment;
+        let end_aligned = range.end.div_ceil(alignment) * alignment;
         Range {
             start: start_aligned,
             end: end_aligned,

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -79,10 +79,8 @@ async fn exec_list_manifest(
         _ => u64::MIN..u64::MAX,
     };
 
-    Ok(println!(
-        "{}",
-        list_manifests(path, object_store, range).await?
-    ))
+    println!("{}", list_manifests(path, object_store, range).await?);
+    Ok(())
 }
 
 async fn exec_create_checkpoint(
@@ -101,7 +99,8 @@ async fn exec_create_checkpoint(
         },
     )
     .await?;
-    Ok(println!("{:?}", result))
+    println!("{:?}", result);
+    Ok(())
 }
 
 async fn exec_refresh_checkpoint(
@@ -110,10 +109,11 @@ async fn exec_refresh_checkpoint(
     id: Uuid,
     lifetime: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
-    Ok(println!(
+    println!(
         "{:?}",
         Db::refresh_checkpoint(path, object_store, id, lifetime).await?
-    ))
+    );
+    Ok(())
 }
 
 async fn exec_delete_checkpoint(
@@ -121,10 +121,8 @@ async fn exec_delete_checkpoint(
     object_store: Arc<dyn ObjectStore>,
     id: Uuid,
 ) -> Result<(), Box<dyn Error>> {
-    Ok(println!(
-        "{:?}",
-        Db::delete_checkpoint(path, object_store, id).await?
-    ))
+    println!("{:?}", Db::delete_checkpoint(path, object_store, id).await?);
+    Ok(())
 }
 
 async fn exec_list_checkpoints(
@@ -133,7 +131,8 @@ async fn exec_list_checkpoints(
 ) -> Result<(), Box<dyn Error>> {
     let checkpoint = list_checkpoints(path, object_store).await?;
     let checkpoint_json = serde_json::to_string(&checkpoint)?;
-    Ok(println!("{}", checkpoint_json))
+    println!("{}", checkpoint_json);
+    Ok(())
 }
 
 async fn exec_gc_once(

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -178,7 +178,7 @@ impl FlatBufferManifestCodec {
     }
 }
 
-impl<'b> CompactedSstId<'b> {
+impl CompactedSstId<'_> {
     pub(crate) fn ulid(&self) -> Ulid {
         Ulid::from((self.high(), self.low()))
     }

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -50,7 +50,7 @@ impl<'a> KeyValueIterator for MemTableIterator<'a> {
     }
 }
 
-impl<'a> MemTableIterator<'a> {
+impl MemTableIterator<'_> {
     pub(crate) fn next_entry_sync(&mut self) -> Option<RowEntry> {
         self.0.next().map(|entry| RowEntry {
             key: entry.key().clone(),

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -317,7 +317,7 @@ pub(crate) struct EncodedSsTableBuilder<'a> {
     compression_codec: Option<CompressionCodec>,
 }
 
-impl<'a> EncodedSsTableBuilder<'a> {
+impl EncodedSsTableBuilder<'_> {
     /// Create a builder based on target block size.
     fn new(
         block_size: usize,


### PR DESCRIPTION
Clippy has started failing with a couple of silly issues. They added a `div_ceil` detector fairly recently, which is now complaining. It's also grumbling about unused lifetimes. Fixing those.