### PR TITLE
POC: Improve database throughput.

### DIFF
--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -50,7 +50,7 @@ pub(crate) struct WriteBatchRequest {
 
 impl DbInner {
     #[allow(clippy::panic)]
-    async fn write_batch(&self, batch: WriteBatch) -> Result<Arc<KVTable>, SlateDBError> {
+    pub async fn write_batch(&self, batch: WriteBatch) -> Result<Arc<KVTable>, SlateDBError> {
         let now = self.options.clock.now();
 
         let current_table = if self.wal_enabled() {


### PR DESCRIPTION
I think I've narrowed down the main bottle neck on the synchronous ping pong case. This brought pushing and reading 100k records synchronously from java from `3.5s` to `650ms` (there might still be slowdown compared to 0.2, but these are ok-ish numbers for now).

This PR should work as a basis for discussion on how to solve this, I think the write through an actor model existed for a reason.

---

Before:

```
     Running benches/db_operations.rs (target/release/deps/db_operations-34a404d6f2deac98)
Benchmarking put: Warming up for 3.0000 s
Warning: Unable to complete 1000 samples in 5.0s. You may wish to increase target time to 5.5s, enable flat sampling, or reduce sample count to 670.
put                     time:   [11.095 µs 11.160 µs 11.231 µs]
                        change: [+3020.4% +3048.1% +3074.8%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 81 outliers among 1000 measurements (8.10%)
  7 (0.70%) low severe
  17 (1.70%) low mild
  34 (3.40%) high mild
  23 (2.30%) high severe
```

After:

```
     Running benches/db_operations.rs (target/release/deps/db_operations-34a404d6f2deac98)
put                     time:   [429.34 ns 429.87 ns 430.40 ns]
                        change: [-96.209% -96.175% -96.143%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 141 outliers among 1000 measurements (14.10%)
  1 (0.10%) low severe
  121 (12.10%) low mild
  11 (1.10%) high mild
  8 (0.80%) high severe
```

Any thoughts?