### PR TITLE
Add `cargo bench` PR check and `bencher`nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  benchmark:
+  benchmarks:
     name: Nightly Benchmark Run
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,13 +45,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./microbenchmarks-cache
-          key: ${{ runner.os }}-benchmark
+          key: ${{ runner.os }}-microbenchmarks
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: cargo bench --bench db_operations
           tool: 'cargo'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file-path: output.txt
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
           comment-on-alert: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,6 +33,7 @@ jobs:
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
+          fail-on-alert: true
           summary-always: true
           max-items-in-chart: 30
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -53,11 +53,7 @@ jobs:
           name: cargo bench --bench db_operations
           tool: 'cargo'
           output-file-path: output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '200%'
+          external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
           comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
-          skip-fetch-gh-pages: true
-          auto-push: false
-          save-data-file: false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,5 +31,3 @@ jobs:
           comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
-          auto-push: true
-          skip-fetch-gh-pages: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,12 +20,12 @@ jobs:
         run: cargo bench -- --output-format bencher | tee output.txt
 
       - name: Download nightly benchmark data
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks
 
-      - name: Store benchmark result
+      - name: Update benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: cargo bench
@@ -36,3 +36,9 @@ jobs:
           comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
+
+      - name: Save nightly benchmark data
+        uses: actions/cache/save@v4
+        with:
+          path: ./microbenchmarks-cache
+          key: ${{ runner.os }}-microbenchmarks

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,6 @@ permissions:
 
 jobs:
   benchmarks:
-    name: Nightly Benchmark Run
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,7 +22,7 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Nightly Benchmarks
+          name: cargo run --release --bin bencher
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -31,3 +30,28 @@ jobs:
           comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
+
+  microbenchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run benchmark
+        # Hardcode microbenchmarks because `libtest` runs otherwise. See:
+        # https://bheisler.github.io/criterion.rs/book/faq.html
+        run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: cargo bench --bench db_operations
+          tool: 'cargo'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '200%'
+          comment-on-alert: true
+          summary-always: true
+          max-items-in-chart: 30
+          skip-fetch-gh-pages: true
+          auto-push: false
+          save-data-file: false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,8 +30,8 @@ jobs:
         with:
           name: cargo bench
           tool: 'cargo'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
           comment-on-alert: true
           summary-always: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run benchmark
-        run: cargo bench | tee output.txt
+        run: cargo bench -- --output-format bencher | tee output.txt
 
       - name: Download nightly benchmark data
         uses: actions/cache@v4
@@ -48,7 +48,7 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: cargo bench --bench db_operations
+          name: cargo bench
           tool: 'cargo'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           output-file-path: output.txt

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,26 +11,6 @@ permissions:
   contents: write
 
 jobs:
-  # benchmarks:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-
-  #     - name: Run bencher
-  #       run: cargo run --release --bin bencher | tee output.txt
-
-  #     - name: Store benchmark result
-  #       uses: benchmark-action/github-action-benchmark@v1
-  #       with:
-  #         name: cargo run --release --bin bencher
-  #         tool: 'cargo'
-  #         output-file-path: output.txt
-  #         github-token: ${{ secrets.GITHUB_TOKEN }}
-  #         alert-threshold: '200%'
-  #         comment-on-alert: true
-  #         summary-always: true
-  #         max-items-in-chart: 30
-
   microbenchmarks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -33,7 +33,6 @@ jobs:
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
-          comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,34 @@
+name: Nightly Benchmarks
+
+on:
+  schedule:
+    # Run at midnight Pacific (8 AM UTC)
+    - cron: '0 8 * * *'
+  workflow_dispatch:  # Allow manual trigger
+
+permissions:
+  # Required for storing benchmark results
+  contents: write
+
+jobs:
+  benchmark:
+    name: Nightly Benchmark Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run bencher
+        run: cargo run --release --bin bencher | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Nightly Benchmarks
+          tool: 'cargo'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '200%'
+          comment-on-alert: true
+          summary-always: true
+          max-items-in-chart: 30
+          auto-push: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -11,25 +11,25 @@ permissions:
   contents: write
 
 jobs:
-  benchmarks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+  # benchmarks:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Run bencher
-        run: cargo run --release --bin bencher | tee output.txt
+  #     - name: Run bencher
+  #       run: cargo run --release --bin bencher | tee output.txt
 
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: cargo run --release --bin bencher
-          tool: 'cargo'
-          output-file-path: output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '200%'
-          comment-on-alert: true
-          summary-always: true
-          max-items-in-chart: 30
+  #     - name: Store benchmark result
+  #       uses: benchmark-action/github-action-benchmark@v1
+  #       with:
+  #         name: cargo run --release --bin bencher
+  #         tool: 'cargo'
+  #         output-file-path: output.txt
+  #         github-token: ${{ secrets.GITHUB_TOKEN }}
+  #         alert-threshold: '200%'
+  #         comment-on-alert: true
+  #         summary-always: true
+  #         max-items-in-chart: 30
 
   microbenchmarks:
     runs-on: ubuntu-latest
@@ -40,6 +40,12 @@ jobs:
         # Hardcode microbenchmarks because `libtest` runs otherwise. See:
         # https://bheisler.github.io/criterion.rs/book/faq.html
         run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
+
+      - name: Download nightly benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./microbenchmarks-cache
+          key: ${{ runner.os }}-benchmark
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,3 +32,4 @@ jobs:
           summary-always: true
           max-items-in-chart: 30
           auto-push: true
+          skip-fetch-gh-pages: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -37,9 +37,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run benchmark
-        # Hardcode microbenchmarks because `libtest` runs otherwise. See:
-        # https://bheisler.github.io/criterion.rs/book/faq.html
-        run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
+        run: cargo bench | tee output.txt
 
       - name: Download nightly benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,3 +68,23 @@ jobs:
       - name: Run Tests
         run: cargo nextest run --all-features --profile ci
 
+  benchmark:
+    name: Performance Regression Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run benchmark
+        run: cargo bench | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Rust Benchmark
+          tool: 'cargo'
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '200%'
+          comment-on-alert: true
+          summary-always: true
+          max-items-in-chart: 30

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,6 +96,7 @@ jobs:
           name: cargo bench --bench db_operations
           tool: 'cargo'
           output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
           comment-on-alert: true
           summary-always: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,7 +84,7 @@ jobs:
         # https://bheisler.github.io/criterion.rs/book/faq.html
         run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
 
-      - name: Download previous benchmark data
+      - name: Download nightly benchmark data
         uses: actions/cache@v4
         with:
           path: ./microbenchmarks-cache
@@ -96,12 +96,7 @@ jobs:
           name: cargo bench --bench db_operations
           tool: 'cargo'
           output-file-path: output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
-          alert-threshold: '200%'
           comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
-          skip-fetch-gh-pages: true
-          auto-push: false
-          save-data-file: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./microbenchmarks-cache
-          key: ${{ runner.os }}-benchmark
+          key: ${{ runner.os }}-microbenchmarks
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -88,7 +88,7 @@ jobs:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks
 
-      - name: Store benchmark result
+      - name: Update benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: cargo bench

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,7 +83,7 @@ jobs:
         run: cargo bench -- --output-format bencher | tee output.txt
 
       - name: Download nightly benchmark data
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,7 +81,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run benchmark
-        run: cargo bench | tee output.txt
+        # Hardcode microbenchmarks because `libtest` runs otherwise. See:
+        # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+        run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -96,3 +96,4 @@ jobs:
           comment-on-alert: true
           summary-always: true
           max-items-in-chart: 30
+          skip-fetch-gh-pages: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,9 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run benchmark
-        # Hardcode microbenchmarks because `libtest` runs otherwise. See:
-        # https://bheisler.github.io/criterion.rs/book/faq.html
-        run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
+        run: cargo bench | tee output.txt
 
       - name: Download nightly benchmark data
         uses: actions/cache@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -98,3 +98,4 @@ jobs:
           max-items-in-chart: 30
           skip-fetch-gh-pages: true
           auto-push: false
+          save-data-file: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -75,7 +75,6 @@ jobs:
         run: cargo nextest run --all-features --profile ci
 
   microbenchmarks:
-    name: Performance Regression Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -85,6 +84,12 @@ jobs:
         # https://bheisler.github.io/criterion.rs/book/faq.html
         run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
 
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./microbenchmarks-cache
+          key: ${{ runner.os }}-benchmark
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -92,6 +97,7 @@ jobs:
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
           alert-threshold: '200%'
           comment-on-alert: true
           summary-always: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,6 +11,12 @@ on:
 env:
   RUSTFLAGS: "-Dwarnings"
 
+permissions:
+  # Required for PR comments
+  pull-requests: write
+  # Required for storing benchmark results
+  contents: write
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run benchmark
-        run: cargo bench | tee output.txt
+        run: cargo bench -- --output-format bencher | tee output.txt
 
       - name: Download nightly benchmark data
         uses: actions/cache@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: cargo bench --bench db_operations
+          name: cargo bench
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Tests
         run: cargo nextest run --all-features --profile ci
 
-  benchmark:
+  microbenchmarks:
     name: Performance Regression Check
     runs-on: ubuntu-latest
     steps:
@@ -82,13 +82,13 @@ jobs:
 
       - name: Run benchmark
         # Hardcode microbenchmarks because `libtest` runs otherwise. See:
-        # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
+        # https://bheisler.github.io/criterion.rs/book/faq.html
         run: cargo bench --bench db_operations -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: Rust Benchmark
+          name: cargo bench --bench db_operations
           tool: 'cargo'
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -97,3 +97,4 @@ jobs:
           summary-always: true
           max-items-in-chart: 30
           skip-fetch-gh-pages: true
+          auto-push: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,15 +80,26 @@ foyer = ["dep:foyer"]
 [profile.bench]
 lto = true
 
+[lib]
+# Disable `libtest` harness because it fights with Criterion's `--output-format bencher`
+# See https://bheisler.github.io/criterion.rs/book/faq.html
+bench = false
+
 [[bin]]
 name = "bencher"
 path = "src/bencher/main.rs"
 required-features = ["bencher"]
+# Disable `libtest` harness because it fights with Criterion's `--output-format bencher`
+# See https://bheisler.github.io/criterion.rs/book/faq.html
+bench = false
 
 [[bin]]
 name = "slatedb"
 path = "src/cli/main.rs"
 required-features = ["cli"]
+# Disable `libtest` harness because it fights with Criterion's `--output-format bencher`
+# See https://bheisler.github.io/criterion.rs/book/faq.html
+bench = false
 
 [[bench]]
 name = "db_operations"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,9 @@ wal_disable = []
 moka = ["dep:moka"]
 foyer = ["dep:foyer"]
 
+[profile.bench]
+lto = true
+
 [[bin]]
 name = "bencher"
 path = "src/bencher/main.rs"


### PR DESCRIPTION
This PR adds a `cargo bench` that adds two new GH action jobs:

- Runs `cargo bench` whenever a PR is submitted
- Runs `carbo bench` nightly at 12AM Pacific

Both bench commands run the microbenchmarks in the `/benches` folder.

The PR check will leave a comment on the PR if the check resulted in a >= 200% slowdown, but it will not fail the PR. The PR check also will not save its results; it simply compares the most recent nightly's microbench data against the branch.

The nightly check behaves much like the PR check except that it saves the results using GH's `actions/cache` action, and the job will fail if there is a >= 200% slowdown.