### PR TITLE
Add `benchmark-db.sh` to nightly and publish results to the website

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -63,7 +63,7 @@ jobs:
           name: src/bencher/benchmark-db.sh
           tool: 'customBiggerIsBetter'
           output-file-path: target/bencher/results/benchmark-data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
           external-data-json-path: ./benchmarks-cache/benchmark-data.json
           fail-on-alert: true
           summary-always: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -69,6 +69,8 @@ jobs:
           summary-always: true
           max-items-in-chart: 30
           auto-push: true
+          gh-repository: github.com/slatedb/slatedb-website
+          benchmark-data-dir-path: performance/benchmarks/main
 
       - name: Save nightly benchmark data
         uses: actions/cache/save@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,16 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run benchmark
+      - name: Run microbenchmark
         run: cargo bench -- --output-format bencher | tee output.txt
 
-      - name: Download nightly benchmark data
+      - name: Download nightly microbenchmark data
         uses: actions/cache/restore@v4
         with:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks
 
-      - name: Update benchmark result
+      - name: Update microbenchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: cargo bench
@@ -37,8 +37,41 @@ jobs:
           summary-always: true
           max-items-in-chart: 30
 
-      - name: Save nightly benchmark data
+      - name: Save nightly microbenchmark data
         uses: actions/cache/save@v4
         with:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks
+
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run benchmark
+        run: src/bencher/benchmark-db.sh
+
+      - name: Download nightly benchmark data
+        uses: actions/cache/restore@v4
+        with:
+          path: ./benchmarks-cache
+          key: ${{ runner.os }}-benchmarks
+
+      - name: Update benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: src/bencher/benchmark-db.sh
+          tool: 'customBiggerIsBetter'
+          output-file-path: target/bencher/results/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          external-data-json-path: ./benchmarks-cache/benchmark-data.json
+          fail-on-alert: true
+          summary-always: true
+          max-items-in-chart: 30
+          auto-push: true
+
+      - name: Save nightly benchmark data
+        uses: actions/cache/save@v4
+        with:
+          path: ./benchmarks-cache
+          key: ${{ runner.os }}-benchmarks

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -29,7 +29,7 @@ run_bench() {
   $bench_cmd | tee "$log_file"
 }
 
-parse_stats() {
+generate_dat() {
     local input_file="$1"
     local output_file="$2"
 
@@ -60,6 +60,60 @@ generate_plot() {
     '$input_file' skip $warmup using 1:3 with linespoints linewidth 2 title 'Gets/s';"
 }
 
+generate_json() {
+    local output_file="$OUT/benchmark-data.json"
+    echo "[" > "$output_file"
+    local first_entry=true
+
+    for dat_file in "$OUT"/dats/*.dat; do
+        # Extract put_percentage and concurrency from filename
+        local filename=$(basename "$dat_file")
+        local put_percentage=$(echo "$filename" | cut -d'_' -f1)
+        local concurrency=$(echo "$filename" | cut -d'_' -f2 | cut -d'.' -f1)
+
+        # Read the last line of the dat file for final stats
+        local stats=$(tail -n 1 "$dat_file")
+        local elapsed=$(echo "$stats" | awk '{print $1}')
+        local puts=$(echo "$stats" | awk '{print $2}')
+        local gets=$(echo "$stats" | awk '{print $3}')
+
+        # Assert that all required values are non-empty
+        [ -n "$elapsed" ] || { echo "Error: elapsed time is empty in $dat_file"; exit 1; }
+        [ -n "$puts" ] || { echo "Error: puts/s is empty in $dat_file"; exit 1; }
+        [ -n "$gets" ] || { echo "Error: gets/s is empty in $dat_file"; exit 1; }
+
+        # Add comma for all but first entry
+        if [ "$first_entry" = true ]; then
+            first_entry=false
+        else
+            echo "," >> "$output_file"
+        fi
+
+        # Append benchmark results
+        cat >> "$output_file" << EOF
+    {
+        "name": "SlateDB ${put_percentage}% Puts ${concurrency} Threads - Puts/s",
+        "unit": "ops/sec",
+        "value": $puts
+    },
+    {
+        "name": "SlateDB ${put_percentage}% Puts ${concurrency} Threads - Gets/s",
+        "unit": "ops/sec",
+        "value": $gets
+    },
+    {
+        "name": "SlateDB ${put_percentage}% Puts ${concurrency} Threads - Duration",
+        "unit": "seconds",
+        "value": $elapsed
+    }
+EOF
+    done
+
+    # Remove the last comma and close the array
+    echo "]" >> "$output_file"
+    echo "Generated benchmark data in $output_file"
+}
+
 for put_percentage in 20 40 60 80 100; do
   for concurrency in 1 4; do
     log_file="$OUT/logs/${put_percentage}_${concurrency}.log"
@@ -67,7 +121,9 @@ for put_percentage in 20 40 60 80 100; do
     svg_file="$OUT/plots/${put_percentage}_${concurrency}.svg"
 
     run_bench "$put_percentage" "$concurrency" "$log_file"
-    parse_stats "$log_file" "$dat_file"
+    generate_dat "$log_file" "$dat_file"
     generate_plot "$dat_file" "$svg_file"
   done
 done
+
+generate_json

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -73,12 +73,10 @@ generate_json() {
 
         # Read the last line of the dat file for final stats
         local stats=$(tail -n 1 "$dat_file")
-        local elapsed=$(echo "$stats" | awk '{print $1}')
         local puts=$(echo "$stats" | awk '{print $2}')
         local gets=$(echo "$stats" | awk '{print $3}')
 
         # Assert that all required values are non-empty
-        [ -n "$elapsed" ] || { echo "Error: elapsed time is empty in $dat_file"; exit 1; }
         [ -n "$puts" ] || { echo "Error: puts/s is empty in $dat_file"; exit 1; }
         [ -n "$gets" ] || { echo "Error: gets/s is empty in $dat_file"; exit 1; }
 
@@ -100,11 +98,6 @@ generate_json() {
         "name": "SlateDB ${put_percentage}% Puts ${concurrency} Threads - Gets/s",
         "unit": "ops/sec",
         "value": $gets
-    },
-    {
-        "name": "SlateDB ${put_percentage}% Puts ${concurrency} Threads - Duration",
-        "unit": "seconds",
-        "value": $elapsed
     }
 EOF
     done

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -65,7 +65,8 @@ generate_json() {
     echo "[" > "$output_file"
     local first_entry=true
 
-    for dat_file in "$OUT"/dats/*.dat; do
+    # Use find to get a sorted list of dat files
+    for dat_file in $(find "$OUT/dats" -name "*.dat" | sort -Vr); do
         # Extract put_percentage and concurrency from filename
         local filename=$(basename "$dat_file")
         local put_percentage=$(echo "$filename" | cut -d'_' -f1)

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -9,7 +9,15 @@ OUT="target/bencher/results"
 mkdir -p $OUT/plots
 mkdir -p $OUT/dats
 mkdir -p $OUT/logs
-gnuplot -V # just to make sure gnuplot is present
+
+# Check if gnuplot is available
+has_gnuplot() {
+    if command -v gnuplot >/dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
 
 run_bench() {
   local put_percentage="$1"
@@ -116,7 +124,11 @@ for put_percentage in 20 40 60 80 100; do
 
     run_bench "$put_percentage" "$concurrency" "$log_file"
     generate_dat "$log_file" "$dat_file"
-    generate_plot "$dat_file" "$svg_file"
+    if has_gnuplot; then
+      generate_plot "$dat_file" "$svg_file"
+    else
+      echo "gnuplot is missing, so skipping plot generation"
+    fi
   done
 done
 


### PR DESCRIPTION
In #381, I added microbenchmarking checks to all PRs. I also added a nightly run that would set a new microbenchmark baseline.

This PR extends that work to add a nightly that runs the `benchmark-db.sh` script from #247. The new nightly job does the following:

- Runs `benchmark-db.sh`
- Pushes results to https://github.com/slatedb/slatedb-website's gh-pages branch under  the `performance/benchmarks/main` folder
- Fails if there is a >= 200% performance slowdown
- Caches results

To make all this work, I had to tweak `benchmark-db.sh` in a couple of places:

- Adds a `generate_json` method to generate a JSON file compatible with [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark)
- Makes `gnuplot` plot generation optional in `benchmark-db.sh`