### PR TITLE
Use Buildjet runner for nightly `benchmark-db.sh` performance test

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-microbenchmarks
 
   benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Our `benchmark-db.sh` benchmark runs are failing right now because Github only provides 14GiB of space in its standard runners and we're using 16GiB. I took a look at upgrading to GH Teams in order to get us access to the large runners, but it's $4 per-seat. So, I opted to try out [Buildjet](https://buildjet.com/). I'm only enabling the image for our nightly `benchmark-db.sh` script. The microbenchmarks will continue to use a standard GH runner.

We might still want to migrate to actual AWS machines and an AWS GH runner, but in the meantime, this Buildjet will hopefully suffice.