### PR TITLE
Ditch Buildjet for Warpbuild

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-microbenchmarks
 
   benchmarks:
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: warp-custom-slatedb-x64-32vCPU-128GB-RAM-300GB-DISK
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Buildjet was still running out of disk. The machines might be fast enough to fill quite a bit of disk. It appears Buildjet only has 64GB disk runners, so I'm switching to Warpbuild. Warpbuild also has the advantage of offering BYOC, which means we should be able to use it to provision AWS machines as well.