### PR TITLE
Add `--clean` option for `bencher`

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -64,6 +64,7 @@ jobs:
         env:
           CLOUD_PROVIDER: local
           LOCAL_PATH: ${{ github.workspace }}/benchmark-data
+          SLATEDB_BENCH_CLEAN: true
         run: mkdir -p ${{ github.workspace }}/benchmark-data && ./src/bencher/benchmark-db.sh
 
       - name: Download nightly benchmark data

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -63,20 +63,12 @@ pub async fn delete_objects_with_prefix(
     object_store: Arc<dyn ObjectStore>,
     prefix: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    // Obtain the stream of objects with the specified prefix
     let mut stream = object_store.list(Some(prefix));
 
-    // Consume the stream
     while let Some(object_meta_result) = stream.next().await {
         match object_meta_result {
-            Ok(object_meta) => {
-                // Delete the object
-                object_store.delete(&object_meta.location).await?;
-            }
-            Err(err) => {
-                // Handle any errors from the stream
-                return Err(Box::new(err));
-            }
+            Ok(object_meta) => object_store.delete(&object_meta.location).await?,
+            Err(err) => return Err(Box::new(err)),
         }
     }
 

--- a/src/bencher/README.md
+++ b/src/bencher/README.md
@@ -69,7 +69,14 @@ the repository root:
 ./src/bencher/benchmark-db.sh
 ```
 
-The command above will produce results at `target/bencher/results` directory. 
+The command above will produce results at `target/bencher/results` directory. The results include:
+
+- `plots`: Plots for each benchmark
+- `dats`: Data files for each benchmark
+- `logs`: Log files for each benchmark
+- `benchmark-data.json`: A JSON file containing all the benchmark results in [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) format.
+
+The script also has a `SLATEDB_BENCH_CLEAN` environment variable which can be set to `true` to clean up the test data in object storage after each benchmark.
 
 ## `compaction` Subcommand
 

--- a/src/bencher/args.rs
+++ b/src/bencher/args.rs
@@ -36,6 +36,13 @@ pub(crate) struct BencherArgs {
     )]
     pub(crate) path: String,
 
+    #[arg(
+        long,
+        help = "Clean up object storage files after the benchmark run completes",
+        default_value_t = false
+    )]
+    pub(crate) clean: bool,
+
     #[command(subcommand)]
     pub(crate) command: BencherCommands,
 }
@@ -134,13 +141,6 @@ pub(crate) struct BenchmarkDbArgs {
         default_value_t = 20
     )]
     pub(crate) put_percentage: u32,
-
-    #[arg(
-        long,
-        help = "Clean up object storage files after the benchmark run completes",
-        default_value_t = false
-    )]
-    pub(crate) clean: bool,
 }
 
 impl BenchmarkDbArgs {

--- a/src/bencher/args.rs
+++ b/src/bencher/args.rs
@@ -134,6 +134,13 @@ pub(crate) struct BenchmarkDbArgs {
         default_value_t = 20
     )]
     pub(crate) put_percentage: u32,
+
+    #[arg(
+        long,
+        help = "Clean up object storage files after the benchmark run completes",
+        default_value_t = false
+    )]
+    pub(crate) clean: bool,
 }
 
 impl BenchmarkDbArgs {

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -36,7 +36,7 @@ run_bench() {
     --val-len 8192 \
     --block-cache-size 134217728 \
     --put-percentage $put_percentage \
-    --concurrency $concurrency
+    --concurrency $concurrency \
   "
 
   $bench_cmd | tee "$log_file"

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -25,14 +25,13 @@ run_bench() {
   local log_file="$3"
 
   local bench_cmd="cargo run -r --bin bencher --features=bencher -- \
-    --path /slatedb-bencher_${put_percentage}_${concurrency} db \
+    --path /slatedb-bencher_${put_percentage}_${concurrency} --clean db \
     --db-options-path $DIR/Slatedb.toml \
     --duration 60 \
     --val-len 8192 \
     --block-cache-size 134217728 \
     --put-percentage $put_percentage \
-    --concurrency $concurrency \
-    --clean
+    --concurrency $concurrency
   "
 
   $bench_cmd | tee "$log_file"

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -32,6 +32,7 @@ run_bench() {
     --block-cache-size 134217728 \
     --put-percentage $put_percentage \
     --concurrency $concurrency \
+    --clean
   "
 
   $bench_cmd | tee "$log_file"

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -25,7 +25,7 @@ run_bench() {
   local log_file="$3"
 
   local clean_flag=""
-  if [ -n "$SLATEDB_BENCH_CLEAN" ]; then
+  if [ -n "${SLATEDB_BENCH_CLEAN:-}" ]; then
     clean_flag="--clean"
   fi
 

--- a/src/bencher/benchmark-db.sh
+++ b/src/bencher/benchmark-db.sh
@@ -24,8 +24,13 @@ run_bench() {
   local concurrency="$2"
   local log_file="$3"
 
+  local clean_flag=""
+  if [ -n "$SLATEDB_BENCH_CLEAN" ]; then
+    clean_flag="--clean"
+  fi
+
   local bench_cmd="cargo run -r --bin bencher --features=bencher -- \
-    --path /slatedb-bencher_${put_percentage}_${concurrency} --clean db \
+    --path /slatedb-bencher_${put_percentage}_${concurrency} $clean_flag db \
     --db-options-path $DIR/Slatedb.toml \
     --duration 60 \
     --val-len 8192 \

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -139,7 +139,7 @@ async fn cleanup_data(
     let temp_path = path.child(CLEANUP_NAME);
     if object_store.head(&temp_path).await.is_ok() {
         info!("Cleaning up test data in: {}", path);
-        if let Err(e) = admin::delete_objects_with_prefix(object_store.clone(), Some(&path)).await {
+        if let Err(e) = admin::delete_objects_with_prefix(object_store.clone(), Some(path)).await {
             error!("Error cleaning up test data: {}", e);
         }
     } else {

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if args.clean {
-        tracing::info!("Cleaning up test data");
+        tracing::info!("Cleaning up test data in {}", path);
         let result = admin::delete_objects_with_prefix(object_store, &path).await;
         if let Err(e) = result {
             tracing::error!("Error cleaning up test data: {}", e);

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -123,7 +123,12 @@ async fn create_temp_file(
 ) -> Result<PutResult, ObjectStoreError> {
     let temp_path = path.child(CLEANUP_NAME);
     info!("Creating cleanup lock file at: {}", temp_path);
-    object_store.put(&temp_path, PutPayload::from_bytes(Bytes::from(format!("{}", chrono::Utc::now())))).await
+    object_store
+        .put(
+            &temp_path,
+            PutPayload::from_bytes(Bytes::from(format!("{}", chrono::Utc::now()))),
+        )
+        .await
 }
 
 /// Cleans up test data if a temporary lock file exists.


### PR DESCRIPTION
`bencher` now has a `--clean` argument that will delete all objects in the input path after the `bencher` subcommand runs. This switch works for both the compaction benchmarks and the db benchmarks.

By default, `--clean` is disabled since it's destructive. If `--clean` is set, `bencher` will check that the object store path is empty. If it is, it'll create a `.clean_benchmark_data` file, which will signal that the data should be deleted after the benchmark runs. If the path is not empty, the benchmark will fail. After the benchmark runs, if `--clean` is set and a `.clean_benchmark_data` exists, `bencher` will remove all objects from the path.