### PR TITLE
Disable custom benchmark caching

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -67,12 +67,6 @@ jobs:
           SLATEDB_BENCH_CLEAN: true
         run: mkdir -p ${{ github.workspace }}/benchmark-data && ./src/bencher/benchmark-db.sh
 
-      - name: Download nightly benchmark data
-        uses: actions/cache/restore@v4
-        with:
-          path: ./benchmarks-cache
-          key: ${{ runner.os }}-benchmarks
-
       - name: Update benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -80,16 +74,9 @@ jobs:
           tool: 'customBiggerIsBetter'
           output-file-path: target/bencher/results/benchmark-data.json
           github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          external-data-json-path: ./benchmarks-cache/benchmark-data.json
           fail-on-alert: true
           summary-always: true
           max-items-in-chart: 30
           auto-push: true
           gh-repository: github.com/slatedb/slatedb-website
           benchmark-data-dir-path: performance/benchmarks/main
-
-      - name: Save nightly benchmark data
-        uses: actions/cache/save@v4
-        with:
-          path: ./benchmarks-cache
-          key: ${{ runner.os }}-benchmarks


### PR DESCRIPTION
The `benchmarks` nightly job currently caches data using Github's cache. It turns out github-action-benchmark doesn't allow us to do this _and_ publish to our slatedb-website repo; it's either/or. So, I'm disabling the custom download/save caching jobs, and removing `external-data-json-path` so that the GH action simply uses the JSON data that's stored in the slatedb-website repo when saving and comparing old results.