### PR TITLE
Simplify test_utils::assert_iterator.

### DIFF
--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -148,10 +148,10 @@ mod tests {
     use crate::error::SlateDBError;
     use crate::iter::KeyValueIterator;
     use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
-    use crate::test_utils::{assert_iterator, gen_attrs};
-    use crate::types::{RowEntry, ValueDeletable};
-    use bytes::Bytes;
+    use crate::test_utils::assert_iterator;
+    use crate::types::RowEntry;
     use std::collections::VecDeque;
+    use std::vec;
 
     #[tokio::test]
     async fn test_merge_iterator_should_include_entries_in_order() {
@@ -179,52 +179,16 @@ mod tests {
 
         assert_iterator(
             &mut merge_iter,
-            &[
-                (
-                    "aaaa".into(),
-                    ValueDeletable::Value(Bytes::from("1111")),
-                    gen_attrs(0),
-                ),
-                (
-                    "bbbb".into(),
-                    ValueDeletable::Value(Bytes::from("2222")),
-                    gen_attrs(3),
-                ),
-                (
-                    "cccc".into(),
-                    ValueDeletable::Value(Bytes::from("3333")),
-                    gen_attrs(1),
-                ),
-                (
-                    "dddd".into(),
-                    ValueDeletable::Value(Bytes::from("4444")),
-                    gen_attrs(6),
-                ),
-                (
-                    "eeee".into(),
-                    ValueDeletable::Value(Bytes::from("5555")),
-                    gen_attrs(7),
-                ),
-                (
-                    "gggg".into(),
-                    ValueDeletable::Value(Bytes::from("7777")),
-                    gen_attrs(8),
-                ),
-                (
-                    "xxxx".into(),
-                    ValueDeletable::Value(Bytes::from("24242424")),
-                    gen_attrs(4),
-                ),
-                (
-                    "yyyy".into(),
-                    ValueDeletable::Value(Bytes::from("25252525")),
-                    gen_attrs(5),
-                ),
-                (
-                    "zzzz".into(),
-                    ValueDeletable::Value(Bytes::from("26262626")),
-                    gen_attrs(2),
-                ),
+            vec![
+                RowEntry::new_value(b"aaaa", b"1111", 0),
+                RowEntry::new_value(b"bbbb", b"2222", 0),
+                RowEntry::new_value(b"cccc", b"3333", 0),
+                RowEntry::new_value(b"dddd", b"4444", 0),
+                RowEntry::new_value(b"eeee", b"5555", 0),
+                RowEntry::new_value(b"gggg", b"7777", 0),
+                RowEntry::new_value(b"xxxx", b"24242424", 0),
+                RowEntry::new_value(b"yyyy", b"25252525", 0),
+                RowEntry::new_value(b"zzzz", b"26262626", 0),
             ],
         )
         .await;
@@ -254,27 +218,11 @@ mod tests {
 
         assert_iterator(
             &mut merge_iter,
-            &[
-                (
-                    "aaaa".into(),
-                    ValueDeletable::Value(Bytes::from("1111")),
-                    gen_attrs(0),
-                ),
-                (
-                    "bbbb".into(),
-                    ValueDeletable::Value(Bytes::from("2222")),
-                    gen_attrs(4),
-                ),
-                (
-                    "cccc".into(),
-                    ValueDeletable::Value(Bytes::from("use this one c")),
-                    gen_attrs(1),
-                ),
-                (
-                    "xxxx".into(),
-                    ValueDeletable::Value(Bytes::from("use this one x")),
-                    gen_attrs(3),
-                ),
+            vec![
+                RowEntry::new_value(b"aaaa", b"1111", 0),
+                RowEntry::new_value(b"bbbb", b"2222", 0),
+                RowEntry::new_value(b"cccc", b"use this one c", 0),
+                RowEntry::new_value(b"xxxx", b"use this one x", 0),
             ],
         )
         .await;
@@ -295,37 +243,13 @@ mod tests {
 
         assert_iterator(
             &mut merge_iter,
-            &[
-                (
-                    "aaaa".into(),
-                    ValueDeletable::Value(Bytes::from("1111")),
-                    gen_attrs(0),
-                ),
-                (
-                    "bbbb".into(),
-                    ValueDeletable::Value(Bytes::from("2222")),
-                    gen_attrs(3),
-                ),
-                (
-                    "cccc".into(),
-                    ValueDeletable::Value(Bytes::from("3333")),
-                    gen_attrs(1),
-                ),
-                (
-                    "xxxx".into(),
-                    ValueDeletable::Value(Bytes::from("24242424")),
-                    gen_attrs(4),
-                ),
-                (
-                    "yyyy".into(),
-                    ValueDeletable::Value(Bytes::from("25252525")),
-                    gen_attrs(5),
-                ),
-                (
-                    "zzzz".into(),
-                    ValueDeletable::Value(Bytes::from("26262626")),
-                    gen_attrs(2),
-                ),
+            vec![
+                RowEntry::new_value(b"aaaa", b"1111", 0),
+                RowEntry::new_value(b"bbbb", b"2222", 0),
+                RowEntry::new_value(b"cccc", b"3333", 0),
+                RowEntry::new_value(b"xxxx", b"24242424", 0),
+                RowEntry::new_value(b"yyyy", b"25252525", 0),
+                RowEntry::new_value(b"zzzz", b"26262626", 0),
             ],
         )
         .await;
@@ -344,22 +268,10 @@ mod tests {
 
         assert_iterator(
             &mut merge_iter,
-            &[
-                (
-                    "aaaa".into(),
-                    ValueDeletable::Value(Bytes::from("1111")),
-                    gen_attrs(0),
-                ),
-                (
-                    "cccc".into(),
-                    ValueDeletable::Value(Bytes::from("use this one c")),
-                    gen_attrs(1),
-                ),
-                (
-                    "xxxx".into(),
-                    ValueDeletable::Value(Bytes::from("24242424")),
-                    gen_attrs(3),
-                ),
+            vec![
+                RowEntry::new_value(b"aaaa", b"1111", 0),
+                RowEntry::new_value(b"cccc", b"use this one c", 0),
+                RowEntry::new_value(b"xxxx", b"24242424", 0),
             ],
         )
         .await;

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -587,7 +587,7 @@ mod tests {
     #[cfg(feature = "moka")]
     use crate::tablestore::DbCache;
     use crate::tablestore::TableStore;
-    use crate::test_utils::{assert_iterator, gen_attrs, gen_empty_attrs};
+    use crate::test_utils::assert_iterator;
     use crate::types::{RowEntry, ValueDeletable};
     use crate::{
         block::Block, block_iterator::BlockIterator, db_state::SsTableId, iter::KeyValueIterator,
@@ -654,23 +654,11 @@ mod tests {
             .unwrap();
         assert_iterator(
             &mut iter,
-            &[
-                (
-                    vec![b'a'; 16],
-                    ValueDeletable::Value(Bytes::copy_from_slice(&[1u8; 16])),
-                    gen_attrs(1),
-                ),
-                (
-                    vec![b'b'; 16],
-                    ValueDeletable::Value(Bytes::copy_from_slice(&[2u8; 16])),
-                    gen_attrs(2),
-                ),
-                (vec![b'c'; 16], ValueDeletable::Tombstone, gen_empty_attrs()),
-                (
-                    vec![b'd'; 16],
-                    ValueDeletable::Value(Bytes::copy_from_slice(&[4u8; 16])),
-                    gen_attrs(4),
-                ),
+            vec![
+                RowEntry::new_value(&[b'a'; 16], &[1u8; 16], 0),
+                RowEntry::new_value(&[b'b'; 16], &[2u8; 16], 0),
+                RowEntry::new_tombstone(&[b'c'; 16], 0),
+                RowEntry::new_value(&[b'd'; 16], &[4u8; 16], 0),
             ],
         )
         .await;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,43 +1,19 @@
 use crate::config::Clock;
 use crate::iter::KeyValueIterator;
-use crate::types::{KeyValue, RowAttributes, ValueDeletable};
+use crate::types::{KeyValue, RowAttributes, RowEntry};
 use bytes::Bytes;
 use rand::Rng;
 use std::sync::atomic::{AtomicI64, Ordering};
 
-pub(crate) async fn assert_iterator<T: KeyValueIterator>(
-    iterator: &mut T,
-    entries: &[(Vec<u8>, ValueDeletable, RowAttributes)],
-) {
-    // We use Vec<u8> instead of &[u8] for the keys in the entries for several reasons:
-    // 1. Ownership and Lifetime: Vec<u8> owns its data, while &[u8] is a borrowed slice.
-    //    Using Vec<u8> allows us to store and manipulate the data without worrying about lifetimes.
-
-    // 2. Flexibility: Vec<u8> can be easily cloned, extended, or modified if needed.
-    //    This is particularly useful when working with keys that might need to be adjusted or compared.
-
-    // 3. Consistency with Bytes: The iterator returns keys as Bytes, which is similar to Vec<u8> in that
-    //    it owns its data. Using Vec<u8> in our test data maintains this consistency.
-
-    // 4. Avoid Slice Referencing Issues: Using &[u8] could lead to complicated lifetime issues,
-    //    especially if the original data the slice refers to goes out of scope.
-
-    // 5. Performance: While Vec<u8> has a slight overhead compared to &[u8], the difference is
-    //    negligible for most use cases, especially in tests where convenience and clarity are prioritized.
-
-    for (expected_k, expected_v, expected_attr) in entries.iter() {
-        let kv = iterator
+/// Asserts that the iterator returns the exact set of expected values in correct order.
+pub(crate) async fn assert_iterator<T: KeyValueIterator>(iterator: &mut T, entries: Vec<RowEntry>) {
+    for expected_entry in entries.iter() {
+        let actual_entry = iterator
             .next_entry()
             .await
             .expect("iterator next_entry failed")
             .expect("expected iterator to return a value");
-        assert_eq!(kv.key, Bytes::from(expected_k.clone()));
-        assert_eq!(kv.value, *expected_v);
-        assert_eq!(
-            kv.expire_ts, expected_attr.expire_ts,
-            "Attribute expire_ts mismatch at key {:?}",
-            kv.key
-        );
+        assert_eq!(actual_entry, expected_entry.clone());
     }
     assert!(iterator
         .next_entry()

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,6 +55,17 @@ impl RowEntry {
             expire_ts: None,
         }
     }
+
+    #[cfg(test)]
+    pub fn with_create_ts(&self, create_ts: i64) -> Self {
+        Self {
+            key: self.key.clone(),
+            value: self.value.clone(),
+            seq: self.seq,
+            create_ts: Some(create_ts),
+            expire_ts: self.expire_ts,
+        }
+    }
 }
 
 /// The metadata associated with a `KeyValueDeletable`


### PR DESCRIPTION
This change also fixes correctness, because the original version was ignoring seq and create_ts from assertion.

Prerequisite for https://github.com/slatedb/slatedb/pull/391