### PR TITLE
Don't Block Tokio Runtime in GC Thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -697,6 +697,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,6 +1547,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2122,8 +2152,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2134,8 +2173,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2575,6 +2620,7 @@ dependencies = [
  "siphasher",
  "snap",
  "tempfile",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
@@ -2709,6 +2755,28 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2947,10 +3015,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ figment = { version = "0.10.19", features = ["env", "json", "toml", "yaml"] }
 duration-str = { version = "0.11.2", features = ["serde", "time"], default-features = false }
 
 [dev-dependencies]
+test-log = "0.2.16"
 tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 fail-parallel = { version = "0.5.1", features = ["failpoints"] }
 tempfile = "3.3"

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -14,7 +14,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -605,7 +605,7 @@ impl DirGcStatus {
             // DirGcStatus::Done => crossbeam_channel::never(),
             DirGcStatus::Indefinite(duration) => tokio::time::interval(*duration),
             DirGcStatus::OneMore => {
-                tokio::time::interval_at(tokio::time::Instant::now(), Duration::from_secs(0))
+                tokio::time::interval_at(tokio::time::Instant::now(), Duration::from_millis(100))
             },
             DirGcStatus::Done => tokio::time::interval(Duration::from_secs(u64::MAX)),
         }
@@ -1158,7 +1158,7 @@ mod tests {
     /// - One inactive unexpired SST
     /// The test then runs the compactor to verify that only the inactive expired SSTs
     /// are deleted.
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_collect_garbage_compacted_ssts() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
         let l0_sst_handle = create_sst(table_store.clone()).await;


### PR DESCRIPTION
fixes: #380 


Additions: This PR adds a dev-dependency `test-log` so as to include the tracing info during cargo test which can be disabled via `RUST_LOG` environment variable


Current status: Draft PR 

Next Steps:

1. write a tokio's version of `crossbeam_channel::at` and use that
2. remove `mut orchescrator` which is not safe to send across threads. (and is most likely the source of `cargo test` hanging)