### PR TITLE
Add checksum to filter and index block

### DIFF
--- a/src/sst.rs
+++ b/src/sst.rs
@@ -534,7 +534,6 @@ mod tests {
     use std::vec;
 
     use bytes::BytesMut;
-    use flatbuffers::FlatBufferBuilder;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;


### PR DESCRIPTION
- Add checksum to both filter and index block, and do checksum validation while decoding them. 

Fixes #365