### PR TITLE
Brand SlateDB as a member of Commonhaus

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,9 @@ SlateDB is licensed under the Apache License, Version 2.0.
 SlateDB is a member of the [Commonhaus Foundation](https://www.commonhaus.org/).
 
 [![Commonhaus Foundation](https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_default_200px.png?raw=true)](https://www.commonhaus.org/)
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_reverse_200px.png?raw=true">
+  <img src="https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_default_200px.png?raw=true">
+</picture>
+

--- a/README.md
+++ b/README.md
@@ -99,3 +99,9 @@ SlateDB is currently in the early stages of development. It is not yet ready for
 ## License
 
 SlateDB is licensed under the Apache License, Version 2.0.
+
+## Foundation
+
+SlateDB is a member of the [Commonhaus Foundation](https://www.commonhaus.org/).
+
+[![Commonhaus Foundation](https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_default_200px.png?raw=true)](https://www.commonhaus.org/)

--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ SlateDB is licensed under the Apache License, Version 2.0.
 
 SlateDB is a member of the [Commonhaus Foundation](https://www.commonhaus.org/).
 
-[![Commonhaus Foundation](https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_default_200px.png?raw=true)](https://www.commonhaus.org/)
-
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_reverse_200px.png?raw=true">
   <img src="https://github.com/commonhaus/artwork/blob/main/foundation/brand/png/CF_logo_horizontal_single_default_200px.png?raw=true">


### PR DESCRIPTION
I'm using this strategy to handle both light and dark themes:

https://www.stefanjudis.com/notes/how-to-define-dark-light-mode-images-in-github-markdown/
https://github.com/stefanjudis/github-light-dark-image-example

Looks to work well on Github. I'm not sure if it'll work on Crates.io, but I'm OK with that.