### PR TITLE
Upgrade `object_store` to support `put_if_not_exists` on S3 without DynamoDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,15 +1947,16 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "futures",
+ "httparse",
  "humantime",
  "hyper",
  "itertools 0.13.0",
@@ -2301,9 +2302,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ flatbuffers = "24.3.25"
 futures = "0.3.30"
 humantime = {  version = "2.1.0", optional = true }
 leaky-bucket = {  version = "1.1", optional = true }
-object_store = "0.11.0"
+object_store = "0.11.2"
 parking_lot = "0.12.3"
 siphasher = "1"
 thiserror = "1.0.63"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -7,7 +7,6 @@ use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use futures::{StreamExt, TryStreamExt};
 #[cfg(feature = "aws")]
-use log::warn;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use std::env;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -180,7 +180,7 @@ pub fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
     let builder = if let Some(dynamodb_table) = dynamodb_table {
         builder.with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new(dynamodb_table)))
     } else {
-        builder
+        builder.with_conditional_put(S3ConditionalPut::ETagMatch)
     };
 
     let builder = if let Some(endpoint) = endpoint {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -6,7 +6,6 @@ use crate::metrics::DbStats;
 use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use futures::{StreamExt, TryStreamExt};
-#[cfg(feature = "aws")]
 use object_store::path::Path;
 use object_store::ObjectStore;
 use std::env;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -182,10 +182,6 @@ pub fn load_aws() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
     let builder = if let Some(dynamodb_table) = dynamodb_table {
         builder.with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new(dynamodb_table)))
     } else {
-        warn!(
-            "Running without configuring a DynamoDB Table. This is OK when running an admin, \
-        but any operations that attempt a CAS will fail."
-        );
         builder
     };
 


### PR DESCRIPTION
This PR updates the `object_store` crate to `0.11.2`, which contains this commit:

https://github.com/apache/arrow-rs/pull/6682

@benesch added S3 CAS support, which we can now take advantage of.

I removed a `warn!` in the `admin.rs` `load_aws` method since loading an AWS `ObjectStore` without a DynamoDB table should work now. I opted to leave support for DynamoDB intact in `admin.rs` since some users might wish to keep DynamoDB for other reasons.

Fixes #164