### PR TITLE
Fix flaky `test_should_recover_imm_from_wal_after_flush_error` test

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2507,17 +2507,28 @@ mod tests {
         assert!(flush_result.is_err());
         db.close().await.unwrap();
 
+        // pause write-compacted-sst-io-error to prevent immutable tables
+        // from being flushed, so we can snapshot the state when there is
+        // an immutable table to verify its contents.
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "pause").unwrap();
+
         // reload the db
-        let db = Db::open_with_opts(
+        let db = Db::open_with_fp_registry(
             path.clone(),
             test_db_options(0, 128, None),
             object_store.clone(),
+            fp_registry.clone(),
         )
         .await
         .unwrap();
 
         // verify that we reload imm
         let snapshot = db.inner.state.read().snapshot();
+
+        // resume write-compacted-sst-io-error since we got a snapshot and
+        // want to let the test finish.
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
+
         assert_eq!(snapshot.state.imm_memtable.len(), 1);
 
         // one empty wal and one wal for the first put


### PR DESCRIPTION
I started noticing that `test_should_recover_imm_from_wal_after_flush_error` was failing sporadically when I was testing #418. Upon some investigation, it appears that this test has a race condition.

The test simulates a writer that fails after a write goes to the WAL but before it is written to L0. The test then creates a new DB client, which loads the WAL SSTs into a memtable table and freezes it using `replay_wal`. The problem appears to be that `maybe_freeze_memtable` in `replay_wal`:

https://github.com/slatedb/slatedb/blob/e87bc82cab78da2ac1759e53d3382fc104b6f64b/src/db.rs#L517

Freezes the memtable, which we want, but then it tells `mem_table_flush.rs` to flush the immutable memtable:

https://github.com/slatedb/slatedb/blob/e87bc82cab78da2ac1759e53d3382fc104b6f64b/src/db_common.rs#L18-L21

Since the second DB client does not use an `fp_registry`, the `mem_table_flush.rs` loop might pick up the `MemtableFlushThreadMsg::FlushImmutableMemtables` message, flush the memtable, and pop the imm_memtable off the back in `db_state.rs`'s `move_imm_memtable_to_l0`.

To fix this, I paused the imm_memtable flushes to prevent the `mem_table_flush.rs` loop from popping the immutable memtable until we can take a snapshot of the DB state to do our checks.