### PR TITLE
Remove unnecessary allow dead_code annotation

### DIFF
--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -87,7 +87,6 @@ impl<'a> DbIterator<'a> {
     ///
     /// Returns [`SlateDBError::InvalidatedIterator`] if the iterator has been
     ///  invalidated in order to reclaim resources.
-    #[allow(dead_code)]
     pub async fn seek(&mut self, next_key: Bytes) -> Result<(), SlateDBError> {
         if let Some(error) = self.invalidated_error.clone() {
             Err(SlateDBError::InvalidatedIterator(Box::new(error)))


### PR DESCRIPTION
This must have snuck in during development.

## test plan:
Followed `main/CONTRIBUTING.md`, the following were successful:

```
cargo clippy --all-targets --all-features
cargo fmt
cargo test --all-features
```