### PR TITLE
[draft] Add `PutLocalObjectStore` to buffer puts to local disk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1952,7 +1958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "futures",
@@ -2507,7 +2513,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2891,6 +2897,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "atomic",
+ "base64 0.21.7",
  "bitflags 2.6.0",
  "bytemuck",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,12 +257,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1958,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eb4c22c6154a1e759d7099f9ffad7cc5ef8245f9efbab4a41b92623079c82f3"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -2513,7 +2507,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2897,7 +2891,7 @@ dependencies = [
  "async-channel",
  "async-trait",
  "atomic",
- "base64 0.21.7",
+ "base64",
  "bitflags 2.6.0",
  "bytemuck",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 async-channel = "2.3.1"
 async-trait = "0.1.82"
 atomic = "0.6.0"
+base64 = "0.21.7"
 bitflags = "2.6.0"
 bytemuck = "1.18.0"
 bytes = { version = "1.7.1", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 async-channel = "2.3.1"
 async-trait = "0.1.82"
 atomic = "0.6.0"
-base64 = "0.21.7"
+base64 = "0.22.1"
 bitflags = "2.6.0"
 bytemuck = "1.18.0"
 bytes = { version = "1.7.1", features = ["serde"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ mod merge_iterator;
 mod metrics;
 #[cfg(test)]
 mod proptest_util;
+mod put_local_object_store;
 mod row_codec;
 pub mod size_tiered_compaction;
 mod sorted_run_iterator;

--- a/src/put_local_object_store.rs
+++ b/src/put_local_object_store.rs
@@ -1,0 +1,304 @@
+use std::collections::VecDeque;
+use std::path::{Path as FsPath, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use bytes::Bytes;
+use futures::{future::BoxFuture, stream::BoxStream};
+use object_store::{path::Path, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta};
+use object_store::{ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult};
+use tokio::fs;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+/// Task representing an async put operation
+enum PutTask {
+    InFlight(JoinHandle<object_store::Result<PutResult>>),
+    Finished(object_store::Result<PutResult>),
+}
+
+/// A wrapper around an ObjectStore that writes data to local files first, then asynchronously
+/// uploads them to the wrapped ObjectStore.
+pub struct PutLocalObjectStore {
+    /// The wrapped object store where data will eventually be stored
+    inner: Arc<dyn ObjectStore>,
+    /// Directory where temporary files are stored before being uploaded
+    temp_dir: PathBuf,
+    /// Queue of ongoing put tasks
+    put_tasks: Arc<Mutex<VecDeque<PutTask>>>,
+    /// Maximum number of concurrent put tasks
+    max_put_tasks: usize,
+}
+
+impl PutLocalObjectStore {
+    /// Create a new PutLocalObjectStore
+    pub async fn new(
+        inner: Arc<dyn ObjectStore>,
+        temp_dir: PathBuf,
+        max_put_tasks: usize,
+    ) -> object_store::Result<Self> {
+        // Create temp directory if it doesn't exist
+        fs::create_dir_all(&temp_dir).await?;
+
+        let store = Self {
+            inner,
+            temp_dir: temp_dir.clone(),
+            put_tasks: Arc::new(Mutex::new(VecDeque::new())),
+            max_put_tasks,
+        };
+
+        // Recover any files that were not uploaded
+        store.recover_local_files().await?;
+
+        Ok(store)
+    }
+
+    /// Generate a temporary file path for a given object path
+    fn temp_file_path(&self, location: &Path) -> PathBuf {
+        let filename = location
+            .parts()
+            .collect::<Vec<_>>()
+            .join("_");
+        self.temp_dir.join(filename)
+    }
+
+    /// Recover any files in the temporary directory by uploading them
+    async fn recover_local_files(&self) -> object_store::Result<()> {
+        let mut entries = fs::read_dir(&self.temp_dir).await?;
+        
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.is_file().await? {
+                let bytes = fs::read(&path).await?;
+                let location = Path::from(
+                    path.file_name()
+                        .unwrap()
+                        .to_str()
+                        .unwrap()
+                        .replace("_", "/"),
+                );
+                
+                // Upload file to object store
+                self.inner
+                    .put_opts(
+                        &location,
+                        bytes.into(),
+                        PutOptions::default(),
+                    )
+                    .await?;
+                
+                // Delete temporary file
+                fs::remove_file(path).await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Process completed put tasks and remove them from the queue
+    async fn process_completed_tasks(&self) -> object_store::Result<()> {
+        let mut tasks = self.put_tasks.lock().await;
+        
+        let mut i = 0;
+        while i < tasks.len() {
+            match &tasks[i] {
+                PutTask::InFlight(handle) if handle.is_finished() => {
+                    // Replace with Finished variant
+                    if let Some(PutTask::InFlight(handle)) = tasks.remove(i) {
+                        let result = handle.await?;
+                        tasks.push_back(PutTask::Finished(Ok(result)));
+                    }
+                }
+                PutTask::Finished(_) => {
+                    tasks.remove(i);
+                }
+                _ => i += 1,
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for PutLocalObjectStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        // Process any completed tasks
+        self.process_completed_tasks().await?;
+
+        // Write to local file
+        let temp_path = self.temp_file_path(location);
+        let bytes = match payload {
+            PutPayload::Bytes(bytes) => bytes,
+            PutPayload::File(path) => Bytes::from(fs::read(path).await?),
+        };
+        fs::write(&temp_path, &bytes).await?;
+
+        // Create metadata for result
+        let meta = ObjectMeta {
+            location: location.clone(),
+            last_modified: SystemTime::now(),
+            size: bytes.len(),
+            e_tag: None,
+            version: None,
+        };
+
+        // Spawn task to upload file and clean up
+        let inner = self.inner.clone();
+        let temp_path_clone = temp_path.clone();
+        let location_clone = location.clone();
+
+        let mut tasks = self.put_tasks.lock().await;
+        while tasks.len() >= self.max_put_tasks {
+            drop(tasks);
+            tokio::task::yield_now().await;
+            self.process_completed_tasks().await?;
+            tasks = self.put_tasks.lock().await;
+        }
+
+        let handle = tokio::spawn(async move {
+            // Upload to inner store
+            let result = inner
+                .put_opts(
+                    &location_clone,
+                    bytes.into(),
+                    opts,
+                )
+                .await?;
+
+            // Delete temporary file
+            fs::remove_file(temp_path_clone).await?;
+
+            Ok(result)
+        });
+
+        tasks.push_back(PutTask::InFlight(handle));
+
+        Ok(PutResult {
+            e_tag: None,
+            version: None,
+        })
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        self.inner.delete(location).await
+    }
+
+    async fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> BoxStream<'_, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.rename(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.rename_if_not_exists(from, to).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOpts,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_put_local_object_store() -> object_store::Result<()> {
+        let inner = Arc::new(InMemory::new());
+        let temp_dir = tempdir()?.into_path();
+        let store = PutLocalObjectStore::new(inner.clone(), temp_dir.clone(), 2).await?;
+
+        // Put some data
+        let data = Bytes::from("hello world");
+        let location = Path::from("test/file.txt");
+        store
+            .put_opts(&location, data.clone().into(), PutOptions::default())
+            .await?;
+
+        // Verify data was written to temp file
+        let temp_path = store.temp_file_path(&location);
+        assert!(temp_path.exists());
+
+        // Wait for async upload to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Verify data was uploaded to inner store
+        let result = inner.get(&location).await?;
+        assert_eq!(result.bytes().await?, data);
+
+        // Verify temp file was cleaned up
+        assert!(!temp_path.exists());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_recover_local_files() -> object_store::Result<()> {
+        let inner = Arc::new(InMemory::new());
+        let temp_dir = tempdir()?.into_path();
+        
+        // Write a file to temp directory
+        let data = Bytes::from("test data");
+        let location = Path::from("test/recovery.txt");
+        let temp_path = temp_dir.join("test_recovery.txt");
+        fs::write(&temp_path, &data).await?;
+
+        // Create store which should recover the file
+        let store = PutLocalObjectStore::new(inner.clone(), temp_dir.clone(), 2).await?;
+
+        // Verify data was uploaded to inner store
+        let result = inner.get(&location).await?;
+        assert_eq!(result.bytes().await?, data);
+
+        // Verify temp file was cleaned up
+        assert!(!temp_path.exists());
+
+        Ok(())
+    }
+}

--- a/src/put_local_object_store.rs
+++ b/src/put_local_object_store.rs
@@ -15,6 +15,8 @@
 //!
 //! Puts will be retried up to `max_retries` times if the upload fails. If the upload still fails after
 //! the maximum retries, a failure will be returned when the next `put_opts` is called.
+//! 
+//! ETags and versions are not supported.
 //!
 //! # Examples
 //!

--- a/src/put_local_object_store.rs
+++ b/src/put_local_object_store.rs
@@ -151,15 +151,6 @@ impl ObjectStore for PutLocalObjectStore {
         };
         fs::write(&temp_path, &bytes).await?;
 
-        // Create metadata for result
-        let meta = ObjectMeta {
-            location: location.clone(),
-            last_modified: SystemTime::now(),
-            size: bytes.len(),
-            e_tag: None,
-            version: None,
-        };
-
         // Spawn task to upload file and clean up
         let inner = self.inner.clone();
         let temp_path_clone = temp_path.clone();


### PR DESCRIPTION
This PR introduces `PutLocalObjectStore`, a wrapper around object store implementations that buffers write operations to local disk before asynchronously uploading them to the underlying store. 

Key features:
- Configurable concurrent upload tasks and retry attempts
- Base64URL-encoded temporary file paths for safe filesystem storage
- Automatic recovery of incomplete uploads on initialization
- Pass-through read operations to maintain eventual consistency

Note that reads are always directed to the underlying store, which means there may be a delay between a successful write returning and the data being available for read operations.

I _think_ this should work for the use cases described in #162, where users might wish to buffer writes to EBS or a local filesystem in order to speed up writes without completely giving up on durability. In such use cases, I think users _must_ set `max_put_tasks` to 1 in order to prevent out of order writes, which would ruin the semantics of the WAL fencing (since we don't support parallel WAL puts right now).

I think we'd still want to split the `object_store` in `table_store` into `wal_object_store` and `compacted_object_store` so that we can use `PutLocalObjectStore` _just_ for the `wal_object_store`. This should allow users to use a standard S3 (CAS) object store for the manifest and SST and the `PutLocalObjectStore` for the WAL.

Fixes #162