### PR TITLE
fix issue with clock tick recovery reading from WAL

### DIFF
--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -37,8 +37,9 @@ table ManifestV1 {
     // A list of the sorted runs that are valid to read in the `compacted` folder.
     compacted: [SortedRun] (required);
 
-    // The last clock tick
-    last_clock_tick: long;
+    // The last L0 clock tick (the database should restore the latest
+    // tick when recovering from WAL if there are any WAL entries)
+    last_l0_clock_tick: long;
 
     // A list of checkpoints that are currently open.
     checkpoints: [Checkpoint] (required);

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -89,7 +89,6 @@ impl DbInner {
                 panic!("wal_disabled feature must be enabled");
             }
             let mut guard = self.state.write();
-            guard.update_clock_tick(now)?;
             let current_memtable = guard.memtable();
             for op in batch.ops {
                 match op {

--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -52,12 +52,11 @@ pub(crate) struct WriteBatchRequest {
 impl DbInner {
     #[allow(clippy::panic)]
     async fn write_batch(&self, batch: WriteBatch) -> Result<Arc<KVTable>, SlateDBError> {
-        let now = self.options.clock.now();
+        let now = self.mono_clock.now()?;
 
         let current_table = if self.wal_enabled() {
             let mut guard = self.state.write();
 
-            guard.update_clock_tick(now)?;
             let current_wal = guard.wal();
             for op in batch.ops {
                 match op {

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -218,7 +218,7 @@ impl CompactionExecuteBench {
             destination: 0,
             ssts,
             sorted_runs: vec![],
-            compaction_ts: manifest.db_state().last_clock_tick,
+            compaction_ts: manifest.db_state().last_l0_clock_tick,
         })
     }
 
@@ -244,7 +244,7 @@ impl CompactionExecuteBench {
             destination: 0,
             ssts: vec![],
             sorted_runs: srs,
-            compaction_ts: state.last_clock_tick,
+            compaction_ts: state.last_l0_clock_tick,
         }
     }
 

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -247,7 +247,7 @@ impl CompactorOrchestrator {
             destination: compaction.destination,
             ssts,
             sorted_runs,
-            compaction_ts: db_state.last_clock_tick,
+            compaction_ts: db_state.last_l0_clock_tick,
         });
     }
 
@@ -452,7 +452,7 @@ mod tests {
         let db_state = db_state.expect("db was not compacted");
         assert!(db_state.l0_last_compacted.is_some());
         assert_eq!(db_state.compacted.len(), 1);
-        assert_eq!(db_state.last_clock_tick, 70);
+        assert_eq!(db_state.last_l0_clock_tick, 70);
         let compacted = &db_state.compacted.first().unwrap().ssts;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -161,7 +161,7 @@ impl CompactorState {
         merged.l0 = merged_l0s;
         merged.last_compacted_wal_sst_id = updated_state.last_compacted_wal_sst_id;
         merged.next_wal_sst_id = updated_state.next_wal_sst_id;
-        merged.last_clock_tick = updated_state.last_clock_tick;
+        merged.last_l0_clock_tick = updated_state.last_l0_clock_tick;
 
         // We also need to account for any new checkpoints
         merged.checkpoints.clone_from(&updated_state.checkpoints);

--- a/src/db.rs
+++ b/src/db.rs
@@ -2918,7 +2918,9 @@ mod tests {
             path.clone(),
             test_db_options_with_clock(0, 1024, None, clock.clone()),
             Arc::clone(&object_store),
-        ).await.unwrap();
+        )
+        .await
+        .unwrap();
 
         assert_eq!(db.inner.mono_clock.last_tick.load(Ordering::SeqCst), 11);
     }
@@ -2934,8 +2936,8 @@ mod tests {
             test_db_options_with_clock(0, 32, None, clock.clone()),
             Arc::clone(&object_store),
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         // this will exceed the l0_sst_size_bytes, meaning a clean shutdown
         // will update the manifest

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -225,6 +225,9 @@ pub(crate) struct CoreDbState {
     pub(crate) compacted: Vec<SortedRun>,
     pub(crate) next_wal_sst_id: u64,
     pub(crate) last_compacted_wal_sst_id: u64,
+    /// the `last_clock_tick` includes all data in L0 and below --
+    /// WAL entries will have their latest ticks recovered on replay
+    /// into the in-memory state
     pub(crate) last_clock_tick: i64,
     pub(crate) checkpoints: Vec<Checkpoint>,
 }
@@ -371,6 +374,7 @@ impl DbState {
         assert!(Arc::ptr_eq(&popped, &imm_memtable));
         state.core.l0.push_front(sst_handle);
         state.core.last_compacted_wal_sst_id = imm_memtable.last_wal_id();
+        state.core.last_clock_tick = imm_memtable.table().last_tick();
         self.update_state(state);
     }
 

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -226,10 +226,10 @@ pub(crate) struct CoreDbState {
     pub(crate) compacted: Vec<SortedRun>,
     pub(crate) next_wal_sst_id: u64,
     pub(crate) last_compacted_wal_sst_id: u64,
-    /// the `last_clock_tick` includes all data in L0 and below --
+    /// the `last_l0_clock_tick` includes all data in L0 and below --
     /// WAL entries will have their latest ticks recovered on replay
     /// into the in-memory state
-    pub(crate) last_clock_tick: i64,
+    pub(crate) last_l0_clock_tick: i64,
     pub(crate) checkpoints: Vec<Checkpoint>,
 }
 
@@ -242,7 +242,7 @@ impl CoreDbState {
             compacted: vec![],
             next_wal_sst_id: 1,
             last_compacted_wal_sst_id: 0,
-            last_clock_tick: i64::MIN,
+            last_l0_clock_tick: i64::MIN,
             checkpoints: vec![],
         }
     }
@@ -378,10 +378,10 @@ impl DbState {
 
         // ensure the persisted manifest tick never goes backwards in time
         let memtable_tick = imm_memtable.table().last_tick();
-        state.core.last_clock_tick = cmp::max(state.core.last_clock_tick, memtable_tick);
-        if state.core.last_clock_tick != memtable_tick {
+        state.core.last_l0_clock_tick = cmp::max(state.core.last_l0_clock_tick, memtable_tick);
+        if state.core.last_l0_clock_tick != memtable_tick {
             return Err(SlateDBError::InvalidClockTick {
-                last_tick: state.core.last_clock_tick,
+                last_tick: state.core.last_l0_clock_tick,
                 next_tick: memtable_tick,
             });
         }

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -161,7 +161,7 @@ impl FlatBufferManifestCodec {
             compacted,
             next_wal_sst_id: manifest.wal_id_last_seen() + 1,
             last_compacted_wal_sst_id: manifest.wal_id_last_compacted(),
-            last_clock_tick: manifest.last_clock_tick(),
+            last_l0_clock_tick: manifest.last_l0_clock_tick(),
             checkpoints,
         };
         Manifest {
@@ -339,7 +339,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 l0_last_compacted,
                 l0: Some(l0),
                 compacted: Some(compacted),
-                last_clock_tick: core.last_clock_tick,
+                last_l0_clock_tick: core.last_l0_clock_tick,
                 checkpoints: Some(checkpoints),
             },
         );

--- a/src/generated/manifest_generated.rs
+++ b/src/generated/manifest_generated.rs
@@ -957,7 +957,7 @@ impl<'a> ManifestV1<'a> {
   pub const VT_L0_LAST_COMPACTED: flatbuffers::VOffsetT = 16;
   pub const VT_L0: flatbuffers::VOffsetT = 18;
   pub const VT_COMPACTED: flatbuffers::VOffsetT = 20;
-  pub const VT_LAST_CLOCK_TICK: flatbuffers::VOffsetT = 22;
+  pub const VT_LAST_L0_CLOCK_TICK: flatbuffers::VOffsetT = 22;
   pub const VT_CHECKPOINTS: flatbuffers::VOffsetT = 24;
 
   #[inline]
@@ -970,7 +970,7 @@ impl<'a> ManifestV1<'a> {
     args: &'args ManifestV1Args<'args>
   ) -> flatbuffers::WIPOffset<ManifestV1<'bldr>> {
     let mut builder = ManifestV1Builder::new(_fbb);
-    builder.add_last_clock_tick(args.last_clock_tick);
+    builder.add_last_l0_clock_tick(args.last_l0_clock_tick);
     builder.add_wal_id_last_seen(args.wal_id_last_seen);
     builder.add_wal_id_last_compacted(args.wal_id_last_compacted);
     builder.add_compactor_epoch(args.compactor_epoch);
@@ -1049,11 +1049,11 @@ impl<'a> ManifestV1<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRun>>>>(ManifestV1::VT_COMPACTED, None).unwrap()}
   }
   #[inline]
-  pub fn last_clock_tick(&self) -> i64 {
+  pub fn last_l0_clock_tick(&self) -> i64 {
     // Safety:
     // Created from valid Table for this object
     // which contains a valid value in this slot
-    unsafe { self._tab.get::<i64>(ManifestV1::VT_LAST_CLOCK_TICK, Some(0)).unwrap()}
+    unsafe { self._tab.get::<i64>(ManifestV1::VT_LAST_L0_CLOCK_TICK, Some(0)).unwrap()}
   }
   #[inline]
   pub fn checkpoints(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>> {
@@ -1080,7 +1080,7 @@ impl flatbuffers::Verifiable for ManifestV1<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<CompactedSstId>>("l0_last_compacted", Self::VT_L0_LAST_COMPACTED, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTable>>>>("l0", Self::VT_L0, true)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SortedRun>>>>("compacted", Self::VT_COMPACTED, true)?
-     .visit_field::<i64>("last_clock_tick", Self::VT_LAST_CLOCK_TICK, false)?
+     .visit_field::<i64>("last_l0_clock_tick", Self::VT_LAST_L0_CLOCK_TICK, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Checkpoint>>>>("checkpoints", Self::VT_CHECKPOINTS, true)?
      .finish();
     Ok(())
@@ -1096,7 +1096,7 @@ pub struct ManifestV1Args<'a> {
     pub l0_last_compacted: Option<flatbuffers::WIPOffset<CompactedSstId<'a>>>,
     pub l0: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTable<'a>>>>>,
     pub compacted: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRun<'a>>>>>,
-    pub last_clock_tick: i64,
+    pub last_l0_clock_tick: i64,
     pub checkpoints: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>>>>,
 }
 impl<'a> Default for ManifestV1Args<'a> {
@@ -1112,7 +1112,7 @@ impl<'a> Default for ManifestV1Args<'a> {
       l0_last_compacted: None,
       l0: None, // required field
       compacted: None, // required field
-      last_clock_tick: 0,
+      last_l0_clock_tick: 0,
       checkpoints: None, // required field
     }
   }
@@ -1160,8 +1160,8 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV1Builder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV1::VT_COMPACTED, compacted);
   }
   #[inline]
-  pub fn add_last_clock_tick(&mut self, last_clock_tick: i64) {
-    self.fbb_.push_slot::<i64>(ManifestV1::VT_LAST_CLOCK_TICK, last_clock_tick, 0);
+  pub fn add_last_l0_clock_tick(&mut self, last_l0_clock_tick: i64) {
+    self.fbb_.push_slot::<i64>(ManifestV1::VT_LAST_L0_CLOCK_TICK, last_l0_clock_tick, 0);
   }
   #[inline]
   pub fn add_checkpoints(&mut self, checkpoints: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Checkpoint<'b >>>>) {
@@ -1197,7 +1197,7 @@ impl core::fmt::Debug for ManifestV1<'_> {
       ds.field("l0_last_compacted", &self.l0_last_compacted());
       ds.field("l0", &self.l0());
       ds.field("compacted", &self.compacted());
-      ds.field("last_clock_tick", &self.last_clock_tick());
+      ds.field("last_l0_clock_tick", &self.last_l0_clock_tick());
       ds.field("checkpoints", &self.checkpoints());
       ds.finish()
   }

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -251,7 +251,6 @@ impl ManifestStore {
         id: u64,
         manifest: &Manifest,
     ) -> Result<(), SlateDBError> {
-        println!("{:?}", manifest);
         let manifest_path = &self.get_manifest_path(id);
 
         self.object_store

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -251,6 +251,7 @@ impl ManifestStore {
         id: u64,
         manifest: &Manifest,
     ) -> Result<(), SlateDBError> {
+        println!("{:?}", manifest);
         let manifest_path = &self.get_manifest_path(id);
 
         self.object_store

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -177,6 +177,10 @@ impl WritableKVTable {
     pub(crate) fn size(&self) -> usize {
         self.table.size()
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.size() == 0
+    }
 }
 
 impl KVTable {

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -1,12 +1,12 @@
-use std::cell::Cell;
-use std::collections::VecDeque;
-use std::ops::{RangeBounds, RangeFull};
-use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::sync::atomic::Ordering::SeqCst;
 use bytes::Bytes;
 use crossbeam_skiplist::map::Range;
 use crossbeam_skiplist::SkipMap;
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::ops::{RangeBounds, RangeFull};
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use crate::bytes_range::BytesRange;
 use crate::error::SlateDBError;

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -1,18 +1,19 @@
+use std::cell::Cell;
+use std::collections::VecDeque;
+use std::ops::{RangeBounds, RangeFull};
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use crossbeam_skiplist::map::Range;
+use crossbeam_skiplist::SkipMap;
+
 use crate::bytes_range::BytesRange;
 use crate::error::SlateDBError;
 use crate::iter::{KeyValueIterator, SeekToKey};
 use crate::merge_iterator::MergeIterator;
 use crate::types::{RowAttributes, RowEntry, ValueDeletable};
 use crate::utils::WatchableOnceCell;
-use bytes::Bytes;
-use crossbeam_skiplist::map::Range;
-use crossbeam_skiplist::SkipMap;
-use std::cell::Cell;
-use std::collections::VecDeque;
-use std::ops::{RangeBounds, RangeFull};
-use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
-use std::sync::Arc;
 
 pub(crate) struct KVTable {
     map: SkipMap<Bytes, ValueWithAttributes>,

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use std::ops::{RangeBounds, RangeFull};
 use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
 use std::sync::Arc;
-
+use std::sync::atomic::Ordering::SeqCst;
 use bytes::Bytes;
 use crossbeam_skiplist::map::Range;
 use crossbeam_skiplist::SkipMap;

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -74,7 +74,7 @@ impl MemtableFlusher {
                 .await?;
             {
                 let mut guard = self.db_inner.state.write();
-                guard.move_imm_memtable_to_l0(imm_memtable.clone(), sst_handle);
+                guard.move_imm_memtable_to_l0(imm_memtable.clone(), sst_handle)?;
             }
             imm_memtable.notify_flush_to_l0(Ok(()));
             self.write_manifest_safely().await?;

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -659,7 +659,7 @@ mod tests {
             compacted: srs,
             next_wal_sst_id: 0,
             last_compacted_wal_sst_id: 0,
-            last_clock_tick: 0,
+            last_l0_clock_tick: 0,
             checkpoints: vec![],
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -351,4 +351,27 @@ mod tests {
             panic!("Expected InvalidClockTick from mono_clock")
         }
     }
+
+    #[test]
+    fn test_monotonicity_enforcement_on_mono_clock_set_tick() {
+        // Given:
+        let clock = Arc::new(TestClock::new());
+        let mono_clock = MonotonicClock::new(clock.clone(), 0);
+
+        // When:
+        clock.ticker.store(10, SeqCst);
+        mono_clock.now().unwrap();
+
+        // Then:
+        if let Err(SlateDBError::InvalidClockTick {
+            last_tick,
+            next_tick,
+        }) = mono_clock.set_last_tick(5)
+        {
+            assert_eq!(last_tick, 10);
+            assert_eq!(next_tick, 5);
+        } else {
+            panic!("Expected InvalidClockTick from mono_clock")
+        }
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,9 @@
+use crate::config::Clock;
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::{BackgroundTaskPanic, BackgroundTaskShutdown};
 use std::future::Future;
+use std::sync::atomic::AtomicI64;
+use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct WatchableOnceCell<T: Clone> {
@@ -138,11 +141,50 @@ where
         .expect("failed to create monitor thread")
 }
 
+/// SlateDB uses MonotonicClock internally so that it can enforce that clock ticks
+/// from the underlying implementation are montonoically increasing
+pub(crate) struct MonotonicClock {
+    pub(crate) last_tick: AtomicI64,
+    delegate: Arc<dyn Clock + Send + Sync>,
+}
+
+impl MonotonicClock {
+    pub(crate) fn new(delegate: Arc<dyn Clock + Send + Sync>, init_tick: i64) -> Self {
+        Self {
+            delegate,
+            last_tick: AtomicI64::new(init_tick),
+        }
+    }
+
+    pub(crate) fn set_last_tick(&self, tick: i64) -> Result<i64, SlateDBError> {
+        self.enforce_monotonic(tick)
+    }
+
+    pub(crate) fn now(&self) -> Result<i64, SlateDBError> {
+        let tick = self.delegate.now();
+        self.enforce_monotonic(tick)
+    }
+
+    fn enforce_monotonic(&self, tick: i64) -> Result<i64, SlateDBError> {
+        let updated_last_tick = self.last_tick.fetch_max(tick, SeqCst);
+        if tick < updated_last_tick {
+            return Err(SlateDBError::InvalidClockTick {
+                last_tick: updated_last_tick,
+                next_tick: tick,
+            });
+        }
+
+        Ok(tick)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::SlateDBError;
-    use crate::utils::{spawn_bg_task, spawn_bg_thread, WatchableOnceCell};
+    use crate::test_utils::TestClock;
+    use crate::utils::{spawn_bg_task, spawn_bg_thread, MonotonicClock, WatchableOnceCell};
     use parking_lot::Mutex;
+    use std::sync::atomic::Ordering::SeqCst;
     use std::sync::Arc;
 
     struct ErrorCaptor {
@@ -284,5 +326,29 @@ mod tests {
         });
         register.write(123);
         h.await.unwrap();
+    }
+
+    #[test]
+    fn test_monotonicity_enforcement_on_mono_clock() {
+        // Given:
+        let clock = Arc::new(TestClock::new());
+        let mono_clock = MonotonicClock::new(clock.clone(), 0);
+
+        // When:
+        clock.ticker.store(10, SeqCst);
+        mono_clock.now().unwrap();
+        clock.ticker.store(5, SeqCst);
+
+        // Then:
+        if let Err(SlateDBError::InvalidClockTick {
+            last_tick,
+            next_tick,
+        }) = mono_clock.now()
+        {
+            assert_eq!(last_tick, 10);
+            assert_eq!(next_tick, 5);
+        } else {
+            panic!("Expected InvalidClockTick from mono_clock")
+        }
     }
 }


### PR DESCRIPTION
fixes #431 - the clock tick in the manifest will be valid up until `wal_id_last_seen` however restore will attempt to update the clock tick even for wals earlier than `wal_id_last_seen`, which causes the symptoms in #431

The fix here makes a few changes:
1. the db state (manifest) last clock tick is only updated when either a WAL is flushed (wal enabled) or the memtable is flushed to L0 (wal disabled)
2. recovery no longer updates the db state last clock tick, but instead updates the internal clock's "last tick"
3. wraps the user-supplied `DbOptions` with `DbConfig` which allows us to create internally managed objects, such as `MonotonicClock` which is introduced in this PR
4. The `MonotonicClock` is initialized when loading the DB from the manifest/WALs
