### PR TITLE
Writer should merge added checkpoints into its db state

### DIFF
--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -278,7 +278,7 @@ impl CompactorOrchestrator {
     }
 
     fn refresh_db_state(&mut self) -> Result<(), SlateDBError> {
-        self.state.refresh_db_state(self.manifest.db_state()?);
+        self.state.merge_db_state(self.manifest.db_state()?);
         self.maybe_schedule_compactions()?;
         Ok(())
     }

--- a/src/compactor_state.rs
+++ b/src/compactor_state.rs
@@ -136,7 +136,7 @@ impl CompactorState {
         Ok(())
     }
 
-    pub(crate) fn refresh_db_state(&mut self, writer_state: &CoreDbState) {
+    pub(crate) fn merge_db_state(&mut self, writer_state: &CoreDbState) {
         // the writer may have added more l0 SSTs. Add these to our l0 list.
         let last_compacted_l0 = self.db_state.l0_last_compacted;
         let mut merged_l0s = VecDeque::new();
@@ -350,7 +350,7 @@ mod tests {
             wait_for_manifest_with_l0_len(&mut sm, rt.handle(), state.db_state().l0.len() + 1);
 
         // when:
-        state.refresh_db_state(&writer_db_state);
+        state.merge_db_state(&writer_db_state);
 
         // then:
         assert!(state.db_state().l0_last_compacted.is_none());
@@ -394,7 +394,7 @@ mod tests {
         let db_state_before_merge = state.db_state().clone();
 
         // when:
-        state.refresh_db_state(&writer_db_state);
+        state.merge_db_state(&writer_db_state);
 
         // then:
         let db_state = state.db_state();
@@ -451,7 +451,7 @@ mod tests {
             wait_for_manifest_with_l0_len(&mut sm, rt.handle(), original_l0s.len() + 1);
 
         // when:
-        state.refresh_db_state(&writer_db_state);
+        state.merge_db_state(&writer_db_state);
 
         // then:
         let db_state = state.db_state();

--- a/src/db.rs
+++ b/src/db.rs
@@ -250,7 +250,7 @@ impl DbInner {
                 }
                 Err(SlateDBError::Fenced) => {
                     let updated_state = manifest.refresh().await?;
-                    self.state.write().refresh_db_state(updated_state);
+                    self.state.write().merge_db_state(updated_state);
                     empty_wal_id += 1;
                 }
                 Err(e) => {

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -25,9 +25,9 @@ pub(crate) struct MemtableFlusher {
 
 impl MemtableFlusher {
     pub(crate) async fn load_manifest(&mut self) -> Result<(), SlateDBError> {
-        let current_manifest = self.manifest.refresh().await?;
+        let core_state = self.manifest.refresh().await?;
         let mut wguard_state = self.db_inner.state.write();
-        wguard_state.refresh_db_state(current_manifest);
+        wguard_state.merge_db_state(core_state);
         Ok(())
     }
 


### PR DESCRIPTION
Fixes a bug found in https://github.com/slatedb/slatedb/pull/430 which causes checkpoints to get lost after the writer updates the manifest. Since checkpoints are added externally, we need to merge them into the writer's state. I've also changed the name `refresh_db_state` to `merge_db_state` since I think that reflects the usage a bit more clearly.