### PR TITLE
MINOR: reduce log level on clean shutdown and fix clippy warns

### DIFF
--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -97,7 +97,7 @@ impl<'a> DbIterator<'a> {
         } else if self
             .last_key
             .clone()
-            .map_or(false, |last_key| next_key <= last_key)
+            .is_some_and(|last_key| next_key <= last_key)
         {
             Err(SlateDBError::InvalidArgument {
                 msg: "Cannot seek to a key less than the last returned key".to_string(),

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -75,7 +75,7 @@ impl SeekToKey for VecDequeKeyValueIterator {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         loop {
             let front = self.rows.front();
-            if front.map_or(false, |record| record.key < next_key) {
+            if front.is_some_and(|record| record.key < next_key) {
                 self.rows.pop_front();
             } else {
                 return Ok(());
@@ -90,7 +90,7 @@ pub(crate) struct ValueWithAttributes {
     pub(crate) attrs: RowAttributes,
 }
 
-impl<'a, T: RangeBounds<Bytes>> KeyValueIterator for MemTableIterator<'a, T> {
+impl<T: RangeBounds<Bytes>> KeyValueIterator for MemTableIterator<'_, T> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         Ok(self.next_entry_sync())
     }

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -538,7 +538,7 @@ pub(crate) struct EncodedSsTableWriter<'a> {
     blocks_written: usize,
 }
 
-impl<'a> EncodedSsTableWriter<'a> {
+impl EncodedSsTableWriter<'_> {
     pub async fn add(&mut self, entry: RowEntry) -> Result<(), SlateDBError> {
         self.builder.add(entry)?;
         self.drain_blocks().await


### PR DESCRIPTION
See #434 for context on reducing log level