### PR TITLE
make metrics publicly visible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod manifest_store;
 mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
-mod metrics;
+pub mod metrics;
 #[cfg(test)]
 mod proptest_util;
 mod row_codec;


### PR DESCRIPTION
Currently users are expected to access metrics by calling `Db::metrics` which returns an `Arc<DbStats>`. `DbStats` is publicly visible, but the containing module `metrics` is not, so users cannot actually access the statistics. This patch changes the visibility of `metrics` to `pub`