### PR TITLE
Logic for creating checkpoints with control over scope

### DIFF
--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -162,9 +162,6 @@ enum CheckpointScope {
 
 /// Specify options to provide when creating a checkpoint.
 struct CheckpointOptions {
-    /// Specifies the scope targeted by the checkpoint (see above)
-    scope: CheckpointScope,
-
     /// Optionally specifies the lifetime of the checkpoint to create. The expire time will be set to
     /// the current wallclock time plus the specified lifetime. If lifetime is None, then the checkpoint
     /// is created without an expiry time.
@@ -204,7 +201,11 @@ impl Db {
 
     /// Creates a checkpoint of an opened db using the provided options. Returns the ID of the created
     /// checkpoint and the id of the referenced manifest.
-    pub async fn create_checkpoint(&self, options: &CheckpointOptions) -> Result<CheckpointCreateResult, SlateDBError> {
+    pub async fn create_checkpoint(
+        &self,
+        scope: CheckpointScope,
+        options: &CheckpointOptions,
+    ) -> Result<CheckpointCreateResult, SlateDBError> {
         …
     }
 

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -208,15 +208,6 @@ impl Db {
         …
     }
 
-    /// Creates a checkpoint of the db stored in the object store at the specified path using the provided options.
-    /// Note that the scope option does not impact the behaviour of this method. The checkpoint will reference
-    /// the current active manifest of the db.
-    pub async fn create_checkpoint(
-       path: &Path,
-       object_store: Arc<dyn ObjectStore>,
-       options: &CheckpointOptions,
-    ) -> Result<CheckpointCreateResult, SlateDBError> {}
-
     /// Refresh the lifetime of an existing checkpoint. Takes the id of an existing checkpoint
     /// and a lifetime, and sets the lifetime of the checkpoint to the specified lifetime. If
     /// there is no checkpoint with the specified id, then this fn fails with
@@ -245,6 +236,17 @@ impl Db {
    pub async fn destroy(path: Path, object_store: Arc<dyn ObjectStore>, soft: bool) -> Result<(), SlateDbError> {
        …
    }
+}
+
+mod admin {
+    /// Creates a checkpoint of the db stored in the object store at the specified path using the provided options.
+    /// Note that the scope option does not impact the behaviour of this method. The checkpoint will reference
+    /// the current active manifest of the db.
+    pub async fn create_checkpoint(
+        path: &Path,
+        object_store: Arc<dyn ObjectStore>,
+        options: &CheckpointOptions,
+    ) -> Result<CheckpointCreateResult, SlateDBError> {}    
 }
 
 /// Configuration options for the database reader. These options are set on client startup.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -14,7 +14,6 @@ use std::error::Error;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 use tokio::runtime::Handle;
-use uuid::Uuid;
 
 /// read-only access to the latest manifest file
 pub async fn read_manifest(
@@ -223,10 +222,9 @@ pub async fn create_checkpoint(
 ) -> Result<CheckpointCreateResult, SlateDBError> {
     let manifest_store = Arc::new(ManifestStore::new(path, object_store));
     let mut stored_manifest = StoredManifest::load(manifest_store).await?;
-    let id = Uuid::new_v4();
-    let checkpoint = stored_manifest.write_new_checkpoint(id, options).await?;
+    let checkpoint = stored_manifest.write_new_checkpoint(options).await?;
     Ok(CheckpointCreateResult {
-        id,
+        id: checkpoint.id,
         manifest_id: checkpoint.manifest_id,
     })
 }

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -436,8 +436,8 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
         db.flush().await.unwrap();
 
-        let checkpoint_result = tokio::join!(checkpoint_handle).0.unwrap().unwrap();
-        eprintln!("{checkpoint_result:?}")
+        tokio::join!(checkpoint_handle).0.unwrap().unwrap();
+
     }
 
     async fn test_checkpoint_scope_all<F: FnOnce(Manifest) -> SsTableId>(

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -89,16 +89,9 @@ async fn exec_create_checkpoint(
     lifetime: Option<Duration>,
     source: Option<Uuid>,
 ) -> Result<(), Box<dyn Error>> {
-    let result = admin::create_checkpoint(
-        path,
-        object_store,
-        &CheckpointOptions {
-            scope: CheckpointScope::Durable,
-            lifetime,
-            source,
-        },
-    )
-    .await?;
+    let result =
+        admin::create_checkpoint(path, object_store, &CheckpointOptions { lifetime, source })
+            .await?;
     println!("{:?}", result);
     Ok(())
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -89,7 +89,7 @@ async fn exec_create_checkpoint(
     lifetime: Option<Duration>,
     source: Option<Uuid>,
 ) -> Result<(), Box<dyn Error>> {
-    let result = Db::create_checkpoint(
+    let result = admin::create_checkpoint(
         path,
         object_store,
         &CheckpointOptions {

--- a/src/config.rs
+++ b/src/config.rs
@@ -349,9 +349,6 @@ pub enum CheckpointScope {
 /// Specify options to provide when creating a checkpoint.
 #[derive(Debug, Clone)]
 pub struct CheckpointOptions {
-    /// Specifies the scope targeted by the checkpoint (see above)
-    pub scope: CheckpointScope,
-
     /// Optionally specifies the lifetime of the checkpoint to create. The expire time will be
     /// set to the current wallclock time plus the specified lifetime. If lifetime is None, then
     /// the checkpoint is created without an expiry time.
@@ -366,7 +363,6 @@ pub struct CheckpointOptions {
 impl Default for CheckpointOptions {
     fn default() -> Self {
         Self {
-            scope: CheckpointScope::Durable,
             lifetime: None,
             source: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -347,7 +347,7 @@ pub enum CheckpointScope {
 }
 
 /// Specify options to provide when creating a checkpoint.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CheckpointOptions {
     /// Optionally specifies the lifetime of the checkpoint to create. The expire time will be
     /// set to the current wallclock time plus the specified lifetime. If lifetime is None, then
@@ -358,15 +358,6 @@ pub struct CheckpointOptions {
     /// is useful for users to establish checkpoints from existing checkpoints, but with a different
     /// lifecycle and/or metadata.
     pub source: Option<Uuid>,
-}
-
-impl Default for CheckpointOptions {
-    fn default() -> Self {
-        Self {
-            lifetime: None,
-            source: None,
-        }
-    }
 }
 
 /// Configuration options for the database. These options are set on client startup.

--- a/src/config.rs
+++ b/src/config.rs
@@ -340,12 +340,14 @@ fn default_clock() -> Arc<dyn Clock + Send + Sync> {
 /// flush_interval or reaching l0_sst_size_bytes, respectively. If set to Durable, then the
 /// checkpoint includes only writes that were durable at the time of the call. This will be faster,
 /// but may not include data from recent writes.
+#[derive(Debug, Copy, Clone)]
 pub enum CheckpointScope {
     All { force_flush: bool },
     Durable,
 }
 
 /// Specify options to provide when creating a checkpoint.
+#[derive(Debug, Clone)]
 pub struct CheckpointOptions {
     /// Specifies the scope targeted by the checkpoint (see above)
     pub scope: CheckpointScope,

--- a/src/db.rs
+++ b/src/db.rs
@@ -446,7 +446,19 @@ impl DbInner {
         self.send_flush_memtables(false).await
     }
 
+    #[cfg(feature = "wal_disable")]
+    fn freeze_memtable(&self) -> Result<(), SlateDBError> {
+        let mut guard = self.state.write();
+        let wal_id = guard.last_written_wal_id();
+        guard.freeze_memtable(wal_id)
+    }
+
     async fn send_flush_memtables(&self, force_flush: bool) -> Result<(), SlateDBError> {
+        #[cfg(feature = "wal_disable")]
+        if !self.wal_enabled() && force_flush {
+            self.freeze_memtable()?;
+        }
+
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.memtable_flush_notifier
             .send((

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -17,7 +17,10 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id)?;
         self.memtable_flush_notifier
-            .send((None, MemtableFlushThreadMsg::FlushImmutableMemtables))
+            .send((
+                None,
+                MemtableFlushThreadMsg::FlushImmutableMemtables { force_flush: true },
+            ))
             .map_err(|_| SlateDBError::MemtableFlushChannelError)?;
         Ok(())
     }
@@ -35,7 +38,10 @@ impl DbInner {
         }
         guard.freeze_wal()?;
         self.wal_flush_notifier
-            .send((None, WalFlushThreadMsg::FlushImmutableWals))
+            .send((
+                None,
+                WalFlushThreadMsg::FlushImmutableWals { force_flush: true },
+            ))
             .map_err(|_| SlateDBError::WalFlushChannelError)?;
         Ok(())
     }

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -17,10 +17,7 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id)?;
         self.memtable_flush_notifier
-            .send((
-                None,
-                MemtableFlushThreadMsg::FlushImmutableMemtables { force_flush: true },
-            ))
+            .send((None, MemtableFlushThreadMsg::FlushImmutableMemtables))
             .map_err(|_| SlateDBError::MemtableFlushChannelError)?;
         Ok(())
     }
@@ -38,10 +35,7 @@ impl DbInner {
         }
         guard.freeze_wal()?;
         self.wal_flush_notifier
-            .send((
-                None,
-                WalFlushThreadMsg::FlushImmutableWals { force_flush: true },
-            ))
+            .send((None, WalFlushThreadMsg::FlushImmutableWals))
             .map_err(|_| SlateDBError::WalFlushChannelError)?;
         Ok(())
     }

--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -4,7 +4,7 @@ use crate::db::DbInner;
 use crate::db_state::DbState;
 use crate::error::SlateDBError;
 use crate::flush::WalFlushThreadMsg;
-use crate::mem_table_flush::MemtableFlushThreadMsg;
+use crate::mem_table_flush::MemtableFlushMsg;
 
 impl DbInner {
     pub(crate) fn maybe_freeze_memtable(
@@ -17,7 +17,7 @@ impl DbInner {
         }
         guard.freeze_memtable(wal_id)?;
         self.memtable_flush_notifier
-            .send((None, MemtableFlushThreadMsg::FlushImmutableMemtables))
+            .send(MemtableFlushMsg::FlushImmutableMemtables { sender: None })
             .map_err(|_| SlateDBError::MemtableFlushChannelError)?;
         Ok(())
     }

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -13,6 +13,7 @@ use std::ops::{Bound, Range};
 use std::sync::Arc;
 use tracing::debug;
 use ulid::Ulid;
+use uuid::Uuid;
 use SsTableId::{Compacted, Wal};
 
 #[derive(Clone, PartialEq, Serialize)]
@@ -255,6 +256,10 @@ impl CoreDbState {
         debug!("{:?}", l0s);
         debug!("{:?}", compacted);
         debug!("-----------------");
+    }
+
+    pub(crate) fn find_checkpoint(&self, checkpoint_id: &Uuid) -> Option<&Checkpoint> {
+        self.checkpoints.iter().find(|c| c.id == *checkpoint_id)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::sync::Mutex;
 use std::{path::PathBuf, sync::Arc};
 use thiserror::Error;
+use uuid::Uuid;
 
 #[derive(Clone, Debug, Error)]
 pub enum SlateDBError {
@@ -79,13 +80,16 @@ pub enum SlateDBError {
     #[error("Error flushing memtables: channel closed")]
     MemtableFlushChannelError,
 
+    #[error("Error creating checkpoint: channel closed")]
+    CheckpointChannelError,
+
     #[error("Read channel error: {0}")]
     ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
 
     #[error("Iterator invalidated after unexpected error {0}")]
     InvalidatedIterator(#[from] Box<SlateDBError>),
 
-    #[error("Invalid Argument")]
+    #[error("Invalid argument: {msg}")]
     InvalidArgument { msg: String },
 
     #[error("background task panic'd")]
@@ -95,6 +99,9 @@ pub enum SlateDBError {
 
     #[error("background task shutdown")]
     BackgroundTaskShutdown,
+
+    #[error("Checkpoint {0} missing")]
+    CheckpointMissing(Uuid),
 }
 
 impl From<std::io::Error> for SlateDBError {

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, info};
 
 use crate::db::{DbInner, FlushMsg};
+use crate::db_state;
 use crate::db_state::SsTableHandle;
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskShutdown;
@@ -14,7 +15,6 @@ use crate::iter::KeyValueIterator;
 use crate::mem_table::{ImmutableWal, KVTable, WritableKVTable};
 use crate::types::{RowAttributes, ValueDeletable};
 use crate::utils::spawn_bg_task;
-use crate::db_state;
 
 #[derive(Debug)]
 pub(crate) enum WalFlushThreadMsg {
@@ -198,5 +198,4 @@ impl DbInner {
             }
         }
     }
-
 }

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -201,9 +201,9 @@ impl StoredManifest {
 
     pub(crate) async fn write_new_checkpoint(
         &mut self,
-        checkpoint_id: Uuid,
         options: &CheckpointOptions,
     ) -> Result<Checkpoint, SlateDBError> {
+        let checkpoint_id = Uuid::new_v4();
         self.maybe_apply_db_state_update(|stored_manifest| {
             let checkpoint = stored_manifest.new_checkpoint(checkpoint_id, options)?;
             let mut updated_db_state = stored_manifest.db_state().clone();
@@ -789,12 +789,12 @@ mod tests {
             .unwrap();
 
         let checkpoint1 = sm
-            .write_new_checkpoint(Uuid::new_v4(), &CheckpointOptions::default())
+            .write_new_checkpoint(&CheckpointOptions::default())
             .await
             .unwrap();
 
         let _ = sm
-            .write_new_checkpoint(Uuid::new_v4(), &CheckpointOptions::default())
+            .write_new_checkpoint(&CheckpointOptions::default())
             .await
             .unwrap();
 

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -1,26 +1,28 @@
+use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
+use crate::db::{CheckpointMsg, DbInner, FlushMsg, FlushSender};
+use crate::db_state::{CoreDbState, SsTableId};
+use crate::error::SlateDBError;
+use crate::error::SlateDBError::{BackgroundTaskShutdown, CheckpointMissing};
+use crate::manifest_store::FenceableManifest;
+use crate::utils;
+use crate::utils::spawn_bg_task;
 use std::sync::Arc;
-
+use std::time::SystemTime;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracing::{error, info, warn};
 use ulid::Ulid;
 
-use crate::db::{DbInner, FlushMsg};
-use crate::db_state::SsTableId;
-use crate::error::SlateDBError;
-use crate::error::SlateDBError::BackgroundTaskShutdown;
-use crate::manifest_store::FenceableManifest;
-use crate::utils::spawn_bg_task;
-
 #[derive(Debug)]
 pub enum MemtableFlushThreadMsg {
     Shutdown,
-    FlushImmutableMemtables,
+    FlushImmutableMemtables { force_flush: bool },
 }
 
 pub(crate) struct MemtableFlusher {
     db_inner: Arc<DbInner>,
     manifest: FenceableManifest,
+    flush_waiters: Vec<FlushSender>,
 }
 
 impl MemtableFlusher {
@@ -31,7 +33,26 @@ impl MemtableFlusher {
         Ok(())
     }
 
-    pub(crate) async fn write_manifest(&mut self) -> Result<(), SlateDBError> {
+    async fn write_checkpoint(
+        &mut self,
+        checkpoint_msg: &CheckpointMsg,
+    ) -> Result<CheckpointCreateResult, SlateDBError> {
+        let mut core = {
+            let rguard_state = self.db_inner.state.read();
+            rguard_state.state().core.clone()
+        };
+
+        let checkpoint = self.build_checkpoint(&core, checkpoint_msg)?;
+        let result = CheckpointCreateResult {
+            id: checkpoint.id,
+            manifest_id: checkpoint.manifest_id,
+        };
+        core.checkpoints.push(checkpoint);
+        self.manifest.update_db_state(core).await?;
+        Ok(result)
+    }
+
+    async fn write_manifest(&mut self) -> Result<(), SlateDBError> {
         let core = {
             let rguard_state = self.db_inner.state.read();
             rguard_state.state().core.clone()
@@ -39,20 +60,69 @@ impl MemtableFlusher {
         self.manifest.update_db_state(core).await
     }
 
-    pub(crate) async fn write_manifest_safely(&mut self) -> Result<(), SlateDBError> {
+    fn build_checkpoint(
+        &self,
+        state: &CoreDbState,
+        msg: &CheckpointMsg,
+    ) -> Result<Checkpoint, SlateDBError> {
+        let checkpoint_manifest_id = if let Some(source_id) = &msg.options.source {
+            if let Some(checkpoint) = state.find_checkpoint(source_id) {
+                checkpoint.manifest_id
+            } else {
+                return Err(CheckpointMissing(*source_id));
+            }
+        } else {
+            self.manifest.next_manifest_id()
+        };
+
+        let expire_time = msg.options.lifetime.map(|l| SystemTime::now() + l);
+
+        Ok(Checkpoint {
+            id: msg.id,
+            manifest_id: checkpoint_manifest_id,
+            expire_time,
+            create_time: SystemTime::now(),
+        })
+    }
+
+    pub(crate) async fn write_checkpoint_safely(
+        &mut self,
+        checkpoint: &CheckpointMsg,
+    ) -> Result<CheckpointCreateResult, SlateDBError> {
         loop {
             self.load_manifest().await?;
-            match self.write_manifest().await {
-                Ok(_) => return Ok(()),
-                Err(SlateDBError::ManifestVersionExists) => {
-                    error!("conflicting manifest version. retry write");
-                }
-                Err(err) => return Err(err),
+            let result = self.write_checkpoint(checkpoint).await;
+            if matches!(result, Err(SlateDBError::ManifestVersionExists)) {
+                error!("conflicting manifest version. retry write");
+            } else {
+                return result;
             }
         }
     }
 
-    pub(crate) async fn flush_imm_memtables_to_l0(&mut self) -> Result<(), SlateDBError> {
+    pub(crate) async fn write_manifest_safely(&mut self) -> Result<(), SlateDBError> {
+        loop {
+            self.load_manifest().await?;
+            let result = self.write_manifest().await;
+            if matches!(result, Err(SlateDBError::ManifestVersionExists)) {
+                error!("conflicting manifest version. retry write");
+            } else {
+                return result;
+            }
+        }
+    }
+
+    async fn flush(&mut self) -> Result<(), SlateDBError> {
+        let result = self.flush_imm_memtables_to_l0().await;
+        while let Some(sender) = self.flush_waiters.pop() {
+            if let Err(Err(e)) = sender.send(result.clone()) {
+                error!("Failed to send flush error: {e}");
+            }
+        }
+        result
+    }
+
+    async fn flush_imm_memtables_to_l0(&mut self) -> Result<(), SlateDBError> {
         while let Some(imm_memtable) = {
             let rguard = self.db_inner.state.read();
             if rguard.state().core.l0.len() >= self.db_inner.options.l0_max_ssts {
@@ -85,10 +155,24 @@ impl MemtableFlusher {
 }
 
 impl DbInner {
+    async fn flush_and_record(
+        self: &Arc<Self>,
+        flusher: &mut MemtableFlusher,
+    ) -> Result<(), SlateDBError> {
+        let result = flusher.flush().await;
+        if let Err(err) = &result {
+            error!("error from memtable flush: {err}");
+        } else {
+            self.db_stats.immutable_memtable_flushes.inc();
+        }
+        result
+    }
+
     pub(crate) fn spawn_memtable_flush_task(
         self: &Arc<Self>,
         manifest: FenceableManifest,
-        mut rx: UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>,
+        mut flush_rx: UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>,
+        mut checkpoint_rx: UnboundedReceiver<CheckpointMsg>,
         tokio_handle: &Handle,
     ) -> Option<tokio::task::JoinHandle<Result<(), SlateDBError>>> {
         let this = Arc::clone(self);
@@ -96,7 +180,8 @@ impl DbInner {
         async fn core_flush_loop(
             this: &Arc<DbInner>,
             flusher: &mut MemtableFlusher,
-            rx: &mut UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>,
+            flush_rx: &mut UnboundedReceiver<FlushMsg<MemtableFlushThreadMsg>>,
+            checkpoint_rx: &mut UnboundedReceiver<CheckpointMsg>,
         ) -> Result<(), SlateDBError> {
             let mut manifest_poll_interval =
                 tokio::time::interval(this.options.manifest_poll_interval);
@@ -114,40 +199,29 @@ impl DbInner {
                             error!("error loading manifest: {err}");
                             return Err(err);
                         }
-                        match flusher.flush_imm_memtables_to_l0().await {
-                            Ok(_) => {
-                                this.db_stats.immutable_memtable_flushes.inc();
-                            }
-                            Err(err) => {
-                                error!("error from memtable flush: {err}");
-                                return Err(err);
-                            }
-                        }
+                        this.flush_and_record(flusher).await?
                     }
-                    msg = rx.recv() => {
-                        let (rsp_sender, msg) = msg.expect("channel unexpectedly closed");
+                    flush_msg = flush_rx.recv() => {
+                        let (rsp_sender, msg) = flush_msg.expect("channel unexpectedly closed");
                         match msg {
                             MemtableFlushThreadMsg::Shutdown => {
                                 return Ok(());
                             },
-                            MemtableFlushThreadMsg::FlushImmutableMemtables => {
-                                let result = flusher.flush_imm_memtables_to_l0().await;
-                                if let Some(rsp_sender) = rsp_sender {
-                                    let res = rsp_sender.send(result.clone());
-                                    if let Err(Err(err)) = res {
-                                        error!("error sending flush response: {err}");
-                                    }
+                            MemtableFlushThreadMsg::FlushImmutableMemtables { force_flush } => {
+                                if let Some(sender) = rsp_sender {
+                                    flusher.flush_waiters.push(sender);
                                 }
-                                match result {
-                                    Ok(_) => {
-                                        this.db_stats.immutable_memtable_flushes.inc();
-                                    }
-                                    Err(err) => {
-                                        error!("error from memtable flush: {err}");
-                                        return Err(err);
-                                    }
+                                if force_flush {
+                                    this.flush_and_record(flusher).await?;
                                 }
                             }
+                        }
+                    },
+                    checkpoint_msg = checkpoint_rx.recv() => {
+                        let checkpoint_msg = checkpoint_msg.expect("channel unexpectedly closed");
+                        let write_result = flusher.write_checkpoint_safely(&checkpoint_msg).await;
+                        if let Err(Err(e)) = checkpoint_msg.sender.send(write_result) {
+                            error!("Failed to send checkpoint error: {e}");
                         }
                     }
                 }
@@ -158,20 +232,19 @@ impl DbInner {
             let mut flusher = MemtableFlusher {
                 db_inner: this.clone(),
                 manifest,
+                flush_waiters: Vec::new(),
             };
 
             // Stop the loop when the shut down has been received *and* all
-            // remaining `rx` flushes have been drained.
-            let result = core_flush_loop(&this, &mut flusher, &mut rx).await;
+            // remaining `rx` flushes and checkpoints have been drained.
+            let result =
+                core_flush_loop(&this, &mut flusher, &mut flush_rx, &mut checkpoint_rx).await;
 
             // respond to any pending msgs
-            let pending_result = result.clone().and_then(|_| Err(BackgroundTaskShutdown));
-            while !rx.is_empty() {
-                let (rsp_sender, _) = rx.recv().await.expect("channel unexpectedly closed");
-                if let Some(rsp_sender) = rsp_sender {
-                    let _ = rsp_sender.send(pending_result.clone());
-                }
-            }
+            let pending_error = result.clone().err().unwrap_or(BackgroundTaskShutdown);
+            utils::close_and_drain_receiver(&mut flush_rx, &pending_error).await;
+            utils::drain_sender_queue(&mut flusher.flush_waiters, &pending_error);
+            Self::close_and_drain_checkpoint_receiver(&mut checkpoint_rx, &pending_error).await;
 
             if let Err(err) = flusher.write_manifest_safely().await {
                 error!("error writing manifest on shutdown: {}", err);
@@ -202,5 +275,16 @@ impl DbInner {
             },
             fut,
         ))
+    }
+
+    async fn close_and_drain_checkpoint_receiver(
+        rx: &mut UnboundedReceiver<CheckpointMsg>,
+        error: &SlateDBError,
+    ) {
+        rx.close();
+        while !rx.is_empty() {
+            let msg = rx.recv().await.expect("channel unexpectedly closed");
+            let _ = msg.sender.send(Err(error.clone()));
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,6 @@ use crate::error::SlateDBError::{BackgroundTaskPanic, BackgroundTaskShutdown};
 use std::future::Future;
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc::UnboundedReceiver;
-use tokio::sync::oneshot::Sender;
 
 pub(crate) struct WatchableOnceCell<T: Clone> {
     rx: tokio::sync::watch::Receiver<Option<T>>,
@@ -151,15 +150,6 @@ pub(crate) async fn close_and_drain_receiver<T>(
         if let Some(sender) = rsp_sender {
             let _ = sender.send(Err(error.clone()));
         }
-    }
-}
-
-pub(crate) fn drain_sender_queue<S>(
-    senders: &mut Vec<Sender<Result<S, SlateDBError>>>,
-    error: &SlateDBError,
-) {
-    while let Some(sender) = senders.pop() {
-        let _ = sender.send(Err(error.clone()));
     }
 }
 


### PR DESCRIPTION
Implement new instance `Db::create_checkpoint` specified in [RFC-0004](https://github.com/slatedb/slatedb/blob/main/rfcs/0004-checkpoints.md) which allows users control over the checkpoint scope.