### PR TITLE
make KeyValue visible so users of scan can access it

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ mod tablestore;
 mod test_utils;
 mod transactional_object_store;
 mod types;
-pub use types::{KeyValue};
+pub use types::KeyValue;
 mod utils;
 
 /// Re-export the bytes crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod tablestore;
 #[cfg(test)]
 mod test_utils;
 mod transactional_object_store;
-mod types;
+pub mod types;
 mod utils;
 
 /// Re-export the bytes crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,8 @@ mod tablestore;
 #[cfg(test)]
 mod test_utils;
 mod transactional_object_store;
-pub mod types;
+mod types;
+pub use types::{KeyValue};
 mod utils;
 
 /// Re-export the bytes crate.

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 
 /// Represents a key-value pair known not to be a tombstone.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct KeyValue {
     pub key: Bytes,
@@ -90,7 +91,7 @@ impl RowEntry {
     }
 
     #[cfg(test)]
-    pub fn with_expire_ts(&self, expire_ts: i64) -> Self {
+    pub(crate) fn with_expire_ts(&self, expire_ts: i64) -> Self {
         Self {
             key: self.key.clone(),
             value: self.value.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,15 +22,15 @@ where
 /// Represents a key-value pair that may be a tombstone.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct RowEntry {
-    pub key: Bytes,
-    pub value: ValueDeletable,
-    pub seq: u64,
-    pub create_ts: Option<i64>,
-    pub expire_ts: Option<i64>,
+    pub(crate) key: Bytes,
+    pub(crate) value: ValueDeletable,
+    pub(crate) seq: u64,
+    pub(crate) create_ts: Option<i64>,
+    pub(crate) expire_ts: Option<i64>,
 }
 
 impl RowEntry {
-    pub fn new(
+    pub(crate) fn new(
         key: Bytes,
         value: ValueDeletable,
         seq: u64,
@@ -46,7 +46,7 @@ impl RowEntry {
         }
     }
     #[cfg(test)]
-    pub fn new_value(key: &[u8], value: &[u8], seq: u64) -> Self {
+    pub(crate) fn new_value(key: &[u8], value: &[u8], seq: u64) -> Self {
         Self {
             key: Bytes::copy_from_slice(key),
             value: ValueDeletable::Value(Bytes::copy_from_slice(value)),
@@ -57,7 +57,7 @@ impl RowEntry {
     }
 
     #[cfg(test)]
-    pub fn new_merge(key: &[u8], value: &[u8], seq: u64) -> Self {
+    pub(crate) fn new_merge(key: &[u8], value: &[u8], seq: u64) -> Self {
         Self {
             key: Bytes::copy_from_slice(key),
             value: ValueDeletable::Merge(Bytes::copy_from_slice(value)),
@@ -68,7 +68,7 @@ impl RowEntry {
     }
 
     #[cfg(test)]
-    pub fn new_tombstone(key: &[u8], seq: u64) -> Self {
+    pub(crate) fn new_tombstone(key: &[u8], seq: u64) -> Self {
         Self {
             key: Bytes::copy_from_slice(key),
             value: ValueDeletable::Tombstone,
@@ -79,7 +79,7 @@ impl RowEntry {
     }
 
     #[cfg(test)]
-    pub fn with_create_ts(&self, create_ts: i64) -> Self {
+    pub(crate) fn with_create_ts(&self, create_ts: i64) -> Self {
         Self {
             key: self.key.clone(),
             value: self.value.clone(),
@@ -103,9 +103,9 @@ impl RowEntry {
 
 /// The metadata associated with a `KeyValueDeletable`
 #[derive(Debug, Clone, PartialEq)]
-pub struct RowAttributes {
-    pub ts: Option<i64>,
-    pub expire_ts: Option<i64>,
+pub(crate) struct RowAttributes {
+    pub(crate) ts: Option<i64>,
+    pub(crate) expire_ts: Option<i64>,
 }
 
 /// Represents a value that may be a tombstone.
@@ -114,14 +114,14 @@ pub struct RowAttributes {
 /// that a key does not exist, and `Tombstone` indicating
 /// that the key exists but has a tombstone value.
 #[derive(Debug, Clone, PartialEq)]
-pub enum ValueDeletable {
+pub(crate) enum ValueDeletable {
     Value(Bytes),
     Merge(Bytes),
     Tombstone,
 }
 
 impl ValueDeletable {
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         match self {
             ValueDeletable::Value(v) | ValueDeletable::Merge(v) => v.len(),
             ValueDeletable::Tombstone => 0,


### PR DESCRIPTION
This patch makes KeyValue visible by making the types module pub. The types module also contains a bunch of internal types, so these have all been changed to pub(crate)