### PR TITLE
use static lifetimes for iterators in DbIterator

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -171,11 +171,11 @@ impl DbInner {
         Ok(None)
     }
 
-    pub async fn scan_with_options<'a>(
-        &'a self,
+    pub async fn scan_with_options(
+        &self,
         range: BytesRange,
         options: &ScanOptions,
-    ) -> Result<DbIterator<'a>, SlateDBError> {
+    ) -> Result<DbIterator, SlateDBError> {
         self.check_error()?;
         let snapshot = Arc::new(self.state.read().snapshot());
         let mut memtables = VecDeque::new();
@@ -1473,7 +1473,7 @@ mod tests {
     async fn assert_ordered_scan_in_range(
         table: &BTreeMap<Bytes, Bytes>,
         range: &BytesRange,
-        iter: &mut DbIterator<'_>,
+        iter: &mut DbIterator,
     ) {
         let mut expected = table.range((range.start_bound().cloned(), range.end_bound().cloned()));
 

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -16,19 +16,19 @@ type ScanIterator<'a> = TwoMergeIterator<
     TwoMergeIterator<MergeIterator<SstIterator<'a>>, MergeIterator<SortedRunIterator<'a>>>,
 >;
 
-pub struct DbIterator<'a> {
+pub struct DbIterator {
     range: BytesRange,
-    iter: ScanIterator<'a>,
+    iter: ScanIterator<'static>,
     invalidated_error: Option<SlateDBError>,
     last_key: Option<Bytes>,
 }
 
-impl<'a> DbIterator<'a> {
+impl DbIterator {
     pub(crate) async fn new(
         range: BytesRange,
         mem_iter: VecDequeKeyValueIterator,
-        l0_iters: VecDeque<SstIterator<'a>>,
-        sr_iters: VecDeque<SortedRunIterator<'a>>,
+        l0_iters: VecDeque<SstIterator<'static>>,
+        sr_iters: VecDeque<SortedRunIterator<'static>>,
     ) -> Result<Self, SlateDBError> {
         let (l0_iter, sr_iter) =
             tokio::join!(MergeIterator::new(l0_iters), MergeIterator::new(sr_iters),);


### PR DESCRIPTION
This patch drops the lifetime parameter from DbIterator and uses 'static for the lifetimes of the contained iterators. This is safe because those iterators always own their range bound bytes and sst handles.