### PR TITLE
Fix `wal_id_last_seen` race condition

### DIFF
--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -335,21 +335,19 @@ impl DbState {
         Ok(())
     }
 
-    pub fn freeze_wal(&mut self) -> Result<Option<u64>, SlateDBError> {
+    pub fn freeze_wal(&mut self) -> Result<(), SlateDBError> {
         if let Some(err) = self.error.reader().read() {
             return Err(err.clone());
         }
         if self.wal.table().is_empty() {
-            return Ok(None);
+            return Ok(());
         }
         let old_wal = std::mem::replace(&mut self.wal, WritableKVTable::new());
         let mut state = self.state_copy();
-        let imm_wal = Arc::new(ImmutableWal::new(state.core.next_wal_sst_id, old_wal));
-        let id = imm_wal.id();
+        let imm_wal = Arc::new(ImmutableWal::new(old_wal));
         state.imm_wal.push_front(imm_wal);
-        state.core.next_wal_sst_id += 1;
         self.update_state(state);
-        Ok(Some(id))
+        Ok(())
     }
 
     pub fn pop_imm_wal(&mut self) {

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -45,7 +45,11 @@ impl DbInner {
         Ok(handle)
     }
 
-    async fn flush_imm_wal(&self, id: u64, imm: Arc<ImmutableWal>) -> Result<SsTableHandle, SlateDBError> {
+    async fn flush_imm_wal(
+        &self,
+        id: u64,
+        imm: Arc<ImmutableWal>,
+    ) -> Result<SsTableHandle, SlateDBError> {
         let wal_id = db_state::SsTableId::Wal(id);
         self.flush_imm_table(&wal_id, imm.table()).await
     }
@@ -84,7 +88,11 @@ impl DbInner {
         while let Some((imm, id)) = {
             let rguard = self.state.read();
             let state = rguard.state();
-            state.imm_wal.back().cloned().map(|imm| (imm, state.core.next_wal_sst_id))
+            state
+                .imm_wal
+                .back()
+                .cloned()
+                .map(|imm| (imm, state.core.next_wal_sst_id))
         } {
             self.flush_imm_wal(id, imm.clone()).await?;
             let mut wguard = self.state.write();

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -45,8 +45,8 @@ impl DbInner {
         Ok(handle)
     }
 
-    async fn flush_imm_wal(&self, imm: Arc<ImmutableWal>) -> Result<SsTableHandle, SlateDBError> {
-        let wal_id = db_state::SsTableId::Wal(imm.id());
+    async fn flush_imm_wal(&self, id: u64, imm: Arc<ImmutableWal>) -> Result<SsTableHandle, SlateDBError> {
+        let wal_id = db_state::SsTableId::Wal(id);
         self.flush_imm_table(&wal_id, imm.table()).await
     }
 
@@ -81,16 +81,18 @@ impl DbInner {
     }
 
     async fn flush_imm_wals(&self) -> Result<(), SlateDBError> {
-        while let Some(imm) = {
+        while let Some((imm, id)) = {
             let rguard = self.state.read();
-            rguard.state().imm_wal.back().cloned()
+            let state = rguard.state();
+            state.imm_wal.back().cloned().map(|imm| (imm, state.core.next_wal_sst_id))
         } {
-            self.flush_imm_wal(imm.clone()).await?;
+            self.flush_imm_wal(id, imm.clone()).await?;
             let mut wguard = self.state.write();
             wguard.pop_imm_wal();
+            wguard.increment_next_wal_id();
             // flush to the memtable before notifying so that data is available for reads
             self.flush_imm_wal_to_memtable(wguard.memtable(), imm.table());
-            self.maybe_freeze_memtable(&mut wguard, imm.id())?;
+            self.maybe_freeze_memtable(&mut wguard, id)?;
             imm.table().notify_durable(Ok(()));
         }
         Ok(())
@@ -174,8 +176,8 @@ impl DbInner {
                 state.record_fatal_error(err.clone());
                 info!("notifying writeable wal of error");
                 state.wal().table().notify_durable(Err(err.clone()));
+                info!("notifying immutable wals of error");
                 for imm in state.snapshot().state.imm_wal.iter() {
-                    info!("notifying immutable wal {} of error", imm.id());
                     imm.table().notify_durable(Err(err.clone()));
                 }
             },

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -135,9 +135,7 @@ impl ImmutableMemtable {
 
 impl ImmutableWal {
     pub(crate) fn new(table: WritableKVTable) -> Self {
-        Self {
-            table: table.table,
-        }
+        Self { table: table.table }
     }
 
     pub(crate) fn table(&self) -> Arc<KVTable> {

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -32,7 +32,6 @@ pub(crate) struct ImmutableMemtable {
 }
 
 pub(crate) struct ImmutableWal {
-    id: u64,
     table: Arc<KVTable>,
 }
 
@@ -135,15 +134,10 @@ impl ImmutableMemtable {
 }
 
 impl ImmutableWal {
-    pub(crate) fn new(id: u64, table: WritableKVTable) -> Self {
+    pub(crate) fn new(table: WritableKVTable) -> Self {
         Self {
-            id,
             table: table.table,
         }
-    }
-
-    pub(crate) fn id(&self) -> u64 {
-        self.id
     }
 
     pub(crate) fn table(&self) -> Arc<KVTable> {


### PR DESCRIPTION
I found `next_wal_sst_id` to be overloaded. It currently seems to represent two things:

- The last WAL SST ID that was written (as `next_wal_sst_id - 1`)
- The next WAL SST ID to use when creating an immutable WAL (that hasn't yet been written)

After discussing with @agavra, it seems like the simplest thing to do was to remove ID from `ImmutableWal`, and read/update the `next_wal_sst_id` in `flush.rs` when the write actually occurs. Changes include:

- Keeps the previous test I wrote
- Removes `id` from `ImmutableWal`
- Uses `next_wal_sst_id` in `flush.rs` to determine the next WAL SST ID to use
- Increments `next_wal_sst_id` via (`increment_next_wal_id`) upon a successful WAL write

Fixes #433