### PR TITLE
Replace `Bytes` with `&[u8]` and `Vec<u8>` in `MergeOperator`

### DIFF
--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -117,7 +117,8 @@ impl<T: KeyValueIterator> MergeOperatorIterator<T> {
                     match next_entry.value {
                         ValueDeletable::Value(value) => {
                             // Final merge with a regular value
-                            let merged_value = self.merge_operator.merge(&merged_value, &value)?;
+                            let merged_value =
+                                self.merge_operator.merge(&merged_value, value.as_ref())?;
                             return Ok(Some(RowEntry::new(
                                 key,
                                 ValueDeletable::Value(merged_value.into()),
@@ -128,7 +129,8 @@ impl<T: KeyValueIterator> MergeOperatorIterator<T> {
                         }
                         ValueDeletable::Merge(value) => {
                             // Continue merging
-                            merged_value = self.merge_operator.merge(&merged_value, &value)?;
+                            merged_value =
+                                self.merge_operator.merge(&merged_value, value.as_ref())?;
                             continue;
                         }
                         ValueDeletable::Tombstone => {


### PR DESCRIPTION
As a follow-on to #450, I'm eliminating `Bytes` from user-facing APIs. The `MergeOperator` currently uses `Bytes` for inputs and outputs. I've replaced the inputs with `&[u8]` and the output with `Vec<u8>`. I opted against `AsRef<[u8]>` for the inputs since this is a callback from our own SlateDB code, and we know what we're passing. We don't need the added flexibility. Plus, it broke the vtable lookups to include generics in a trait. I opted for `Vec<u8>` for the return in keeping with our other public return methods.

I took a look at [`Bytes::from` for `Vec<u8>`](https://docs.rs/bytes/latest/src/bytes/bytes.rs.html#964-997). It seems not to do unnecessary copies, so I think it should be OK for us here.