### PR TITLE
MINOR: Refactor wal flush msg for consistent pattern

### DIFF
--- a/src/db_common.rs
+++ b/src/db_common.rs
@@ -3,7 +3,7 @@ use parking_lot::RwLockWriteGuard;
 use crate::db::DbInner;
 use crate::db_state::DbState;
 use crate::error::SlateDBError;
-use crate::flush::WalFlushThreadMsg;
+use crate::flush::WalFlushMsg;
 use crate::mem_table_flush::MemtableFlushMsg;
 
 impl DbInner {
@@ -35,7 +35,7 @@ impl DbInner {
         }
         guard.freeze_wal()?;
         self.wal_flush_notifier
-            .send((None, WalFlushThreadMsg::FlushImmutableWals))
+            .send(WalFlushMsg::FlushImmutableWals { sender: None })
             .map_err(|_| SlateDBError::WalFlushChannelError)?;
         Ok(())
     }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -4,9 +4,10 @@ use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::select;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::sync::oneshot::Sender;
 use tracing::{error, info};
 
-use crate::db::{DbInner, FlushMsg};
+use crate::db::DbInner;
 use crate::db_state;
 use crate::db_state::SsTableHandle;
 use crate::error::SlateDBError;
@@ -17,9 +18,11 @@ use crate::types::{RowAttributes, ValueDeletable};
 use crate::utils::spawn_bg_task;
 
 #[derive(Debug)]
-pub(crate) enum WalFlushThreadMsg {
+pub(crate) enum WalFlushMsg {
     Shutdown,
-    FlushImmutableWals,
+    FlushImmutableWals {
+        sender: Option<Sender<Result<(), SlateDBError>>>,
+    },
 }
 
 impl DbInner {
@@ -108,13 +111,13 @@ impl DbInner {
 
     pub(crate) fn spawn_flush_task(
         self: &Arc<Self>,
-        mut rx: UnboundedReceiver<FlushMsg<WalFlushThreadMsg>>,
+        mut rx: UnboundedReceiver<WalFlushMsg>,
         tokio_handle: &Handle,
     ) -> Option<tokio::task::JoinHandle<Result<(), SlateDBError>>> {
         let this = Arc::clone(self);
         async fn core_flush_loop(
             this: &Arc<DbInner>,
-            rx: &mut UnboundedReceiver<FlushMsg<WalFlushThreadMsg>>,
+            rx: &mut UnboundedReceiver<WalFlushMsg>,
         ) -> Result<(), SlateDBError> {
             let mut ticker = tokio::time::interval(this.options.flush_interval);
             let mut err_reader = this.state.read().error_reader();
@@ -132,21 +135,20 @@ impl DbInner {
                         }
                     }
                     msg = rx.recv() => {
-                        let (rsp_sender, msg) = msg.expect("channel unexpectedly closed");
-                        match msg {
-                            WalFlushThreadMsg::Shutdown => {
+                        match msg.expect("channel unexpectedly closed") {
+                            WalFlushMsg::Shutdown => {
                                 // Stop the thread.
                                 _ = this.flush().await;
                                 return Ok(())
                             },
-                            WalFlushThreadMsg::FlushImmutableWals => {
+                            WalFlushMsg::FlushImmutableWals { sender } => {
                                 let result = this.flush().await;
                                 if let Err(err) = result {
                                     error!("error from wal flush: {err}");
                                     return Err(err);
                                 }
 
-                                if let Some(rsp_sender) = rsp_sender {
+                                if let Some(rsp_sender) = sender {
                                     let res = rsp_sender.send(result);
                                     if let Err(Err(err)) = res {
                                         error!("error sending flush response: {err}");
@@ -186,14 +188,17 @@ impl DbInner {
         ))
     }
 
-    async fn close_and_drain_receiver<T>(
-        rx: &mut UnboundedReceiver<FlushMsg<T>>,
+    async fn close_and_drain_receiver(
+        rx: &mut UnboundedReceiver<WalFlushMsg>,
         error: &SlateDBError,
     ) {
         rx.close();
         while !rx.is_empty() {
-            let (rsp_sender, _) = rx.recv().await.expect("channel unexpectedly closed");
-            if let Some(sender) = rsp_sender {
+            let msg = rx.recv().await.expect("channel unexpectedly closed");
+            if let WalFlushMsg::FlushImmutableWals {
+                sender: Some(sender),
+            } = msg
+            {
                 let _ = sender.send(Err(error.clone()));
             }
         }


### PR DESCRIPTION
We ended up refactoring the memtable flusher so that it no longer uses `FlushMsg`. This patch makes a similar transformation for the wal flush msg for simpler and more consistent usage.