### PR TITLE
Consolidate checkpoint creation logic

### DIFF
--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -1,13 +1,12 @@
-use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
+use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::{CoreDbState, SsTableId};
+use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
-use crate::error::SlateDBError::{BackgroundTaskShutdown, CheckpointMissing};
+use crate::error::SlateDBError::BackgroundTaskShutdown;
 use crate::manifest_store::FenceableManifest;
 use crate::utils::spawn_bg_task;
 use std::sync::Arc;
-use std::time::SystemTime;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::oneshot::Sender;
@@ -48,15 +47,12 @@ impl MemtableFlusher {
             let rguard_state = self.db_inner.state.read();
             rguard_state.state().core.clone()
         };
-
-        let checkpoint = self.build_checkpoint(&core, options)?;
-        let result = CheckpointCreateResult {
-            id: checkpoint.id,
-            manifest_id: checkpoint.manifest_id,
-        };
+        let id = Uuid::new_v4();
+        let checkpoint = self.manifest.new_checkpoint(id, options)?;
+        let manifest_id = checkpoint.manifest_id;
         core.checkpoints.push(checkpoint);
         self.manifest.update_db_state(core).await?;
-        Ok(result)
+        Ok(CheckpointCreateResult { id, manifest_id })
     }
 
     async fn write_manifest(&mut self) -> Result<(), SlateDBError> {
@@ -65,32 +61,6 @@ impl MemtableFlusher {
             rguard_state.state().core.clone()
         };
         self.manifest.update_db_state(core).await
-    }
-
-    fn build_checkpoint(
-        &self,
-        state: &CoreDbState,
-        options: &CheckpointOptions,
-    ) -> Result<Checkpoint, SlateDBError> {
-        let id = Uuid::new_v4();
-        let manifest_id = if let Some(source_id) = &options.source {
-            if let Some(checkpoint) = state.find_checkpoint(source_id) {
-                checkpoint.manifest_id
-            } else {
-                return Err(CheckpointMissing(*source_id));
-            }
-        } else {
-            self.manifest.next_manifest_id()
-        };
-
-        let expire_time = options.lifetime.map(|l| SystemTime::now() + l);
-
-        Ok(Checkpoint {
-            id,
-            manifest_id,
-            expire_time,
-            create_time: SystemTime::now(),
-        })
     }
 
     pub(crate) async fn write_checkpoint_safely(


### PR DESCRIPTION
Follow-up for https://github.com/slatedb/slatedb/pull/443/files. We were left with two separate paths for checkpoint creation with slightly inconsistent behavior. For one, we used a different error when the source checkpoint could not be found. Additionally, when no source manifest was provided, we used the current manifest ID through one path and the next manifest ID through the other. This patch consolidates the two paths so that they use the same function to construct the checkpoint object.