### PR TITLE
Rename `bytes.rs` and re-export `bytes` crate

### DIFF
--- a/src/bytes_generator.rs
+++ b/src/bytes_generator.rs
@@ -51,7 +51,7 @@ impl OrderedBytesGenerator {
 mod tests {
     use bytes::{BufMut, Bytes};
 
-    use crate::bytes::OrderedBytesGenerator;
+    use crate::bytes_generator::OrderedBytesGenerator;
 
     #[test]
     fn test_should_generate_ordered_bytes() {

--- a/src/compaction_execute_bench.rs
+++ b/src/compaction_execute_bench.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 use tracing::{error, info};
 use ulid::Ulid;
 
-use crate::bytes::OrderedBytesGenerator;
+use crate::bytes_generator::OrderedBytesGenerator;
 use crate::compactor::WorkerToOrchestratorMsg;
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod blob;
 mod block;
 mod block_iterator;
 #[cfg(any(test, feature = "bencher"))]
-mod bytes;
+mod bytes_generator;
 mod bytes_range;
 mod cached_object_store;
 pub mod checkpoint;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,14 +53,21 @@ mod transactional_object_store;
 mod types;
 mod utils;
 
+/// Re-export the bytes crate.
+///
+/// This is useful for users of the crate who want to use SlateDB
+/// without having to depend on the bytes crate directly.
+pub use bytes;
+
+/// Re-export the fail-parallel crate.
+///
+/// This is useful for users of the crate who want to use SlateDB
+/// with failpoints in their tests without having to depend on the
+/// fail-parallel crate directly.
+pub use fail_parallel;
+
 /// Re-export the object store crate.
 ///
 /// This is useful for users of the crate who want to use SlateDB
 /// without having to depend on the object store crate directly.
 pub use object_store;
-
-/// Re-export the fail-parallel crate.
-///
-/// This is useful for users of the crate who want to use SlateDB
-/// with failpoints in their tests without having to depend on the fail-parallel crate directly.
-pub use fail_parallel;

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -149,7 +149,7 @@ impl SeekToKey for SortedRunIterator<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bytes::OrderedBytesGenerator;
+    use crate::bytes_generator::OrderedBytesGenerator;
     use crate::db_state::SsTableId;
     use crate::proptest_util;
     use crate::proptest_util::sample;

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -366,7 +366,7 @@ impl SeekToKey for SstIterator<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bytes::OrderedBytesGenerator;
+    use crate::bytes_generator::OrderedBytesGenerator;
     use crate::db_state::SsTableId;
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, gen_attrs};


### PR DESCRIPTION
This PR renames `bytes.rs` to `bytes_generator.rs` so that we can re-export the `bytes` crate without a name conflict. This is to lay the groundwork for #450, where we've decided we want to keep `Bytes` as the return type for our API. To make life easier on users, I think we should re-export the `bytes` crate since we're using it in our public API (like we do with the `object_store` and `fail_parallel` crates).

I considered deleting `bytes.rs` and moving its content into `test_utils.rs`, but `OrderedBytesGenerator` is used by the `bencher` feature, which is a feature flag, not a test. When importing `test_utils` for `bencher`, it was causing a bunch of "unused" errors because of all the test functions that weren't used.

I also considered trying to use `extern` to somehow alias the `bytes` crate in `lib.rs`, but was unsuccessful. I don't want to export it under a separate name because that would be confusing to users.

This led me to simply rename the `bytes.rs` file to get around the conflict.