### PR TITLE
Factor out path resolver

### DIFF
--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -939,7 +939,7 @@ mod tests {
     #[tokio::test]
     async fn test_collect_garbage_wal_ssts() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
-        let path_builder = PathResolver::new("/");
+        let path_resolver = PathResolver::new("/");
 
         // write a wal sst
         let id1 = SsTableId::Wal(1);
@@ -951,7 +951,7 @@ mod tests {
         // Set the first WAL SST file to be a day old
         let now_minus_24h = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&SsTableId::Wal(1)),
+            &path_resolver.table_path(&SsTableId::Wal(1)),
             86400,
         );
 
@@ -993,7 +993,7 @@ mod tests {
     #[tokio::test]
     async fn test_do_not_remove_wals_referenced_by_active_checkpoints() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
-        let path_builder = PathResolver::new("/");
+        let path_resolver = PathResolver::new("/");
 
         let id1 = SsTableId::Wal(1);
         write_sst(table_store.clone(), &id1).await.unwrap();
@@ -1029,7 +1029,7 @@ mod tests {
         for i in 1..=3 {
             set_modified(
                 local_object_store.clone(),
-                &path_builder.table_path(&SsTableId::Wal(i)),
+                &path_resolver.table_path(&SsTableId::Wal(i)),
                 86400,
             );
         }
@@ -1053,7 +1053,7 @@ mod tests {
     #[tokio::test]
     async fn test_collect_garbage_wal_ssts_and_keep_expired_last_compacted() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
-        let path_builder = PathResolver::new("/");
+        let path_resolver = PathResolver::new("/");
 
         // write a wal sst
         let id1 = SsTableId::Wal(1);
@@ -1072,12 +1072,12 @@ mod tests {
         // Set the both WAL SST file to be a day old
         let now_minus_24h_1 = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&SsTableId::Wal(1)),
+            &path_resolver.table_path(&SsTableId::Wal(1)),
             86400,
         );
         let now_minus_24h_2 = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&SsTableId::Wal(2)),
+            &path_resolver.table_path(&SsTableId::Wal(2)),
             86400,
         );
 
@@ -1139,27 +1139,27 @@ mod tests {
         let active_expired_sst_handle = create_sst(table_store.clone()).await;
         let inactive_expired_sst_handle = create_sst(table_store.clone()).await;
         let inactive_unexpired_sst_handle = create_sst(table_store.clone()).await;
-        let path_builder = PathResolver::new("");
+        let path_resolver = PathResolver::new("");
 
         // Set expiration for the old SSTs
         let now_minus_24h_expired_l0_sst = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&active_expired_l0_sst_handle.id),
+            &path_resolver.table_path(&active_expired_l0_sst_handle.id),
             86400,
         );
         let now_minus_24h_inactive_expired_l0_sst = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&inactive_expired_l0_sst_handle.id),
+            &path_resolver.table_path(&inactive_expired_l0_sst_handle.id),
             86400,
         );
         let now_minus_24h_active_expired_sst = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&active_expired_sst_handle.id),
+            &path_resolver.table_path(&active_expired_sst_handle.id),
             86400,
         );
         let now_minus_24h_inactive_expired_sst_id = set_modified(
             local_object_store.clone(),
-            &path_builder.table_path(&inactive_expired_sst_handle.id),
+            &path_resolver.table_path(&inactive_expired_sst_handle.id),
             86400,
         );
 
@@ -1252,7 +1252,7 @@ mod tests {
         let active_sst_handle = create_sst(table_store.clone()).await;
         let active_checkpoint_sst_handle = create_sst(table_store.clone()).await;
         let inactive_sst_handle = create_sst(table_store.clone()).await;
-        let path_builder = PathResolver::new("");
+        let path_resolver = PathResolver::new("");
 
         // Set expiration for all SSTs to make them eligible for deletion
         let all_tables = vec![
@@ -1266,7 +1266,7 @@ mod tests {
         for table in &all_tables {
             set_modified(
                 local_object_store.clone(),
-                &path_builder.table_path(&table.id),
+                &path_resolver.table_path(&table.id),
                 86400,
             );
         }

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -618,7 +618,7 @@ mod tests {
     use crate::config::GcExecutionMode::Once;
     use crate::error::SlateDBError;
     use crate::metrics::Counter;
-    use crate::paths::PathBuilder;
+    use crate::paths::PathResolver;
     use crate::types::RowEntry;
     use crate::{
         db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId},
@@ -939,7 +939,7 @@ mod tests {
     #[tokio::test]
     async fn test_collect_garbage_wal_ssts() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
-        let path_builder = PathBuilder::new("/");
+        let path_builder = PathResolver::new("/");
 
         // write a wal sst
         let id1 = SsTableId::Wal(1);
@@ -993,7 +993,7 @@ mod tests {
     #[tokio::test]
     async fn test_do_not_remove_wals_referenced_by_active_checkpoints() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
-        let path_builder = PathBuilder::new("/");
+        let path_builder = PathResolver::new("/");
 
         let id1 = SsTableId::Wal(1);
         write_sst(table_store.clone(), &id1).await.unwrap();
@@ -1053,7 +1053,7 @@ mod tests {
     #[tokio::test]
     async fn test_collect_garbage_wal_ssts_and_keep_expired_last_compacted() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
-        let path_builder = PathBuilder::new("/");
+        let path_builder = PathResolver::new("/");
 
         // write a wal sst
         let id1 = SsTableId::Wal(1);
@@ -1139,7 +1139,7 @@ mod tests {
         let active_expired_sst_handle = create_sst(table_store.clone()).await;
         let inactive_expired_sst_handle = create_sst(table_store.clone()).await;
         let inactive_unexpired_sst_handle = create_sst(table_store.clone()).await;
-        let path_builder = PathBuilder::new("");
+        let path_builder = PathResolver::new("");
 
         // Set expiration for the old SSTs
         let now_minus_24h_expired_l0_sst = set_modified(
@@ -1252,7 +1252,7 @@ mod tests {
         let active_sst_handle = create_sst(table_store.clone()).await;
         let active_checkpoint_sst_handle = create_sst(table_store.clone()).await;
         let inactive_sst_handle = create_sst(table_store.clone()).await;
-        let path_builder = PathBuilder::new("");
+        let path_builder = PathResolver::new("");
 
         // Set expiration for all SSTs to make them eligible for deletion
         let all_tables = vec![

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -618,6 +618,7 @@ mod tests {
     use crate::config::GcExecutionMode::Once;
     use crate::error::SlateDBError;
     use crate::metrics::Counter;
+    use crate::paths::PathBuilder;
     use crate::types::RowEntry;
     use crate::{
         db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId},
@@ -938,6 +939,7 @@ mod tests {
     #[tokio::test]
     async fn test_collect_garbage_wal_ssts() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
+        let path_builder = PathBuilder::new("/");
 
         // write a wal sst
         let id1 = SsTableId::Wal(1);
@@ -949,7 +951,7 @@ mod tests {
         // Set the first WAL SST file to be a day old
         let now_minus_24h = set_modified(
             local_object_store.clone(),
-            &Path::from(format!("wal/{:020}.{}", 1, "sst")),
+            &path_builder.table_path(&SsTableId::Wal(1)),
             86400,
         );
 
@@ -991,6 +993,7 @@ mod tests {
     #[tokio::test]
     async fn test_do_not_remove_wals_referenced_by_active_checkpoints() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
+        let path_builder = PathBuilder::new("/");
 
         let id1 = SsTableId::Wal(1);
         write_sst(table_store.clone(), &id1).await.unwrap();
@@ -1026,7 +1029,7 @@ mod tests {
         for i in 1..=3 {
             set_modified(
                 local_object_store.clone(),
-                &Path::from(format!("wal/{:020}.{}", i, "sst")),
+                &path_builder.table_path(&SsTableId::Wal(i)),
                 86400,
             );
         }
@@ -1050,6 +1053,7 @@ mod tests {
     #[tokio::test]
     async fn test_collect_garbage_wal_ssts_and_keep_expired_last_compacted() {
         let (manifest_store, table_store, local_object_store, db_stats) = build_objects();
+        let path_builder = PathBuilder::new("/");
 
         // write a wal sst
         let id1 = SsTableId::Wal(1);
@@ -1068,12 +1072,12 @@ mod tests {
         // Set the both WAL SST file to be a day old
         let now_minus_24h_1 = set_modified(
             local_object_store.clone(),
-            &Path::from(format!("wal/{:020}.{}", 1, "sst")),
+            &path_builder.table_path(&SsTableId::Wal(1)),
             86400,
         );
         let now_minus_24h_2 = set_modified(
             local_object_store.clone(),
-            &Path::from(format!("wal/{:020}.{}", 2, "sst")),
+            &path_builder.table_path(&SsTableId::Wal(2)),
             86400,
         );
 
@@ -1135,42 +1139,27 @@ mod tests {
         let active_expired_sst_handle = create_sst(table_store.clone()).await;
         let inactive_expired_sst_handle = create_sst(table_store.clone()).await;
         let inactive_unexpired_sst_handle = create_sst(table_store.clone()).await;
+        let path_builder = PathBuilder::new("");
 
         // Set expiration for the old SSTs
         let now_minus_24h_expired_l0_sst = set_modified(
             local_object_store.clone(),
-            &Path::from(format!(
-                "compacted/{:020}.{}",
-                active_expired_l0_sst_handle.id.unwrap_compacted_id(),
-                "sst"
-            )),
+            &path_builder.table_path(&active_expired_l0_sst_handle.id),
             86400,
         );
         let now_minus_24h_inactive_expired_l0_sst = set_modified(
             local_object_store.clone(),
-            &Path::from(format!(
-                "compacted/{:020}.{}",
-                inactive_expired_l0_sst_handle.id.unwrap_compacted_id(),
-                "sst"
-            )),
+            &path_builder.table_path(&inactive_expired_l0_sst_handle.id),
             86400,
         );
         let now_minus_24h_active_expired_sst = set_modified(
             local_object_store.clone(),
-            &Path::from(format!(
-                "compacted/{:020}.{}",
-                active_expired_sst_handle.id.unwrap_compacted_id(),
-                "sst"
-            )),
+            &path_builder.table_path(&active_expired_sst_handle.id),
             86400,
         );
         let now_minus_24h_inactive_expired_sst_id = set_modified(
             local_object_store.clone(),
-            &Path::from(format!(
-                "compacted/{:020}.{}",
-                inactive_expired_sst_handle.id.unwrap_compacted_id(),
-                "sst"
-            )),
+            &path_builder.table_path(&inactive_expired_sst_handle.id),
             86400,
         );
 
@@ -1263,6 +1252,7 @@ mod tests {
         let active_sst_handle = create_sst(table_store.clone()).await;
         let active_checkpoint_sst_handle = create_sst(table_store.clone()).await;
         let inactive_sst_handle = create_sst(table_store.clone()).await;
+        let path_builder = PathBuilder::new("");
 
         // Set expiration for all SSTs to make them eligible for deletion
         let all_tables = vec![
@@ -1276,11 +1266,7 @@ mod tests {
         for table in &all_tables {
             set_modified(
                 local_object_store.clone(),
-                &Path::from(format!(
-                    "compacted/{:020}.{}",
-                    table.id.unwrap_compacted_id(),
-                    "sst"
-                )),
+                &path_builder.table_path(&table.id),
                 86400,
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod mem_table_flush;
 mod merge_iterator;
 pub mod merge_operator;
 pub mod metrics;
+mod paths;
 #[cfg(test)]
 mod proptest_util;
 mod row_codec;

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,123 @@
+use crate::db_state::SsTableId;
+use crate::db_state::SsTableId::{Compacted, Wal};
+use crate::error::SlateDBError;
+use object_store::path::Path;
+use ulid::Ulid;
+
+pub(crate) struct PathBuilder {
+    root_path: Path,
+    wal_path: &'static str,
+    compacted_path: &'static str,
+}
+
+impl PathBuilder {
+    pub(crate) fn new<P: Into<Path>>(root_path: P) -> Self {
+        Self {
+            root_path: root_path.into(),
+            wal_path: "wal",
+            compacted_path: "compacted",
+        }
+    }
+
+    pub(crate) fn wal_path(&self) -> Path {
+        Path::from(format!("{}/{}/", &self.root_path, self.wal_path))
+    }
+
+    pub(crate) fn compacted_path(&self) -> Path {
+        Path::from(format!("{}/{}/", &self.root_path, self.compacted_path))
+    }
+
+    pub(crate) fn parse_table_id(&self, path: &Path) -> Result<Option<SsTableId>, SlateDBError> {
+        if let Some(mut suffix_iter) = path.prefix_match(&self.root_path) {
+            match suffix_iter.next() {
+                Some(a) if a.as_ref() == self.wal_path => suffix_iter
+                    .next()
+                    .and_then(|s| s.as_ref().split('.').next().map(|s| s.parse::<u64>()))
+                    .transpose()
+                    .map(|r| r.map(SsTableId::Wal))
+                    .map_err(|_| SlateDBError::InvalidDBState),
+                Some(a) if a.as_ref() == self.compacted_path => suffix_iter
+                    .next()
+                    .and_then(|s| s.as_ref().split('.').next().map(Ulid::from_string))
+                    .transpose()
+                    .map(|r| r.map(SsTableId::Compacted))
+                    .map_err(|_| SlateDBError::InvalidDBState),
+                _ => Ok(None),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub(crate) fn table_path(&self, table_id: &SsTableId) -> Path {
+        match table_id {
+            Wal(id) => Path::from(format!(
+                "{}/{}/{:020}.sst",
+                &self.root_path, self.wal_path, id
+            )),
+            Compacted(ulid) => Path::from(format!(
+                "{}/{}/{}.sst",
+                &self.root_path,
+                self.compacted_path,
+                ulid.to_string()
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db_state::SsTableId;
+    use crate::paths::PathBuilder;
+    use object_store::path::Path;
+    use proptest::arbitrary::any;
+    use proptest::proptest;
+    use ulid::Ulid;
+
+    const ROOT: &str = "/root";
+
+    proptest! {
+        #[test]
+        fn should_serialize_and_deserialize_wal_paths(
+            wal_id in any::<u64>(),
+        ) {
+            let path_builder = PathBuilder::new(Path::from(ROOT));
+            let table_id = SsTableId::Wal(wal_id);
+            let path = path_builder.table_path(&table_id);
+            let parsed_table_id = path_builder.parse_table_id(&path).unwrap();
+            assert_eq!(Some(table_id), parsed_table_id);
+        }
+
+        #[test]
+        fn should_serialize_and_deserialize_compacted_paths(
+            compacted_id in any::<u128>(),
+        ) {
+            let path_builder = PathBuilder::new(Path::from(ROOT));
+            let table_id = SsTableId::Compacted(Ulid::from(compacted_id));
+            let path = path_builder.table_path(&table_id);
+            let parsed_table_id = path_builder.parse_table_id(&path).unwrap();
+            assert_eq!(Some(table_id), parsed_table_id);
+        }
+    }
+
+    #[test]
+    fn test_parse_id() {
+        let path_builder = PathBuilder::new(Path::from(ROOT));
+        let path = Path::from("/root/wal/00000000000000000003.sst");
+        let id = path_builder.parse_table_id(&path).unwrap();
+        assert_eq!(id, Some(SsTableId::Wal(3)));
+
+        let path = Path::from("/root/compacted/01J79C21YKR31J2BS1EFXJZ7MR.sst");
+        let id = path_builder.parse_table_id(&path).unwrap();
+        assert_eq!(
+            id,
+            Some(SsTableId::Compacted(
+                Ulid::from_string("01J79C21YKR31J2BS1EFXJZ7MR").unwrap()
+            ))
+        );
+
+        let path = Path::from("/root/invalid/00000000000000000001.sst");
+        let id = path_builder.parse_table_id(&path).unwrap();
+        assert_eq!(id, None);
+    }
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -4,13 +4,13 @@ use crate::error::SlateDBError;
 use object_store::path::Path;
 use ulid::Ulid;
 
-pub(crate) struct PathBuilder {
+pub(crate) struct PathResolver {
     root_path: Path,
     wal_path: &'static str,
     compacted_path: &'static str,
 }
 
-impl PathBuilder {
+impl PathResolver {
     pub(crate) fn new<P: Into<Path>>(root_path: P) -> Self {
         Self {
             root_path: root_path.into(),
@@ -68,7 +68,7 @@ impl PathBuilder {
 #[cfg(test)]
 mod tests {
     use crate::db_state::SsTableId;
-    use crate::paths::PathBuilder;
+    use crate::paths::PathResolver;
     use object_store::path::Path;
     use proptest::arbitrary::any;
     use proptest::proptest;
@@ -81,7 +81,7 @@ mod tests {
         fn should_serialize_and_deserialize_wal_paths(
             wal_id in any::<u64>(),
         ) {
-            let path_builder = PathBuilder::new(Path::from(ROOT));
+            let path_builder = PathResolver::new(Path::from(ROOT));
             let table_id = SsTableId::Wal(wal_id);
             let path = path_builder.table_path(&table_id);
             let parsed_table_id = path_builder.parse_table_id(&path).unwrap();
@@ -92,7 +92,7 @@ mod tests {
         fn should_serialize_and_deserialize_compacted_paths(
             compacted_id in any::<u128>(),
         ) {
-            let path_builder = PathBuilder::new(Path::from(ROOT));
+            let path_builder = PathResolver::new(Path::from(ROOT));
             let table_id = SsTableId::Compacted(Ulid::from(compacted_id));
             let path = path_builder.table_path(&table_id);
             let parsed_table_id = path_builder.parse_table_id(&path).unwrap();
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_parse_id() {
-        let path_builder = PathBuilder::new(Path::from(ROOT));
+        let path_builder = PathResolver::new(Path::from(ROOT));
         let path = Path::from("/root/wal/00000000000000000003.sst");
         let id = path_builder.parse_table_id(&path).unwrap();
         assert_eq!(id, Some(SsTableId::Wal(3)));

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -81,10 +81,10 @@ mod tests {
         fn should_serialize_and_deserialize_wal_paths(
             wal_id in any::<u64>(),
         ) {
-            let path_builder = PathResolver::new(Path::from(ROOT));
+            let path_resolver = PathResolver::new(Path::from(ROOT));
             let table_id = SsTableId::Wal(wal_id);
-            let path = path_builder.table_path(&table_id);
-            let parsed_table_id = path_builder.parse_table_id(&path).unwrap();
+            let path = path_resolver.table_path(&table_id);
+            let parsed_table_id = path_resolver.parse_table_id(&path).unwrap();
             assert_eq!(Some(table_id), parsed_table_id);
         }
 
@@ -92,23 +92,23 @@ mod tests {
         fn should_serialize_and_deserialize_compacted_paths(
             compacted_id in any::<u128>(),
         ) {
-            let path_builder = PathResolver::new(Path::from(ROOT));
+            let path_resolver = PathResolver::new(Path::from(ROOT));
             let table_id = SsTableId::Compacted(Ulid::from(compacted_id));
-            let path = path_builder.table_path(&table_id);
-            let parsed_table_id = path_builder.parse_table_id(&path).unwrap();
+            let path = path_resolver.table_path(&table_id);
+            let parsed_table_id = path_resolver.parse_table_id(&path).unwrap();
             assert_eq!(Some(table_id), parsed_table_id);
         }
     }
 
     #[test]
     fn test_parse_id() {
-        let path_builder = PathResolver::new(Path::from(ROOT));
+        let path_resolver = PathResolver::new(Path::from(ROOT));
         let path = Path::from("/root/wal/00000000000000000003.sst");
-        let id = path_builder.parse_table_id(&path).unwrap();
+        let id = path_resolver.parse_table_id(&path).unwrap();
         assert_eq!(id, Some(SsTableId::Wal(3)));
 
         let path = Path::from("/root/compacted/01J79C21YKR31J2BS1EFXJZ7MR.sst");
-        let id = path_builder.parse_table_id(&path).unwrap();
+        let id = path_resolver.parse_table_id(&path).unwrap();
         assert_eq!(
             id,
             Some(SsTableId::Compacted(
@@ -117,7 +117,7 @@ mod tests {
         );
 
         let path = Path::from("/root/invalid/00000000000000000001.sst");
-        let id = path_builder.parse_table_id(&path).unwrap();
+        let id = path_resolver.parse_table_id(&path).unwrap();
         assert_eq!(id, None);
     }
 }

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -18,7 +18,7 @@ use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::filter::BloomFilter;
 use crate::flatbuffer_types::SsTableIndexOwned;
-use crate::paths::PathBuilder;
+use crate::paths::PathResolver;
 use crate::sst::{EncodedSsTable, EncodedSsTableBuilder, SsTableFormat};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
@@ -29,7 +29,7 @@ use crate::{blob::ReadOnlyBlob, block::Block, db_cache::DbCache};
 pub struct TableStore {
     object_store: Arc<dyn ObjectStore>,
     sst_format: SsTableFormat,
-    path_builder: PathBuilder,
+    path_builder: PathResolver,
     #[allow(dead_code)]
     fp_registry: Arc<FailPointRegistry>,
     transactional_wal_store: Arc<dyn TransactionalObjectStore>,
@@ -96,7 +96,7 @@ impl TableStore {
         Self {
             object_store: object_store.clone(),
             sst_format,
-            path_builder: PathBuilder::new(root_path),
+            path_builder: PathResolver::new(root_path),
             fp_registry,
             transactional_wal_store: Arc::new(DelegatingTransactionalObjectStore::new(
                 Path::from("/"),

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -18,6 +18,7 @@ use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::filter::BloomFilter;
 use crate::flatbuffer_types::SsTableIndexOwned;
+use crate::paths::PathBuilder;
 use crate::sst::{EncodedSsTable, EncodedSsTableBuilder, SsTableFormat};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
@@ -28,9 +29,7 @@ use crate::{blob::ReadOnlyBlob, block::Block, db_cache::DbCache};
 pub struct TableStore {
     object_store: Arc<dyn ObjectStore>,
     sst_format: SsTableFormat,
-    root_path: Path,
-    wal_path: &'static str,
-    compacted_path: &'static str,
+    path_builder: PathBuilder,
     #[allow(dead_code)]
     fp_registry: Arc<FailPointRegistry>,
     transactional_wal_store: Arc<dyn TransactionalObjectStore>,
@@ -97,9 +96,7 @@ impl TableStore {
         Self {
             object_store: object_store.clone(),
             sst_format,
-            root_path: root_path.into(),
-            wal_path: "wal",
-            compacted_path: "compacted",
+            path_builder: PathBuilder::new(root_path),
             fp_registry,
             transactional_wal_store: Arc::new(DelegatingTransactionalObjectStore::new(
                 Path::from("/"),
@@ -120,11 +117,11 @@ impl TableStore {
         id_range: R,
     ) -> Result<Vec<SstFileMetadata>, SlateDBError> {
         let mut wal_list: Vec<SstFileMetadata> = Vec::new();
-        let wal_path = &Path::from(format!("{}/{}/", &self.root_path, self.wal_path));
+        let wal_path = &self.path_builder.wal_path();
         let mut files_stream = self.object_store.list(Some(wal_path));
 
         while let Some(file) = files_stream.next().await.transpose()? {
-            match Self::parse_id(&self.root_path, &file.location) {
+            match self.path_builder.parse_table_id(&file.location) {
                 Ok(Some(SsTableId::Wal(id))) => {
                     if id_range.contains(&id) {
                         wal_list.push(SstFileMetadata {
@@ -251,11 +248,11 @@ impl TableStore {
         id_range: R,
     ) -> Result<Vec<SstFileMetadata>, SlateDBError> {
         let mut sst_list: Vec<SstFileMetadata> = Vec::new();
-        let sst_path = &Path::from(format!("{}/{}/", &self.root_path, self.compacted_path));
-        let mut files_stream = self.object_store.list(Some(sst_path));
+        let compacted_path = self.path_builder.compacted_path();
+        let mut files_stream = self.object_store.list(Some(&compacted_path));
 
         while let Some(file) = files_stream.next().await.transpose()? {
-            match Self::parse_id(&self.root_path, &file.location) {
+            match self.path_builder.parse_table_id(&file.location) {
                 Ok(Some(SsTableId::Compacted(id))) => {
                     if id_range.contains(&id) {
                         sst_list.push(SstFileMetadata {
@@ -492,41 +489,7 @@ impl TableStore {
     }
 
     fn path(&self, id: &SsTableId) -> Path {
-        match id {
-            SsTableId::Wal(id) => Path::from(format!(
-                "{}/{}/{:020}.sst",
-                &self.root_path, self.wal_path, id
-            )),
-            SsTableId::Compacted(ulid) => Path::from(format!(
-                "{}/{}/{}.sst",
-                &self.root_path,
-                self.compacted_path,
-                ulid.to_string()
-            )),
-        }
-    }
-
-    /// Parses the SsTableId from a given path
-    fn parse_id(root_path: &Path, path: &Path) -> Result<Option<SsTableId>, SlateDBError> {
-        if let Some(mut suffix_iter) = path.prefix_match(root_path) {
-            match suffix_iter.next() {
-                Some(a) if a.as_ref() == "wal" => suffix_iter
-                    .next()
-                    .and_then(|s| s.as_ref().split('.').next().map(|s| s.parse::<u64>()))
-                    .transpose()
-                    .map(|r| r.map(SsTableId::Wal))
-                    .map_err(|_| SlateDBError::InvalidDBState),
-                Some(a) if a.as_ref() == "compacted" => suffix_iter
-                    .next()
-                    .and_then(|s| s.as_ref().split('.').next().map(Ulid::from_string))
-                    .transpose()
-                    .map(|r| r.map(SsTableId::Compacted))
-                    .map_err(|_| SlateDBError::InvalidDBState),
-                _ => Ok(None),
-            }
-        } else {
-            Ok(None)
-        }
+        self.path_builder.table_path(id)
     }
 }
 
@@ -602,27 +565,6 @@ mod tests {
     };
 
     const ROOT: &str = "/root";
-
-    #[test]
-    fn test_parse_id() {
-        let root = Path::from(ROOT);
-        let path = Path::from("/root/wal/00000000000000000003.sst");
-        let id = TableStore::parse_id(&root, &path).unwrap();
-        assert_eq!(id, Some(SsTableId::Wal(3)));
-
-        let path = Path::from("/root/compacted/01J79C21YKR31J2BS1EFXJZ7MR.sst");
-        let id = TableStore::parse_id(&root, &path).unwrap();
-        assert_eq!(
-            id,
-            Some(SsTableId::Compacted(
-                Ulid::from_string("01J79C21YKR31J2BS1EFXJZ7MR").unwrap()
-            ))
-        );
-
-        let path = Path::from("/root/invalid/00000000000000000001.sst");
-        let id = TableStore::parse_id(&root, &path).unwrap();
-        assert_eq!(id, None);
-    }
 
     #[tokio::test]
     async fn test_sst_writer_should_write_sst() {


### PR DESCRIPTION
Pull logic for building and parsing paths into a separate `PathResolver`. This is more convenient in contexts where we may not need a tablestore.