### PR TITLE
restructure exports to top level of crate

### DIFF
--- a/benches/db_operations.rs
+++ b/benches/db_operations.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use object_store::{memory::InMemory, path::Path};
 use pprof::criterion::{Output, PProfProfiler};
 use slatedb::config::{PutOptions, WriteOptions};
-use slatedb::{config::DbOptions, db::Db};
+use slatedb::{config::DbOptions, Db};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -40,7 +40,7 @@ impl Default for WriteBatch {
     }
 }
 
-pub enum WriteOp {
+pub(crate) enum WriteOp {
     Put(Bytes, Bytes, PutOptions),
     Delete(Bytes),
 }

--- a/src/bencher/args.rs
+++ b/src/bencher/args.rs
@@ -11,7 +11,7 @@ use slatedb::{
         moka::{MokaCache, MokaCacheOptions},
         DbCache,
     },
-    error::DbOptionsError,
+    DbOptionsError,
 };
 
 use crate::db::{FixedSetKeyGenerator, KeyGenerator, RandomKeyGenerator};

--- a/src/bencher/db.rs
+++ b/src/bencher/db.rs
@@ -43,7 +43,7 @@ use bytes::Bytes;
 use rand::{Rng, RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use slatedb::config::{PutOptions, WriteOptions};
-use slatedb::db::Db;
+use slatedb::Db;
 use tokio::time::Instant;
 use tracing::info;
 

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -14,7 +14,7 @@ use object_store::PutResult;
 use slatedb::admin;
 use slatedb::compaction_execute_bench::CompactionExecuteBench;
 use slatedb::config::WriteOptions;
-use slatedb::db::Db;
+use slatedb::Db;
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
+#[non_exhaustive]
 #[derive(Clone, PartialEq, Serialize, Debug)]
 pub struct Checkpoint {
     pub id: Uuid,
@@ -18,6 +19,7 @@ pub struct Checkpoint {
     pub create_time: SystemTime,
 }
 
+#[non_exhaustive]
 #[derive(Debug)]
 pub struct CheckpointCreateResult {
     /// The id of the created checkpoint.

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -7,7 +7,7 @@ use slatedb::config::GcExecutionMode::{Once, Periodic};
 use slatedb::config::{
     CheckpointOptions, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
 };
-use slatedb::db::Db;
+use slatedb::Db;
 use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/config.rs
+++ b/src/config.rs
@@ -328,13 +328,16 @@ fn default_clock() -> Arc<dyn Clock + Send + Sync> {
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum CheckpointScope {
-    #[non_exhaustive] All { force_flush: bool },
+    #[non_exhaustive]
+    All {
+        force_flush: bool,
+    },
     Durable,
 }
 
 impl CheckpointScope {
     pub fn all_with_force_flush(force_flush: bool) -> Self {
-        Self::All{force_flush,}
+        Self::All { force_flush }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,6 +174,7 @@ use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
 /// write is considered durably committed if all future calls to read are guaranteed
 /// to serve the data written by the write, until some later durably committed write
 /// updates the same key.
+#[non_exhaustive]
 #[derive(Clone, Default)]
 pub enum ReadLevel {
     /// Client reads will only see data that's been committed durably to the DB.
@@ -272,6 +273,7 @@ impl PutOptions {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Default)]
 pub enum Ttl {
     #[default]
@@ -323,10 +325,17 @@ fn default_clock() -> Arc<dyn Clock + Send + Sync> {
 /// flush_interval or reaching l0_sst_size_bytes, respectively. If set to Durable, then the
 /// checkpoint includes only writes that were durable at the time of the call. This will be faster,
 /// but may not include data from recent writes.
+#[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum CheckpointScope {
-    All { force_flush: bool },
+    #[non_exhaustive] All { force_flush: bool },
     Durable,
+}
+
+impl CheckpointScope {
+    pub fn all_with_force_flush(force_flush: bool) -> Self {
+        Self::All{force_flush,}
+    }
 }
 
 /// Specify options to provide when creating a checkpoint.
@@ -664,6 +673,7 @@ fn default_block_cache() -> Option<Arc<dyn DbCache>> {
 }
 
 /// The compression algorithm to use for SSTables.
+#[non_exhaustive]
 #[derive(Clone, Copy, Deserialize, PartialEq, Debug, Serialize)]
 pub enum CompressionCodec {
     #[cfg(feature = "snappy")]

--- a/src/db_cache/mod.rs
+++ b/src/db_cache/mod.rs
@@ -99,6 +99,7 @@ pub trait DbCache: Send + Sync {
 /// The key is a tuple of an SSTable ID and a block ID.
 /// The tuple is private to this module, so the implementation details
 /// of the cache are not exposed publicly.
+#[non_exhaustive]
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct CachedKey(SsTableId, u64);
 
@@ -108,6 +109,7 @@ impl From<(SsTableId, u64)> for CachedKey {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone)]
 enum CachedItem {
     Block(Arc<Block>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 use crate::merge_operator::MergeOperatorError;
 
+#[non_exhaustive]
 #[derive(Clone, Debug, Error)]
 pub enum SlateDBError {
     #[error("IO error: {0}")]
@@ -126,6 +127,7 @@ impl From<object_store::Error> for SlateDBError {
 ///
 /// This enum encapsulates various error conditions that may arise
 /// when parsing or processing database configuration options.
+#[non_exhaustive]
 #[derive(Error, Debug)]
 pub enum DbOptionsError {
     #[error("Unknown configuration file format: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,83 +4,6 @@
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]
 
-pub mod admin;
-
-mod batch;
-pub use batch::WriteBatch;
-
-mod batch_write;
-mod blob;
-mod block;
-mod block_iterator;
-#[cfg(any(test, feature = "bencher"))]
-mod bytes_generator;
-mod bytes_range;
-mod cached_object_store;
-
-mod checkpoint;
-pub use checkpoint::{Checkpoint, CheckpointCreateResult};
-
-#[cfg(feature = "bencher")]
-pub mod compaction_execute_bench;
-
-mod compactor;
-mod compactor_executor;
-mod compactor_state;
-
-pub mod config;
-
-mod db;
-pub use db::Db;
-
-pub mod db_cache;
-
-mod db_common;
-
-mod db_iter;
-pub use db_iter::DbIterator;
-
-mod db_state;
-
-mod error;
-pub use error::{DbOptionsError, SlateDBError};
-
-mod filter;
-mod flatbuffer_types;
-mod flush;
-mod garbage_collector;
-mod iter;
-mod manifest;
-mod manifest_store;
-mod mem_table;
-mod mem_table_flush;
-mod merge_iterator;
-
-mod merge_operator;
-pub use merge_operator::{MergeOperator, MergeOperatorError};
-
-pub mod metrics;
-
-mod paths;
-#[cfg(test)]
-mod proptest_util;
-mod row_codec;
-
-pub mod size_tiered_compaction;
-
-mod sorted_run_iterator;
-mod sst;
-mod sst_iter;
-mod tablestore;
-#[cfg(test)]
-mod test_utils;
-mod transactional_object_store;
-
-mod types;
-pub use types::KeyValue;
-
-mod utils;
-
 /// Re-export the bytes crate.
 ///
 /// This is useful for users of the crate who want to use SlateDB
@@ -99,3 +22,62 @@ pub use fail_parallel;
 /// This is useful for users of the crate who want to use SlateDB
 /// without having to depend on the object store crate directly.
 pub use object_store;
+
+pub use batch::WriteBatch;
+pub use checkpoint::{Checkpoint, CheckpointCreateResult};
+pub use db::Db;
+pub use db_iter::DbIterator;
+pub use error::{DbOptionsError, SlateDBError};
+pub use merge_operator::{MergeOperator, MergeOperatorError};
+pub use types::KeyValue;
+
+pub mod admin;
+#[cfg(feature = "bencher")]
+pub mod compaction_execute_bench;
+pub mod config;
+pub mod db_cache;
+pub mod metrics;
+pub mod size_tiered_compaction;
+
+mod batch;
+mod batch_write;
+mod blob;
+mod block;
+mod block_iterator;
+#[cfg(any(test, feature = "bencher"))]
+mod bytes_generator;
+mod bytes_range;
+mod cached_object_store;
+mod checkpoint;
+mod compactor;
+mod compactor_executor;
+mod compactor_state;
+mod db;
+mod db_common;
+mod db_iter;
+mod db_state;
+mod error;
+mod filter;
+mod flatbuffer_types;
+mod flush;
+mod garbage_collector;
+mod iter;
+mod manifest;
+mod manifest_store;
+mod mem_table;
+mod mem_table_flush;
+mod merge_iterator;
+mod merge_operator;
+mod paths;
+#[cfg(test)]
+mod proptest_util;
+mod row_codec;
+mod sorted_run_iterator;
+mod sst;
+mod sst_iter;
+mod tablestore;
+#[cfg(test)]
+mod test_utils;
+mod transactional_object_store;
+mod types;
+mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@
 #![cfg_attr(test, allow(clippy::panic))]
 
 pub mod admin;
-pub mod batch;
+
+mod batch;
+pub use batch::WriteBatch;
+
 mod batch_write;
 mod blob;
 mod block;
@@ -14,19 +17,34 @@ mod block_iterator;
 mod bytes_generator;
 mod bytes_range;
 mod cached_object_store;
-pub mod checkpoint;
+
+mod checkpoint;
+pub use checkpoint::{Checkpoint, CheckpointCreateResult};
+
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
+
 mod compactor;
 mod compactor_executor;
 mod compactor_state;
+
 pub mod config;
-pub mod db;
+
+mod db;
+pub use db::Db;
+
 pub mod db_cache;
+
 mod db_common;
-pub mod db_iter;
+
+mod db_iter;
+pub use db_iter::DbIterator;
+
 mod db_state;
-pub mod error;
+
+mod error;
+pub use error::{DbOptionsError, SlateDBError};
+
 mod filter;
 mod flatbuffer_types;
 mod flush;
@@ -37,13 +55,19 @@ mod manifest_store;
 mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
-pub mod merge_operator;
+
+mod merge_operator;
+pub use merge_operator::{MergeOperator, MergeOperatorError};
+
 pub mod metrics;
+
 mod paths;
 #[cfg(test)]
 mod proptest_util;
 mod row_codec;
+
 pub mod size_tiered_compaction;
+
 mod sorted_run_iterator;
 mod sst;
 mod sst_iter;
@@ -51,8 +75,10 @@ mod tablestore;
 #[cfg(test)]
 mod test_utils;
 mod transactional_object_store;
+
 mod types;
 pub use types::KeyValue;
+
 mod utils;
 
 /// Re-export the bytes crate.

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -10,6 +10,7 @@ use crate::{
     utils::merge_options,
 };
 
+#[non_exhaustive]
 #[derive(Clone, Debug, Error)]
 pub enum MergeOperatorError {}
 
@@ -29,7 +30,7 @@ pub enum MergeOperatorError {}
 /// Here's an example of a counter merge operator:
 /// ```
 /// use bytes::Bytes;
-/// use slatedb::merge_operator::{MergeOperator, MergeOperatorError};
+/// use slatedb::{MergeOperator, MergeOperatorError};
 ///
 /// struct CounterMergeOperator;
 ///

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use atomic::{Atomic, Ordering};
 use bytemuck::NoUninit;
 
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct Counter {
-    pub value: Arc<Atomic<u64>>,
+    pub(crate) value: Arc<Atomic<u64>>,
 }
 
 impl Counter {
@@ -71,6 +72,7 @@ impl Gauge<i64> {
     }
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct DbStats {
     pub immutable_memtable_flushes: Counter,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use atomic::{Atomic, Ordering};
 use bytemuck::NoUninit;
 
-#[non_exhaustive]
 #[derive(Clone, Debug)]
 pub struct Counter {
     pub(crate) value: Arc<Atomic<u64>>,


### PR DESCRIPTION
This patch makes a couple of changes to the way public names are exported:
- It exports many of the public names at the top level of the crate (e.g. lib.rs) to avoid leaking the internal module structure. I retained a few public modules for cases where I think it makes sense to expose the contained names within a module because the components should be grouped (e.g. configs, metrics, pluggable stuff like the dbcache)
- It adds non_exhaustive to all enums to force any users matching on the enums to include wildcards in case new variants are added.
- Adds non_exhaustive to all pub structs with all pub fields that are constructed by calling into a fn exported by slatedb to prevent users from constructing these directly. In the case that the struct contains a private or pub(crate) field we don't add non_exhaustive as these cannot be created by users anyway. In cases where the struct implements Default we don't add non_exhaustive to retain the ability to construct the type using the functional update syntax with the result of `default` as this is a better way to ensure compatibility than adding new constructor fns whenever we add fields.