### PR TITLE
Use byte array ref in scan instead of AsRef

### DIFF
--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -1,43 +1,40 @@
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::BytesRefRange;
 use crate::db_state::{SortedRun, SsTableHandle};
 use crate::error::SlateDBError;
 use crate::iter::{KeyValueIterator, SeekToKey};
 use crate::sst_iter::{SstIterator, SstIteratorOptions, SstView};
 use crate::tablestore::TableStore;
 use crate::types::RowEntry;
-use bytes::Bytes;
 use std::collections::VecDeque;
-use std::ops::{Bound, RangeBounds};
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 #[derive(Debug)]
 enum SortedRunView<'a> {
-    Owned(VecDeque<SsTableHandle>, BytesRange),
-    Borrowed(
-        VecDeque<&'a SsTableHandle>,
-        (Bound<&'a [u8]>, Bound<&'a [u8]>),
-    ),
+    Owned(VecDeque<SsTableHandle>),
+    Borrowed(VecDeque<&'a SsTableHandle>),
 }
 
 impl<'a> SortedRunView<'a> {
     fn pop_sst(&mut self) -> Option<SstView<'a>> {
         match self {
-            SortedRunView::Owned(tables, r) => tables
+            SortedRunView::Owned(tables) => tables
                 .pop_front()
-                .map(|table| SstView::Owned(table, r.clone())),
-            SortedRunView::Borrowed(tables, r) => {
-                tables.pop_front().map(|table| SstView::Borrowed(table, *r))
-            }
+                .map(|table| SstView::Owned(table)),
+            SortedRunView::Borrowed(tables) => tables
+                .pop_front()
+                .map(|table| SstView::Borrowed(table))
         }
     }
 
     pub(crate) async fn build_next_iter(
         &mut self,
+        range: BytesRefRange<'a>,
         table_store: Arc<TableStore>,
         sst_iterator_options: SstIteratorOptions,
     ) -> Result<Option<SstIterator<'a>>, SlateDBError> {
         let next_iter = if let Some(view) = self.pop_sst() {
-            Some(SstIterator::new(view, table_store.clone(), sst_iterator_options).await?)
+            Some(SstIterator::new(view, range, table_store.clone(), sst_iterator_options).await?)
         } else {
             None
         };
@@ -46,8 +43,8 @@ impl<'a> SortedRunView<'a> {
 
     fn peek_next_table(&self) -> Option<&SsTableHandle> {
         match self {
-            SortedRunView::Owned(tables, _) => tables.front(),
-            SortedRunView::Borrowed(tables, _) => tables.front().copied(),
+            SortedRunView::Owned(tables) => tables.front(),
+            SortedRunView::Borrowed(tables) => tables.front().cloned(),
         }
     }
 }
@@ -56,12 +53,14 @@ pub(crate) struct SortedRunIterator<'a> {
     table_store: Arc<TableStore>,
     sst_iter_options: SstIteratorOptions,
     view: SortedRunView<'a>,
+    range: BytesRefRange<'a>,
     current_iter: Option<SstIterator<'a>>,
 }
 
 impl<'a> SortedRunIterator<'a> {
     async fn new(
         view: SortedRunView<'a>,
+        range: BytesRefRange<'a>,
         table_store: Arc<TableStore>,
         sst_iter_options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
@@ -69,22 +68,23 @@ impl<'a> SortedRunIterator<'a> {
             table_store,
             sst_iter_options,
             view,
+            range,
             current_iter: None,
         };
         res.advance_table().await?;
         Ok(res)
     }
 
-    pub(crate) async fn new_owned<T: RangeBounds<Bytes>>(
+    pub(crate) async fn new_owned<T: RangeBounds<&'a [u8]>>(
         range: T,
         sorted_run: SortedRun,
         table_store: Arc<TableStore>,
         sst_iter_options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
-        let range = BytesRange::from(range);
-        let tables = sorted_run.into_tables_covering_range(range.as_ref());
-        let view = SortedRunView::Owned(tables, range);
-        SortedRunIterator::new(view, table_store, sst_iter_options).await
+        let bounds = (range.start_bound().cloned(), range.end_bound().cloned());
+        let tables = sorted_run.into_tables_covering_range(bounds);
+        let view = SortedRunView::Owned(tables);
+        SortedRunIterator::new(view, BytesRefRange::new(range), table_store, sst_iter_options).await
     }
 
     pub(crate) async fn new_borrowed<T: RangeBounds<&'a [u8]>>(
@@ -93,10 +93,10 @@ impl<'a> SortedRunIterator<'a> {
         table_store: Arc<TableStore>,
         sst_iter_options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
-        let range = (range.start_bound().cloned(), range.end_bound().cloned());
-        let tables = sorted_run.tables_covering_range(range);
-        let view = SortedRunView::Borrowed(tables, range);
-        SortedRunIterator::new(view, table_store, sst_iter_options).await
+        let bounds = (range.start_bound().cloned(), range.end_bound().cloned());
+        let tables = sorted_run.tables_covering_range(bounds);
+        let view = SortedRunView::Borrowed(tables);
+        SortedRunIterator::new(view, BytesRefRange::new(range), table_store, sst_iter_options).await
     }
 
     pub(crate) async fn for_key(
@@ -111,7 +111,7 @@ impl<'a> SortedRunIterator<'a> {
     async fn advance_table(&mut self) -> Result<(), SlateDBError> {
         self.current_iter = self
             .view
-            .build_next_iter(self.table_store.clone(), self.sst_iter_options)
+            .build_next_iter(self.range.clone(), self.table_store.clone(), self.sst_iter_options)
             .await?;
         Ok(())
     }
@@ -156,7 +156,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, gen_attrs};
 
-    use bytes::{BufMut, BytesMut};
+    use bytes::{BufMut, Bytes, BytesMut};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
     use proptest::test_runner::TestRng;

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -1,12 +1,11 @@
-use bytes::Bytes;
 use std::cmp::min;
 use std::collections::VecDeque;
 use std::ops::Bound::{Excluded, Included, Unbounded};
-use std::ops::{Bound, Range, RangeBounds};
+use std::ops::{Range, RangeBounds};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::BytesRefRange;
 use crate::db_state::SsTableHandle;
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::{SsTableIndex, SsTableIndexOwned};
@@ -45,48 +44,15 @@ impl Default for SstIteratorOptions {
 /// needed for [`crate::db::Db::scan`] since it returns the iterator, while [`SstView::Borrowed`]
 /// accommodates access by reference which is useful for [`crate::db::Db::get`].
 pub(crate) enum SstView<'a> {
-    Owned(SsTableHandle, BytesRange),
-    Borrowed(&'a SsTableHandle, (Bound<&'a [u8]>, Bound<&'a [u8]>)),
+    Owned(SsTableHandle),
+    Borrowed(&'a SsTableHandle),
 }
 
 impl SstView<'_> {
-    fn start_key(&self) -> Bound<&[u8]> {
-        match self {
-            SstView::Owned(_, r) => r.start_bound().map(|b| b.as_ref()),
-            SstView::Borrowed(_, (start, _)) => *start,
-        }
-    }
-
-    fn end_key(&self) -> Bound<&[u8]> {
-        match self {
-            SstView::Owned(_, r) => r.end_bound().map(|b| b.as_ref()),
-            SstView::Borrowed(_, (_, end)) => *end,
-        }
-    }
-
     fn table_as_ref(&self) -> &SsTableHandle {
         match self {
-            SstView::Owned(t, _) => t,
-            SstView::Borrowed(t, _) => t,
-        }
-    }
-
-    /// Check whether a key is contained within this view.
-    fn contains(&self, key: &[u8]) -> bool {
-        match self {
-            SstView::Owned(_, r) => r.contains(key),
-            SstView::Borrowed(_, r) => {
-                <(Bound<&[u8]>, Bound<&[u8]>) as RangeBounds<[u8]>>::contains::<[u8]>(r, key)
-            }
-        }
-    }
-
-    /// Check whether a key exceeds the range of this view.
-    fn key_exceeds(&self, key: &[u8]) -> bool {
-        match self.end_key() {
-            Included(end) => key > end,
-            Excluded(end) => key >= end,
-            Unbounded => false,
+            SstView::Owned(t) => t,
+            SstView::Borrowed(t) => t,
         }
     }
 }
@@ -121,6 +87,7 @@ impl IteratorState {
 
 pub(crate) struct SstIterator<'a> {
     view: SstView<'a>,
+    range: BytesRefRange<'a>,
     index: Arc<SsTableIndexOwned>,
     state: IteratorState,
     next_block_idx_to_fetch: usize,
@@ -133,16 +100,18 @@ pub(crate) struct SstIterator<'a> {
 impl<'a> SstIterator<'a> {
     pub(crate) async fn new(
         view: SstView<'a>,
+        range: BytesRefRange<'a>,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
         assert!(options.max_fetch_tasks > 0);
         assert!(options.blocks_to_fetch > 0);
         let index = table_store.read_index(view.table_as_ref()).await?;
-        let block_idx_range = SstIterator::blocks_covering_view(&index.borrow(), &view);
+        let block_idx_range = SstIterator::blocks_covering_range(&index.borrow(), &range);
 
         let mut iter = Self {
             view,
+            range,
             index,
             state: IteratorState::new(),
             next_block_idx_to_fetch: block_idx_range.start,
@@ -158,14 +127,14 @@ impl<'a> SstIterator<'a> {
         Ok(iter)
     }
 
-    pub(crate) async fn new_owned<T: RangeBounds<Bytes>>(
+    pub(crate) async fn new_owned<T: RangeBounds<&'a [u8]>>(
         range: T,
         table: SsTableHandle,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
-        let view = SstView::Owned(table, BytesRange::from(range));
-        Self::new(view, table_store.clone(), options).await
+        let view = SstView::Owned(table);
+        Self::new(view, BytesRefRange::new(range), table_store.clone(), options).await
     }
 
     pub(crate) async fn new_borrowed<T: RangeBounds<&'a [u8]>>(
@@ -174,9 +143,8 @@ impl<'a> SstIterator<'a> {
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
-        let bounds = (range.start_bound().cloned(), range.end_bound().cloned());
-        let view = SstView::Borrowed(table, bounds);
-        Self::new(view, table_store.clone(), options).await
+        let view = SstView::Borrowed(table);
+        Self::new(view, BytesRefRange::new(range), table_store.clone(), options).await
     }
 
     pub(crate) async fn for_key(
@@ -216,15 +184,15 @@ impl<'a> SstIterator<'a> {
         found_block_id
     }
 
-    fn blocks_covering_view(index: &SsTableIndex, view: &SstView) -> Range<usize> {
-        let start_block_id = match view.start_key() {
+    fn blocks_covering_range(index: &SsTableIndex, range: &BytesRefRange<'_>) -> Range<usize> {
+        let start_block_id = match range.start_bound {
             Included(k) | Excluded(k) => {
                 Self::first_block_with_data_including_or_after_key(index, k)
             }
             Unbounded => 0,
         };
 
-        let end_block_id_exclusive = match view.end_key() {
+        let end_block_id_exclusive = match range.end_bound {
             Included(k) => Self::first_block_with_data_including_or_after_key(index, k) + 1,
             Excluded(k) => {
                 let block_index = Self::first_block_with_data_including_or_after_key(index, k);
@@ -298,7 +266,7 @@ impl<'a> SstIterator<'a> {
     async fn advance_block(&mut self) -> Result<(), SlateDBError> {
         if !self.state.is_finished() {
             if let Some(mut iter) = self.next_iter().await? {
-                match self.view.start_key() {
+                match self.range.start_bound {
                     Included(start_key) | Excluded(start_key) => iter.seek(start_key).await?,
                     Unbounded => (),
                 }
@@ -328,9 +296,9 @@ impl KeyValueIterator for SstIterator<'_> {
 
             match next_entry {
                 Some(kv) => {
-                    if self.view.contains(&kv.key) {
+                    if self.range.contains(&kv.key) {
                         return Ok(Some(kv));
-                    } else if self.view.key_exceeds(&kv.key) {
+                    } else if self.range.key_exceeds(&kv.key) {
                         self.stop()
                     }
                 }
@@ -343,10 +311,10 @@ impl KeyValueIterator for SstIterator<'_> {
 
 impl SeekToKey for SstIterator<'_> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
-        if !self.view.contains(next_key) {
+        if !self.range.contains(next_key) {
             return Err(SlateDBError::InvalidArgument {
                 msg: format!("Cannot seek to a key '{:?}' which is outside the iterator range (start: {:?}, end: {:?})",
-                             next_key, self.view.start_key(), self.view.end_key())
+                             next_key, self.range.start_bound, self.range.end_bound)
             });
         }
 


### PR DESCRIPTION
Putting this up to collect feedback. In https://github.com/slatedb/slatedb/pull/450, we replaced the direct usage of `Bytes` in `Db::scan` with an `AsRef<[u8]>`. I think the hope is to have more flexible usage of the API, but also potentially to avoid copying the byte array. The first goal is probably achieved, but the second goal seems not possible at present without propagating the `K: AsRef<[u8]>` parameter into all of the internal iterators as well as `DbIterator`. 

Here I've attempted an alternative using `&[u8]` directly instead of through `AsRef<[u8]>`. The resulting `DbIterator` then is tied to both the lifetime of the `Db` instance as well as the range. One benefit is that this allows us to pull the `range` out of `SstView` and `SortedRunView` since range is then consistently a reference. Unfortunately, we can't avoid the copy to `Bytes` because `SkipMap::range` still requires it. However, one day perhaps we'll have an alternative implementation which can use `&[u8]` so it is still nice to avoid the dependency on `Bytes` in the public API.

Going back to the original approach... In principle, it ought to be possible to extract the `&[u8]` references from `K: AsRef<[u8]>` and use the same approach. I couldn't figure out how to do so when the references are wrapped in `RangeBounds`. This is what I tried:
```rust
    pub async fn scan_with_options<'a, K, T>(
        &'a self,
        range: T,
        options: &ScanOptions,
    ) -> Result<DbIterator<'a>, SlateDBError>
    where
        K: AsRef<[u8]> + 'a,
        T: RangeBounds<K>,
    {
        let range = BytesRefRange {
            start_bound: range.start_bound().map(|b| b.as_ref()),
            end_bound: range.end_bound().map(|b| b.as_ref()),
        };
...
```

Unfortunately, this doesn't work because rust still thinks we're borrowing `range.` Perhaps someone knows how to do this?