### PR TITLE
MINOR: propogate failure on out of order memtable clock tick

### DIFF
--- a/src/batch_write.rs
+++ b/src/batch_write.rs
@@ -68,7 +68,7 @@ impl DbInner {
                                 ts: Some(now),
                                 expire_ts: opts.expire_ts_from(self.options.default_ttl, now),
                             },
-                        );
+                        )?;
                     }
                     WriteOp::Delete(key) => {
                         current_wal.delete(
@@ -77,7 +77,7 @@ impl DbInner {
                                 ts: Some(now),
                                 expire_ts: None,
                             },
-                        );
+                        )?;
                     }
                 }
             }
@@ -100,7 +100,7 @@ impl DbInner {
                                 ts: Some(now),
                                 expire_ts: opts.expire_ts_from(self.options.default_ttl, now),
                             },
-                        );
+                        )?;
                     }
                     WriteOp::Delete(key) => {
                         current_memtable.delete(
@@ -109,7 +109,7 @@ impl DbInner {
                                 ts: Some(now),
                                 expire_ts: None,
                             },
-                        );
+                        )?;
                     }
                 }
             }

--- a/src/db.rs
+++ b/src/db.rs
@@ -508,7 +508,7 @@ impl DbInner {
                                     ts: kv.create_ts,
                                     expire_ts: kv.expire_ts,
                                 },
-                            );
+                            )?;
                         }
                         ValueDeletable::Merge(_) => {
                             todo!()
@@ -519,7 +519,7 @@ impl DbInner {
                                 ts: kv.create_ts,
                                 expire_ts: kv.expire_ts,
                             },
-                        ),
+                        )?,
                     }
                 }
                 self.maybe_freeze_memtable(&mut guard, sst_id)?;
@@ -2211,21 +2211,27 @@ mod tests {
 
         let memtable = {
             let mut lock = kv_store.inner.state.write();
-            lock.wal().put(
-                Bytes::copy_from_slice(b"abc1111"),
-                Bytes::copy_from_slice(b"value1111"),
-                gen_attrs(1),
-            );
-            lock.wal().put(
-                Bytes::copy_from_slice(b"abc2222"),
-                Bytes::copy_from_slice(b"value2222"),
-                gen_attrs(2),
-            );
-            lock.wal().put(
-                Bytes::copy_from_slice(b"abc3333"),
-                Bytes::copy_from_slice(b"value3333"),
-                gen_attrs(3),
-            );
+            lock.wal()
+                .put(
+                    Bytes::copy_from_slice(b"abc1111"),
+                    Bytes::copy_from_slice(b"value1111"),
+                    gen_attrs(1),
+                )
+                .unwrap();
+            lock.wal()
+                .put(
+                    Bytes::copy_from_slice(b"abc2222"),
+                    Bytes::copy_from_slice(b"value2222"),
+                    gen_attrs(2),
+                )
+                .unwrap();
+            lock.wal()
+                .put(
+                    Bytes::copy_from_slice(b"abc3333"),
+                    Bytes::copy_from_slice(b"value3333"),
+                    gen_attrs(3),
+                )
+                .unwrap();
             lock.wal().table().clone()
         };
 


### PR DESCRIPTION
This does the follow up from https://github.com/slatedb/slatedb/pull/432#discussion_r1919411079

The actual code change is in `put_or_delete` which now returns an error if clock tick is out of order:
```rs
    fn put_or_delete(
        &self,
        key: Bytes,
        value: ValueDeletable,
        attrs: RowAttributes,
    ) -> Result<(), SlateDBError> {
```