### PR TITLE
Use `u64` with `ObjectStorage` to support large SSTs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,6 +1607,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,8 +1957,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+source = "git+https://github.com/apache/arrow-rs.git?branch=main#2375c4f75901fe513128d5f684c5cfd4a12b8e5b"
 dependencies = [
  "async-trait",
  "base64",
@@ -1959,7 +1967,7 @@ dependencies = [
  "httparse",
  "humantime",
  "hyper",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -1969,7 +1977,7 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "snafu",
+ "thiserror 2.0.7",
  "tokio",
  "tracing",
  "url",
@@ -2946,27 +2954,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snafu"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
-dependencies = [
- "snafu-derive",
-]
-
-[[package]]
-name = "snafu-derive"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
 
 [[package]]
 name = "snap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ flatbuffers = "24.3.25"
 futures = "0.3.30"
 humantime = {  version = "2.1.0", optional = true }
 leaky-bucket = {  version = "1.1", optional = true }
-object_store = "0.11.2"
+object_store = { git = "https://github.com/apache/arrow-rs.git", branch = "main", package = "object_store" }
 parking_lot = "0.12.3"
 siphasher = "1"
 thiserror = "1.0.63"

--- a/src/cached_object_store/object_store.rs
+++ b/src/cached_object_store/object_store.rs
@@ -138,10 +138,11 @@ impl CachedObjectStore {
     /// save the GetResult to the disk cache, a GetResult may be transformed into multiple part
     /// files and a meta file. please note that the `range` in the GetResult is expected to be
     /// aligned with the part size.
-    async fn save_result(&self, result: GetResult) -> object_store::Result<usize> {
-        assert!(result.range.start % self.part_size_bytes == 0);
+    async fn save_result(&self, result: GetResult) -> object_store::Result<u64> {
+        let part_size_bytes_u64 = self.part_size_bytes as u64;
+        assert!(result.range.start % part_size_bytes_u64 == 0);
         assert!(
-            result.range.end % self.part_size_bytes == 0 || result.range.end == result.meta.size
+            result.range.end % part_size_bytes_u64 == 0 || result.range.end == result.meta.size
         );
 
         let entry = self
@@ -150,7 +151,8 @@ impl CachedObjectStore {
         entry.save_head((&result.meta, &result.attributes)).await?;
 
         let mut buffer = BytesMut::new();
-        let mut part_number = result.range.start / self.part_size_bytes;
+        let mut part_number = usize::try_from(result.range.start / part_size_bytes_u64)
+            .expect("Part number exceeds u32 on a 32-bit system. Try increasing part size.");
         let object_size = result.meta.size;
 
         let mut stream = result.into_stream();
@@ -175,14 +177,15 @@ impl CachedObjectStore {
     }
 
     // split the range into parts, and return the part id and the range inside the part.
-    fn split_range_into_parts(&self, range: Range<usize>) -> Vec<(PartID, Range<usize>)> {
+    fn split_range_into_parts(&self, range: Range<u64>) -> Vec<(PartID, Range<usize>)> {
+        let part_size_bytes_u64 = self.part_size_bytes as u64;
         let range_aligned = self.align_range(&range, self.part_size_bytes);
-        let start_part = range_aligned.start / self.part_size_bytes;
-        let end_part = range_aligned.end / self.part_size_bytes;
+        let start_part = range_aligned.start / part_size_bytes_u64;
+        let end_part = range_aligned.end / part_size_bytes_u64;
         let mut parts: Vec<_> = (start_part..end_part)
             .map(|part_id| {
                 (
-                    part_id,
+                    usize::try_from(part_id).expect("Number of parts exceeds usize"),
                     Range {
                         start: 0,
                         end: self.part_size_bytes,
@@ -194,11 +197,13 @@ impl CachedObjectStore {
             return vec![];
         }
         if let Some(first_part) = parts.first_mut() {
-            first_part.1.start = range.start % self.part_size_bytes;
+            first_part.1.start = usize::try_from(range.start % part_size_bytes_u64)
+                .expect("Part size is too large to fit in a usize");
         }
         if let Some(last_part) = parts.last_mut() {
-            if range.end % self.part_size_bytes != 0 {
-                last_part.1.end = range.end % self.part_size_bytes;
+            if range.end % part_size_bytes_u64 != 0 {
+                last_part.1.end = usize::try_from(range.end % part_size_bytes_u64)
+                    .expect("Part size is too large to fit in a usize");
             }
         }
         parts
@@ -230,8 +235,8 @@ impl CachedObjectStore {
             // the object stores is expected to return the result whenever the `start` of the range
             // is not out of the object size.
             let range = Range {
-                start: part_id * part_size,
-                end: (part_id + 1) * part_size,
+                start: (part_id * part_size) as u64,
+                end: ((part_id + 1) * part_size) as u64,
             };
             let get_result = object_store
                 .get_opts(
@@ -259,8 +264,8 @@ impl CachedObjectStore {
     fn canonicalize_range(
         &self,
         range: Option<GetRange>,
-        object_size: usize,
-    ) -> object_store::Result<Range<usize>> {
+        object_size: u64,
+    ) -> object_store::Result<Range<u64>> {
         let (start_offset, end_offset) = match range {
             None => (0, object_size),
             Some(range) => match range {
@@ -317,13 +322,14 @@ impl CachedObjectStore {
                 GetRange::Suffix(suffix_aligned)
             }
             GetRange::Offset(offset) => {
-                let offset_aligned = *offset - *offset % self.part_size_bytes;
+                let offset_aligned = *offset - *offset % self.part_size_bytes as u64;
                 GetRange::Offset(offset_aligned)
             }
         }
     }
 
-    fn align_range(&self, range: &Range<usize>, alignment: usize) -> Range<usize> {
+    fn align_range(&self, range: &Range<u64>, alignment: usize) -> Range<u64> {
+        let alignment = alignment as u64;
         let start_aligned = range.start - range.start % alignment;
         let end_aligned = range.end.div_ceil(alignment) * alignment;
         Range {
@@ -387,7 +393,7 @@ impl ObjectStore for CachedObjectStore {
         self.object_store.delete(location).await
     }
 
-    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, object_store::Result<ObjectMeta>> {
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
         self.object_store.list(prefix)
     }
 
@@ -395,7 +401,7 @@ impl ObjectStore for CachedObjectStore {
         &self,
         prefix: Option<&Path>,
         offset: &Path,
-    ) -> BoxStream<'_, object_store::Result<ObjectMeta>> {
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
         self.object_store.list_with_offset(prefix, offset)
     }
 
@@ -423,10 +429,10 @@ impl ObjectStore for CachedObjectStore {
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum InvalidGetRange {
     #[error("Range start too large, requested: {requested}, length: {length}")]
-    StartTooLarge { requested: usize, length: usize },
+    StartTooLarge { requested: u64, length: u64 },
 
     #[error("Range started at {start} and ended at {end}")]
-    Inconsistent { start: usize, end: usize },
+    Inconsistent { start: u64, end: u64 },
 }
 
 #[cfg(test)]
@@ -654,7 +660,7 @@ mod tests {
 
         for t in tests.iter() {
             let range = cached_store
-                .canonicalize_range(t.input.0.clone(), t.input.1)
+                .canonicalize_range(t.input.0.clone(), t.input.1 as u64)
                 .unwrap();
             let parts = cached_store.split_range_into_parts(range);
             assert_eq!(parts, t.expect, "input: {:?}", t.input);

--- a/src/cached_object_store/storage.rs
+++ b/src/cached_object_store/storage.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, fmt::Display, ops::Range};
 pub struct LocalCacheHead {
     pub location: String,
     pub last_modified: String,
-    pub size: usize,
+    pub size: u64,
     pub e_tag: Option<String>,
     pub version: Option<String>,
     pub attributes: HashMap<String, String>,

--- a/src/manifest_store.rs
+++ b/src/manifest_store.rs
@@ -329,7 +329,7 @@ pub(crate) struct ManifestFileMetadata {
     pub(crate) location: Path,
     pub(crate) last_modified: chrono::DateTime<Utc>,
     #[allow(dead_code)]
-    pub(crate) size: usize,
+    pub(crate) size: u32,
 }
 
 fn serialize_path<S>(path: &Path, serializer: S) -> Result<S::Ok, S::Error>
@@ -421,7 +421,7 @@ impl ManifestStore {
                         id,
                         location: file.location,
                         last_modified: file.last_modified,
-                        size: file.size,
+                        size: file.size as u32,
                     });
                 }
                 Err(_) => warn!("Unknown file in manifest directory: {:?}", file.location),

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -191,18 +191,25 @@ impl SsTableFormat {
             return Ok(VecDeque::new());
         }
         let range = self.block_range(blocks.clone(), info, &index);
-        let start_offset = range.start as usize;
+        let start_range = range.start;
         let bytes: Bytes = obj.read_range(range).await?;
         let mut decoded_blocks = VecDeque::new();
         let compression_codec = info.compression_codec;
         for block in blocks {
             let block_meta = index.block_meta().get(block);
-            let block_bytes_start = block_meta.offset() as usize - start_offset;
+            let block_bytes_start = usize::try_from(block_meta.offset() - start_range).expect(
+                "attempted to read byte data with size \
+                larger than 32 bits on a 32-bit system",
+            );
             let block_bytes = if block == index.block_meta().len() - 1 {
                 bytes.slice(block_bytes_start..)
             } else {
                 let next_block_meta = index.block_meta().get(block + 1);
-                let block_bytes_end = next_block_meta.offset() as usize - start_offset;
+                let block_bytes_end = usize::try_from(next_block_meta.offset() - start_range)
+                    .expect(
+                        "attempted to read byte data with size \
+                        larger than 32 bits on a 32-bit system",
+                    );
                 bytes.slice(block_bytes_start..block_bytes_end)
             };
             decoded_blocks.push_back(self.decode_block(block_bytes, compression_codec)?);

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -45,13 +45,10 @@ struct ReadOnlyObject {
 impl ReadOnlyBlob for ReadOnlyObject {
     async fn len(&self) -> Result<u64, SlateDBError> {
         let object_metadata = self.object_store.head(&self.path).await?;
-        Ok(object_metadata.size as u64)
+        Ok(object_metadata.size)
     }
 
     async fn read_range(&self, range: Range<u64>) -> Result<Bytes, SlateDBError> {
-        // This will go away when we upgrade object store, which now takes u64's
-        // See https://github.com/apache/arrow-rs/issues/5351
-        let range = range.start as usize..range.end as usize;
         let bytes = self.object_store.get_range(&self.path, range).await?;
         Ok(bytes)
     }
@@ -70,7 +67,7 @@ pub(crate) struct SstFileMetadata {
     pub(crate) location: Path,
     pub(crate) last_modified: chrono::DateTime<Utc>,
     #[allow(dead_code)]
-    pub(crate) size: usize,
+    pub(crate) size: u64,
 }
 
 impl TableStore {


### PR DESCRIPTION
The next release of the `object_store` crate has breaking changes. It changes the byte lengths from `usize` to `u64`. This patch updates SlateDB to use the new `u64` types. I also added some paranoia with `try_from` instead of `as u32`.

Depends on https://github.com/apache/arrow-rs/issues/6903