### PR TITLE
fix: cleanup compaction job on failure

### DIFF
--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -7,6 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::Handle;
 use tracing::{error, info, warn};
 use ulid::Ulid;
+use uuid::Uuid;
 
 use crate::compactor::stats::CompactionStats;
 use crate::compactor::CompactorMainMsg::Shutdown;
@@ -29,7 +30,10 @@ enum CompactorMainMsg {
 }
 
 pub(crate) enum WorkerToOrchestratorMsg {
-    CompactionFinished(Result<SortedRun, SlateDBError>),
+    CompactionFinished {
+        id: Uuid,
+        result: Result<SortedRun, SlateDBError>,
+    },
 }
 
 pub(crate) struct Compactor {
@@ -44,7 +48,7 @@ impl Compactor {
         options: CompactorOptions,
         tokio_handle: Handle,
         stat_registry: &StatRegistry,
-        cleanup_fn: impl FnOnce(&SlateDBError) + Send + 'static,
+        cleanup_fn: impl FnOnce(&Result<(), SlateDBError>) + Send + 'static,
     ) -> Result<Self, SlateDBError> {
         let (external_tx, external_rx) = crossbeam_channel::unbounded();
         let (err_tx, err_rx) = tokio::sync::oneshot::channel();
@@ -88,15 +92,10 @@ impl Compactor {
 }
 
 struct CompactorOrchestrator {
-    options: Arc<CompactorOptions>,
-    manifest: FenceableManifest,
-    tokio_handle: Handle,
-    state: CompactorState,
-    scheduler: Box<dyn CompactionScheduler>,
-    executor: Box<dyn CompactionExecutor>,
+    ticker: crossbeam_channel::Receiver<std::time::Instant>,
     external_rx: crossbeam_channel::Receiver<CompactorMainMsg>,
     worker_rx: crossbeam_channel::Receiver<WorkerToOrchestratorMsg>,
-    stats: Arc<CompactionStats>,
+    handler: CompactorEventHandler,
 }
 
 impl CompactorOrchestrator {
@@ -109,29 +108,29 @@ impl CompactorOrchestrator {
         stats: Arc<CompactionStats>,
     ) -> Result<Self, SlateDBError> {
         let options = Arc::new(options);
-        let stored_manifest =
-            tokio_handle.block_on(StoredManifest::load(manifest_store.clone()))?;
-        let manifest = tokio_handle.block_on(FenceableManifest::init_compactor(stored_manifest))?;
-        let state = Self::load_state(&manifest)?;
+        let ticker = crossbeam_channel::tick(options.poll_interval);
         let scheduler = Self::load_compaction_scheduler(options.as_ref());
         let (worker_tx, worker_rx) = crossbeam_channel::unbounded();
-        let executor = TokioCompactionExecutor::new(
+        let executor = Box::new(TokioCompactionExecutor::new(
             tokio_handle.clone(),
             options.clone(),
             worker_tx,
             table_store.clone(),
             stats.clone(),
-        );
-        let orchestrator = Self {
-            options,
-            manifest,
+        ));
+        let handler = CompactorEventHandler::new(
             tokio_handle,
-            state,
+            &manifest_store,
+            options,
             scheduler,
-            executor: Box::new(executor),
+            executor,
+            stats,
+        )?;
+        let orchestrator = Self {
+            ticker,
             external_rx,
             worker_rx,
-            stats,
+            handler,
         };
         Ok(orchestrator)
     }
@@ -140,43 +139,98 @@ impl CompactorOrchestrator {
         options.compaction_scheduler.compaction_scheduler()
     }
 
-    fn load_state(stored_manifest: &FenceableManifest) -> Result<CompactorState, SlateDBError> {
-        let db_state = stored_manifest.db_state()?;
-        Ok(CompactorState::new(db_state.clone()))
-    }
-
     fn run(&mut self) -> Result<(), SlateDBError> {
-        let ticker = crossbeam_channel::tick(self.options.poll_interval);
         let db_runs_log_ticker = crossbeam_channel::tick(Duration::from_secs(10));
 
         // Stop the loop when the executor is shut down *and* all remaining
         // `worker_rx` messages have been drained.
-        while !(self.executor.is_stopped() && self.worker_rx.is_empty()) {
+        while !(self.handler.is_executor_stopped() && self.worker_rx.is_empty()) {
             crossbeam_channel::select! {
                 recv(db_runs_log_ticker) -> _ => {
-                    self.log_compaction_state();
+                    self.handler.handle_log_ticker();
                 }
-                recv(ticker) -> _ => {
-                    if !self.executor.is_stopped() {
-                        self.load_manifest().expect("fatal error loading manifest");
-                    }
+                recv(self.ticker) -> _ => {
+                    self.handler.handle_ticker();
                 }
                 recv(self.worker_rx) -> msg => {
-                    let WorkerToOrchestratorMsg::CompactionFinished(result) = msg.expect("fatal error receiving worker msg");
-                    match result {
-                        Ok(sr) => self.finish_compaction(sr).expect("fatal error finishing compaction"),
-                        Err(err) => error!("error executing compaction: {:#?}", err)
-                    }
+                    self.handler.handle_worker_rx(msg.expect("fatal error receiving worker msg"));
                 }
                 recv(self.external_rx) -> _ => {
                     // Stop the executor. Don't return because there might
                     // still be messages in `worker_rx`. Let the loop continue
                     // to drain them until empty.
-                    self.executor.stop();
+                    self.handler.stop_executor();
                 }
             }
         }
         Ok(())
+    }
+}
+
+struct CompactorEventHandler {
+    tokio_handle: tokio::runtime::Handle,
+    state: CompactorState,
+    manifest: FenceableManifest,
+    options: Arc<CompactorOptions>,
+    scheduler: Box<dyn CompactionScheduler>,
+    executor: Box<dyn CompactionExecutor>,
+    stats: Arc<CompactionStats>,
+}
+
+impl CompactorEventHandler {
+    fn new(
+        tokio_handle: tokio::runtime::Handle,
+        manifest_store: &Arc<ManifestStore>,
+        options: Arc<CompactorOptions>,
+        scheduler: Box<dyn CompactionScheduler>,
+        executor: Box<dyn CompactionExecutor>,
+        stats: Arc<CompactionStats>,
+    ) -> Result<Self, SlateDBError> {
+        let stored_manifest =
+            tokio_handle.block_on(StoredManifest::load(manifest_store.clone()))?;
+        let manifest = tokio_handle.block_on(FenceableManifest::init_compactor(stored_manifest))?;
+        let db_state = manifest.db_state()?;
+        let state = CompactorState::new(db_state.clone());
+        Ok(Self {
+            tokio_handle,
+            state,
+            manifest,
+            options,
+            scheduler,
+            executor,
+            stats,
+        })
+    }
+
+    fn handle_log_ticker(&self) {
+        self.log_compaction_state();
+    }
+
+    fn handle_ticker(&mut self) {
+        if !self.is_executor_stopped() {
+            self.load_manifest().expect("fatal error loading manifest");
+        }
+    }
+
+    fn handle_worker_rx(&mut self, msg: WorkerToOrchestratorMsg) {
+        let WorkerToOrchestratorMsg::CompactionFinished { id, result } = msg;
+        match result {
+            Ok(sr) => self
+                .finish_compaction(id, sr)
+                .expect("fatal error finishing compaction"),
+            Err(err) => {
+                error!("error executing compaction: {:#?}", err);
+                self.finish_failed_compaction(id);
+            }
+        }
+    }
+
+    fn stop_executor(&self) {
+        self.executor.stop();
+    }
+
+    fn is_executor_stopped(&self) -> bool {
+        self.executor.is_stopped()
     }
 
     fn load_manifest(&mut self) -> Result<(), SlateDBError> {
@@ -221,7 +275,7 @@ impl CompactorOrchestrator {
         Ok(())
     }
 
-    fn start_compaction(&mut self, compaction: Compaction) {
+    fn start_compaction(&mut self, id: Uuid, compaction: Compaction) {
         self.log_compaction_state();
         let db_state = self.state.db_state();
         let compacted_sst_iter = db_state.compacted.iter().flat_map(|sr| sr.ssts.iter());
@@ -246,6 +300,7 @@ impl CompactorOrchestrator {
             .filter_map(|id| srs_by_id.get(&id).map(|t| (*t).clone()))
             .collect();
         self.executor.start_compaction(CompactionJob {
+            id,
             destination: compaction.destination,
             ssts,
             sorted_runs,
@@ -254,9 +309,12 @@ impl CompactorOrchestrator {
     }
 
     // state writers
+    fn finish_failed_compaction(&mut self, id: Uuid) {
+        self.state.finish_failed_compaction(id);
+    }
 
-    fn finish_compaction(&mut self, output_sr: SortedRun) -> Result<(), SlateDBError> {
-        self.state.finish_compaction(output_sr);
+    fn finish_compaction(&mut self, id: Uuid, output_sr: SortedRun) -> Result<(), SlateDBError> {
+        self.state.finish_compaction(id, output_sr);
         self.log_compaction_state();
         self.write_manifest_safely()?;
         self.maybe_schedule_compactions()?;
@@ -271,11 +329,11 @@ impl CompactorOrchestrator {
 
     fn submit_compaction(&mut self, compaction: Compaction) -> Result<(), SlateDBError> {
         let result = self.state.submit_compaction(compaction.clone());
-        if result.is_err() {
+        let Ok(id) = result.as_ref() else {
             warn!("invalid compaction: {:?}", result);
             return Ok(());
-        }
-        self.start_compaction(compaction);
+        };
+        self.start_compaction(*id, compaction);
         Ok(())
     }
 
@@ -338,26 +396,35 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
+    use parking_lot::Mutex;
+    use rand::RngCore;
     use tokio::runtime::Runtime;
     use ulid::Ulid;
 
     use crate::compactor::stats::CompactionStats;
-    use crate::compactor::{CompactorOptions, CompactorOrchestrator, WorkerToOrchestratorMsg};
-    use crate::compactor_state::{Compaction, SourceId};
+    use crate::compactor::{
+        CompactionScheduler, CompactorEventHandler, CompactorOptions, WorkerToOrchestratorMsg,
+    };
+    use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
+    use crate::compactor_state::{Compaction, CompactorState, SourceId};
+    use crate::compactor_stats::LAST_COMPACTION_TS_SEC;
     use crate::config::{
-        DbOptions, ObjectStoreCacheOptions, PutOptions, SizeTieredCompactionSchedulerOptions, Ttl,
-        WriteOptions,
+        DbOptions, PutOptions, SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
     };
     use crate::db::Db;
     use crate::db_state::CoreDbState;
     use crate::iter::KeyValueIterator;
     use crate::manifest_store::{ManifestStore, StoredManifest};
+
+    use crate::proptest_util::rng;
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
+    use crate::stats::StatRegistry;
     use crate::tablestore::TableStore;
     use crate::test_utils::{assert_iterator, TestClock};
     use crate::types::RowEntry;
+    use crate::SlateDBError;
 
     const PATH: &str = "/test/db";
 
@@ -519,59 +586,164 @@ mod tests {
         .await;
     }
 
+    struct CompactorEventHandlerTestFixture {
+        rt: Runtime,
+        manifest: StoredManifest,
+        options: DbOptions,
+        db: Db,
+        scheduler: Box<MockScheduler>,
+        executor: Box<MockExecutor>,
+        real_executor: Box<dyn CompactionExecutor>,
+        real_executor_rx: crossbeam_channel::Receiver<WorkerToOrchestratorMsg>,
+        stats_registry: StatRegistry,
+        handler: CompactorEventHandler,
+    }
+
+    impl CompactorEventHandlerTestFixture {
+        fn new() -> Self {
+            let rt = build_runtime();
+            let compactor_options = Arc::new(compactor_options());
+            let options = db_options(None, Arc::new(TestClock::new()));
+            let (_, manifest_store, table_store, db) = rt.block_on(build_test_db(options.clone()));
+            let scheduler = Box::new(MockScheduler::new());
+            let executor = Box::new(MockExecutor::new());
+            let (real_executor_tx, real_executor_rx) = crossbeam_channel::unbounded();
+            let stats_registry = StatRegistry::new();
+            let compactor_stats = Arc::new(CompactionStats::new(&stats_registry));
+            let real_executor = Box::new(TokioCompactionExecutor::new(
+                rt.handle().clone(),
+                compactor_options.clone(),
+                real_executor_tx,
+                table_store,
+                compactor_stats.clone(),
+            ));
+            let handler = CompactorEventHandler::new(
+                rt.handle().clone(),
+                &manifest_store,
+                compactor_options,
+                scheduler.clone(),
+                executor.clone(),
+                compactor_stats,
+            )
+            .unwrap();
+            let manifest = rt
+                .block_on(StoredManifest::load(manifest_store.clone()))
+                .unwrap();
+            Self {
+                rt,
+                manifest,
+                options,
+                db,
+                scheduler,
+                executor,
+                real_executor_rx,
+                real_executor,
+                stats_registry,
+                handler,
+            }
+        }
+
+        fn latest_db_state(&mut self) -> CoreDbState {
+            self.rt.block_on(self.manifest.refresh()).unwrap().clone()
+        }
+
+        fn write_l0(&mut self) {
+            let fut = async {
+                let mut rng = rng::new_test_rng(None);
+                let state = self.manifest.refresh().await.unwrap();
+                let l0s = state.l0.len();
+                // TODO: add an explicit flush_memtable fn to db and use that instead
+                let mut k = vec![0u8; self.options.l0_sst_size_bytes];
+                rng.fill_bytes(&mut k);
+                self.db.put(&k, &[b'x'; 10]).await.unwrap();
+                self.db.flush().await.unwrap();
+                loop {
+                    let state = self.manifest.refresh().await.unwrap().clone();
+                    if state.l0.len() > l0s {
+                        break;
+                    }
+                }
+            };
+            self.rt.block_on(fut);
+        }
+
+        fn build_l0_compaction(&mut self) -> Compaction {
+            let l0_ids_to_compact: Vec<SourceId> = self
+                .latest_db_state()
+                .l0
+                .iter()
+                .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+                .collect();
+            Compaction::new(l0_ids_to_compact, 0)
+        }
+
+        fn assert_started_compaction(&self, num: usize) -> Vec<CompactionJob> {
+            let compactions = self.executor.pop_jobs();
+            assert_eq!(num, compactions.len());
+            compactions
+        }
+
+        fn assert_and_forward_compactions(&self, num: usize) {
+            for c in self.assert_started_compaction(num) {
+                self.real_executor.start_compaction(c)
+            }
+        }
+    }
+
+    #[test]
+    fn test_should_record_last_compaction_ts() {
+        // given:
+        let mut fixture = CompactorEventHandlerTestFixture::new();
+        fixture.write_l0();
+        let compaction = fixture.build_l0_compaction();
+        fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker();
+        fixture.assert_and_forward_compactions(1);
+        let msg = fixture
+            .real_executor_rx
+            .recv_timeout(Duration::from_secs(10))
+            .unwrap();
+        let starting_last_ts = fixture
+            .stats_registry
+            .lookup(LAST_COMPACTION_TS_SEC)
+            .unwrap()
+            .get();
+
+        // when:
+        fixture.handler.handle_worker_rx(msg);
+
+        // then:
+        assert!(
+            fixture
+                .stats_registry
+                .lookup(LAST_COMPACTION_TS_SEC)
+                .unwrap()
+                .get()
+                > starting_last_ts
+        );
+    }
+
     #[test]
     fn test_should_write_manifest_safely() {
         // given:
-        // write an l0
-        let clock = Arc::new(TestClock::new());
-        let options = db_options(None, clock.clone());
-        let rt = build_runtime();
-        let (os, manifest_store, table_store, db) = rt.block_on(build_test_db(options.clone()));
-        let mut stored_manifest = rt
-            .block_on(StoredManifest::load(manifest_store.clone()))
+        let mut fixture = CompactorEventHandlerTestFixture::new();
+        fixture.write_l0();
+        let compaction = fixture.build_l0_compaction();
+        fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker();
+        fixture.assert_and_forward_compactions(1);
+        let msg = fixture
+            .real_executor_rx
+            .recv_timeout(Duration::from_secs(10))
             .unwrap();
-        rt.block_on(db.put(&[b'a'; 32], &[b'b'; 96])).unwrap();
-        rt.block_on(db.close()).unwrap();
-        let (_, external_rx) = crossbeam_channel::unbounded();
-        let mut orchestrator = CompactorOrchestrator::new(
-            compactor_options(),
-            manifest_store.clone(),
-            table_store.clone(),
-            rt.handle().clone(),
-            external_rx,
-            Arc::new(CompactionStats::new(db.metrics().as_ref())),
-        )
-        .unwrap();
-        let l0_ids_to_compact: Vec<SourceId> = orchestrator
-            .state
-            .db_state()
-            .l0
-            .iter()
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
-            .collect();
-        // write another l0
-        let db = rt
-            .block_on(Db::open_with_opts(
-                Path::from(PATH),
-                options.clone(),
-                os.clone(),
-            ))
-            .unwrap();
-        rt.block_on(db.put(&[b'j'; 32], &[b'k'; 96])).unwrap();
-        rt.block_on(db.close()).unwrap();
-        orchestrator
-            .submit_compaction(Compaction::new(l0_ids_to_compact.clone(), 0))
-            .unwrap();
-        let msg = orchestrator.worker_rx.recv().unwrap();
-        let WorkerToOrchestratorMsg::CompactionFinished(Ok(sr)) = msg else {
-            panic!("compaction failed")
-        };
+        // write an l0 before handling compaction finished
+        fixture.write_l0();
 
         // when:
-        orchestrator.finish_compaction(sr).unwrap();
+        fixture.handler.handle_worker_rx(msg);
 
         // then:
-        let db_state = rt.block_on(stored_manifest.refresh()).unwrap();
+        let db_state = fixture.latest_db_state();
         assert_eq!(db_state.l0.len(), 1);
         assert_eq!(db_state.compacted.len(), 1);
         let l0_id = db_state.l0.front().unwrap().id.unwrap_compacted_id();
@@ -586,11 +758,54 @@ mod tests {
         assert!(!compacted_l0s.contains(&l0_id));
         assert_eq!(
             db_state.l0_last_compacted.unwrap(),
-            l0_ids_to_compact
+            compaction
+                .sources
                 .first()
                 .and_then(|id| id.maybe_unwrap_sst())
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn test_should_clear_compaction_on_failure_and_retry() {
+        // given:
+        let mut fixture = CompactorEventHandlerTestFixture::new();
+        fixture.write_l0();
+        let compaction = fixture.build_l0_compaction();
+        fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker();
+        let job = fixture.assert_started_compaction(1).pop().unwrap();
+        let msg = WorkerToOrchestratorMsg::CompactionFinished {
+            id: job.id,
+            result: Err(SlateDBError::InvalidDBState),
+        };
+
+        // when:
+        fixture.handler.handle_worker_rx(msg);
+
+        // then:
+        fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker();
+        fixture.assert_started_compaction(1);
+    }
+
+    #[test]
+    fn test_should_not_schedule_conflicting_compaction() {
+        // given:
+        let mut fixture = CompactorEventHandlerTestFixture::new();
+        fixture.write_l0();
+        let compaction = fixture.build_l0_compaction();
+        fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker();
+        fixture.assert_started_compaction(1);
+        fixture.write_l0();
+        fixture.scheduler.inject_compaction(compaction.clone());
+
+        // when:
+        fixture.handler.handle_ticker();
+
+        // then:
+        assert_eq!(0, fixture.executor.pop_jobs().len())
     }
 
     fn build_runtime() -> Runtime {
@@ -661,30 +876,83 @@ mod tests {
             #[cfg(feature = "wal_disable")]
             wal_enabled: true,
             manifest_poll_interval: Duration::from_millis(100),
-            min_filter_keys: 0,
-            filter_bits_per_key: 10,
-            max_unflushed_bytes: 1_073_741_824,
             l0_sst_size_bytes: 128,
             l0_max_ssts: 8,
             compactor_options,
-            compression_codec: None,
-            object_store_cache_options: ObjectStoreCacheOptions::default(),
-            block_cache: None,
-            garbage_collector_options: None,
             clock,
-            default_ttl: None,
+            ..DbOptions::default()
         }
     }
 
     fn compactor_options() -> CompactorOptions {
         CompactorOptions {
             poll_interval: Duration::from_millis(100),
-            max_sst_size: 1024 * 1024 * 1024,
-            compaction_scheduler: Arc::new(SizeTieredCompactionSchedulerSupplier::new(
-                SizeTieredCompactionSchedulerOptions::default(),
-            )),
             max_concurrent_compactions: 1,
-            compaction_runtime: None,
+            ..CompactorOptions::default()
+        }
+    }
+
+    struct MockSchedulerInner {
+        compaction: Vec<Compaction>,
+    }
+
+    #[derive(Clone)]
+    struct MockScheduler {
+        inner: Arc<Mutex<MockSchedulerInner>>,
+    }
+
+    impl MockScheduler {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(MockSchedulerInner { compaction: vec![] })),
+            }
+        }
+
+        fn inject_compaction(&self, compaction: Compaction) {
+            let mut inner = self.inner.lock();
+            inner.compaction.push(compaction);
+        }
+    }
+
+    impl CompactionScheduler for MockScheduler {
+        fn maybe_schedule_compaction(&self, _state: &CompactorState) -> Vec<Compaction> {
+            let mut inner = self.inner.lock();
+            std::mem::take(&mut inner.compaction)
+        }
+    }
+
+    struct MockExecutorInner {
+        jobs: Vec<CompactionJob>,
+    }
+
+    #[derive(Clone)]
+    struct MockExecutor {
+        inner: Arc<Mutex<MockExecutorInner>>,
+    }
+
+    impl MockExecutor {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(Mutex::new(MockExecutorInner { jobs: vec![] })),
+            }
+        }
+
+        fn pop_jobs(&self) -> Vec<CompactionJob> {
+            let mut guard = self.inner.lock();
+            std::mem::take(&mut guard.jobs)
+        }
+    }
+
+    impl CompactionExecutor for MockExecutor {
+        fn start_compaction(&self, compaction: CompactionJob) {
+            let mut guard = self.inner.lock();
+            guard.jobs.push(compaction);
+        }
+
+        fn stop(&self) {}
+
+        fn is_stopped(&self) -> bool {
+            false
         }
     }
 }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -14,7 +14,7 @@ use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskShutdown;
 use crate::iter::KeyValueIterator;
 use crate::mem_table::{ImmutableWal, KVTable, WritableKVTable};
-use crate::utils::spawn_bg_task;
+use crate::utils::{bg_task_result_into_err, spawn_bg_task};
 
 #[derive(Debug)]
 pub(crate) enum WalFlushMsg {
@@ -148,7 +148,8 @@ impl DbInner {
         let this = Arc::clone(self);
         Some(spawn_bg_task(
             tokio_handle,
-            move |err| {
+            move |result| {
+                let err = bg_task_result_into_err(result);
                 warn!("flush task exited with {:?}", err);
                 // notify any waiters about the failure
                 let mut state = this.state.write();

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -51,7 +51,7 @@ impl GarbageCollector {
         options: GarbageCollectorOptions,
         tokio_handle: Handle,
         stat_registry: Arc<StatRegistry>,
-        cleanup_fn: impl FnOnce(&SlateDBError) + Send + 'static,
+        cleanup_fn: impl FnOnce(&Result<(), SlateDBError>) + Send + 'static,
     ) -> Self {
         let (external_tx, external_rx) = crossbeam_channel::unbounded();
         let tokio_handle = options.gc_runtime.clone().unwrap_or(tokio_handle);

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -5,7 +5,7 @@ use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskShutdown;
 use crate::manifest_store::FenceableManifest;
-use crate::utils::spawn_bg_task;
+use crate::utils::{bg_task_result_into_err, spawn_bg_task};
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -219,7 +219,8 @@ impl DbInner {
         let this = Arc::clone(self);
         Some(spawn_bg_task(
             tokio_handle,
-            move |err| {
+            move |result| {
+                let err = bg_task_result_into_err(result);
                 warn!("memtable flush task exited with {:?}", err);
                 // notify any waiters that the task has exited
                 let mut state = this.state.write();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,7 +59,7 @@ impl<T: Clone> WatchableOnceCellReader<T> {
 /// Spawn a monitored background tokio task. The task must return a Result<T, SlateDBError>.
 /// The task is spawned by a monitor task. When the task exits, the monitor task
 /// calls a provided cleanup fn with a reference to the returned result. If the spawned task
-/// panics, the cleanup fn is called with Err(BackgroundTaskFailed).
+/// panics, the cleanup fn is called with Err(BackgroundTaskPanic).
 pub(crate) fn spawn_bg_task<F, T, C>(
     handle: &tokio::runtime::Handle,
     cleanup_fn: C,
@@ -75,7 +75,6 @@ where
         let jh = inner_handle.spawn(future);
         match jh.await {
             Ok(result) => {
-                // task exited with an error
                 cleanup_fn(&result);
                 result
             }
@@ -96,7 +95,7 @@ where
 /// Spawn a monitored background os thread. The thread must return a Result<T, SlateDBError>.
 /// The thread is spawned by a monitor thread. When the thread exits, the monitor thread
 /// calls a provided cleanup fn with the returned result. If the spawned thread panics, the
-/// cleanup fn is called with Err(BackgroundTaskFailed).
+/// cleanup fn is called with Err(BackgroundTaskPanic).
 pub(crate) fn spawn_bg_thread<F, T, C>(
     name: &str,
     cleanup_fn: C,
@@ -125,7 +124,6 @@ where
                     err
                 }
                 Ok(result) => {
-                    // thread exited with an error
                     cleanup_fn(&result);
                     result
                 }


### PR DESCRIPTION
This patch makes a few changes to ensure we cleanup compaction jobs when they fail:
- We now track compaction jobs by a unique id rather than the destination. Though this is not strictly required, it feels a bit safer as a way to correlate msgs from the executor with the compactor's state.
- When a compaction fails, the executor's message includes both the id and the error.
- The compactor orchestrator clears the compaction job from its state when a compaction fails.
- Changes the executor to use a monitored background task for compaction, and to send the orchestrator the result from the task's cleanup fn. This way we also report failures due to a compaction panic'ing. This also required changing the cleanup fn to take a Result rather than just an error, and updating the existing cleanup fns (e.g. for flush, batch-write, etc) accordingly.

Finally, to make this change easier to test this patch refactors the CompactorOrchestrator by splitting it into:
 - CompactorEventHandler has all the logic for handling events form the orchestrator's event loop.
 - CompactorOrchestrator now just runs the event loop and delegates handling to CompactorEventHandler. This makes it easier to test the orchestrator's event handling because the test can generate a deterministic sequence of events to handle.

The tests for the orchestrator have been refactored a bit to move all the common setup into CompactorEventHandlerTestFixture.