### PR TITLE
add stats about block cache hits/misses and usage

### DIFF
--- a/src/bytes_generator.rs
+++ b/src/bytes_generator.rs
@@ -9,7 +9,7 @@ pub(crate) struct OrderedBytesGenerator {
 }
 
 impl OrderedBytesGenerator {
-    #[cfg(feature = "bencher")]
+    #[cfg(any(feature = "bencher", test))]
     pub(crate) fn new_with_suffix(suffix: &[u8], bytes: &[u8]) -> Self {
         Self::new(suffix, bytes, u8::MIN, u8::MAX)
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -43,6 +43,7 @@ use crate::compactor::Compactor;
 use crate::config::ReadLevel::Uncommitted;
 use crate::config::{DbOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions};
 use crate::db::SstFilterResult::{FilterNegative, FilterPositive, RangeNegative, RangePositive};
+use crate::db_cache::DbCacheWrapper;
 use crate::db_iter::DbIterator;
 use crate::db_state::{CoreDbState, DbState, SortedRun, SsTableHandle, SsTableId};
 use crate::db_stats::DbStats;
@@ -750,7 +751,10 @@ impl Db {
             sst_format.clone(),
             path.clone(),
             fp_registry.clone(),
-            options.block_cache.clone(),
+            options
+                .block_cache
+                .as_ref()
+                .map(|c| DbCacheWrapper::new(c.clone(), stat_registry.as_ref())),
         ));
 
         let manifest_store = Arc::new(ManifestStore::new(&path, maybe_cached_object_store.clone()));

--- a/src/db.rs
+++ b/src/db.rs
@@ -43,7 +43,7 @@ use crate::compactor::Compactor;
 use crate::config::ReadLevel::Uncommitted;
 use crate::config::{DbOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions};
 use crate::db::SstFilterResult::{FilterNegative, FilterPositive, RangeNegative, RangePositive};
-use crate::db_cache::DbCacheWrapper;
+use crate::db_cache::{DbCache, DbCacheWrapper};
 use crate::db_iter::DbIterator;
 use crate::db_state::{CoreDbState, DbState, SortedRun, SsTableHandle, SsTableId};
 use crate::db_stats::DbStats;
@@ -751,10 +751,9 @@ impl Db {
             sst_format.clone(),
             path.clone(),
             fp_registry.clone(),
-            options
-                .block_cache
-                .as_ref()
-                .map(|c| DbCacheWrapper::new(c.clone(), stat_registry.as_ref())),
+            options.block_cache.as_ref().map(|c| {
+                Arc::new(DbCacheWrapper::new(c.clone(), stat_registry.as_ref())) as Arc<dyn DbCache>
+            }),
         ));
 
         let manifest_store = Arc::new(ManifestStore::new(&path, maybe_cached_object_store.clone()));

--- a/src/db_cache/foyer.rs
+++ b/src/db_cache/foyer.rs
@@ -102,6 +102,7 @@ impl DbCache for FoyerCache {
     }
 
     fn entry_count(&self) -> u64 {
-        self.inner.usage() as _
+        // foyer cache doesn't support an entry count estimate
+        0
     }
 }

--- a/src/db_cache/foyer.rs
+++ b/src/db_cache/foyer.rs
@@ -30,7 +30,7 @@
 //! }
 //! ```
 //!
-use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
+use crate::db_cache::{CachedEntry, CachedKey, DbCache, GetTarget, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
 
 /// The options for the Foyer cache.
@@ -89,7 +89,7 @@ impl Default for FoyerCache {
 
 #[async_trait]
 impl DbCache for FoyerCache {
-    async fn get(&self, key: CachedKey) -> Option<CachedEntry> {
+    async fn get(&self, key: CachedKey, _target: GetTarget) -> Option<CachedEntry> {
         self.inner.get(&key).map(|entry| entry.value().clone())
     }
 

--- a/src/db_cache/mod.rs
+++ b/src/db_cache/mod.rs
@@ -1,6 +1,6 @@
 //! # DB Cache
 //!
-//! This module provides an in-memory caching solution for storing and retrieving
+//! This module provides a pluggable caching solution for storing and retrieving
 //! cached blocks, index and bloom filters associated with SSTable IDs.
 //!
 //! There are currently two built-in cache implementations:
@@ -15,6 +15,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use crate::db_cache::stats::DbCacheStats;
+use crate::stats::StatRegistry;
 use crate::{
     block::Block, db_state::SsTableId, filter::BloomFilter, flatbuffer_types::SsTableIndexOwned,
 };
@@ -27,30 +29,42 @@ pub mod moka;
 /// The default max capacity for the cache. (64MB)
 pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 
-/// A trait for in-memory caches.
+/// A trait for slatedb's block cache.
 ///
-/// This trait defines the interface for an in-memory cache,
+/// This trait defines the interface for a block cache,
 /// which is used to store and retrieve cached blocks associated with SSTable IDs.
 ///
 /// Example:
 ///
-/// ```rust,no_run,compile_fail
+/// ```rust,no_run
 /// use async_trait::async_trait;
 /// use object_store::local::LocalFileSystem;
-/// use slatedb::db::Db;
+/// use slatedb::Db;
 /// use slatedb::config::DbOptions;
 /// use slatedb::db_cache::{DbCache, CachedEntry, CachedKey};
-/// use ssc::HashMap;
-/// use std::sync::Arc;
+/// use std::collections::HashMap;
+/// use std::sync::{Arc, Mutex};
 ///
 /// struct MyCache {
-///     inner: HashMap<CachedKey, CachedEntry>,
+///     inner: Mutex<MyCacheInner>,
+/// }
+///
+/// struct MyCacheInner {
+///     data: HashMap<CachedKey, CachedEntry>,
+///     usage: u64,
+///     capacity: u64
 /// }
 ///
 /// impl MyCache {
-///     pub fn new() -> Self {
+///     pub fn new(capacity: u64) -> Self {
 ///         Self {
-///             inner: HashMap::new(),
+///             inner: Mutex::new(
+///                 MyCacheInner{
+///                     data: HashMap::new(),
+///                     usage: 0,
+///                     capacity,
+///                 }
+///             )
 ///         }
 ///     }
 /// }
@@ -58,30 +72,43 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 /// #[async_trait]
 /// impl DbCache for MyCache {
 ///     async fn get(&self, key: CachedKey) -> Option<CachedEntry> {
-///         self.inner.get_async(&key).await.cloned()
+///         let guard = self.inner.lock().unwrap();
+///         guard.data.get(&key).cloned()
 ///     }
 ///
 ///     async fn insert(&self, key: CachedKey, value: CachedEntry) {
-///         self.inner.insert_async(key, value).await;
+///         let mut guard = self.inner.lock().unwrap();
+///         guard.usage += value.size() as u64;
+///         if let Some(v) = guard.data.insert(key, value) {
+///             guard.usage -= v.size() as u64;
+///         }
 ///     }
 ///
 ///     async fn remove(&self, key: CachedKey) {
-///         self.inner.remove_async(&key).await;
+///         let mut guard = self.inner.lock().unwrap();
+///         if let Some(v) = guard.data.remove(&key) {
+///             guard.usage -= v.size() as u64;
+///         }
 ///     }
 ///
 ///     fn entry_count(&self) -> u64 {
-///         self.inner.len() as u64
+///         let mut guard = self.inner.lock().unwrap();
+///         guard.capacity
 ///     }
 /// }
 ///
 /// #[::tokio::main]
 /// async fn main() {
+///     use object_store::path::Path;
+///     use slatedb::db_cache::DbCacheWrapper;
 ///     let object_store = Arc::new(LocalFileSystem::new());
+///     let cache = Arc::new(MyCache::new(128u64 * 1024 * 1024));
 ///     let options = DbOptions {
-///         block_cache: Some(Arc::new(MyCache::new())),
+///         block_cache: Some(cache),
 ///         ..Default::default()
 ///     };
-///     let db = Db::open_with_opts("path/to/db".into(), options, object_store).await;
+///     let path = Path::from("/path/to/db");
+///     let db = Db::open_with_opts(path, options, object_store).await;
 /// }
 /// ```
 #[async_trait]
@@ -179,6 +206,302 @@ impl CachedEntry {
             CachedItem::Block(block) => block.size(),
             CachedItem::SsTableIndex(sst_index) => sst_index.size(),
             CachedItem::BloomFilter(bloom_filter) => bloom_filter.size(),
+        }
+    }
+}
+
+pub struct DbCacheWrapper {
+    stats: DbCacheStats,
+    cache: Arc<dyn DbCache>,
+}
+
+impl DbCacheWrapper {
+    pub fn new(cache: Arc<dyn DbCache>, stats_registry: &StatRegistry) -> Self {
+        Self {
+            stats: DbCacheStats::new(stats_registry),
+            cache,
+        }
+    }
+
+    pub(crate) async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry> {
+        let result = self.cache.get(key).await;
+        if result.is_some() {
+            self.stats.filter_hit.inc();
+        } else {
+            self.stats.filter_miss.inc();
+        }
+        result
+    }
+
+    pub(crate) async fn get_index(&self, key: CachedKey) -> Option<CachedEntry> {
+        let result = self.cache.get(key).await;
+        if result.is_some() {
+            self.stats.index_hit.inc();
+        } else {
+            self.stats.index_miss.inc();
+        }
+        result
+    }
+
+    pub(crate) async fn get_data_block(&self, key: CachedKey) -> Option<CachedEntry> {
+        let result = self.cache.get(key).await;
+        if result.is_some() {
+            self.stats.data_block_hit.inc();
+        } else {
+            self.stats.data_block_miss.inc();
+        }
+        result
+    }
+
+    pub(crate) async fn insert(&self, key: CachedKey, value: CachedEntry) {
+        self.cache.insert(key, value).await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn remove(&self, key: CachedKey) {
+        self.cache.remove(key).await
+    }
+}
+
+pub mod stats {
+    use crate::stats::{Counter, StatRegistry};
+    use std::sync::Arc;
+
+    macro_rules! dbcache_stat_name {
+        ($suffix:expr) => {
+            crate::stat_name!("dbcache", $suffix)
+        };
+    }
+
+    pub const DB_CACHE_FILTER_HIT: &str = dbcache_stat_name!("filter_hit");
+    pub const DB_CACHE_FILTER_MISS: &str = dbcache_stat_name!("filter_miss");
+    pub const DB_CACHE_INDEX_HIT: &str = dbcache_stat_name!("index_hit");
+    pub const DB_CACHE_INDEX_MISS: &str = dbcache_stat_name!("index_miss");
+    pub const DB_CACHE_DATA_BLOCK_HIT: &str = dbcache_stat_name!("data_block_hit");
+    pub const DB_CACHE_DATA_BLOCK_MISS: &str = dbcache_stat_name!("data_block_miss");
+
+    pub(super) struct DbCacheStats {
+        pub(super) filter_hit: Arc<Counter>,
+        pub(super) filter_miss: Arc<Counter>,
+        pub(super) index_hit: Arc<Counter>,
+        pub(super) index_miss: Arc<Counter>,
+        pub(super) data_block_hit: Arc<Counter>,
+        pub(super) data_block_miss: Arc<Counter>,
+    }
+
+    impl DbCacheStats {
+        pub(super) fn new(registry: &StatRegistry) -> Self {
+            let stats = Self {
+                filter_hit: Arc::new(Counter::default()),
+                filter_miss: Arc::new(Counter::default()),
+                index_hit: Arc::new(Counter::default()),
+                index_miss: Arc::new(Counter::default()),
+                data_block_hit: Arc::new(Counter::default()),
+                data_block_miss: Arc::new(Counter::default()),
+            };
+            registry.register(DB_CACHE_FILTER_HIT, stats.filter_hit.clone());
+            registry.register(DB_CACHE_FILTER_MISS, stats.filter_miss.clone());
+            registry.register(DB_CACHE_INDEX_HIT, stats.index_hit.clone());
+            registry.register(DB_CACHE_INDEX_MISS, stats.index_miss.clone());
+            registry.register(DB_CACHE_DATA_BLOCK_HIT, stats.data_block_hit.clone());
+            registry.register(DB_CACHE_DATA_BLOCK_MISS, stats.data_block_miss.clone());
+            stats
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db_cache::{CachedEntry, CachedKey, DbCache, DbCacheWrapper};
+    use crate::db_state::SsTableId;
+    use crate::sst::SsTableFormat;
+    use crate::stats::{ReadableStat, StatRegistry};
+    use crate::test_utils::{build_test_sst, SstData};
+    use async_trait::async_trait;
+    use rstest::{fixture, rstest};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+    use ulid::Ulid;
+
+    const SST_ID: SsTableId = SsTableId::Compacted(Ulid::from_parts(0u64, 0u128));
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_should_count_filter_hits(
+        cache: DbCacheWrapper,
+        sst_format: SsTableFormat,
+        sst: SstData,
+    ) {
+        // given:
+        let filter = sst_format
+            .read_filter_raw(&sst.info, &sst.data)
+            .unwrap()
+            .unwrap();
+        let key = CachedKey::from((SST_ID, 12345u64));
+        cache
+            .insert(key.clone(), CachedEntry::with_bloom_filter(filter))
+            .await;
+
+        for i in 1..4 {
+            // when:
+            let _ = cache.get_filter(key.clone()).await;
+
+            // then:
+            assert_eq!(0, cache.stats.filter_miss.get());
+            assert_eq!(i, cache.stats.filter_hit.get());
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_should_count_filter_misses(cache: DbCacheWrapper) {
+        // given:
+        let key = CachedKey::from((SST_ID, 12345u64));
+
+        for i in 1..4 {
+            // when:
+            let _ = cache.get_filter(key.clone()).await;
+
+            // then:
+            assert_eq!(i, cache.stats.filter_miss.get());
+            assert_eq!(0, cache.stats.filter_hit.get());
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_should_count_index_hits(
+        cache: DbCacheWrapper,
+        sst_format: SsTableFormat,
+        sst: SstData,
+    ) {
+        // given:
+        let index = sst_format.read_index_raw(&sst.info, &sst.data).unwrap();
+        let key = CachedKey::from((SST_ID, 12345u64));
+        cache
+            .insert(key.clone(), CachedEntry::with_sst_index(Arc::new(index)))
+            .await;
+
+        for i in 1..4 {
+            // when:
+            let _ = cache.get_index(key.clone()).await;
+
+            // then:
+            assert_eq!(0, cache.stats.index_miss.get());
+            assert_eq!(i, cache.stats.index_hit.get());
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_should_count_index_misses(cache: DbCacheWrapper) {
+        // given:
+        let key = CachedKey::from((SST_ID, 12345u64));
+
+        for i in 1..4 {
+            // when:
+            let _ = cache.get_index(key.clone()).await;
+
+            // then:
+            assert_eq!(i, cache.stats.index_miss.get());
+            assert_eq!(0, cache.stats.index_hit.get());
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_should_count_data_block_hits(
+        cache: DbCacheWrapper,
+        sst_format: SsTableFormat,
+        sst: SstData,
+    ) {
+        // given:
+        let index = sst_format.read_index_raw(&sst.info, &sst.data).unwrap();
+        let block = sst_format
+            .read_block_raw(&sst.info, &index, 0, &sst.data)
+            .unwrap();
+        let key = CachedKey::from((SST_ID, 12345u64));
+        cache
+            .insert(key.clone(), CachedEntry::with_block(Arc::new(block)))
+            .await;
+
+        for i in 1..4 {
+            // when:
+            let _ = cache.get_data_block(key.clone()).await;
+
+            // then:
+            assert_eq!(0, cache.stats.data_block_miss.get());
+            assert_eq!(i, cache.stats.data_block_hit.get());
+        }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_should_count_data_block_misses(cache: DbCacheWrapper) {
+        // given:
+        let key = CachedKey::from((SST_ID, 12345u64));
+
+        for i in 1..4 {
+            // when:
+            let _ = cache.get_data_block(key.clone()).await;
+
+            // then:
+            assert_eq!(i, cache.stats.data_block_miss.get());
+            assert_eq!(0, cache.stats.data_block_hit.get());
+        }
+    }
+
+    #[fixture]
+    fn cache() -> DbCacheWrapper {
+        let registry = StatRegistry::new();
+        DbCacheWrapper::new(Arc::new(TestCache::new()), &registry)
+    }
+
+    #[fixture]
+    fn sst_format() -> SsTableFormat {
+        SsTableFormat {
+            block_size: 128,
+            ..SsTableFormat::default()
+        }
+    }
+
+    #[fixture]
+    fn sst(sst_format: SsTableFormat) -> SstData {
+        build_test_sst(&sst_format, 1)
+    }
+
+    struct TestCache {
+        items: Mutex<HashMap<CachedKey, CachedEntry>>,
+    }
+
+    impl TestCache {
+        fn new() -> Self {
+            Self {
+                items: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl DbCache for TestCache {
+        async fn get(&self, key: CachedKey) -> Option<CachedEntry> {
+            let guard = self.items.lock().unwrap();
+            guard.get(&key).cloned()
+        }
+
+        async fn insert(&self, key: CachedKey, value: CachedEntry) {
+            let mut guard = self.items.lock().unwrap();
+            guard.insert(key, value);
+        }
+
+        async fn remove(&self, key: CachedKey) {
+            let mut guard = self.items.lock().unwrap();
+            guard.remove(&key);
+        }
+
+        fn entry_count(&self) -> u64 {
+            let guard = self.items.lock().unwrap();
+            guard.iter().count() as u64
         }
     }
 }

--- a/src/db_cache/moka.rs
+++ b/src/db_cache/moka.rs
@@ -30,7 +30,7 @@
 //! }
 //! ```
 //!
-use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
+use crate::db_cache::{CachedEntry, CachedKey, DbCache, GetTarget, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
 use std::time::Duration;
 
@@ -103,7 +103,7 @@ impl Default for MokaCache {
 
 #[async_trait]
 impl DbCache for MokaCache {
-    async fn get(&self, key: CachedKey) -> Option<CachedEntry> {
+    async fn get(&self, key: CachedKey, _target: GetTarget) -> Option<CachedEntry> {
         self.inner.get(&key).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use cached_object_store::stats as cached_object_store_stats;
 pub use checkpoint::{Checkpoint, CheckpointCreateResult};
 pub use compactor::stats as compactor_stats;
 pub use db::Db;
+pub use db_cache::stats as db_cache_stats;
 pub use db_iter::DbIterator;
 pub use error::{DbOptionsError, SlateDBError};
 pub use garbage_collector::stats as garbage_collector_stats;

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -75,6 +75,24 @@ impl SsTableFormat {
         Ok(filter)
     }
 
+    #[cfg(test)]
+    pub(crate) fn read_filter_raw(
+        &self,
+        info: &SsTableInfo,
+        sst_bytes: &Bytes,
+    ) -> Result<Option<Arc<BloomFilter>>, SlateDBError> {
+        if info.filter_len == 0 {
+            return Ok(None);
+        }
+        let filter_end = info.filter_offset + info.filter_len;
+        let filter_offset_range = info.filter_offset as usize..filter_end as usize;
+        let filter_bytes = sst_bytes.slice(filter_offset_range);
+        let compression_codec = info.compression_codec;
+        Ok(Some(Arc::new(
+            self.decode_filter(filter_bytes, compression_codec)?,
+        )))
+    }
+
     pub(crate) fn decode_filter(
         &self,
         bytes: Bytes,

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -13,7 +13,7 @@ use object_store::ObjectStore;
 use tokio::io::AsyncWriteExt;
 use ulid::Ulid;
 
-use crate::db_cache::CachedEntry;
+use crate::db_cache::{CachedEntry, DbCacheWrapper};
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::filter::BloomFilter;
@@ -24,7 +24,7 @@ use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
 use crate::types::RowEntry;
-use crate::{blob::ReadOnlyBlob, block::Block, db_cache::DbCache};
+use crate::{blob::ReadOnlyBlob, block::Block};
 
 pub struct TableStore {
     object_store: Arc<dyn ObjectStore>,
@@ -34,7 +34,7 @@ pub struct TableStore {
     fp_registry: Arc<FailPointRegistry>,
     transactional_wal_store: Arc<dyn TransactionalObjectStore>,
     /// In-memory cache for blocks
-    block_cache: Option<Arc<dyn DbCache>>,
+    block_cache: Option<DbCacheWrapper>,
 }
 
 struct ReadOnlyObject {
@@ -78,7 +78,7 @@ impl TableStore {
         object_store: Arc<dyn ObjectStore>,
         sst_format: SsTableFormat,
         root_path: P,
-        block_cache: Option<Arc<dyn DbCache>>,
+        block_cache: Option<DbCacheWrapper>,
     ) -> Self {
         Self::new_with_fp_registry(
             object_store,
@@ -94,7 +94,7 @@ impl TableStore {
         sst_format: SsTableFormat,
         root_path: P,
         fp_registry: Arc<FailPointRegistry>,
-        block_cache: Option<Arc<dyn DbCache>>,
+        block_cache: Option<DbCacheWrapper>,
     ) -> Self {
         Self {
             object_store: object_store.clone(),
@@ -298,7 +298,7 @@ impl TableStore {
     ) -> Result<Option<Arc<BloomFilter>>, SlateDBError> {
         if let Some(cache) = &self.block_cache {
             if let Some(filter) = cache
-                .get((handle.id, handle.info.filter_offset).into())
+                .get_filter((handle.id, handle.info.filter_offset).into())
                 .await
                 .and_then(|entry| entry.bloom_filter())
             {
@@ -330,7 +330,7 @@ impl TableStore {
     ) -> Result<Arc<SsTableIndexOwned>, SlateDBError> {
         if let Some(cache) = &self.block_cache {
             if let Some(index) = cache
-                .get((handle.id, handle.info.index_offset).into())
+                .get_index((handle.id, handle.info.index_offset).into())
                 .await
                 .and_then(|entry| entry.sst_index())
             {
@@ -402,7 +402,7 @@ impl TableStore {
                 let block_meta = index_borrow.block_meta().get(block_num);
                 let offset = block_meta.offset();
                 cache
-                    .get((handle.id, offset).into())
+                    .get_data_block((handle.id, offset).into())
                     .await
                     .and_then(|entry| entry.block())
             }))
@@ -555,11 +555,13 @@ mod tests {
     use proptest::proptest;
     use ulid::Ulid;
 
+    use crate::db_cache::DbCache;
     use crate::error;
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
+    use crate::stats::StatRegistry;
     #[cfg(feature = "moka")]
-    use crate::tablestore::DbCache;
+    use crate::tablestore::DbCacheWrapper;
     use crate::tablestore::TableStore;
     use crate::test_utils::assert_iterator;
     use crate::types::{RowEntry, ValueDeletable};
@@ -659,12 +661,14 @@ mod tests {
             ..SsTableFormat::default()
         };
 
+        let stat_registry = StatRegistry::new();
         let block_cache = Arc::new(MokaCache::new());
+        let wrapper = DbCacheWrapper::new(block_cache.clone(), &stat_registry);
         let ts = Arc::new(TableStore::new(
             os.clone(),
             format,
             Path::from("/root"),
-            Some(block_cache.clone()),
+            Some(wrapper),
         ));
 
         // Create and write SST

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,9 +2,9 @@ use crate::config::{Clock, PutOptions, WriteOptions};
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, KeyValueIterator};
 use crate::row_codec::SstRowCodecV0;
-use crate::types::{KeyValue, RowAttributes, RowEntry};
-use bytes::Bytes;
-use rand::Rng;
+use crate::types::{KeyValue, RowAttributes, RowEntry, ValueDeletable};
+use bytes::{BufMut, Bytes, BytesMut};
+use rand::{Rng, RngCore};
 use std::collections::BTreeMap;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, RangeBounds};
@@ -88,9 +88,12 @@ macro_rules! assert_debug_snapshot {
     };
 }
 
+use crate::bytes_generator::OrderedBytesGenerator;
 use crate::bytes_range::BytesRange;
 use crate::db::Db;
 use crate::db_iter::DbIterator;
+use crate::db_state::SsTableInfo;
+use crate::sst::SsTableFormat;
 pub(crate) use assert_debug_snapshot;
 
 pub(crate) fn decode_codec_entries(
@@ -199,4 +202,37 @@ pub(crate) async fn seed_database(
     }
 
     Ok(())
+}
+
+pub(crate) struct SstData {
+    pub(crate) info: SsTableInfo,
+    pub(crate) data: Bytes,
+}
+
+pub(crate) fn build_test_sst(format: &SsTableFormat, num_blocks: usize) -> SstData {
+    let mut rng = rand::thread_rng();
+    let mut keygen = OrderedBytesGenerator::new_with_suffix(&[], &[0u8; 16]);
+    let mut encoded_sst_builder = format.table_builder();
+    let mut blocks = 0;
+    let mut data = BytesMut::with_capacity(num_blocks * (format.block_size + 1));
+    while blocks < num_blocks {
+        let k = keygen.next();
+        let mut val = BytesMut::with_capacity(32);
+        val.put_bytes(0u8, 32);
+        rng.fill_bytes(&mut val);
+        let row = RowEntry::new(k, ValueDeletable::Value(val.freeze()), 0u64, None, None);
+        encoded_sst_builder.add(row).unwrap();
+        if let Some(block) = encoded_sst_builder.next_block() {
+            data.put(block);
+            blocks += 1;
+        }
+    }
+    let mut encoded_table = encoded_sst_builder.build().unwrap();
+    while let Some(block) = encoded_table.unconsumed_blocks.pop_front() {
+        data.put(block);
+    }
+    SstData {
+        info: encoded_table.info,
+        data: data.freeze(),
+    }
 }


### PR DESCRIPTION
This patch adds some stats about block cache accesses and usage. The stats are measured and reported in a way that works when the cache is shared between multiple slatedb instances:
- The stats are added to a separate struct (DbCacheStats) from the main DbStats struct.
- The stats are measured via a wrapper of the main cache backend arc called DbCacheWrapper. This patch changes the type that's passed into the config and stored in the TableStore to DbCacheWrapper. Users now need to create a DbCacheWrapper instance from the Arc<dyn DbCache> if they want to provide a specific cache implementation.
- The stats can be accessed via the stats fn in DbCacheWrapper. So users that pass a single DbCacheWrapper instance to multiple SlateDBs can get aggregated stats for the cache.