### PR TITLE
fix: clamp the buffers backing entries inserted to the block cache

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,6 @@
 use crate::config::Clock;
 use crate::error::SlateDBError;
-use crate::error::SlateDBError::{BackgroundTaskPanic};
+use crate::error::SlateDBError::BackgroundTaskPanic;
 use bytes::{BufMut, Bytes};
 use std::cmp;
 use std::future::Future;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use crate::config::Clock;
 use crate::error::SlateDBError;
-use crate::error::SlateDBError::BackgroundTaskPanic;
+use crate::error::SlateDBError::{BackgroundTaskPanic};
+use bytes::{BufMut, Bytes};
 use std::cmp;
 use std::future::Future;
 use std::sync::atomic::AtomicI64;
@@ -204,11 +205,26 @@ pub(crate) fn merge_options<T>(
     }
 }
 
+fn bytes_into_minimal_vec(bytes: &Bytes) -> Vec<u8> {
+    let mut clamped = Vec::new();
+    clamped.reserve_exact(bytes.len());
+    clamped.put_slice(bytes.as_ref());
+    clamped
+}
+
+pub(crate) fn clamp_allocated_size_bytes(bytes: &Bytes) -> Bytes {
+    bytes_into_minimal_vec(bytes).into()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::error::SlateDBError;
     use crate::test_utils::TestClock;
-    use crate::utils::{spawn_bg_task, spawn_bg_thread, MonotonicClock, WatchableOnceCell};
+    use crate::utils::{
+        bytes_into_minimal_vec, clamp_allocated_size_bytes, spawn_bg_task, spawn_bg_thread,
+        MonotonicClock, WatchableOnceCell,
+    };
+    use bytes::{BufMut, BytesMut};
     use parking_lot::Mutex;
     use std::sync::atomic::Ordering::SeqCst;
     use std::sync::Arc;
@@ -430,5 +446,34 @@ mod tests {
 
         let result = tick_future.await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_should_clamp_bytes_to_minimal_vec() {
+        let mut bytes = BytesMut::with_capacity(2048);
+        bytes.put_bytes(0u8, 2048);
+        let bytes = bytes.freeze();
+        let slice = bytes.slice(100..1124);
+
+        let clamped = bytes_into_minimal_vec(&slice);
+
+        assert_eq!(slice.as_ref(), clamped.as_slice());
+        assert_eq!(clamped.capacity(), 1024);
+    }
+
+    #[test]
+    fn test_should_clamp_bytes_and_preserve_data() {
+        let mut bytes = BytesMut::with_capacity(2048);
+        bytes.put_bytes(0u8, 2048);
+        let bytes = bytes.freeze();
+        let slice = bytes.slice(100..1124);
+
+        let clamped = clamp_allocated_size_bytes(&slice);
+
+        assert_eq!(clamped, slice);
+        // It doesn't seem to be possible to assert that the clamped block's data is actually
+        // a buffer of the minimal size, as Bytes doesn't expose the underlying buffer's
+        // capacity. The best we can do is assert it allocated a new buffer.
+        assert_ne!(clamped.as_ptr(), slice.as_ptr());
     }
 }


### PR DESCRIPTION
This patch changes the cache wrapper to clamp buffers backing entries to the block cache to the minimally sized buffer required.

Normally, the buffer backing an entry may be significantly larger than the entry itself:
- some entries (like data blocks) internally contain slices that point to a larger buffer that was used to fetch a larger chunk of data (e.g. in the data block example, a scan will read a range of blocks and hand each block a slice)
- even entries derived from reads of just the relevant data (like indexes and filters) may contain larger backing buffers due to the behaviour of dynamically sized buffer data structures like Vec, which allocate the data by doubling it when required to achieve amortized O(1) updates.

Consequently, the block cache may think that it's cached some number of bytes when in reality the associated memory is much larger. This can make it difficult/impossible to set a reasonable limit on the cache size, leading to OOM. It also wastes memory.

This patch fixes this problem by reallocating the buffer backing cache entries to a minimally sized buffer and copying the data. This does represent a performance tradeoff but it should be relatively small compared to the existing cost of getting a cache entry from the backing store before caching it.

To see the difference in memory usage, here's the memory used from my application before this change. The application runs 8 embedded slatedb instances that all share a cache that is bound to 5GB. The red line represents the container's
climit for memory usage. The blue line is the memory used (RSS). This application crashed because it crossed the limit:

<img width="416" alt="Screen Shot 2025-02-19 at 11 48 51 PM" src="https://github.com/user-attachments/assets/555e7296-60c2-4f55-80ba-32999248c1bd" />

And here's the usage after:

<img width="413" alt="Screen Shot 2025-02-19 at 11 48 59 PM" src="https://github.com/user-attachments/assets/4f323e75-d766-4930-b330-628dc189e5d8" />
