### PR TITLE
write manifests more safely by verifying the expected next id

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -58,9 +58,9 @@ pub(crate) async fn create_clone<P: Into<Path>>(
         )
         .await?;
 
-        let mut initialized_db_state = clone_manifest.db_state().clone();
-        initialized_db_state.initialized = true;
-        clone_manifest.update_db_state(initialized_db_state).await?;
+        let mut dirty = clone_manifest.prepare_dirty();
+        dirty.core.initialized = true;
+        clone_manifest.update_manifest(dirty).await?;
     }
 
     Ok(())

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -2,6 +2,7 @@ use crate::bytes_range;
 use crate::checkpoint::Checkpoint;
 use crate::config::CompressionCodec;
 use crate::error::SlateDBError;
+use crate::manifest::store::DirtyManifest;
 use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, WritableKVTable};
 use crate::utils::{WatchableOnceCell, WatchableOnceCellReader};
 use bytes::Bytes;
@@ -216,7 +217,13 @@ pub(crate) struct DbState {
 pub(crate) struct COWDbState {
     pub(crate) imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
     pub(crate) imm_wal: VecDeque<Arc<ImmutableWal>>,
-    pub(crate) core: CoreDbState,
+    pub(crate) manifest: DirtyManifest,
+}
+
+impl COWDbState {
+    pub(crate) fn core(&self) -> &CoreDbState {
+        &self.manifest.core
+    }
 }
 
 /// represent the in-memory state of the manifest
@@ -288,15 +295,15 @@ pub(crate) struct DbStateSnapshot {
 }
 
 impl DbState {
-    pub fn new(core_db_state: CoreDbState) -> Self {
-        let last_l0_seq = core_db_state.last_l0_seq;
+    pub fn new(manifest: DirtyManifest) -> Self {
+        let last_l0_seq = manifest.core.last_l0_seq;
         Self {
             memtable: WritableKVTable::new(),
             wal: WritableKVTable::new(),
             state: Arc::new(COWDbState {
                 imm_memtable: VecDeque::new(),
                 imm_wal: VecDeque::new(),
-                core: core_db_state,
+                manifest,
             }),
             error: WatchableOnceCell::new(),
             last_seq: last_l0_seq,
@@ -316,8 +323,8 @@ impl DbState {
     }
 
     pub fn last_written_wal_id(&self) -> u64 {
-        assert!(self.state.core.next_wal_sst_id > 0);
-        self.state.core.next_wal_sst_id - 1
+        assert!(self.state.core().next_wal_sst_id > 0);
+        self.state.core().next_wal_sst_id - 1
     }
 
     pub fn error_reader(&self) -> WatchableOnceCellReader<SlateDBError> {
@@ -390,21 +397,22 @@ impl DbState {
             .pop_back()
             .expect("expected imm memtable");
         assert!(Arc::ptr_eq(&popped, &imm_memtable));
-        state.core.l0.push_front(sst_handle);
-        state.core.last_compacted_wal_sst_id = imm_memtable.last_wal_id();
+        state.manifest.core.l0.push_front(sst_handle);
+        state.manifest.core.last_compacted_wal_sst_id = imm_memtable.last_wal_id();
 
         // ensure the persisted manifest tick never goes backwards in time
         let memtable_tick = imm_memtable.table().last_tick();
-        state.core.last_l0_clock_tick = cmp::max(state.core.last_l0_clock_tick, memtable_tick);
-        if state.core.last_l0_clock_tick != memtable_tick {
+        state.manifest.core.last_l0_clock_tick =
+            cmp::max(state.manifest.core.last_l0_clock_tick, memtable_tick);
+        if state.manifest.core.last_l0_clock_tick != memtable_tick {
             return Err(SlateDBError::InvalidClockTick {
-                last_tick: state.core.last_l0_clock_tick,
+                last_tick: state.manifest.core.last_l0_clock_tick,
                 next_tick: memtable_tick,
             });
         }
         // update the persisted manifest last_l0_seq as the latest seq in the imm.
         if let Some(seq) = imm_memtable.table().last_seq() {
-            state.core.last_l0_seq = seq;
+            state.manifest.core.last_l0_seq = seq;
         }
 
         self.update_state(state);
@@ -413,7 +421,7 @@ impl DbState {
 
     pub fn increment_next_wal_id(&mut self) {
         let mut state = self.state_copy();
-        state.core.next_wal_sst_id += 1;
+        state.manifest.core.next_wal_sst_id += 1;
         self.update_state(state);
     }
 
@@ -429,12 +437,13 @@ impl DbState {
         self.last_seq = seq;
     }
 
-    pub fn merge_db_state(&mut self, updated_state: &CoreDbState) {
+    pub fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyManifest) {
         // The compactor removes tables from l0_last_compacted, so we
         // only want to keep the tables up to there.
-        let l0_last_compacted = &updated_state.l0_last_compacted;
+        let l0_last_compacted = &remote_manifest.core.l0_last_compacted;
         let new_l0 = if let Some(l0_last_compacted) = l0_last_compacted {
             self.state
+                .manifest
                 .core
                 .l0
                 .iter()
@@ -442,21 +451,23 @@ impl DbState {
                 .take_while(|sst| sst.id.unwrap_compacted_id() != *l0_last_compacted)
                 .collect()
         } else {
-            self.state.core.l0.iter().cloned().collect()
+            self.state.manifest.core.l0.iter().cloned().collect()
         };
 
-        let compacted = updated_state.compacted.clone();
         let mut state = self.state_copy();
-        state.core.l0_last_compacted.clone_from(l0_last_compacted);
-        state.core.l0 = new_l0;
-        state.core.compacted = compacted;
-
-        // Checkpoints may also be added externally, so we need to copy them.
-        state
-            .core
-            .checkpoints
-            .clone_from(&updated_state.checkpoints);
-
+        let my_db_state = state.core();
+        remote_manifest.core = CoreDbState {
+            initialized: my_db_state.initialized,
+            l0_last_compacted: remote_manifest.core.l0_last_compacted,
+            l0: new_l0,
+            compacted: remote_manifest.core.compacted,
+            next_wal_sst_id: my_db_state.next_wal_sst_id,
+            last_compacted_wal_sst_id: my_db_state.last_compacted_wal_sst_id,
+            last_l0_clock_tick: my_db_state.last_l0_clock_tick,
+            last_l0_seq: my_db_state.last_l0_seq,
+            checkpoints: remote_manifest.core.checkpoints,
+        };
+        state.manifest = remote_manifest;
         self.update_state(state);
     }
 }
@@ -464,7 +475,8 @@ impl DbState {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
-    use crate::db_state::{CoreDbState, DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::proptest_util::arbitrary;
     use crate::test_utils;
     use bytes::Bytes;
@@ -480,56 +492,58 @@ mod tests {
     #[test]
     fn test_should_merge_db_state_with_new_checkpoints() {
         // given:
-        let mut db_state = DbState::new(CoreDbState::new());
+        let mut db_state = DbState::new(new_dirty_manifest());
         // mimic an externally added checkpoint
-        let mut updated_state = db_state.state.core.clone();
+        let mut updated_state = new_dirty_manifest();
+        updated_state.core = db_state.state.core().clone();
         let checkpoint = Checkpoint {
             id: Uuid::new_v4(),
             manifest_id: 1,
             expire_time: None,
             create_time: SystemTime::now(),
         };
-        updated_state.checkpoints.push(checkpoint.clone());
+        updated_state.core.checkpoints.push(checkpoint.clone());
 
         // when:
-        db_state.merge_db_state(&updated_state);
+        db_state.merge_remote_manifest(updated_state);
 
         // then:
-        assert_eq!(vec![checkpoint], db_state.state.core.checkpoints);
+        assert_eq!(vec![checkpoint], db_state.state.core().checkpoints);
     }
 
     #[test]
     fn test_should_merge_db_state_with_l0s_up_to_last_compacted() {
         // given:
-        let mut db_state = DbState::new(CoreDbState::new());
+        let mut db_state = DbState::new(new_dirty_manifest());
         add_l0s_to_dbstate(&mut db_state, 4);
         // mimic the compactor popping off l0s
-        let mut compactor_state = db_state.state.core.clone();
-        let last_compacted = compactor_state.l0.pop_back().unwrap();
-        compactor_state.l0_last_compacted = Some(last_compacted.id.unwrap_compacted_id());
+        let mut compactor_state = new_dirty_manifest();
+        compactor_state.core = db_state.state.core().clone();
+        let last_compacted = compactor_state.core.l0.pop_back().unwrap();
+        compactor_state.core.l0_last_compacted = Some(last_compacted.id.unwrap_compacted_id());
 
         // when:
-        db_state.merge_db_state(&compactor_state);
+        db_state.merge_remote_manifest(compactor_state.clone());
 
         // then:
-        let expected: Vec<SsTableId> = compactor_state.l0.iter().map(|l0| l0.id).collect();
-        let merged: Vec<SsTableId> = db_state.state.core.l0.iter().map(|l0| l0.id).collect();
+        let expected: Vec<SsTableId> = compactor_state.core.l0.iter().map(|l0| l0.id).collect();
+        let merged: Vec<SsTableId> = db_state.state.core().l0.iter().map(|l0| l0.id).collect();
         assert_eq!(expected, merged);
     }
 
     #[test]
     fn test_should_merge_db_state_with_all_l0s_if_none_compacted() {
         // given:
-        let mut db_state = DbState::new(CoreDbState::new());
+        let mut db_state = DbState::new(new_dirty_manifest());
         add_l0s_to_dbstate(&mut db_state, 4);
-        let l0s = db_state.state.core.l0.clone();
+        let l0s = db_state.state.core().l0.clone();
 
         // when:
-        db_state.merge_db_state(&CoreDbState::new());
+        db_state.merge_remote_manifest(new_dirty_manifest());
 
         // then:
         let expected: Vec<SsTableId> = l0s.iter().map(|l0| l0.id).collect();
-        let merged: Vec<SsTableId> = db_state.state.core.l0.iter().map(|l0| l0.id).collect();
+        let merged: Vec<SsTableId> = db_state.state.core().l0.iter().map(|l0| l0.id).collect();
         assert_eq!(expected, merged);
     }
 

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -74,7 +74,7 @@ impl DbInner {
                 .imm_wal
                 .back()
                 .cloned()
-                .map(|imm| (imm, state.core.next_wal_sst_id))
+                .map(|imm| (imm, state.core().next_wal_sst_id))
         } {
             self.flush_imm_wal(id, imm.clone()).await?;
             let mut wguard = self.state.write();

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -1,11 +1,11 @@
 use crate::checkpoint::Checkpoint;
 use crate::config::GcExecutionMode::Periodic;
 use crate::config::{GarbageCollectorDirectoryOptions, GarbageCollectorOptions, GcExecutionMode};
-use crate::db_state::{CoreDbState, SsTableId};
+use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
 use crate::garbage_collector::stats::GcStats;
 use crate::garbage_collector::GarbageCollectorMessage::*;
-use crate::manifest::store::{ManifestStore, StoredManifest};
+use crate::manifest::store::{DirtyManifest, ManifestStore, StoredManifest};
 use crate::manifest::Manifest;
 use crate::stats::StatRegistry;
 use crate::tablestore::{SstFileMetadata, TableStore};
@@ -431,10 +431,11 @@ impl GarbageCollectorOrchestrator {
 
     fn filter_expired_checkpoints(
         manifest: &StoredManifest,
-    ) -> Result<Option<CoreDbState>, SlateDBError> {
+    ) -> Result<Option<DirtyManifest>, SlateDBError> {
         let utc_now = Utc::now();
-        let mut db_state = manifest.db_state().clone();
-        let retained_checkpoints: Vec<Checkpoint> = db_state
+        let mut dirty = manifest.prepare_dirty();
+        let retained_checkpoints: Vec<Checkpoint> = dirty
+            .core
             .checkpoints
             .iter()
             .filter(|checkpoint| match checkpoint.expire_time {
@@ -444,19 +445,19 @@ impl GarbageCollectorOrchestrator {
             .cloned()
             .collect();
 
-        let updated_state = if db_state.checkpoints.len() != retained_checkpoints.len() {
-            db_state.checkpoints = retained_checkpoints;
-            Some(db_state)
+        let maybe_dirty = if dirty.core.checkpoints.len() != retained_checkpoints.len() {
+            dirty.core.checkpoints = retained_checkpoints;
+            Some(dirty)
         } else {
             None
         };
-        Ok(updated_state)
+        Ok(maybe_dirty)
     }
 
     async fn remove_expired_checkpoints(&self) -> Result<(), SlateDBError> {
         let mut stored_manifest = self.load_stored_manifest().await?;
         stored_manifest
-            .maybe_apply_db_state_update(Self::filter_expired_checkpoints)
+            .maybe_apply_manifest_update(Self::filter_expired_checkpoints)
             .await
     }
 
@@ -682,7 +683,7 @@ mod tests {
 
         // Add a second manifest
         stored_manifest
-            .update_db_state(state.clone())
+            .update_manifest(stored_manifest.prepare_dirty())
             .await
             .unwrap();
 
@@ -714,15 +715,14 @@ mod tests {
         let (manifest_store, table_store, _) = build_objects();
 
         // Create a manifest
-        let state = CoreDbState::new();
         let mut stored_manifest =
-            StoredManifest::create_new_db(manifest_store.clone(), state.clone())
+            StoredManifest::create_new_db(manifest_store.clone(), CoreDbState::new())
                 .await
                 .unwrap();
 
         // Add a second manifest
         stored_manifest
-            .update_db_state(state.clone())
+            .update_manifest(stored_manifest.prepare_dirty())
             .await
             .unwrap();
 
@@ -755,11 +755,11 @@ mod tests {
         stored_manifest: &mut StoredManifest,
         expire_time: Option<SystemTime>,
     ) -> Result<Uuid, SlateDBError> {
-        let mut updated_state = stored_manifest.db_state().clone();
+        let mut dirty = stored_manifest.prepare_dirty();
         let checkpoint = new_checkpoint(stored_manifest.id(), expire_time);
         let checkpoint_id = checkpoint.id;
-        updated_state.checkpoints.push(checkpoint);
-        stored_manifest.update_db_state(updated_state).await?;
+        dirty.core.checkpoints.push(checkpoint);
+        stored_manifest.update_manifest(dirty).await?;
         Ok(checkpoint_id)
     }
 
@@ -767,15 +767,16 @@ mod tests {
         checkpoint_id: Uuid,
         stored_manifest: &mut StoredManifest,
     ) -> Result<(), SlateDBError> {
-        let mut updated_state = stored_manifest.db_state().clone();
-        let updated_checkpoints = updated_state
+        let mut dirty = stored_manifest.prepare_dirty();
+        let updated_checkpoints = dirty
+            .core
             .checkpoints
             .iter()
             .filter(|checkpoint| checkpoint.id != checkpoint_id)
             .cloned()
             .collect();
-        updated_state.checkpoints = updated_checkpoints;
-        stored_manifest.update_db_state(updated_state).await?;
+        dirty.core.checkpoints = updated_checkpoints;
+        stored_manifest.update_manifest(dirty).await?;
         Ok(())
     }
 
@@ -899,15 +900,14 @@ mod tests {
         let (manifest_store, table_store, local_object_store) = build_objects();
 
         // Create a manifest
-        let state = CoreDbState::new();
         let mut stored_manifest =
-            StoredManifest::create_new_db(manifest_store.clone(), state.clone())
+            StoredManifest::create_new_db(manifest_store.clone(), CoreDbState::new())
                 .await
                 .unwrap();
 
         // Add a second manifest
         stored_manifest
-            .update_db_state(state.clone())
+            .update_manifest(stored_manifest.prepare_dirty())
             .await
             .unwrap();
 
@@ -1025,14 +1025,11 @@ mod tests {
         assert_eq!(1, stored_manifest.id());
 
         // Manifest 2 with checkpoint referencing Manifest 1
-        let mut updated_state = state.clone();
-        updated_state.last_compacted_wal_sst_id = 3;
-        updated_state.next_wal_sst_id = 4;
-        updated_state.checkpoints.push(new_checkpoint(1, None));
-        stored_manifest
-            .update_db_state(updated_state)
-            .await
-            .unwrap();
+        let mut dirty = stored_manifest.prepare_dirty();
+        dirty.core.last_compacted_wal_sst_id = 3;
+        dirty.core.next_wal_sst_id = 4;
+        dirty.core.checkpoints.push(new_checkpoint(1, None));
+        stored_manifest.update_manifest(dirty).await.unwrap();
         assert_eq!(2, stored_manifest.id());
 
         // All tables are eligible for deletion
@@ -1288,10 +1285,10 @@ mod tests {
             .unwrap();
 
         // Now drop the active tables from the checkpoint
-        let mut state = stored_manifest.db_state().clone();
-        state.l0.truncate(1);
-        state.compacted.truncate(1);
-        stored_manifest.update_db_state(state).await.unwrap();
+        let mut dirty = stored_manifest.prepare_dirty();
+        dirty.core.l0.truncate(1);
+        dirty.core.compacted.truncate(1);
+        stored_manifest.update_manifest(dirty).await.unwrap();
 
         // Start the garbage collector
         run_gc_once(manifest_store.clone(), table_store.clone()).await;

--- a/src/manifest/store.rs
+++ b/src/manifest/store.rs
@@ -10,6 +10,7 @@ use crate::manifest::{Manifest, ManifestCodec, ParentDb};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
+use crate::SlateDBError::ManifestVersionExists;
 use chrono::Utc;
 use futures::StreamExt;
 use object_store::path::Path;
@@ -22,6 +23,51 @@ use std::sync::Arc;
 use std::time::SystemTime;
 use tracing::warn;
 use uuid::Uuid;
+
+/// Represents a local view of the manifest that is in the process of being updated
+#[derive(Clone, Debug)]
+pub(crate) struct DirtyManifest {
+    id: u64,
+    next_id: u64,
+    parent: Option<ParentDb>,
+    pub(crate) core: CoreDbState,
+    writer_epoch: u64,
+    compactor_epoch: u64,
+}
+
+impl From<DirtyManifest> for Manifest {
+    fn from(manifest: DirtyManifest) -> Manifest {
+        Manifest {
+            parent: manifest.parent,
+            core: manifest.core,
+            writer_epoch: manifest.writer_epoch,
+            compactor_epoch: manifest.compactor_epoch,
+        }
+    }
+}
+
+impl DirtyManifest {
+    fn new(id: u64, next_id: u64, manifest: Manifest) -> Self {
+        Self {
+            id,
+            next_id,
+            parent: manifest.parent,
+            core: manifest.core,
+            writer_epoch: manifest.writer_epoch,
+            compactor_epoch: manifest.compactor_epoch,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn next_id(&self) -> u64 {
+        self.next_id
+    }
+}
 
 pub(crate) struct FenceableManifest {
     stored_manifest: StoredManifest,
@@ -56,10 +102,10 @@ impl FenceableManifest {
     async fn init(
         mut stored_manifest: StoredManifest,
         stored_epoch: fn(&Manifest) -> u64,
-        set_epoch: fn(&mut Manifest, u64),
+        set_epoch: fn(&mut DirtyManifest, u64),
     ) -> Result<Self, SlateDBError> {
-        let mut manifest = stored_manifest.manifest.clone();
-        let local_epoch = stored_epoch(&manifest) + 1;
+        let local_epoch = stored_epoch(&stored_manifest.manifest) + 1;
+        let mut manifest = stored_manifest.prepare_dirty();
         set_epoch(&mut manifest, local_epoch);
         stored_manifest.update_manifest(manifest).await?;
         Ok(Self {
@@ -69,22 +115,22 @@ impl FenceableManifest {
         })
     }
 
-    pub(crate) fn db_state(&self) -> Result<&CoreDbState, SlateDBError> {
-        self.check_epoch()?;
-        Ok(self.stored_manifest.db_state())
-    }
-
-    pub(crate) async fn refresh(&mut self) -> Result<&CoreDbState, SlateDBError> {
+    pub(crate) async fn refresh(&mut self) -> Result<(), SlateDBError> {
         self.stored_manifest.refresh().await?;
-        self.db_state()
+        self.check_epoch()
     }
 
-    pub(crate) async fn update_db_state(
+    pub(crate) fn prepare_dirty(&self) -> Result<DirtyManifest, SlateDBError> {
+        self.check_epoch()?;
+        Ok(self.stored_manifest.prepare_dirty())
+    }
+
+    pub(crate) async fn update_manifest(
         &mut self,
-        db_state: CoreDbState,
+        manifest: DirtyManifest,
     ) -> Result<(), SlateDBError> {
         self.check_epoch()?;
-        self.stored_manifest.update_db_state(db_state).await
+        self.stored_manifest.update_manifest(manifest).await
     }
 
     pub(crate) fn new_checkpoint(
@@ -101,29 +147,31 @@ impl FenceableManifest {
         options: &CheckpointOptions,
     ) -> Result<Checkpoint, SlateDBError> {
         let checkpoint_id = checkpoint_id.unwrap_or(Uuid::new_v4());
-        self.maybe_apply_db_state_update(|stored_manifest| {
+        self.maybe_apply_manifest_update(|stored_manifest| {
             stored_manifest
                 .apply_new_checkpoint_to_db_state(checkpoint_id, options)
                 .map(Some)
         })
         .await?;
         let checkpoint = self
-            .db_state()?
+            .stored_manifest
+            .manifest()
+            .core
             .find_checkpoint(&checkpoint_id)
             .expect("update applied but checkpoint not found")
             .clone();
         Ok(checkpoint)
     }
 
-    pub(crate) async fn maybe_apply_db_state_update<F>(
+    pub(crate) async fn maybe_apply_manifest_update<F>(
         &mut self,
         mutator: F,
     ) -> Result<(), SlateDBError>
     where
-        F: Fn(&StoredManifest) -> Result<Option<CoreDbState>, SlateDBError>,
+        F: Fn(&StoredManifest) -> Result<Option<DirtyManifest>, SlateDBError>,
     {
         self.stored_manifest
-            .maybe_apply_db_state_update(|sm| {
+            .maybe_apply_manifest_update(|sm| {
                 Self::check_epoch_against_manifest(
                     self.local_epoch,
                     self.stored_epoch,
@@ -233,17 +281,21 @@ impl StoredManifest {
         &self.manifest
     }
 
+    pub(crate) fn prepare_dirty(&self) -> DirtyManifest {
+        DirtyManifest::new(self.id, self.next_id(), self.manifest.clone())
+    }
+
     pub(crate) fn db_state(&self) -> &CoreDbState {
         &self.manifest.core
     }
 
-    pub(crate) async fn refresh(&mut self) -> Result<&CoreDbState, SlateDBError> {
+    pub(crate) async fn refresh(&mut self) -> Result<&Manifest, SlateDBError> {
         let Some((id, manifest)) = self.manifest_store.try_read_latest_manifest().await? else {
             return Err(InvalidDBState);
         };
         self.manifest = manifest;
         self.id = id;
-        Ok(&self.manifest.core)
+        Ok(&self.manifest)
     }
 
     fn next_id(&self) -> u64 {
@@ -256,11 +308,11 @@ impl StoredManifest {
         &self,
         checkpoint_id: Uuid,
         options: &CheckpointOptions,
-    ) -> Result<CoreDbState, SlateDBError> {
+    ) -> Result<DirtyManifest, SlateDBError> {
         let checkpoint = self.new_checkpoint(checkpoint_id, options)?;
-        let mut updated_db_state = self.db_state().clone();
-        updated_db_state.checkpoints.push(checkpoint);
-        Ok(updated_db_state)
+        let mut dirty = self.prepare_dirty();
+        dirty.core.checkpoints.push(checkpoint);
+        Ok(dirty)
     }
 
     /// Create a new checkpoint from the latest manifest state. This only creates
@@ -301,7 +353,7 @@ impl StoredManifest {
         options: &CheckpointOptions,
     ) -> Result<Checkpoint, SlateDBError> {
         let checkpoint_id = checkpoint_id.unwrap_or(Uuid::new_v4());
-        self.maybe_apply_db_state_update(|stored_manifest| {
+        self.maybe_apply_manifest_update(|stored_manifest| {
             stored_manifest
                 .apply_new_checkpoint_to_db_state(checkpoint_id, options)
                 .map(Some)
@@ -335,23 +387,21 @@ impl StoredManifest {
         }
 
         let manifest = Manifest::cloned(parent_db, parent_manifest);
-        self.update_manifest(manifest).await
+        let dirty = DirtyManifest::new(self.id, self.next_id(), manifest);
+        self.update_manifest(dirty).await
     }
 
-    pub(crate) async fn update_db_state(&mut self, core: CoreDbState) -> Result<(), SlateDBError> {
-        let manifest = Manifest {
-            parent: self.manifest.parent.clone(),
-            core,
-            writer_epoch: self.manifest.writer_epoch,
-            compactor_epoch: self.manifest.compactor_epoch,
-        };
-        self.update_manifest(manifest).await
-    }
-
-    async fn update_manifest(&mut self, manifest: Manifest) -> Result<(), SlateDBError> {
-        let new_id = self.id + 1;
+    pub(crate) async fn update_manifest(
+        &mut self,
+        manifest: DirtyManifest,
+    ) -> Result<(), SlateDBError> {
+        let new_id = self.next_id();
+        if manifest.next_id() != new_id {
+            return Err(ManifestVersionExists);
+        }
+        let manifest = manifest.into();
         self.manifest_store
-            .write_manifest(new_id, &manifest)
+            .write_manifest(self.next_id(), &manifest)
             .await?;
         self.manifest = manifest;
         self.id = new_id;
@@ -364,19 +414,19 @@ impl StoredManifest {
     /// the mutator parameter, which is a function that takes a &StoredManifest and returns
     /// an optional [`CoreDbState`]. If the mutator returns `None`, then no update will
     /// be applied.
-    pub(crate) async fn maybe_apply_db_state_update<F>(
+    pub(crate) async fn maybe_apply_manifest_update<F>(
         &mut self,
         mutator: F,
     ) -> Result<(), SlateDBError>
     where
-        F: Fn(&StoredManifest) -> Result<Option<CoreDbState>, SlateDBError>,
+        F: Fn(&StoredManifest) -> Result<Option<DirtyManifest>, SlateDBError>,
     {
         loop {
-            let Some(mutated_db_state) = mutator(self)? else {
+            let Some(dirty) = mutator(self)? else {
                 return Ok(());
             };
 
-            return match self.update_db_state(mutated_db_state).await {
+            return match self.update_manifest(dirty).await {
                 Err(SlateDBError::ManifestVersionExists) => {
                     self.refresh().await?;
                     continue;
@@ -581,6 +631,17 @@ impl ManifestStore {
 }
 
 #[cfg(test)]
+pub(crate) mod test_utils {
+    use crate::db_state::CoreDbState;
+    use crate::manifest::store::DirtyManifest;
+    use crate::manifest::Manifest;
+
+    pub(crate) fn new_dirty_manifest() -> DirtyManifest {
+        DirtyManifest::new(1u64, 2u64, Manifest::initial(CoreDbState::new()))
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::config::CheckpointOptions;
@@ -608,9 +669,9 @@ mod tests {
             .await
             .unwrap();
         let mut sm2 = StoredManifest::load(ms.clone()).await.unwrap();
-        sm.update_db_state(state.clone()).await.unwrap();
+        sm.update_manifest(sm.prepare_dirty()).await.unwrap();
 
-        let result = sm2.update_db_state(state.clone()).await;
+        let result = sm2.update_manifest(sm2.prepare_dirty()).await;
 
         assert!(matches!(
             result.unwrap_err(),
@@ -625,7 +686,7 @@ mod tests {
         let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
             .unwrap();
-        sm.update_db_state(state.clone()).await.unwrap();
+        sm.update_manifest(sm.prepare_dirty()).await.unwrap();
 
         let (version, _) = ms.read_latest_manifest().await.unwrap();
 
@@ -635,12 +696,12 @@ mod tests {
     #[tokio::test]
     async fn test_should_update_local_state_on_write() {
         let ms = new_memory_manifest_store();
-        let mut state = CoreDbState::new();
-        let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
+        let mut sm = StoredManifest::create_new_db(ms.clone(), CoreDbState::new())
             .await
             .unwrap();
-        state.next_wal_sst_id = 123;
-        sm.update_db_state(state.clone()).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.next_wal_sst_id = 123;
+        sm.update_manifest(dirty).await.unwrap();
 
         assert_eq!(sm.db_state().next_wal_sst_id, 123);
     }
@@ -648,17 +709,17 @@ mod tests {
     #[tokio::test]
     async fn test_should_refresh() {
         let ms = new_memory_manifest_store();
-        let mut state = CoreDbState::new();
-        let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
+        let mut sm = StoredManifest::create_new_db(ms.clone(), CoreDbState::new())
             .await
             .unwrap();
         let mut sm2 = StoredManifest::load(ms.clone()).await.unwrap();
-        state.next_wal_sst_id = 123;
-        sm.update_db_state(state.clone()).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.next_wal_sst_id = 123;
+        sm.update_manifest(dirty).await.unwrap();
 
         let refreshed = sm2.refresh().await.unwrap();
 
-        assert_eq!(refreshed.next_wal_sst_id, 123);
+        assert_eq!(refreshed.core.next_wal_sst_id, 123);
         assert_eq!(sm2.db_state().next_wal_sst_id, 123);
     }
 
@@ -678,24 +739,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_should_fail_on_writer_fenced() {
+    async fn test_should_fail_refresh_on_writer_fenced() {
         let ms = new_memory_manifest_store();
-        let mut state = CoreDbState::new();
+        let state = CoreDbState::new();
         let sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
             .unwrap();
         let mut writer1 = FenceableManifest::init_writer(sm).await.unwrap();
         let sm2 = StoredManifest::load(ms.clone()).await.unwrap();
 
-        let mut writer2 = FenceableManifest::init_writer(sm2).await.unwrap();
+        FenceableManifest::init_writer(sm2).await.unwrap();
 
         let result = writer1.refresh().await;
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
-        state.next_wal_sst_id = 123;
-        let result = writer1.update_db_state(state.clone()).await;
-        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
-        let refreshed = writer2.refresh().await.unwrap();
-        assert_eq!(refreshed.next_wal_sst_id, 1);
     }
 
     #[tokio::test]
@@ -714,24 +770,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_should_fail_on_compactor_fenced() {
+    async fn test_should_fail_refresh_on_compactor_fenced() {
         let ms = new_memory_manifest_store();
-        let mut state = CoreDbState::new();
+        let state = CoreDbState::new();
         let sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
             .unwrap();
         let mut compactor1 = FenceableManifest::init_compactor(sm).await.unwrap();
         let sm2 = StoredManifest::load(ms.clone()).await.unwrap();
 
-        let mut compactor2 = FenceableManifest::init_compactor(sm2).await.unwrap();
+        FenceableManifest::init_compactor(sm2).await.unwrap();
 
         let result = compactor1.refresh().await;
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
-        state.next_wal_sst_id = 123;
-        let result = compactor1.update_db_state(state.clone()).await;
-        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
-        let refreshed = compactor2.refresh().await.unwrap();
-        assert_eq!(refreshed.next_wal_sst_id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_should_fail_manifest_write_of_stale_dirty_manifest() {
+        let ms = new_memory_manifest_store();
+        let state = CoreDbState::new();
+        let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
+            .await
+            .unwrap();
+        let stale = sm.prepare_dirty();
+        sm.update_manifest(sm.prepare_dirty()).await.unwrap();
+
+        let result = sm.update_manifest(stale).await;
+
+        assert!(matches!(result, Err(SlateDBError::ManifestVersionExists)));
     }
 
     #[tokio::test]
@@ -763,10 +829,10 @@ mod tests {
         let mut fm2 = FenceableManifest::init_writer(sm2).await.unwrap();
 
         let result = fm1
-            .maybe_apply_db_state_update(|sm| {
-                let mut dbstate = sm.manifest.core.clone();
-                dbstate.last_l0_seq += 1;
-                Ok(Some(dbstate))
+            .maybe_apply_manifest_update(|sm| {
+                let mut dirty = sm.prepare_dirty();
+                dirty.core.last_l0_seq += 1;
+                Ok(Some(dirty))
             })
             .await;
 
@@ -775,9 +841,9 @@ mod tests {
     }
 
     async fn assert_state_not_updated(fm: &mut FenceableManifest) {
-        let original_db_state = fm.db_state().unwrap().clone();
+        let original_db_state = fm.stored_manifest.manifest().core.clone();
         fm.refresh().await.unwrap();
-        let refreshed_db_state = fm.db_state().unwrap().clone();
+        let refreshed_db_state = fm.stored_manifest.manifest().core.clone();
         assert_eq!(refreshed_db_state, original_db_state);
     }
 
@@ -791,9 +857,9 @@ mod tests {
             .await
             .unwrap();
 
-        let mut updated_state = state.clone();
-        updated_state.checkpoints.push(new_checkpoint(sm.id));
-        sm.update_db_state(updated_state).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.checkpoints.push(new_checkpoint(sm.id));
+        sm.update_manifest(dirty).await.unwrap();
 
         // When
         let manifest = ms.try_read_manifest(2).await.unwrap().unwrap();
@@ -809,7 +875,7 @@ mod tests {
         let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
             .unwrap();
-        sm.update_db_state(state.clone()).await.unwrap();
+        sm.update_manifest(sm.prepare_dirty()).await.unwrap();
 
         // Check unbounded
         let manifests = ms.list_manifests(..).await.unwrap();
@@ -840,7 +906,7 @@ mod tests {
         let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
             .unwrap();
-        sm.update_db_state(state.clone()).await.unwrap();
+        sm.update_manifest(sm.prepare_dirty()).await.unwrap();
         let manifests = ms.list_manifests(..).await.unwrap();
         assert_eq!(manifests.len(), 2);
         assert_eq!(manifests[0].id, 1);
@@ -859,7 +925,7 @@ mod tests {
         let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
             .unwrap();
-        sm.update_db_state(state.clone()).await.unwrap();
+        sm.update_manifest(sm.prepare_dirty()).await.unwrap();
         let manifests = ms.list_manifests(..).await.unwrap();
         assert_eq!(manifests.len(), 2);
         assert_eq!(manifests[0].id, 1);
@@ -909,9 +975,9 @@ mod tests {
         );
 
         // Add a checkpoint referencing the latest manifest
-        let mut updated_state = state.clone();
-        updated_state.checkpoints.push(new_checkpoint(sm.id));
-        sm.update_db_state(updated_state).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.checkpoints.push(new_checkpoint(sm.id));
+        sm.update_manifest(dirty).await.unwrap();
         let active_manifests = ms.read_active_manifests().await.unwrap();
         assert_eq!(2, active_manifests.len());
         assert_eq!(
@@ -921,9 +987,9 @@ mod tests {
         assert_eq!(Some(&sm.manifest), active_manifests.get(&sm.id));
 
         // Remove the checkpoint and verify that only the latest manifest is active
-        let mut updated_state = state.clone();
-        updated_state.checkpoints.clear();
-        sm.update_db_state(updated_state).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.checkpoints.clear();
+        sm.update_manifest(dirty).await.unwrap();
         let active_manifests = ms.read_active_manifests().await.unwrap();
         assert_eq!(1, active_manifests.len());
         assert_eq!(Some(&sm.manifest), active_manifests.get(&sm.id));
@@ -938,10 +1004,10 @@ mod tests {
             .unwrap();
 
         let initial_id = sm.id;
-        sm.maybe_apply_db_state_update(|_| Ok(None)).await.unwrap();
+        sm.maybe_apply_manifest_update(|_| Ok(None)).await.unwrap();
         assert_eq!(initial_id, sm.id);
 
-        sm.maybe_apply_db_state_update(|sm| Ok(Some(sm.db_state().clone())))
+        sm.maybe_apply_manifest_update(|sm| Ok(Some(sm.prepare_dirty())))
             .await
             .unwrap();
         assert_eq!(initial_id + 1, sm.id);
@@ -1031,9 +1097,9 @@ mod tests {
         let parent_path = "/parent/path";
         let mut sm = create_uninitialized_clone(parent_path).await;
 
-        let mut initialized_core = sm.db_state().clone();
-        initialized_core.initialized = true;
-        sm.update_db_state(initialized_core).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.initialized = true;
+        sm.update_manifest(dirty).await.unwrap();
 
         let parent_manifest = Manifest::initial(CoreDbState::new());
         let parent_db = ParentDb {
@@ -1053,9 +1119,9 @@ mod tests {
         let initial_parent_path = "/initial/parent/path";
         let mut sm = create_uninitialized_clone(initial_parent_path).await;
 
-        let mut initialized_core = sm.db_state().clone();
-        initialized_core.initialized = true;
-        sm.update_db_state(initialized_core).await.unwrap();
+        let mut dirty = sm.prepare_dirty();
+        dirty.core.initialized = true;
+        sm.update_manifest(dirty).await.unwrap();
 
         let updated_parent_path = "/updated/parent/path";
         let parent_manifest = Manifest::initial(CoreDbState::new());

--- a/src/manifest/store.rs
+++ b/src/manifest/store.rs
@@ -395,16 +395,16 @@ impl StoredManifest {
         &mut self,
         manifest: DirtyManifest,
     ) -> Result<(), SlateDBError> {
-        let new_id = self.next_id();
-        if manifest.next_id() != new_id {
+        let next_id = self.next_id();
+        if manifest.next_id() != next_id {
             return Err(ManifestVersionExists);
         }
         let manifest = manifest.into();
         self.manifest_store
-            .write_manifest(self.next_id(), &manifest)
+            .write_manifest(next_id, &manifest)
             .await?;
         self.manifest = manifest;
-        self.id = new_id;
+        self.id = next_id;
         Ok(())
     }
 

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -33,9 +33,9 @@ pub(crate) struct MemtableFlusher {
 
 impl MemtableFlusher {
     pub(crate) async fn load_manifest(&mut self) -> Result<(), SlateDBError> {
-        let core_state = self.manifest.refresh().await?;
+        self.manifest.refresh().await?;
         let mut wguard_state = self.db_inner.state.write();
-        wguard_state.merge_db_state(core_state);
+        wguard_state.merge_remote_manifest(self.manifest.prepare_dirty()?);
         Ok(())
     }
 
@@ -43,24 +43,24 @@ impl MemtableFlusher {
         &mut self,
         options: &CheckpointOptions,
     ) -> Result<CheckpointCreateResult, SlateDBError> {
-        let mut core = {
+        let mut dirty = {
             let rguard_state = self.db_inner.state.read();
-            rguard_state.state().core.clone()
+            rguard_state.state().manifest.clone()
         };
         let id = Uuid::new_v4();
         let checkpoint = self.manifest.new_checkpoint(id, options)?;
         let manifest_id = checkpoint.manifest_id;
-        core.checkpoints.push(checkpoint);
-        self.manifest.update_db_state(core).await?;
+        dirty.core.checkpoints.push(checkpoint);
+        self.manifest.update_manifest(dirty).await?;
         Ok(CheckpointCreateResult { id, manifest_id })
     }
 
     async fn write_manifest(&mut self) -> Result<(), SlateDBError> {
-        let core = {
+        let dirty = {
             let rguard_state = self.db_inner.state.read();
-            rguard_state.state().core.clone()
+            rguard_state.state().manifest.clone()
         };
-        self.manifest.update_db_state(core).await
+        self.manifest.update_manifest(dirty).await
     }
 
     pub(crate) async fn write_checkpoint_safely(
@@ -80,10 +80,10 @@ impl MemtableFlusher {
 
     pub(crate) async fn write_manifest_safely(&mut self) -> Result<(), SlateDBError> {
         loop {
-            self.load_manifest().await?;
             let result = self.write_manifest().await;
             if matches!(result, Err(SlateDBError::ManifestVersionExists)) {
                 error!("conflicting manifest version. retry write");
+                self.load_manifest().await?;
             } else {
                 return result;
             }
@@ -93,13 +93,13 @@ impl MemtableFlusher {
     async fn flush_imm_memtables_to_l0(&mut self) -> Result<(), SlateDBError> {
         while let Some(imm_memtable) = {
             let rguard = self.db_inner.state.read();
-            if rguard.state().core.l0.len() >= self.db_inner.options.l0_max_ssts {
+            if rguard.state().core().l0.len() >= self.db_inner.options.l0_max_ssts {
                 warn!(
                     "too many l0 files {} >= {}. Won't flush imm to l0",
-                    rguard.state().core.l0.len(),
+                    rguard.state().core().l0.len(),
                     self.db_inner.options.l0_max_ssts
                 );
-                rguard.state().core.log_db_runs();
+                rguard.state().core().log_db_runs();
                 None
             } else {
                 rguard.state().imm_memtable.back().cloned()

--- a/src/size_tiered_compaction.rs
+++ b/src/size_tiered_compaction.rs
@@ -337,6 +337,7 @@ mod tests {
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
     use crate::config::SizeTieredCompactionSchedulerOptions;
     use crate::db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
 
     #[test]
@@ -666,7 +667,9 @@ mod tests {
     }
 
     fn create_compactor_state(db_state: CoreDbState) -> CompactorState {
-        CompactorState::new(db_state)
+        let mut dirty = new_dirty_manifest();
+        dirty.core = db_state;
+        CompactorState::new(dirty)
     }
 
     fn create_l0_compaction(l0: &[SsTableHandle], dst: u32) -> Compaction {


### PR DESCRIPTION
This patch refactors the manifest store by changing the way that manifests are updated. To update a manifest you now call prepare_dirty, which returns an instance of DirtyManifest. DirtyManifest contains the manifest contents, along with its id, and the id that it will be written with (next_id). You then make changes to the dirty manifest, and pass it to update_manifest. update_manifest verifies that next_id matches the expected next id before writing out the dirty manifest.

DbState/CompactorState now work by storing a DirtyManifest with the local changes, rather than just CoreDbState, and the db/compactor use this dirty manifest when updating the manifest.

This change confers two benefits:

Firstly, and the primary goal of this patch, it makes manifest updates safer by reducing the likelihood of accidentally writing a stale manifest version. Previously, the following sequence was possible:
1. Writer/Compactor merges the current manifest into its local state (DbState /CompactorState)
2. Writer/Compactor updates the manifest without going through the local state. For example, maybe it creates a checkpoint directly in its FenceableManifest.
3. Writer/Compactor writes the manifest from local state to FenceableManifest. The write will go through because FeneableManifest is fully up-to-date, though the local state is not. After this patch, if the local state's dirty manifest is not fully up-to-date with FenceableManifest/StoredManifest, then the update will fail.

Secondly, DirtyManifest has information about the id and next id. This means we can do checkpoint management from outside StoredManifest/FenceableManifest, which feels out of place currently. This change is not implemented in this patch however