### PR TITLE
Make flush_interval optional (#505)

### DIFF
--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -377,7 +377,7 @@ mod tests {
     #[tokio::test]
     async fn test_checkpoint_scope_with_force_flush() {
         let db_options = DbOptions {
-            flush_interval: Duration::from_millis(5000),
+            flush_interval: Some(Duration::from_millis(5000)),
             ..DbOptions::default()
         };
         test_checkpoint_scope_all(db_options, true, |manifest| {
@@ -389,7 +389,7 @@ mod tests {
     #[tokio::test]
     async fn test_checkpoint_scope_with_no_force_flush() {
         let db_options = DbOptions {
-            flush_interval: Duration::from_millis(10),
+            flush_interval: Some(Duration::from_millis(10)),
             ..DbOptions::default()
         };
         test_checkpoint_scope_all(db_options, false, |manifest| {

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -402,7 +402,7 @@ mod tests {
     #[cfg(feature = "wal_disable")]
     async fn test_checkpoint_scope_with_force_flush_wal_disabled() {
         let db_options = DbOptions {
-            flush_interval: Duration::from_millis(5000),
+            flush_interval: Some(Duration::from_millis(5000)),
             wal_enabled: false,
             ..DbOptions::default()
         };
@@ -416,7 +416,7 @@ mod tests {
     #[cfg(feature = "wal_disable")]
     async fn test_checkpoint_scope_with_no_force_flush_wal_disabled() {
         let db_options = DbOptions {
-            flush_interval: Duration::from_millis(10),
+            flush_interval: Some(Duration::from_millis(10)),
             wal_enabled: false,
             ..DbOptions::default()
         };

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -951,7 +951,7 @@ mod tests {
 
     fn db_options(compactor_options: Option<CompactorOptions>, clock: Arc<TestClock>) -> DbOptions {
         DbOptions {
-            flush_interval: Duration::from_millis(100),
+            flush_interval: Some(Duration::from_millis(100)),
             #[cfg(feature = "wal_disable")]
             wal_enabled: true,
             manifest_poll_interval: Duration::from_millis(100),

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,7 +375,7 @@ pub struct DbOptions {
     /// Keep in mind that the flush interval does not include the network latency. A
     /// 100ms flush interval will result in a 100ms + the time it takes to send the
     /// bytes to object storage.
-    /// 
+    ///
     /// If this value is None, automatic flushing will be disabled. The application
     /// can flush by calling `Db::flush()` manually, and by closing the database.
     #[serde(deserialize_with = "deserialize_option_duration")]

--- a/src/db.rs
+++ b/src/db.rs
@@ -3276,7 +3276,7 @@ mod tests {
 
         let db_options = DbOptions {
             wal_enabled: false,
-            flush_interval: Duration::from_secs(10),
+            flush_interval: Some(Duration::from_secs(10)),
             ..DbOptions::default()
         };
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1957,7 +1957,7 @@ mod tests {
 
         let runtime = Runtime::new().unwrap();
         let mut db_options = test_db_options(0, 1024, None);
-        db_options.flush_interval = Duration::from_secs(5);
+        db_options.flush_interval = Some(Duration::from_secs(5));
         let db = runtime.block_on(build_database_from_table(&table, db_options, false));
 
         runner
@@ -3485,7 +3485,7 @@ mod tests {
         ttl: Option<u64>,
     ) -> DbOptions {
         DbOptions {
-            flush_interval: Duration::from_millis(100),
+            flush_interval: Some(Duration::from_millis(100)),
             #[cfg(feature = "wal_disable")]
             wal_enabled: true,
             manifest_poll_interval: Duration::from_millis(100),

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -100,7 +100,7 @@ impl DbInner {
         ) -> Result<(), SlateDBError> {
             let Some(period) = this.options.flush_interval else {
                 // If flush_interval is not set, we do not start the flush task.
-                return Ok(())
+                return Ok(());
             };
 
             let mut ticker = tokio::time::interval(period);

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -98,7 +98,12 @@ impl DbInner {
             this: &Arc<DbInner>,
             rx: &mut UnboundedReceiver<WalFlushMsg>,
         ) -> Result<(), SlateDBError> {
-            let mut ticker = tokio::time::interval(this.options.flush_interval);
+            let Some(period) = this.options.flush_interval else {
+                // If flush_interval is not set, we do not start the flush task.
+                return Ok(())
+            };
+
+            let mut ticker = tokio::time::interval(period);
             let mut err_reader = this.state.read().error_reader();
             loop {
                 select! {


### PR DESCRIPTION
This makes the flush loop optional. I haven't added any new tests, but I have confirmed that existing tests pass.