### PR TITLE
Introduce SsTableHande::compacted_first_key to simplify handling of e…

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -256,6 +256,8 @@ impl DbInner {
         DbIterator::new(range.clone(), mem_iter, l0_iters, sr_iters).await
     }
 
+    /// Fences all writers with an older epoch than the provided `manifest` by flushing an empty WAL file that acts
+    /// as a barrier. Any parallel old writers will fail with `SlateDBError::Fenced` when trying to "re-write" this file.
     async fn fence_writers(
         &self,
         manifest: &mut FenceableManifest,

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -35,28 +35,36 @@ impl SsTableHandle {
         SsTableHandle { id, info }
     }
 
+    // Compacted (non-WAL) SSTs are never empty. They are created by compaction or
+    // memtable flushes, which should never produce empty SSTs.
+    pub(crate) fn compacted_first_key(&self) -> &Bytes {
+        assert!(matches!(self.id, Compacted(_)));
+        match &self.info.first_key {
+            Some(k) => k,
+            None => unreachable!("Compacted SSTs must be non-empty."),
+        }
+    }
+
     pub(crate) fn range_covers_key(&self, key: &[u8]) -> bool {
         if let Some(first_key) = self.info.first_key.as_ref() {
             return key >= first_key;
         }
+        // If there is no first key, it means the SST is empty so it doesn't cover the key.
         false
     }
 
     pub(crate) fn intersects_range(
         &self,
-        end_bound_key: Option<Bytes>,
+        end_bound: Bound<&[u8]>,
         range: (Bound<&[u8]>, Bound<&[u8]>),
     ) -> bool {
         let start_bound = match &self.info.first_key {
-            None => Unbounded,
             Some(key) => Included(key.as_ref()),
+            None => {
+                // If there is no first key, it means the SST is empty so there is no intersection.
+                return false;
+            }
         };
-
-        let end_bound = match &end_bound_key {
-            None => Unbounded,
-            Some(key) => Excluded(key.as_ref()),
-        };
-
         bytes_range::has_nonempty_intersection(range, (start_bound, end_bound))
     }
 
@@ -139,13 +147,9 @@ impl SortedRun {
 
     pub(crate) fn find_sst_with_range_covering_key_idx(&self, key: &[u8]) -> Option<usize> {
         // returns the sst after the one whose range includes the key
-        let first_sst = self.ssts.partition_point(|sst| {
-            sst.info
-                .first_key
-                .as_ref()
-                .expect("sst must have first key")
-                <= key
-        });
+        let first_sst = self
+            .ssts
+            .partition_point(|sst| sst.compacted_first_key() <= key);
         if first_sst > 0 {
             return Some(first_sst - 1);
         }
@@ -167,9 +171,9 @@ impl SortedRun {
 
             let upper_bound_key = if idx + 1 < self.ssts.len() {
                 let next_sst = &self.ssts[idx + 1];
-                next_sst.info.first_key.clone()
+                Excluded(next_sst.compacted_first_key().as_ref())
             } else {
-                None
+                Unbounded
             };
 
             if current_sst.intersects_range(upper_bound_key, range) {
@@ -582,7 +586,7 @@ mod tests {
                 assert!(range_end_key <= first_key);
             } else {
                 let covering_first_key = covering_tables.front()
-                .and_then(|t| t.info.first_key.clone())
+                .map(|t| t.compacted_first_key().clone())
                 .unwrap();
 
                 if range_start_key < covering_first_key {
@@ -590,7 +594,7 @@ mod tests {
                 }
 
                 let covering_last_key = covering_tables.iter().last()
-                .and_then(|t| t.info.first_key.clone())
+                .map(|t| t.compacted_first_key().clone())
                 .unwrap();
                 if covering_last_key == range_end_key {
                     assert_eq!(Included(range_end_key), range.end_bound().cloned());

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -133,10 +133,10 @@ impl KeyValueIterator for SortedRunIterator<'_> {
 impl SeekToKey for SortedRunIterator<'_> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         while let Some(next_table) = self.view.peek_next_table() {
-            let next_table_first_key = next_table.info.first_key.as_ref();
-            match next_table_first_key {
-                Some(key) if key < next_key => self.advance_table().await?,
-                _ => break,
+            if next_table.compacted_first_key() < next_key {
+                self.advance_table().await?;
+            } else {
+                break;
             }
         }
         if let Some(iter) = &mut self.current_iter {


### PR DESCRIPTION
…mpty first_keys.

This is something that makes code unnecessarily complex during prototyping of "projections". The only reason we allow for empty SSTs is WAL fencing.