### PR TITLE
Add version bytes for SST and manifest byte formats

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -112,6 +112,12 @@ pub enum SlateDBError {
 
     #[error("Database already exists: {msg}")]
     DatabaseAlreadyExists { msg: String },
+
+    #[error("Byte format version mismatch")]
+    InvalidVersion {
+        expected_version: u16,
+        actual_version: u16,
+    },
 }
 
 impl From<std::io::Error> for SlateDBError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,7 +113,7 @@ pub enum SlateDBError {
     #[error("Database already exists: {msg}")]
     DatabaseAlreadyExists { msg: String },
 
-    #[error("Byte format version mismatch")]
+    #[error("Byte format version mismatch: expected {expected_version}, actual {actual_version}")]
     InvalidVersion {
         expected_version: u16,
         actual_version: u16,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum SlateDBError {
     #[error("Empty block")]
     EmptyBlock,
 
+    #[error("Empty manifest")]
+    EmptyManifest,
+
     #[error("Object store error: {0}")]
     ObjectStoreError(#[from] Arc<object_store::Error>),
 

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -108,6 +108,9 @@ impl ManifestCodec for FlatBufferManifestCodec {
     }
 
     fn decode(&self, bytes: &Bytes) -> Result<Manifest, SlateDBError> {
+        if bytes.len() < 2 {
+            return Err(SlateDBError::EmptyManifest);
+        }
         let version = u16::from_be_bytes([bytes[0], bytes[1]]);
         if version != MANIFEST_FORMAT_VERSION {
             return Err(SlateDBError::InvalidVersion {

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use bytes::Bytes;
+use bytes::{BufMut, Bytes, BytesMut};
 use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, InvalidFlatbuffer, Vector, WIPOffset};
 use ulid::Ulid;
 
@@ -29,6 +29,8 @@ use crate::flatbuffer_types::manifest_generated::{
 };
 use crate::manifest::{ExternalDb, Manifest, ManifestCodec};
 use crate::utils::clamp_allocated_size_bytes;
+
+pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 1;
 
 /// A wrapper around a `Bytes` buffer containing a FlatBuffer-encoded `SsTableIndex`.
 pub(crate) struct SsTableIndexOwned {
@@ -106,7 +108,15 @@ impl ManifestCodec for FlatBufferManifestCodec {
     }
 
     fn decode(&self, bytes: &Bytes) -> Result<Manifest, SlateDBError> {
-        let manifest = flatbuffers::root::<ManifestV1>(bytes)?;
+        let version = u16::from_be_bytes([bytes[0], bytes[1]]);
+        if version != MANIFEST_FORMAT_VERSION {
+            return Err(SlateDBError::InvalidVersion {
+                expected_version: MANIFEST_FORMAT_VERSION,
+                actual_version: version,
+            });
+        }
+        let unversioned_bytes = bytes.slice(2..);
+        let manifest = flatbuffers::root::<ManifestV1>(unversioned_bytes.as_ref())?;
         Ok(Self::manifest(&manifest))
     }
 }
@@ -405,7 +415,10 @@ impl<'b> DbFlatBufferBuilder<'b> {
             },
         );
         self.builder.finish(manifest, None);
-        Bytes::copy_from_slice(self.builder.finished_data())
+        let mut bytes = BytesMut::new();
+        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_slice(self.builder.finished_data());
+        bytes.into()
     }
 
     fn create_sst_info(&mut self, info: &SsTableInfo) -> Bytes {
@@ -461,17 +474,20 @@ pub(crate) mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use crate::checkpoint;
     use crate::db_state::{CoreDbState, SsTableId};
     use crate::flatbuffer_types::{FlatBufferManifestCodec, SsTableIndexOwned};
     use crate::manifest::{ExternalDb, Manifest, ManifestCodec};
+    use crate::{checkpoint, SlateDBError};
     use std::time::{Duration, SystemTime};
 
     use crate::flatbuffer_types::test_utils::assert_index_clamped;
     use crate::sst::SsTableFormat;
     use crate::test_utils::build_test_sst;
+    use bytes::{BufMut, BytesMut};
     use ulid::Ulid;
     use uuid::Uuid;
+
+    use super::MANIFEST_FORMAT_VERSION;
 
     #[test]
     fn test_should_encode_decode_manifest_checkpoints() {
@@ -545,5 +561,42 @@ mod tests {
         let clamped = index.clamp_allocated_size();
 
         assert_index_clamped(&clamped, &index);
+    }
+
+    #[test]
+    fn test_should_validate_manifest_version() {
+        let codec = FlatBufferManifestCodec {};
+
+        // Create a valid manifest with current version
+        let mut bytes = BytesMut::with_capacity(4);
+        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_slice(&[0, 0]); // Minimal valid flatbuffer data
+        let valid_bytes = bytes.freeze();
+
+        // Test valid version
+        match codec.decode(&valid_bytes) {
+            Err(SlateDBError::InvalidVersion { .. }) => {
+                panic!("Expected current version in manifest")
+            }
+            Err(_) => { /* Expected error due to invalid flatbuffer data */ }
+            Ok(_) => panic!("Should fail due to invalid flatbuffer data"),
+        }
+
+        // Test invalid version
+        let mut bytes = BytesMut::with_capacity(4);
+        bytes.put_u16(MANIFEST_FORMAT_VERSION + 1);
+        bytes.put_slice(&[0, 0]); // Minimal valid flatbuffer data
+        let invalid_bytes = bytes.freeze();
+
+        match codec.decode(&invalid_bytes) {
+            Err(SlateDBError::InvalidVersion {
+                expected_version,
+                actual_version,
+            }) => {
+                assert_eq!(expected_version, MANIFEST_FORMAT_VERSION);
+                assert_eq!(actual_version, MANIFEST_FORMAT_VERSION + 1);
+            }
+            _ => panic!("Should fail with version mismatch"),
+        }
     }
 }


### PR DESCRIPTION
This PR adds very rudimentary version number handling for SSTs and manifests. My main goal is simply to get the version bytes in the right spot, so we can implement proper version handling going forward. The most important part of this PR are the byte sizes and locations in the byte formats.

Changes:

- Adds a u16 to the _end_ of an SST's on-disk byte format
- Adds a u16 to the _beginning_ of a manifest's on-disk byte format
- Adds version validation logic in `FlatBufferManifestCodec::decode`
- Adds version validation logic in `SsTableFormat::read_info`
- Adds an `InvalidVersion` error
- Adds tests for validation logic

A couple of notes/oddities:

- I opted to put the encode/decode logic inside the manifest's flat buffer codec because we don't currently have an intermediate builder for it the way that we do for SSTs (using `EncodedSsTableBuilder`).
- On the SST side, I opted to validate the version in `read_info` since you can't do anything without reading the SST info for an SST first.
- The SST bytes are at the end while they're at the beginning for the Manifest. This felt most intuitive to me, but if everyone is grossed out by it, I can put the version bytes at the heat of the SST or tail of the manifest.
- The current decoders simply validate the versions are identical. We only have a single version right now, so this is fine. The work to support cross-version decoding is left for a later PR.

The changes are a first step toward #446.