### PR TITLE
Pass checkpoint id by value in find_checkpoint

### DIFF
--- a/src/clone.rs
+++ b/src/clone.rs
@@ -130,7 +130,7 @@ async fn create_clone_manifest(
 
         if external_db_manifest
             .db_state()
-            .find_checkpoint(&final_checkpoint_id)
+            .find_checkpoint(final_checkpoint_id)
             .is_none()
         {
             external_db_manifest
@@ -159,7 +159,7 @@ async fn get_or_create_parent_checkpoint(
     maybe_checkpoint_id: Option<Uuid>,
 ) -> Result<Checkpoint, SlateDBError> {
     let checkpoint = match maybe_checkpoint_id {
-        Some(checkpoint_id) => match manifest.db_state().find_checkpoint(&checkpoint_id) {
+        Some(checkpoint_id) => match manifest.db_state().find_checkpoint(checkpoint_id) {
             Some(found_checkpoint) => found_checkpoint.clone(),
             None => return Err(CheckpointMissing(checkpoint_id)),
         },
@@ -230,7 +230,7 @@ async fn validate_external_dbs_contain_final_checkpoint(
         let external_manifest = external_manifest_store.read_latest_manifest().await?.1;
         if external_manifest
             .core
-            .find_checkpoint(&final_checkpoint_id)
+            .find_checkpoint(final_checkpoint_id)
             .is_none()
         {
             return Err(SlateDBError::DatabaseAlreadyExists {

--- a/src/db_reader.rs
+++ b/src/db_reader.rs
@@ -154,7 +154,7 @@ impl DbReaderInner {
         let checkpoint = if let Some(checkpoint_id) = checkpoint_id {
             manifest
                 .db_state()
-                .find_checkpoint(&checkpoint_id)
+                .find_checkpoint(checkpoint_id)
                 .ok_or(SlateDBError::CheckpointMissing(checkpoint_id))?
                 .clone()
         } else {
@@ -1002,7 +1002,7 @@ mod tests {
 
         let manifest = manifest_store.read_latest_manifest().await.unwrap().1;
         assert!(!manifest.core.checkpoints.is_empty());
-        assert_eq!(None, manifest.core.find_checkpoint(&initial_checkpoint_id));
+        assert_eq!(None, manifest.core.find_checkpoint(initial_checkpoint_id));
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -286,8 +286,8 @@ impl CoreDbState {
         debug!("-----------------");
     }
 
-    pub(crate) fn find_checkpoint(&self, checkpoint_id: &Uuid) -> Option<&Checkpoint> {
-        self.checkpoints.iter().find(|c| c.id == *checkpoint_id)
+    pub(crate) fn find_checkpoint(&self, checkpoint_id: Uuid) -> Option<&Checkpoint> {
+        self.checkpoints.iter().find(|c| c.id == checkpoint_id)
     }
 }
 

--- a/src/manifest/store.rs
+++ b/src/manifest/store.rs
@@ -151,7 +151,7 @@ impl FenceableManifest {
             .stored_manifest
             .manifest()
             .core
-            .find_checkpoint(&checkpoint_id)
+            .find_checkpoint(checkpoint_id)
             .expect("update applied but checkpoint not found")
             .clone();
         Ok(checkpoint)
@@ -323,8 +323,7 @@ impl StoredManifest {
         let db_state = self.db_state();
         let manifest_id = match options.source {
             Some(source_checkpoint_id) => {
-                let Some(source_checkpoint) = db_state.find_checkpoint(&source_checkpoint_id)
-                else {
+                let Some(source_checkpoint) = db_state.find_checkpoint(source_checkpoint_id) else {
                     return Err(CheckpointMissing(source_checkpoint_id));
                 };
                 source_checkpoint.manifest_id
@@ -358,7 +357,7 @@ impl StoredManifest {
         .await?;
         Ok(self
             .db_state()
-            .find_checkpoint(&checkpoint_id)
+            .find_checkpoint(checkpoint_id)
             .expect("update applied but checkpoint not found")
             .clone())
     }
@@ -408,7 +407,7 @@ impl StoredManifest {
         .await?;
         let new_checkpoint = self
             .db_state()
-            .find_checkpoint(&new_checkpoint_id)
+            .find_checkpoint(new_checkpoint_id)
             .expect("update applied but checkpoint not found")
             .clone();
         Ok(new_checkpoint)
@@ -434,7 +433,7 @@ impl StoredManifest {
         .await?;
         let checkpoint = self
             .db_state()
-            .find_checkpoint(&checkpoint_id)
+            .find_checkpoint(checkpoint_id)
             .expect("update applied but checkpoint not found")
             .clone();
         Ok(checkpoint)
@@ -1117,7 +1116,7 @@ mod tests {
 
         assert_eq!(
             Some(&refreshed_checkpoint),
-            sm.manifest.core.find_checkpoint(&checkpoint.id)
+            sm.manifest.core.find_checkpoint(checkpoint.id)
         );
     }
 
@@ -1159,10 +1158,10 @@ mod tests {
             .await
             .unwrap();
         assert_ne!(checkpoint.id, replaced_checkpoint.id);
-        assert_eq!(None, sm.manifest.core.find_checkpoint(&checkpoint.id));
+        assert_eq!(None, sm.manifest.core.find_checkpoint(checkpoint.id));
         assert_eq!(
             Some(&replaced_checkpoint),
-            sm.manifest.core.find_checkpoint(&replaced_checkpoint.id),
+            sm.manifest.core.find_checkpoint(replaced_checkpoint.id),
         );
     }
 
@@ -1182,7 +1181,7 @@ mod tests {
 
         assert_eq!(
             Some(&replaced_checkpoint),
-            sm.manifest.core.find_checkpoint(&replaced_checkpoint.id),
+            sm.manifest.core.find_checkpoint(replaced_checkpoint.id),
         );
     }
 
@@ -1200,7 +1199,7 @@ mod tests {
             .unwrap();
 
         sm.delete_checkpoint(checkpoint.id).await.unwrap();
-        assert_eq!(None, sm.manifest.core.find_checkpoint(&checkpoint.id));
+        assert_eq!(None, sm.manifest.core.find_checkpoint(checkpoint.id));
     }
 
     #[tokio::test]


### PR DESCRIPTION
As suggested [here](https://github.com/slatedb/slatedb/pull/498#discussion_r1990352580), since `Uuid` implements `Copy`, we can pass by value in `CoreDbState.find_checkpoint`.