### PR TITLE
fix: handle repeated keys during sst index search

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1387,6 +1387,46 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "wal_disable")]
+    async fn test_find_with_multiple_repeated_keys() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut options = test_db_options(0, 1024 * 1024, None);
+        options.wal_enabled = false;
+        let db = Db::open_with_opts(
+            Path::from("/tmp/test_kv_store"),
+            options.clone(),
+            object_store,
+        )
+            .await
+            .unwrap();
+
+        // write enough rows with the same key that we yield an L0 SST with multiple blocks
+        let mut last_val: String = "foo".to_string();
+        for x in 0..4096 {
+            let val = format!("val{}", x);
+            db.put_with_options(
+                b"key", val.as_bytes(),
+                &PutOptions{ ttl: Default::default() },
+                &WriteOptions{await_durable: false}
+            ).await.unwrap();
+            last_val = val;
+            if db.inner.state.write().memtable().size() > (SsTableFormat::default().block_size * 3) {
+                break;
+            }
+        }
+        assert_eq!(Some(Bytes::copy_from_slice(last_val.as_bytes())), db.get(b"key").await.unwrap());
+        db.flush().await.unwrap();
+
+        let state = db.inner.state.read().snapshot();
+        assert_eq!(1, state.state.manifest.core.l0.len());
+        let sst = state.state.manifest.core.l0.front().unwrap();
+        let index = db.inner.table_store.read_index(sst).await.unwrap();
+        assert!(index.borrow().block_meta().len() >= 3);
+        assert_eq!(Some(Bytes::copy_from_slice(last_val.as_bytes())), db.get(b"key").await.unwrap());
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_get_with_row_override_ttl_and_read_committed() {
         let clock = Arc::new(TestClock::new());
         let ttl = 100;

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -218,7 +218,7 @@ impl<'a> SstIterator<'a> {
                         break;
                     }
                     high = mid;
-                },
+                }
             }
         }
         found_block_id
@@ -376,13 +376,13 @@ mod tests {
     use super::*;
     use crate::bytes_generator::OrderedBytesGenerator;
     use crate::db_state::SsTableId;
+    use crate::flatbuffer_types::{BlockMeta, BlockMetaArgs, SsTableIndexArgs};
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, gen_attrs};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
     use rstest::rstest;
     use std::sync::Arc;
-    use crate::flatbuffer_types::{BlockMeta, BlockMetaArgs, SsTableIndexArgs};
 
     #[tokio::test]
     async fn test_one_block_sst_iter() {
@@ -619,7 +619,7 @@ mod tests {
     }
 
     struct FindFirstBlockTestCase {
-        first_keys: Vec<&'static [u8]>
+        first_keys: Vec<&'static [u8]>,
     }
 
     #[rstest]
@@ -641,14 +641,17 @@ mod tests {
     #[case::all_same_first_key(FindFirstBlockTestCase{
         first_keys: vec![b"bbbb", b"bbbb", b"bbbb"]
     })]
-    fn test_find_first_block_with_data_including_or_after_key(#[case] case: FindFirstBlockTestCase) {
+    fn test_find_first_block_with_data_including_or_after_key(
+        #[case] case: FindFirstBlockTestCase,
+    ) {
         let first_keys = &case.first_keys;
         let index = build_index_with_first_keys(first_keys);
 
         // do a search where the key is earlier than the first key
         let found_block = SstIterator::first_block_with_data_including_or_after_key(
             &index.borrow(),
-            b"\x00\x00\x00");
+            b"\x00\x00\x00",
+        );
         assert_eq!(0, found_block);
 
         let mut prev_key = None;
@@ -656,10 +659,11 @@ mod tests {
         for i in 0..first_keys.len() {
             // do a search where the key matches this block's first key
             let key = first_keys[i];
-            let found_block = SstIterator::first_block_with_data_including_or_after_key(&index.borrow(), key);
+            let found_block =
+                SstIterator::first_block_with_data_including_or_after_key(&index.borrow(), key);
             expected_found_block = match prev_key {
                 Some(prev_key) if prev_key == key => expected_found_block,
-                _ => i
+                _ => i,
             };
             assert_eq!(expected_found_block, found_block);
             prev_key = Some(key);
@@ -670,7 +674,10 @@ mod tests {
                 // we could do something more robust here, but its fine since the test cases are
                 // static.
                 let key = [key, b"bla"].concat();
-                let found_block = SstIterator::first_block_with_data_including_or_after_key(&index.borrow(), &key);
+                let found_block = SstIterator::first_block_with_data_including_or_after_key(
+                    &index.borrow(),
+                    &key,
+                );
                 assert_eq!(i, found_block);
             }
         }
@@ -685,8 +692,8 @@ mod tests {
                 &mut index_builder,
                 &BlockMetaArgs {
                     first_key: Some(fk),
-                    offset: 0u64
-                }
+                    offset: 0u64,
+                },
             );
             block_metas.push(block_meta);
         }
@@ -694,8 +701,8 @@ mod tests {
         let index_wip = SsTableIndex::create(
             &mut index_builder,
             &SsTableIndexArgs {
-                block_meta: Some(block_metas)
-            }
+                block_meta: Some(block_metas),
+            },
         );
         index_builder.finish(index_wip, None);
         let index_bytes = Bytes::copy_from_slice(index_builder.finished_data());


### PR DESCRIPTION
This patch fixes the SstIterator's index search path to correctly handle SSTs where multiple blocks contain the same starting key (which is now possible in l0 since we store multiple key versions in the memtable). The fix is to not terminate the binary search of the block metas when a match is found - but rather to keep looking for a lower-indexed block.

fixes #517