### PR TITLE
fix block filtering when creating sst iterator

### DIFF
--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -28,6 +28,7 @@ use crate::flatbuffer_types::manifest_generated::{
     UuidArgs,
 };
 use crate::manifest::{ExternalDb, Manifest, ManifestCodec};
+use crate::partitioned_keyspace::RangePartitionedKeySpace;
 use crate::utils::clamp_allocated_size_bytes;
 
 pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 1;
@@ -56,6 +57,16 @@ impl SsTableIndexOwned {
     /// Returns the size of the SSTable index in bytes.
     pub(crate) fn size(&self) -> usize {
         self.data.len()
+    }
+}
+
+impl<'a> RangePartitionedKeySpace for SsTableIndex<'a> {
+    fn partitions(&self) -> usize {
+        self.block_meta().len()
+    }
+
+    fn partition_first_key(&self, partition: usize) -> &[u8] {
+        self.block_meta().get(partition).first_key().bytes()
     }
 }
 

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -60,7 +60,7 @@ impl SsTableIndexOwned {
     }
 }
 
-impl<'a> RangePartitionedKeySpace for SsTableIndex<'a> {
+impl RangePartitionedKeySpace for SsTableIndex<'_> {
     fn partitions(&self) -> usize {
         self.block_meta().len()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
 mod merge_operator;
+mod partitioned_keyspace;
 mod paths;
 #[cfg(test)]
 mod proptest_util;

--- a/src/partitioned_keyspace.rs
+++ b/src/partitioned_keyspace.rs
@@ -226,7 +226,7 @@ mod tests {
         partitions: Vec<&'a [u8]>,
     }
 
-    impl<'a> RangePartitionedKeySpace for TestKeyspace<'a> {
+    impl RangePartitionedKeySpace for TestKeyspace<'_> {
         fn partitions(&self) -> usize {
             self.partitions.len()
         }

--- a/src/partitioned_keyspace.rs
+++ b/src/partitioned_keyspace.rs
@@ -1,0 +1,238 @@
+/// Represents a set of keys that are partitioned into multiple partitions, where each
+/// partition stores some range of keys and the keys in a given partition are greater than
+/// or equal to all keys from the previous partitions. The space is a multiset, so a given key
+/// can be present in multiple contiguous partitions. Each partition specifies a min key that
+/// is less than or equal to all its keys, and greater than or equal to all keys in the
+/// previous partition.
+pub(crate) trait RangePartitionedKeySpace {
+    fn partitions(&self) -> usize;
+
+    fn partition_first_key(&self, partition: usize) -> &[u8];
+}
+
+// equivalent to https://doc.rust-lang.org/std/primitive.slice.html#method.partition_point
+fn partition_point<T: RangePartitionedKeySpace, P: Fn(&[u8]) -> bool>(
+    keyspace: &T,
+    pred: P,
+) -> usize {
+    if keyspace.partitions() == 0 {
+        return 0;
+    }
+    let mut low = 0;
+    let mut high = keyspace.partitions() - 1;
+    let mut part_point = 0;
+    while low <= high {
+        let mid = low + (high - low) / 2;
+        let mid_part_first_key = keyspace.partition_first_key(mid);
+        if pred(mid_part_first_key) {
+            low = mid + 1;
+            part_point = mid + 1;
+        } else if mid > low {
+            high = mid - 1;
+        } else {
+            break;
+        }
+    }
+    part_point
+}
+
+/// Returns the first partition that could include keys that are greater than or equal to
+/// the specified key.
+pub(crate) fn first_partition_including_or_after_key<T: RangePartitionedKeySpace>(
+    keyspace: &T,
+    key: &[u8],
+) -> usize {
+    // If the whole keyspace is larger than the key, then just return the first partition
+    first_partition_including_key(keyspace, key).unwrap_or(0)
+}
+
+/// Returns the first partition that could include the given key. Returns None if all partitions
+/// contain keys that are strictly greater than the specified key.
+pub(crate) fn first_partition_including_key<T: RangePartitionedKeySpace>(
+    keyspace: &T,
+    key: &[u8],
+) -> Option<usize> {
+    let part_point = partition_point(keyspace, |first_key| first_key < key);
+    if part_point > 0 {
+        // Some partition after the first has first_key >= key, so return the previous partition
+        return Some(part_point - 1);
+    }
+    // If the first partition starts with key, then return it. Otherwise, the key is not present
+    // in the keyspace because the first partition's first_key is strictly greater.
+    if keyspace.partition_first_key(0) == key {
+        return Some(0);
+    }
+    None
+}
+
+/// Returns the last partition that could include the given key. Returns None if all partitions
+/// contain keys that are strictly greater than the given key.
+pub(crate) fn last_partition_including_key<T: RangePartitionedKeySpace>(
+    keyspace: &T,
+    key: &[u8],
+) -> Option<usize> {
+    let part_point = partition_point(keyspace, |first_key| first_key <= key);
+    if part_point == 0 {
+        // If the partition point is 0, that means the first partition's first_key is strictly
+        // greater than the key, so no partitions include the key.
+        return None;
+    }
+    Some(part_point - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::partitioned_keyspace::{
+        first_partition_including_key, last_partition_including_key, partition_point,
+        RangePartitionedKeySpace,
+    };
+    use rstest::rstest;
+
+    #[test]
+    fn test_partition_point() {
+        for len in 0..20 {
+            let mut keyspace = TestKeyspace {
+                partitions: vec![b"x"; len],
+            };
+            assert_eq!(0, partition_point(&keyspace, |k| k.is_empty()));
+            for i in 0..len {
+                keyspace.partitions[i] = b"";
+                let partition_point = partition_point(&keyspace, |k| k.is_empty());
+                assert_eq!(i + 1, partition_point);
+            }
+        }
+    }
+
+    struct FirstPartitionIncludingKeyTestCase {
+        first_keys: Vec<&'static [u8]>,
+    }
+
+    #[rstest]
+    #[case::one_partition(FirstPartitionIncludingKeyTestCase{
+        first_keys: vec![b"aaaa"]
+    })]
+    #[case::two_partitions(FirstPartitionIncludingKeyTestCase{
+        first_keys: vec![b"aaaa", b"bbbb"]
+    })]
+    #[case::three_partitions(FirstPartitionIncludingKeyTestCase{
+        first_keys: vec![b"aaaa", b"bbbb", b"cccccc"]
+    })]
+    #[case::five_partitions(FirstPartitionIncludingKeyTestCase{
+        first_keys: vec![b"aaaa", b"bbbb", b"cccccccc", b"ddd", b"eeeee"]
+    })]
+    #[case::five_partitions_same_first_key(FirstPartitionIncludingKeyTestCase{
+        first_keys: vec![b"aaaa", b"bbbb", b"bbbb", b"bbbb", b"bbbb"]
+    })]
+    #[case::all_same_first_key(FirstPartitionIncludingKeyTestCase{
+        first_keys: vec![b"bbbb", b"bbbb", b"bbbb"]
+    })]
+    fn test_first_partition_including_key(#[case] case: FirstPartitionIncludingKeyTestCase) {
+        let first_keys = &case.first_keys;
+        let keyspace = TestKeyspace {
+            partitions: case.first_keys.clone(),
+        };
+
+        // do a search where the key is earlier than the first key
+        let found_partition = first_partition_including_key(&keyspace, b"\x00\x00\x00");
+        assert_eq!(None, found_partition);
+
+        let mut prev_key = None;
+        let mut expected_found_partition = 0;
+        for i in 0..first_keys.len() {
+            // do a search where the key matches this partition's first key
+            let key = first_keys[i];
+            let found_partition = first_partition_including_key(&keyspace, key);
+            expected_found_partition = match prev_key {
+                Some(prev_key) if prev_key == key => expected_found_partition,
+                _ => {
+                    if i == 0 {
+                        0
+                    } else {
+                        i - 1
+                    }
+                }
+            };
+            assert_eq!(Some(expected_found_partition), found_partition);
+            prev_key = Some(key);
+
+            // if this is the last partition, or the next partition is not the same key, do a search
+            // where the key is between this partition and the next one
+            if i == first_keys.len() - 1 || key != first_keys[i + 1] {
+                // we could do something more robust here, but its fine since the test cases are
+                // static.
+                let key = [key, b"bla"].concat();
+                let found_partition = first_partition_including_key(&keyspace, &key);
+                assert_eq!(Some(i), found_partition);
+            }
+        }
+    }
+
+    struct LastPartitionIncludingKeyTestCase {
+        first_keys: Vec<&'static [u8]>,
+    }
+
+    #[rstest]
+    #[case::one_partition(LastPartitionIncludingKeyTestCase{
+    first_keys: vec![b"aaaa"]
+    })]
+    #[case::two_partitions(LastPartitionIncludingKeyTestCase{
+    first_keys: vec![b"aaaa", b"bbbb"]
+    })]
+    #[case::three_partitions(LastPartitionIncludingKeyTestCase{
+    first_keys: vec![b"aaaa", b"bbbb", b"cccccc"]
+    })]
+    #[case::five_partitions(LastPartitionIncludingKeyTestCase{
+    first_keys: vec![b"aaaa", b"bbbb", b"cccccccc", b"ddd", b"eeeee"]
+    })]
+    #[case::five_partitions_same_first_key(LastPartitionIncludingKeyTestCase{
+    first_keys: vec![b"aaaa", b"bbbb", b"bbbb", b"bbbb", b"bbbb"]
+    })]
+    #[case::all_same_first_key(LastPartitionIncludingKeyTestCase{
+    first_keys: vec![b"bbbb", b"bbbb", b"bbbb"]
+    })]
+    fn test_last_partition_including_key(#[case] case: LastPartitionIncludingKeyTestCase) {
+        let first_keys = &case.first_keys;
+        let keyspace = TestKeyspace {
+            partitions: case.first_keys.clone(),
+        };
+
+        // do a search where the key is earlier than the first key
+        let found_partition = last_partition_including_key(&keyspace, b"\x00\x00\x00");
+        assert_eq!(None, found_partition);
+
+        for i in 0..first_keys.len() {
+            // do a search where the key matches this partition's first key
+            let key = first_keys[i];
+            let found_partition = last_partition_including_key(&keyspace, key);
+            let mut expected_found_partition = i;
+            for p in i..first_keys.len() {
+                if keyspace.partition_first_key(p) == key {
+                    expected_found_partition = p;
+                }
+            }
+            assert_eq!(Some(expected_found_partition), found_partition);
+
+            // if this is the last partition, or the next partition is not the same key, do a search
+            // where the key is between this partition and the next one
+            if i == first_keys.len() - 1 || key != first_keys[i + 1] {
+                let key = [key, b"bla"].concat();
+                let found_partition = last_partition_including_key(&keyspace, &key);
+                assert_eq!(Some(i), found_partition);
+            }
+        }
+    }
+
+    struct TestKeyspace<'a> {
+        partitions: Vec<&'a [u8]>,
+    }
+
+    impl<'a> RangePartitionedKeySpace for TestKeyspace<'a> {
+        fn partitions(&self) -> usize {
+            self.partitions.len()
+        }
+
+        fn partition_first_key(&self, partition: usize) -> &[u8] {
+            self.partitions[partition]
+        }
+    }
+}

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -12,8 +12,8 @@ use crate::error::SlateDBError;
 use crate::flatbuffer_types::{SsTableIndex, SsTableIndexOwned};
 use crate::iter::SeekToKey;
 use crate::{
-    block::Block, block_iterator::BlockIterator, iter::KeyValueIterator, tablestore::TableStore,
-    types::RowEntry,
+    block::Block, block_iterator::BlockIterator, iter::KeyValueIterator, partitioned_keyspace,
+    tablestore::TableStore, types::RowEntry,
 };
 
 enum FetchTask {
@@ -192,36 +192,12 @@ impl<'a> SstIterator<'a> {
         Self::new_borrowed(key..=key, table, table_store, options).await
     }
 
+    fn last_block_with_data_including_key(index: &SsTableIndex, key: &[u8]) -> Option<usize> {
+        partitioned_keyspace::last_partition_including_key(index, key)
+    }
+
     fn first_block_with_data_including_or_after_key(index: &SsTableIndex, key: &[u8]) -> usize {
-        let mut low = 0;
-        let mut high = index.block_meta().len() - 1;
-        let mut found_block_id = 0;
-        let block_meta = index.block_meta();
-        while low <= high {
-            let mid = low + (high - low) / 2;
-            let mid_block_first_key = block_meta.get(mid).first_key().bytes();
-            match mid_block_first_key.cmp(key) {
-                std::cmp::Ordering::Less => {
-                    low = mid + 1;
-                    found_block_id = mid;
-                }
-                std::cmp::Ordering::Greater => {
-                    if mid > 0 {
-                        high = mid - 1;
-                    } else {
-                        break;
-                    }
-                }
-                std::cmp::Ordering::Equal => {
-                    found_block_id = mid;
-                    if low == mid {
-                        break;
-                    }
-                    high = mid;
-                }
-            }
-        }
-        found_block_id
+        partitioned_keyspace::first_partition_including_or_after_key(index, key)
     }
 
     fn blocks_covering_view(index: &SsTableIndex, view: &SstView) -> Range<usize> {
@@ -233,14 +209,21 @@ impl<'a> SstIterator<'a> {
         };
 
         let end_block_id_exclusive = match view.end_key() {
-            Included(k) => Self::first_block_with_data_including_or_after_key(index, k) + 1,
+            Included(k) => Self::last_block_with_data_including_key(index, k)
+                .map(|b| b + 1)
+                .unwrap_or(start_block_id),
             Excluded(k) => {
-                let block_index = Self::first_block_with_data_including_or_after_key(index, k);
-                let block = index.block_meta().get(block_index);
-                if k == block.first_key().bytes() {
-                    block_index
-                } else {
-                    block_index + 1
+                let block_index = Self::last_block_with_data_including_key(index, k);
+                match block_index {
+                    None => start_block_id,
+                    Some(block_index) => {
+                        let block = index.block_meta().get(block_index);
+                        if k == block.first_key().bytes() {
+                            block_index
+                        } else {
+                            block_index + 1
+                        }
+                    }
                 }
             }
             Unbounded => index.block_meta().len(),
@@ -376,12 +359,10 @@ mod tests {
     use super::*;
     use crate::bytes_generator::OrderedBytesGenerator;
     use crate::db_state::SsTableId;
-    use crate::flatbuffer_types::{BlockMeta, BlockMetaArgs, SsTableIndexArgs};
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, gen_attrs};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
-    use rstest::rstest;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -616,97 +597,6 @@ mod tests {
         .unwrap();
 
         assert!(iter.next().await.unwrap().is_none());
-    }
-
-    struct FindFirstBlockTestCase {
-        first_keys: Vec<&'static [u8]>,
-    }
-
-    #[rstest]
-    #[case::one_block(FindFirstBlockTestCase{
-        first_keys: vec![b"aaaa"]
-    })]
-    #[case::two_blocks(FindFirstBlockTestCase{
-        first_keys: vec![b"aaaa", b"bbbb"]
-    })]
-    #[case::three_blocks(FindFirstBlockTestCase{
-        first_keys: vec![b"aaaa", b"bbbb", b"cccccc"]
-    })]
-    #[case::five_blocks(FindFirstBlockTestCase{
-        first_keys: vec![b"aaaa", b"bbbb", b"cccccccc", b"ddd", b"eeeee"]
-    })]
-    #[case::five_blocks_same_first_key(FindFirstBlockTestCase{
-        first_keys: vec![b"aaaa", b"bbbb", b"bbbb", b"bbbb", b"bbbb"]
-    })]
-    #[case::all_same_first_key(FindFirstBlockTestCase{
-        first_keys: vec![b"bbbb", b"bbbb", b"bbbb"]
-    })]
-    fn test_find_first_block_with_data_including_or_after_key(
-        #[case] case: FindFirstBlockTestCase,
-    ) {
-        let first_keys = &case.first_keys;
-        let index = build_index_with_first_keys(first_keys);
-
-        // do a search where the key is earlier than the first key
-        let found_block = SstIterator::first_block_with_data_including_or_after_key(
-            &index.borrow(),
-            b"\x00\x00\x00",
-        );
-        assert_eq!(0, found_block);
-
-        let mut prev_key = None;
-        let mut expected_found_block = 0;
-        for i in 0..first_keys.len() {
-            // do a search where the key matches this block's first key
-            let key = first_keys[i];
-            let found_block =
-                SstIterator::first_block_with_data_including_or_after_key(&index.borrow(), key);
-            expected_found_block = match prev_key {
-                Some(prev_key) if prev_key == key => expected_found_block,
-                _ => i,
-            };
-            assert_eq!(expected_found_block, found_block);
-            prev_key = Some(key);
-
-            // if this is the last block, or the next block is not the same key, do a search
-            // where the key is between this block and the next one
-            if i == first_keys.len() - 1 || key != first_keys[i + 1] {
-                // we could do something more robust here, but its fine since the test cases are
-                // static.
-                let key = [key, b"bla"].concat();
-                let found_block = SstIterator::first_block_with_data_including_or_after_key(
-                    &index.borrow(),
-                    &key,
-                );
-                assert_eq!(i, found_block);
-            }
-        }
-    }
-
-    fn build_index_with_first_keys(first_keys: &[&[u8]]) -> SsTableIndexOwned {
-        let mut index_builder = flatbuffers::FlatBufferBuilder::new();
-        let mut block_metas = Vec::new();
-        for fk in first_keys {
-            let fk = index_builder.create_vector(fk);
-            let block_meta = BlockMeta::create(
-                &mut index_builder,
-                &BlockMetaArgs {
-                    first_key: Some(fk),
-                    offset: 0u64,
-                },
-            );
-            block_metas.push(block_meta);
-        }
-        let block_metas = index_builder.create_vector(&block_metas);
-        let index_wip = SsTableIndex::create(
-            &mut index_builder,
-            &SsTableIndexArgs {
-                block_meta: Some(block_metas),
-            },
-        );
-        index_builder.finish(index_wip, None);
-        let index_bytes = Bytes::copy_from_slice(index_builder.finished_data());
-        SsTableIndexOwned::new(index_bytes).unwrap()
     }
 
     async fn build_sst_with_n_blocks(


### PR DESCRIPTION
This patch fixes two issues with selecting the start and end blocks for an sst iterator:
- for the start block, in the case where iteration starts from the same key as the first key in a block B, we were selecting B as the start block. Instead, if B > 0 we should start from B-1 because block B-1 may end with the specified key.
- for the last block, we were selecting the block after the start block. After fixing the above bug, in the case where a key first appears as the first key in some block B, we wind up excluding B because the search spans [B-1,B).

This patch makes a few changes to fix these problems:
- It adds a trait called RangePartitionedKeySpace that defines a key space that is split up into a list of partitions, each of which has a first key. We need this trait because we can't treat the block meta as a slice to get the nice binary search fns. We can't treat it as a slice because it uses a custom flatbuffer vector type.
- It implements RangePartitionedKeySpace for SsTableIndex.
- It provides the following helper fns that operate on RangePartitionedKeySpace
  - first_partition_including_key: returns the first partition that could include data with a given key
  - last_partition_including_key: returns the last partition that could include data with a given key
- SST Iterator now uses these helper fns to bound the iteration space.

In a later patch we can also implement RangePartitionedKeySpace for SortedRun so we can use the same search fns to triangulate a keys position in the ssts in a sorted run.

Fixes #517