### PR TITLE
add a dbcache impl that uses the foyer hybrid cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "array-util"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,19 +554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,15 +577,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -950,6 +934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,79 +950,82 @@ dependencies = [
 
 [[package]]
 name = "foyer"
-version = "0.11.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de727a58f28ad9c5ff9952979d2392851b5917785ca657e07277890109cd3a0"
+checksum = "ddac72b94b174f342300f54f6dfda93c87a4a220e2def9ee2590e3ac474b5f6d"
 dependencies = [
  "ahash",
  "anyhow",
+ "equivalent",
  "fastrace",
  "foyer-common",
  "foyer-memory",
  "foyer-storage",
- "futures",
  "madsim-tokio",
- "pin-project",
+ "mixtrics",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-common"
-version = "0.9.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6577040f1b773e4a606180638ec48f5528d3d843d73092c06b5a8876bc4576"
+checksum = "3a2fec9e9293931608eb6bb4b032d05b8b45c8749ec6a0ace82bfe40ab5d68c4"
 dependencies = [
+ "ahash",
  "bytes",
  "cfg-if",
- "crossbeam",
  "fastrace",
- "futures",
- "hashbrown 0.14.5",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "madsim-tokio",
- "metrics",
+ "mixtrics",
  "parking_lot",
  "pin-project",
  "serde",
+ "tokio",
 ]
 
 [[package]]
-name = "foyer-intrusive"
-version = "0.9.5"
+name = "foyer-intrusive-collections"
+version = "0.10.0-dev"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01dbfd6763227809019a1dc01c98b6a78949c63d3a204d0a6f8e0325f077ab5c"
+checksum = "6e4fee46bea69e0596130e3210e65d3424e0ac1e6df3bde6636304bdf1ca4a3b"
 dependencies = [
- "foyer-common",
- "itertools 0.13.0",
+ "memoffset",
 ]
 
 [[package]]
 name = "foyer-memory"
-version = "0.7.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c59933e075daa88363e228475ce4fa9098689b9e13a26442666a3a3142da8d"
+checksum = "5c5016e4ca89ead9045c56f10e7e4cca8068e0b114a57f9df32ad768f90f4c33"
 dependencies = [
  "ahash",
+ "arc-swap",
  "bitflags 2.9.0",
  "cmsketch",
+ "equivalent",
  "fastrace",
  "foyer-common",
- "foyer-intrusive",
- "futures",
- "hashbrown 0.14.5",
- "itertools 0.13.0",
+ "foyer-intrusive-collections",
+ "hashbrown 0.15.2",
+ "itertools 0.14.0",
  "madsim-tokio",
+ "mixtrics",
  "parking_lot",
  "pin-project",
  "serde",
+ "thiserror 2.0.12",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "foyer-storage"
-version = "0.10.5"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6976958440e7fee57bd25f6c04df0759484c18a233f00740f6c2c5a47b939d90"
+checksum = "f6ab33a86920fddf66dae2485e37dbcaf0e56f424875d752b639df62d3f4c056"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1041,35 +1034,38 @@ dependencies = [
  "async-channel",
  "auto_enums",
  "bincode",
- "bitflags 2.9.0",
  "bytes",
  "clap",
- "either",
+ "equivalent",
  "fastrace",
  "flume",
  "foyer-common",
  "foyer-memory",
  "fs4",
- "futures",
- "itertools 0.13.0",
+ "futures-core",
+ "futures-util",
+ "itertools 0.14.0",
  "libc",
  "lz4",
  "madsim-tokio",
+ "ordered_hash_map",
  "parking_lot",
+ "paste",
  "pin-project",
- "rand 0.8.5",
+ "rand 0.9.0",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
+ "tokio",
  "tracing",
- "twox-hash",
+ "twox-hash 2.1.0",
  "zstd",
 ]
 
 [[package]]
 name = "fs4"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c6b3bd49c37d2aa3f3f2220233b29a7cd23f79d1fe70e5337d25fb390793de"
+checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
 dependencies = [
  "rustix 0.38.44",
  "windows-sys 0.52.0",
@@ -1261,12 +1257,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -1274,6 +1269,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1621,15 +1621,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1774,7 +1765,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -1866,13 +1857,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.23.0"
+name = "memoffset"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "ahash",
- "portable-atomic",
+ "autocfg",
 ]
 
 [[package]]
@@ -1899,6 +1889,16 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mixtrics"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4d2b55cea00ffba84e3df1e875d9190331e2f3bba2ee3bdd3abcc739639a71"
+dependencies = [
+ "itertools 0.14.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2044,6 +2044,15 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "ordered_hash_map"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0e5f22bf6dd04abd854a8874247813a8fa2c8c1260eba6fbb150270ce7c176"
+dependencies = [
+ "hashbrown 0.13.2",
+]
 
 [[package]]
 name = "overload"
@@ -3504,8 +3513,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
  "static_assertions",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+dependencies = [
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 moka = { version = "0.12.8", features = ["future"], optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }
-foyer = { version = "0.11.2", optional = true }
+foyer = { version = "0.14.1", optional = true }
 walkdir = "2.3.3"
 radix_trie = "0.2.1"
 figment = { version = "0.10.19", features = ["env", "json", "toml", "yaml"] }

--- a/src/db_cache/foyer.rs
+++ b/src/db_cache/foyer.rs
@@ -33,6 +33,7 @@
 
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
+use crate::SlateDBError;
 
 /// The options for the Foyer cache.
 #[derive(Clone, Copy, Debug)]
@@ -90,16 +91,16 @@ impl Default for FoyerCache {
 
 #[async_trait]
 impl DbCache for FoyerCache {
-    async fn get_block(&self, key: CachedKey) -> Option<CachedEntry> {
-        self.inner.get(&key).map(|entry| entry.value().clone())
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
     }
 
-    async fn get_index(&self, key: CachedKey) -> Option<CachedEntry> {
-        self.inner.get(&key).map(|entry| entry.value().clone())
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry> {
-        self.inner.get(&key).map(|entry| entry.value().clone())
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
     }
 
     async fn insert(&self, key: CachedKey, value: CachedEntry) {

--- a/src/db_cache/foyer.rs
+++ b/src/db_cache/foyer.rs
@@ -32,8 +32,8 @@
 //!
 
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
-use async_trait::async_trait;
 use crate::SlateDBError;
+use async_trait::async_trait;
 
 /// The options for the Foyer cache.
 #[derive(Clone, Copy, Debug)]

--- a/src/db_cache/foyer_hybrid.rs
+++ b/src/db_cache/foyer_hybrid.rs
@@ -20,7 +20,6 @@
 //! use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
 //! use slatedb::config::DbOptions;
 //! use std::sync::Arc;
-//! use tempfile::tempdir;
 //!
 //! #[::tokio::main]
 //! async fn main() {
@@ -31,7 +30,7 @@
 //!             .with_weighter(|_, v: &CachedEntry| v.size())
 //!             .storage(Engine::Large)
 //!             .with_device_options(
-//!                 DirectFsDeviceOptions::new(tempdir().path()).with_capacity(1024 * 1024))
+//!                 DirectFsDeviceOptions::new("/tmp/slatedb-cache").with_capacity(1024 * 1024))
 //!             .build()
 //!             .await
 //!             .unwrap();
@@ -54,7 +53,7 @@ pub struct FoyerHybridCache {
 }
 
 impl FoyerHybridCache {
-    pub async fn new_with_cache(cache: foyer::HybridCache<CachedKey, CachedEntry>) -> Self {
+    pub fn new_with_cache(cache: foyer::HybridCache<CachedKey, CachedEntry>) -> Self {
         Self { inner: cache }
     }
 }
@@ -163,6 +162,6 @@ mod tests {
             .build()
             .await
             .unwrap();
-        (FoyerHybridCache::new_with_cache(cache).await, tempdir)
+        (FoyerHybridCache::new_with_cache(cache), tempdir)
     }
 }

--- a/src/db_cache/foyer_hybrid.rs
+++ b/src/db_cache/foyer_hybrid.rs
@@ -1,0 +1,124 @@
+use async_trait::async_trait;
+use crate::db_cache::{CachedEntry, CachedKey, DbCache};
+use crate::SlateDBError;
+use crate::SlateDBError::DbCacheError;
+
+pub struct FoyerHybridCache {
+    inner: foyer::HybridCache<CachedKey, CachedEntry>,
+}
+
+impl FoyerHybridCache {
+    pub async fn new_with_cache(cache: foyer::HybridCache<CachedKey, CachedEntry>) -> Self {
+        Self { inner: cache }
+    }
+}
+
+impl FoyerHybridCache {
+    async fn get(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        self.inner.get(&key)
+            .await
+            .map_err(|e| DbCacheError {msg: e.to_string()})
+            .map(|maybe_v| maybe_v.map(|v| v.value().clone()))
+    }
+}
+
+#[async_trait]
+impl DbCache for FoyerHybridCache {
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        self.get(key).await
+    }
+
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        self.get(key).await
+    }
+
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        self.get(key).await
+    }
+
+    async fn insert(&self, key: CachedKey, value: CachedEntry) {
+        self.inner.insert(key, value);
+    }
+
+    async fn remove(&self, key: CachedKey) {
+        self.inner.remove(&key);
+    }
+
+    fn entry_count(&self) -> u64 {
+        // foyer cache doesn't support an entry count estimate
+        0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+    use foyer::{DirectFsDeviceOptions, Engine, HybridCacheBuilder};
+    use rand::RngCore;
+    use tempfile::{TempDir, tempdir};
+    use crate::block::{BlockBuilder};
+    use crate::db_cache::{CachedEntry, CachedKey, DbCache};
+    use crate::db_cache::foyer_hybrid::FoyerHybridCache;
+    use crate::db_state::SsTableId;
+    use crate::types::RowAttributes;
+
+    const SST_ID: SsTableId = SsTableId::Wal(123);
+
+    #[tokio::test]
+    async fn test_hybrid_cache() {
+        let (cache, dir) = setup();
+        let mut items = HashMap::new();
+        for b in 0u64..256 {
+            let k = CachedKey(SST_ID, b);
+            let v = build_block();
+            cache.insert(k.clone(), v.clone()).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            items.insert(k, v);
+        }
+        let mut found = 0;
+        let mut notfound = 0;
+        for (k, v) in items {
+            let cached_v = cache.get_block(k).await.unwrap();
+            if let Some(cached_v) = cached_v {
+                assert!(v.block().unwrap().as_ref() == cached_v.block().unwrap().as_ref());
+                found += 1;
+            } else {
+                notfound +=1;
+            }
+        }
+        println!("found: {}, notfound: {}", found, notfound);
+        assert!(found > 0);
+    }
+
+    fn build_block() -> CachedEntry {
+        let mut rng = rand::thread_rng();
+        let mut builder = BlockBuilder::new(1024);
+        loop {
+            let mut k = vec![0u8; 32];
+            rng.fill_bytes(&mut k);
+            let mut v = vec![0u8; 128];
+            rng.fill_bytes(&mut v);
+            if builder.add_value(&k, &v, RowAttributes{ts: None, expire_ts: None}) {
+                break;
+            }
+        }
+        let block = Arc::new(builder.build().unwrap());
+        CachedEntry::with_block(block)
+    }
+
+    async fn setup() -> (FoyerHybridCache, TempDir) {
+        let tempdir = tempdir().unwrap();
+        let cache = HybridCacheBuilder::new()
+            .with_name("hybrid_cache_test")
+            .memory(1024)
+            .with_weighter(|_, v: &CachedEntry| v.size())
+            .storage(Engine::Large)
+            .with_device_options(DirectFsDeviceOptions::new(tempdir.path()).with_capacity(1024 * 1024))
+            .build()
+            .await
+            .unwrap();
+        (FoyerHybridCache::new_with_cache(cache), tempdir)
+    }
+}

--- a/src/db_cache/foyer_hybrid.rs
+++ b/src/db_cache/foyer_hybrid.rs
@@ -6,6 +6,8 @@
 //!
 //! ## Features
 //!
+//! - **Hybrid Cache**: Caches blocks using a tiered cache that stores data across memory and
+//!   local disk.
 //! - **Custom Weigher**: Implements a custom weigher to account for the size of cached blocks.
 //! - **Flexible Configuration**: The HybridCache instance is passed to the cache, so you are free
 //!   to configure it as needed for your use case.

--- a/src/db_cache/mod.rs
+++ b/src/db_cache/mod.rs
@@ -20,7 +20,10 @@ use tracing::{debug, error};
 
 use crate::db_cache::stats::DbCacheStats;
 use crate::stats::StatRegistry;
-use crate::{block::Block, db_state::SsTableId, filter::BloomFilter, flatbuffer_types::SsTableIndexOwned, SlateDBError};
+use crate::{
+    block::Block, db_state::SsTableId, filter::BloomFilter, flatbuffer_types::SsTableIndexOwned,
+    SlateDBError,
+};
 
 #[cfg(feature = "foyer")]
 pub mod foyer;
@@ -244,7 +247,7 @@ pub struct DbCacheWrapper {
     cache: Arc<dyn DbCache>,
     // Records the last time that the wrapper logged an error from the wrapped cache at error
     // level. Used to ensure we only log at error level once every ERROR_LOG_INTERVAL.
-    last_err_log_instant: Mutex<Option<Instant>>
+    last_err_log_instant: Mutex<Option<Instant>>,
 }
 
 impl DbCacheWrapper {
@@ -252,7 +255,7 @@ impl DbCacheWrapper {
         Self {
             stats: DbCacheStats::new(stats_registry),
             cache,
-            last_err_log_instant: Mutex::new(None)
+            last_err_log_instant: Mutex::new(None),
         }
     }
 }
@@ -273,8 +276,8 @@ impl DbCacheWrapper {
                 Some(i) if i.elapsed() > ERROR_LOG_INTERVAL => {
                     *guard = Some(Instant::now());
                     true
-                },
-                _ => false
+                }
+                _ => false,
             }
         };
         if log_at_err {
@@ -412,12 +415,12 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::stats::{ReadableStat, StatRegistry};
     use crate::test_utils::{build_test_sst, SstData};
+    use crate::SlateDBError;
     use async_trait::async_trait;
     use rstest::{fixture, rstest};
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use ulid::Ulid;
-    use crate::SlateDBError;
 
     const SST_ID: SsTableId = SsTableId::Compacted(Ulid::from_parts(0u64, 0u128));
 

--- a/src/db_cache/mod.rs
+++ b/src/db_cache/mod.rs
@@ -328,7 +328,7 @@ impl DbCache for DbCacheWrapper {
             Ok(e) => e,
             Err(err) => {
                 self.record_get_err("filter", &err);
-                return Err(err)
+                return Err(err);
             }
         };
         if entry.is_some() {

--- a/src/db_cache/mod.rs
+++ b/src/db_cache/mod.rs
@@ -12,17 +12,20 @@
 //! To use the cache, you need to configure the [DbOptions](crate::config::DbOptions) with the desired cache implementation.
 
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
+use parking_lot::Mutex;
+use tracing::{debug, error};
 
 use crate::db_cache::stats::DbCacheStats;
 use crate::stats::StatRegistry;
-use crate::{
-    block::Block, db_state::SsTableId, filter::BloomFilter, flatbuffer_types::SsTableIndexOwned,
-};
+use crate::{block::Block, db_state::SsTableId, filter::BloomFilter, flatbuffer_types::SsTableIndexOwned, SlateDBError};
 
 #[cfg(feature = "foyer")]
 pub mod foyer;
+#[cfg(feature = "foyer")]
+pub mod foyer_hybrid;
 #[cfg(feature = "moka")]
 pub mod moka;
 mod serde;
@@ -43,6 +46,7 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 /// use slatedb::Db;
 /// use slatedb::config::DbOptions;
 /// use slatedb::db_cache::{DbCache, CachedEntry, CachedKey};
+/// use slatedb::SlateDBError;
 /// use std::collections::HashMap;
 /// use std::sync::{Arc, Mutex};
 ///
@@ -72,19 +76,19 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 ///
 /// #[async_trait]
 /// impl DbCache for MyCache {
-///     async fn get_block(&self, key: CachedKey) -> Option<CachedEntry> {
+///     async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
 ///         let guard = self.inner.lock().unwrap();
-///         guard.data.get(&key).cloned()
+///         Ok(guard.data.get(&key).cloned())
 ///     }
 ///
-///     async fn get_index(&self, key: CachedKey) -> Option<CachedEntry> {
+///     async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
 ///         let guard = self.inner.lock().unwrap();
-///         guard.data.get(&key).cloned()
+///         Ok(guard.data.get(&key).cloned())
 ///     }
 ///
-///     async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry> {
+///     async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
 ///         let guard = self.inner.lock().unwrap();
-///         guard.data.get(&key).cloned()
+///         Ok(guard.data.get(&key).cloned())
 ///     }
 ///
 ///     async fn insert(&self, key: CachedKey, value: CachedEntry) {
@@ -124,9 +128,9 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 /// ```
 #[async_trait]
 pub trait DbCache: Send + Sync {
-    async fn get_block(&self, key: CachedKey) -> Option<CachedEntry>;
-    async fn get_index(&self, key: CachedKey) -> Option<CachedEntry>;
-    async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry>;
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
     async fn insert(&self, key: CachedKey, value: CachedEntry);
     #[allow(dead_code)]
     async fn remove(&self, key: CachedKey);
@@ -238,6 +242,7 @@ impl CachedEntry {
 pub struct DbCacheWrapper {
     stats: DbCacheStats,
     cache: Arc<dyn DbCache>,
+    last_err_log: Mutex<Option<Instant>>
 }
 
 impl DbCacheWrapper {
@@ -245,40 +250,86 @@ impl DbCacheWrapper {
         Self {
             stats: DbCacheStats::new(stats_registry),
             cache,
+            last_err_log: Mutex::new(None)
         }
+    }
+}
+
+const LOG_INTERVAL: Duration = Duration::from_secs(1);
+
+impl DbCacheWrapper {
+    fn record_get_err(&self, block_type: &str, err: SlateDBError) {
+        let log_at_err = {
+            let mut guard = self.last_err_log.lock();
+            match *guard {
+                None => {
+                    *guard = Some(Instant::now());
+                    true
+                }
+                Some(i) if i.elapsed() > LOG_INTERVAL => {
+                    *guard = Some(Instant::now());
+                    true
+                },
+                _ => false
+            }
+        };
+        if log_at_err {
+            error!("error getting {} from cache: {}", block_type, err);
+        } else {
+            debug!("error getting {} from cache: {}", block_type, err);
+        }
+        self.stats.get_error.inc();
     }
 }
 
 #[async_trait]
 impl DbCache for DbCacheWrapper {
-    async fn get_block(&self, key: CachedKey) -> Option<CachedEntry> {
-        let entry = self.cache.get_block(key).await;
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        let entry = match self.cache.get_block(key).await {
+            Ok(e) => e,
+            Err(err) => {
+                self.record_get_err("block", err);
+                None
+            }
+        };
         if entry.is_some() {
             self.stats.data_block_hit.inc();
         } else {
             self.stats.data_block_miss.inc();
         }
-        entry
+        Ok(entry)
     }
 
-    async fn get_index(&self, key: CachedKey) -> Option<CachedEntry> {
-        let entry = self.cache.get_index(key).await;
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        let entry = match self.cache.get_index(key).await {
+            Ok(e) => e,
+            Err(err) => {
+                self.record_get_err("index", err);
+                None
+            }
+        };
         if entry.is_some() {
             self.stats.index_hit.inc();
         } else {
             self.stats.index_miss.inc();
         }
-        entry
+        Ok(entry)
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry> {
-        let entry = self.cache.get_filter(key).await;
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        let entry = match self.cache.get_filter(key).await {
+            Ok(e) => e,
+            Err(err) => {
+                self.record_get_err("filter", err);
+                None
+            }
+        };
         if entry.is_some() {
             self.stats.filter_hit.inc();
         } else {
             self.stats.filter_miss.inc();
         }
-        entry
+        Ok(entry)
     }
 
     async fn insert(&self, key: CachedKey, value: CachedEntry) {
@@ -311,6 +362,7 @@ pub mod stats {
     pub const DB_CACHE_INDEX_MISS: &str = dbcache_stat_name!("index_miss");
     pub const DB_CACHE_DATA_BLOCK_HIT: &str = dbcache_stat_name!("data_block_hit");
     pub const DB_CACHE_DATA_BLOCK_MISS: &str = dbcache_stat_name!("data_block_miss");
+    pub const DB_CACHE_GET_ERROR: &str = dbcache_stat_name!("get_error");
 
     pub(super) struct DbCacheStats {
         pub(super) filter_hit: Arc<Counter>,
@@ -319,6 +371,7 @@ pub mod stats {
         pub(super) index_miss: Arc<Counter>,
         pub(super) data_block_hit: Arc<Counter>,
         pub(super) data_block_miss: Arc<Counter>,
+        pub(super) get_error: Arc<Counter>,
     }
 
     impl DbCacheStats {
@@ -330,6 +383,7 @@ pub mod stats {
                 index_miss: Arc::new(Counter::default()),
                 data_block_hit: Arc::new(Counter::default()),
                 data_block_miss: Arc::new(Counter::default()),
+                get_error: Arc::new(Counter::default()),
             };
             registry.register(DB_CACHE_FILTER_HIT, stats.filter_hit.clone());
             registry.register(DB_CACHE_FILTER_MISS, stats.filter_miss.clone());
@@ -337,6 +391,7 @@ pub mod stats {
             registry.register(DB_CACHE_INDEX_MISS, stats.index_miss.clone());
             registry.register(DB_CACHE_DATA_BLOCK_HIT, stats.data_block_hit.clone());
             registry.register(DB_CACHE_DATA_BLOCK_MISS, stats.data_block_miss.clone());
+            registry.register(DB_CACHE_GET_ERROR, stats.get_error.clone());
             stats
         }
     }
@@ -358,6 +413,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use ulid::Ulid;
+    use crate::SlateDBError;
 
     const SST_ID: SsTableId = SsTableId::Compacted(Ulid::from_parts(0u64, 0u128));
 
@@ -443,7 +499,7 @@ mod tests {
             .await;
 
         // when:
-        let cached = cache.get_index(key).await.unwrap();
+        let cached = cache.get_index(key).await.unwrap().unwrap();
 
         // then:
         assert_index_clamped(index.as_ref(), cached.sst_index().unwrap().as_ref());
@@ -541,19 +597,19 @@ mod tests {
 
     #[async_trait]
     impl DbCache for TestCache {
-        async fn get_block(&self, key: CachedKey) -> Option<CachedEntry> {
+        async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
             let guard = self.items.lock().unwrap();
-            guard.get(&key).cloned()
+            Ok(guard.get(&key).cloned())
         }
 
-        async fn get_index(&self, key: CachedKey) -> Option<CachedEntry> {
+        async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
             let guard = self.items.lock().unwrap();
-            guard.get(&key).cloned()
+            Ok(guard.get(&key).cloned())
         }
 
-        async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry> {
+        async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
             let guard = self.items.lock().unwrap();
-            guard.get(&key).cloned()
+            Ok(guard.get(&key).cloned())
         }
 
         async fn insert(&self, key: CachedKey, value: CachedEntry) {

--- a/src/db_cache/mod.rs
+++ b/src/db_cache/mod.rs
@@ -265,7 +265,7 @@ impl DbCacheWrapper {
 const ERROR_LOG_INTERVAL: Duration = Duration::from_secs(1);
 
 impl DbCacheWrapper {
-    fn record_get_err(&self, block_type: &str, err: SlateDBError) {
+    fn record_get_err(&self, block_type: &str, err: &SlateDBError) {
         let log_at_err = {
             let mut guard = self.last_err_log_instant.lock();
             match *guard {
@@ -295,8 +295,8 @@ impl DbCache for DbCacheWrapper {
         let entry = match self.cache.get_block(key).await {
             Ok(e) => e,
             Err(err) => {
-                self.record_get_err("block", err);
-                None
+                self.record_get_err("block", &err);
+                return Err(err);
             }
         };
         if entry.is_some() {
@@ -311,8 +311,8 @@ impl DbCache for DbCacheWrapper {
         let entry = match self.cache.get_index(key).await {
             Ok(e) => e,
             Err(err) => {
-                self.record_get_err("index", err);
-                None
+                self.record_get_err("index", &err);
+                return Err(err);
             }
         };
         if entry.is_some() {
@@ -327,8 +327,8 @@ impl DbCache for DbCacheWrapper {
         let entry = match self.cache.get_filter(key).await {
             Ok(e) => e,
             Err(err) => {
-                self.record_get_err("filter", err);
-                None
+                self.record_get_err("filter", &err);
+                return Err(err)
             }
         };
         if entry.is_some() {

--- a/src/db_cache/moka.rs
+++ b/src/db_cache/moka.rs
@@ -31,9 +31,9 @@
 //! ```
 //!
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
+use crate::SlateDBError;
 use async_trait::async_trait;
 use std::time::Duration;
-use crate::SlateDBError;
 
 /// The options for the Moka cache.
 #[derive(Clone, Copy, Debug)]

--- a/src/db_cache/moka.rs
+++ b/src/db_cache/moka.rs
@@ -33,6 +33,7 @@
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
 use std::time::Duration;
+use crate::SlateDBError;
 
 /// The options for the Moka cache.
 #[derive(Clone, Copy, Debug)]
@@ -103,16 +104,16 @@ impl Default for MokaCache {
 
 #[async_trait]
 impl DbCache for MokaCache {
-    async fn get_block(&self, key: CachedKey) -> Option<CachedEntry> {
-        self.inner.get(&key).await
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(&key).await)
     }
 
-    async fn get_index(&self, key: CachedKey) -> Option<CachedEntry> {
-        self.inner.get(&key).await
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(&key).await)
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Option<CachedEntry> {
-        self.inner.get(&key).await
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(&key).await)
     }
 
     async fn insert(&self, key: CachedKey, value: CachedEntry) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -123,7 +123,7 @@ pub enum SlateDBError {
     },
 
     #[error("Db Cache error: {msg}")]
-    DbCacheError{ msg: String }
+    DbCacheError { msg: String },
 }
 
 impl From<std::io::Error> for SlateDBError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,6 +121,9 @@ pub enum SlateDBError {
         expected_version: u16,
         actual_version: u16,
     },
+
+    #[error("Db Cache error: {msg}")]
+    DbCacheError{ msg: String }
 }
 
 impl From<std::io::Error> for SlateDBError {

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -313,6 +313,7 @@ impl TableStore {
             if let Some(filter) = cache
                 .get_filter((handle.id, handle.info.filter_offset).into())
                 .await
+                .unwrap_or(None)
                 .and_then(|e| e.bloom_filter())
             {
                 return Ok(Some(filter));
@@ -345,6 +346,7 @@ impl TableStore {
             if let Some(index) = cache
                 .get_index((handle.id, handle.info.index_offset).into())
                 .await
+                .unwrap_or(None)
                 .and_then(|e| e.sst_index())
             {
                 return Ok(index);
@@ -417,6 +419,7 @@ impl TableStore {
                 cache
                     .get_block((handle.id, offset).into())
                     .await
+                    .unwrap_or(None)
                     .and_then(|entry| entry.block())
             }))
             .await;
@@ -719,6 +722,7 @@ mod tests {
                 block_cache
                     .get_block((handle.id, offset).into())
                     .await
+                    .unwrap_or(None)
                     .is_some(),
                 "Block with offset {} should be in cache",
                 offset
@@ -749,6 +753,7 @@ mod tests {
                 block_cache
                     .get_block((handle.id, offset).into())
                     .await
+                    .unwrap_or(None)
                     .is_some(),
                 "Block with offset {} should be in cache after partial hit",
                 offset
@@ -773,6 +778,7 @@ mod tests {
                 block_cache
                     .get_block((handle.id, offset).into())
                     .await
+                    .unwrap_or(None)
                     .is_some(),
                 "Block with offset {} should be in cache after SST emptying",
                 offset


### PR DESCRIPTION
This patch adds an implementation of `DbCache` that uses a foyer hybrid cache to store cached blocks on-disk as well as in-memory. `FoyerHybridCache` can fail gets, so this patch also changes `DbCache` to support returning errors. Currently errors are handled as follows:
- tablestore just ignores errors and treats them as cache misses
- `DbCacheWrapper` tracks a counter of errors, and logs them. The log is rate-limited to once per second (so as not to spam logs on non-transient errors like out-of-disk).