### PR TITLE
cache l0 SSTs on write

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -146,7 +146,11 @@ impl DbInner {
         loop {
             let empty_wal = WritableKVTable::new();
             match self
-                .flush_imm_table(&SsTableId::Wal(empty_wal_id), empty_wal.table().clone())
+                .flush_imm_table(
+                    &SsTableId::Wal(empty_wal_id),
+                    empty_wal.table().clone(),
+                    false,
+                )
                 .await
             {
                 Ok(_) => {

--- a/src/flatbuffer_types.rs
+++ b/src/flatbuffer_types.rs
@@ -34,7 +34,7 @@ use crate::utils::clamp_allocated_size_bytes;
 pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 1;
 
 /// A wrapper around a `Bytes` buffer containing a FlatBuffer-encoded `SsTableIndex`.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub(crate) struct SsTableIndexOwned {
     data: Bytes,
 }
@@ -572,9 +572,10 @@ mod tests {
     fn test_should_clamp_index_alloc() {
         let format = SsTableFormat::default();
         let sst = build_test_sst(&format, 3);
+        let data = sst.remaining_as_bytes();
         let start_off = sst.info.index_offset as usize;
         let end_off = sst.info.index_offset as usize + sst.info.index_len as usize;
-        let index_bytes = sst.data.slice(start_off..end_off);
+        let index_bytes = data.slice(start_off..end_off);
         let index = SsTableIndexOwned::new(index_bytes).unwrap();
 
         let clamped = index.clamp_allocated_size();

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -35,6 +35,7 @@ impl DbInner {
         &self,
         id: &db_state::SsTableId,
         imm_table: Arc<KVTable>,
+        write_cache: bool,
     ) -> Result<SsTableHandle, SlateDBError> {
         let mut sst_builder = self.table_store.table_builder();
         let mut iter = imm_table.iter();
@@ -43,7 +44,10 @@ impl DbInner {
         }
 
         let encoded_sst = sst_builder.build()?;
-        let handle = self.table_store.write_sst(id, encoded_sst).await?;
+        let handle = self
+            .table_store
+            .write_sst(id, encoded_sst, write_cache)
+            .await?;
 
         self.mono_clock
             .fetch_max_last_durable_tick(imm_table.last_tick());
@@ -56,7 +60,7 @@ impl DbInner {
         imm: Arc<ImmutableWal>,
     ) -> Result<SsTableHandle, SlateDBError> {
         let wal_id = db_state::SsTableId::Wal(id);
-        self.flush_imm_table(&wal_id, imm.table()).await
+        self.flush_imm_table(&wal_id, imm.table(), false).await
     }
 
     fn flush_imm_wal_to_memtable(&self, mem_table: &mut WritableKVTable, imm_table: Arc<KVTable>) {

--- a/src/garbage_collector.rs
+++ b/src/garbage_collector.rs
@@ -947,7 +947,7 @@ mod tests {
         let mut sst = table_store.table_builder();
         sst.add(RowEntry::new_value(b"key", b"value", 0))?;
         let table1 = sst.build()?;
-        table_store.write_sst(table_id, table1).await?;
+        table_store.write_sst(table_id, table1, false).await?;
         Ok(())
     }
 
@@ -1063,13 +1063,13 @@ mod tests {
         sst1.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
 
         let table1 = sst1.build().unwrap();
-        table_store.write_sst(&id1, table1).await.unwrap();
+        table_store.write_sst(&id1, table1, false).await.unwrap();
 
         let id2 = SsTableId::Wal(2);
         let mut sst2 = table_store.table_builder();
         sst2.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
         let table2 = sst2.build().unwrap();
-        table_store.write_sst(&id2, table2).await.unwrap();
+        table_store.write_sst(&id2, table2, false).await.unwrap();
 
         // Set the both WAL SST file to be a day old
         let now_minus_24h_1 = set_modified(
@@ -1391,7 +1391,7 @@ mod tests {
         let mut sst = table_store.table_builder();
         sst.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
         let table = sst.build().unwrap();
-        table_store.write_sst(&sst_id, table).await.unwrap()
+        table_store.write_sst(&sst_id, table, false).await.unwrap()
     }
 
     /// Set the modified time of a file to be a certain number of seconds ago.

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -108,7 +108,7 @@ impl MemtableFlusher {
             let id = SsTableId::Compacted(Ulid::new());
             let sst_handle = self
                 .db_inner
-                .flush_imm_table(&id, imm_memtable.table())
+                .flush_imm_table(&id, imm_memtable.table(), true)
                 .await?;
             {
                 let mut guard = self.db_inner.state.write();

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -186,7 +186,7 @@ mod tests {
         builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
         let encoded = builder.build().unwrap();
         let id = SsTableId::Compacted(Ulid::new());
-        let handle = table_store.write_sst(&id, encoded).await.unwrap();
+        let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
             ssts: vec![handle],
@@ -229,12 +229,12 @@ mod tests {
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
         let encoded = builder.build().unwrap();
         let id1 = SsTableId::Compacted(Ulid::new());
-        let handle1 = table_store.write_sst(&id1, encoded).await.unwrap();
+        let handle1 = table_store.write_sst(&id1, encoded, false).await.unwrap();
         let mut builder = table_store.table_builder();
         builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
         let encoded = builder.build().unwrap();
         let id2 = SsTableId::Compacted(Ulid::new());
-        let handle2 = table_store.write_sst(&id2, encoded).await.unwrap();
+        let handle2 = table_store.write_sst(&id2, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
             ssts: vec![handle1, handle2],
@@ -448,7 +448,7 @@ mod tests {
 
             let encoded = builder.build().unwrap();
             let id = SsTableId::Compacted(Ulid::new());
-            let handle = table_store.write_sst(&id, encoded).await.unwrap();
+            let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
             ssts.push(handle);
         }
 

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -386,7 +386,7 @@ mod tests {
         builder.add_value(b"key4", b"value4", gen_attrs(4)).unwrap();
         let encoded = builder.build().unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded)
+            .write_sst(&SsTableId::Wal(0), encoded, false)
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
@@ -446,7 +446,7 @@ mod tests {
 
         let encoded = builder.build().unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded)
+            .write_sst(&SsTableId::Wal(0), encoded, false)
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();


### PR DESCRIPTION
This patch changes the memtable flush path to write L0 sst data to the db cache when a memtable is flushed. The idea is that this data was recently written and so is more likely to be read than other data in the cache.

This change required a few supporting changes from EncodedSsTable(Builder):
- Rather than storing a list of raw block bytes, the builder now stores a list of EncodedSsTableBlock which contains the encoded + compressed bytes, the decoded block, and its offset so that it can be easily inserted into the cache.
- The implementation of the builder is refactored a bit to support maintianing this list. finish_block now calls to a new fn called prepare_block which constructs EncodedSsTableBlock, and finish_block is in charge of setting the builder state to reflect the completion of the current block and start of the next block.
- EncodedSsTable now has fns for writing all the bytes into a buffer, which the tests and tablestore use rather than re-implementing this logic everywhere.