### PR TITLE
change read level to durability filter

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -176,14 +176,14 @@ use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
 /// updates the same key.
 #[non_exhaustive]
 #[derive(Clone, Default, Debug, Copy)]
-pub enum ReadLevel {
+pub enum DurabilityLevel {
     /// Client reads will only see data that's been committed durably to the DB.
     #[default]
-    Committed,
+    Remote,
 
     /// Clients will see all writes, including those not yet durably committed to the
     /// DB.
-    Uncommitted,
+    Memory,
 }
 
 /// Configuration for client read operations. `ReadOptions` is supplied for each
@@ -191,13 +191,13 @@ pub enum ReadLevel {
 #[derive(Clone, Default)]
 pub struct ReadOptions {
     /// The read commit level for read operations.
-    pub read_level: ReadLevel,
+    pub durability_filter: DurabilityLevel,
 }
 
 #[derive(Clone)]
 pub struct ScanOptions {
     /// The read commit level for read operations
-    pub read_level: ReadLevel,
+    pub durability_filter: DurabilityLevel,
     /// The number of bytes to read ahead. The value is rounded up to the nearest
     /// block size when fetching from object storage. The default is 1, which
     /// rounds up to one block.
@@ -207,10 +207,10 @@ pub struct ScanOptions {
 }
 
 impl Default for ScanOptions {
-    /// Create a new ScanOptions with `read_level` set to [`ReadLevel::Committed`].
+    /// Create a new ScanOptions with `read_level` set to [`DurabilityLevel::Remote`].
     fn default() -> Self {
         Self {
-            read_level: ReadLevel::Committed,
+            durability_filter: DurabilityLevel::Remote,
             read_ahead_bytes: 1,
             cache_blocks: false,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,11 +176,12 @@ use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
 #[non_exhaustive]
 #[derive(Clone, Default, Debug, Copy)]
 pub enum DurabilityLevel {
-    /// Describes data currently stored durably in object storage.
+    /// Includes only data currently stored durably in object storage.
     #[default]
     Remote,
 
-    /// Describes data currently only stored in-memory, awaiting flush to object storage.
+    /// Includes data with level Remote and data currently only stored in-memory awaiting flush
+    /// to object storage.
     Memory,
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -171,6 +171,7 @@ impl DbInner {
         Self::wal_enabled_in_options(&self.options)
     }
 
+    #[allow(unused_variables)]
     pub(crate) fn wal_enabled_in_options(options: &DbOptions) -> bool {
         #[cfg(feature = "wal_disable")]
         return options.wal_enabled;

--- a/src/db.rs
+++ b/src/db.rs
@@ -94,6 +94,7 @@ impl DbInner {
             table_store: Arc::clone(&table_store),
             db_stats: db_stats.clone(),
             mono_clock: Arc::clone(&mono_clock),
+            wal_enabled: DbInner::wal_enabled_in_options(&options)
         };
 
         let db_inner = Self {
@@ -167,8 +168,12 @@ impl DbInner {
     }
 
     pub(crate) fn wal_enabled(&self) -> bool {
+        Self::wal_enabled_in_options(&self.options)
+    }
+
+    pub(crate) fn wal_enabled_in_options(options: &DbOptions) -> bool {
         #[cfg(feature = "wal_disable")]
-        return self.options.wal_enabled;
+        return options.wal_enabled;
         #[cfg(not(feature = "wal_disable"))]
         return true;
     }
@@ -835,7 +840,7 @@ impl Db {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, config::ScanOptions, config::ReadLevel, SlateDBError};
+    /// use slatedb::{Db, config::ScanOptions, config::DurabilityLevel, SlateDBError};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
@@ -847,7 +852,7 @@ impl Db {
     ///     db.put(b"b", b"b_value").await?;
     ///
     ///     let mut iter = db.scan_with_options("a".."b", &ScanOptions {
-    ///         read_level: ReadLevel::Uncommitted,
+    ///         durability_filter: DurabilityLevel::Memory,
     ///         ..ScanOptions::default()
     ///     }).await?;
     ///     assert_eq!(Some((b"a", b"a_value").into()), iter.next().await?);
@@ -1154,7 +1159,7 @@ mod tests {
         OBJECT_STORE_CACHE_PART_ACCESS, OBJECT_STORE_CACHE_PART_HITS,
     };
     use crate::cached_object_store::FsCacheStorage;
-    use crate::config::ReadLevel::{Committed, Uncommitted};
+    use crate::config::DurabilityLevel::{Remote, Memory};
     use crate::config::{
         CompactorOptions, ObjectStoreCacheOptions, SizeTieredCompactionSchedulerOptions, Ttl,
     };
@@ -1226,7 +1231,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Uncommitted
+                        durability_filter: Memory
                     }
                 )
                 .await
@@ -1241,7 +1246,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Uncommitted
+                        durability_filter: Memory
                     }
                 )
                 .await
@@ -1289,7 +1294,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Uncommitted
+                        durability_filter: Memory
                     }
                 )
                 .await
@@ -1304,7 +1309,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Uncommitted
+                        durability_filter: Memory
                     }
                 )
                 .await
@@ -1345,7 +1350,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Committed
+                        durability_filter: Remote
                     }
                 )
                 .await
@@ -1360,7 +1365,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Committed
+                        durability_filter: Remote
                     }
                 )
                 .await
@@ -1376,7 +1381,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Committed
+                        durability_filter: Remote
                     }
                 )
                 .await
@@ -1384,6 +1389,33 @@ mod tests {
         );
 
         kv_store.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "wal_disable")]
+    async fn test_get_with_durability_level_when_wal_disabled() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut options = test_db_options(0, 1024 * 1024, None);
+        options.wal_enabled = false;
+        let db = Db::open_with_opts(
+            Path::from("/tmp/test_kv_store"),
+            options.clone(),
+            object_store,
+        )
+            .await
+            .unwrap();
+        let put_options = PutOptions::default();
+        let write_options = WriteOptions{await_durable: false};
+        let get_memory_options = ReadOptions{durability_filter: Memory};
+        let get_remote_options = ReadOptions{durability_filter: Remote};
+
+        db.put_with_options(b"foo", b"bar", &put_options, &write_options).await.unwrap();
+        let val_bytes = Bytes::copy_from_slice(b"bar");
+        assert_eq!(None, db.get_with_options(b"foo", &get_remote_options).await.unwrap());
+        assert_eq!(Some(val_bytes.clone()), db.get_with_options(b"foo", &get_memory_options).await.unwrap());
+        db.flush().await.unwrap();
+        assert_eq!(Some(val_bytes.clone()), db.get_with_options(b"foo", &get_remote_options).await.unwrap());
+        assert_eq!(Some(val_bytes.clone()), db.get_with_options(b"foo", &get_memory_options).await.unwrap());
     }
 
     #[tokio::test]
@@ -1424,7 +1456,7 @@ mod tests {
         }
         assert_eq!(
             Some(Bytes::copy_from_slice(last_val.as_bytes())),
-            db.get(b"key").await.unwrap()
+            db.get_with_options(b"key", &ReadOptions{durability_filter: Memory}).await.unwrap()
         );
         db.flush().await.unwrap();
 
@@ -1481,7 +1513,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Committed
+                        durability_filter: Remote
                     }
                 )
                 .await
@@ -1496,7 +1528,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Committed
+                        durability_filter: Remote
                     }
                 )
                 .await
@@ -1512,7 +1544,7 @@ mod tests {
                 .get_with_options(
                     key,
                     &ReadOptions {
-                        read_level: Committed
+                        durability_filter: Remote
                     }
                 )
                 .await
@@ -1760,7 +1792,7 @@ mod tests {
         runner
             .run(&arbitrary::nonempty_range(10), |range| {
                 let scan_options = ScanOptions {
-                    read_level: Uncommitted,
+                    durability_filter: Memory,
                     ..ScanOptions::default()
                 };
                 runtime.block_on(assert_records_in_range(&table, &db, &scan_options, range));
@@ -2500,7 +2532,7 @@ mod tests {
             .get_with_options(
                 "foo".as_bytes(),
                 &ReadOptions {
-                    read_level: Uncommitted,
+                    durability_filter: Memory,
                 },
             )
             .await
@@ -2552,7 +2584,7 @@ mod tests {
             .get_with_options(
                 "foo".as_bytes(),
                 &ReadOptions {
-                    read_level: Uncommitted,
+                    durability_filter: Memory,
                 },
             )
             .await
@@ -2598,7 +2630,7 @@ mod tests {
             .get_with_options(
                 "foo".as_bytes(),
                 &ReadOptions {
-                    read_level: Uncommitted,
+                    durability_filter: Memory,
                 },
             )
             .await

--- a/src/db_reader.rs
+++ b/src/db_reader.rs
@@ -132,6 +132,7 @@ impl DbReaderInner {
             table_store: Arc::clone(&table_store),
             db_stats: db_stats.clone(),
             mono_clock: Arc::clone(&mono_clock),
+            wal_enabled: true,
         };
 
         Ok(Self {
@@ -721,7 +722,7 @@ impl DbReader {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, config::DbReaderOptions, config::ScanOptions, config::ReadLevel, SlateDBError};
+    /// use slatedb::{Db, DbReader, config::DbReaderOptions, config::ScanOptions, config::DurabilityLevel, SlateDBError};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,6 +1,5 @@
 use crate::bytes_range::BytesRange;
-use crate::config::ReadLevel::Uncommitted;
-use crate::config::{ReadOptions, ScanOptions};
+use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
 use crate::db_state::{CoreDbState, SortedRun, SsTableHandle};
 use crate::db_stats::DbStats;
 use crate::filter_iterator::FilterIterator;
@@ -47,9 +46,22 @@ pub(crate) struct Reader {
     pub(crate) table_store: Arc<TableStore>,
     pub(crate) db_stats: DbStats,
     pub(crate) mono_clock: Arc<MonotonicClock>,
+    pub(crate) wal_enabled: bool
 }
 
 impl Reader {
+    fn include_wal_memtables(&self, durability_filter: DurabilityLevel) -> bool {
+        matches!(durability_filter, DurabilityLevel::Memory)
+    }
+
+    fn include_memtables(&self, durability_filter: DurabilityLevel) -> bool {
+        if self.wal_enabled {
+            true
+        } else {
+            matches!(durability_filter, DurabilityLevel::Memory)
+        }
+    }
+
     pub(crate) async fn get_with_options<K: AsRef<[u8]>>(
         &self,
         key: K,
@@ -57,9 +69,9 @@ impl Reader {
         snapshot: &(dyn ReadSnapshot + Sync),
     ) -> Result<Option<Bytes>, SlateDBError> {
         let key = key.as_ref();
-        let ttl_now = get_now_for_read(self.mono_clock.clone(), options.read_level).await?;
+        let ttl_now = get_now_for_read(self.mono_clock.clone(), options.durability_filter).await?;
 
-        if matches!(options.read_level, Uncommitted) {
+        if self.include_wal_memtables(options.durability_filter) {
             let maybe_val = std::iter::once(snapshot.wal())
                 .chain(snapshot.imm_wal().iter().map(|imm| imm.table()))
                 .find_map(|memtable| memtable.get(key));
@@ -68,11 +80,13 @@ impl Reader {
             }
         }
 
-        let maybe_val = std::iter::once(snapshot.memtable())
-            .chain(snapshot.imm_memtable().iter().map(|imm| imm.table()))
-            .find_map(|memtable| memtable.get(key));
-        if let Some(val) = maybe_val {
-            return Ok(Self::unwrap_value_if_not_expired(&val, ttl_now));
+        if self.include_memtables(options.durability_filter) {
+            let maybe_val = std::iter::once(snapshot.memtable())
+                .chain(snapshot.imm_memtable().iter().map(|imm| imm.table()))
+                .find_map(|memtable| memtable.get(key));
+            if let Some(val) = maybe_val {
+                return Ok(Self::unwrap_value_if_not_expired(&val, ttl_now));
+            }
         }
 
         // Since the key remains unchanged during the point query, we only need to compute
@@ -138,16 +152,18 @@ impl Reader {
     ) -> Result<DbIterator<'a>, SlateDBError> {
         let mut memtables = VecDeque::new();
 
-        if matches!(options.read_level, Uncommitted) {
+        if self.include_wal_memtables(options.durability_filter) {
             memtables.push_back(Arc::clone(&snapshot.wal()));
             for imm_wal in snapshot.imm_wal() {
                 memtables.push_back(imm_wal.table());
             }
         }
 
-        memtables.push_back(Arc::clone(&snapshot.memtable()));
-        for memtable in snapshot.imm_memtable() {
-            memtables.push_back(memtable.table());
+        if self.include_memtables(options.durability_filter) {
+            memtables.push_back(Arc::clone(&snapshot.memtable()));
+            for memtable in snapshot.imm_memtable() {
+                memtables.push_back(memtable.table());
+            }
         }
 
         let mem_iter =

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -46,7 +46,7 @@ pub(crate) struct Reader {
     pub(crate) table_store: Arc<TableStore>,
     pub(crate) db_stats: DbStats,
     pub(crate) mono_clock: Arc<MonotonicClock>,
-    pub(crate) wal_enabled: bool
+    pub(crate) wal_enabled: bool,
 }
 
 impl Reader {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
-use crate::config::ReadLevel::{Committed, Uncommitted};
-use crate::config::{Clock, ReadLevel};
+use crate::config::DurabilityLevel::{Remote, Memory};
+use crate::config::{Clock, DurabilityLevel};
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskPanic;
 use crate::types::RowEntry;
@@ -139,7 +139,7 @@ where
 
 pub(crate) async fn get_now_for_read(
     mono_clock: Arc<MonotonicClock>,
-    read_level: ReadLevel,
+    durability_level: DurabilityLevel,
 ) -> Result<i64, SlateDBError> {
     /*
      Note: the semantics of filtering expired records on read differ slightly depending on
@@ -157,9 +157,9 @@ pub(crate) async fn get_now_for_read(
      filtered out due to ttl expiry, it is guaranteed not to be seen again by future Committed
      reads.
     */
-    match read_level {
-        Committed => Ok(mono_clock.get_last_durable_tick()),
-        Uncommitted => mono_clock.now().await,
+    match durability_level {
+        Remote => Ok(mono_clock.get_last_durable_tick()),
+        Memory => mono_clock.now().await,
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::config::DurabilityLevel::{Remote, Memory};
+use crate::config::DurabilityLevel::{Memory, Remote};
 use crate::config::{Clock, DurabilityLevel};
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskPanic;


### PR DESCRIPTION
This patch changes the current ReadLevel and ReadOptions.read_level to DurabilityLevel and ReadOptions.durability_filter as described in RFC-8. It also changes the read path when wal is disabled to respect the durability filter by only reading from the memtable if the durability_filter is set to Memory. Previously we were disregarding the read level when wal was disabled.