### PR TITLE
refactor(reader.rs): add a LevelGet struct that filter max_seq in get() and tests with expire_ts handling

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -120,7 +120,9 @@ impl DbInner {
     ) -> Result<Option<Bytes>, SlateDBError> {
         self.check_error()?;
         let snapshot = self.state.read().snapshot();
-        self.reader.get_with_options(key, options, &snapshot).await
+        self.reader
+            .get_with_options(key, options, &snapshot, None)
+            .await
     }
 
     pub async fn scan_with_options<'a>(

--- a/src/db_reader.rs
+++ b/src/db_reader.rs
@@ -176,7 +176,7 @@ impl DbReaderInner {
         self.check_error()?;
         let snapshot = Arc::clone(&self.state.read());
         self.reader
-            .get_with_options(key, options, snapshot.as_ref())
+            .get_with_options(key, options, snapshot.as_ref(), None)
             .await
     }
 

--- a/src/filter_iterator.rs
+++ b/src/filter_iterator.rs
@@ -15,7 +15,7 @@ impl FilterIteratorPredicateBuilder {
         Self { ttl_now, max_seq }
     }
 
-    pub(crate) fn build(self) -> Box<dyn Fn(&RowEntry) -> bool + Send> {
+    pub(crate) fn build(self) -> Box<dyn Fn(&RowEntry) -> bool + Send + Sync> {
         Box::new(move |entry: &RowEntry| {
             let not_expired = self
                 .ttl_now
@@ -32,11 +32,14 @@ impl FilterIteratorPredicateBuilder {
 
 pub(crate) struct FilterIterator<T: KeyValueIterator> {
     iterator: T,
-    predicate: Arc<dyn Fn(&RowEntry) -> bool + Send>,
+    predicate: Arc<dyn Fn(&RowEntry) -> bool + Send + Sync>,
 }
 
 impl<T: KeyValueIterator> FilterIterator<T> {
-    pub(crate) fn new(iterator: T, predicate: Arc<dyn Fn(&RowEntry) -> bool + Send>) -> Self {
+    pub(crate) fn new(
+        iterator: T,
+        predicate: Arc<dyn Fn(&RowEntry) -> bool + Send + Sync>,
+    ) -> Self {
         Self {
             predicate,
             iterator,

--- a/src/filter_iterator.rs
+++ b/src/filter_iterator.rs
@@ -102,4 +102,28 @@ mod tests {
 
         assert_eq!(filter_iter.next().await.unwrap(), None);
     }
+
+    #[tokio::test]
+    async fn test_filter_iterator_predicate_builder() {
+        let iter = crate::test_utils::TestIterator::new()
+            .with_entry(b"a", b"val1", 5)
+            .with_entry(b"b", b"val2", 2)
+            .with_entry(b"b", b"val2", 10)
+            .with_entry(b"c", b"val3", 10)
+            .with_entry(b"d", b"val4", 8);
+
+        let now = 1000;
+        let predicate = FilterIteratorPredicateBuilder::new(Some(now), Some(9)).build();
+        let mut filter_iter = FilterIterator::new(iter, Arc::new(predicate));
+
+        assert_iterator(
+            &mut filter_iter,
+            vec![
+                RowEntry::new_value(b"a", b"val1", 5),
+                RowEntry::new_value(b"b", b"val2", 2),
+                RowEntry::new_value(b"d", b"val4", 8),
+            ],
+        )
+        .await;
+    }
 }

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -283,14 +283,13 @@ impl KVTable {
         ));
         self.map
             .range(range)
-            .filter(|entry| {
+            .find(|entry| {
                 if let Some(max_seq) = max_seq {
                     entry.key().seq <= max_seq
                 } else {
                     true
                 }
             })
-            .next()
             .map(|entry| entry.value().clone())
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -76,14 +76,14 @@ impl Reader {
         let get = LevelGet {
             key: key.as_ref(),
             max_seq,
-            snapshot: snapshot,
+            snapshot,
             table_store: self.table_store.clone(),
             db_stats: self.db_stats.clone(),
             now,
             include_wal_memtables: self.include_wal_memtables(options.durability_filter),
             include_memtables: self.include_memtables(options.durability_filter),
         };
-        Ok(get.get().await?)
+        get.get().await
     }
 
     pub(crate) async fn scan_with_options<'a>(

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -519,7 +519,7 @@ mod tests {
                 9,
                 Some(10000 - 5000),
                 Some(10000 + 4000), // not expired
-            )), // tombstone
+            )),
             None,
             Some(RowEntry::new(
                 Bytes::from_static(b"key"),
@@ -527,7 +527,7 @@ mod tests {
                 9,
                 Some(10000 - 5000),
                 None, // no expiration
-            )), // not expired
+            )), // tombstone
         ],
         expected: Some(Bytes::from_static(b"v1")),
     })]


### PR DESCRIPTION
`get()` and `scan()` runs different code path. besides adding `max_seq` for `scan()` in #536, it's also needed to have the `max_seq` filter in `get()`.

(we can consider add some proptest that checks that `get()` should always return the exactly the same result as `scan().next_entry()` in the next change)

this pr still needs some test cases.

this pr is also related with #489.