### PR TITLE
make StoreProvider Send+Sync

### DIFF
--- a/src/store_provider.rs
+++ b/src/store_provider.rs
@@ -6,7 +6,7 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use std::sync::Arc;
 
-pub(crate) trait StoreProvider {
+pub(crate) trait StoreProvider: Send + Sync {
     fn table_store(&self) -> Arc<TableStore>;
     fn manifest_store(&self) -> Arc<ManifestStore>;
 }


### PR DESCRIPTION
StoreProvider needs to be Send+Sync for the future returned by DbReader::open to be Send. Without this you can't use DbReader from something that impls a trait using async_trait