### PR TITLE
chore: wrap async-trait to KeyValueIterator & SeekToKey

### DIFF
--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -4,10 +4,11 @@ use crate::iter::IterationOrder::Ascending;
 use crate::iter::{IterationOrder, SeekToKey};
 use crate::row_codec::SstRowCodecV0;
 use crate::{block::Block, error::SlateDBError, iter::KeyValueIterator, types::RowEntry};
+use async_trait::async_trait;
 use bytes::{Buf, Bytes};
 use IterationOrder::Descending;
 
-pub trait BlockLike {
+pub trait BlockLike: Send + Sync {
     fn data(&self) -> &Bytes;
     fn offsets(&self) -> &[u16];
 }
@@ -51,6 +52,7 @@ pub struct BlockIterator<B: BlockLike> {
     ordering: IterationOrder,
 }
 
+#[async_trait]
 impl<B: BlockLike> KeyValueIterator for BlockIterator<B> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let result = self.load_at_current_off();
@@ -65,6 +67,7 @@ impl<B: BlockLike> KeyValueIterator for BlockIterator<B> {
     }
 }
 
+#[async_trait]
 impl<B: BlockLike> SeekToKey for BlockIterator<B> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         loop {

--- a/src/filter_iterator.rs
+++ b/src/filter_iterator.rs
@@ -5,16 +5,15 @@ use crate::types::RowEntry;
 use crate::utils::is_not_expired;
 use crate::SlateDBError;
 
+pub(crate) type FilterPredicate = Box<dyn Fn(&RowEntry) -> bool + Send + Sync>;
+
 pub(crate) struct FilterIterator<T: KeyValueIterator> {
     iterator: T,
-    predicate: Box<dyn Fn(&RowEntry) -> bool + Send + Sync>,
+    predicate: FilterPredicate,
 }
 
 impl<T: KeyValueIterator> FilterIterator<T> {
-    pub(crate) fn new(
-        iterator: T,
-        predicate: Box<dyn Fn(&RowEntry) -> bool + Send + Sync>,
-    ) -> Self {
+    pub(crate) fn new(iterator: T, predicate: FilterPredicate) -> Self {
         Self {
             predicate,
             iterator,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::error::SlateDBError;
 use crate::types::RowEntry;
 use crate::types::{KeyValue, ValueDeletable};
@@ -13,7 +15,9 @@ pub(crate) enum IterationOrder {
 /// because next will need to be made async to support SSTs, which are loaded over
 /// the network.
 /// See: https://github.com/slatedb/slatedb/issues/12
-pub trait KeyValueIterator {
+
+#[async_trait]
+pub trait KeyValueIterator: Send + Sync {
     /// Returns the next non-deleted key-value pair in the iterator.
     async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
         loop {
@@ -40,6 +44,7 @@ pub trait KeyValueIterator {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError>;
 }
 
+#[async_trait]
 pub(crate) trait SeekToKey {
     /// Seek to the next (inclusive) key
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError>;

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -4,6 +4,7 @@ use std::ops::{Bound, RangeBounds};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use crossbeam_skiplist::map::Range;
 use crossbeam_skiplist::SkipMap;
@@ -156,12 +157,14 @@ impl VecDequeKeyValueIterator {
     }
 }
 
+#[async_trait]
 impl KeyValueIterator for VecDequeKeyValueIterator {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         Ok(self.rows.pop_front())
     }
 }
 
+#[async_trait]
 impl SeekToKey for VecDequeKeyValueIterator {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         loop {
@@ -175,6 +178,7 @@ impl SeekToKey for VecDequeKeyValueIterator {
     }
 }
 
+#[async_trait]
 impl<T: RangeBounds<KVTableInternalKey>> KeyValueIterator for MemTableIterator<'_, T> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         Ok(self.next_entry_sync())

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -1,3 +1,5 @@
+use async_trait::async_trait;
+
 use crate::error::SlateDBError;
 use crate::iter::{KeyValueIterator, SeekToKey};
 use crate::types::RowEntry;
@@ -114,6 +116,7 @@ where
     }
 }
 
+#[async_trait]
 impl<T1, T2> SeekToKey for TwoMergeIterator<T1, T2>
 where
     T1: KeyValueIterator + SeekToKey,
@@ -125,6 +128,7 @@ where
     }
 }
 
+#[async_trait]
 impl<T1: KeyValueIterator, T2: KeyValueIterator> KeyValueIterator for TwoMergeIterator<T1, T2> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let mut current_kv = match self.advance_inner().await? {
@@ -238,6 +242,7 @@ impl<T: KeyValueIterator> MergeIterator<T> {
     }
 }
 
+#[async_trait]
 impl<T: KeyValueIterator> KeyValueIterator for MergeIterator<T> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let mut current_kv = match self.advance().await? {
@@ -260,6 +265,7 @@ impl<T: KeyValueIterator> KeyValueIterator for MergeIterator<T> {
     }
 }
 
+#[async_trait]
 impl<T: KeyValueIterator + SeekToKey> SeekToKey for MergeIterator<T> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         let mut seek_futures = VecDeque::new();

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use thiserror::Error;
 
@@ -174,6 +175,7 @@ impl<T: KeyValueIterator> MergeOperatorIterator<T> {
     }
 }
 
+#[async_trait]
 impl<T: KeyValueIterator> KeyValueIterator for MergeOperatorIterator<T> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let next_entry = match self.buffered_entry.take() {
@@ -340,6 +342,7 @@ mod tests {
         values: VecDeque<RowEntry>,
     }
 
+    #[async_trait]
     impl KeyValueIterator for MockKeyValueIterator {
         async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
             Ok(self.values.pop_front())

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -5,6 +5,7 @@ use crate::iter::{KeyValueIterator, SeekToKey};
 use crate::sst_iter::{SstIterator, SstIteratorOptions, SstView};
 use crate::tablestore::TableStore;
 use crate::types::RowEntry;
+use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::VecDeque;
 use std::ops::{Bound, RangeBounds};
@@ -117,6 +118,7 @@ impl<'a> SortedRunIterator<'a> {
     }
 }
 
+#[async_trait]
 impl KeyValueIterator for SortedRunIterator<'_> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         while let Some(iter) = &mut self.current_iter {
@@ -130,6 +132,7 @@ impl KeyValueIterator for SortedRunIterator<'_> {
     }
 }
 
+#[async_trait]
 impl SeekToKey for SortedRunIterator<'_> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         while let Some(next_table) = self.view.peek_next_table() {

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use bytes::Bytes;
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -308,6 +309,7 @@ impl<'a> SstIterator<'a> {
     }
 }
 
+#[async_trait]
 impl KeyValueIterator for SstIterator<'_> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         while !self.state.is_finished() {
@@ -332,6 +334,7 @@ impl KeyValueIterator for SstIterator<'_> {
     }
 }
 
+#[async_trait]
 impl SeekToKey for SstIterator<'_> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         if !self.view.contains(next_key) {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -3,6 +3,7 @@ use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, KeyValueIterator, SeekToKey};
 use crate::row_codec::SstRowCodecV0;
 use crate::types::{KeyValue, RowAttributes, RowEntry, ValueDeletable};
+use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::{Rng, RngCore};
 use std::collections::{BTreeMap, VecDeque};
@@ -72,6 +73,7 @@ impl TestIterator {
     }
 }
 
+#[async_trait]
 impl KeyValueIterator for TestIterator {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         self.entries.pop_front().map_or(Ok(None), |e| match e {
@@ -81,6 +83,7 @@ impl KeyValueIterator for TestIterator {
     }
 }
 
+#[async_trait]
 impl SeekToKey for TestIterator {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         while let Some(entry_result) = self.entries.front() {


### PR DESCRIPTION
currently `MergeIterator` has a limitation: all the iterators passed to it has to be the same type.

i tried passing a `Box<dyn KeyValueIterator>` to it, but rust type system fails that `KeyValueIterator` is not able to be used as trait object.

```
   --> src/merge_iterator.rs:150:13
    |
150 |     it: Box<dyn KeyValueIterator>,
    |             ^^^^^^^^^^^^^^^^^^^^ `KeyValueIterator` cannot be made into an object
    |
note: for a trait to be "dyn-compatible" it needs to allow building a vtable to allow the call to be resolvable dynamically; for more information visit <https://doc.rust-lang.org/reference/items/traits.html#object-safety>
   --> src/iter.rs:18:14
    |
16  | pub trait KeyValueIterator {
    |           ---------------- this trait cannot be made into an object...
17  |     /// Returns the next non-deleted key-value pair in the iterator.
18  |     async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
    |              ^^^^ ...because method `next` is `async`
...
40  |     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError>;
    |              ^^^^^^^^^^ ...because method `next_entry` is `async`
    = help: consider moving `next` to another trait
    = help: consider moving `next_entry` to another trait
    = help: the following types implement the trait, consider defining an enum where each variant holds one of these types, implementing `KeyValueIterator` for this new enum and using it instead:
              block_iterator::BlockIterator<B>
              filter_iterator::FilterIterator<T>
              mem_table::VecDequeKeyValueIterator
              mem_table::MemTableIterator<'_, T>
              merge_iterator::TwoMergeIterator<T1, T2>
              merge_iterator::MergeIterator<T>
              merge_operator::MergeOperatorIterator<T>
              sorted_run_iterator::SortedRunIterator<'_>
              sst_iter::SstIterator<'_>


```


this pr wraps an `async-trait` to it, so it allows this trait to be used as trait object.

it seems that `async-trait` may help us transforming an `async fn` in the trait into a `-> Box<Future<Output = Result<(), SlateDBError>>>`. it's not considered as a "zero-cost abstraction" due to it has a heap allocation, so having `Box<Future<..>>` is not the default behaviour for `async` functions in the rust compiler.