### PR TITLE
Multi get

### DIFF
--- a/src/db_reader.rs
+++ b/src/db_reader.rs
@@ -180,6 +180,18 @@ impl DbReaderInner {
             .await
     }
 
+    async fn multi_get_with_options<K: AsRef<[u8]> + Send>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
+        self.check_error()?;
+        let snapshot = Arc::clone(&self.state.read());
+        self.reader
+            .multi_get_with_options(keys, options, snapshot.as_ref())
+            .await
+    }
+
     async fn scan_with_options(
         &self,
         range: BytesRange,
@@ -654,6 +666,22 @@ impl DbReader {
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, SlateDBError> {
         self.inner.get_with_options(key, options).await
+    }
+
+    pub async fn multi_get<K: AsRef<[u8]> + Send>(
+        &self,
+        key: &[K],
+    ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
+        self.multi_get_with_options(key, &ReadOptions::default())
+            .await
+    }
+
+    pub async fn multi_get_with_options<K: AsRef<[u8]> + Send>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
+        self.inner.multi_get_with_options(keys, options).await
     }
 
     /// Scan a range of keys using the default scan options.

--- a/src/db_state.rs
+++ b/src/db_state.rs
@@ -54,6 +54,14 @@ impl SsTableHandle {
         false
     }
 
+    pub(crate) fn key_may_be_before(&self, key: &[u8]) -> bool {
+        if let Some(first_key) = self.info.first_key.as_ref() {
+            return key <= first_key;
+        }
+        // If there is no first key, it means the SST is empty so it doesn't cover the key.
+        true
+    }
+
     pub(crate) fn intersects_range(
         &self,
         end_bound: Bound<&[u8]>,


### PR DESCRIPTION
work of #301 ，need suggestions.

1、I retained the single-key get interface. While we could merge it with the MultiGet interface, I prefer not to do so. On one hand, merging these interfaces would conflict with ongoing community efforts (e.g., modifications to the filterIterator). On the other hand, retaining the standalone single-key get preserves optimization opportunities (modifying the code would become cumbersome and bloated if single-key get were integrated into MultiGet).
2、I’ve introduced only a simple implementation for now, which I believe is straightforward, effective, and offers significant flexibility for future adjustments. Additionally, premature optimization might complicate the introduction of new operators, such as the Merge Operator.