### PR TITLE
refactor: let MergeIterator accepts Box<dyn KeyValueIterator>; merge SeekToKey into KeyValueIterator

### DIFF
--- a/src/block_iterator.rs
+++ b/src/block_iterator.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
+use crate::iter::IterationOrder;
 use crate::iter::IterationOrder::Ascending;
-use crate::iter::{IterationOrder, SeekToKey};
 use crate::row_codec::SstRowCodecV0;
 use crate::{block::Block, error::SlateDBError, iter::KeyValueIterator, types::RowEntry};
 use async_trait::async_trait;
@@ -65,10 +65,7 @@ impl<B: BlockLike> KeyValueIterator for BlockIterator<B> {
             Err(e) => Err(e),
         }
     }
-}
 
-#[async_trait]
-impl<B: BlockLike> SeekToKey for BlockIterator<B> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         loop {
             let result = self.load_at_current_off();
@@ -148,7 +145,7 @@ mod tests {
     use crate::block::BlockBuilder;
     use crate::block_iterator::BlockIterator;
     use crate::bytes_range::BytesRange;
-    use crate::iter::{KeyValueIterator, SeekToKey};
+    use crate::iter::KeyValueIterator;
     use crate::proptest_util::{arbitrary, sample};
     use crate::test_utils::{assert_iterator, assert_next_entry, gen_attrs, gen_empty_attrs};
     use crate::types::RowEntry;

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -98,10 +98,7 @@ impl TokioCompactionExecutorInner {
     async fn load_iterators<'a>(
         &self,
         compaction: &'a CompactionJob,
-    ) -> Result<
-        TwoMergeIterator<MergeIterator<SstIterator<'a>>, MergeIterator<SortedRunIterator<'a>>>,
-        SlateDBError,
-    > {
+    ) -> Result<TwoMergeIterator<MergeIterator<'a>, MergeIterator<'a>>, SlateDBError> {
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 4,
             blocks_to_fetch: 256,

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -1,6 +1,6 @@
 use crate::bytes_range::BytesRange;
 use crate::error::SlateDBError;
-use crate::iter::{KeyValueIterator, SeekToKey};
+use crate::iter::KeyValueIterator;
 use crate::mem_table::VecDequeKeyValueIterator;
 use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
 use crate::sorted_run_iterator::SortedRunIterator;

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -13,7 +13,7 @@ use std::ops::RangeBounds;
 
 type ScanIterator<'a> = TwoMergeIterator<
     VecDequeKeyValueIterator,
-    TwoMergeIterator<MergeIterator<SstIterator<'a>>, MergeIterator<SortedRunIterator<'a>>>,
+    TwoMergeIterator<MergeIterator<'a>, MergeIterator<'a>>,
 >;
 
 pub struct DbIterator<'a> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum SlateDBError {
     #[error("Invalid DB state error")]
     InvalidDBState,
 
+    #[error("Unsupported operation: {0}")]
+    Unsupported(String),
+
     #[error("Invalid Compaction")]
     InvalidCompaction,
 

--- a/src/filter_iterator.rs
+++ b/src/filter_iterator.rs
@@ -47,6 +47,10 @@ impl<T: KeyValueIterator> KeyValueIterator for FilterIterator<T> {
         }
         Ok(None)
     }
+
+    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+        self.iterator.seek(next_key).await
+    }
 }
 
 #[cfg(test)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -42,10 +42,7 @@ pub trait KeyValueIterator: Send + Sync {
     /// Returns the next entry in the iterator, which may be a key-value pair or
     /// a tombstone of a deleted key-value pair.
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError>;
-}
 
-#[async_trait]
-pub(crate) trait SeekToKey {
     /// Seek to the next (inclusive) key
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError>;
 }

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::Ordering::SeqCst;
 
 use crate::bytes_range::BytesRange;
 use crate::error::SlateDBError;
-use crate::iter::{IterationOrder, KeyValueIterator, SeekToKey};
+use crate::iter::{IterationOrder, KeyValueIterator};
 use crate::merge_iterator::MergeIterator;
 use crate::types::RowEntry;
 use crate::utils::WatchableOnceCell;
@@ -162,10 +162,7 @@ impl KeyValueIterator for VecDequeKeyValueIterator {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         Ok(self.rows.pop_front())
     }
-}
 
-#[async_trait]
-impl SeekToKey for VecDequeKeyValueIterator {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         loop {
             let front = self.rows.front();
@@ -182,6 +179,12 @@ impl SeekToKey for VecDequeKeyValueIterator {
 impl<T: RangeBounds<KVTableInternalKey>> KeyValueIterator for MemTableIterator<'_, T> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         Ok(self.next_entry_sync())
+    }
+
+    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+        Err(SlateDBError::Unsupported(
+            "seek is not supported for memtable iterator".to_string(),
+        ))
     }
 }
 

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -138,7 +138,7 @@ impl VecDequeKeyValueIterator {
         Self { rows }
     }
 
-    pub(crate) async fn materialize_range<'a>(
+    pub(crate) async fn materialize_range(
         tables: VecDeque<Arc<KVTable>>,
         range: BytesRange,
     ) -> Result<Self, SlateDBError> {
@@ -183,7 +183,7 @@ impl<T: RangeBounds<KVTableInternalKey>> KeyValueIterator for MemTableIterator<'
         Ok(self.next_entry_sync())
     }
 
-    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+    async fn seek(&mut self, _next_key: &[u8]) -> Result<(), SlateDBError> {
         Err(SlateDBError::Unsupported(
             "seek is not supported for memtable iterator".to_string(),
         ))
@@ -340,7 +340,7 @@ impl KVTable {
         ordering: IterationOrder,
     ) -> MemTableIterator<KVTableInternalKeyRange> {
         MemTableIterator {
-            inner: self.clone().map.range(range.into()),
+            inner: self.map.range(range.into()),
             ordering,
         }
     }

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -170,21 +170,21 @@ impl<'a> MergeIteratorHeapEntry<'a> {
     }
 }
 
-impl<'a> Eq for MergeIteratorHeapEntry<'a> {}
+impl Eq for MergeIteratorHeapEntry<'_> {}
 
-impl<'a> PartialEq<Self> for MergeIteratorHeapEntry<'a> {
+impl PartialEq<Self> for MergeIteratorHeapEntry<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index && self.next_kv == other.next_kv
     }
 }
 
-impl<'a> PartialOrd<Self> for MergeIteratorHeapEntry<'a> {
+impl PartialOrd<Self> for MergeIteratorHeapEntry<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'a> Ord for MergeIteratorHeapEntry<'a> {
+impl Ord for MergeIteratorHeapEntry<'_> {
     fn cmp(&self, other: &Self) -> Ordering {
         // we'll wrap a Reverse in the BinaryHeap, so the cmp here is in increasing order.
         // after Reverse is wrapped, it will return the entries with higher seqnum first.
@@ -238,7 +238,7 @@ impl<'a> MergeIterator<'a> {
 }
 
 #[async_trait]
-impl<'a> KeyValueIterator for MergeIterator<'a> {
+impl KeyValueIterator for MergeIterator<'_> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let mut current_kv = match self.advance().await? {
             Some(kv) => kv,

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -141,18 +141,18 @@ impl<T1: KeyValueIterator, T2: KeyValueIterator> KeyValueIterator for TwoMergeIt
     }
 }
 
-struct MergeIteratorHeapEntry<T: KeyValueIterator> {
+struct MergeIteratorHeapEntry<'a> {
     next_kv: RowEntry,
     index: u32,
-    iterator: T,
+    iterator: Box<dyn KeyValueIterator + 'a>,
 }
 
-impl<T: KeyValueIterator> MergeIteratorHeapEntry<T> {
+impl<'a> MergeIteratorHeapEntry<'a> {
     /// Seek the iterator and return a new heap entry
     async fn seek(
         mut self,
         next_key: &[u8],
-    ) -> Result<Option<MergeIteratorHeapEntry<T>>, SlateDBError> {
+    ) -> Result<Option<MergeIteratorHeapEntry<'a>>, SlateDBError> {
         if self.next_kv.key >= next_key {
             Ok(Some(self))
         } else {
@@ -170,21 +170,21 @@ impl<T: KeyValueIterator> MergeIteratorHeapEntry<T> {
     }
 }
 
-impl<T: KeyValueIterator> Eq for MergeIteratorHeapEntry<T> {}
+impl<'a> Eq for MergeIteratorHeapEntry<'a> {}
 
-impl<T: KeyValueIterator> PartialEq<Self> for MergeIteratorHeapEntry<T> {
+impl<'a> PartialEq<Self> for MergeIteratorHeapEntry<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.index == other.index && self.next_kv == other.next_kv
     }
 }
 
-impl<T: KeyValueIterator> PartialOrd<Self> for MergeIteratorHeapEntry<T> {
+impl<'a> PartialOrd<Self> for MergeIteratorHeapEntry<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T: KeyValueIterator> Ord for MergeIteratorHeapEntry<T> {
+impl<'a> Ord for MergeIteratorHeapEntry<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
         // we'll wrap a Reverse in the BinaryHeap, so the cmp here is in increasing order.
         // after Reverse is wrapped, it will return the entries with higher seqnum first.
@@ -192,13 +192,15 @@ impl<T: KeyValueIterator> Ord for MergeIteratorHeapEntry<T> {
     }
 }
 
-pub(crate) struct MergeIterator<T: KeyValueIterator> {
-    current: Option<MergeIteratorHeapEntry<T>>,
-    iterators: BinaryHeap<Reverse<MergeIteratorHeapEntry<T>>>,
+pub(crate) struct MergeIterator<'a> {
+    current: Option<MergeIteratorHeapEntry<'a>>,
+    iterators: BinaryHeap<Reverse<MergeIteratorHeapEntry<'a>>>,
 }
 
-impl<T: KeyValueIterator> MergeIterator<T> {
-    pub(crate) async fn new(mut iterators: VecDeque<T>) -> Result<Self, SlateDBError> {
+impl<'a> MergeIterator<'a> {
+    pub(crate) async fn new<T: KeyValueIterator + 'a>(
+        mut iterators: VecDeque<T>,
+    ) -> Result<Self, SlateDBError> {
         let mut heap = BinaryHeap::new();
         let mut index = 0;
         while let Some(mut iterator) = iterators.pop_front() {
@@ -206,7 +208,7 @@ impl<T: KeyValueIterator> MergeIterator<T> {
                 heap.push(Reverse(MergeIteratorHeapEntry {
                     next_kv: kv,
                     index,
-                    iterator,
+                    iterator: Box::new(iterator),
                 }));
             }
             index += 1;
@@ -236,7 +238,7 @@ impl<T: KeyValueIterator> MergeIterator<T> {
 }
 
 #[async_trait]
-impl<T: KeyValueIterator> KeyValueIterator for MergeIterator<T> {
+impl<'a> KeyValueIterator for MergeIterator<'a> {
     async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let mut current_kv = match self.advance().await? {
             Some(kv) => kv,
@@ -289,7 +291,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_iterator_should_include_entries_in_order() {
-        let mut iters = VecDeque::new();
+        let mut iters: VecDeque<TestIterator> = VecDeque::new();
         iters.push_back(
             TestIterator::new()
                 .with_entry(b"aaaa", b"1111", 0)
@@ -330,7 +332,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge_iterator_should_write_one_entry_with_given_key() {
-        let mut iters = VecDeque::new();
+        let mut iters: VecDeque<TestIterator> = VecDeque::new();
         iters.push_back(
             TestIterator::new()
                 .with_entry(b"aaaa", b"0000", 5)
@@ -414,7 +416,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_seek_merge_iter() {
-        let mut iters = VecDeque::new();
+        let mut iters: VecDeque<TestIterator> = VecDeque::new();
         iters.push_back(
             TestIterator::new()
                 .with_entry(b"aa", b"aa1", 0)
@@ -442,7 +444,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_seek_merge_iter_to_current_key() {
-        let mut iters = VecDeque::new();
+        let mut iters: VecDeque<TestIterator> = VecDeque::new();
         iters.push_back(
             TestIterator::new()
                 .with_entry(b"aa", b"aa1", 0)

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -195,6 +195,10 @@ impl<T: KeyValueIterator> KeyValueIterator for MergeOperatorIterator<T> {
         }
         Ok(None)
     }
+
+    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+        self.delegate.seek(next_key).await
+    }
 }
 
 #[cfg(test)]
@@ -346,6 +350,11 @@ mod tests {
     impl KeyValueIterator for MockKeyValueIterator {
         async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
             Ok(self.values.pop_front())
+        }
+
+        async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+            self.values.retain(|entry| entry.key == next_key);
+            Ok(())
         }
     }
 

--- a/src/sorted_run_iterator.rs
+++ b/src/sorted_run_iterator.rs
@@ -1,7 +1,7 @@
 use crate::bytes_range::BytesRange;
 use crate::db_state::{SortedRun, SsTableHandle};
 use crate::error::SlateDBError;
-use crate::iter::{KeyValueIterator, SeekToKey};
+use crate::iter::KeyValueIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions, SstView};
 use crate::tablestore::TableStore;
 use crate::types::RowEntry;
@@ -130,10 +130,7 @@ impl KeyValueIterator for SortedRunIterator<'_> {
         }
         Ok(None)
     }
-}
 
-#[async_trait]
-impl SeekToKey for SortedRunIterator<'_> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         while let Some(next_table) = self.view.peek_next_table() {
             if next_table.compacted_first_key() < next_key {

--- a/src/sst_iter.rs
+++ b/src/sst_iter.rs
@@ -11,7 +11,6 @@ use crate::bytes_range::BytesRange;
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::{SsTableIndex, SsTableIndexOwned};
-use crate::iter::SeekToKey;
 use crate::{
     block::Block, block_iterator::BlockIterator, iter::KeyValueIterator, partitioned_keyspace,
     tablestore::TableStore, types::RowEntry,
@@ -332,10 +331,7 @@ impl KeyValueIterator for SstIterator<'_> {
         }
         Ok(None)
     }
-}
 
-#[async_trait]
-impl SeekToKey for SstIterator<'_> {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         if !self.view.contains(next_key) {
             return Err(SlateDBError::InvalidArgument {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,6 @@
 use crate::config::{Clock, PutOptions, WriteOptions};
 use crate::error::SlateDBError;
-use crate::iter::{IterationOrder, KeyValueIterator, SeekToKey};
+use crate::iter::{IterationOrder, KeyValueIterator};
 use crate::row_codec::SstRowCodecV0;
 use crate::types::{KeyValue, RowAttributes, RowEntry, ValueDeletable};
 use async_trait::async_trait;
@@ -81,10 +81,7 @@ impl KeyValueIterator for TestIterator {
             Err(err) => Err(err),
         })
     }
-}
 
-#[async_trait]
-impl SeekToKey for TestIterator {
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         while let Some(entry_result) = self.entries.front() {
             let entry = entry_result.clone()?;


### PR DESCRIPTION
currently there's a limitation in `MergeIterator`: the children iterator passed to it has to be the same type.

this pr makes KeyValueIterator able to be used as a trait object, so we can pass different implementations of `KeyValueIterator` into it.

Rust type system does not allow things like `Box<dyn KeyValueIterator + SeekToKey>`, so this pr has to merge the trait `SeekToKey` into `KeyValueIterator` together.
