### PR TITLE
chore: fix clippy; add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-04-12"
+components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/src/bencher/main.rs
+++ b/src/bencher/main.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("README.md")]
+#![allow(clippy::result_large_err)]
 
 use crate::args::BencherArgs;
 use args::{BencherCommands, BenchmarkCompactionArgs, BenchmarkDbArgs, CompactionSubcommands};

--- a/src/cached_object_store/storage_fs.rs
+++ b/src/cached_object_store/storage_fs.rs
@@ -254,7 +254,7 @@ impl LocalCacheEntry for FsCacheEntry {
         for part_file_name in part_file_names.iter() {
             let part_number = part_file_name
                 .split('-')
-                .last()
+                .next_back()
                 .and_then(|part_number| part_number.parse::<usize>().ok());
             if let Some(part_number) = part_number {
                 part_numbers.push(part_number);

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -114,7 +114,7 @@ async fn create_clone_manifest(
     };
 
     fail_point!(fp_registry, "create-clone-manifest-io-error", |_| Err(
-        SlateDBError::from(std::io::Error::new(std::io::ErrorKind::Other, "oops"))
+        SlateDBError::from(std::io::Error::other("oops"))
     ));
 
     // Ensure all external databases contain the final checkpoint.
@@ -280,7 +280,7 @@ async fn copy_wal_ssts(
     let mut wal_id = parent_checkpoint_state.last_compacted_wal_sst_id + 1;
     while wal_id < parent_checkpoint_state.next_wal_sst_id {
         fail_point!(fp_registry.clone(), "copy-wal-ssts-io-error", |_| Err(
-            SlateDBError::from(std::io::Error::new(std::io::ErrorKind::Other, "oops"))
+            SlateDBError::from(std::io::Error::other("oops"))
         ));
 
         let id = SsTableId::Wal(wal_id);

--- a/src/db.rs
+++ b/src/db.rs
@@ -773,7 +773,7 @@ impl Db {
     /// ## Arguments
     /// - `key`: the key to get
     /// - `options`: the read options to use (Note that [`ReadOptions::read_level`] has no effect for readers, which
-    ///    can only observe committed state).
+    ///   can only observe committed state).
     ///
     /// ## Returns
     /// - `Result<Option<Bytes>, SlateDBError>`:

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,6 +148,7 @@ pub enum DbOptionsError {
     #[error("Unknown configuration file format: {0}")]
     UnknownFormat(PathBuf),
 
+    // TODO: clippy complains this error is too large
     #[error("Invalid configuration format: {0}")]
     InvalidFormat(#[from] figment::Error),
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -309,7 +309,7 @@ mod tests {
 
         assert_eq!(clamped.buffer, filter.buffer);
         assert_eq!(clamped.num_probes, filter.num_probes);
-        assert!(clamped.buffer.as_ptr() != filter.buffer.as_ptr());
+        assert_ne!(clamped.buffer.as_ptr(), filter.buffer.as_ptr());
     }
 
     #[test]

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -30,7 +30,7 @@ impl BloomFilterBuilder {
     pub(crate) fn filter_size_bytes(num_keys: u32, bits_per_key: u32) -> usize {
         let filter_bits = num_keys * bits_per_key;
         // compute filter bytes rounded up to the number of bytes required to fit the filter
-        ((filter_bits + 7) / 8) as usize
+        filter_bits.div_ceil(8) as usize
     }
 
     pub(crate) fn build(&self) -> BloomFilter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]
+#![allow(clippy::result_large_err)]
 
 /// Re-export the bytes crate.
 ///

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -123,10 +123,7 @@ impl TableStore {
         id_range: R,
     ) -> Result<Vec<SstFileMetadata>, SlateDBError> {
         fail_point!(Arc::clone(&self.fp_registry), "list-wal-ssts", |_| {
-            Err(SlateDBError::from(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "oops",
-            )))
+            Err(SlateDBError::from(std::io::Error::other("oops")))
         });
 
         let mut wal_list: Vec<SstFileMetadata> = Vec::new();

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -562,7 +562,7 @@ impl EncodedSsTableWriter<'_> {
 
 #[allow(dead_code)]
 fn slatedb_io_error() -> SlateDBError {
-    SlateDBError::from(std::io::Error::new(std::io::ErrorKind::Other, "oops"))
+    SlateDBError::from(std::io::Error::other("oops"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
recent PRs have failed on clippy several times, but I cannot reproduce the clippy error locally without upgrading my local rust toolchain.

it seems the github workflow may upgrade the rust toolchain randomly.

this PR adds a rust-toolchain.toml file to ensure the consistency between workflow and local, and fix the clippy errors.
