### PR TITLE
[bug] db_options.flush_interval=None broken

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1221,6 +1221,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_no_flush_interval() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db_options_no_flush_interval = {
+            let mut db_options = test_db_options(0, 1024, None);
+            db_options.flush_interval = None;
+            db_options
+        };
+        let kv_store = Db::open_with_opts(
+            Path::from("/tmp/test_kv_store"),
+            db_options_no_flush_interval,
+            object_store,
+        )
+        .await
+        .unwrap();
+        let key = b"test_key";
+        let value = b"test_value";
+
+        kv_store
+            .put_with_options(
+                key,
+                value,
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                },
+            )
+            .await
+            .unwrap();
+
+        // a sanity check: the wal contains the most recent write
+        assert!(!kv_store.inner.state.write().wal().is_empty());
+
+        // and a flush() should clear it
+        kv_store.flush().await.unwrap();
+        assert!(kv_store.inner.state.write().wal().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_get_with_default_ttl_and_read_uncommitted() {
         let clock = Arc::new(TestClock::new());
         let ttl = 100;

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -1,5 +1,6 @@
 use log::warn;
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::runtime::Handle;
 use tokio::select;
@@ -98,12 +99,12 @@ impl DbInner {
             this: &Arc<DbInner>,
             rx: &mut UnboundedReceiver<WalFlushMsg>,
         ) -> Result<(), SlateDBError> {
-            let Some(period) = this.options.flush_interval else {
-                // If flush_interval is not set, we do not start the flush task.
-                return Ok(());
-            };
-
+            // Periodic flushing is disabled if `flush_interval` is set to None. Even if we do
+            // not perform periodic flushing, we still need to handle manual flush requests,
+            // and the final flush when the database is closed.
+            let period = this.options.flush_interval.unwrap_or(Duration::MAX);
             let mut ticker = tokio::time::interval(period);
+
             let mut err_reader = this.state.read().error_reader();
             loop {
                 select! {
@@ -131,7 +132,6 @@ impl DbInner {
                                     error!("error from wal flush: {err}");
                                     return Err(err);
                                 }
-
                                 if let Some(rsp_sender) = sender {
                                     let res = rsp_sender.send(result);
                                     if let Err(Err(err)) = res {


### PR DESCRIPTION
## the problem
I noticed that setting `flush_interval` as `None` currently does not work. If it's set as `None`, currently the flush task just stops:
https://github.com/slatedb/slatedb/blob/9e4a80b37fd91cd29b7a485712ea3cb2ba7388f8/src/flush.rs#L101-L104
However this task not only performs periodic flushes, it also handles manual flush requests (which don't work in this case):
https://github.com/slatedb/slatedb/blob/9e4a80b37fd91cd29b7a485712ea3cb2ba7388f8/src/flush.rs#L128-L129

## fix
When `flush_interval` is `None`, change the behavior to start the flush task- just without the periodic ticking.

## test plan
The test I added in `db.rs` fails without the code change in `flush.rs`:
```
$ git restore --source=HEAD^ src/flush.rs
$ cargo test  test_no_flush_interval
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running unittests src/lib.rs (target/debug/deps/slatedb-0ec2a6b3d07b9b56)

running 1 test
test db::tests::test_no_flush_interval ... FAILED

failures:

---- db::tests::test_no_flush_interval stdout ----
thread 'db::tests::test_no_flush_interval' panicked at src/db.rs:1255:32:
called `Result::unwrap()` on an `Err` value: WalFlushChannelError
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    db::tests::test_no_flush_interval

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 361 filtered out; finished in 0.00s

error: test failed, to rerun pass `--lib`
```

