### PR TITLE
refactor keyvalueIterator

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(block.data, block_clamped.data);
         assert_eq!(block.offsets, block_clamped.offsets);
         assert_ne!(block.data.as_ptr(), block_clamped.data.as_ptr());
-        let mut iter = BlockIterator::new_ascending(block_clamped);
+        let mut iter = BlockIterator::new_ascending(block_clamped).unwrap();
         assert_iterator(&mut iter, case.entries).await;
     }
 

--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -530,7 +530,7 @@ mod tests {
         .await
         .unwrap();
 
-        let wal_entry = wal_iter.next().await.unwrap().unwrap();
+        let wal_entry = wal_iter.take_and_next_kv().await.unwrap().unwrap();
         assert_eq!(*kv.1, wal_entry.value)
     }
 }

--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -507,16 +507,16 @@ mod tests {
         .await
         .unwrap();
         for i in 0..4 {
-            let kv = iter.next().await.unwrap().unwrap();
+            let kv = iter.take_and_next_kv().await.unwrap().unwrap();
             assert_eq!(kv.key.as_ref(), &[b'a' + i as u8; 16]);
             assert_eq!(kv.value.as_ref(), &[b'b' + i as u8; 48]);
         }
         for i in 0..4 {
-            let kv = iter.next().await.unwrap().unwrap();
+            let kv = iter.take_and_next_kv().await.unwrap().unwrap();
             assert_eq!(kv.key.as_ref(), &[b'j' + i as u8; 16]);
             assert_eq!(kv.value.as_ref(), &[b'k' + i as u8; 48]);
         }
-        assert!(iter.next().await.unwrap().is_none());
+        assert!(iter.take_and_next_kv().await.unwrap().is_none());
         // todo: test that the db can read the k/vs (once we implement reading from compacted)
     }
 

--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -137,7 +137,7 @@ impl TokioCompactionExecutorInner {
             .table_writer(SsTableId::Compacted(Ulid::new()));
         let mut current_size = 0usize;
 
-        while let Some(raw_kv) = all_iter.next_entry().await? {
+        while let Some(raw_kv) = all_iter.take_and_next_entry().await? {
             // filter out any expired entries -- eventually we can consider
             // abstracting this away into generic, pluggable compaction filters
             // but for now we do it inline

--- a/src/db.rs
+++ b/src/db.rs
@@ -2309,13 +2309,13 @@ mod tests {
                 SstIterator::new_borrowed(.., sst1, table_store.clone(), sst_iter_options)
                     .await
                     .unwrap();
-            let kv = iter.next().await.unwrap().unwrap();
+            let kv = iter.take_and_next_kv().await.unwrap().unwrap();
             assert_eq!(kv.key.as_ref(), [b'a' + i; 16]);
             assert_eq!(kv.value.as_ref(), [b'b' + i; 50]);
-            let kv = iter.next().await.unwrap().unwrap();
+            let kv = iter.take_and_next_kv().await.unwrap().unwrap();
             assert_eq!(kv.key.as_ref(), [b'j' + i; 16]);
             assert_eq!(kv.value.as_ref(), [b'k' + i; 50]);
-            let kv = iter.next().await.unwrap();
+            let kv = iter.take_and_next_kv().await.unwrap();
             assert!(kv.is_none());
         }
         assert!(
@@ -2432,15 +2432,15 @@ mod tests {
         };
 
         let mut iter = memtable.iter();
-        let kv = iter.next().await.unwrap().unwrap();
+        let kv = iter.take_and_next_kv().await.unwrap().unwrap();
         assert_eq!(kv.key, b"abc1111".as_slice());
 
         kv_store.flush().await.unwrap();
 
-        let kv = iter.next().await.unwrap().unwrap();
+        let kv = iter.take_and_next_kv().await.unwrap().unwrap();
         assert_eq!(kv.key, b"abc2222".as_slice());
 
-        let kv = iter.next().await.unwrap().unwrap();
+        let kv = iter.take_and_next_kv().await.unwrap().unwrap();
         assert_eq!(kv.key, b"abc3333".as_slice());
     }
 

--- a/src/db_cache/serde.rs
+++ b/src/db_cache/serde.rs
@@ -219,7 +219,7 @@ mod tests {
 
         let decoded_block = decoded.block().unwrap();
         assert!(block.as_ref() == decoded_block.as_ref());
-        let mut iter = BlockIterator::new(decoded_block, IterationOrder::Ascending);
+        let mut iter = BlockIterator::new(decoded_block, IterationOrder::Ascending).unwrap();
         assert_iterator(&mut iter, rows).await;
     }
 

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -49,7 +49,7 @@ impl<'a> DbIterator<'a> {
         if let Some(error) = self.invalidated_error.clone() {
             Err(SlateDBError::InvalidatedIterator(Box::new(error)))
         } else {
-            let result = self.iter.next().await;
+            let result = self.iter.take_and_next_kv().await;
             self.maybe_invalidate(result)
         }
     }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -38,7 +38,7 @@ impl DbInner {
     ) -> Result<SsTableHandle, SlateDBError> {
         let mut sst_builder = self.table_store.table_builder();
         let mut iter = imm_table.iter();
-        while let Some(entry) = iter.next_entry().await? {
+        while let Some(entry) = iter.take_and_next_entry().await? {
             sst_builder.add(entry)?;
         }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -19,9 +19,9 @@ pub(crate) enum IterationOrder {
 #[async_trait]
 pub trait KeyValueIterator: Send + Sync {
     /// Returns the next non-deleted key-value pair in the iterator.
-    async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
+    async fn take_and_next_kv(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
         loop {
-            let entry = self.next_entry().await?;
+            let entry = self.take_and_next_entry().await?;
             if let Some(kv) = entry {
                 match kv.value {
                     ValueDeletable::Value(v) => {
@@ -41,7 +41,9 @@ pub trait KeyValueIterator: Send + Sync {
 
     /// Returns the next entry in the iterator, which may be a key-value pair or
     /// a tombstone of a deleted key-value pair.
-    async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError>;
+    async fn take_and_next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError>;
+
+    fn peek(&self) -> Option<&RowEntry>;
 
     /// Seek to the next (inclusive) key
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError>;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -244,7 +244,7 @@ impl<'a> LevelGet<'a> {
                     .await?;
 
                     let mut iter = FilterIterator::new_with_max_seq(iter, self.max_seq);
-                    if let Some(entry) = iter.next_entry().await? {
+                    if let Some(entry) = iter.take_and_next_entry().await? {
                         if entry.key == self.key {
                             return Ok(Some(entry));
                         }
@@ -283,7 +283,7 @@ impl<'a> LevelGet<'a> {
                     .await?;
 
                     let mut iter = FilterIterator::new_with_max_seq(iter, self.max_seq);
-                    if let Some(entry) = iter.next_entry().await? {
+                    if let Some(entry) = iter.take_and_next_entry().await? {
                         if entry.key == self.key {
                             return Ok(Some(entry));
                         }

--- a/src/sst.rs
+++ b/src/sst.rs
@@ -715,7 +715,7 @@ mod tests {
         assert!(block.is_some());
         let block = block.unwrap();
         let block = Block::decode(block.slice(..block.len() - 4));
-        BlockIterator::new(block, Ascending)
+        BlockIterator::new(block, Ascending).unwrap()
     }
 
     #[tokio::test]
@@ -798,7 +798,7 @@ mod tests {
         let block = format
             .read_block_raw(&encoded.info, &index, 0, &raw_sst)
             .unwrap();
-        let mut iter = BlockIterator::new_ascending(block);
+        let mut iter = BlockIterator::new_ascending(block).unwrap();
         assert_iterator(
             &mut iter,
             vec![RowEntry::new_value(&[b'a'; 8], &[b'1'; 8], 0).with_create_ts(1)],
@@ -807,7 +807,7 @@ mod tests {
         let block = format
             .read_block_raw(&encoded.info, &index, 1, &raw_sst)
             .unwrap();
-        let mut iter = BlockIterator::new_ascending(block);
+        let mut iter = BlockIterator::new_ascending(block).unwrap();
         assert_iterator(
             &mut iter,
             vec![RowEntry::new_value(&[b'b'; 8], &[b'2'; 8], 0).with_create_ts(2)],
@@ -816,7 +816,7 @@ mod tests {
         let block = format
             .read_block_raw(&encoded.info, &index, 2, &raw_sst)
             .unwrap();
-        let mut iter = BlockIterator::new_ascending(block);
+        let mut iter = BlockIterator::new_ascending(block).unwrap();
         assert_iterator(
             &mut iter,
             vec![RowEntry::new_value(&[b'c'; 8], &[b'3'; 8], 0).with_create_ts(3)],
@@ -1067,7 +1067,7 @@ mod tests {
 
         // then:
         for expected_entries in expected_blocks {
-            let mut iter = BlockIterator::new(blocks.pop_front().unwrap(), Ascending);
+            let mut iter = BlockIterator::new(blocks.pop_front().unwrap(), Ascending).unwrap();
             assert_iterator(&mut iter, expected_entries).await;
         }
         assert!(blocks.is_empty())

--- a/src/tablestore.rs
+++ b/src/tablestore.rs
@@ -807,8 +807,8 @@ mod tests {
         let mut expected_iter = expected.iter();
 
         while let (Some(block), Some(expected_item)) = (block_iter.next(), expected_iter.next()) {
-            let mut iter = BlockIterator::new_ascending(block.clone());
-            let kv = iter.next().await.unwrap().unwrap();
+            let mut iter = BlockIterator::new_ascending(block.clone()).unwrap();
+            let kv = iter.take_and_next_kv().await.unwrap().unwrap();
             assert_eq!(kv.key, expected_item.0);
             assert_eq!(ValueDeletable::Value(kv.value), expected_item.1);
         }

--- a/src/wal_replay.rs
+++ b/src/wal_replay.rs
@@ -214,7 +214,7 @@ impl WalReplayIterator<'_> {
         while !self.current_iter.is_finished() {
             if let Some(sst_iter) = &mut self.current_iter.current_iter {
                 let wal_id = sst_iter.table_id().unwrap_wal_id();
-                while let Some(row_entry) = sst_iter.next_entry().await? {
+                while let Some(row_entry) = sst_iter.take_and_next_entry().await? {
                     let meta = table.metadata();
                     if self.table_store.estimate_encoded_size(
                         meta.entry_num + 1,
@@ -380,7 +380,7 @@ mod tests {
             }
 
             let mut iter = replayed_table.table.table().iter();
-            while let Some(next_entry) = iter.next_entry().await.unwrap() {
+            while let Some(next_entry) = iter.take_and_next_entry().await.unwrap() {
                 full_replayed_table.put(next_entry);
             }
         }
@@ -427,7 +427,7 @@ mod tests {
             assert!(replayed_table.table.metadata().entries_size_in_bytes <= max_memtable_bytes);
 
             let mut iter = replayed_table.table.table().iter();
-            while let Some(next_entry) = iter.next_entry().await.unwrap() {
+            while let Some(next_entry) = iter.take_and_next_entry().await.unwrap() {
                 full_replayed_table.put(next_entry);
             }
         }


### PR DESCRIPTION
work of https://github.com/slatedb/slatedb/issues/494

1.The original next_entry method had ambiguous semantics—its name suggested it should return the next entry, but in practice, it returned the current entry and advanced the iterator. To resolve this, I renamed it to take_and_next_entry to better reflect its behavior. I initially considered a design where next would not return a value and instead rely on peek to provide a reference, but this approach introduced significant performance overhead compared to the original implementation. Thus, I opted to retain the original semantics while renaming the methods for clarity.

2.In the previous implementation, TwoMergeIterator and MergeIterator stored copies of the current value within their internal state. This led to unnecessary copies, especially when TwoMergeIterator wrapped a MergeIterator, effectively tripling the number of copies in scan operations. By removing these internal copies and introducing the peek method, we now directly expose references to the current entries of their child iterators, eliminating redundant data duplication.

3.The BlockIterator constructor was modified to return a Result and operate asynchronously. This change was necessary to support peek, which requires loading and validating the first entry during initialization.
Ideally, the entire block should be decoded upfront to verify correctness before creating the iterator. The original implementation overlooked potential risks (e.g., corrupted first_key), which should be addressed in future refactoring.

4.The comparator for MergeIteratorHeapEntry now uses unwrap(I think we could do better,but I'm not sure how to code.Please excuse my stupidity, I need help) and prioritizes index over seq.
Consider a scenario where multiple identical keys are written in a batch: if a memtable flush splits these keys into two L0 SSTs with identical keys and sequence numbers (seq), the heap must rely on the iterator’s index to ensure deterministic ordering. 
The use of unwrap is safe here because the merge iterator’s internal logic guarantees all child iterators are valid during comparison.

5.The seek method was modified to return () (no value) instead of the post-seek entry. This avoids unnecessary data copying when the caller only needs to position the iterator. If the post-seek value is required, it can be efficiently retrieved via peek, eliminating the overhead of returning extra data.

6.Due to my limited familiarity with Rust’s async/await patterns, I struggled to refactor seek to be async while maintaining correctness after removing its return value. As a temporary measure, I removed the async implementation. I welcome guidance on resolving this issue to restore async functionality without compromising correctness.