### PR TITLE
refactor: remove MergeTwoIterator

### DIFF
--- a/src/compactor_executor.rs
+++ b/src/compactor_executor.rs
@@ -14,7 +14,7 @@ use crate::config::CompactorOptions;
 use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
-use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
+use crate::merge_iterator::MergeIterator;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
@@ -98,7 +98,7 @@ impl TokioCompactionExecutorInner {
     async fn load_iterators<'a>(
         &self,
         compaction: &'a CompactionJob,
-    ) -> Result<TwoMergeIterator<MergeIterator<'a>, MergeIterator<'a>>, SlateDBError> {
+    ) -> Result<MergeIterator<'a>, SlateDBError> {
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 4,
             blocks_to_fetch: 256,
@@ -123,7 +123,7 @@ impl TokioCompactionExecutorInner {
             sr_iters.push_back(iter);
         }
         let sr_merge_iter = MergeIterator::new(sr_iters).await?;
-        TwoMergeIterator::new(l0_merge_iter, sr_merge_iter).await
+        MergeIterator::new([l0_merge_iter, sr_merge_iter]).await
     }
 
     async fn execute_compaction(

--- a/src/db_iter.rs
+++ b/src/db_iter.rs
@@ -1,7 +1,7 @@
 use crate::bytes_range::BytesRange;
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
-use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
+use crate::merge_iterator::MergeIterator;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::SstIterator;
 use crate::types::KeyValue;
@@ -10,12 +10,9 @@ use bytes::Bytes;
 use std::collections::VecDeque;
 use std::ops::RangeBounds;
 
-type ScanIterator<'a> =
-    TwoMergeIterator<MergeIterator<'a>, TwoMergeIterator<MergeIterator<'a>, MergeIterator<'a>>>;
-
 pub struct DbIterator<'a> {
     range: BytesRange,
-    iter: ScanIterator<'a>,
+    iter: MergeIterator<'a>,
     invalidated_error: Option<SlateDBError>,
     last_key: Option<Bytes>,
 }
@@ -29,8 +26,8 @@ impl<'a> DbIterator<'a> {
     ) -> Result<Self, SlateDBError> {
         let (l0_iter, sr_iter) =
             tokio::join!(MergeIterator::new(l0_iters), MergeIterator::new(sr_iters),);
-        let sst_iter = TwoMergeIterator::new(l0_iter?, sr_iter?).await?;
-        let iter = TwoMergeIterator::new(mem_iter, sst_iter).await?;
+        let sst_iter = MergeIterator::new([l0_iter?, sr_iter?]).await?;
+        let iter = MergeIterator::new([mem_iter, sst_iter]).await?;
         Ok(DbIterator {
             range,
             iter,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -46,3 +46,18 @@ pub trait KeyValueIterator: Send + Sync {
     /// Seek to the next (inclusive) key
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError>;
 }
+
+#[async_trait]
+impl<'a> KeyValueIterator for Box<dyn KeyValueIterator + 'a> {
+    async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
+        self.as_mut().next().await
+    }
+
+    async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
+        self.as_mut().next_entry().await
+    }
+
+    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+        self.as_mut().seek(next_key).await
+    }
+}

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -6,141 +6,6 @@ use crate::types::RowEntry;
 use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, VecDeque};
 
-pub(crate) struct TwoMergeIterator<T1: KeyValueIterator, T2: KeyValueIterator> {
-    iterator1: (T1, Option<RowEntry>),
-    iterator2: (T2, Option<RowEntry>),
-}
-
-impl<T1: KeyValueIterator, T2: KeyValueIterator> TwoMergeIterator<T1, T2> {
-    pub(crate) async fn new(mut iterator1: T1, mut iterator2: T2) -> Result<Self, SlateDBError> {
-        let next1 = iterator1.next_entry().await?;
-        let next2 = iterator2.next_entry().await?;
-        Ok(Self {
-            iterator1: (iterator1, next1),
-            iterator2: (iterator2, next2),
-        })
-    }
-
-    async fn advance1(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
-        if self.iterator1.1.is_none() {
-            return Ok(None);
-        }
-        Ok(std::mem::replace(
-            &mut self.iterator1.1,
-            self.iterator1.0.next_entry().await?,
-        ))
-    }
-
-    async fn advance2(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
-        if self.iterator2.1.is_none() {
-            return Ok(None);
-        }
-        Ok(std::mem::replace(
-            &mut self.iterator2.1,
-            self.iterator2.0.next_entry().await?,
-        ))
-    }
-
-    fn peek1(&self) -> Option<&RowEntry> {
-        self.iterator1.1.as_ref()
-    }
-
-    fn peek2(&self) -> Option<&RowEntry> {
-        self.iterator2.1.as_ref()
-    }
-
-    fn peek_inner(&self) -> Option<&RowEntry> {
-        match (self.peek1(), self.peek2()) {
-            (None, None) => None,
-            (Some(v1), None) => Some(v1),
-            (None, Some(v2)) => Some(v2),
-            (Some(v1), Some(v2)) => {
-                if v1.key < v2.key {
-                    Some(v1)
-                } else {
-                    Some(v2)
-                }
-            }
-        }
-    }
-
-    async fn advance_inner(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
-        match (self.peek1(), self.peek2()) {
-            (None, None) => Ok(None),
-            (Some(_), None) => self.advance1().await,
-            (None, Some(_)) => self.advance2().await,
-            (Some(next1), Some(next2)) => {
-                if next1.key < next2.key {
-                    self.advance1().await
-                } else {
-                    self.advance2().await
-                }
-            }
-        }
-    }
-}
-
-impl<T1, T2> TwoMergeIterator<T1, T2>
-where
-    T1: KeyValueIterator,
-    T2: KeyValueIterator,
-{
-    async fn seek1(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
-        match &self.iterator1.1 {
-            None => Ok(()),
-            Some(val) => {
-                if val.key < next_key {
-                    self.iterator1.0.seek(next_key).await?;
-                    self.iterator1.1 = self.iterator1.0.next_entry().await?;
-                    Ok(())
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    }
-
-    async fn seek2(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
-        match &self.iterator2.1 {
-            None => Ok(()),
-            Some(val) => {
-                if val.key < next_key {
-                    self.iterator2.0.seek(next_key).await?;
-                    self.iterator2.1 = self.iterator2.0.next_entry().await?;
-                    Ok(())
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    }
-}
-
-#[async_trait]
-impl<T1: KeyValueIterator, T2: KeyValueIterator> KeyValueIterator for TwoMergeIterator<T1, T2> {
-    async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
-        let mut current_kv = match self.advance_inner().await? {
-            Some(kv) => kv,
-            None => return Ok(None),
-        };
-        while let Some(peeked_kv) = self.peek_inner() {
-            if peeked_kv.key != current_kv.key {
-                break;
-            }
-            if peeked_kv.seq > current_kv.seq {
-                current_kv = peeked_kv.clone();
-            }
-            self.advance_inner().await?;
-        }
-        Ok(Some(current_kv))
-    }
-
-    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
-        self.seek1(next_key).await?;
-        self.seek2(next_key).await
-    }
-}
-
 struct MergeIteratorHeapEntry<'a> {
     next_kv: RowEntry,
     index: u32,
@@ -283,7 +148,7 @@ impl KeyValueIterator for MergeIterator<'_> {
 #[cfg(test)]
 mod tests {
     use crate::iter::KeyValueIterator;
-    use crate::merge_iterator::{MergeIterator, TwoMergeIterator};
+    use crate::merge_iterator::MergeIterator;
     use crate::test_utils::{assert_iterator, assert_next_entry, TestIterator};
     use crate::types::RowEntry;
     use std::collections::VecDeque;
@@ -376,7 +241,7 @@ mod tests {
             .with_entry(b"xxxx", b"24242424", 0)
             .with_entry(b"yyyy", b"25252525", 0);
 
-        let mut merge_iter = TwoMergeIterator::new(iter1, iter2).await.unwrap();
+        let mut merge_iter = MergeIterator::new([iter1, iter2]).await.unwrap();
 
         assert_iterator(
             &mut merge_iter,
@@ -401,7 +266,7 @@ mod tests {
             .with_entry(b"cccc", b"badc1", 2)
             .with_entry(b"xxxx", b"24242424", 3);
 
-        let mut merge_iter = TwoMergeIterator::new(iter1, iter2).await.unwrap();
+        let mut merge_iter = MergeIterator::new([iter1, iter2]).await.unwrap();
 
         assert_iterator(
             &mut merge_iter,
@@ -486,7 +351,7 @@ mod tests {
             .with_entry(b"cc", b"cc2", 6)
             .with_entry(b"ee", b"ee2", 7);
 
-        let mut merge_iter = TwoMergeIterator::new(iter1, iter2).await.unwrap();
+        let mut merge_iter = MergeIterator::new([iter1, iter2]).await.unwrap();
         merge_iter.seek(b"b".as_ref()).await.unwrap();
 
         assert_iterator(

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -199,11 +199,11 @@ pub(crate) struct MergeIterator<'a> {
 
 impl<'a> MergeIterator<'a> {
     pub(crate) async fn new<T: KeyValueIterator + 'a>(
-        mut iterators: VecDeque<T>,
+        iterators: impl IntoIterator<Item = T>,
     ) -> Result<Self, SlateDBError> {
         let mut heap = BinaryHeap::new();
         let mut index = 0;
-        while let Some(mut iterator) = iterators.pop_front() {
+        for mut iterator in iterators {
             if let Some(kv) = iterator.next_entry().await? {
                 heap.push(Reverse(MergeIteratorHeapEntry {
                     next_kv: kv,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -111,9 +111,9 @@ impl Reader {
         let memtable_iters = memtables
             .iter()
             .map(|t| t.range_ascending(range.clone()))
-            .collect();
+            .collect::<Vec<_>>();
 
-        let mem_iter = MergeIterator::new(memtable_iters).await?;
+        let mem_iter = MergeIterator::new(memtable_iters.into_iter()).await?;
 
         let read_ahead_blocks = self.table_store.bytes_to_blocks(options.read_ahead_bytes);
 


### PR DESCRIPTION
this pr made the following refactors:

- let `Box<KeyValueIterator + 'a>` implements the `KeyValueIterator` trait
- let `MergeIterator` accepts `impl IntoIterator<T>` instead of `VecDeque<T>`
- replaces `MergeTwoIterator(it1, it2)` into `MergeIterator([it1, it2])`