### PR TITLE
fix: fix build error when using dbiterator behind a Box<dyn>

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4,7 +4,7 @@ use crate::db_state::{CoreDbState, SortedRun, SsTableHandle};
 use crate::db_stats::DbStats;
 use crate::filter_iterator::FilterIterator;
 use crate::iter::KeyValueIterator;
-use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable};
+use crate::mem_table::{ImmutableMemtable, ImmutableWal, KVTable, MemTableIterator};
 use crate::merge_iterator::MergeIterator;
 use crate::reader::SstFilterResult::{
     FilterNegative, FilterPositive, RangeNegative, RangePositive,
@@ -108,7 +108,10 @@ impl Reader {
                 memtables.push_back(memtable.table());
             }
         }
-        let memtable_iters = memtables.iter().map(|t| t.range_ascending(range.clone()));
+        let memtable_iters: Vec<MemTableIterator> = memtables
+            .iter()
+            .map(|t| t.range_ascending(range.clone()))
+            .collect();
         let mem_iter = MergeIterator::new(memtable_iters).await?;
 
         let read_ahead_blocks = self.table_store.bytes_to_blocks(options.read_ahead_bytes);


### PR DESCRIPTION
Before this patch, if you tried to use DbIterator behind a Box<dyn> you would get build errors complaining about the lifetime associated with the closure used to generate the memtable iterators. This is a pretty common use case where a user may want to abstract away the underlying storage engine from the rest of their application. I think the error is because of the extra constraints introduced by async_trait. To fix this, we collect the iterators into a Vec before passing them to MergeIterator. 

The patch also includes a test that replicates the error. Before the fix, the test case fails to build with:

```
error: implementation of `FnOnce` is not general enough
    --> src/db.rs:1816:76
     |
1816 |               async fn iterator<'a>(&'a self) -> Box<dyn IteratorTrait + 'a> {
     |  ____________________________________________________________________________^
1817 | |                 let range = BytesRange::new(
1818 | |                     Excluded(Bytes::from(b"foo".as_slice())),
1819 | |                     Excluded(Bytes::from(b"foo".as_slice()))
...    |
1826 | |                 Box::new(iter)
1827 | |             }
     | |_____________^ implementation of `FnOnce` is not general enough
     |
     = note: closure with signature `fn(&'0 std::sync::Arc<mem_table::KVTable>) -> MemTableIteratorInner<mem_table::KVTableInternalKeyRange>` must implement `FnOnce<(&'1 std::sync::Arc<mem_table::KVTable>,)>`, for any two lifetimes `'0` and `'1`...
     = note: ...but it actually implements `FnOnce<(&std::sync::Arc<mem_table::KVTable>,)>`
```