### PR TITLE
chore: housekeeping

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,6 +17,10 @@ permissions:
   # Required for storing benchmark results
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -25,7 +29,8 @@ jobs:
       - name: cargo install cargo-hack
         run: cargo +stable install cargo-hack --locked
       - name: cargo check
-        run: cargo hack check --each-feature --no-dev-deps
+        uses: Swatinem/rust-cache@v2
+      - run: cargo hack check --each-feature --no-dev-deps
 
   clippy:
     runs-on: ubuntu-latest
@@ -34,7 +39,8 @@ jobs:
       - name: cargo install cargo-hack
         run: cargo +stable install cargo-hack --locked
       - name: cargo clippy
-        run: cargo hack clippy --each-feature --no-dev-deps && cargo hack clippy --lib -p slatedb --tests
+        uses: Swatinem/rust-cache@v2
+      - run: cargo hack clippy --each-feature --no-dev-deps && cargo hack clippy --lib -p slatedb --tests
 
   style:
     runs-on: ubuntu-latest
@@ -42,6 +48,14 @@ jobs:
       - uses: actions/checkout@v4
       - name: cargo fmt
         run: cargo fmt -- --check
+
+  typos:
+    runs-on: ubuntu-latest
+    name: typos
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check spelling
+        uses: crate-ci/typos@master
 
   flatbuffers:
     runs-on: ubuntu-latest
@@ -71,6 +85,8 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.84
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
       - name: Run Tests
         run: cargo nextest run --all-features --profile ci
       - name: Run Doc Tests

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,6 @@
+# If there are words that you think should not be treated as typo.
+# Please list here along with a comment.
+[default.extend-words]
+"fpr" = "fpr"
+
+[files]

--- a/.typos.toml
+++ b/.typos.toml
@@ -2,5 +2,6 @@
 # Please list here along with a comment.
 [default.extend-words]
 "fpr" = "fpr"
+"Pn" = "Pn"
 
 [files]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Join our [Discord server](https://discord.gg/mHYmGy5MgA) to chat with the develo
 Please follow the instructions below before making a PR:
 
 - Run `cargo clippy --all-targets --all-features` and `cargo fmt` on your patch to fix lints and formatting issues.
-- Run `cargo test --all-features` to check that your patch doesn't break any tests.
+- Run `cargo nextest --all-features` to check that your patch doesn't break any tests.
 
 ## Contributor License Agreement
 

--- a/rfcs/0001-manifest.md
+++ b/rfcs/0001-manifest.md
@@ -345,7 +345,7 @@ Traditionally, LSMs store WAL data in a different format from the SSTs; this is 
 
 _NOTE: We discussed using a different format for the WAL [here](https://github.com/slatedb/slatedb/pull/39/files#r1590087062), but decided against it._
 
-This design does not use [prefixes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html). AWS allows, "3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per partitioned Amazon S3 prefix." This limits a single writer to 3,500 writes and 5,500 reads per-second. With a `flush_interval` set to 1ms, a client would write 1,000 writes per-second (not including compactions). Wth caching, the client should be far below the 5,500 reads per-second limit.
+This design does not use [prefixes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-prefixes.html). AWS allows, "3,500 PUT/COPY/POST/DELETE or 5,500 GET/HEAD requests per second per partitioned Amazon S3 prefix." This limits a single writer to 3,500 writes and 5,500 reads per-second. With a `flush_interval` set to 1ms, a client would write 1,000 writes per-second (not including compactions). With caching, the client should be far below the 5,500 reads per-second limit.
 
 This design also does not expose writer epochs in WAL SST filenames (e.g. `[writer_epoch].[sequence_number].sst`). We discussed this in detail [here](https://github.com/slatedb/slatedb/pull/39/files#r1588892292) and [here](https://github.com/slatedb/slatedb/pull/24/files#r1585569744). Ultimately, we chose "un-namespaced" filenames (i.e. filenames without epoch prefix) because it's simpler to reason about.
 

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -370,7 +370,7 @@ Generally to take a checkpoint from the current manifest, the client runs a proc
 3. Compute a new v4 UUID id for the checkpoint.
 4. Create a new entry in `checkpoints` with:
     - `id` set to the id computed in the previous step
-    - `manfiest_id` set to V or V+1. We use V+1 to allow addition of the checkpoint to be included with other updates.
+    - `manifest_id` set to V or V+1. We use V+1 to allow addition of the checkpoint to be included with other updates.
     - other fields set as appropriate (e.g. expiry time based on relevant checkpoint creation params)
 5. Write a new manifest M' at version V+1. If CAS fails, go to step 1.
 

--- a/rfcs/0006-merge-operator.md
+++ b/rfcs/0006-merge-operator.md
@@ -224,7 +224,7 @@ For each key, SlateDB maintains a history of operations, which is subject to com
 Let's denote each operation as `OPi`. A key (`K`) that has experienced `n` changes looks like this logically (physically, the changes could be spread across the memtable and multiple SST files):
 
 ```
-K:    OP1    OP2    OP3    ...    OOn
+K:    OP1    OP2    OP3    ...    OPn
 
 earliest --------------------> latest
 ```
@@ -232,7 +232,7 @@ earliest --------------------> latest
 Currently, during a read operation, SlateDB always observes the latest known state of the database. In other words, it only needs to look up the latest operation. If it's a `Value`, it simply returns it, and if it's a `Tombstone`, it returns `None`. All previous operations can be ignored and will be removed by compaction at some point.
 
 ```
-K:    OP1    OP2    OP3    ...    OOn
+K:    OP1    OP2    OP3    ...    OPn
                                    ^
                                    |
                                   GET
@@ -241,7 +241,7 @@ K:    OP1    OP2    OP3    ...    OOn
 With the addition of a **Merge Operand**, it may be necessary to look backwards at previous values, up to the point where we encounter either a `Value` or a `Tombstone`. Everything beyond that point can be ignored.
 
 ```
-K:    OP1    OP2    OP3    OP4    OOn
+K:    OP1    OP2    OP3    OP4    OPn
             Value  Merge  Merge  Merge
                                    ^
                                    |
@@ -252,7 +252,7 @@ K:    OP1    OP2    OP3    OP4    OOn
 In the above example, `get` should essentially return something like:
 
 ```
-Merge(OP2, Merge(OP3, Merge(OP4, OOn)))
+Merge(OP2, Merge(OP3, Merge(OP4, OPn)))
 ```
 
 ### Write Path & Compactions

--- a/rfcs/0006-merge-operator.md
+++ b/rfcs/0006-merge-operator.md
@@ -213,7 +213,7 @@ This change is backwards compatible.
 
 ### Block Format
 
-The block format remains unchanged. It's useful to hightlight that merge operands are also stored in the bloom filters, so they have the same filtering guarantees as regular values.
+The block format remains unchanged. It's useful to highlight that merge operands are also stored in the bloom filters, so they have the same filtering guarantees as regular values.
 
 ### Read Path
 
@@ -224,7 +224,7 @@ For each key, SlateDB maintains a history of operations, which is subject to com
 Let's denote each operation as `OPi`. A key (`K`) that has experienced `n` changes looks like this logically (physically, the changes could be spread across the memtable and multiple SST files):
 
 ```
-K:    OP1    OP2    OP3    ...    OPn
+K:    OP1    OP2    OP3    ...    OOn
 
 earliest --------------------> latest
 ```
@@ -232,7 +232,7 @@ earliest --------------------> latest
 Currently, during a read operation, SlateDB always observes the latest known state of the database. In other words, it only needs to look up the latest operation. If it's a `Value`, it simply returns it, and if it's a `Tombstone`, it returns `None`. All previous operations can be ignored and will be removed by compaction at some point.
 
 ```
-K:    OP1    OP2    OP3    ...    OPn
+K:    OP1    OP2    OP3    ...    OOn
                                    ^
                                    |
                                   GET
@@ -241,7 +241,7 @@ K:    OP1    OP2    OP3    ...    OPn
 With the addition of a **Merge Operand**, it may be necessary to look backwards at previous values, up to the point where we encounter either a `Value` or a `Tombstone`. Everything beyond that point can be ignored.
 
 ```
-K:    OP1    OP2    OP3    OP4    OPn
+K:    OP1    OP2    OP3    OP4    OOn
             Value  Merge  Merge  Merge
                                    ^
                                    |
@@ -252,7 +252,7 @@ K:    OP1    OP2    OP3    OP4    OPn
 In the above example, `get` should essentially return something like:
 
 ```
-Merge(OP2, Merge(OP3, Merge(OP4, OPn)))
+Merge(OP2, Merge(OP3, Merge(OP4, OOn)))
 ```
 
 ### Write Path & Compactions
@@ -368,7 +368,7 @@ SlateDB supports two TTL approaches:
 
 1. **Operation-Level TTL**
    - Each operation (put/merge) has its own independent TTL, specified via:
-     - `Ttl::ExpireAfter(duration)`: Expires after specified duration (interally this is implemented as `ExpireAt(Instant::now() + duration)`)
+     - `Ttl::ExpireAfter(duration)`: Expires after specified duration (internally this is implemented as `ExpireAt(Instant::now() + duration)`)
      - `Ttl::ExpireAt(timestamp)`: Expires at specified timestamp
    - Enables per-element expiration in collections
 

--- a/rfcs/0008-synchronous-commit.md
+++ b/rfcs/0008-synchronous-commit.md
@@ -312,7 +312,7 @@ While `SyncLevel` and `DurabilityLevel` may appear similar, they serve distinct 
 
 ## Implementation
 
-The key change is to seperate "Append to WAL" and "Commit to make it visible" into two different steps.
+The key change is to separate "Append to WAL" and "Commit to make it visible" into two different steps.
 
 In the current design, whenever a write operation is called, it'll append the data to the WAL, the data is becoming visible to readers with `DurabilityLevel::Memory` immediately, as the readers will read the data from the WAL in front of MemTable. And when the WAL buffer reaches the `flush.interval` or `flush.size`, it'll be flushed to storage, and apply to MemTable.
 
@@ -427,5 +427,5 @@ However, it's a different codebase, it would be better to keep code structure ch
 
 ## Updates
 
-- 2025-02-20: added the comparision between `sync` and `await_durable`
+- 2025-02-20: added the comparison between `sync` and `await_durable`
 - 2025-03-12: revise the api with `with_durability_filter` and `with_dirty`

--- a/src/cached_object_store/storage_fs.rs
+++ b/src/cached_object_store/storage_fs.rs
@@ -449,7 +449,7 @@ impl FsCacheEvictorInner {
     }
 
     // scan the cache folder, and load the cache entries into the in memory trie cache_entries.
-    // this function is only called on start up, and it's expected to runned interleavely with
+    // this function is only called on start up, and it's expected to run interleavely with
     // maybe_evict is being called.
     pub async fn scan_entries(self: Arc<Self>, evict: bool) {
         // walk the cache folder, record the files and their last access time into the cache_entries

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -333,7 +333,7 @@ impl KVTable {
         self.map.compare_insert(internal_key, row, |previous_row| {
             // Optimistically calculate the size of the previous value.
             // `compare_fn` might be called multiple times in case of concurrent
-            // writes to the same key, so we use `Cell` to avoid substracting
+            // writes to the same key, so we use `Cell` to avoid subtracting
             // the size multiple times. The last call will set the correct size.
             previous_size.set(Some(previous_row.estimated_size()));
             true

--- a/src/merge_iterator.rs
+++ b/src/merge_iterator.rs
@@ -133,8 +133,8 @@ impl KeyValueIterator for MergeIterator<'_> {
         }
 
         for seek_result in futures::future::join_all(seek_futures).await {
-            if let Some(seeked_iterator) = seek_result? {
-                self.iterators.push(Reverse(seeked_iterator));
+            if let Some(sought_iterator) = seek_result? {
+                self.iterators.push(Reverse(sought_iterator));
             }
         }
 


### PR DESCRIPTION
- fix typos
- add typos check in ci
- add cache in ci
- add concurrency check in ci
- use `cargo nextest` instead in Contributing.md