### PR TITLE
Initial support for separate WAL object store

### DIFF
--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -68,6 +68,9 @@ table ManifestV1 {
 
     // The last seq number
     last_l0_seq: ulong;
+
+    // The URI of the object store dedicated specifically for WAL, if any.
+    wal_object_store_uri: string;
 }
 
 table SortedRun {

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -8,6 +8,7 @@ use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
 
 use crate::clone;
+use crate::object_stores::ObjectStores;
 use fail_parallel::FailPointRegistry;
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
@@ -116,8 +117,7 @@ pub async fn run_gc_instance(
         .await?;
     let sst_format = SsTableFormat::default(); // read only SSTs, can use default
     let table_store = Arc::new(TableStore::new(
-        object_store.clone(),
-        None,
+        ObjectStores::new(object_store.clone(), None),
         sst_format.clone(),
         path.clone(),
         None, // no need for cache in GC

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -114,6 +114,7 @@ pub async fn run_gc_instance(
     let sst_format = SsTableFormat::default(); // read only SSTs, can use default
     let table_store = Arc::new(TableStore::new(
         object_store.clone(),
+        None,
         sst_format.clone(),
         path.clone(),
         None, // no need for cache in GC

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -111,6 +111,9 @@ pub async fn run_gc_instance(
     gc_opts: GarbageCollectorOptions,
 ) -> Result<(), Box<dyn Error>> {
     let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
+    manifest_store
+        .validate_no_wal_object_store_configured()
+        .await?;
     let sst_format = SsTableFormat::default(); // read only SSTs, can use default
     let table_store = Arc::new(TableStore::new(
         object_store.clone(),
@@ -252,6 +255,9 @@ pub async fn create_checkpoint<P: Into<Path>>(
     options: &CheckpointOptions,
 ) -> Result<CheckpointCreateResult, SlateDBError> {
     let manifest_store = Arc::new(ManifestStore::new(&path.into(), object_store));
+    manifest_store
+        .validate_no_wal_object_store_configured()
+        .await?;
     let mut stored_manifest = StoredManifest::load(manifest_store).await?;
     let checkpoint = stored_manifest.write_checkpoint(None, options).await?;
     Ok(CheckpointCreateResult {

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -122,6 +122,7 @@ mod tests {
     use crate::iter::KeyValueIterator;
     use crate::manifest::store::ManifestStore;
     use crate::manifest::Manifest;
+    use crate::object_stores::ObjectStores;
     use crate::proptest_util::{rng, sample};
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
@@ -528,8 +529,7 @@ mod tests {
         kv: (&Bytes, &Bytes),
     ) {
         let table_store = Arc::new(TableStore::new(
-            Arc::clone(&object_store),
-            None,
+            ObjectStores::new(Arc::clone(&object_store), None),
             SsTableFormat::default(),
             path.clone(),
             None,

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -529,6 +529,7 @@ mod tests {
     ) {
         let table_store = Arc::new(TableStore::new(
             Arc::clone(&object_store),
+            None,
             SsTableFormat::default(),
             path.clone(),
             None,

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -24,6 +24,7 @@ use crate::config::{CompactorOptions, CompressionCodec};
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::manifest::store::{ManifestStore, StoredManifest};
+use crate::object_stores::ObjectStores;
 use crate::sst::SsTableFormat;
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
@@ -57,8 +58,7 @@ impl CompactionExecuteBench {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            self.object_store.clone(),
-            None,
+            ObjectStores::new(self.object_store.clone(), None),
             sst_format,
             self.path.clone(),
             None,
@@ -272,8 +272,7 @@ impl CompactionExecuteBench {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            self.object_store.clone(),
-            None,
+            ObjectStores::new(self.object_store.clone(), None),
             sst_format,
             self.path.clone(),
             None,

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -58,6 +58,7 @@ impl CompactionExecuteBench {
         };
         let table_store = Arc::new(TableStore::new(
             self.object_store.clone(),
+            None,
             sst_format,
             self.path.clone(),
             None,
@@ -272,6 +273,7 @@ impl CompactionExecuteBench {
         };
         let table_store = Arc::new(TableStore::new(
             self.object_store.clone(),
+            None,
             sst_format,
             self.path.clone(),
             None,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1037,6 +1037,7 @@ mod tests {
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let table_store = Arc::new(TableStore::new(
             os.clone(),
+            None,
             sst_format,
             Path::from(PATH),
             None,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -456,6 +456,7 @@ mod tests {
     use tokio::runtime::Runtime;
     use ulid::Ulid;
 
+    use super::*;
     use crate::compactor::stats::CompactionStats;
     use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
@@ -467,8 +468,7 @@ mod tests {
     use crate::db_state::{CoreDbState, SortedRun};
     use crate::iter::KeyValueIterator;
     use crate::manifest::store::{ManifestStore, StoredManifest};
-
-    use super::*;
+    use crate::object_stores::ObjectStores;
     use crate::proptest_util::rng;
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
     use crate::sst::SsTableFormat;
@@ -1036,8 +1036,7 @@ mod tests {
         };
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let table_store = Arc::new(TableStore::new(
-            os.clone(),
-            None,
+            ObjectStores::new(os.clone(), None),
             sst_format,
             Path::from(PATH),
             None,

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -182,6 +182,7 @@ impl CompactorState {
             last_l0_clock_tick: remote_manifest.core.last_l0_clock_tick,
             last_l0_seq: remote_manifest.core.last_l0_seq,
             checkpoints: remote_manifest.core.checkpoints.clone(),
+            wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
         };
         remote_manifest.core = merged;
         self.manifest = remote_manifest;

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3149,8 +3149,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_put_get_reopen_delete_with_separate_wal_store() {
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let wal_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let object_store = Arc::new(InMemory::new());
+        let wal_object_store = Arc::new(InMemory::new());
         let kv_store = Db::builder("/tmp/test_kv_store", object_store.clone())
             .with_settings(test_db_options(0, 1024, None))
             .with_wal_object_store(wal_object_store.clone())
@@ -3193,8 +3193,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_wal_store_reconfiguration_fails() {
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let wal_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let object_store = Arc::new(InMemory::new());
+        let wal_object_store = Arc::new(InMemory::new());
 
         let kv_store = Db::builder("/tmp/test_kv_store", object_store.clone())
             .with_settings(test_db_options(0, 1024, None))

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -965,6 +965,7 @@ mod tests {
     use crate::db_stats::IMMUTABLE_MEMTABLE_FLUSHES;
     use crate::iter::KeyValueIterator;
     use crate::manifest::store::{ManifestStore, StoredManifest};
+    use crate::object_stores::ObjectStores;
     use crate::proptest_util::arbitrary;
     use crate::proptest_util::sample;
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
@@ -2056,8 +2057,7 @@ mod tests {
         let path = Path::from("/tmp/test_kv_store");
         let sst_format = SsTableFormat::default();
         let table_store = Arc::new(TableStore::new(
-            object_store.clone(),
-            None,
+            ObjectStores::new(object_store.clone(), None),
             sst_format,
             path.clone(),
             None,
@@ -2143,8 +2143,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store.clone(),
-            None,
+            ObjectStores::new(object_store.clone(), None),
             sst_format,
             path,
             None,
@@ -2728,8 +2727,7 @@ mod tests {
 
         let manifest_store = ManifestStore::new(&Path::from(path), object_store.clone());
         let table_store = Arc::new(TableStore::new(
-            object_store.clone(),
-            None,
+            ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
             path,
             None,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -106,6 +106,7 @@ use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
 use crate::garbage_collector::GarbageCollector;
 use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
+use crate::object_stores::ObjectStores;
 use crate::paths::PathResolver;
 use crate::sst::SsTableFormat;
 use crate::stats::StatRegistry;
@@ -284,8 +285,10 @@ impl<P: Into<Path>> DbBuilder<P> {
         // Create path resolver and table store
         let path_resolver = PathResolver::new_with_external_ssts(path.clone(), external_ssts);
         let table_store = Arc::new(TableStore::new_with_fp_registry(
-            maybe_cached_main_object_store.clone(),
-            self.wal_object_store.clone(),
+            ObjectStores::new(
+                maybe_cached_main_object_store.clone(),
+                self.wal_object_store.clone(),
+            ),
             sst_format.clone(),
             path_resolver.clone(),
             self.fp_registry.clone(),
@@ -367,8 +370,10 @@ impl<P: Into<Path>> DbBuilder<P> {
 
             // Not to pollute the cache during compaction
             let uncached_table_store = Arc::new(TableStore::new_with_fp_registry(
-                self.main_object_store.clone(),
-                self.wal_object_store.clone(),
+                ObjectStores::new(
+                    self.main_object_store.clone(),
+                    self.wal_object_store.clone(),
+                ),
                 sst_format,
                 path_resolver,
                 self.fp_registry.clone(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -274,6 +274,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         let path_resolver = PathResolver::new_with_external_ssts(path.clone(), external_ssts);
         let table_store = Arc::new(TableStore::new_with_fp_registry(
             maybe_cached_main_object_store.clone(),
+            self.wal_object_store.clone(),
             sst_format.clone(),
             path_resolver.clone(),
             self.fp_registry.clone(),
@@ -355,6 +356,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             // Not to pollute the cache during compaction
             let uncached_table_store = Arc::new(TableStore::new_with_fp_registry(
                 self.main_object_store.clone(),
+                self.wal_object_store.clone(),
                 sst_format,
                 path_resolver,
                 self.fp_registry.clone(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -307,8 +307,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         let stored_manifest = match latest_manifest {
             Some(manifest) => manifest,
             None => {
-                let mut state = CoreDbState::new();
-                state.wal_object_store_uri = wal_object_store_uri;
+                let state = CoreDbState::new_with_wal_object_store(wal_object_store_uri);
                 StoredManifest::create_new_db(manifest_store.clone(), state).await?
             }
         };

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -120,6 +120,7 @@ pub struct DbBuilder<P: Into<Path>> {
     path: P,
     settings: Settings,
     main_object_store: Arc<dyn ObjectStore>,
+    wal_object_store: Option<Arc<dyn ObjectStore>>,
     block_cache: Option<Arc<dyn DbCache>>,
     clock: Option<Arc<dyn Clock + Send + Sync>>,
     gc_runtime: Option<Handle>,
@@ -135,6 +136,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             path,
             main_object_store,
             settings: Settings::default(),
+            wal_object_store: None,
             block_cache: None,
             clock: None,
             gc_runtime: None,
@@ -147,6 +149,16 @@ impl<P: Into<Path>> DbBuilder<P> {
     /// Sets the database settings.
     pub fn with_settings(mut self, settings: Settings) -> Self {
         self.settings = settings;
+        self
+    }
+
+    /// Sets the separate object store dedicated specifically for WAL.
+    ///
+    /// NOTE: WAL durability and availability properties depend on the properties
+    /// of the underlying object store. Make sure the configured object store is
+    /// durable and available enough for your use case.
+    pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
+        self.wal_object_store = Some(wal_object_store);
         self
     }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -812,6 +812,7 @@ mod tests {
     use crate::db_state::CoreDbState;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::Manifest;
+    use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::proptest_util::rng::new_test_rng;
     use crate::proptest_util::sample;
@@ -1144,8 +1145,7 @@ mod tests {
     impl StoreProvider for TestProvider {
         fn table_store(&self) -> Arc<TableStore> {
             Arc::new(TableStore::new_with_fp_registry(
-                Arc::clone(&self.object_store),
-                None,
+                ObjectStores::new(Arc::clone(&self.object_store), None),
                 SsTableFormat::default(),
                 PathResolver::new(self.path.clone()),
                 Arc::clone(&self.fp_registry),

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1145,6 +1145,7 @@ mod tests {
         fn table_store(&self) -> Arc<TableStore> {
             Arc::new(TableStore::new_with_fp_registry(
                 Arc::clone(&self.object_store),
+                None,
                 SsTableFormat::default(),
                 PathResolver::new(self.path.clone()),
                 Arc::clone(&self.fp_registry),

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -248,6 +248,7 @@ pub(crate) struct CoreDbState {
     /// SST is created in the manifest.
     pub(crate) last_l0_seq: u64,
     pub(crate) checkpoints: Vec<Checkpoint>,
+    pub(crate) wal_object_store_uri: Option<String>,
 }
 
 impl CoreDbState {
@@ -262,6 +263,7 @@ impl CoreDbState {
             last_l0_clock_tick: i64::MIN,
             last_l0_seq: 0,
             checkpoints: vec![],
+            wal_object_store_uri: None,
         }
     }
 
@@ -511,6 +513,7 @@ impl DbState {
             last_l0_clock_tick: my_db_state.last_l0_clock_tick,
             last_l0_seq: my_db_state.last_l0_seq,
             checkpoints: remote_manifest.core.checkpoints,
+            wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
         };
         state.manifest = remote_manifest;
         self.update_state(state);

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -267,6 +267,12 @@ impl CoreDbState {
         }
     }
 
+    pub(crate) fn new_with_wal_object_store(wal_object_store_uri: Option<String>) -> Self {
+        let mut this = Self::new();
+        this.wal_object_store_uri = wal_object_store_uri;
+        this
+    }
+
     pub(crate) fn init_clone_db(&self) -> CoreDbState {
         let mut clone = self.clone();
         clone.initialized = false;

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -652,4 +652,16 @@ mod tests {
             _ => panic!("Should fail with version mismatch"),
         }
     }
+
+    #[test]
+    fn test_should_encode_decode_wal_object_store_uri() {
+        let mut manifest = Manifest::initial(CoreDbState::new());
+        manifest.core.wal_object_store_uri = Some("s3://bucket/path".to_string());
+
+        let codec = FlatBufferManifestCodec {};
+        let bytes = codec.encode(&manifest);
+        let decoded = codec.decode(&bytes).unwrap();
+
+        assert_eq!(manifest, decoded);
+    }
 }

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -203,6 +203,7 @@ impl FlatBufferManifestCodec {
             last_l0_seq: manifest.last_l0_seq(),
             last_l0_clock_tick: manifest.last_l0_clock_tick(),
             checkpoints,
+            wal_object_store_uri: manifest.wal_object_store_uri().map(|uri| uri.to_string()),
         };
         let external_dbs = manifest.external_dbs().map(|external_dbs| {
             external_dbs
@@ -415,6 +416,11 @@ impl<'b> DbFlatBufferBuilder<'b> {
             Some(self.builder.create_vector(external_dbs.as_ref()))
         };
 
+        let wal_object_store_uri = core
+            .wal_object_store_uri
+            .as_ref()
+            .map(|uri| self.builder.create_string(uri));
+
         let manifest = ManifestV1::create(
             &mut self.builder,
             &ManifestV1Args {
@@ -431,6 +437,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 last_l0_clock_tick: core.last_l0_clock_tick,
                 checkpoints: Some(checkpoints),
                 last_l0_seq: core.last_l0_seq,
+                wal_object_store_uri,
             },
         );
         self.builder.finish(manifest, None);
@@ -611,6 +618,7 @@ mod tests {
                 checkpoints: Some(checkpoints),
                 last_l0_clock_tick: 0,
                 last_l0_seq: 0,
+                wal_object_store_uri: None,
             },
         );
         fbb.finish(manifest, None);

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -669,6 +669,7 @@ mod tests {
     };
 
     use crate::garbage_collector::stats::GC_COUNT;
+    use crate::object_stores::ObjectStores;
 
     #[tokio::test]
     async fn test_collect_garbage_manifest() {
@@ -1330,8 +1331,7 @@ mod tests {
         let manifest_store = Arc::new(ManifestStore::new(&path, local_object_store.clone()));
         let sst_format = SsTableFormat::default();
         let table_store = Arc::new(TableStore::new(
-            local_object_store.clone(),
-            None,
+            ObjectStores::new(local_object_store.clone(), None),
             sst_format,
             path.clone(),
             None,

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1331,6 +1331,7 @@ mod tests {
         let sst_format = SsTableFormat::default();
         let table_store = Arc::new(TableStore::new(
             local_object_store.clone(),
+            None,
             sst_format,
             path.clone(),
             None,

--- a/slatedb/src/generated/manifest_generated.rs
+++ b/slatedb/src/generated/manifest_generated.rs
@@ -1112,6 +1112,7 @@ impl<'a> ManifestV1<'a> {
   pub const VT_LAST_L0_CLOCK_TICK: flatbuffers::VOffsetT = 24;
   pub const VT_CHECKPOINTS: flatbuffers::VOffsetT = 26;
   pub const VT_LAST_L0_SEQ: flatbuffers::VOffsetT = 28;
+  pub const VT_WAL_OBJECT_STORE_URI: flatbuffers::VOffsetT = 30;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -1130,6 +1131,7 @@ impl<'a> ManifestV1<'a> {
     builder.add_compactor_epoch(args.compactor_epoch);
     builder.add_writer_epoch(args.writer_epoch);
     builder.add_manifest_id(args.manifest_id);
+    if let Some(x) = args.wal_object_store_uri { builder.add_wal_object_store_uri(x); }
     if let Some(x) = args.checkpoints { builder.add_checkpoints(x); }
     if let Some(x) = args.compacted { builder.add_compacted(x); }
     if let Some(x) = args.l0 { builder.add_l0(x); }
@@ -1231,6 +1233,13 @@ impl<'a> ManifestV1<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<u64>(ManifestV1::VT_LAST_L0_SEQ, Some(0)).unwrap()}
   }
+  #[inline]
+  pub fn wal_object_store_uri(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ManifestV1::VT_WAL_OBJECT_STORE_URI, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for ManifestV1<'_> {
@@ -1253,6 +1262,7 @@ impl flatbuffers::Verifiable for ManifestV1<'_> {
      .visit_field::<i64>("last_l0_clock_tick", Self::VT_LAST_L0_CLOCK_TICK, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Checkpoint>>>>("checkpoints", Self::VT_CHECKPOINTS, true)?
      .visit_field::<u64>("last_l0_seq", Self::VT_LAST_L0_SEQ, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("wal_object_store_uri", Self::VT_WAL_OBJECT_STORE_URI, false)?
      .finish();
     Ok(())
   }
@@ -1271,6 +1281,7 @@ pub struct ManifestV1Args<'a> {
     pub last_l0_clock_tick: i64,
     pub checkpoints: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>>>>,
     pub last_l0_seq: u64,
+    pub wal_object_store_uri: Option<flatbuffers::WIPOffset<&'a str>>,
 }
 impl<'a> Default for ManifestV1Args<'a> {
   #[inline]
@@ -1289,6 +1300,7 @@ impl<'a> Default for ManifestV1Args<'a> {
       last_l0_clock_tick: 0,
       checkpoints: None, // required field
       last_l0_seq: 0,
+      wal_object_store_uri: None,
     }
   }
 }
@@ -1351,6 +1363,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV1Builder<'a, 'b, A> {
     self.fbb_.push_slot::<u64>(ManifestV1::VT_LAST_L0_SEQ, last_l0_seq, 0);
   }
   #[inline]
+  pub fn add_wal_object_store_uri(&mut self, wal_object_store_uri: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV1::VT_WAL_OBJECT_STORE_URI, wal_object_store_uri);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ManifestV1Builder<'a, 'b, A> {
     let start = _fbb.start_table();
     ManifestV1Builder {
@@ -1384,6 +1400,7 @@ impl core::fmt::Debug for ManifestV1<'_> {
       ds.field("last_l0_clock_tick", &self.last_l0_clock_tick());
       ds.field("checkpoints", &self.checkpoints());
       ds.field("last_l0_seq", &self.last_l0_seq());
+      ds.field("wal_object_store_uri", &self.wal_object_store_uri());
       ds.finish()
   }
 }

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -80,6 +80,7 @@ mod mem_table;
 mod mem_table_flush;
 mod merge_iterator;
 mod merge_operator;
+mod object_stores;
 mod partitioned_keyspace;
 mod paths;
 #[cfg(test)]

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -682,6 +682,16 @@ impl ManifestStore {
         self.try_read_manifest(id).await?.ok_or(ManifestMissing(id))
     }
 
+    pub(crate) async fn validate_no_wal_object_store_configured(&self) -> Result<(), SlateDBError> {
+        let (_, manifest) = self.read_latest_manifest().await?;
+        if manifest.core.wal_object_store_uri.is_some() {
+            return Err(SlateDBError::Unsupported(
+                "WAL object store is not supported".into(),
+            ));
+        }
+        Ok(())
+    }
+
     fn parse_id(&self, path: &Path, expected_extension: &str) -> Result<u64, SlateDBError> {
         match path.extension() {
             Some(ext) if ext == expected_extension => path

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -682,11 +682,15 @@ impl ManifestStore {
         self.try_read_manifest(id).await?.ok_or(ManifestMissing(id))
     }
 
+    /// Validates that no dedicated WAL object store is configured in the latest
+    /// manifest of this `ManifestStore`.
+    ///
+    /// Used to disallow certain currently unsupported operations like cloning.
     pub(crate) async fn validate_no_wal_object_store_configured(&self) -> Result<(), SlateDBError> {
         let (_, manifest) = self.read_latest_manifest().await?;
         if manifest.core.wal_object_store_uri.is_some() {
             return Err(SlateDBError::Unsupported(
-                "WAL object store is not supported".into(),
+                "dedicated WAL object store is not supported".into(),
             ));
         }
         Ok(())

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -1,0 +1,176 @@
+use crate::db_state::SsTableId;
+use crate::transactional_object_store::{
+    DelegatingTransactionalObjectStore, TransactionalObjectStore,
+};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use std::sync::Arc;
+
+/// Resolves object stores for different [object store types](ObjectStoreType).
+pub(crate) struct ObjectStores {
+    /// The main object store used for everything that doesn't have a more
+    /// specific object store configured.
+    main_object_store: Arc<dyn ObjectStore>,
+    /// Optional WAL object store dedicated specifically for WAL.
+    wal_object_store: Option<Arc<dyn ObjectStore>>,
+
+    /// The transactional store of the main object store used for everything
+    /// that doesn't have a more specific object store configured.
+    main_transactional_store: Arc<dyn TransactionalObjectStore>,
+    /// Optional transactional store of the WAL object store dedicated
+    /// specifically for WAL.
+    wal_transactional_store: Option<Arc<dyn TransactionalObjectStore>>,
+}
+
+pub(crate) enum ObjectStoreType {
+    Main,
+    Wal,
+}
+
+impl ObjectStores {
+    pub(crate) fn new(
+        main_object_store: Arc<dyn ObjectStore>,
+        wal_object_store: Option<Arc<dyn ObjectStore>>,
+    ) -> Self {
+        Self {
+            main_object_store: main_object_store.clone(),
+            wal_object_store: wal_object_store.clone(),
+            main_transactional_store: Arc::new(DelegatingTransactionalObjectStore::new(
+                Path::from("/"),
+                main_object_store,
+            )),
+            wal_transactional_store: wal_object_store.map(|wal_object_store| {
+                Arc::new(DelegatingTransactionalObjectStore::new(
+                    Path::from("/"),
+                    wal_object_store,
+                )) as Arc<dyn TransactionalObjectStore>
+            }),
+        }
+    }
+
+    pub(crate) fn store_of(&self, store_type: ObjectStoreType) -> &Arc<dyn ObjectStore> {
+        match store_type {
+            ObjectStoreType::Main => &self.main_object_store,
+            ObjectStoreType::Wal => {
+                if let Some(wal_object_store) = &self.wal_object_store {
+                    wal_object_store
+                } else {
+                    &self.main_object_store
+                }
+            }
+        }
+    }
+
+    pub(crate) fn transactional_store_of(
+        &self,
+        store_type: ObjectStoreType,
+    ) -> &Arc<dyn TransactionalObjectStore> {
+        match store_type {
+            ObjectStoreType::Main => &self.main_transactional_store,
+            ObjectStoreType::Wal => {
+                if let Some(wal_transactional_store) = &self.wal_transactional_store {
+                    wal_transactional_store
+                } else {
+                    &self.main_transactional_store
+                }
+            }
+        }
+    }
+
+    pub(crate) fn store_for(&self, id: &SsTableId) -> Arc<dyn ObjectStore> {
+        match id {
+            SsTableId::Wal(..) => self.store_of(ObjectStoreType::Wal).clone(),
+            SsTableId::Compacted(..) => self.store_of(ObjectStoreType::Main).clone(),
+        }
+    }
+
+    pub(crate) fn transactional_store_for(
+        &self,
+        id: &SsTableId,
+    ) -> Arc<dyn TransactionalObjectStore> {
+        match id {
+            SsTableId::Wal(..) => self.transactional_store_of(ObjectStoreType::Wal).clone(),
+            SsTableId::Compacted(..) => self.transactional_store_of(ObjectStoreType::Main).clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+    use ulid::Ulid;
+
+    #[test]
+    fn test_main_object_store_only_setup() {
+        let main_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let stores = ObjectStores::new(main_store.clone(), None);
+
+        assert!(Arc::ptr_eq(
+            &stores.store_of(ObjectStoreType::Main),
+            &main_store
+        ));
+        assert!(Arc::ptr_eq(
+            &stores.store_of(ObjectStoreType::Wal),
+            &main_store
+        ));
+
+        let transactional_store = stores.transactional_store_of(ObjectStoreType::Main);
+        assert!(Arc::ptr_eq(
+            &stores.transactional_store_of(ObjectStoreType::Wal),
+            &transactional_store
+        ));
+
+        assert!(Arc::ptr_eq(
+            &stores.store_for(&SsTableId::Wal(0)),
+            &main_store
+        ));
+        assert!(Arc::ptr_eq(
+            &stores.store_for(&SsTableId::Compacted(Ulid::new())),
+            &main_store
+        ));
+
+        let transactional_store = stores.transactional_store_for(&SsTableId::Wal(0));
+        assert!(Arc::ptr_eq(
+            &stores.transactional_store_for(&SsTableId::Compacted(Ulid::new())),
+            &transactional_store
+        ));
+    }
+
+    #[test]
+    fn test_main_and_wal_object_stores_setup() {
+        let main_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wal_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let stores = ObjectStores::new(main_store.clone(), Some(wal_store.clone()));
+
+        assert!(Arc::ptr_eq(
+            &stores.store_of(ObjectStoreType::Main),
+            &main_store
+        ));
+        assert!(Arc::ptr_eq(
+            &stores.store_of(ObjectStoreType::Wal),
+            &wal_store
+        ));
+
+        let transactional_store = stores.transactional_store_of(ObjectStoreType::Main);
+        assert!(!Arc::ptr_eq(
+            &stores.transactional_store_of(ObjectStoreType::Wal),
+            &transactional_store
+        ));
+
+        assert!(Arc::ptr_eq(
+            &stores.store_for(&SsTableId::Wal(0)),
+            &wal_store
+        ));
+        assert!(Arc::ptr_eq(
+            &stores.store_for(&SsTableId::Compacted(Ulid::new())),
+            &main_store
+        ));
+
+        let transactional_store = stores.transactional_store_for(&SsTableId::Wal(0));
+        assert!(!Arc::ptr_eq(
+            &stores.transactional_store_for(&SsTableId::Compacted(Ulid::new())),
+            &transactional_store
+        ));
+    }
+}

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -22,8 +22,8 @@ impl ObjectStores {
         wal_object_store: Option<Arc<dyn ObjectStore>>,
     ) -> Self {
         Self {
-            main_object_store: main_object_store.clone(),
-            wal_object_store: wal_object_store.clone(),
+            main_object_store,
+            wal_object_store,
         }
     }
 

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -107,18 +107,18 @@ mod tests {
         let stores = ObjectStores::new(main_store.clone(), None);
 
         assert!(Arc::ptr_eq(
-            &stores.store_of(ObjectStoreType::Main),
+            stores.store_of(ObjectStoreType::Main),
             &main_store
         ));
         assert!(Arc::ptr_eq(
-            &stores.store_of(ObjectStoreType::Wal),
+            stores.store_of(ObjectStoreType::Wal),
             &main_store
         ));
 
         let transactional_store = stores.transactional_store_of(ObjectStoreType::Main);
         assert!(Arc::ptr_eq(
-            &stores.transactional_store_of(ObjectStoreType::Wal),
-            &transactional_store
+            stores.transactional_store_of(ObjectStoreType::Wal),
+            transactional_store
         ));
 
         assert!(Arc::ptr_eq(
@@ -144,18 +144,18 @@ mod tests {
         let stores = ObjectStores::new(main_store.clone(), Some(wal_store.clone()));
 
         assert!(Arc::ptr_eq(
-            &stores.store_of(ObjectStoreType::Main),
+            stores.store_of(ObjectStoreType::Main),
             &main_store
         ));
         assert!(Arc::ptr_eq(
-            &stores.store_of(ObjectStoreType::Wal),
+            stores.store_of(ObjectStoreType::Wal),
             &wal_store
         ));
 
         let transactional_store = stores.transactional_store_of(ObjectStoreType::Main);
         assert!(!Arc::ptr_eq(
-            &stores.transactional_store_of(ObjectStoreType::Wal),
-            &transactional_store
+            stores.transactional_store_of(ObjectStoreType::Wal),
+            transactional_store
         ));
 
         assert!(Arc::ptr_eq(

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -361,6 +361,7 @@ impl<'a> LevelGet<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::object_stores::ObjectStores;
     use crate::{sst::SsTableFormat, stats::StatRegistry, types::ValueDeletable};
     use object_store::{memory::InMemory, path::Path};
     use rstest::rstest;
@@ -540,8 +541,7 @@ mod tests {
             max_seq: None,
             snapshot: &mock_read_snapshot,
             table_store: Arc::new(TableStore::new(
-                Arc::new(InMemory::new()),
-                None,
+                ObjectStores::new(Arc::new(InMemory::new()), None),
                 SsTableFormat::default(),
                 Path::from(""),
                 None,

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -541,6 +541,7 @@ mod tests {
             snapshot: &mock_read_snapshot,
             table_store: Arc::new(TableStore::new(
                 Arc::new(InMemory::new()),
+                None,
                 SsTableFormat::default(),
                 Path::from(""),
                 None,

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -663,6 +663,7 @@ mod tests {
             last_l0_seq: 0,
             last_l0_clock_tick: 0,
             checkpoints: vec![],
+            wal_object_store_uri: None,
         }
     }
 

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -176,6 +176,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -220,6 +221,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -272,6 +274,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -316,6 +319,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -354,6 +358,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -380,6 +385,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             SsTableFormat::default(),
             root_path.clone(),
             None,

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -156,6 +156,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, gen_attrs};
 
+    use crate::object_stores::ObjectStores;
     use bytes::{BufMut, BytesMut};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
@@ -175,8 +176,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -220,8 +220,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -273,8 +272,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -318,8 +316,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -357,8 +354,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -384,8 +380,7 @@ mod tests {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             SsTableFormat::default(),
             root_path.clone(),
             None,

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -724,6 +724,7 @@ mod tests {
     use crate::db_state::SsTableId;
     use crate::filter::filter_hash;
     use crate::iter::IterationOrder::Ascending;
+    use crate::object_stores::ObjectStores;
     use crate::tablestore::TableStore;
     use crate::test_utils::{assert_iterator, build_test_sst, gen_attrs, gen_empty_attrs};
 
@@ -771,7 +772,12 @@ mod tests {
             block_size: 32,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, None, format, root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format,
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder
             .add_value(&[b'a'; 8], &[b'1'; 8], gen_attrs(1))
@@ -817,7 +823,12 @@ mod tests {
             block_size: 32,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format.clone(),
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder
             .add_value(&[b'a'; 8], &[b'1'; 8], gen_attrs(1))
@@ -898,7 +909,12 @@ mod tests {
     ) {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format.clone(),
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         for k in 1..=8 {
             builder
@@ -974,7 +990,12 @@ mod tests {
             compression_codec: compression,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, None, format, root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format,
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
@@ -1028,8 +1049,12 @@ mod tests {
             compression_codec: compression,
             ..SsTableFormat::default()
         };
-        let table_store =
-            TableStore::new(object_store.clone(), None, format, root_path.clone(), None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            format,
+            root_path.clone(),
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
@@ -1045,7 +1070,12 @@ mod tests {
             compression_codec: dummy_codec,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, None, format, root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format,
+            root_path,
+            None,
+        );
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         let index = table_store.read_index(&sst_handle).await.unwrap();
         let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
@@ -1096,7 +1126,12 @@ mod tests {
             min_filter_keys: 1,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format.clone(),
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder
             .add_value(&[b'a'; 2], &[1u8; 2], gen_empty_attrs())
@@ -1139,7 +1174,12 @@ mod tests {
             ..SsTableFormat::default()
         };
 
-        let table_store = TableStore::new(object_store, None, format, root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format,
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
@@ -1196,7 +1236,12 @@ mod tests {
             ..SsTableFormat::default()
         };
 
-        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
+        let table_store = TableStore::new(
+            ObjectStores::new(object_store, None),
+            format.clone(),
+            root_path,
+            None,
+        );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -771,7 +771,7 @@ mod tests {
             block_size: 32,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, format, root_path, None);
+        let table_store = TableStore::new(object_store, None, format, root_path, None);
         let mut builder = table_store.table_builder();
         builder
             .add_value(&[b'a'; 8], &[b'1'; 8], gen_attrs(1))
@@ -817,7 +817,7 @@ mod tests {
             block_size: 32,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, format.clone(), root_path, None);
+        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
         let mut builder = table_store.table_builder();
         builder
             .add_value(&[b'a'; 8], &[b'1'; 8], gen_attrs(1))
@@ -898,7 +898,7 @@ mod tests {
     ) {
         let root_path = Path::from("");
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let table_store = TableStore::new(object_store, format.clone(), root_path, None);
+        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
         let mut builder = table_store.table_builder();
         for k in 1..=8 {
             builder
@@ -974,7 +974,7 @@ mod tests {
             compression_codec: compression,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, format, root_path, None);
+        let table_store = TableStore::new(object_store, None, format, root_path, None);
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
@@ -1028,7 +1028,8 @@ mod tests {
             compression_codec: compression,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store.clone(), format, root_path.clone(), None);
+        let table_store =
+            TableStore::new(object_store.clone(), None, format, root_path.clone(), None);
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
@@ -1044,7 +1045,7 @@ mod tests {
             compression_codec: dummy_codec,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, format, root_path, None);
+        let table_store = TableStore::new(object_store, None, format, root_path, None);
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         let index = table_store.read_index(&sst_handle).await.unwrap();
         let filter = table_store.read_filter(&sst_handle).await.unwrap().unwrap();
@@ -1095,7 +1096,7 @@ mod tests {
             min_filter_keys: 1,
             ..SsTableFormat::default()
         };
-        let table_store = TableStore::new(object_store, format.clone(), root_path, None);
+        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
         let mut builder = table_store.table_builder();
         builder
             .add_value(&[b'a'; 2], &[1u8; 2], gen_empty_attrs())
@@ -1138,7 +1139,7 @@ mod tests {
             ..SsTableFormat::default()
         };
 
-        let table_store = TableStore::new(object_store, format, root_path, None);
+        let table_store = TableStore::new(object_store, None, format, root_path, None);
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
@@ -1195,7 +1196,7 @@ mod tests {
             ..SsTableFormat::default()
         };
 
-        let table_store = TableStore::new(object_store, format.clone(), root_path, None);
+        let table_store = TableStore::new(object_store, None, format.clone(), root_path, None);
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -374,6 +374,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -427,6 +428,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -484,6 +486,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -533,6 +536,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,
@@ -576,6 +580,7 @@ mod tests {
         };
         let table_store = Arc::new(TableStore::new(
             object_store,
+            None,
             format,
             root_path.clone(),
             None,

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -358,6 +358,7 @@ mod tests {
     use super::*;
     use crate::bytes_generator::OrderedBytesGenerator;
     use crate::db_state::SsTableId;
+    use crate::object_stores::ObjectStores;
     use crate::sst::SsTableFormat;
     use crate::test_utils::{assert_kv, gen_attrs};
     use object_store::path::Path;
@@ -373,8 +374,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -427,8 +427,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -485,8 +484,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -535,8 +533,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,
@@ -579,8 +576,7 @@ mod tests {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            object_store,
-            None,
+            ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
             None,

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -21,6 +21,7 @@ impl StoreProvider for DefaultStoreProvider {
     fn table_store(&self) -> Arc<TableStore> {
         Arc::new(TableStore::new(
             Arc::clone(&self.object_store),
+            None,
             SsTableFormat::default(),
             self.path.clone(),
             self.block_cache.clone(),

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,5 +1,6 @@
 use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
+use crate::object_stores::ObjectStores;
 use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use object_store::path::Path;
@@ -20,8 +21,7 @@ pub(crate) struct DefaultStoreProvider {
 impl StoreProvider for DefaultStoreProvider {
     fn table_store(&self) -> Arc<TableStore> {
         Arc::new(TableStore::new(
-            Arc::clone(&self.object_store),
-            None,
+            ObjectStores::new(Arc::clone(&self.object_store), None),
             SsTableFormat::default(),
             self.path.clone(),
             self.block_cache.clone(),

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -296,7 +296,7 @@ impl TableStore {
 
     /// Delete an SSTable from the object store.
     pub(crate) async fn delete_sst(&self, id: &SsTableId) -> Result<(), SlateDBError> {
-        let object_store = self.object_store_for(&id);
+        let object_store = self.object_store_for(id);
         let path = self.path(id);
         object_store.delete(&path).await.map_err(SlateDBError::from)
     }
@@ -345,7 +345,7 @@ impl TableStore {
     }
 
     pub(crate) async fn open_sst(&self, id: &SsTableId) -> Result<SsTableHandle, SlateDBError> {
-        let object_store = self.object_store_for(&id);
+        let object_store = self.object_store_for(id);
         let path = self.path(id);
         let obj = ReadOnlyObject { object_store, path };
         let info = self.sst_format.read_info(&obj).await?;

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -27,13 +27,20 @@ use crate::types::RowEntry;
 use crate::{blob::ReadOnlyBlob, block::Block};
 
 pub struct TableStore {
+    /// The main object store used for everything that doesn't have a more
+    /// specific object store configured.
     main_object_store: Arc<dyn ObjectStore>,
+    /// Optional WAL object store dedicated specifically for WAL.
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     sst_format: SsTableFormat,
     path_resolver: PathResolver,
     #[allow(dead_code)]
     fp_registry: Arc<FailPointRegistry>,
+    /// The transactional store of the main object store used for everything
+    /// that doesn't have a more specific object store configured.
     main_transactional_store: Arc<dyn TransactionalObjectStore>,
+    /// Optional transactional store of the WAL object store dedicated
+    /// specifically for WAL.
     wal_transactional_store: Option<Arc<dyn TransactionalObjectStore>>,
     /// In-memory cache for blocks
     block_cache: Option<Arc<dyn DbCache>>,

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use fail_parallel::{fail_point, FailPointRegistry};
 use futures::{future::join_all, StreamExt};
-use log::warn;
+use log::{debug, warn};
 use object_store::buffered::BufWriter;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -249,7 +249,10 @@ impl TableStore {
             .await
             .map_err(|e| match e {
                 object_store::Error::AlreadyExists { path: _, source: _ } => match id {
-                    SsTableId::Wal(_) => SlateDBError::Fenced,
+                    SsTableId::Wal(_) => {
+                        debug!("Path {path} already exists");
+                        SlateDBError::Fenced
+                    }
                     SsTableId::Compacted(_) => SlateDBError::from(e),
                 },
                 _ => SlateDBError::from(e),

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -505,6 +505,7 @@ mod tests {
         let path = Path::from("/tmp/test_kv_store");
         Arc::new(TableStore::new(
             object_store.clone(),
+            None,
             SsTableFormat::default(),
             path.clone(),
             None,

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -271,6 +271,7 @@ mod tests {
     use crate::db_state::{CoreDbState, SsTableId};
     use crate::iter::{IterationOrder, KeyValueIterator};
     use crate::mem_table::WritableKVTable;
+    use crate::object_stores::ObjectStores;
     use crate::proptest_util::{rng, sample};
     use crate::sst::SsTableFormat;
     use crate::tablestore::TableStore;
@@ -504,8 +505,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
         Arc::new(TableStore::new(
-            object_store.clone(),
-            None,
+            ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
             path.clone(),
             None,


### PR DESCRIPTION
This PR is the first in the series and introduces the following:

- Configuration support via `DbBuilder`.
- `TableStore` now selects an appropriate object store based on a `SsTableId`.
- `Manifest(V1)` now contains `wal_object_store_uri`, currently serving just as
   a flag.