### PR TITLE
chore: add comment about last_wal_id and wal_id_last_compacted

### DIFF
--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -42,7 +42,9 @@ table ManifestV1 {
     // The current compactor's epoch.
     compactor_epoch: ulong;
 
-    // The most recent SST in the WAL that's been compacted.
+    // Tracks the most recent SST in the WAL that has completed compaction. When an Immutable Memtable 
+    // (IMM) is flushed to L0, we record the last WAL ID associated with this IMM here. During recovery,
+    // we use `wal_id_last_compacted + 1` as the starting point for WAL replay.
     wal_id_last_compacted: ulong;
 
     // The most recent SST in the WAL at the time manifest was updated.

--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -113,6 +113,10 @@ pub(crate) struct WritableKVTable {
 }
 
 pub(crate) struct ImmutableMemtable {
+    /// The last WAL ID of this IMM. This is used to determine the starting position of
+    /// WAL replay during recovery. After an IMM is flushed to L0, we do not need to care
+    /// about the earlier WALs which produced this IMM, all we need to know is the last
+    /// WAL ID of the last L0 compacted.
     last_wal_id: u64,
     table: Arc<KVTable>,
     flushed: WatchableOnceCell<Result<(), SlateDBError>>,


### PR DESCRIPTION
this PR adds brief descriptions for two fields related to WAL replays during the recovery phase.