### PR TITLE
chore: Add memtable track last_seq test

### DIFF
--- a/src/mem_table.rs
+++ b/src/mem_table.rs
@@ -495,11 +495,6 @@ mod tests {
         assert_eq!(metadata.entry_num, 2);
         assert_eq!(metadata.entries_size_in_bytes, 29);
 
-        table.put(RowEntry::new_tombstone(b"first", 2));
-        metadata = table.table().metadata();
-        assert_eq!(metadata.entry_num, 2);
-        assert_eq!(metadata.entries_size_in_bytes, 29);
-
         table.put(RowEntry::new_value(b"abc333", b"val1", 1));
         metadata = table.table().metadata();
         assert_eq!(metadata.entry_num, 3);
@@ -519,6 +514,37 @@ mod tests {
         metadata = table.table().metadata();
         assert_eq!(metadata.entry_num, 6);
         assert_eq!(metadata.entries_size_in_bytes, 104);
+    }
+
+    #[tokio::test]
+    async fn test_memtable_track_last_seq() {
+        let mut table = WritableKVTable::new();
+        let mut metadata = table.table().metadata();
+
+        assert_eq!(metadata.last_seq, 0);
+        table.put(RowEntry::new_value(b"first", b"foo", 1));
+        metadata = table.table().metadata();
+        assert_eq!(metadata.last_seq, 1);
+
+        table.put(RowEntry::new_tombstone(b"first", 2));
+        metadata = table.table().metadata();
+        assert_eq!(metadata.last_seq, 2);
+
+        table.put(RowEntry::new_value(b"abc333", b"val1", 1));
+        metadata = table.table().metadata();
+        assert_eq!(metadata.last_seq, 2);
+
+        table.put(RowEntry::new_value(b"def456", b"blablabla", 2));
+        metadata = table.table().metadata();
+        assert_eq!(metadata.last_seq, 2);
+
+        table.put(RowEntry::new_value(b"def456", b"blabla", 3));
+        metadata = table.table().metadata();
+        assert_eq!(metadata.last_seq, 3);
+
+        table.put(RowEntry::new_tombstone(b"abc333", 4));
+        metadata = table.table().metadata();
+        assert_eq!(metadata.last_seq, 4);
     }
 
     #[rstest]


### PR DESCRIPTION
1. Add meetable track last_seq test
2. Delete duplicate test examples 