### PR TITLE
Make shutdown manifest conflict logs less scary

### DIFF
--- a/src/compactor.rs
+++ b/src/compactor.rs
@@ -293,7 +293,7 @@ impl CompactorEventHandler {
             match self.write_manifest() {
                 Ok(_) => return Ok(()),
                 Err(SlateDBError::ManifestVersionExists) => {
-                    warn!("conflicting manifest version. retry write");
+                    warn!("conflicting manifest version. updating and retrying write again.");
                 }
                 Err(err) => return Err(err),
             }

--- a/src/mem_table_flush.rs
+++ b/src/mem_table_flush.rs
@@ -71,7 +71,7 @@ impl MemtableFlusher {
             self.load_manifest().await?;
             let result = self.write_checkpoint(options).await;
             if matches!(result, Err(SlateDBError::ManifestVersionExists)) {
-                error!("conflicting manifest version. retry write");
+                warn!("conflicting manifest version. updating and retrying write again.");
             } else {
                 return result;
             }
@@ -82,7 +82,7 @@ impl MemtableFlusher {
         loop {
             let result = self.write_manifest().await;
             if matches!(result, Err(SlateDBError::ManifestVersionExists)) {
-                error!("conflicting manifest version. retry write");
+                warn!("conflicting manifest version. updating and retrying write again.");
                 self.load_manifest().await?;
             } else {
                 return result;


### PR DESCRIPTION
The shutdown messages for the memtable flusher are a little scary. I've updated them to be a WARN and imply that the manifest update is retrying.

Fixes #566