### PR TITLE
Decompress block bytes before decoding

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3176,7 +3176,7 @@ mod tests {
             let value = format!("{}{}", "v".repeat(i), i);
             let put_option = PutOptions::default();
             let write_option = WriteOptions {
-                await_durable: false,
+                await_durable: true,
             };
             db.put_with_options(key.as_bytes(), value.clone(), &put_option, &write_option)
                 .await

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3160,7 +3160,6 @@ mod tests {
         // error in Block::decode
 
         use crate::config::CompressionCodec;
-        use object_store::local::LocalFileSystem;
         use std::str::FromStr;
 
         // Create and load inital database
@@ -3183,8 +3182,8 @@ mod tests {
                 .await
                 .expect("failed to put");
         }
-        // db.flush().await.expect("flush failed");
-        // db.close().await.expect("failed to close db");
+        db.flush().await.expect("flush failed");
+        db.close().await.expect("failed to close db");
 
         // Reload DB and read a value to trigger error
         let db_builder = Db::builder("/tmp/test_kv_store", os.clone()).with_settings(Settings {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3183,8 +3183,8 @@ mod tests {
                 .await
                 .expect("failed to put");
         }
-        db.flush().await.expect("flush failed");
-        db.close().await.expect("failed to close db");
+        // db.flush().await.expect("flush failed");
+        // db.close().await.expect("failed to close db");
 
         // Reload DB and read a value to trigger error
         let db_builder = Db::builder("/tmp/test_kv_store", os.clone()).with_settings(Settings {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3102,64 +3102,6 @@ mod tests {
         assert_eq!(last_clock_tick, 11);
     }
 
-    #[cfg(all(feature = "zstd", feature = "wal_disable"))]
-    #[tokio::test]
-    async fn test_compression_overflow_bug() {
-        // This test reproduces the bug reported in issue #555
-        // https://github.com/slatedb/slatedb/issues/555
-        // where using zstd compression with flush() followed by get() causes
-        // an "attempt to subtract with overflow" error in Block::decode
-
-        use crate::config::CompressionCodec;
-        use std::str::FromStr;
-
-        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let compress = CompressionCodec::from_str("zstd").unwrap();
-        let db_options = Settings {
-            flush_interval: None,
-            wal_enabled: false,
-            compression_codec: Some(compress),
-            ..Settings::default()
-        };
-        let path = "/tmp/test_compression_overflow_bug";
-        let db = Db::builder(path, os.clone())
-            .with_settings(db_options)
-            .build()
-            .await
-            .unwrap();
-
-        // Insert some data with large values to trigger compression
-        for i in 0..100 {
-            let key = format!("k{}", i);
-            let value = format!("{}{}", "v".repeat(10000), i);
-            db.put_with_options(
-                key.as_bytes(),
-                value.clone(),
-                &PutOptions::default(),
-                &WriteOptions {
-                    await_durable: false,
-                },
-            )
-            .await
-            .expect("failed to put");
-        }
-
-        // Flush the database to disk - this is part of the bug reproduction
-        info!("Flushing database...");
-        let _ = db.flush().await;
-        info!("Flush completed");
-
-        // Now try to read a value back - this should trigger the overflow error
-        let read_option = ReadOptions {
-            durability_filter: Memory,
-        };
-
-        // This get operation should trigger the "attempt to subtract with overflow" error
-        let result = db.get_with_options("k5", &read_option).await.unwrap();
-        let expected_value = format!("{}{}", "v".repeat(10000), 5);
-        assert_eq!(result, Some(expected_value.into()));
-    }
-
     #[tokio::test]
     #[cfg(feature = "wal_disable")]
     async fn test_recover_clock_tick_from_manifest() {
@@ -3208,6 +3150,53 @@ mod tests {
         // set correctly due to visibility issues.
         let write_options = WriteOptions::default();
         assert!(write_options.await_durable);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "zstd")]
+    async fn test_compression_overflow_bug() {
+        // This test reproduces the bug reported in https://github.com/slatedb/slatedb/issues/555
+        // where re-opening a DB using zstd compression causes "attempt to subtract with overflow"
+        // error in Block::decode
+
+        use crate::config::CompressionCodec;
+        use object_store::local::LocalFileSystem;
+        use std::str::FromStr;
+
+        // Create and load inital database
+        let os: Arc<dyn ObjectStore> =
+            Arc::new(LocalFileSystem::new_with_prefix("/tmp/slatedb-555-data").unwrap());
+        let compress = CompressionCodec::from_str("zstd").unwrap();
+        let db_builder = Db::builder("/tmp/test_kv_store", os.clone()).with_settings(Settings {
+            compression_codec: Some(compress),
+            ..Settings::default()
+        });
+        let db = db_builder.build().await.unwrap();
+
+        for i in 0..1000 {
+            let key = format!("k{}", i);
+            let value = format!("{}{}", "v".repeat(i), i);
+            let put_option = PutOptions::default();
+            let write_option = WriteOptions {
+                await_durable: false,
+            };
+            db.put_with_options(key.as_bytes(), value.clone(), &put_option, &write_option)
+                .await
+                .expect("failed to put");
+        }
+        db.flush().await.expect("flush failed");
+        db.close().await.expect("failed to close db");
+
+        // Reload DB and read a value to trigger error
+        let db_builder = Db::builder("/tmp/test_kv_store", os.clone()).with_settings(Settings {
+            compression_codec: Some(compress),
+            ..Settings::default()
+        });
+        let db = db_builder.build().await.unwrap();
+        let v = db.get("k1").await.expect("get failed").unwrap();
+        assert_eq!(v.as_ref(), b"v1");
+
+        db.close().await.expect("failed to close db");
     }
 
     async fn wait_for_manifest_condition(

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3176,7 +3176,7 @@ mod tests {
             let value = format!("{}{}", "v".repeat(i), i);
             let put_option = PutOptions::default();
             let write_option = WriteOptions {
-                await_durable: true,
+                await_durable: false,
             };
             db.put_with_options(key.as_bytes(), value.clone(), &put_option, &write_option)
                 .await

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3164,8 +3164,7 @@ mod tests {
         use std::str::FromStr;
 
         // Create and load inital database
-        let os: Arc<dyn ObjectStore> =
-            Arc::new(LocalFileSystem::new_with_prefix("/tmp/slatedb-555-data").unwrap());
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let compress = CompressionCodec::from_str("zstd").unwrap();
         let db_builder = Db::builder("/tmp/test_kv_store", os.clone()).with_settings(Settings {
             compression_codec: Some(compress),

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -273,8 +273,8 @@ impl SsTableFormat {
     ) -> Result<Block, SlateDBError> {
         let block_bytes = self.validate_checksum(bytes)?;
         let decompressed_bytes = match compression_codec {
-            Some(c) => Self::decompress(block_bytes.clone(), c)?,
-            None => block_bytes.clone(),
+            Some(c) => Self::decompress(block_bytes, c)?,
+            None => block_bytes,
         };
         Ok(Block::decode(decompressed_bytes))
     }

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -272,15 +272,11 @@ impl SsTableFormat {
         compression_codec: Option<CompressionCodec>,
     ) -> Result<Block, SlateDBError> {
         let block_bytes = self.validate_checksum(bytes)?;
-        let decoded_block = Block::decode(block_bytes);
         let decompressed_bytes = match compression_codec {
-            Some(c) => Self::decompress(decoded_block.data, c)?,
-            None => decoded_block.data,
+            Some(c) => Self::decompress(block_bytes.clone(), c)?,
+            None => block_bytes.clone(),
         };
-        Ok(Block {
-            data: decompressed_bytes,
-            offsets: decoded_block.offsets,
-        })
+        Ok(Block::decode(decompressed_bytes))
     }
 
     pub(crate) async fn read_block(


### PR DESCRIPTION
This PR fixes a bug in how we compress blocks. Before the fix, we were compressing the entire block _after_ it was encoded. This means that we should decompress the entire block _before_ it's decoded. Unfortunately, we were not. Instead, we were calling `Block::decode` and _then_ calling decompress. This will of course give the wrong bytes to the decode method. As a result, we were seeing a subtraction overflow because we were getting random (compressed) bytes for the `entry_offsets_len` in the Block::decode method.

I've fixed this issue by decompressing the block bytes _before_ they're decoded.

Fixes #555