### PR TITLE
support patch releases after main has advanced

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
+          ref: ${{ github.ref }}
 
       # Set up Rust stable
       - name: Install cargo-edit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,12 @@ SlateDB releases are published using a Github release action defined in `.github
 1. Go to the [release action page](https://github.com/slatedb/slatedb/actions/workflows/release.yaml)
 2. Input a version value in the format `X.Y.Z` and click `Run workflow`.
 
+ To create a patch release for an existing version:
+
+1. If it doesn't already exist, create a <major>.<minor>.x branch from the release tag. So for example, for the v0.6.0 release, run `git checkout -b 0.6.x v0.6.0`.
+2. Cherry-pick the desired changes onto the release branch and push it.
+3. Run the release workflow against the release branch and specify the desired release version (e.g. v0.6.1)
+
 The release action will do the following:
 
 1. Verify that the version adheres to the semantic versioning format.


### PR DESCRIPTION
Allow running publish from a branch to allow patch releases after main has advanced. Publish will now check out the branch that the workflow was run against. This will allow us to create a branch like "0.6.x" from the initial 0.6.0 release tag, and then do future patch releases from that branch so that we can continue to patch release even after main has advanced and included potentially breaking changes.