### PR TITLE
Centralize RNG logic and add deterministic seeding support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
  "naive-timer",
  "panic-message",
  "rand 0.8.5",
- "rand_xoshiro 0.6.0",
+ "rand_xoshiro",
  "rustversion",
  "serde",
  "spin",
@@ -2468,15 +2468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
-dependencies = [
- "rand_core 0.9.3",
-]
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,9 +2965,8 @@ dependencies = [
  "proptest",
  "radix_trie",
  "rand 0.8.5",
- "rand_core 0.9.3",
  "rand_xorshift",
- "rand_xoshiro 0.7.0",
+ "rand_xoshiro",
  "rstest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,6 +2947,7 @@ dependencies = [
  "dotenvy",
  "duration-str",
  "fail-parallel",
+ "fastrand",
  "figment",
  "filetime",
  "flatbuffers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3499,11 +3499,12 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ulid"
-version = "1.2.1"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+checksum = "04f903f293d11f31c0c29e4148f6dc0d033a7f80cebc0282bea147611667d289"
 dependencies = [
- "rand 0.9.0",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "serde",
  "web-time",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2974,6 +2974,7 @@ dependencies = [
  "proptest",
  "radix_trie",
  "rand 0.8.5",
+ "rand_core 0.9.3",
  "rand_xorshift",
  "rand_xoshiro 0.7.0",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ dependencies = [
  "naive-timer",
  "panic-message",
  "rand 0.8.5",
- "rand_xoshiro",
+ "rand_xoshiro 0.6.0",
  "rustversion",
  "serde",
  "spin",
@@ -2468,6 +2468,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,7 +2956,6 @@ dependencies = [
  "dotenvy",
  "duration-str",
  "fail-parallel",
- "fastrand",
  "figment",
  "filetime",
  "flatbuffers",
@@ -2967,6 +2975,7 @@ dependencies = [
  "radix_trie",
  "rand 0.8.5",
  "rand_xorshift",
+ "rand_xoshiro 0.7.0",
  "rstest",
  "serde",
  "serde_json",

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -49,6 +49,7 @@ walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }
 tokio-util = { version = "0.7.15", default-features = false, features = ["rt"] }
 rand_xoshiro = "0.7.0"
+rand_core = "0.9.3"
 
 [dev-dependencies]
 bincode = "1"

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -48,7 +48,7 @@ uuid = { version = "1.11.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }
 tokio-util = { version = "0.7.15", default-features = false, features = ["rt"] }
-fastrand = "2.3.0"
+rand_xoshiro = "0.7.0"
 
 [dev-dependencies]
 bincode = "1"

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -48,6 +48,7 @@ uuid = { version = "1.11.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }
 tokio-util = { version = "0.7.15", default-features = false, features = ["rt"] }
+fastrand = "2.3.0"
 
 [dev-dependencies]
 bincode = "1"

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -36,6 +36,7 @@ parking_lot = "0.12.3"
 radix_trie = "0.2.1"
 rand = "0.8.5"
 rand_xorshift = "0.3.0"
+rand_xoshiro = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 siphasher = "1"
@@ -48,8 +49,6 @@ uuid = { version = "1.11.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }
 tokio-util = { version = "0.7.15", default-features = false, features = ["rt"] }
-rand_xoshiro = "0.7.0"
-rand_core = "0.9.3"
 
 [dev-dependencies]
 bincode = "1"

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -44,7 +44,7 @@ snap = { version = "1.1.1", optional = true }
 thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["fs", "macros", "sync", "rt", "rt-multi-thread", "signal"] }
 tracing = { version = "0.1.40", features = ["log"] }
-ulid = { version = "1.1.3", features = ["serde"] }
+ulid = { version = "=1.1.3", features = ["serde"] }
 uuid = { version = "1.11.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = "1.0.63"
 tokio = { version = "1.40.0", features = ["fs", "macros", "sync", "rt", "rt-multi-thread", "signal"] }
 tracing = { version = "0.1.40", features = ["log"] }
 ulid = { version = "=1.1.3", features = ["serde"] }
-uuid = { version = "1.11.0", features = ["v4", "serde"] }
+uuid = { version = "1.12.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }
 tokio-util = { version = "0.7.15", default-features = false, features = ["rt"] }

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -10,7 +10,6 @@ use object_store::path::Path;
 use object_store::{Attributes, ObjectMeta};
 use radix_trie::{Trie, TrieCommon};
 use rand::seq::IteratorRandom;
-use rand::SeedableRng;
 use rand::{distributions::Alphanumeric, Rng};
 use tokio::fs::File;
 use tokio::{
@@ -146,7 +145,7 @@ impl FsCacheEntry {
     }
 
     fn make_rand_suffix(&self) -> String {
-        let mut rng = rand::thread_rng();
+        let mut rng = crate::rand::thread_rng();
         (0..24).map(|_| rng.sample(Alphanumeric) as char).collect()
     }
 }
@@ -618,7 +617,7 @@ impl FsCacheEvictorInner {
 
     async fn random_pick_entry(&self) -> Option<(std::path::PathBuf, (SystemTime, usize))> {
         let cache_entries = self.cache_entries.lock().await;
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = crate::rand::thread_rng();
 
         let mut rand_child = match cache_entries.children().choose(&mut rng) {
             None => return None,

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -255,7 +255,7 @@ mod tests {
             .await
             .unwrap();
 
-        let source_checkpoint_id = uuid::Uuid::new_v4();
+        let source_checkpoint_id = crate::utils::uuid();
         let result = admin::create_checkpoint(
             path,
             object_store.clone(),
@@ -351,7 +351,7 @@ mod tests {
         let result = Db::refresh_checkpoint(
             &path,
             object_store.clone(),
-            uuid::Uuid::new_v4(),
+            crate::utils::uuid(),
             Some(Duration::from_secs(1000)),
         )
         .await;

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -314,7 +314,6 @@ mod tests {
     use object_store::path::Path;
     use std::ops::RangeFull;
     use std::sync::Arc;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn should_clone_latest_state_if_no_checkpoint_provided() {
@@ -434,7 +433,7 @@ mod tests {
 
         // Create an uninitialized manifest with an invalid checkpoint id
         let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-        let non_existent_source_checkpoint_id = Uuid::new_v4();
+        let non_existent_source_checkpoint_id = crate::utils::uuid();
         StoredManifest::create_uninitialized_clone(
             clone_manifest_store,
             &Manifest::initial(CoreDbState::new()),
@@ -521,7 +520,7 @@ mod tests {
             Arc::clone(&clone_manifest_store),
             &parent_manifest,
             original_parent_path.to_string(),
-            Uuid::new_v4(),
+            crate::utils::uuid(),
         )
         .await
         .unwrap();

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -13,7 +13,6 @@ use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 use ulid::Ulid;
-use uuid::Uuid;
 
 use crate::bytes_generator::OrderedBytesGenerator;
 use crate::compactor::stats::CompactionStats;
@@ -219,7 +218,7 @@ impl CompactionExecuteBench {
             .map(|id| ssts_by_id.get(&id).expect("expected sst").clone())
             .collect();
         Ok(CompactionJob {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             destination: 0,
             ssts,
             sorted_runs: vec![],
@@ -251,7 +250,7 @@ impl CompactionExecuteBench {
             .collect();
         info!("loaded compaction job");
         CompactionJob {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             destination: 0,
             ssts: vec![],
             sorted_runs: srs,

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use futures::future::join_all;
 use parking_lot::Mutex;
 use tokio::task::JoinHandle;
-use ulid::Ulid;
 
 use crate::compactor::WorkerToOrchestratorMsg;
 use crate::compactor::WorkerToOrchestratorMsg::CompactionFinished;
@@ -133,11 +132,9 @@ impl TokioCompactionExecutorInner {
     ) -> Result<SortedRun, SlateDBError> {
         let mut all_iter = self.load_iterators(&compaction).await?;
         let mut output_ssts = Vec::new();
-        let mut current_writer =
-            self.table_store
-                .table_writer(SsTableId::Compacted(Ulid::with_source(
-                    &mut crate::rand::thread_rng(),
-                )));
+        let mut current_writer = self
+            .table_store
+            .table_writer(SsTableId::Compacted(crate::utils::ulid()));
         let mut current_size = 0usize;
 
         while let Some(raw_kv) = all_iter.next_entry().await? {
@@ -175,7 +172,7 @@ impl TokioCompactionExecutorInner {
                 let finished_writer = mem::replace(
                     &mut current_writer,
                     self.table_store
-                        .table_writer(SsTableId::Compacted(Ulid::new())),
+                        .table_writer(SsTableId::Compacted(crate::utils::ulid())),
                 );
                 output_ssts.push(finished_writer.close().await?);
                 self.stats.bytes_compacted.add(current_size as u64);

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -133,9 +133,11 @@ impl TokioCompactionExecutorInner {
     ) -> Result<SortedRun, SlateDBError> {
         let mut all_iter = self.load_iterators(&compaction).await?;
         let mut output_ssts = Vec::new();
-        let mut current_writer = self
-            .table_store
-            .table_writer(SsTableId::Compacted(Ulid::new()));
+        let mut current_writer =
+            self.table_store
+                .table_writer(SsTableId::Compacted(Ulid::with_source(
+                    &mut crate::rand::thread_rng(),
+                )));
         let mut current_size = 0usize;
 
         while let Some(raw_kv) = all_iter.next_entry().await? {

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -145,7 +145,7 @@ impl CompactorState {
             }
         }
         info!("accepted submitted compaction: {:?}", compaction);
-        let id = Uuid::new_v4();
+        let id = crate::utils::uuid();
         self.compactions.insert(id, compaction);
         Ok(id)
     }
@@ -280,7 +280,6 @@ mod tests {
     use object_store::path::Path;
     use object_store::ObjectStore;
     use tokio::runtime::{Handle, Runtime};
-    use uuid::Uuid;
 
     const PATH: &str = "/test/db";
 
@@ -521,7 +520,7 @@ mod tests {
         // mimic an externally added checkpoint
         let mut dirty = new_dirty_manifest();
         let checkpoint = Checkpoint {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             manifest_id: 1,
             expire_time: None,
             create_time: SystemTime::now(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -231,7 +231,9 @@ impl<P: Into<Path>> DbBuilder<P> {
             info!(?path, ?self.settings, "Opening SlateDB database");
         }
 
-        let rng = self.rng.unwrap_or_else(|| Arc::new(rand::rngs::StdRng::from_entropy()));
+        let rng = self
+            .rng
+            .unwrap_or_else(|| Arc::new(rand::rngs::StdRng::from_entropy()));
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock::new()));
         let block_cache = self.block_cache.or_else(default_block_cache);
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -88,11 +88,9 @@ use fail_parallel::FailPointRegistry;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use parking_lot::Mutex;
-use rand::RngCore;
-use rand::SeedableRng;
 use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::cached_object_store::stats::CachedObjectStoreStats;
 use crate::cached_object_store::CachedObjectStore;
@@ -132,7 +130,7 @@ pub struct DbBuilder<P: Into<Path>> {
     compaction_scheduler_supplier: Option<Arc<dyn CompactionSchedulerSupplier>>,
     fp_registry: Arc<FailPointRegistry>,
     cancellation_token: CancellationToken,
-    rng: Option<Arc<dyn RngCore>>,
+    seed: Option<u64>,
 }
 
 impl<P: Into<Path>> DbBuilder<P> {
@@ -150,7 +148,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             compaction_scheduler_supplier: None,
             fp_registry: Arc::new(FailPointRegistry::new()),
             cancellation_token: CancellationToken::new(),
-            rng: None,
+            seed: None,
         }
     }
 
@@ -213,8 +211,13 @@ impl<P: Into<Path>> DbBuilder<P> {
         self
     }
 
-    pub fn with_rng(mut self, rng: Arc<dyn RngCore>) -> Self {
-        self.rng = Some(rng);
+    /// Sets the seed to use for the database's random number generator. All random behavior
+    /// in SlateDB will use randomm number generators based off of this seed. This includes
+    /// random bytes for UUIDs and ULIDS, as well as random pickers in cache eviction policies.
+    ///
+    /// If not set, SlateDB uses the OS's random number generator to generate a seed.
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
         self
     }
 
@@ -231,9 +234,11 @@ impl<P: Into<Path>> DbBuilder<P> {
             info!(?path, ?self.settings, "Opening SlateDB database");
         }
 
-        let rng = self
-            .rng
-            .unwrap_or_else(|| Arc::new(rand::rngs::StdRng::from_entropy()));
+        if let Some(seed) = self.seed {
+            debug!("Using user-specified seed");
+            crate::rand::seed(seed);
+        }
+
         let clock = self.clock.unwrap_or_else(|| Arc::new(SystemClock::new()));
         let block_cache = self.block_cache.or_else(default_block_cache);
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -914,7 +914,7 @@ mod tests {
 
         let parent_manifest = Manifest::initial(CoreDbState::new());
         let parent_path = "/tmp/parent_store".to_string();
-        let source_checkpoint_id = Uuid::new_v4();
+        let source_checkpoint_id = crate::utils::uuid();
 
         let _ = StoredManifest::create_uninitialized_clone(
             Arc::clone(&manifest_store),

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -545,7 +545,6 @@ mod tests {
     use std::ops::RangeBounds;
     use std::time::SystemTime;
     use ulid::Ulid;
-    use uuid::Uuid;
 
     #[test]
     fn test_should_merge_db_state_with_new_checkpoints() {
@@ -555,7 +554,7 @@ mod tests {
         let mut updated_state = new_dirty_manifest();
         updated_state.core = db_state.state.core().clone();
         let checkpoint = Checkpoint {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             manifest_id: 1,
             expire_time: None,
             create_time: SystemTime::now(),

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -544,7 +544,6 @@ mod tests {
     use std::collections::Bound::Included;
     use std::ops::RangeBounds;
     use std::time::SystemTime;
-    use ulid::Ulid;
 
     #[test]
     fn test_should_merge_db_state_with_new_checkpoints() {
@@ -611,7 +610,10 @@ mod tests {
                 .freeze_memtable(i as u64)
                 .expect("db in error state");
             let imm = db_state.state.imm_memtable.back().unwrap().clone();
-            let handle = SsTableHandle::new(SsTableId::Compacted(Ulid::new()), dummy_info.clone());
+            let handle = SsTableHandle::new(
+                SsTableId::Compacted(crate::utils::ulid()),
+                dummy_info.clone(),
+            );
             db_state.move_imm_memtable_to_l0(imm, handle).unwrap();
         }
     }
@@ -668,7 +670,7 @@ mod tests {
 
     fn create_compacted_sst_handle(first_key: Option<Bytes>) -> SsTableHandle {
         let sst_info = create_sst_info(first_key);
-        let sst_id = SsTableId::Compacted(Ulid::new());
+        let sst_id = SsTableId::Compacted(crate::utils::ulid());
         SsTableHandle::new(sst_id, sst_info.clone())
     }
 

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -510,7 +510,6 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::test_utils::build_test_sst;
     use bytes::{BufMut, BytesMut};
-    use ulid::Ulid;
 
     use super::{manifest_generated, MANIFEST_FORMAT_VERSION};
 
@@ -553,15 +552,15 @@ mod tests {
                 source_checkpoint_id: crate::utils::uuid(),
                 final_checkpoint_id: Some(crate::utils::uuid()),
                 sst_ids: vec![
-                    SsTableId::Compacted(Ulid::new()),
-                    SsTableId::Compacted(Ulid::new()),
+                    SsTableId::Compacted(crate::utils::ulid()),
+                    SsTableId::Compacted(crate::utils::ulid()),
                 ],
             },
             ExternalDb {
                 path: "/path/to/external/second".to_string(),
                 source_checkpoint_id: crate::utils::uuid(),
                 final_checkpoint_id: Some(crate::utils::uuid()),
-                sst_ids: vec![SsTableId::Compacted(Ulid::new())],
+                sst_ids: vec![SsTableId::Compacted(crate::utils::ulid())],
             },
         ];
         let codec = FlatBufferManifestCodec {};

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -511,7 +511,6 @@ mod tests {
     use crate::test_utils::build_test_sst;
     use bytes::{BufMut, BytesMut};
     use ulid::Ulid;
-    use uuid::Uuid;
 
     use super::{manifest_generated, MANIFEST_FORMAT_VERSION};
 
@@ -521,13 +520,13 @@ mod tests {
         let mut core = CoreDbState::new();
         core.checkpoints = vec![
             checkpoint::Checkpoint {
-                id: uuid::Uuid::new_v4(),
+                id: crate::utils::uuid(),
                 manifest_id: 1,
                 expire_time: None,
                 create_time: SystemTime::UNIX_EPOCH + Duration::from_secs(100),
             },
             checkpoint::Checkpoint {
-                id: uuid::Uuid::new_v4(),
+                id: crate::utils::uuid(),
                 manifest_id: 2,
                 expire_time: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1000)),
                 create_time: SystemTime::UNIX_EPOCH + Duration::from_secs(200),
@@ -551,8 +550,8 @@ mod tests {
         manifest.external_dbs = vec![
             ExternalDb {
                 path: "/path/to/external/first".to_string(),
-                source_checkpoint_id: Uuid::new_v4(),
-                final_checkpoint_id: Some(Uuid::new_v4()),
+                source_checkpoint_id: crate::utils::uuid(),
+                final_checkpoint_id: Some(crate::utils::uuid()),
                 sst_ids: vec![
                     SsTableId::Compacted(Ulid::new()),
                     SsTableId::Compacted(Ulid::new()),
@@ -560,8 +559,8 @@ mod tests {
             },
             ExternalDb {
                 path: "/path/to/external/second".to_string(),
-                source_checkpoint_id: Uuid::new_v4(),
-                final_checkpoint_id: Some(Uuid::new_v4()),
+                source_checkpoint_id: crate::utils::uuid(),
+                final_checkpoint_id: Some(crate::utils::uuid()),
                 sst_ids: vec![SsTableId::Compacted(Ulid::new())],
             },
         ];

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -364,7 +364,7 @@ mod tests {
 
     fn new_checkpoint(manifest_id: u64, expire_time: Option<SystemTime>) -> Checkpoint {
         Checkpoint {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             manifest_id,
             expire_time,
             create_time: SystemTime::now(),

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -274,7 +274,6 @@ mod tests {
 
     use chrono::{DateTime, Utc};
     use object_store::{local::LocalFileSystem, path::Path};
-    use ulid::Ulid;
     use uuid::Uuid;
 
     use crate::checkpoint::Checkpoint;
@@ -970,7 +969,7 @@ mod tests {
         // and then ULID sorting is based on the random part.
         std::thread::sleep(std::time::Duration::from_millis(1));
 
-        let sst_id = SsTableId::Compacted(Ulid::new());
+        let sst_id = SsTableId::Compacted(crate::utils::ulid());
         let mut sst = table_store.table_builder();
         sst.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
         let table = sst.build().unwrap();

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -85,6 +85,7 @@ mod partitioned_keyspace;
 mod paths;
 #[cfg(test)]
 mod proptest_util;
+mod rand;
 mod reader;
 mod row_codec;
 mod sorted_run_iterator;

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -42,7 +42,7 @@ impl Manifest {
             clone_external_dbs.push(ExternalDb {
                 path: parent_external_db.path.clone(),
                 source_checkpoint_id: parent_external_db.source_checkpoint_id,
-                final_checkpoint_id: Some(Uuid::new_v4()),
+                final_checkpoint_id: Some(crate::utils::uuid()),
                 sst_ids: parent_external_db.sst_ids.clone(),
             });
         }
@@ -59,7 +59,7 @@ impl Manifest {
         clone_external_dbs.push(ExternalDb {
             path: parent_path,
             source_checkpoint_id,
-            final_checkpoint_id: Some(Uuid::new_v4()),
+            final_checkpoint_id: Some(crate::utils::uuid()),
             sst_ids: parent_owned_sst_ids,
         });
 

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -153,7 +153,7 @@ impl FenceableManifest {
         checkpoint_id: Option<Uuid>,
         options: &CheckpointOptions,
     ) -> Result<Checkpoint, SlateDBError> {
-        let checkpoint_id = checkpoint_id.unwrap_or(Uuid::new_v4());
+        let checkpoint_id = checkpoint_id.unwrap_or(crate::utils::uuid());
         self.maybe_apply_manifest_update(|stored_manifest| {
             stored_manifest
                 .apply_new_checkpoint_to_db_state(checkpoint_id, options)
@@ -361,7 +361,7 @@ impl StoredManifest {
         checkpoint_id: Option<Uuid>,
         options: &CheckpointOptions,
     ) -> Result<Checkpoint, SlateDBError> {
-        let checkpoint_id = checkpoint_id.unwrap_or(Uuid::new_v4());
+        let checkpoint_id = checkpoint_id.unwrap_or(crate::utils::uuid());
         self.maybe_apply_manifest_update(|stored_manifest| {
             stored_manifest
                 .apply_new_checkpoint_to_db_state(checkpoint_id, options)
@@ -405,7 +405,7 @@ impl StoredManifest {
         old_checkpoint_id: Uuid,
         new_checkpoint_options: &CheckpointOptions,
     ) -> Result<Checkpoint, SlateDBError> {
-        let new_checkpoint_id = Uuid::new_v4();
+        let new_checkpoint_id = crate::utils::uuid();
         self.maybe_apply_manifest_update(|stored_manifest| {
             let new_checkpoint =
                 stored_manifest.new_checkpoint(new_checkpoint_id, new_checkpoint_options)?;
@@ -738,7 +738,6 @@ mod tests {
     use object_store::path::Path;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
-    use uuid::Uuid;
 
     const ROOT: &str = "/root/path";
 
@@ -1031,7 +1030,7 @@ mod tests {
 
     fn new_checkpoint(manifest_id: u64) -> Checkpoint {
         Checkpoint {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             manifest_id,
             expire_time: None,
             create_time: now_rounded_to_nearest_sec(),
@@ -1155,7 +1154,7 @@ mod tests {
             .await
             .unwrap();
 
-        let checkpoint_id = Uuid::new_v4();
+        let checkpoint_id = crate::utils::uuid();
         let result = sm
             .refresh_checkpoint(checkpoint_id, Duration::from_secs(100))
             .await;
@@ -1200,7 +1199,7 @@ mod tests {
             .await
             .unwrap();
 
-        let missing_checkpoint_id = Uuid::new_v4();
+        let missing_checkpoint_id = crate::utils::uuid();
         let replaced_checkpoint = sm
             .replace_checkpoint(missing_checkpoint_id, &CheckpointOptions::default())
             .await
@@ -1237,7 +1236,7 @@ mod tests {
             .await
             .unwrap();
 
-        let checkpoint_id = Uuid::new_v4();
+        let checkpoint_id = crate::utils::uuid();
         let manifest_id = sm.id;
         sm.delete_checkpoint(checkpoint_id).await.unwrap();
         sm.refresh().await.unwrap();

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -11,7 +11,6 @@ use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info, warn};
-use ulid::Ulid;
 
 #[derive(Debug)]
 pub(crate) enum MemtableFlushMsg {
@@ -104,7 +103,7 @@ impl MemtableFlusher {
                 rguard.state().imm_memtable.back().cloned()
             }
         } {
-            let id = SsTableId::Compacted(Ulid::with_source(&mut crate::rand::thread_rng()));
+            let id = SsTableId::Compacted(crate::utils::ulid());
             let sst_handle = self
                 .db_inner
                 .flush_imm_table(&id, imm_memtable.table(), true)

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -105,7 +105,7 @@ impl MemtableFlusher {
                 rguard.state().imm_memtable.back().cloned()
             }
         } {
-            let id = SsTableId::Compacted(Ulid::new());
+            let id = SsTableId::Compacted(Ulid::with_source(&mut crate::rand::thread_rng()));
             let sst_handle = self
                 .db_inner
                 .flush_imm_table(&id, imm_memtable.table(), true)

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -12,7 +12,6 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::oneshot::Sender;
 use tracing::{error, info, warn};
 use ulid::Ulid;
-use uuid::Uuid;
 
 #[derive(Debug)]
 pub(crate) enum MemtableFlushMsg {
@@ -47,7 +46,7 @@ impl MemtableFlusher {
             let rguard_state = self.db_inner.state.read();
             rguard_state.state().manifest.clone()
         };
-        let id = Uuid::new_v4();
+        let id = crate::utils::uuid();
         let checkpoint = self.manifest.new_checkpoint(id, options)?;
         let manifest_id = checkpoint.manifest_id;
         dirty.core.checkpoints.push(checkpoint);

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -52,7 +52,6 @@ impl ObjectStores {
 mod tests {
     use super::*;
     use object_store::memory::InMemory;
-    use ulid::Ulid;
 
     #[test]
     fn test_main_object_store_only_setup() {
@@ -73,7 +72,7 @@ mod tests {
             &main_store
         ));
         assert!(Arc::ptr_eq(
-            &stores.store_for(&SsTableId::Compacted(Ulid::new())),
+            &stores.store_for(&SsTableId::Compacted(crate::utils::ulid())),
             &main_store
         ));
     }
@@ -98,7 +97,7 @@ mod tests {
             &wal_store
         ));
         assert!(Arc::ptr_eq(
-            &stores.store_for(&SsTableId::Compacted(Ulid::new())),
+            &stores.store_for(&SsTableId::Compacted(crate::utils::ulid())),
             &main_store
         ));
     }

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -8,7 +8,10 @@
 //!
 //! Each thread also has its own random number generator that is initialized from the global
 //! random number generator. This ensures that each thread has its own random number generator
-//! that is initialized with the same seed.
+//! that is initialized deterministically from the global random number generator. This is useful
+//! for deterministic simulation testing. We can seed the root RNG and have all random numbers
+//! derive from that without having to share the root RNG across threads, which would create a
+//! point of contention.
 //!
 //! ## Usage
 //!

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -4,14 +4,15 @@
 //! To do so, we need a way to easily seed all random number generators in the library in a
 //! deterministic way.
 //!
-//! To do this, we use a global random number generator that is initialized with a seed.
+//! Each thread also has a thread-local random number generator that is initialized from a
+//! root-level random number generator. This ensures that each thread is seeded
+//! deterministically from the root RNG.
 //!
-//! Each thread also has its own random number generator that is initialized from the global
-//! random number generator. This ensures that each thread has its own random number generator
-//! that is initialized deterministically from the global random number generator. This is useful
-//! for deterministic simulation testing. We can seed the root RNG and have all random numbers
-//! derive from that without having to share the root RNG across threads, which would create a
-//! point of contention.
+//! The root-level random number generator starts unset. It is set in one of two ways:
+//!
+//! - `seed(seed: u64)` is called with a seed value.
+//! - `thread_rng()` is called while the root RNG is unset. This will initialize the root RNG
+//!   with a random seed.
 //!
 //! ## Usage
 //!
@@ -19,106 +20,117 @@
 //! use slate_db::rand::seed;
 //!
 //! seed(42);
-//! let _ = with_rng(|rng| rng.u64(..));
+//! let _ = rng().next_u64();
 //! ```
 
-use rand_core::{RngCore, SeedableRng};
-use rand_xoshiro::Xoroshiro128Plus;
 use std::cell::RefCell;
 use std::sync::{Mutex, OnceLock};
 
-use crate::SlateDBError;
+use rand_core::{RngCore, SeedableRng};
+use rand_xoshiro::Xoroshiro128PlusPlus;
 
-type RngAlg = Xoroshiro128Plus;
+type RngAlg = Xoroshiro128PlusPlus;
 
-// A global random number generator used for all randomness in SlateDB.
-//
-// Uses `OnceLock` to ensure that the random number generator is initialized exactly once regardless
-// of which thread it was initialized on. Uses `Mutex` so we can grab a mutable reference to the
-// random number generator when forking the root RNG in a local thread.
 static ROOT_RNG: OnceLock<Mutex<RngAlg>> = OnceLock::new();
 
-thread_local! {
-    // A thread-local random number generator used for all randomness in a single thread. Not
-    // threadsafe.
-    static THREAD_RNG: RefCell<Option<RngAlg>> = const { RefCell::new(None) };
-}
-
-/// Initialize the global random number generator with a seed. This should only be called once
-/// upon start.
+/// Seed the root random number generator.
 ///
-/// ## Errors
-///
-/// Returns an error if the random number generator has already been initialized.
-pub(crate) fn seed(seed: u64) -> Result<(), SlateDBError> {
+/// This function can only be called once. If it is called multiple times, it will panic.
+pub fn seed(seed: u64) {
+    let rng = RngAlg::seed_from_u64(seed);
     ROOT_RNG
-        .set(Mutex::new(RngAlg::seed_from_u64(seed)))
-        .map_err(|_| SlateDBError::InvalidDBState)
+        .set(Mutex::new(rng))
+        .expect("rand::seed() can only be called once");
 }
 
-/// Execute a function with a thread-local random number generator.
-///
-/// If the thread-local random number generator hasn't been initialized, it will be initialized
-/// using a random seed from the global random number generator.
-///
-/// If the global random number generator hasn't been initialized, a default root random number
-/// generator will be created with a random seed.
-pub fn with_rng<T>(f: impl FnOnce(&mut dyn RngCore) -> T) -> T {
-    THREAD_RNG.with(|cell| {
-        let mut maybe_rng = cell.borrow_mut();
-        if maybe_rng.is_none() {
-            let mut root_rng = ROOT_RNG
-                .get_or_init(|| Mutex::new(RngAlg::seed_from_u64(0)))
-                .lock()
-                .expect("mutex poisoned");
-            let thread_local_rng = Xoroshiro128Plus::seed_from_u64(root_rng.next_u64());
-            *maybe_rng = Some(thread_local_rng);
-        }
-        f(maybe_rng.as_mut().expect("rng not initialized"))
-    })
+fn root_lock() -> &'static Mutex<RngAlg> {
+    ROOT_RNG.get_or_init(|| Mutex::new(RngAlg::from_os_rng()))
+}
+
+thread_local! {
+    static THREAD_RNG: RefCell<RngAlg> = {
+        let mut guard = root_lock().lock().expect("root rng poisoned");
+        let child_seed = guard.next_u64();
+        RefCell::new(RngAlg::seed_from_u64(child_seed))
+    };
+}
+
+// ThreadRng is a zero-sized type that provides a handle to a thread's RNG. We have to
+// do this because the RNG needs to be mutable and we can't return a RefMut from the
+// `rng()` function (the lifetime of the RefMut would be the lifetime of the `rng()`
+// function).
+
+/// A thread-local random number generator.
+pub struct ThreadRng;
+
+impl ThreadRng {
+    #[inline(always)]
+    fn with<R>(f: impl FnOnce(&mut RngAlg) -> R) -> R {
+        THREAD_RNG.with(|cell| {
+            let mut borrow = cell.borrow_mut();
+            f(&mut *borrow)
+        })
+    }
+}
+
+impl RngCore for ThreadRng {
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        ThreadRng::with(|rng| rng.next_u32())
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        ThreadRng::with(|rng| rng.next_u64())
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        ThreadRng::with(|rng| rng.fill_bytes(dest))
+    }
+}
+
+/// Returns a handle to the thread-local random number generator.
+#[inline]
+pub fn rng() -> ThreadRng {
+    ThreadRng
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // Helper to force a thread-local random number generator to use a specific seed so we
-    // can test deterministic behavior.
+    // Force a thread-local RNG to use a specific seed so we can test deterministically.
     fn seed_local(seed: u64) {
         THREAD_RNG.with(|cell| {
-            cell.replace(Some(Xoroshiro128Plus::seed_from_u64(seed)));
+            cell.replace(RngAlg::seed_from_u64(seed));
         });
     }
 
     #[test]
     fn test_rng() {
-        seed_local(42);
-        let rand_u64 = with_rng(|rng| rng.next_u64());
-        assert_eq!(rand_u64, 16629283624882167704);
+        std::thread::spawn(move || {
+            seed_local(42);
+            let rand_u64 = rng().next_u64();
+            assert_eq!(rand_u64, 16756476715040848931);
+        })
+        .join()
+        .unwrap();
     }
 
     #[test]
     fn test_rng_thread_local() {
-        seed_local(42);
-        with_rng(|outer_rng| {
-            let outer_u64 = outer_rng.next_u64();
+        std::thread::spawn(move || {
+            seed_local(42);
+            let outer_u64 = rng().next_u64();
             let inner_u64 = std::thread::spawn(move || {
                 seed_local(64);
-                with_rng(|inner_rng| inner_rng.next_u64())
+                rng().next_u64()
             })
             .join()
             .unwrap();
-            assert_eq!(inner_u64, 18322729244133645280);
-            assert_eq!(outer_u64, 16629283624882167704);
-        });
-    }
-
-    #[test]
-    fn test_rng_lazy_init() {
-        std::thread::spawn(move || {
-            assert!(THREAD_RNG.with(|c| c.borrow().is_none()));
-            with_rng(|_| {});
-            assert!(THREAD_RNG.with(|c| c.borrow().is_some()));
+            assert_eq!(inner_u64, 12172458793332410705);
+            assert_eq!(outer_u64, 16756476715040848931);
         })
         .join()
         .unwrap();

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -22,7 +22,7 @@
 //! let _ = with_rng(|rng| rng.u64(..));
 //! ```
 
-use rand_xoshiro::rand_core::{RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 use rand_xoshiro::Xoroshiro128Plus;
 use std::cell::RefCell;
 use std::sync::{Mutex, OnceLock};

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -1,0 +1,120 @@
+//! SlateDB's module for generating random data.
+//!
+//! This module exists because we want to do deterministic simulation testing for SlateDB.
+//! To do so, we need a way to easily seed all random number generators in the library in a
+//! deterministic way.
+//!
+//! To do this, we use a global random number generator that is initialized with a seed.
+//!
+//! Each thread also has its own random number generator that is initialized from the global
+//! random number generator. This ensures that each thread has its own random number generator
+//! that is initialized with the same seed.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use slate_db::rand::seed;
+//!
+//! seed(42);
+//! let _ = with_rng(|rng| rng.u64(..));
+//! ```
+
+use fastrand::Rng;
+use std::cell::RefCell;
+use std::sync::{Mutex, OnceLock};
+
+use crate::SlateDBError;
+
+// A global random number generator used for all randomness in SlateDB.
+//
+// Uses `OnceLock` to ensure that the random number generator is initialized exactly once regardless
+// of which thread it was initialized on. Uses `Mutex` so we can grab a mutable reference to the
+// random number generator when forking the root RNG in a local thread.
+static ROOT_RNG: OnceLock<Mutex<Rng>> = OnceLock::new();
+
+thread_local! {
+    // A thread-local random number generator used for all randomness in a single thread. Not
+    // threadsafe.
+    static THREAD_RNG: RefCell<Option<Rng>> = RefCell::new(None);
+}
+
+/// Initialize the global random number generator with a seed. This should only be called once
+/// upon start.
+///
+/// ## Errors
+///
+/// Returns an error if the random number generator has already been initialized.
+pub(crate) fn seed(seed: u64) -> Result<(), SlateDBError> {
+    ROOT_RNG
+        .set(Mutex::new(Rng::with_seed(seed)))
+        .map_err(|_| SlateDBError::InvalidDBState)
+}
+
+/// Execute a function with a thread-local random number generator.
+///
+/// If the thread-local random number generator hasn't been initialized, it will be initialized
+/// using a random seed from the global random number generator.
+///
+/// If the global random number generator hasn't been initialized, a default root random number
+/// generator will be created with a random seed.
+pub fn with_rng<T>(f: impl FnOnce(&mut Rng) -> T) -> T {
+    THREAD_RNG.with(|cell| {
+        let mut maybe_rng = cell.borrow_mut();
+        if maybe_rng.is_none() {
+            let rng = ROOT_RNG
+                .get_or_init(|| Mutex::new(Rng::new()))
+                .lock()
+                .expect("mutex poisoned")
+                .fork();
+            *maybe_rng = Some(rng);
+        }
+        f(maybe_rng.as_mut().expect("rng not initialized"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper to force a thread-local random number generator to use a specific seed so we
+    // can test deterministic behavior.
+    fn seed_local(seed: u64) {
+        THREAD_RNG.with(|cell| {
+            cell.replace(Some(Rng::with_seed(seed)));
+        });
+    }
+
+    #[test]
+    fn test_rng() {
+        seed_local(42);
+        let rand_u64 = with_rng(|rng| rng.u64(..));
+        assert_eq!(rand_u64, 14587678697106979209);
+    }
+
+    #[test]
+    fn test_rng_thread_local() {
+        seed_local(42);
+        with_rng(|outer_rng| {
+            let outer_u64 = outer_rng.u64(..);
+            let inner_u64 = std::thread::spawn(move || {
+                seed_local(64);
+                with_rng(|inner_rng| inner_rng.u64(..))
+            })
+            .join()
+            .unwrap();
+            assert_eq!(inner_u64, 13858685378923336244);
+            assert_eq!(outer_u64, 14587678697106979209);
+        });
+    }
+
+    #[test]
+    fn test_rng_lazy_init() {
+        std::thread::spawn(move || {
+            assert!(THREAD_RNG.with(|c| c.borrow().is_none()));
+            with_rng(|_| {});
+            assert!(THREAD_RNG.with(|c| c.borrow().is_some()));
+        })
+        .join()
+        .unwrap();
+    }
+}

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -22,7 +22,8 @@
 //! let _ = with_rng(|rng| rng.u64(..));
 //! ```
 
-use fastrand::Rng;
+use rand_xoshiro::rand_core::{RngCore, SeedableRng};
+use rand_xoshiro::Xoroshiro128Plus;
 use std::cell::RefCell;
 use std::sync::{Mutex, OnceLock};
 
@@ -33,12 +34,12 @@ use crate::SlateDBError;
 // Uses `OnceLock` to ensure that the random number generator is initialized exactly once regardless
 // of which thread it was initialized on. Uses `Mutex` so we can grab a mutable reference to the
 // random number generator when forking the root RNG in a local thread.
-static ROOT_RNG: OnceLock<Mutex<Rng>> = OnceLock::new();
+static ROOT_RNG: OnceLock<Mutex<Xoroshiro128Plus>> = OnceLock::new();
 
 thread_local! {
     // A thread-local random number generator used for all randomness in a single thread. Not
     // threadsafe.
-    static THREAD_RNG: RefCell<Option<Rng>> = const { RefCell::new(None) };
+    static THREAD_RNG: RefCell<Option<Xoroshiro128Plus>> = const { RefCell::new(None) };
 }
 
 /// Initialize the global random number generator with a seed. This should only be called once
@@ -49,7 +50,7 @@ thread_local! {
 /// Returns an error if the random number generator has already been initialized.
 pub(crate) fn seed(seed: u64) -> Result<(), SlateDBError> {
     ROOT_RNG
-        .set(Mutex::new(Rng::with_seed(seed)))
+        .set(Mutex::new(Xoroshiro128Plus::seed_from_u64(seed)))
         .map_err(|_| SlateDBError::InvalidDBState)
 }
 
@@ -60,16 +61,16 @@ pub(crate) fn seed(seed: u64) -> Result<(), SlateDBError> {
 ///
 /// If the global random number generator hasn't been initialized, a default root random number
 /// generator will be created with a random seed.
-pub fn with_rng<T>(f: impl FnOnce(&mut Rng) -> T) -> T {
+pub fn with_rng<T>(f: impl FnOnce(&mut Xoroshiro128Plus) -> T) -> T {
     THREAD_RNG.with(|cell| {
         let mut maybe_rng = cell.borrow_mut();
         if maybe_rng.is_none() {
-            let rng = ROOT_RNG
-                .get_or_init(|| Mutex::new(Rng::new()))
+            let mut root_rng = ROOT_RNG
+                .get_or_init(|| Mutex::new(Xoroshiro128Plus::seed_from_u64(0)))
                 .lock()
-                .expect("mutex poisoned")
-                .fork();
-            *maybe_rng = Some(rng);
+                .expect("mutex poisoned");
+            let thread_local_rng = Xoroshiro128Plus::seed_from_u64(root_rng.next_u64());
+            *maybe_rng = Some(thread_local_rng);
         }
         f(maybe_rng.as_mut().expect("rng not initialized"))
     })
@@ -77,36 +78,38 @@ pub fn with_rng<T>(f: impl FnOnce(&mut Rng) -> T) -> T {
 
 #[cfg(test)]
 mod tests {
+    use rand_xoshiro::rand_core::RngCore;
+
     use super::*;
 
     // Helper to force a thread-local random number generator to use a specific seed so we
     // can test deterministic behavior.
     fn seed_local(seed: u64) {
         THREAD_RNG.with(|cell| {
-            cell.replace(Some(Rng::with_seed(seed)));
+            cell.replace(Some(Xoroshiro128Plus::seed_from_u64(seed)));
         });
     }
 
     #[test]
     fn test_rng() {
         seed_local(42);
-        let rand_u64 = with_rng(|rng| rng.u64(..));
-        assert_eq!(rand_u64, 14587678697106979209);
+        let rand_u64 = with_rng(|rng| rng.next_u64());
+        assert_eq!(rand_u64, 16629283624882167704);
     }
 
     #[test]
     fn test_rng_thread_local() {
         seed_local(42);
         with_rng(|outer_rng| {
-            let outer_u64 = outer_rng.u64(..);
+            let outer_u64 = outer_rng.next_u64();
             let inner_u64 = std::thread::spawn(move || {
                 seed_local(64);
-                with_rng(|inner_rng| inner_rng.u64(..))
+                with_rng(|inner_rng| inner_rng.next_u64())
             })
             .join()
             .unwrap();
-            assert_eq!(inner_u64, 13858685378923336244);
-            assert_eq!(outer_u64, 14587678697106979209);
+            assert_eq!(inner_u64, 18322729244133645280);
+            assert_eq!(outer_u64, 16629283624882167704);
         });
     }
 

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -41,13 +41,12 @@ pub(crate) fn seed(seed: u64) {
         .expect("rand::seed() can only be called once");
 }
 
-fn root_lock() -> &'static Mutex<RngAlg> {
-    ROOT_RNG.get_or_init(|| Mutex::new(RngAlg::from_os_rng()))
-}
-
 thread_local! {
     static THREAD_RNG: UnsafeCell<RngAlg> = {
-        let mut guard = root_lock().lock().expect("root rng poisoned");
+        let mut guard = ROOT_RNG
+            .get_or_init(|| Mutex::new(RngAlg::from_os_rng()))
+            .lock()
+            .expect("root rng poisoned");
         let child_seed = guard.next_u64();
         UnsafeCell::new(RngAlg::seed_from_u64(child_seed))
     };

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -14,6 +14,10 @@
 //! - `thread_rng()` is called while the root RNG is unset. This will initialize the root RNG
 //!   with a random seed.
 //!
+//! The module currently uses Xoshiro128++ for all random number generators. The rand crate's
+//! `seed_from_u64` method uses SplitMix64 under the hood, which makes it safe to use the root
+//! RNG to seed the thread-local RNGs to avoid any correlation between the RNGs.
+//!
 //! ## Usage
 //!
 //! ```ignore

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -38,7 +38,7 @@ static ROOT_RNG: OnceLock<Mutex<Rng>> = OnceLock::new();
 thread_local! {
     // A thread-local random number generator used for all randomness in a single thread. Not
     // threadsafe.
-    static THREAD_RNG: RefCell<Option<Rng>> = RefCell::new(None);
+    static THREAD_RNG: RefCell<Option<Rng>> = const { RefCell::new(None) };
 }
 
 /// Initialize the global random number generator with a seed. This should only be called once

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -634,7 +634,7 @@ mod tests {
             compression_codec: None,
         };
         SsTableHandle {
-            id: SsTableId::Compacted(ulid::Ulid::new()),
+            id: SsTableId::Compacted(crate::utils::ulid()),
             info,
         }
     }

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -165,7 +165,6 @@ mod tests {
     use rand::Rng;
     use std::collections::BTreeMap;
     use std::sync::Arc;
-    use ulid::Ulid;
 
     #[tokio::test]
     async fn test_one_sst_sr_iter() {
@@ -186,7 +185,7 @@ mod tests {
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
         builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
         let encoded = builder.build().unwrap();
-        let id = SsTableId::Compacted(Ulid::new());
+        let id = SsTableId::Compacted(crate::utils::ulid());
         let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
@@ -229,12 +228,12 @@ mod tests {
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
         let encoded = builder.build().unwrap();
-        let id1 = SsTableId::Compacted(Ulid::new());
+        let id1 = SsTableId::Compacted(crate::utils::ulid());
         let handle1 = table_store.write_sst(&id1, encoded, false).await.unwrap();
         let mut builder = table_store.table_builder();
         builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
         let encoded = builder.build().unwrap();
-        let id2 = SsTableId::Compacted(Ulid::new());
+        let id2 = SsTableId::Compacted(crate::utils::ulid());
         let handle2 = table_store.write_sst(&id2, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
@@ -448,7 +447,7 @@ mod tests {
             }
 
             let encoded = builder.build().unwrap();
-            let id = SsTableId::Compacted(Ulid::new());
+            let id = SsTableId::Compacted(crate::utils::ulid());
             let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
             ssts.push(handle);
         }
@@ -465,7 +464,7 @@ mod tests {
     ) -> SortedRun {
         let mut ssts = Vec::<SsTableHandle>::new();
         for _ in 0..n {
-            let mut writer = table_store.table_writer(SsTableId::Compacted(Ulid::new()));
+            let mut writer = table_store.table_writer(SsTableId::Compacted(crate::utils::ulid()));
             for _ in 0..keys_per_sst {
                 let entry =
                     RowEntry::new_value(key_gen.next().as_ref(), val_gen.next().as_ref(), 0);

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -579,7 +579,6 @@ mod tests {
     use rstest::rstest;
     use std::collections::VecDeque;
     use std::sync::Arc;
-    use ulid::Ulid;
 
     use crate::db_cache::test_utils::TestCache;
     use crate::db_cache::{DbCache, DbCacheWrapper};
@@ -640,7 +639,7 @@ mod tests {
             Path::from(ROOT),
             None,
         ));
-        let id = SsTableId::Compacted(Ulid::new());
+        let id = SsTableId::Compacted(crate::utils::ulid());
 
         // when:
         let mut writer = ts.table_writer(id);
@@ -810,7 +809,7 @@ mod tests {
         ));
 
         // Create and write SST
-        let id = SsTableId::Compacted(Ulid::new());
+        let id = SsTableId::Compacted(crate::utils::ulid());
         let mut writer = ts.table_writer(id);
         let mut expected_data = Vec::with_capacity(20);
         for i in 0..20 {
@@ -934,7 +933,7 @@ mod tests {
             Path::from("/root"),
             Some(wrapper),
         ));
-        let id = SsTableId::Compacted(Ulid::new());
+        let id = SsTableId::Compacted(crate::utils::ulid());
         let sst = build_test_sst(&ts.sst_format, 3);
         let sst_bytes = sst.remaining_as_bytes();
         let sst_info = sst.info.clone();
@@ -970,7 +969,7 @@ mod tests {
             Path::from("/root"),
             Some(wrapper),
         ));
-        let id = SsTableId::Compacted(Ulid::new());
+        let id = SsTableId::Compacted(crate::utils::ulid());
         let sst = build_test_sst(&ts.sst_format, 3);
         let sst_bytes = sst.remaining_as_bytes();
         let sst_info = sst.info.clone();
@@ -1013,6 +1012,8 @@ mod tests {
         #[case] main_store: Arc<dyn ObjectStore>,
         #[case] wal_store: Option<Arc<dyn ObjectStore>>,
     ) {
+        use ulid::Ulid;
+
         let format = SsTableFormat {
             block_size: 32,
             min_filter_keys: 1,
@@ -1028,7 +1029,7 @@ mod tests {
         // Create id1, id2, and i3 as three random UUIDs that have been sorted ascending.
         // Need to do this because the Ulids are sometimes generated in the same millisecond
         // and the random suffix is used to break the tie, which might be out of order.
-        let mut ulids = (0..3).map(|_| Ulid::new()).collect::<Vec<Ulid>>();
+        let mut ulids = (0..3).map(|_| crate::utils::ulid()).collect::<Vec<Ulid>>();
         ulids.sort();
         let (id1, id2, id3) = (
             SsTableId::Compacted(ulids[0]),
@@ -1172,8 +1173,8 @@ mod tests {
             None,
         ));
 
-        let id1 = SsTableId::Compacted(Ulid::new());
-        let id2 = SsTableId::Compacted(Ulid::new());
+        let id1 = SsTableId::Compacted(crate::utils::ulid());
+        let id2 = SsTableId::Compacted(crate::utils::ulid());
         let path1 = ts.path(&id1);
         let path2 = ts.path(&id2);
         main_store.put(&path1, Bytes::new().into()).await.unwrap();

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -4,6 +4,7 @@ use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskPanic;
 use crate::types::RowEntry;
 use bytes::{BufMut, Bytes};
+use rand::RngCore;
 use std::cmp;
 use std::future::Future;
 use std::sync::atomic::AtomicI64;
@@ -11,6 +12,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use tracing::info;
+use uuid::{Builder, Uuid};
 
 static EMPTY_KEY: Bytes = Bytes::new();
 
@@ -300,6 +302,12 @@ fn compute_lower_bound(prev_block_last_key: &Bytes, this_block_first_key: &Bytes
     // if we didn't find a mismatch yet then the prev block's key must be shorter,
     // so just use the common prefix plus the next byte in this block's key
     this_block_first_key.slice(..prev_block_last_key.len() + 1)
+}
+
+pub(crate) fn uuid() -> Uuid {
+    let mut random_bytes = [0; 16];
+    crate::rand::thread_rng().fill_bytes(&mut random_bytes);
+    Builder::from_random_bytes(random_bytes).into_uuid()
 }
 
 #[cfg(test)]

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
 use tracing::info;
+use ulid::Ulid;
 use uuid::{Builder, Uuid};
 
 static EMPTY_KEY: Bytes = Bytes::new();
@@ -308,6 +309,10 @@ pub(crate) fn uuid() -> Uuid {
     let mut random_bytes = [0; 16];
     crate::rand::thread_rng().fill_bytes(&mut random_bytes);
     Builder::from_random_bytes(random_bytes).into_uuid()
+}
+
+pub(crate) fn ulid() -> Ulid {
+    Ulid::with_source(&mut crate::rand::thread_rng())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR:

* Introduces a new internal `slatedb::rand` module that encapsulates all random-number generation using `Xoshiro128PlusPlus`. I chose `Xoshiro128PlusPlus` because I wanted a PRNG that was portable across operating systems (so we can reproduce GH action failures locally). The standard `rand` PRNG's aren't portable. I didn't go with `ChaCha` because `Xoshiro128PlusPlus` is faster and we don't need cryptographically secure RNG.
* Replaces every direct call to `rand::thread_rng()`, `Ulid::new()`, and `Uuid::new_v4()` (including in tests) with the new helpers:

  * `crate::rand::thread_rng()`
  * `crate::utils::ulid()`
  * `crate::utils::uuid()`
* Adds a `DbBuilder::with_seed(u64)` method so users can configure a global seed for fully deterministic behavior.
* Bumps dependencies to pull in `rand_xoshiro = "0.6.0"`, pins `ulid = "=1.1.3"`, and upgrades `uuid` to `1.12.0`. I had ot do this to make proptests, uuid, and slatedb::rand all work off of the same underlying `0.8^` rand version. Starting in `0.9^`, the `rand` crate made a bunch of incompatible API changes. Until https://github.com/proptest-rs/proptest/issues/553, we're stuck on `rand`'s `0.8`.

See the `crate::rand` module documentation for design docs.

These changes ensure all randomness in SlateDB is traceable, reproducible in tests, and configurable by the caller.

_NOTE: I didn't actually update the tests to set a seed for now. I plan to use `with_seed` for DST (see #267). LMK if you think we should always seed tests._

---

## Motivation

* **Deterministic testing**: Previously, tests that relied on ULIDs or UUIDs could produce non-reproducible failures. Centralizing RNGs lets us inject a fixed seed and guarantee identical test runs, even across threads.
* **Consistency**: By seeding thread-local RNGs from a single root RNG (with safe SplitMix64 under the hood), we avoid subtle correlations and contention points.
* **Flexibility**: Consumers now have a first-class API (`with_seed`) to opt into deterministic behavior; if unset, SlateDB still falls back to OS entropy.

## Usage

```rust
// deterministic mode:
let db = DbBuilder::new("/path/to/db")
    .with_seed(42)
    .build()
    .await?;

// or default (OS entropy):
let db = DbBuilder::new("/path/to/db").build().await?;
```