### PR TITLE
Centralize clock operations with the DB internal clock

### DIFF
--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -5,7 +5,7 @@ use slatedb::admin;
 use slatedb::admin::{
     list_checkpoints, list_manifests, read_manifest, run_gc_in_background, run_gc_once,
 };
-use slatedb::clock::SystemClock;
+use slatedb::clock::DefaultSystemClock;
 use slatedb::config::{
     CheckpointOptions, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
 };
@@ -132,7 +132,7 @@ async fn exec_refresh_checkpoint(
     id: Uuid,
     lifetime: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
-    let clock = Arc::new(SystemClock::new());
+    let clock = Arc::new(DefaultSystemClock::new());
     println!(
         "{:?}",
         Db::refresh_checkpoint(path, object_store, id, lifetime, clock).await?

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -5,6 +5,7 @@ use slatedb::admin;
 use slatedb::admin::{
     list_checkpoints, list_manifests, read_manifest, run_gc_in_background, run_gc_once,
 };
+use slatedb::clock::SystemClock;
 use slatedb::config::{
     CheckpointOptions, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
 };
@@ -131,9 +132,10 @@ async fn exec_refresh_checkpoint(
     id: Uuid,
     lifetime: Option<Duration>,
 ) -> Result<(), Box<dyn Error>> {
+    let clock = Arc::new(SystemClock::new());
     println!(
         "{:?}",
-        Db::refresh_checkpoint(path, object_store, id, lifetime).await?
+        Db::refresh_checkpoint(path, object_store, id, lifetime, clock).await?
     );
     Ok(())
 }

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1,5 +1,5 @@
 use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
-use crate::clock::SystemClock;
+use crate::clock::DefaultSystemClock;
 use crate::config::{CheckpointOptions, GarbageCollectorOptions};
 use crate::error::SlateDBError;
 use crate::garbage_collector::stats::GcStats;
@@ -137,7 +137,7 @@ pub async fn run_gc_once(
     ));
 
     let stats = Arc::new(StatRegistry::new());
-    let clock = Arc::new(SystemClock::new());
+    let clock = Arc::new(DefaultSystemClock::new());
     GarbageCollector::run_gc_once(manifest_store, table_store, stats, gc_opts, clock).await;
     Ok(())
 }
@@ -174,7 +174,7 @@ pub async fn run_gc_in_background(
 
     let tracker = TaskTracker::new();
     let ct = cancellation_token.clone();
-    let clock = Arc::new(SystemClock::new());
+    let clock = Arc::new(DefaultSystemClock::new());
 
     tracker.spawn(GarbageCollector::start_async_task(
         manifest_store,

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -52,7 +52,7 @@ pub(crate) struct WriteBatchRequest {
 impl DbInner {
     #[allow(clippy::panic)]
     async fn write_batch(&self, batch: WriteBatch) -> Result<Arc<KVTable>, SlateDBError> {
-        let now = self.mono_clock.now().await?;
+        let now = self.user_clock.now().await?;
 
         let current_table = if self.wal_enabled {
             let mut guard = self.state.write();

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -446,7 +446,7 @@ mod tests {
     use crate::cached_object_store::stats::CachedObjectStoreStats;
     use crate::cached_object_store::storage_fs::FsCacheStorage;
     use crate::cached_object_store::{storage::PartID, storage_fs::FsCacheEntry};
-    use crate::clock::SystemClock;
+    use crate::clock::DefaultSystemClock;
     use crate::stats::StatRegistry;
     use crate::test_utils::gen_rand_bytes;
 
@@ -467,7 +467,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         object_store
             .put(
                 &Path::from("/data/testfile1"),
@@ -538,7 +538,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         object_store
             .put(
                 &Path::from("/data/testfile1"),
@@ -593,7 +593,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
@@ -683,7 +683,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
@@ -706,7 +706,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
@@ -737,7 +737,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -446,6 +446,7 @@ mod tests {
     use crate::cached_object_store::stats::CachedObjectStoreStats;
     use crate::cached_object_store::storage_fs::FsCacheStorage;
     use crate::cached_object_store::{storage::PartID, storage_fs::FsCacheEntry};
+    use crate::clock::SystemClock;
     use crate::stats::StatRegistry;
     use crate::test_utils::gen_rand_bytes;
 
@@ -466,6 +467,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         object_store
             .put(
                 &Path::from("/data/testfile1"),
@@ -480,6 +482,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            clock.clone(),
         ));
 
         let part_size = 1024;
@@ -535,6 +538,7 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         object_store
             .put(
                 &Path::from("/data/testfile1"),
@@ -550,6 +554,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            clock.clone(),
         ));
 
         let cached_store =
@@ -588,11 +593,13 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
             None,
             stats.clone(),
+            clock.clone(),
         ));
 
         let cached_store =
@@ -676,11 +683,13 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
             None,
             stats.clone(),
+            clock.clone(),
         ));
         let cached_store =
             CachedObjectStore::new(object_store, cache_storage, 1024, stats).unwrap();
@@ -697,11 +706,13 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
             None,
             stats.clone(),
+            clock.clone(),
         ));
         let cached_store =
             CachedObjectStore::new(object_store, cache_storage, 1024, stats).unwrap();
@@ -726,11 +737,13 @@ mod tests {
         let test_cache_folder = new_test_cache_folder();
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         let cache_storage = Arc::new(FsCacheStorage::new(
             test_cache_folder.clone(),
             None,
             None,
             stats.clone(),
+            clock.clone(),
         ));
         let cached_store =
             CachedObjectStore::new(object_store.clone(), cache_storage, 1024, stats).unwrap();

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, SystemTime};
 use std::{fmt::Display, io::SeekFrom};
 
 use crate::cached_object_store::stats::CachedObjectStoreStats;
-use crate::clock::SysClock;
+use crate::clock::SystemClock;
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::{Attributes, ObjectMeta};
@@ -35,7 +35,7 @@ impl FsCacheStorage {
         max_cache_size_bytes: Option<usize>,
         scan_interval: Option<Duration>,
         stats: Arc<CachedObjectStoreStats>,
-        clock: Arc<dyn SysClock>,
+        clock: Arc<dyn SystemClock>,
     ) -> Self {
         let evictor = max_cache_size_bytes.map(|max_cache_size_bytes| {
             Arc::new(FsCacheEvictor::new(
@@ -328,7 +328,7 @@ struct FsCacheEvictor {
     background_evict_handle: OnceCell<tokio::task::JoinHandle<()>>,
     background_scan_handle: OnceCell<tokio::task::JoinHandle<()>>,
     stats: Arc<CachedObjectStoreStats>,
-    clock: Arc<dyn SysClock>,
+    clock: Arc<dyn SystemClock>,
 }
 
 impl FsCacheEvictor {
@@ -337,7 +337,7 @@ impl FsCacheEvictor {
         max_cache_size_bytes: usize,
         scan_interval: Option<Duration>,
         stats: Arc<CachedObjectStoreStats>,
-        clock: Arc<dyn SysClock>,
+        clock: Arc<dyn SystemClock>,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
         Self {
@@ -389,7 +389,7 @@ impl FsCacheEvictor {
     async fn background_evict(
         inner: Arc<FsCacheEvictorInner>,
         mut rx: tokio::sync::mpsc::Receiver<FsCacheEvictorWork>,
-        clock: Arc<dyn SysClock>,
+        clock: Arc<dyn SystemClock>,
     ) {
         loop {
             match rx.recv().await {

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -1,4 +1,4 @@
-use crate::clock::Clock;
+use crate::clock::SysClock;
 use crate::config::{CheckpointOptions, CheckpointScope};
 use crate::db::Db;
 use crate::error::SlateDBError;
@@ -78,7 +78,7 @@ impl Db {
         object_store: Arc<dyn ObjectStore>,
         id: Uuid,
         lifetime: Option<Duration>,
-        clock: Arc<dyn Clock>,
+        clock: Arc<dyn SysClock>,
     ) -> Result<(), SlateDBError> {
         let manifest_store = Arc::new(ManifestStore::new(path, object_store));
         let mut stored_manifest = StoredManifest::load(manifest_store).await?;
@@ -129,7 +129,7 @@ impl Db {
 mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::checkpoint::CheckpointCreateResult;
-    use crate::clock::{Clock, SystemClock};
+    use crate::clock::{SysClock, SystemClock};
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
     use crate::db_state::SsTableId;
@@ -310,7 +310,7 @@ mod tests {
         let clock = Arc::new(SystemClock::new());
         let _ = Db::builder(path.clone(), object_store.clone())
             .with_settings(Settings::default())
-            .with_user_clock(clock.clone())
+            .with_system_clock(clock.clone())
             .build()
             .await
             .unwrap();

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -310,7 +310,7 @@ mod tests {
         let clock = Arc::new(SystemClock::new());
         let _ = Db::builder(path.clone(), object_store.clone())
             .with_settings(Settings::default())
-            .with_clock(clock.clone())
+            .with_user_clock(clock.clone())
             .build()
             .await
             .unwrap();
@@ -363,7 +363,7 @@ mod tests {
         let clock = Arc::new(SystemClock::new());
         let _ = Db::builder(path.clone(), object_store.clone())
             .with_settings(Settings::default())
-            .with_clock(clock.clone())
+            .with_user_clock(clock.clone())
             .build()
             .await
             .unwrap();

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -24,7 +24,7 @@ impl Checkpoint {
     /// Creates a new checkpoint with the given manifest id, create time, and optional expire time.
     pub fn new(manifest_id: u64, create_time: SystemTime, expire_time: Option<SystemTime>) -> Self {
         Self {
-            id: Uuid::new_v4(),
+            id: crate::utils::uuid(),
             manifest_id,
             create_time,
             expire_time,

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -25,12 +25,7 @@ pub trait Clock: Debug + Send + Sync {
 }
 
 /// Defines the clock that SlateDB will use for user facing operations.
-pub trait UserClock: Clock {
-    /// Returns the current time plus the given duration.
-    fn add(&self, duration: Duration) -> i64 {
-        self.now() + duration.as_millis() as i64
-    }
-}
+pub trait UserClock: Clock {}
 
 /// Defines the clock that SlateDB will use for system operations.
 pub trait SystemClock: Clock {

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,0 +1,204 @@
+use std::{
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use tracing::info;
+
+use crate::{config::DurabilityLevel, SlateDBError};
+
+/// defines the clock that SlateDB will use during this session
+pub trait Clock: Debug + Send + Sync {
+    /// Returns a timestamp (typically measured in millis since the unix epoch),
+    /// must return monotonically increasing numbers (this is enforced
+    /// at runtime and will panic if the invariant is broken).
+    ///
+    /// Note that this clock does not need to return a number that
+    /// represents the unix timestamp; the only requirement is that
+    /// it represents a sequence that can attribute a logical ordering
+    /// to actions on the database.
+    fn now(&self) -> i64;
+
+    /// Returns the current time as a SystemTime.
+    ///
+    /// This function panics if the Clock time cannot be converted to a SystemTime.
+    fn now_systime(&self) -> SystemTime {
+        chrono::DateTime::from_timestamp_millis(self.now())
+            .map(SystemTime::from)
+            .expect("Failed to convert Clock time to SystemTime")
+    }
+}
+
+/// contains the default implementation of the Clock, and will return the system time
+#[derive(Debug)]
+pub struct SystemClock {
+    last_tick: AtomicI64,
+}
+
+impl SystemClock {
+    pub fn new() -> Self {
+        Self {
+            last_tick: AtomicI64::new(i64::MIN),
+        }
+    }
+}
+
+impl Clock for SystemClock {
+    fn now(&self) -> i64 {
+        // since SystemTime is not guaranteed to be monotonic, we enforce it here
+        let tick = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_millis() as i64, // Time is after the epoch
+            Err(e) => -(e.duration().as_millis() as i64), // Time is before the epoch, return negative
+        };
+        self.last_tick.fetch_max(tick, Ordering::SeqCst).max(tick)
+    }
+}
+
+/// SlateDB uses MonotonicClock internally so that it can enforce that clock ticks
+/// from the underlying implementation are monotonically increasing
+pub(crate) struct MonotonicClock {
+    pub(crate) last_tick: AtomicI64,
+    pub(crate) last_durable_tick: AtomicI64,
+    delegate: Arc<dyn Clock>,
+}
+
+impl MonotonicClock {
+    pub(crate) fn new(delegate: Arc<dyn Clock>, init_tick: i64) -> Self {
+        Self {
+            delegate,
+            last_tick: AtomicI64::new(init_tick),
+            last_durable_tick: AtomicI64::new(init_tick),
+        }
+    }
+
+    pub(crate) fn set_last_tick(&self, tick: i64) -> Result<i64, SlateDBError> {
+        self.enforce_monotonic(tick)
+    }
+
+    pub(crate) fn fetch_max_last_durable_tick(&self, tick: i64) -> i64 {
+        self.last_durable_tick.fetch_max(tick, Ordering::SeqCst)
+    }
+
+    pub(crate) fn get_last_durable_tick(&self) -> i64 {
+        self.last_durable_tick.load(Ordering::SeqCst)
+    }
+
+    pub(crate) async fn now(&self) -> Result<i64, SlateDBError> {
+        let tick = self.delegate.now();
+        match self.enforce_monotonic(tick) {
+            Err(SlateDBError::InvalidClockTick {
+                last_tick,
+                next_tick: _,
+            }) => {
+                let sync_millis = std::cmp::min(10_000, 2 * (last_tick - tick).unsigned_abs());
+                info!(
+                    "Clock tick {} is lagging behind the last known tick {}. \
+                    Sleeping {}ms to potentially resolve skew before returning InvalidClockTick.",
+                    tick, last_tick, sync_millis
+                );
+                tokio::time::sleep(Duration::from_millis(sync_millis)).await;
+                self.enforce_monotonic(self.delegate.now())
+            }
+            result => result,
+        }
+    }
+
+    // The semantics of filtering expired records on read differ slightly depending on
+    // the configured ReadLevel.
+    //
+    // For Uncommitted we can just use the actual clock's "now"
+    // as this corresponds to the current time seen by uncommitted writes but is not persisted
+    // and only enforces monotonicity via the local in-memory MonotonicClock. This means it's
+    // possible for the mono_clock.now() to go "backwards" following a crash and recovery, which
+    // could result in records that were filtered out before the crash coming back to life and being
+    // returned after the crash.
+    //
+    // If the read level is instead set to Committed, we only use the last_tick of the monotonic
+    // clock to filter out expired records, since this corresponds to the highest time of any
+    // persisted batch and is thus recoverable following a crash. Since the last tick is the
+    // last persisted time we are guaranteed monotonicity of the #get_last_tick function and
+    // thus will not see this "time travel" phenomenon -- with Committed, once a record is
+    // filtered out due to ttl expiry, it is guaranteed not to be seen again by future Committed
+    // reads.
+    pub(crate) async fn now_by_durability(
+        &self,
+        durability_level: DurabilityLevel,
+    ) -> Result<i64, SlateDBError> {
+        match durability_level {
+            DurabilityLevel::Memory => self.now().await,
+            DurabilityLevel::Remote => Ok(self.get_last_durable_tick()),
+        }
+    }
+
+    fn enforce_monotonic(&self, tick: i64) -> Result<i64, SlateDBError> {
+        let updated_last_tick = self.last_tick.fetch_max(tick, Ordering::SeqCst);
+        if tick < updated_last_tick {
+            return Err(SlateDBError::InvalidClockTick {
+                last_tick: updated_last_tick,
+                next_tick: tick,
+            });
+        }
+
+        Ok(tick)
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct ManualClock {
+    ticker: AtomicI64,
+}
+
+#[cfg(test)]
+impl ManualClock {
+    pub(crate) fn new() -> ManualClock {
+        ManualClock {
+            ticker: AtomicI64::new(0),
+        }
+    }
+
+    pub(crate) fn set(&self, tick: i64) {
+        self.ticker.store(tick, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+impl Clock for ManualClock {
+    fn now(&self) -> i64 {
+        self.ticker.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug)]
+pub(crate) struct TokioClock {
+    initial_ts: u128,
+    initial_instant: tokio::time::Instant,
+}
+
+#[cfg(test)]
+impl TokioClock {
+    pub(crate) fn new() -> Self {
+        let ts_millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+
+        Self {
+            initial_ts: ts_millis,
+            initial_instant: tokio::time::Instant::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Clock for TokioClock {
+    fn now(&self) -> i64 {
+        let elapsed = tokio::time::Instant::now().duration_since(self.initial_instant);
+        (self.initial_ts + elapsed.as_millis()) as i64
+    }
+}

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -136,24 +136,24 @@ impl MonotonicClock {
         }
     }
 
-    // Returns the current timbase based on the semantics of the durability level, `DurabilityLevel`.
-    // This is used to filter expired records on read, because their semantics differ slightly depending on
-    // the configured `DurabilityLevel`.
-    //
-    // For `DurabilityLevel::Memory`, we can just use the actual clock's "now"
-    // as this corresponds to the current time seen by uncommitted writes but is not persisted
-    // and only enforces monotonicity via the local in-memory MonotonicClock. This means it's
-    // possible for the `MonotonicClock` to go "backwards" following a crash and recovery, which
-    // could result in records that were filtered out before the crash coming back to life and being
-    // returned after the crash.
-    //
-    // If the read level is instead set to `DurabilityLevel::Remote`, we only use the last_tick of the monotonic
-    // to filter out expired records, since this corresponds to the highest time of any
-    // persisted batch and is thus recoverable following a crash. Since the last tick is the
-    // last persisted time we are guaranteed monotonicity of the #get_last_durable_tick function and
-    // thus will not see this "time travel" phenomenon -- with `DurabilityLevel::Remote`, once a record is
-    // filtered out due to ttl expiry, it is guaranteed not to be seen again by future `DurabilityLevel::Remote`
-    // reads.
+    /// Returns the current timbase based on the semantics of the durability level, `DurabilityLevel`.
+    /// This is used to filter expired records on read, because their semantics differ slightly depending on
+    /// the configured `DurabilityLevel`.
+    ///
+    /// For `DurabilityLevel::Memory`, we can just use the actual clock's "now"
+    /// as this corresponds to the current time seen by uncommitted writes but is not persisted
+    /// and only enforces monotonicity via the local in-memory MonotonicClock. This means it's
+    /// possible for the `MonotonicClock` to go "backwards" following a crash and recovery, which
+    /// could result in records that were filtered out before the crash coming back to life and being
+    /// returned after the crash.
+    ///
+    /// If the read level is instead set to `DurabilityLevel::Remote`, we only use the last_tick of the monotonic
+    /// to filter out expired records, since this corresponds to the highest time of any
+    /// persisted batch and is thus recoverable following a crash. Since the last tick is the
+    /// last persisted time we are guaranteed monotonicity of the #get_last_durable_tick function and
+    /// thus will not see this "time travel" phenomenon -- with `DurabilityLevel::Remote`, once a record is
+    /// filtered out due to ttl expiry, it is guaranteed not to be seen again by future `DurabilityLevel::Remote`
+    /// reads.
     pub(crate) async fn now_by_durability(
         &self,
         durability_level: DurabilityLevel,

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -31,12 +31,32 @@ pub trait Clock: Debug + Send + Sync {
             .map(SystemTime::from)
             .expect("Failed to convert Clock time to SystemTime")
     }
+
+    /// Returns the current time plus the given duration.
+    fn add(&self, duration: Duration) -> i64 {
+        self.now() + duration.as_millis() as i64
+    }
+
+    /// Returns the time that has elapsed since the unix epoch.
+    ///
+    /// This function returns `0` if the current time is before the unix epoch.
+    fn elapsed(&self) -> Duration {
+        self.now_systime()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+    }
 }
 
 /// contains the default implementation of the Clock, and will return the system time
 #[derive(Debug)]
 pub struct SystemClock {
     last_tick: AtomicI64,
+}
+
+impl Default for SystemClock {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SystemClock {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -501,7 +501,7 @@ mod tests {
 
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
-            .with_clock(clock)
+            .with_user_clock(clock)
             .build()
             .await
             .unwrap();
@@ -563,7 +563,7 @@ mod tests {
 
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
-            .with_clock(clock)
+            .with_user_clock(clock)
             .with_compaction_scheduler_supplier(scheduler.clone())
             .build()
             .await
@@ -652,7 +652,7 @@ mod tests {
         options.default_ttl = Some(50);
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
-            .with_clock(insert_clock.clone())
+            .with_user_clock(insert_clock.clone())
             .with_compaction_scheduler_supplier(compaction_scheduler)
             .build()
             .await

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -269,7 +269,7 @@ mod tests {
 
     use super::*;
     use crate::checkpoint::Checkpoint;
-    use crate::clock::{SysClock, SystemClock};
+    use crate::clock::{DefaultSystemClock, SystemClock};
     use crate::compactor_state::CompactionStatus::Submitted;
     use crate::compactor_state::SourceId::Sst;
     use crate::config::Settings;
@@ -518,7 +518,7 @@ mod tests {
     fn test_should_merge_db_state_with_new_checkpoints() {
         // given:
         let mut state = CompactorState::new(new_dirty_manifest());
-        let clock = SystemClock::new();
+        let clock = DefaultSystemClock::new();
         // mimic an externally added checkpoint
         let mut dirty = new_dirty_manifest();
         let checkpoint = Checkpoint::new(1, clock.now_systime(), None);

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -269,6 +269,7 @@ mod tests {
 
     use super::*;
     use crate::checkpoint::Checkpoint;
+    use crate::clock::{Clock, SystemClock};
     use crate::compactor_state::CompactionStatus::Submitted;
     use crate::compactor_state::SourceId::Sst;
     use crate::config::Settings;
@@ -517,14 +518,10 @@ mod tests {
     fn test_should_merge_db_state_with_new_checkpoints() {
         // given:
         let mut state = CompactorState::new(new_dirty_manifest());
+        let clock = SystemClock::new();
         // mimic an externally added checkpoint
         let mut dirty = new_dirty_manifest();
-        let checkpoint = Checkpoint {
-            id: crate::utils::uuid(),
-            manifest_id: 1,
-            expire_time: None,
-            create_time: SystemTime::now(),
-        };
+        let checkpoint = Checkpoint::new(1, clock.now_systime(), None);
         dirty.core.checkpoints.push(checkpoint.clone());
 
         // when:

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -269,7 +269,7 @@ mod tests {
 
     use super::*;
     use crate::checkpoint::Checkpoint;
-    use crate::clock::{Clock, SystemClock};
+    use crate::clock::{SysClock, SystemClock};
     use crate::compactor_state::CompactionStatus::Submitted;
     use crate::compactor_state::SourceId::Sst;
     use crate::config::Settings;

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -158,10 +158,7 @@ use figment::providers::{Env, Format, Json, Toml, Yaml};
 use figment::{Figment, Metadata, Provider};
 use serde::{Deserialize, Serialize, Serializer};
 use std::path::Path;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::{str::FromStr, time::Duration};
 use uuid::Uuid;
 
@@ -283,45 +280,6 @@ pub enum Ttl {
     Default,
     NoExpiry,
     ExpireAfter(u64),
-}
-
-/// defines the clock that SlateDB will use during this session
-pub trait Clock {
-    /// Returns a timestamp (typically measured in millis since the unix epoch),
-    /// must return monotonically increasing numbers (this is enforced
-    /// at runtime and will panic if the invariant is broken).
-    ///
-    /// Note that this clock does not need to return a number that
-    /// represents the unix timestamp; the only requirement is that
-    /// it represents a sequence that can attribute a logical ordering
-    /// to actions on the database.
-    fn now(&self) -> i64;
-}
-
-/// contains the default implementation of the Clock, and will return the system time
-#[derive(Default)]
-pub struct SystemClock {
-    last_tick: AtomicI64,
-}
-
-impl SystemClock {
-    pub fn new() -> Self {
-        Self {
-            last_tick: AtomicI64::new(i64::MIN),
-        }
-    }
-}
-
-impl Clock for SystemClock {
-    fn now(&self) -> i64 {
-        // since SystemTime is not guaranteed to be monotonic, we enforce it here
-        let tick = match SystemTime::now().duration_since(UNIX_EPOCH) {
-            Ok(duration) => duration.as_millis() as i64, // Time is after the epoch
-            Err(e) => -(e.duration().as_millis() as i64), // Time is before the epoch, return negative
-        };
-        self.last_tick.fetch_max(tick, SeqCst);
-        self.last_tick.load(SeqCst)
-    }
 }
 
 /// Defines the scope targeted by a given checkpoint. If set to All, then the checkpoint will

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -963,7 +963,7 @@ mod tests {
     };
     use crate::cached_object_store::{CachedObjectStore, FsCacheStorage};
     use crate::cached_object_store_stats::CachedObjectStoreStats;
-    use crate::clock::ManualClock;
+    use crate::clock::{ManualClock, SystemClock};
     use crate::config::DurabilityLevel::{Memory, Remote};
     use crate::config::{
         CompactorOptions, ObjectStoreCacheOptions, Settings, SizeTieredCompactionSchedulerOptions,
@@ -1492,12 +1492,14 @@ mod tests {
             .unwrap();
         let stats_registry = StatRegistry::new();
         let cache_stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
+        let clock = Arc::new(SystemClock::new());
         let part_size = 1024;
         let cache_storage = Arc::new(FsCacheStorage::new(
             temp_dir.path().to_path_buf(),
             None,
             None,
             cache_stats.clone(),
+            clock,
         ));
 
         let cached_object_store = CachedObjectStore::new(

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -33,7 +33,7 @@ use tokio_util::sync::CancellationToken;
 use crate::batch::WriteBatch;
 use crate::batch_write::{WriteBatchMsg, WriteBatchRequest};
 use crate::bytes_range::BytesRange;
-use crate::clock::{Clock, MonotonicClock};
+use crate::clock::{MonotonicClock, UserClock};
 use crate::compactor::Compactor;
 use crate::config::{PutOptions, ReadOptions, ScanOptions, Settings, WriteOptions};
 use crate::db_iter::DbIterator;
@@ -74,7 +74,7 @@ impl DbInner {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         settings: Settings,
-        user_clock: Arc<dyn Clock>,
+        user_clock: Arc<dyn UserClock>,
         table_store: Arc<TableStore>,
         manifest: DirtyManifest,
         wal_flush_notifier: UnboundedSender<WalFlushMsg>,
@@ -966,7 +966,7 @@ mod tests {
     };
     use crate::cached_object_store::{CachedObjectStore, FsCacheStorage};
     use crate::cached_object_store_stats::CachedObjectStoreStats;
-    use crate::clock::{ManualClock, SystemClock};
+    use crate::clock::{DefaultSystemClock, ManualClock};
     use crate::config::DurabilityLevel::{Memory, Remote};
     use crate::config::{
         CompactorOptions, ObjectStoreCacheOptions, Settings, SizeTieredCompactionSchedulerOptions,
@@ -1495,7 +1495,7 @@ mod tests {
             .unwrap();
         let stats_registry = StatRegistry::new();
         let cache_stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let part_size = 1024;
         let cache_storage = Arc::new(FsCacheStorage::new(
             temp_dir.path().to_path_buf(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -96,6 +96,7 @@ use crate::cached_object_store::stats::CachedObjectStoreStats;
 use crate::cached_object_store::CachedObjectStore;
 use crate::cached_object_store::FsCacheStorage;
 use crate::clock::Clock;
+use crate::clock::SysClock;
 use crate::clock::SystemClock;
 use crate::compactor::SizeTieredCompactionSchedulerSupplier;
 use crate::compactor::{CompactionSchedulerSupplier, Compactor};
@@ -126,7 +127,7 @@ pub struct DbBuilder<P: Into<Path>> {
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     block_cache: Option<Arc<dyn DbCache>>,
     user_clock: Option<Arc<dyn Clock>>,
-    system_clock: Option<Arc<dyn Clock>>,
+    system_clock: Option<Arc<dyn SysClock>>,
     gc_runtime: Option<Handle>,
     compaction_runtime: Option<Handle>,
     compaction_scheduler_supplier: Option<Arc<dyn CompactionSchedulerSupplier>>,
@@ -192,7 +193,7 @@ impl<P: Into<Path>> DbBuilder<P> {
     /// and WAL flushing. These operations are not affected by the user clock.
     ///
     /// If not set, SlateDB uses the system clock.
-    pub fn with_system_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+    pub fn with_system_clock(mut self, clock: Arc<dyn SysClock>) -> Self {
         self.system_clock = Some(clock);
         self
     }
@@ -286,7 +287,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                             .max_cache_size_bytes,
                         self.settings.object_store_cache_options.scan_interval,
                         stats.clone(),
-                        user_clock.clone(),
+                        system_clock.clone(),
                     ));
 
                     let cached_main_object_store = CachedObjectStore::new(

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -65,7 +65,7 @@
 //! Example with a custom clock:
 //!
 //! ```
-//! use slatedb::{config::SystemClock, Db, SlateDBError};
+//! use slatedb::{clock::SystemClock, Db, SlateDBError};
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
@@ -95,11 +95,12 @@ use tracing::{debug, info, warn};
 use crate::cached_object_store::stats::CachedObjectStoreStats;
 use crate::cached_object_store::CachedObjectStore;
 use crate::cached_object_store::FsCacheStorage;
+use crate::clock::Clock;
+use crate::clock::SystemClock;
 use crate::compactor::SizeTieredCompactionSchedulerSupplier;
 use crate::compactor::{CompactionSchedulerSupplier, Compactor};
 use crate::config::default_block_cache;
-use crate::config::SystemClock;
-use crate::config::{Clock, Settings};
+use crate::config::Settings;
 use crate::db::Db;
 use crate::db::DbInner;
 use crate::db_cache::{DbCache, DbCacheWrapper};
@@ -124,7 +125,7 @@ pub struct DbBuilder<P: Into<Path>> {
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     block_cache: Option<Arc<dyn DbCache>>,
-    clock: Option<Arc<dyn Clock + Send + Sync>>,
+    clock: Option<Arc<dyn Clock>>,
     gc_runtime: Option<Handle>,
     compaction_runtime: Option<Handle>,
     compaction_scheduler_supplier: Option<Arc<dyn CompactionSchedulerSupplier>>,
@@ -175,7 +176,7 @@ impl<P: Into<Path>> DbBuilder<P> {
     }
 
     /// Sets the clock to use for the database.
-    pub fn with_clock(mut self, clock: Arc<dyn Clock + Send + Sync>) -> Self {
+    pub fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
         self.clock = Some(clock);
         self
     }

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     fn build_block() -> CachedEntry {
-        let mut rng = rand::thread_rng();
+        let mut rng = crate::rand::thread_rng();
         let mut builder = BlockBuilder::new(1024);
         loop {
             let mut k = vec![0u8; 32];

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use parking_lot::Mutex;
 use tracing::{debug, error};
 
-use crate::clock::Clock;
+use crate::clock::UserClock;
 use crate::db_cache::stats::DbCacheStats;
 use crate::stats::StatRegistry;
 use crate::{
@@ -240,7 +240,7 @@ impl CachedEntry {
 pub struct DbCacheWrapper {
     stats: DbCacheStats,
     cache: Arc<dyn DbCache>,
-    clock: Arc<dyn Clock>,
+    clock: Arc<dyn UserClock>,
     // Records the last time that the wrapper logged an error from the wrapped cache at error
     // level. Used to ensure we only log at error level once every ERROR_LOG_INTERVAL.
     last_err_log_instant: Mutex<Option<i64>>,
@@ -250,7 +250,7 @@ impl DbCacheWrapper {
     pub fn new(
         cache: Arc<dyn DbCache>,
         stats_registry: &StatRegistry,
-        clock: Arc<dyn Clock>,
+        clock: Arc<dyn UserClock>,
     ) -> Self {
         Self {
             stats: DbCacheStats::new(stats_registry),
@@ -462,7 +462,7 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
 
-    use crate::clock::SystemClock;
+    use crate::clock::DefaultSystemClock;
     use crate::db_cache::{CachedEntry, CachedKey, DbCache, DbCacheWrapper};
     use crate::db_state::SsTableId;
 
@@ -622,7 +622,7 @@ mod tests {
     #[fixture]
     fn cache() -> DbCacheWrapper {
         let registry = StatRegistry::new();
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         DbCacheWrapper::new(Arc::new(TestCache::new()), &registry, clock)
     }
 

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -52,7 +52,7 @@ impl DbInner {
         let last_wal_id = replayed_memtable.last_wal_id;
         guard.set_next_wal_id(last_wal_id + 1);
         guard.update_last_seq(replayed_memtable.last_seq);
-        self.mono_clock.set_last_tick(replayed_memtable.last_tick)?;
+        self.user_clock.set_last_tick(replayed_memtable.last_tick)?;
         guard.replace_memtable(replayed_memtable.table)
     }
 

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -544,7 +544,6 @@ mod tests {
     use std::collections::BTreeSet;
     use std::collections::Bound::Included;
     use std::ops::RangeBounds;
-    use ulid::Ulid;
 
     #[test]
     fn test_should_merge_db_state_with_new_checkpoints() {

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -533,6 +533,7 @@ impl DbState {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
+    use crate::clock::{Clock, SystemClock};
     use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::proptest_util::arbitrary;
@@ -543,21 +544,17 @@ mod tests {
     use std::collections::BTreeSet;
     use std::collections::Bound::Included;
     use std::ops::RangeBounds;
-    use std::time::SystemTime;
+    use ulid::Ulid;
 
     #[test]
     fn test_should_merge_db_state_with_new_checkpoints() {
         // given:
         let mut db_state = DbState::new(new_dirty_manifest());
+        let clock = SystemClock::new();
         // mimic an externally added checkpoint
         let mut updated_state = new_dirty_manifest();
         updated_state.core = db_state.state.core().clone();
-        let checkpoint = Checkpoint {
-            id: crate::utils::uuid(),
-            manifest_id: 1,
-            expire_time: None,
-            create_time: SystemTime::now(),
-        };
+        let checkpoint = Checkpoint::new(1, clock.now_systime(), None);
         updated_state.core.checkpoints.push(checkpoint.clone());
 
         // when:

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -533,7 +533,7 @@ impl DbState {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
-    use crate::clock::{SysClock, SystemClock};
+    use crate::clock::{DefaultSystemClock, SystemClock};
     use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::proptest_util::arbitrary;
@@ -549,7 +549,7 @@ mod tests {
     fn test_should_merge_db_state_with_new_checkpoints() {
         // given:
         let mut db_state = DbState::new(new_dirty_manifest());
-        let clock = SystemClock::new();
+        let clock = DefaultSystemClock::new();
         // mimic an externally added checkpoint
         let mut updated_state = new_dirty_manifest();
         updated_state.core = db_state.state.core().clone();

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -533,7 +533,7 @@ impl DbState {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
-    use crate::clock::{Clock, SystemClock};
+    use crate::clock::{SysClock, SystemClock};
     use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::proptest_util::arbitrary;

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -50,7 +50,7 @@ impl DbInner {
             .write_sst(id, encoded_sst, write_cache)
             .await?;
 
-        self.mono_clock
+        self.user_clock
             .fetch_max_last_durable_tick(imm_table.last_tick());
         Ok(handle)
     }

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1,5 +1,5 @@
 use crate::checkpoint::Checkpoint;
-use crate::clock::Clock;
+use crate::clock::SysClock;
 use crate::config::GarbageCollectorOptions;
 use crate::error::SlateDBError;
 use crate::garbage_collector::stats::GcStats;
@@ -76,7 +76,7 @@ impl GarbageCollector {
         tokio_handle: Handle,
         stat_registry: Arc<StatRegistry>,
         cancellation_token: CancellationToken,
-        clock: Arc<dyn Clock>,
+        clock: Arc<dyn SysClock>,
         cleanup_fn: impl FnOnce(&Result<(), SlateDBError>) + Send + 'static,
     ) -> Self {
         let stats = Arc::new(GcStats::new(stat_registry));
@@ -118,7 +118,7 @@ impl GarbageCollector {
         stats: Arc<GcStats>,
         cancellation_token: CancellationToken,
         options: GarbageCollectorOptions,
-        clock: Arc<dyn Clock>,
+        clock: Arc<dyn SysClock>,
     ) {
         let mut log_ticker = tokio::time::interval(Duration::from_secs(60));
 
@@ -183,7 +183,7 @@ impl GarbageCollector {
         table_store: Arc<TableStore>,
         stat_registry: Arc<StatRegistry>,
         options: GarbageCollectorOptions,
-        clock: Arc<dyn Clock>,
+        clock: Arc<dyn SysClock>,
     ) {
         let stats = Arc::new(GcStats::new(stat_registry));
 
@@ -240,7 +240,7 @@ fn gc_tasks(
 async fn run_gc_task<T: GcTask>(
     task: &mut T,
     manifest_store: Arc<ManifestStore>,
-    clock: Arc<dyn Clock>,
+    clock: Arc<dyn SysClock>,
 ) {
     debug!(
         "Scheduled garbage collection attempt for {}.",
@@ -300,7 +300,7 @@ mod tests {
     use uuid::Uuid;
 
     use crate::checkpoint::Checkpoint;
-    use crate::clock::{Clock, SystemClock};
+    use crate::clock::{SysClock, SystemClock};
     use crate::config::{GarbageCollectorDirectoryOptions, GarbageCollectorOptions};
     use crate::error::SlateDBError;
     use crate::object_stores::ObjectStores;
@@ -387,7 +387,7 @@ mod tests {
 
     async fn checkpoint_current_manifest(
         stored_manifest: &mut StoredManifest,
-        clock: &dyn Clock,
+        clock: &dyn SysClock,
         expire_time: Option<SystemTime>,
     ) -> Result<Uuid, SlateDBError> {
         let mut dirty = stored_manifest.prepare_dirty();

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -2,7 +2,6 @@ use crate::{
     config::GarbageCollectorDirectoryOptions, db_state::SsTableId, manifest::store::ManifestStore,
     tablestore::TableStore, SlateDBError,
 };
-use chrono::{DateTime, Utc};
 use std::collections::HashSet;
 use std::{sync::Arc, time::Duration};
 use tokio::time::Interval;
@@ -59,7 +58,8 @@ impl CompactedGcTask {
 impl GcTask for CompactedGcTask {
     /// Collect garbage from the compacted SSTs. This will delete any compacted SSTs that are
     /// older than the minimum age specified in the options and are not active in the manifest.
-    async fn collect(&self, utc_now: DateTime<Utc>) -> Result<(), SlateDBError> {
+    async fn collect(&self, now_in_millis: i64) -> Result<(), SlateDBError> {
+        let utc_now = super::gc_task_time(now_in_millis);
         let active_ssts = self.list_active_l0_and_compacted_ssts().await?;
         let min_age = self.compacted_sst_min_age();
         let sst_ids_to_delete = self

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -1,7 +1,6 @@
 use crate::{
     config::GarbageCollectorDirectoryOptions, manifest::store::ManifestStore, SlateDBError,
 };
-use chrono::{DateTime, Utc};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -40,7 +39,8 @@ impl ManifestGcTask {
 impl GcTask for ManifestGcTask {
     /// Collect garbage from the manifest store. This will delete any manifests
     /// that are older than the minimum age specified in the options.
-    async fn collect(&self, utc_now: DateTime<Utc>) -> Result<(), SlateDBError> {
+    async fn collect(&self, now_in_millis: i64) -> Result<(), SlateDBError> {
+        let utc_now = super::gc_task_time(now_in_millis);
         let min_age = self.manifest_min_age();
         let mut manifest_metadata_list = self.manifest_store.list_manifests(..).await?;
 

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -65,7 +65,8 @@ impl GcTask for WalGcTask {
     ///  - not referenced by an active checkpoint
     ///  - older than the minimum age specified in the options
     ///  - older than the last compacted WAL SST.
-    async fn collect(&self, utc_now: DateTime<Utc>) -> Result<(), SlateDBError> {
+    async fn collect(&self, now_in_millis: i64) -> Result<(), SlateDBError> {
+        let utc_now = super::gc_task_time(now_in_millis);
         let active_manifests = self.manifest_store.read_active_manifests().await?;
         let latest_manifest = active_manifests
             .last_key_value()

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -40,9 +40,9 @@ pub use merge_operator::{MergeOperator, MergeOperatorError};
 pub use types::KeyValue;
 
 pub mod admin;
+pub mod clock;
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
-pub mod clock;
 pub mod config;
 pub mod db_cache;
 pub mod db_stats;

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -42,6 +42,7 @@ pub use types::KeyValue;
 pub mod admin;
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
+pub mod clock;
 pub mod config;
 pub mod db_cache;
 pub mod db_stats;

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1,5 +1,5 @@
 use crate::checkpoint::Checkpoint;
-use crate::clock::{Clock, SystemClock};
+use crate::clock::{SysClock, SystemClock};
 use crate::config::CheckpointOptions;
 use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
@@ -535,7 +535,7 @@ pub(crate) struct ManifestStore {
     object_store: Box<dyn TransactionalObjectStore>,
     codec: Box<dyn ManifestCodec>,
     manifest_suffix: &'static str,
-    clock: Arc<dyn Clock>,
+    clock: Arc<dyn SysClock>,
 }
 
 impl ManifestStore {
@@ -546,7 +546,7 @@ impl ManifestStore {
     pub(crate) fn new_with_clock(
         root_path: &Path,
         object_store: Arc<dyn ObjectStore>,
-        clock: Arc<dyn Clock>,
+        clock: Arc<dyn SysClock>,
     ) -> Self {
         Self {
             object_store: Box::new(DelegatingTransactionalObjectStore::new(
@@ -743,7 +743,7 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
-    use crate::clock::{Clock, SystemClock};
+    use crate::clock::{SysClock, SystemClock};
     use crate::config::CheckpointOptions;
     use crate::db_state::CoreDbState;
     use crate::error;
@@ -1055,7 +1055,7 @@ mod tests {
         Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()))
     }
 
-    fn now_rounded_to_nearest_sec(clock: &dyn Clock) -> SystemTime {
+    fn now_rounded_to_nearest_sec(clock: &dyn SysClock) -> SystemTime {
         let now_secs = clock.elapsed().as_secs();
         SystemTime::UNIX_EPOCH + Duration::from_secs(now_secs)
     }

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -1,4 +1,5 @@
 use crate::bytes_range::BytesRange;
+use crate::clock::MonotonicClock;
 use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
 use crate::db_state::{CoreDbState, SortedRun, SsTableHandle};
 use crate::db_stats::DbStats;
@@ -12,7 +13,7 @@ use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::types::{RowEntry, ValueDeletable};
-use crate::utils::{get_now_for_read, is_not_expired, MonotonicClock};
+use crate::utils::is_not_expired;
 use crate::{filter, DbIterator, SlateDBError};
 use bytes::Bytes;
 use futures::future::BoxFuture;
@@ -72,7 +73,10 @@ impl Reader {
         snapshot: &(dyn ReadSnapshot + Sync + Send),
         max_seq: Option<u64>,
     ) -> Result<Option<Bytes>, SlateDBError> {
-        let now = get_now_for_read(self.mono_clock.clone(), options.durability_filter).await?;
+        let now = self
+            .mono_clock
+            .now_by_durability(options.durability_filter)
+            .await?;
         let get = LevelGet {
             key: key.as_ref(),
             max_seq,

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -580,6 +580,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Arc;
 
+    use crate::clock::SystemClock;
     use crate::db_cache::test_utils::TestCache;
     use crate::db_cache::{DbCache, DbCacheWrapper};
     use crate::error;
@@ -793,6 +794,7 @@ mod tests {
 
         // Setup
         let os = Arc::new(InMemory::new());
+        let clock = Arc::new(SystemClock::new());
         let format = SsTableFormat {
             block_size: 32,
             ..SsTableFormat::default()
@@ -800,7 +802,11 @@ mod tests {
 
         let stat_registry = StatRegistry::new();
         let block_cache = Arc::new(MokaCache::new());
-        let wrapper = Arc::new(DbCacheWrapper::new(block_cache.clone(), &stat_registry));
+        let wrapper = Arc::new(DbCacheWrapper::new(
+            block_cache.clone(),
+            &stat_registry,
+            clock,
+        ));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             format,
@@ -926,7 +932,8 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let stat_registry = StatRegistry::new();
         let cache = Arc::new(TestCache::new());
-        let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry));
+        let clock = Arc::new(SystemClock::new());
+        let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry, clock));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             SsTableFormat::default(),
@@ -962,7 +969,8 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let stat_registry = StatRegistry::new();
         let cache = Arc::new(TestCache::new());
-        let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry));
+        let clock = Arc::new(SystemClock::new());
+        let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry, clock));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             SsTableFormat::default(),

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -580,7 +580,7 @@ mod tests {
     use std::collections::VecDeque;
     use std::sync::Arc;
 
-    use crate::clock::SystemClock;
+    use crate::clock::DefaultSystemClock;
     use crate::db_cache::test_utils::TestCache;
     use crate::db_cache::{DbCache, DbCacheWrapper};
     use crate::error;
@@ -794,7 +794,7 @@ mod tests {
 
         // Setup
         let os = Arc::new(InMemory::new());
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let format = SsTableFormat {
             block_size: 32,
             ..SsTableFormat::default()
@@ -932,7 +932,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let stat_registry = StatRegistry::new();
         let cache = Arc::new(TestCache::new());
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry, clock));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
@@ -969,7 +969,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let stat_registry = StatRegistry::new();
         let cache = Arc::new(TestCache::new());
-        let clock = Arc::new(SystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
         let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry, clock));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -235,7 +235,7 @@ mod tests {
     };
     use bytes::{BufMut, Bytes, BytesMut};
     use parking_lot::Mutex;
-    
+
     use std::sync::Arc;
     use std::time::Duration;
 

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -2,9 +2,9 @@ use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskPanic;
 use crate::types::RowEntry;
 use bytes::{BufMut, Bytes};
+use rand::RngCore;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
-use rand::RngCore;
 use ulid::Ulid;
 use uuid::{Builder, Uuid};
 
@@ -226,7 +226,7 @@ mod tests {
     };
     use bytes::{BufMut, Bytes, BytesMut};
     use parking_lot::Mutex;
-    
+
     use std::sync::Arc;
     use std::time::Duration;
 

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -2,20 +2,11 @@ use crate::error::SlateDBError;
 use crate::error::SlateDBError::BackgroundTaskPanic;
 use crate::types::RowEntry;
 use bytes::{BufMut, Bytes};
-<<<<<<< HEAD
-use rand::RngCore;
-use std::cmp;
-=======
->>>>>>> a22af85 (Centralize all clock related code into the "clock" module.)
 use std::future::Future;
 use std::sync::{Arc, Mutex};
-<<<<<<< HEAD
-use std::time::{Duration, SystemTime};
-use tracing::info;
+use rand::RngCore;
 use ulid::Ulid;
 use uuid::{Builder, Uuid};
-=======
->>>>>>> a22af85 (Centralize all clock related code into the "clock" module.)
 
 static EMPTY_KEY: Bytes = Bytes::new();
 
@@ -235,7 +226,7 @@ mod tests {
     };
     use bytes::{BufMut, Bytes, BytesMut};
     use parking_lot::Mutex;
-
+    
     use std::sync::Arc;
     use std::time::Duration;
 


### PR DESCRIPTION
Following the steps of #585, this PR tries to centralize all clock operations under the internal `dyn Clock`.

Part of the implementation for #267.