### PR TITLE
[hotfix] Remove statement discouraging production use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,6 @@ Visit [slatedb.io](https://slatedb.io) to learn more.
 
 ## Features
 
-SlateDB is currently in the early stages of development. It is not yet ready for production use.
-
 - [x] Basic API (get, put, delete)
 - [x] SSTs on object storage
 - [x] Range queries ([#8](https://github.com/slatedb/slatedb/issues/8))


### PR DESCRIPTION
I feel it's time to remove this tiny confusing note from README. This actually comes up pretty frequently in conversation with folks looking to adopt SlateDB - why would we use something that clearly states is not production ready.

At this point it seems fair to remove this, since we:
- have pretty extensive testing
- Main APIs have more or less stabilized
- We've committed to binary compatibility
- We want to start doing patch releases

This is already more than most projects people take dependency on do.

We've also touched on this with @rodesai last week at Current and he also felt that this makes sense.

WDYT?