### PR TITLE
Track last_key in DbIterator

### DIFF
--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -216,7 +216,7 @@ mod tests {
         assert!(iter.next().await.unwrap().is_none());
     }
 
-        #[tokio::test]
+    #[tokio::test]
     async fn test_seek_cannot_rewind() {
         // Build a simple memtable with two keys
         let mut mem = WritableKVTable::new();


### PR DESCRIPTION
DbIterator did not track the last key returned, so seek could incorrectly allow seeking backwards. next() now updates last_key after each successful read.