### PR TITLE
Fix race condition in compaction executor

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -491,7 +491,6 @@ mod tests {
         let clock = Arc::new(TestClock::new());
         let compaction_scheduler = Arc::new(SizeTieredCompactionSchedulerSupplier::new(
             SizeTieredCompactionSchedulerOptions {
-                // We'll do exactly two flushes in this test, resulting in 2 L0 files.
                 min_compaction_sources: 1,
                 max_compaction_sources: 999,
                 include_size_threshold: 4.0,
@@ -553,7 +552,7 @@ mod tests {
     }
 
     #[cfg(feature = "wal_disable")]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_should_tombstones_in_l0() {
         let os = Arc::new(InMemory::new());
         let clock = Arc::new(TestClock::new());
@@ -636,7 +635,7 @@ mod tests {
         assert!(next.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_should_compact_expired_entries() {
         // given:
         let os = Arc::new(InMemory::new());


### PR DESCRIPTION
While debugging #595 and its subsequent [GH action failure](https://github.com/slatedb/slatedb/actions/runs/15473197912/job/43562555846), I noticed the other compactor tests were failing sporadically. They were, on occasion, hanging. I added multiple threads for the tests, and they no longer seem to hang.

I don't think this bodes well. I worry there might be some lock that's getting held on to. Things should make progress even on a single async runtime thread. Anyway, we're getting close to DST with #267. When we do DST, we'll be running on one thread, and I expect we'll be able to suss this out.

Separately, I also want to note that the GH action failure was not because of a timeout. We saw this instead:

```
--- STDOUT:              slatedb compactor::tests::test_compactor_compacts_l0 ---

running 1 test
test compactor::tests::test_compactor_compacts_l0 ... FAILED

failures:

failures:
    compactor::tests::test_compactor_compacts_l0

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 407 filtered out; finished in 0.11s


--- STDERR:              slatedb compactor::tests::test_compactor_compacts_l0 ---

thread 'slatedb-compactor' panicked at slatedb/src/compactor_executor.rs:198:9:
assertion failed: !tasks.contains_key(&dst)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'compactor::tests::test_compactor_compacts_l0' panicked at slatedb/src/compactor.rs:547:62:
called `Result::unwrap()` on an `Err` value: BackgroundTaskPanic(Mutex { data: Any { .. }, poisoned: false, .. })
```

This, too, is concerning. It appears we have a race condition where the `SizeTieredCompactionScheduler`'s `ConflictChecker` does not see a conflict when it returns its `Compaction`s. But between that return and the subsequent `start_compaction` call, somehow the scheduler is run again and, again, returns the same `dst`. This seems like a bug.

Fixes #595