### PR TITLE
Add `LogicalClock` and `SystemClock` clocks

### DIFF
--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,0 +1,27 @@
+use std::time::SystemTime;
+
+use crate::utils::system_time_to_millis;
+
+pub trait SystemClock {
+    fn now(&self) -> SystemTime;
+}
+
+pub struct DefaultSystemClock;
+
+impl SystemClock for DefaultSystemClock {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+}
+
+pub trait LogicalClock {
+    fn now(&self) -> i64;
+}
+
+pub struct DefaultLogicalClock;
+
+impl LogicalClock for DefaultLogicalClock {
+    fn now(&self) -> i64 {
+        system_time_to_millis(SystemTime::now())
+    }
+}

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        atomic::{AtomicI64, Ordering},
-        Arc,
-    },
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,20 +1,49 @@
-use std::time::SystemTime;
+use std::{cmp::Ordering, sync::atomic::AtomicI64, time::{SystemTime, UNIX_EPOCH}};
 
 use crate::utils::system_time_to_millis;
 
+/// Defines the physical clock that SlateDB will use to measure time for things
+/// like TTL expiration, garbage collection clock ticks, and so on.
 pub trait SystemClock {
     fn now(&self) -> SystemTime;
 }
 
-pub struct DefaultSystemClock;
+#[derive(Default)]
+pub struct DefaultSystemClock {
+    last_tick: AtomicI64,
+}
 
-impl SystemClock for DefaultSystemClock {
-    fn now(&self) -> SystemTime {
-        SystemTime::now()
+impl DefaultSystemClock {
+    pub fn new() -> Self {
+        Self {
+            last_tick: AtomicI64::new(i64::MIN),
+        }
     }
 }
 
+impl SystemClock for DefaultSystemClock {
+    fn now(&self) -> i64 {
+        // since SystemTime is not guaranteed to be monotonic, we enforce it here
+        let tick = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(duration) => duration.as_millis() as i64, // Time is after the epoch
+            Err(e) => -(e.duration().as_millis() as i64), // Time is before the epoch, return negative
+        };
+        self.last_tick.fetch_max(tick, Ordering::SeqCst);
+        self.last_tick.load(Ordering::SeqCst)
+    }
+}
+
+/// Defines the logical clock that SlateDB will use to measure time for things
+/// like 
 pub trait LogicalClock {
+    /// Returns a timestamp (typically measured in millis since the unix epoch),
+    /// must return monotonically increasing numbers (this is enforced
+    /// at runtime and will panic if the invariant is broken).
+    ///
+    /// Note that this clock does not need to return a number that
+    /// represents the unix timestamp; the only requirement is that
+    /// it represents a sequence that can attribute a logical ordering
+    /// to actions on the database.
     fn now(&self) -> i64;
 }
 

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::atomic::{AtomicI64, Ordering},
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -62,7 +65,9 @@ pub trait LogicalClock: Send + Sync {
     fn now(&self) -> i64;
 }
 
-pub struct DefaultLogicalClock;
+pub struct DefaultLogicalClock {
+    inner: Arc<dyn SystemClock>,
+}
 
 impl Default for DefaultLogicalClock {
     fn default() -> Self {
@@ -72,13 +77,14 @@ impl Default for DefaultLogicalClock {
 
 impl DefaultLogicalClock {
     pub fn new() -> Self {
-        Self
+        Self {
+            inner: Arc::new(DefaultSystemClock::new()),
+        }
     }
 }
 
 impl LogicalClock for DefaultLogicalClock {
     fn now(&self) -> i64 {
-        // TODO use DefaultSystemClock to keep it monotonic
-        system_time_to_millis(SystemTime::now())
+        system_time_to_millis(self.inner.now())
     }
 }

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,10 +1,14 @@
-use std::{cmp::Ordering, sync::atomic::AtomicI64, time::{SystemTime, UNIX_EPOCH}};
+use std::{
+    cmp::Ordering,
+    sync::atomic::AtomicI64,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use crate::utils::system_time_to_millis;
 
 /// Defines the physical clock that SlateDB will use to measure time for things
 /// like TTL expiration, garbage collection clock ticks, and so on.
-pub trait SystemClock {
+pub trait SystemClock: Send + Sync {
     fn now(&self) -> SystemTime;
 }
 
@@ -34,8 +38,8 @@ impl SystemClock for DefaultSystemClock {
 }
 
 /// Defines the logical clock that SlateDB will use to measure time for things
-/// like 
-pub trait LogicalClock {
+/// like
+pub trait LogicalClock: Send + Sync {
     /// Returns a timestamp (typically measured in millis since the unix epoch),
     /// must return monotonically increasing numbers (this is enforced
     /// at runtime and will panic if the invariant is broken).

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,20 +1,24 @@
 use std::{
-    cmp::Ordering,
-    sync::atomic::AtomicI64,
+    sync::atomic::{AtomicI64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::utils::system_time_to_millis;
+use crate::utils::{system_time_from_millis, system_time_to_millis};
 
 /// Defines the physical clock that SlateDB will use to measure time for things
-/// like TTL expiration, garbage collection clock ticks, and so on.
+/// like garbage collection schedule ticks, compaction schedule ticks, and so on.
 pub trait SystemClock: Send + Sync {
     fn now(&self) -> SystemTime;
 }
 
-#[derive(Default)]
 pub struct DefaultSystemClock {
     last_tick: AtomicI64,
+}
+
+impl Default for DefaultSystemClock {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl DefaultSystemClock {
@@ -26,19 +30,19 @@ impl DefaultSystemClock {
 }
 
 impl SystemClock for DefaultSystemClock {
-    fn now(&self) -> i64 {
+    fn now(&self) -> SystemTime {
         // since SystemTime is not guaranteed to be monotonic, we enforce it here
         let tick = match SystemTime::now().duration_since(UNIX_EPOCH) {
             Ok(duration) => duration.as_millis() as i64, // Time is after the epoch
             Err(e) => -(e.duration().as_millis() as i64), // Time is before the epoch, return negative
         };
         self.last_tick.fetch_max(tick, Ordering::SeqCst);
-        self.last_tick.load(Ordering::SeqCst)
+        system_time_from_millis(self.last_tick.load(Ordering::SeqCst))
     }
 }
 
 /// Defines the logical clock that SlateDB will use to measure time for things
-/// like
+/// like TTL expiration.
 pub trait LogicalClock: Send + Sync {
     /// Returns a timestamp (typically measured in millis since the unix epoch),
     /// must return monotonically increasing numbers (this is enforced
@@ -53,8 +57,21 @@ pub trait LogicalClock: Send + Sync {
 
 pub struct DefaultLogicalClock;
 
+impl Default for DefaultLogicalClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DefaultLogicalClock {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
 impl LogicalClock for DefaultLogicalClock {
     fn now(&self) -> i64 {
+        // TODO use DefaultSystemClock to keep it monotonic
         system_time_to_millis(SystemTime::now())
     }
 }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -491,7 +491,7 @@ mod tests {
     async fn test_compactor_compacts_l0() {
         // given:
         let os = Arc::new(InMemory::new());
-        let clock = Arc::new(TestClock::new());
+        let logical_clock = Arc::new(TestClock::new());
         let compaction_scheduler = Arc::new(SizeTieredCompactionSchedulerSupplier::new(
             SizeTieredCompactionSchedulerOptions {
                 min_compaction_sources: 1,
@@ -504,7 +504,7 @@ mod tests {
 
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
-            .with_clock(clock)
+            .with_logical_clock(logical_clock)
             .with_compaction_scheduler_supplier(compaction_scheduler)
             .build()
             .await
@@ -558,7 +558,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_should_tombstones_in_l0() {
         let os = Arc::new(InMemory::new());
-        let clock = Arc::new(TestClock::new());
+        let logical_clock = Arc::new(TestClock::new());
 
         let scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new());
 
@@ -568,7 +568,7 @@ mod tests {
 
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
-            .with_clock(clock)
+            .with_logical_clock(logical_clock)
             .with_compaction_scheduler_supplier(scheduler.clone())
             .build()
             .await
@@ -657,7 +657,7 @@ mod tests {
         options.default_ttl = Some(50);
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
-            .with_clock(insert_clock.clone())
+            .with_logical_clock(insert_clock.clone())
             .with_compaction_scheduler_supplier(compaction_scheduler)
             .build()
             .await

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -158,10 +158,7 @@ use figment::providers::{Env, Format, Json, Toml, Yaml};
 use figment::{Figment, Metadata, Provider};
 use serde::{Deserialize, Serialize, Serializer};
 use std::path::Path;
-use std::sync::atomic::AtomicI64;
-use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::{str::FromStr, time::Duration};
 use uuid::Uuid;
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -76,7 +76,8 @@ impl DbInner {
     pub async fn new(
         settings: Settings,
         logical_clock: Arc<dyn LogicalClock>,
-        system_clock: Arc<dyn SystemClock>,
+        // TODO replace all system clock usage with this
+        _system_clock: Arc<dyn SystemClock>,
         table_store: Arc<TableStore>,
         manifest: DirtyManifest,
         wal_flush_notifier: UnboundedSender<WalFlushMsg>,

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     fn build_block() -> CachedEntry {
-        let mut rng = rand::thread_rng();
+        let mut rng = crate::rand::thread_rng();
         let mut builder = BlockBuilder::new(1024);
         loop {
             let mut k = vec![0u8; 32];

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -847,12 +847,7 @@ mod tests {
     async fn should_get_latest_value_from_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
 
         let db = test_provider.new_db(Settings::default()).await.unwrap();
         let key = b"test_key";
@@ -887,12 +882,7 @@ mod tests {
     async fn should_get_from_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
 
         let db = test_provider.new_db(Settings::default()).await.unwrap();
         let key = b"test_key";
@@ -925,12 +915,7 @@ mod tests {
     async fn should_fail_if_db_is_uninitialized() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
         let manifest_store = test_provider.manifest_store();
 
         let parent_manifest = Manifest::initial(CoreDbState::new());
@@ -956,12 +941,7 @@ mod tests {
     async fn should_scan_from_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
 
         let db = test_provider.new_db(Settings::default()).await.unwrap();
         let checkpoint_key = b"checkpoint_key";
@@ -995,12 +975,7 @@ mod tests {
     async fn should_reestablish_reader_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
 
         let db_options = Settings {
             l0_sst_size_bytes: 256,
@@ -1039,12 +1014,7 @@ mod tests {
     async fn should_refresh_reader_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
 
         let _db = test_provider.new_db(Settings::default()).await;
         let reader_options = DbReaderOptions {
@@ -1084,12 +1054,7 @@ mod tests {
     async fn should_replay_new_wals() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
         let db = test_provider.new_db(Settings::default()).await.unwrap();
 
         let reader_options = DbReaderOptions {
@@ -1118,12 +1083,7 @@ mod tests {
     async fn should_fail_new_reads_if_manifest_poller_crashes() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let test_provider = TestProvider::new(
-            path.clone(),
-            Arc::clone(&object_store),
-            system_clock.clone(),
-        );
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
         let _db = test_provider.new_db(Settings::default()).await.unwrap();
 
         let reader_options = DbReaderOptions {
@@ -1153,17 +1113,14 @@ mod tests {
         object_store: Arc<dyn ObjectStore>,
         path: Path,
         fp_registry: Arc<FailPointRegistry>,
-        logical_clock: Arc<TokioClock>,
-        system_clock: Arc<DefaultSystemClock>,
+        logical_clock: Arc<dyn LogicalClock>,
+        system_clock: Arc<dyn SystemClock>,
     }
 
     impl TestProvider {
-        fn new(
-            path: Path,
-            object_store: Arc<dyn ObjectStore>,
-            system_clock: Arc<DefaultSystemClock>,
-        ) -> Self {
+        fn new(path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
             let logical_clock = Arc::new(TokioClock::new());
+            let system_clock = Arc::new(DefaultSystemClock::new());
             TestProvider {
                 object_store,
                 path,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -915,7 +915,7 @@ mod tests {
     async fn should_fail_if_db_is_uninitialized() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
+        let test_provider = TestProvider::new(path, Arc::clone(&object_store));
         let manifest_store = test_provider.manifest_store();
 
         let parent_manifest = Manifest::initial(CoreDbState::new());

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -42,7 +42,6 @@ struct DbReaderInner {
     table_store: Arc<TableStore>,
     options: DbReaderOptions,
     state: RwLock<Arc<CheckpointState>>,
-    logical_clock: Arc<dyn LogicalClock>,
     system_clock: Arc<dyn SystemClock>,
     user_checkpoint_id: Option<Uuid>,
     reader: Reader,
@@ -141,7 +140,6 @@ impl DbReaderInner {
             table_store,
             options,
             state,
-            logical_clock,
             system_clock,
             user_checkpoint_id: checkpoint_id,
             reader,
@@ -526,7 +524,7 @@ impl DbReader {
             &store_provider,
             checkpoint_id,
             options,
-            Arc::new(DefaultLogicalClock::default()),
+            Arc::new(DefaultLogicalClock),
             Arc::new(DefaultSystemClock::default()),
         )
         .await

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -524,7 +524,7 @@ impl DbReader {
             &store_provider,
             checkpoint_id,
             options,
-            Arc::new(DefaultLogicalClock),
+            Arc::new(DefaultLogicalClock::default()),
             Arc::new(DefaultSystemClock::default()),
         )
         .await
@@ -817,7 +817,7 @@ impl DbReader {
 
 #[cfg(test)]
 mod tests {
-    use crate::clock::{DefaultSystemClock, LogicalClock, SystemClock};
+    use crate::clock::{DefaultLogicalClock, DefaultSystemClock, LogicalClock, SystemClock};
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db_reader::{DbReader, DbReaderOptions};
     use crate::db_state::CoreDbState;
@@ -830,7 +830,6 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::store_provider::StoreProvider;
     use crate::tablestore::TableStore;
-    use crate::test_utils::TokioClock;
     use crate::{test_utils, Db, SlateDBError};
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
@@ -1119,7 +1118,7 @@ mod tests {
 
     impl TestProvider {
         fn new(path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
-            let logical_clock = Arc::new(TokioClock::new());
+            let logical_clock = Arc::new(DefaultLogicalClock::new());
             let system_clock = Arc::new(DefaultSystemClock::new());
             TestProvider {
                 object_store,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -817,7 +817,7 @@ impl DbReader {
 
 #[cfg(test)]
 mod tests {
-    use crate::clock::{LogicalClock, SystemClock};
+    use crate::clock::{DefaultSystemClock, LogicalClock, SystemClock};
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db_reader::{DbReader, DbReaderOptions};
     use crate::db_state::CoreDbState;
@@ -830,7 +830,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::store_provider::StoreProvider;
     use crate::tablestore::TableStore;
-    use crate::test_utils::{TestSystemClock, TokioClock};
+    use crate::test_utils::TokioClock;
     use crate::{test_utils, Db, SlateDBError};
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
@@ -847,7 +847,7 @@ mod tests {
     async fn should_get_latest_value_from_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -887,7 +887,7 @@ mod tests {
     async fn should_get_from_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -925,7 +925,7 @@ mod tests {
     async fn should_fail_if_db_is_uninitialized() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -956,7 +956,7 @@ mod tests {
     async fn should_scan_from_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -995,7 +995,7 @@ mod tests {
     async fn should_reestablish_reader_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -1039,7 +1039,7 @@ mod tests {
     async fn should_refresh_reader_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -1063,7 +1063,6 @@ mod tests {
         assert_eq!(1, initial_manifest.core.checkpoints.len());
         let initial_reader_checkpoint = initial_manifest.core.checkpoints.first().unwrap().clone();
 
-        system_clock.advance(Duration::from_millis(5000));
         tokio::time::sleep(Duration::from_millis(5000)).await;
 
         let updated_manifest = manifest_store.read_latest_manifest().await.unwrap().1;
@@ -1085,7 +1084,7 @@ mod tests {
     async fn should_replay_new_wals() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -1119,7 +1118,7 @@ mod tests {
     async fn should_fail_new_reads_if_manifest_poller_crashes() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
-        let system_clock = Arc::new(TestSystemClock::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
         let test_provider = TestProvider::new(
             path.clone(),
             Arc::clone(&object_store),
@@ -1155,14 +1154,14 @@ mod tests {
         path: Path,
         fp_registry: Arc<FailPointRegistry>,
         logical_clock: Arc<TokioClock>,
-        system_clock: Arc<TestSystemClock>,
+        system_clock: Arc<DefaultSystemClock>,
     }
 
     impl TestProvider {
         fn new(
             path: Path,
             object_store: Arc<dyn ObjectStore>,
-            system_clock: Arc<TestSystemClock>,
+            system_clock: Arc<DefaultSystemClock>,
         ) -> Self {
             let logical_clock = Arc::new(TokioClock::new());
             TestProvider {

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -40,6 +40,7 @@ pub use merge_operator::{MergeOperator, MergeOperatorError};
 pub use types::KeyValue;
 
 pub mod admin;
+pub mod clock;
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
 pub mod config;

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../../README.md")]
-#![warn(clippy::unwrap_used)]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -11,7 +11,6 @@ use crate::manifest::{ExternalDb, Manifest, ManifestCodec};
 use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
-use crate::utils;
 use crate::SlateDBError::ManifestVersionExists;
 use chrono::Utc;
 use futures::StreamExt;

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -1,10 +1,9 @@
-use crate::clock::{LogicalClock, SystemClock};
+use crate::clock::LogicalClock;
 use crate::config::{PutOptions, WriteOptions};
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, KeyValueIterator};
 use crate::row_codec::SstRowCodecV0;
 use crate::types::{KeyValue, RowAttributes, RowEntry, ValueDeletable};
-use crate::utils::{system_time_from_millis, system_time_to_millis};
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::{Rng, RngCore};
@@ -12,7 +11,6 @@ use std::collections::{BTreeMap, VecDeque};
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, RangeBounds};
 use std::sync::atomic::{AtomicI64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Asserts that the iterator returns the exact set of expected values in correct order.
 pub(crate) async fn assert_iterator<T: KeyValueIterator>(iterator: &mut T, entries: Vec<RowEntry>) {

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -115,32 +115,6 @@ impl LogicalClock for TestClock {
     }
 }
 
-pub(crate) struct TokioClock {
-    initial_ts: u128,
-    initial_instant: tokio::time::Instant,
-}
-
-impl TokioClock {
-    pub(crate) fn new() -> Self {
-        let ts_millis = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis();
-
-        Self {
-            initial_ts: ts_millis,
-            initial_instant: tokio::time::Instant::now(),
-        }
-    }
-}
-
-impl LogicalClock for TokioClock {
-    fn now(&self) -> i64 {
-        let elapsed = tokio::time::Instant::now().duration_since(self.initial_instant);
-        (self.initial_ts + elapsed.as_millis()) as i64
-    }
-}
-
 pub(crate) fn gen_rand_bytes(n: usize) -> Bytes {
     let mut rng = crate::rand::thread_rng();
     let random_bytes: Vec<u8> = (0..n).map(|_| rng.gen()).collect();

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -115,29 +115,6 @@ impl LogicalClock for TestClock {
     }
 }
 
-pub(crate) struct TestSystemClock {
-    pub(crate) time_since_epoch_ms: AtomicI64,
-}
-
-impl TestSystemClock {
-    pub(crate) fn new() -> TestSystemClock {
-        TestSystemClock {
-            time_since_epoch_ms: AtomicI64::new(system_time_to_millis(SystemTime::now())),
-        }
-    }
-
-    pub(crate) fn advance(&self, duration: Duration) {
-        self.time_since_epoch_ms
-            .fetch_add(duration.as_millis() as i64, Ordering::SeqCst);
-    }
-}
-
-impl SystemClock for TestSystemClock {
-    fn now(&self) -> SystemTime {
-        system_time_from_millis(self.time_since_epoch_ms.load(Ordering::SeqCst))
-    }
-}
-
 pub(crate) struct TokioClock {
     initial_ts: u128,
     initial_instant: tokio::time::Instant,

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -151,7 +151,7 @@ pub(crate) fn system_time_from_millis(ms: i64) -> SystemTime {
         UNIX_EPOCH + Duration::from_millis(ms as u64)
     } else {
         // negative (including i64::MIN): convert to i128, take abs, cast back to u64
-        let abs_ms = (ms as i128).abs() as u64;
+        let abs_ms = (ms as i128).unsigned_abs() as u64;
         UNIX_EPOCH - Duration::from_millis(abs_ms)
     }
 }


### PR DESCRIPTION
This PR does the following:

- Creates `LogicalTime` and `SystemTime` types, which return i64 and `SystemTime`, respectively.
- Creates a `DefaultSystemTime` that replaced `TokioClock`. This clock gives us normal SystemTimes by default, but allows us to pause the tokio runtime to take control of the clock for DST.
- Creates a `DefaultLogicalTime` that simply uses `DefaultSystemTime` inside.
- Replaces all usage of `Clock` with `LogicalClock`.
- Adds `with_system_clock` and changes `with_clock` to `with_logical_clock`

This PR is a less ambitious version of @calavera's PR (#586). Unlike #586, this PR does not...

1. Attempt to replace all usage of system time (SystemTime::now() and tokio time) with a SystemClock.
2. Attempt to move MonotonicClock. Those two steps are left for future PRs.

These two steps will be left for a follow-on PR.