### PR TITLE
Use `SystemClock` instead of `std::time`

### DIFF
--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -170,6 +170,7 @@ async fn exec_gc_once(
             min_age,
         })
     }
+    let system_clock = Arc::new(DefaultSystemClock::default());
     let gc_opts = match resource {
         GcResource::Manifest => GarbageCollectorOptions {
             manifest_options: create_gc_dir_opts(min_age),
@@ -187,7 +188,7 @@ async fn exec_gc_once(
             compacted_options: create_gc_dir_opts(min_age),
         },
     };
-    run_gc_once(path, object_store, gc_opts).await?;
+    run_gc_once(path, object_store, gc_opts, system_clock).await?;
     Ok(())
 }
 

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -5,6 +5,7 @@ use slatedb::admin;
 use slatedb::admin::{
     list_checkpoints, list_manifests, read_manifest, run_gc_in_background, run_gc_once,
 };
+use slatedb::clock::DefaultSystemClock;
 use slatedb::config::{
     CheckpointOptions, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
 };
@@ -204,12 +205,20 @@ async fn schedule_gc(
             min_age: schedule.min_age,
         })
     }
+    let system_clock = Arc::new(DefaultSystemClock::default());
     let gc_opts = GarbageCollectorOptions {
         manifest_options: manifest_schedule.and_then(create_gc_dir_opts),
         wal_options: wal_schedule.and_then(create_gc_dir_opts),
         compacted_options: compacted_schedule.and_then(create_gc_dir_opts),
     };
 
-    run_gc_in_background(path, object_store, gc_opts, cancellation_token).await?;
+    run_gc_in_background(
+        path,
+        object_store,
+        gc_opts,
+        cancellation_token,
+        system_clock,
+    )
+    .await?;
     Ok(())
 }

--- a/slatedb/clippy.toml
+++ b/slatedb/clippy.toml
@@ -36,6 +36,8 @@ disallowed-types   = [
     { path = "rand_xoshiro::Xoshiro512Plus", reason = "Only our rand.rs may touch this" },
     { path = "rand_xoshiro::Xoshiro512PlusPlus", reason = "Only our rand.rs may touch this" },
     { path = "rand_xoshiro::Xoshiro512StarStar", reason = "Only our rand.rs may touch this" },
+    { path = "uuid::Builder", reason = "Only our utils.rs may touch this" },
+    { path = "ulid::Generator", reason = "Only our utils.rs may touch this" },
 ]
 disallowed-methods = [
     { path = "rand::random", reason = "Only our rand.rs may touch this" },
@@ -43,4 +45,12 @@ disallowed-methods = [
     { path = "rand::prelude::random", reason = "Only our rand.rs may touch this" },
     { path = "rand::prelude::thread_rng", reason = "Only our rand.rs may touch this" },
     { path = "std::time::SystemTime::now", reason = "Only our clock.rs may touch this" },
+    { path = "ulid::Ulid::new", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v1", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v3", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v4", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v5", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v6", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v7", reason = "Only our utils.rs may touch this" },
+    { path = "uuid::Uuid::new_v8", reason = "Only our utils.rs may touch this" },
 ]

--- a/slatedb/clippy.toml
+++ b/slatedb/clippy.toml
@@ -42,4 +42,5 @@ disallowed-methods = [
     { path = "rand::thread_rng", reason = "Only our rand.rs may touch this" },
     { path = "rand::prelude::random", reason = "Only our rand.rs may touch this" },
     { path = "rand::prelude::thread_rng", reason = "Only our rand.rs may touch this" },
+    { path = "std::time::SystemTime::now", reason = "Only our clock.rs may touch this" },
 ]

--- a/slatedb/clippy.toml
+++ b/slatedb/clippy.toml
@@ -46,6 +46,7 @@ disallowed-methods = [
     { path = "rand::prelude::random", reason = "Only our rand.rs may touch this" },
     { path = "rand::prelude::thread_rng", reason = "Only our rand.rs may touch this" },
     { path = "std::time::SystemTime::now", reason = "Only our clock.rs may touch this" },
+    { path = "chrono::Utc::now", reason = "Only our clock.rs may touch this" },
     { path = "ulid::Ulid::new", reason = "Only our utils.rs may touch this" },
     { path = "uuid::Uuid::new_v1", reason = "Only our utils.rs may touch this" },
     { path = "uuid::Uuid::new_v3", reason = "Only our utils.rs may touch this" },

--- a/slatedb/clippy.toml
+++ b/slatedb/clippy.toml
@@ -38,6 +38,7 @@ disallowed-types   = [
     { path = "rand_xoshiro::Xoshiro512StarStar", reason = "Only our rand.rs may touch this" },
     { path = "uuid::Builder", reason = "Only our utils.rs may touch this" },
     { path = "ulid::Generator", reason = "Only our utils.rs may touch this" },
+    { path = "std::time::Instant", reason = "Use tokio::time::Instant instead" },
 ]
 disallowed-methods = [
     { path = "rand::random", reason = "Only our rand.rs may touch this" },

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1,4 +1,5 @@
 use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
+use crate::clock::SystemClock;
 use crate::config::{CheckpointOptions, GarbageCollectorOptions};
 use crate::error::SlateDBError;
 use crate::garbage_collector::stats::GcStats;
@@ -155,6 +156,7 @@ pub async fn run_gc_in_background(
     object_store: Arc<dyn ObjectStore>,
     gc_opts: GarbageCollectorOptions,
     cancellation_token: CancellationToken,
+    system_clock: Arc<dyn SystemClock>,
 ) -> Result<(), Box<dyn Error>> {
     let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
     manifest_store
@@ -179,6 +181,7 @@ pub async fn run_gc_in_background(
         stats,
         ct,
         gc_opts,
+        system_clock,
     ));
     tracker.close();
 

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -123,6 +123,7 @@ pub async fn run_gc_once(
     path: &Path,
     object_store: Arc<dyn ObjectStore>,
     gc_opts: GarbageCollectorOptions,
+    system_clock: Arc<dyn SystemClock>,
 ) -> Result<(), Box<dyn Error>> {
     let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
     manifest_store
@@ -137,7 +138,14 @@ pub async fn run_gc_once(
     ));
 
     let stats = Arc::new(StatRegistry::new());
-    GarbageCollector::run_gc_once(manifest_store, table_store, stats, gc_opts).await;
+    GarbageCollector::run_gc_once_with_clock(
+        manifest_store,
+        table_store,
+        stats,
+        gc_opts,
+        system_clock,
+    )
+    .await;
     Ok(())
 }
 

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -446,6 +446,7 @@ mod tests {
     use crate::cached_object_store::stats::CachedObjectStoreStats;
     use crate::cached_object_store::storage_fs::FsCacheStorage;
     use crate::cached_object_store::{storage::PartID, storage_fs::FsCacheEntry};
+    use crate::clock::DefaultSystemClock;
     use crate::stats::StatRegistry;
     use crate::test_utils::gen_rand_bytes;
 
@@ -480,6 +481,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
 
         let part_size = 1024;
@@ -550,6 +552,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
 
         let cached_store =
@@ -593,6 +596,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
 
         let cached_store =
@@ -681,6 +685,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
         let cached_store =
             CachedObjectStore::new(object_store, cache_storage, 1024, stats).unwrap();
@@ -702,6 +707,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
         let cached_store =
             CachedObjectStore::new(object_store, cache_storage, 1024, stats).unwrap();
@@ -731,6 +737,7 @@ mod tests {
             None,
             None,
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
         let cached_store =
             CachedObjectStore::new(object_store.clone(), cache_storage, 1024, stats).unwrap();

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -656,7 +656,7 @@ fn wrap_io_err(err: impl std::error::Error + Send + Sync + 'static) -> object_st
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::stats::StatRegistry;
+    use crate::{clock::DefaultSystemClock, stats::StatRegistry};
     use crate::test_utils::gen_rand_bytes;
     use filetime::FileTime;
     use std::{io::Write, sync::atomic::Ordering, time::SystemTime};
@@ -690,19 +690,19 @@ mod tests {
 
         let path0 = gen_rand_file(temp_dir.path(), "file0", 1024);
         let evicted = evictor
-            .track_entry_accessed(path0, 1024, SystemTime::now(), true)
+            .track_entry_accessed(path0, 1024, DefaultSystemClock::default().now(), true)
             .await;
         assert_eq!(evicted, 0);
 
         let path1 = gen_rand_file(temp_dir.path(), "file1", 1024);
         let evicted = evictor
-            .track_entry_accessed(path1, 1024, SystemTime::now(), true)
+            .track_entry_accessed(path1, 1024, DefaultSystemClock::default().now(), true)
             .await;
         assert_eq!(evicted, 0);
 
         let path2 = gen_rand_file(temp_dir.path(), "file2", 1024);
         let evicted = evictor
-            .track_entry_accessed(path2, 1024, SystemTime::now(), true)
+            .track_entry_accessed(path2, 1024, DefaultSystemClock::default().now(), true)
             .await;
         assert_eq!(evicted, 2048);
 

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, SystemTime};
 use std::{fmt::Display, io::SeekFrom};
 
 use crate::cached_object_store::stats::CachedObjectStoreStats;
+use crate::clock::SystemClock;
 use bytes::Bytes;
 use object_store::path::Path;
 use object_store::{Attributes, ObjectMeta};
@@ -34,6 +35,7 @@ impl FsCacheStorage {
         max_cache_size_bytes: Option<usize>,
         scan_interval: Option<Duration>,
         stats: Arc<CachedObjectStoreStats>,
+        system_clock: Arc<dyn SystemClock>,
     ) -> Self {
         let evictor = max_cache_size_bytes.map(|max_cache_size_bytes| {
             Arc::new(FsCacheEvictor::new(
@@ -41,6 +43,7 @@ impl FsCacheStorage {
                 max_cache_size_bytes,
                 scan_interval,
                 stats,
+                system_clock,
             ))
         });
 
@@ -325,6 +328,7 @@ struct FsCacheEvictor {
     background_evict_handle: OnceCell<tokio::task::JoinHandle<()>>,
     background_scan_handle: OnceCell<tokio::task::JoinHandle<()>>,
     stats: Arc<CachedObjectStoreStats>,
+    system_clock: Arc<dyn SystemClock>,
 }
 
 impl FsCacheEvictor {
@@ -333,6 +337,7 @@ impl FsCacheEvictor {
         max_cache_size_bytes: usize,
         scan_interval: Option<Duration>,
         stats: Arc<CachedObjectStoreStats>,
+        system_clock: Arc<dyn SystemClock>,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(100);
         Self {
@@ -344,6 +349,7 @@ impl FsCacheEvictor {
             background_evict_handle: OnceCell::new(),
             background_scan_handle: OnceCell::new(),
             stats,
+            system_clock,
         }
     }
 
@@ -368,7 +374,11 @@ impl FsCacheEvictor {
 
         // start the background evictor task, it'll be triggered whenever a new cache entry is added
         self.background_evict_handle
-            .set(tokio::spawn(Self::background_evict(inner, rx)))
+            .set(tokio::spawn(Self::background_evict(
+                inner,
+                rx,
+                self.system_clock.clone(),
+            )))
             .ok();
     }
 
@@ -379,12 +389,13 @@ impl FsCacheEvictor {
     async fn background_evict(
         inner: Arc<FsCacheEvictorInner>,
         mut rx: tokio::sync::mpsc::Receiver<FsCacheEvictorWork>,
+        system_clock: Arc<dyn SystemClock>,
     ) {
         loop {
             match rx.recv().await {
                 Some((path, bytes, evict)) => {
                     inner
-                        .track_entry_accessed(path, bytes, SystemTime::now(), evict)
+                        .track_entry_accessed(path, bytes, system_clock.now(), evict)
                         .await;
                 }
                 None => return,

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -656,8 +656,8 @@ fn wrap_io_err(err: impl std::error::Error + Send + Sync + 'static) -> object_st
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{clock::DefaultSystemClock, stats::StatRegistry};
     use crate::test_utils::gen_rand_bytes;
+    use crate::{clock::DefaultSystemClock, stats::StatRegistry};
     use filetime::FileTime;
     use std::{io::Write, sync::atomic::Ordering, time::SystemTime};
 

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -137,7 +137,7 @@ mod tests {
     use object_store::path::Path;
     use object_store::ObjectStore;
     use std::sync::Arc;
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     #[tokio::test]
     async fn test_should_create_checkpoint() {

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -137,7 +137,6 @@ impl Db {
 mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::checkpoint::CheckpointCreateResult;
-    use crate::clock::DefaultSystemClock;
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
     use crate::db_state::SsTableId;

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -118,6 +118,7 @@ mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::checkpoint::CheckpointCreateResult;
     use crate::clock::DefaultSystemClock;
+    use crate::clock::SystemClock;
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
     use crate::db_state::SsTableId;
@@ -179,7 +180,7 @@ mod tests {
             .unwrap();
         db.close().await.unwrap();
         let manifest_store = ManifestStore::new(&path, object_store.clone());
-        let checkpoint_time = SystemTime::now();
+        let checkpoint_time = DefaultSystemClock::default().now();
 
         let CheckpointCreateResult {
             id: checkpoint_id,

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -1,4 +1,4 @@
-use crate::clock::{DefaultSystemClock, SystemClock};
+use crate::clock::SystemClock;
 use crate::config::{CheckpointOptions, CheckpointScope};
 use crate::db::Db;
 use crate::error::SlateDBError;
@@ -66,26 +66,6 @@ impl Db {
         object_store: Arc<dyn ObjectStore>,
         id: Uuid,
         lifetime: Option<Duration>,
-    ) -> Result<(), SlateDBError> {
-        Self::refresh_checkpoint_with_clock(
-            path,
-            object_store,
-            id,
-            lifetime,
-            Arc::new(DefaultSystemClock::new()),
-        )
-        .await
-    }
-
-    /// Refresh the lifetime of an existing checkpoint. Takes the id of an existing checkpoint
-    /// and a lifetime, and sets the lifetime of the checkpoint to the specified lifetime. If
-    /// there is no checkpoint with the specified id, then this fn fails with
-    /// SlateDBError::InvalidDbState
-    async fn refresh_checkpoint_with_clock(
-        path: &Path,
-        object_store: Arc<dyn ObjectStore>,
-        id: Uuid,
-        lifetime: Option<Duration>,
         system_clock: Arc<dyn SystemClock>,
     ) -> Result<(), SlateDBError> {
         let manifest_store = Arc::new(ManifestStore::new(path, object_store));
@@ -137,6 +117,7 @@ impl Db {
 mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::checkpoint::CheckpointCreateResult;
+    use crate::clock::DefaultSystemClock;
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
     use crate::db_state::SsTableId;
@@ -344,6 +325,7 @@ mod tests {
             object_store.clone(),
             id,
             Some(Duration::from_secs(1000)),
+            Arc::new(DefaultSystemClock::new()),
         )
         .await
         .unwrap();
@@ -375,6 +357,7 @@ mod tests {
             object_store.clone(),
             crate::utils::uuid(),
             Some(Duration::from_secs(1000)),
+            Arc::new(DefaultSystemClock::new()),
         )
         .await;
 

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)]
+#![allow(clippy::disallowed_methods)]
 
 use std::{
     cmp,

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_types)]
+
 use std::{
     cmp,
     sync::{

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -2,6 +2,7 @@
 
 use std::{
     cmp,
+    fmt::Debug,
     sync::{
         atomic::{AtomicI64, Ordering},
         Arc,
@@ -17,7 +18,7 @@ use tracing::info;
 
 /// Defines the physical clock that SlateDB will use to measure time for things
 /// like garbage collection schedule ticks, compaction schedule ticks, and so on.
-pub trait SystemClock: Send + Sync {
+pub trait SystemClock: Debug + Send + Sync {
     fn now(&self) -> SystemTime;
 }
 
@@ -26,6 +27,7 @@ pub trait SystemClock: Send + Sync {
 ///
 /// In test cases, it is possible to advance the clock manually with
 /// `#[tokio::test(start_paused = true)]` and `tokio::time::sleep`.
+#[derive(Debug)]
 pub struct DefaultSystemClock {
     initial_ts: i64,
     initial_instant: tokio::time::Instant,
@@ -59,7 +61,7 @@ impl SystemClock for DefaultSystemClock {
 
 /// Defines the logical clock that SlateDB will use to measure time for things
 /// like TTL expiration.
-pub trait LogicalClock: Send + Sync {
+pub trait LogicalClock: Debug + Send + Sync {
     /// Returns a timestamp (typically measured in millis since the unix epoch),
     /// must return monotonically increasing numbers (this is enforced
     /// at runtime and will panic if the invariant is broken).
@@ -71,6 +73,7 @@ pub trait LogicalClock: Send + Sync {
     fn now(&self) -> i64;
 }
 
+#[derive(Debug)]
 pub struct DefaultLogicalClock {
     last_ts: AtomicI64,
     inner: Arc<dyn SystemClock>,

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -1,12 +1,17 @@
 use std::{
+    cmp,
     sync::{
         atomic::{AtomicI64, Ordering},
         Arc,
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use crate::utils::{system_time_from_millis, system_time_to_millis};
+use crate::{
+    utils::{system_time_from_millis, system_time_to_millis},
+    SlateDBError,
+};
+use tracing::info;
 
 /// Defines the physical clock that SlateDB will use to measure time for things
 /// like garbage collection schedule ticks, compaction schedule ticks, and so on.
@@ -19,13 +24,13 @@ pub trait SystemClock: Send + Sync {
 ///
 /// In test cases, it is possible to advance the clock manually with
 /// `#[tokio::test(start_paused = true)]` and `tokio::time::sleep`.
-pub(crate) struct DefaultSystemClock {
+pub struct DefaultSystemClock {
     initial_ts: i64,
     initial_instant: tokio::time::Instant,
 }
 
 impl DefaultSystemClock {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         let ts_millis = match SystemTime::now().duration_since(UNIX_EPOCH) {
             Ok(duration) => duration.as_millis() as i64, // Time is after the epoch
             Err(e) => -(e.duration().as_millis() as i64), // Time is before the epoch, return negative
@@ -89,5 +94,67 @@ impl LogicalClock for DefaultLogicalClock {
         let current_ts = system_time_to_millis(self.inner.now());
         self.last_ts.fetch_max(current_ts, Ordering::SeqCst);
         self.last_ts.load(Ordering::SeqCst)
+    }
+}
+
+/// SlateDB uses MonotonicClock internally so that it can enforce that clock ticks
+/// from the underlying implementation are monotonically increasing
+pub(crate) struct MonotonicClock {
+    pub(crate) last_tick: AtomicI64,
+    pub(crate) last_durable_tick: AtomicI64,
+    delegate: Arc<dyn LogicalClock>,
+}
+
+impl MonotonicClock {
+    pub(crate) fn new(delegate: Arc<dyn LogicalClock>, init_tick: i64) -> Self {
+        Self {
+            delegate,
+            last_tick: AtomicI64::new(init_tick),
+            last_durable_tick: AtomicI64::new(init_tick),
+        }
+    }
+
+    pub(crate) fn set_last_tick(&self, tick: i64) -> Result<i64, SlateDBError> {
+        self.enforce_monotonic(tick)
+    }
+
+    pub(crate) fn fetch_max_last_durable_tick(&self, tick: i64) -> i64 {
+        self.last_durable_tick.fetch_max(tick, Ordering::SeqCst)
+    }
+
+    pub(crate) fn get_last_durable_tick(&self) -> i64 {
+        self.last_durable_tick.load(Ordering::SeqCst)
+    }
+
+    pub(crate) async fn now(&self) -> Result<i64, SlateDBError> {
+        let tick = self.delegate.now();
+        match self.enforce_monotonic(tick) {
+            Err(SlateDBError::InvalidClockTick {
+                last_tick,
+                next_tick: _,
+            }) => {
+                let sync_millis = cmp::min(10_000, 2 * (last_tick - tick).unsigned_abs());
+                info!(
+                    "Clock tick {} is lagging behind the last known tick {}. \
+                    Sleeping {}ms to potentially resolve skew before returning InvalidClockTick.",
+                    tick, last_tick, sync_millis
+                );
+                tokio::time::sleep(Duration::from_millis(sync_millis)).await;
+                self.enforce_monotonic(self.delegate.now())
+            }
+            result => result,
+        }
+    }
+
+    fn enforce_monotonic(&self, tick: i64) -> Result<i64, SlateDBError> {
+        let updated_last_tick = self.last_tick.fetch_max(tick, Ordering::SeqCst);
+        if tick < updated_last_tick {
+            return Err(SlateDBError::InvalidClockTick {
+                last_tick: updated_last_tick,
+                next_tick: tick,
+            });
+        }
+
+        Ok(tick)
     }
 }

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -136,7 +136,7 @@ impl CompactionExecuteBench {
         val_bytes: usize,
     ) -> Result<(), SlateDBError> {
         let mut rng = crate::rand::thread_rng();
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         let mut suffix = Vec::<u8>::new();
         suffix.put_u32(i);
         let mut key_gen =
@@ -313,7 +313,7 @@ impl CompactionExecuteBench {
                 .await?
             }
         };
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         info!("start compaction job");
         tokio::task::spawn_blocking(move || executor.start_compaction(job));
         let WorkerToOrchestratorMsg::CompactionFinished { id: _, result } =

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -74,6 +74,7 @@ pub(crate) struct Compactor {
 }
 
 impl Compactor {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) async fn new(
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,
@@ -137,6 +138,7 @@ struct CompactorOrchestrator {
 }
 
 impl CompactorOrchestrator {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         options: CompactorOptions,
         manifest_store: Arc<ManifestStore>,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -131,6 +131,10 @@ impl Compactor {
 }
 
 struct CompactorOrchestrator {
+    // TODO: We need to migrate this to tokio::time::Instant for DST
+    // The current orchestrator implementation does not use the tokio runtime
+    // for for its run loop, so we can't make a tokio ticker yet.
+    #[allow(clippy::disallowed_types)]
     ticker: crossbeam_channel::Receiver<std::time::Instant>,
     external_rx: crossbeam_channel::Receiver<CompactorMainMsg>,
     worker_rx: crossbeam_channel::Receiver<WorkerToOrchestratorMsg>,

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -269,6 +269,7 @@ mod tests {
 
     use super::*;
     use crate::checkpoint::Checkpoint;
+    use crate::clock::{DefaultSystemClock, SystemClock};
     use crate::compactor_state::CompactionStatus::Submitted;
     use crate::compactor_state::SourceId::Sst;
     use crate::config::Settings;
@@ -523,7 +524,7 @@ mod tests {
             id: crate::utils::uuid(),
             manifest_id: 1,
             expire_time: None,
-            create_time: SystemTime::now(),
+            create_time: DefaultSystemClock::default().now(),
         };
         dirty.core.checkpoints.push(checkpoint.clone());
 
@@ -540,7 +541,7 @@ mod tests {
     where
         F: FnMut() -> Option<T>,
     {
-        let now = SystemTime::now();
+        let now = DefaultSystemClock::default().now();
         while now.elapsed().unwrap() < duration {
             let maybe_result = f();
             if maybe_result.is_some() {

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -265,7 +265,7 @@ impl CompactorState {
 mod tests {
     use std::sync::Arc;
     use std::thread::sleep;
-    use std::time::{Duration, SystemTime};
+    use std::time::Duration;
 
     use super::*;
     use crate::checkpoint::Checkpoint;

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3362,7 +3362,7 @@ mod tests {
         cond: impl Fn(&CoreDbState) -> bool,
         timeout: Duration,
     ) -> CoreDbState {
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         while start.elapsed() < timeout {
             let manifest = sm.refresh().await.unwrap();
             if cond(&manifest.core) {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -969,6 +969,7 @@ mod tests {
     };
     use crate::cached_object_store::{CachedObjectStore, FsCacheStorage};
     use crate::cached_object_store_stats::CachedObjectStoreStats;
+    use crate::clock::DefaultSystemClock;
     use crate::config::DurabilityLevel::{Memory, Remote};
     use crate::config::{
         CompactorOptions, ObjectStoreCacheOptions, Settings, SizeTieredCompactionSchedulerOptions,
@@ -1503,6 +1504,7 @@ mod tests {
             None,
             None,
             cache_stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         ));
 
         let cached_object_store = CachedObjectStore::new(

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -33,6 +33,7 @@ use tokio_util::sync::CancellationToken;
 use crate::batch::WriteBatch;
 use crate::batch_write::{WriteBatchMsg, WriteBatchRequest};
 use crate::bytes_range::BytesRange;
+use crate::clock::MonotonicClock;
 use crate::clock::{LogicalClock, SystemClock};
 use crate::compactor::Compactor;
 use crate::config::{PutOptions, ReadOptions, ScanOptions, Settings, WriteOptions};
@@ -49,7 +50,6 @@ use crate::reader::Reader;
 use crate::sst_iter::SstIteratorOptions;
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
-use crate::utils::MonotonicClock;
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use tracing::{info, warn};
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -441,7 +441,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                         let mut state = cleanup_inner.state.write();
                         state.record_fatal_error(err.clone())
                     },
-                    system_clock,
+                    system_clock.clone(),
                 )
                 .await?,
             )
@@ -469,6 +469,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                     let mut state = cleanup_inner.state.write();
                     state.record_fatal_error(err.clone())
                 },
+                system_clock.clone(),
             ));
         }
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -284,6 +284,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                             .max_cache_size_bytes,
                         self.settings.object_store_cache_options.scan_interval,
                         stats.clone(),
+                        system_clock.clone(),
                     ));
 
                     let cached_main_object_store = CachedObjectStore::new(

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -371,7 +371,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             DbInner::new(
                 self.settings.clone(),
                 logical_clock,
-                system_clock,
+                system_clock.clone(),
                 table_store.clone(),
                 manifest.prepare_dirty()?,
                 wal_flush_tx,
@@ -440,6 +440,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                         let mut state = cleanup_inner.state.write();
                         state.record_fatal_error(err.clone())
                     },
+                    system_clock,
                 )
                 .await?,
             )

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -12,10 +12,11 @@
 //! To use the cache, you need to configure the [DbOptions](crate::config::DbOptions) with the desired cache implementation.
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
+use tokio::time::Instant;
 use tracing::{debug, error};
 
 use crate::db_cache::stats::DbCacheStats;

--- a/slatedb/src/db_cache/moka.rs
+++ b/slatedb/src/db_cache/moka.rs
@@ -81,10 +81,14 @@ impl MokaCache {
             .weigher(|_, v: &CachedEntry| v.size() as u32)
             .max_capacity(options.max_capacity);
 
+        // TODO: We need to use a SystemClock for DST support
+        // Moka does not currently allow us to inject a clock.
         if let Some(ttl) = options.time_to_live {
             builder = builder.time_to_live(ttl);
         }
 
+        // TODO: We need to use a SystemClock for DST support
+        // Moka does not currently allow us to inject a clock.
         if let Some(tti) = options.time_to_idle {
             builder = builder.time_to_idle(tti);
         }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1,5 +1,7 @@
 use crate::bytes_range::BytesRange;
-use crate::clock::{DefaultLogicalClock, DefaultSystemClock, LogicalClock, SystemClock};
+use crate::clock::{
+    DefaultLogicalClock, DefaultSystemClock, LogicalClock, MonotonicClock, SystemClock,
+};
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
 use crate::db_reader::ManifestPollerMsg::Shutdown;
 use crate::db_state::CoreDbState;
@@ -13,7 +15,7 @@ use crate::sst_iter::SstIteratorOptions;
 use crate::stats::StatRegistry;
 use crate::store_provider::{DefaultStoreProvider, StoreProvider};
 use crate::tablestore::TableStore;
-use crate::utils::{MonotonicClock, WatchableOnceCell};
+use crate::utils::WatchableOnceCell;
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{utils, Checkpoint, DbIterator};
 use bytes::Bytes;

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -533,6 +533,7 @@ impl DbState {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
+    use crate::clock::{DefaultSystemClock, SystemClock};
     use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::proptest_util::arbitrary;
@@ -543,7 +544,6 @@ mod tests {
     use std::collections::BTreeSet;
     use std::collections::Bound::Included;
     use std::ops::RangeBounds;
-    use std::time::SystemTime;
 
     #[test]
     fn test_should_merge_db_state_with_new_checkpoints() {
@@ -556,7 +556,7 @@ mod tests {
             id: crate::utils::uuid(),
             manifest_id: 1,
             expire_time: None,
-            create_time: SystemTime::now(),
+            create_time: DefaultSystemClock::default().now(),
         };
         updated_state.core.checkpoints.push(checkpoint.clone());
 

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -419,7 +419,7 @@ mod tests {
             id: crate::utils::uuid(),
             manifest_id,
             expire_time,
-            create_time: SystemTime::now(),
+            create_time: DefaultSystemClock::default().now(),
         }
     }
 
@@ -464,7 +464,8 @@ mod tests {
                 .unwrap();
 
         // Manifest 2 (expired_checkpoint_id -> 1)
-        let one_day_ago = SystemTime::now()
+        let one_day_ago = DefaultSystemClock::default()
+            .now()
             .checked_sub(std::time::Duration::from_secs(86400))
             .unwrap();
         let _expired_checkpoint_id =
@@ -472,7 +473,8 @@ mod tests {
                 .await
                 .unwrap();
         // Manifest 3 (expired_checkpoint_id -> 1, unexpired_checkpoint_id -> 2)
-        let one_day_ahead = SystemTime::now()
+        let one_day_ahead = DefaultSystemClock::default()
+            .now()
             .checked_add(std::time::Duration::from_secs(86400))
             .unwrap();
         let unexpired_checkpoint_id =
@@ -1043,7 +1045,8 @@ mod tests {
     ) -> DateTime<Utc> {
         let file = local_object_store.path_to_filesystem(path).unwrap();
         let file = File::open(file).unwrap();
-        let now_minus_24h = SystemTime::now()
+        let now_minus_24h = DefaultSystemClock::default()
+            .now()
             .checked_sub(std::time::Duration::from_secs(seconds_ago))
             .unwrap();
         file.set_modified(now_minus_24h).unwrap();

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -136,9 +136,9 @@ impl GarbageCollector {
                     info!("Garbage collector received shutdown signal... shutting down");
                     break;
                 },
-                _ = manifest_ticker.tick() => { run_gc_task(manifest_store.clone(), &mut manifest_gc_task).await; },
-                _ = wal_ticker.tick() => { run_gc_task(manifest_store.clone(), &mut wal_gc_task).await; },
-                _ = compacted_ticker.tick() => { run_gc_task(manifest_store.clone(), &mut compacted_gc_task).await; },
+                _ = manifest_ticker.tick() => { run_gc_task_with_clock(manifest_store.clone(), &mut manifest_gc_task, system_clock.clone()).await; },
+                _ = wal_ticker.tick() => { run_gc_task_with_clock(manifest_store.clone(), &mut wal_gc_task, system_clock.clone()).await; },
+                _ = compacted_ticker.tick() => { run_gc_task_with_clock(manifest_store.clone(), &mut compacted_gc_task, system_clock.clone()).await; },
                 _ = log_ticker.tick() => {
                     debug!("GC has collected {} Manifests, {} WAL SSTs and {} Compacted SSTs.",
                          stats.gc_manifest_count.value.load(Ordering::SeqCst),

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -160,6 +160,7 @@ impl GarbageCollector {
 
     // Keep this private to protect aggainst accidentally using the default clock.
     // External users are forced to use the clock explicitly.
+    #[cfg(test)]
     async fn run_gc_once(
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -747,6 +747,7 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
+    use crate::clock::{DefaultSystemClock, SystemClock};
     use crate::config::CheckpointOptions;
     use crate::db_state::CoreDbState;
     use crate::error;
@@ -1055,7 +1056,8 @@ mod tests {
     }
 
     fn now_rounded_to_nearest_sec() -> SystemTime {
-        let now_secs = SystemTime::now()
+        let now_secs = DefaultSystemClock::default()
+            .now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -1,4 +1,5 @@
 use crate::bytes_range::BytesRange;
+use crate::clock::MonotonicClock;
 use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
 use crate::db_state::{CoreDbState, SortedRun, SsTableHandle};
 use crate::db_stats::DbStats;
@@ -12,7 +13,7 @@ use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::types::{RowEntry, ValueDeletable};
-use crate::utils::{get_now_for_read, is_not_expired, MonotonicClock};
+use crate::utils::{get_now_for_read, is_not_expired};
 use crate::{filter, DbIterator, SlateDBError};
 use bytes::Bytes;
 use futures::future::BoxFuture;

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -95,6 +95,7 @@ impl KeyValueIterator for TestIterator {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct TestClock {
     pub(crate) ticker: AtomicI64,
 }

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -95,6 +95,7 @@ impl KeyValueIterator for TestIterator {
     }
 }
 
+// TODO can we get rid of TestClock?
 #[derive(Debug)]
 pub(crate) struct TestClock {
     pub(crate) ticker: AtomicI64,

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -10,7 +10,7 @@ use std::future::Future;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use ulid::Ulid;
-use uuid::{Builder, Uuid};
+use uuid::Uuid;
 
 static EMPTY_KEY: Bytes = Bytes::new();
 
@@ -249,10 +249,11 @@ fn compute_lower_bound(prev_block_last_key: &Bytes, this_block_first_key: &Bytes
     this_block_first_key.slice(..prev_block_last_key.len() + 1)
 }
 
+#[allow(clippy::disallowed_types)]
 pub(crate) fn uuid() -> Uuid {
     let mut random_bytes = [0; 16];
     crate::rand::thread_rng().fill_bytes(&mut random_bytes);
-    Builder::from_random_bytes(random_bytes).into_uuid()
+    uuid::Builder::from_random_bytes(random_bytes).into_uuid()
 }
 
 pub(crate) fn ulid() -> Ulid {


### PR DESCRIPTION
This PR updates SlateDB to use `SystemTime` instead of the typical `std` system clock. It's part of the work for #267.

The following changes usages of SystemTime have been updated:

- Moved `MonotonicClock` into `clock.rs`
- Made `clippy.toml` detect `std::time`, `uuid`, and `ulid` usage
- checkpoint.rs uses SystemTime::now()
- config.rs's SystemClock, which is used for TTL and checkpoint times.
- CompactorEventHandler::finish_compaction uses SystemTime::now() for logging last compaction timestamp in stats.
- db_cache/mod.rs uses Instant::now() when setting last_err_log_instant
- garbage_collector.rs uses Utc::now() in run_gc_task.
- storage_fs.rs::background_evict uses SystemTime::now()

I could not update the following two usages:

1. In moka.rs if ttl or tti are set. (Note: it appears Foyer only supports max capacity)
2. CompactorOrchestrator uses a non-async crossbeam ticker, which uses std::time::Interval.

For (1), Moka simply doesn't provide a way to inject our clock. There are interfaces for it, but they're all hidden behind `#[cfg(test)]` and `pub(crate)` stuff.

For (2), I will probably refactor `CompactorOrchestrator` to use an async run loop in a separate PR.

I'm not crazy about the changes I had to make to GarbageCollector; they feel invasive. I believe it's more a symptom of the widespread use of associated function rather than a problem with the SystemClock design.

Follow on work:

- Remove `TestClock` since we have control over `DefaultSystemClock` with `tokio`
- Make `CompactorOrchestrator::run` async so we can use tokio's ticker (and thus, its Instant)
- Investigate standardizing how we inject determinism.

Regarding that last point, I have managed to introduce two (and soon to be three) different ways to inject determinism:

- `rand` uses static functions and variables
- `SystemClock`/`LogicalClock` use dependency injection
- `sos-vfs::fs` uses macros to swap `tokio::fs` out at compile time (I haven't submitted a PR for this yet)

It's annoying me that we have three different styles. I'm not 100% sure if it's bad or not; I need to think about it. I wonder if we should use static functions/variables for the clock stuff as well (crate::clock::sys::now() and crate::clock::logical::now()). It seems like it'd add more complexity (global onecell vs. dependency injection) for pretty minimal payoff. It also gives us less fine-grained control. Perhaps we should go the other way, and pass Rng's using dependency injection? Or just leave things as-is? WDYT? (I should note: I'm not enthusiastic about exposing `Rng` through our API. That library breaks compatibility in frustrating ways and it's already caused a lot of problems with proptest/uuid/ulid compatibility)