### PR TITLE
Add `Admin` and `AdminBuilder`

### DIFF
--- a/slatedb-bencher/src/main.rs
+++ b/slatedb-bencher/src/main.rs
@@ -14,7 +14,6 @@ use object_store::ObjectStore;
 use object_store::PutPayload;
 use object_store::PutResult;
 use slatedb::admin;
-use slatedb::admin::AdminBuilder;
 use slatedb::compaction_execute_bench::CompactionExecuteBench;
 use slatedb::config::WriteOptions;
 use slatedb::Db;

--- a/slatedb-bencher/src/main.rs
+++ b/slatedb-bencher/src/main.rs
@@ -7,12 +7,14 @@ use bytes::Bytes;
 use clap::Parser;
 use db::DbBench;
 use futures::StreamExt;
+use futures::TryStreamExt;
 use object_store::path::Path;
 use object_store::Error as ObjectStoreError;
 use object_store::ObjectStore;
 use object_store::PutPayload;
 use object_store::PutResult;
 use slatedb::admin;
+use slatedb::admin::AdminBuilder;
 use slatedb::compaction_execute_bench::CompactionExecuteBench;
 use slatedb::config::WriteOptions;
 use slatedb::Db;
@@ -155,7 +157,7 @@ async fn cleanup_data(
     let temp_path = path.child(CLEANUP_NAME);
     if object_store.head(&temp_path).await.is_ok() {
         info!("Cleaning up test data in: {}", path);
-        if let Err(e) = admin::delete_objects_with_prefix(object_store.clone(), Some(path)).await {
+        if let Err(e) = delete_objects_with_prefix(object_store.clone(), Some(path)).await {
             error!("Error cleaning up test data: {}", e);
         }
     } else {
@@ -165,4 +167,22 @@ async fn cleanup_data(
         );
     }
     Ok(())
+}
+
+/// Deletes all objects with the specified prefix. This includes all
+/// "subdirectories" objects, since object stores are not hierarchical.
+async fn delete_objects_with_prefix(
+    object_store: Arc<dyn ObjectStore>,
+    maybe_prefix: Option<&Path>,
+) -> Result<(), Box<dyn Error>> {
+    let stream = object_store
+        .list(maybe_prefix)
+        .map_ok(|m| m.location)
+        .boxed();
+    object_store
+        .delete_stream(stream)
+        .try_collect::<Vec<Path>>()
+        .await
+        .map(|_| ())
+        .map_err(|e| e.into())
 }

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -12,74 +12,298 @@ use crate::tablestore::TableStore;
 use crate::clone;
 use crate::object_stores::ObjectStores;
 use fail_parallel::FailPointRegistry;
-use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::ObjectStore;
 use std::env;
 use std::error::Error;
 use std::ops::RangeBounds;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use uuid::Uuid;
 
-/// read-only access to the latest manifest file
-pub async fn read_manifest(
-    path: &Path,
-    object_store: Arc<dyn ObjectStore>,
-    maybe_id: Option<u64>,
-) -> Result<Option<String>, Box<dyn Error>> {
-    let manifest_store = ManifestStore::new(path, object_store);
-    let id_manifest = if let Some(id) = maybe_id {
-        manifest_store
-            .try_read_manifest(id)
-            .await?
-            .map(|manifest| (id, manifest))
-    } else {
-        manifest_store.try_read_latest_manifest().await?
-    };
+pub use crate::db::builder::AdminBuilder;
 
-    match id_manifest {
-        None => Ok(None),
-        Some(result) => Ok(Some(serde_json::to_string(&result)?)),
+/// An Admin struct for SlateDB administration operations.
+///
+/// This struct provides methods for administrative functions such as
+/// reading manifests, creating checkpoints, cloning databases, and
+/// running garbage collection.
+pub struct Admin {
+    /// The path to the database.
+    pub path: Path,
+    /// The object store to use for the database.
+    pub object_store: Arc<dyn ObjectStore>,
+    /// The system clock to use for operations.
+    pub system_clock: Arc<dyn SystemClock>,
+}
+
+impl Admin {
+    /// Read-only access to the latest manifest file
+    pub async fn read_manifest(
+        &self,
+        maybe_id: Option<u64>,
+    ) -> Result<Option<String>, Box<dyn Error>> {
+        let manifest_store = ManifestStore::new(&self.path, self.object_store.clone());
+        let id_manifest = if let Some(id) = maybe_id {
+            manifest_store
+                .try_read_manifest(id)
+                .await?
+                .map(|manifest| (id, manifest))
+        } else {
+            manifest_store.try_read_latest_manifest().await?
+        };
+
+        match id_manifest {
+            None => Ok(None),
+            Some(result) => Ok(Some(serde_json::to_string(&result)?)),
+        }
     }
-}
 
-pub async fn list_manifests<R: RangeBounds<u64>>(
-    path: &Path,
-    object_store: Arc<dyn ObjectStore>,
-    range: R,
-) -> Result<String, Box<dyn Error>> {
-    let manifest_store = ManifestStore::new(path, object_store);
-    let manifests = manifest_store.list_manifests(range).await?;
-    Ok(serde_json::to_string(&manifests)?)
-}
+    /// List manifests within a range
+    pub async fn list_manifests<R: RangeBounds<u64>>(
+        &self,
+        range: R,
+    ) -> Result<String, Box<dyn Error>> {
+        let manifest_store = ManifestStore::new(&self.path, self.object_store.clone());
+        let manifests = manifest_store.list_manifests(range).await?;
+        Ok(serde_json::to_string(&manifests)?)
+    }
 
-pub async fn list_checkpoints(
-    path: &Path,
-    object_store: Arc<dyn ObjectStore>,
-) -> Result<Vec<Checkpoint>, Box<dyn Error>> {
-    let manifest_store = ManifestStore::new(path, object_store);
-    let (_, manifest) = manifest_store.read_latest_manifest().await?;
-    Ok(manifest.core.checkpoints)
-}
+    /// List checkpoints
+    pub async fn list_checkpoints(&self) -> Result<Vec<Checkpoint>, Box<dyn Error>> {
+        let manifest_store = ManifestStore::new(&self.path, self.object_store.clone());
+        let (_, manifest) = manifest_store.read_latest_manifest().await?;
+        Ok(manifest.core.checkpoints)
+    }
 
-/// Deletes all objects with the specified prefix. This includes all
-/// "subdirectories" objects, since object stores are not hierarchical.
-pub async fn delete_objects_with_prefix(
-    object_store: Arc<dyn ObjectStore>,
-    maybe_prefix: Option<&Path>,
-) -> Result<(), Box<dyn Error>> {
-    let stream = object_store
-        .list(maybe_prefix)
-        .map_ok(|m| m.location)
-        .boxed();
-    object_store
-        .delete_stream(stream)
-        .try_collect::<Vec<Path>>()
-        .await
-        .map(|_| ())
-        .map_err(|e| e.into())
+    /// Run the garbage collector once in the foreground.
+    ///
+    /// This function runs the garbage collector letting Tokio decide when to run the task.
+    ///
+    /// # Arguments
+    ///
+    /// * `gc_opts`: The garbage collector options.
+    ///
+    pub async fn run_gc_once(
+        &self,
+        gc_opts: GarbageCollectorOptions,
+    ) -> Result<(), Box<dyn Error>> {
+        let manifest_store = Arc::new(ManifestStore::new(&self.path, self.object_store.clone()));
+        manifest_store
+            .validate_no_wal_object_store_configured()
+            .await?;
+        let sst_format = SsTableFormat::default(); // read only SSTs, can use default
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(self.object_store.clone(), None),
+            sst_format.clone(),
+            self.path.clone(),
+            None, // no need for cache in GC
+        ));
+
+        let stats = Arc::new(StatRegistry::new());
+        GarbageCollector::run_gc_once_with_clock(
+            manifest_store,
+            table_store,
+            stats,
+            gc_opts,
+            self.system_clock.clone(),
+        )
+        .await;
+        Ok(())
+    }
+
+    /// Run the garbage collector in the background.
+    ///
+    /// This function runs the garbage collector in a Tokio background task.
+    ///
+    /// # Arguments
+    ///
+    /// * `gc_opts`: The garbage collector options.
+    /// * `cancellation_token`: The cancellation token to stop the garbage collector.
+    pub async fn run_gc_in_background(
+        &self,
+        gc_opts: GarbageCollectorOptions,
+        cancellation_token: CancellationToken,
+    ) -> Result<(), Box<dyn Error>> {
+        let manifest_store = Arc::new(ManifestStore::new(&self.path, self.object_store.clone()));
+        manifest_store
+            .validate_no_wal_object_store_configured()
+            .await?;
+        let sst_format = SsTableFormat::default(); // read only SSTs, can use default
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(self.object_store.clone(), None),
+            sst_format.clone(),
+            self.path.clone(),
+            None, // no need for cache in GC
+        ));
+
+        let stats = Arc::new(GcStats::new(Arc::new(StatRegistry::new())));
+
+        let tracker = TaskTracker::new();
+        let ct = cancellation_token.clone();
+
+        tracker.spawn(GarbageCollector::start_async_task(
+            manifest_store,
+            table_store,
+            stats,
+            ct,
+            gc_opts,
+            self.system_clock.clone(),
+        ));
+        tracker.close();
+
+        tracker.wait().await;
+        Ok(())
+    }
+
+    /// Creates a checkpoint of the db stored in the object store at the specified path using the
+    /// provided options. The checkpoint will reference the current active manifest of the db.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use slatedb::admin::{Admin, AdminBuilder};
+    /// use slatedb::config::CheckpointOptions;
+    /// use slatedb::Db;
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::error::Error;
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn Error>> {
+    ///    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///    let db = Db::open("parent_path", Arc::clone(&object_store)).await?;
+    ///    db.put(b"key", b"value").await?;
+    ///    db.close().await?;
+    ///
+    ///    let admin = AdminBuilder::new("parent_path", object_store).build();
+    ///    let _ = admin.create_checkpoint(
+    ///      &CheckpointOptions::default(),
+    ///    ).await?;
+    ///
+    ///    Ok(())
+    /// }
+    /// ```
+    pub async fn create_checkpoint(
+        &self,
+        options: &CheckpointOptions,
+    ) -> Result<CheckpointCreateResult, SlateDBError> {
+        let manifest_store = Arc::new(ManifestStore::new(&self.path, self.object_store.clone()));
+        manifest_store
+            .validate_no_wal_object_store_configured()
+            .await?;
+        let mut stored_manifest = StoredManifest::load(manifest_store).await?;
+        let checkpoint = stored_manifest.write_checkpoint(None, options).await?;
+        Ok(CheckpointCreateResult {
+            id: checkpoint.id,
+            manifest_id: checkpoint.manifest_id,
+        })
+    }
+
+    /// Refresh the lifetime of an existing checkpoint. Takes the id of an existing checkpoint
+    /// and a lifetime, and sets the lifetime of the checkpoint to the specified lifetime. If
+    /// there is no checkpoint with the specified id, then this fn fails with
+    /// SlateDBError::InvalidDbState
+    pub async fn refresh_checkpoint(
+        &self,
+        id: Uuid,
+        lifetime: Option<Duration>,
+    ) -> Result<(), SlateDBError> {
+        let manifest_store = Arc::new(ManifestStore::new(&self.path, self.object_store.clone()));
+        let mut stored_manifest = StoredManifest::load(manifest_store).await?;
+        stored_manifest
+            .maybe_apply_manifest_update(|stored_manifest| {
+                let mut dirty = stored_manifest.prepare_dirty();
+                let expire_time = lifetime.map(|l| self.system_clock.now() + l);
+                let Some(_) = dirty.core.checkpoints.iter_mut().find_map(|c| {
+                    if c.id == id {
+                        c.expire_time = expire_time;
+                        return Some(());
+                    }
+                    None
+                }) else {
+                    return Err(SlateDBError::InvalidDBState);
+                };
+                Ok(Some(dirty))
+            })
+            .await
+    }
+
+    /// Deletes the checkpoint with the specified id.
+    pub async fn delete_checkpoint(&self, id: Uuid) -> Result<(), SlateDBError> {
+        let manifest_store = Arc::new(ManifestStore::new(&self.path, self.object_store.clone()));
+        let mut stored_manifest = StoredManifest::load(manifest_store).await?;
+        stored_manifest
+            .maybe_apply_manifest_update(|stored_manifest| {
+                let mut dirty = stored_manifest.prepare_dirty();
+                let checkpoints: Vec<Checkpoint> = dirty
+                    .core
+                    .checkpoints
+                    .iter()
+                    .filter(|c| c.id != id)
+                    .cloned()
+                    .collect();
+                dirty.core.checkpoints = checkpoints;
+                Ok(Some(dirty))
+            })
+            .await
+    }
+
+    /// Clone a database. If no db already exists at the specified path, then this will create
+    /// a new db under the path that is a clone of the db at parent_path.
+    ///
+    /// A clone is a shallow copy of the parent database - it starts with a manifest that
+    /// references the same SSTs, but doesn't actually copy those SSTs, except for the WAL.
+    /// New writes will be written to the newly created db and will not be reflected in the
+    /// parent database.
+    ///
+    /// The clone can optionally be created from an existing checkpoint. If
+    /// `parent_checkpoint` is present, then the referenced manifest is used
+    /// as the base for the clone db's manifest. Otherwise, this method creates a new checkpoint
+    /// for the current version of the parent db.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use slatedb::admin::{Admin, AdminBuilder};
+    /// use slatedb::Db;
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::error::Error;
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn Error>> {
+    ///    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    ///    let db = Db::open("parent_path", Arc::clone(&object_store)).await?;
+    ///    db.put(b"key", b"value").await?;
+    ///    db.close().await?;
+    ///
+    ///    let admin = AdminBuilder::new("clone_path", object_store).build();
+    ///    admin.create_clone(
+    ///      "parent_path",
+    ///      None,
+    ///    ).await?;
+    ///
+    ///    Ok(())
+    /// }
+    /// ```
+    pub async fn create_clone<P: Into<Path>>(
+        &self,
+        parent_path: P,
+        parent_checkpoint: Option<Uuid>,
+    ) -> Result<(), Box<dyn Error>> {
+        clone::create_clone(
+            self.path.clone(),
+            parent_path.into(),
+            self.object_store.clone(),
+            parent_checkpoint,
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 /// Loads an object store from configured environment variables.
@@ -107,94 +331,6 @@ pub fn load_object_store_from_env(
         "azure" => load_azure(),
         _ => Err(format!("Unknown CLOUD_PROVIDER: '{}'", provider).into()),
     }
-}
-
-/// Run the garbage collector once in the foreground.
-///
-/// This function runs the garbage collector letting Tokio decide when to run the task.
-///
-/// # Arguments
-///
-/// * `path`: The path to the database.
-/// * `object_store`: The object store to use.
-/// * `gc_opts`: The garbage collector options.
-///
-pub async fn run_gc_once(
-    path: &Path,
-    object_store: Arc<dyn ObjectStore>,
-    gc_opts: GarbageCollectorOptions,
-    system_clock: Arc<dyn SystemClock>,
-) -> Result<(), Box<dyn Error>> {
-    let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
-    manifest_store
-        .validate_no_wal_object_store_configured()
-        .await?;
-    let sst_format = SsTableFormat::default(); // read only SSTs, can use default
-    let table_store = Arc::new(TableStore::new(
-        ObjectStores::new(object_store.clone(), None),
-        sst_format.clone(),
-        path.clone(),
-        None, // no need for cache in GC
-    ));
-
-    let stats = Arc::new(StatRegistry::new());
-    GarbageCollector::run_gc_once_with_clock(
-        manifest_store,
-        table_store,
-        stats,
-        gc_opts,
-        system_clock,
-    )
-    .await;
-    Ok(())
-}
-
-/// Run the garbage collector in the background.
-///
-/// This function runs the garbage collector in a Tokio background task.
-///
-/// # Arguments
-///
-/// * `path`: The path to the database.
-/// * `object_store`: The object store to use.
-/// * `gc_opts`: The garbage collector options.
-/// * `cancellation_token`: The cancellation token to stop the garbage collector.
-pub async fn run_gc_in_background(
-    path: &Path,
-    object_store: Arc<dyn ObjectStore>,
-    gc_opts: GarbageCollectorOptions,
-    cancellation_token: CancellationToken,
-    system_clock: Arc<dyn SystemClock>,
-) -> Result<(), Box<dyn Error>> {
-    let manifest_store = Arc::new(ManifestStore::new(path, object_store.clone()));
-    manifest_store
-        .validate_no_wal_object_store_configured()
-        .await?;
-    let sst_format = SsTableFormat::default(); // read only SSTs, can use default
-    let table_store = Arc::new(TableStore::new(
-        ObjectStores::new(object_store.clone(), None),
-        sst_format.clone(),
-        path.clone(),
-        None, // no need for cache in GC
-    ));
-
-    let stats = Arc::new(GcStats::new(Arc::new(StatRegistry::new())));
-
-    let tracker = TaskTracker::new();
-    let ct = cancellation_token.clone();
-
-    tracker.spawn(GarbageCollector::start_async_task(
-        manifest_store,
-        table_store,
-        stats,
-        ct,
-        gc_opts,
-        system_clock,
-    ));
-    tracker.close();
-
-    tracker.wait().await;
-    Ok(())
 }
 
 /// Loads a local object store instance.
@@ -275,264 +411,4 @@ pub fn load_azure() -> Result<Arc<dyn ObjectStore>, Box<dyn Error>> {
         .with_access_key(key)
         .with_container_name(container);
     Ok(Arc::new(builder.build()?) as Arc<dyn ObjectStore>)
-}
-
-/// Creates a checkpoint of the db stored in the object store at the specified path using the
-/// provided options. The checkpoint will reference the current active manifest of the db.
-///
-/// # Examples
-///
-/// ```
-/// use slatedb::admin;
-/// use slatedb::config::CheckpointOptions;
-/// use slatedb::Db;
-/// use slatedb::object_store::{ObjectStore, memory::InMemory};
-/// use std::error::Error;
-/// use std::sync::Arc;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn Error>> {
-///    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-///    let db = Db::open("parent_path", Arc::clone(&object_store)).await?;
-///    db.put(b"key", b"value").await?;
-///    db.close().await?;
-///
-///    let _ = admin::create_checkpoint(
-///      "parent_path",
-///      object_store,
-///      &CheckpointOptions::default(),
-///    ).await?;
-///
-///    Ok(())
-/// }
-/// ```
-pub async fn create_checkpoint<P: Into<Path>>(
-    path: P,
-    object_store: Arc<dyn ObjectStore>,
-    options: &CheckpointOptions,
-) -> Result<CheckpointCreateResult, SlateDBError> {
-    let manifest_store = Arc::new(ManifestStore::new(&path.into(), object_store));
-    manifest_store
-        .validate_no_wal_object_store_configured()
-        .await?;
-    let mut stored_manifest = StoredManifest::load(manifest_store).await?;
-    let checkpoint = stored_manifest.write_checkpoint(None, options).await?;
-    Ok(CheckpointCreateResult {
-        id: checkpoint.id,
-        manifest_id: checkpoint.manifest_id,
-    })
-}
-
-/// Clone a database. If no db already exists at the specified path, then this will create
-/// a new db under the path that is a clone of the db at parent_path.
-///
-/// A clone is a shallow copy of the parent database - it starts with a manifest that
-/// references the same SSTs, but doesn't actually copy those SSTs, except for the WAL.
-/// New writes will be written to the newly created db and will not be reflected in the
-/// parent database.
-///
-/// The clone can optionally be created from an existing checkpoint. If
-/// `parent_checkpoint` is present, then the referenced manifest is used
-/// as the base for the clone db's manifest. Otherwise, this method creates a new checkpoint
-/// for the current version of the parent db.
-///
-/// # Examples
-///
-/// ```
-/// use slatedb::admin;
-/// use slatedb::Db;
-/// use slatedb::object_store::{ObjectStore, memory::InMemory};
-/// use std::error::Error;
-/// use std::sync::Arc;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn Error>> {
-///    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-///    let db = Db::open("parent_path", Arc::clone(&object_store)).await?;
-///    db.put(b"key", b"value").await?;
-///    db.close().await?;
-///
-///    admin::create_clone(
-///      "clone_path",
-///      "parent_path",
-///      object_store,
-///      None,
-///    ).await?;
-///
-///    Ok(())
-/// }
-/// ```
-pub async fn create_clone<P: Into<Path>>(
-    clone_path: P,
-    parent_path: P,
-    object_store: Arc<dyn ObjectStore>,
-    parent_checkpoint: Option<Uuid>,
-) -> Result<(), Box<dyn Error>> {
-    clone::create_clone(
-        clone_path,
-        parent_path,
-        object_store,
-        parent_checkpoint,
-        Arc::new(FailPointRegistry::new()),
-    )
-    .await?;
-    Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use object_store::{memory::InMemory, path::Path};
-
-    #[tokio::test]
-    async fn test_delete_objects_with_prefix_empty() {
-        let store = Arc::new(InMemory::new());
-        let result = delete_objects_with_prefix(store, Some(&Path::from("test/prefix"))).await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_delete_objects_with_prefix_single_object() {
-        let store = Arc::new(InMemory::new());
-
-        // Put an object
-        store
-            .put(&Path::from("test/prefix/object1"), vec![1, 2, 3].into())
-            .await
-            .unwrap();
-
-        // Delete objects with prefix
-        let result =
-            delete_objects_with_prefix(store.clone(), Some(&Path::from("test/prefix"))).await;
-        assert!(result.is_ok());
-
-        // Verify object is deleted
-        let list_result = store
-            .list(Some(&Path::from("test/prefix")))
-            .collect::<Vec<_>>()
-            .await;
-        assert!(list_result.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_delete_objects_with_prefix_multiple_objects() {
-        let store = Arc::new(InMemory::new());
-
-        // Put multiple objects with same prefix
-        store
-            .put(&Path::from("test/prefix/object1"), vec![1, 2, 3].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("test/prefix/object2"), vec![4, 5, 6].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("test/other/object3"), vec![7, 8, 9].into())
-            .await
-            .unwrap();
-
-        // Delete objects with prefix
-        let result =
-            delete_objects_with_prefix(store.clone(), Some(&Path::from("test/prefix"))).await;
-        assert!(result.is_ok());
-
-        // Verify only objects with prefix are deleted
-        let list_result = store.list(None).collect::<Vec<_>>().await;
-        assert_eq!(list_result.len(), 1);
-        assert_eq!(
-            list_result[0].as_ref().unwrap().location,
-            Path::from("test/other/object3")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_delete_objects_with_empty_prefix() {
-        let store = Arc::new(InMemory::new());
-
-        // Put multiple objects at different paths
-        store
-            .put(&Path::from("test/prefix/object1"), vec![1, 2, 3].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("other/path/object2"), vec![4, 5, 6].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("root_object"), vec![7, 8, 9].into())
-            .await
-            .unwrap();
-
-        // Test with empty string prefix
-        let result = delete_objects_with_prefix(store.clone(), Some(&Path::from(""))).await;
-        assert!(result.is_ok());
-
-        // Verify all objects are deleted
-        let list_result = store.list(None).collect::<Vec<_>>().await;
-        assert!(
-            list_result.is_empty(),
-            "Expected all objects to be deleted with empty prefix"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_delete_objects_with_root_prefix() {
-        let store = Arc::new(InMemory::new());
-
-        // Put multiple objects at different paths
-        store
-            .put(&Path::from("test/prefix/object1"), vec![1, 2, 3].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("other/path/object2"), vec![4, 5, 6].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("root_object"), vec![7, 8, 9].into())
-            .await
-            .unwrap();
-
-        // Test with "/" prefix
-        let result = delete_objects_with_prefix(store.clone(), Some(&Path::from("/"))).await;
-        assert!(result.is_ok());
-
-        // Verify all objects are deleted
-        let list_result = store.list(None).collect::<Vec<_>>().await;
-        assert!(
-            list_result.is_empty(),
-            "Expected all objects to be deleted with '/' prefix"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_delete_objects_with_none_prefix() {
-        let store = Arc::new(InMemory::new());
-
-        // Put multiple objects at different paths
-        store
-            .put(&Path::from("test/prefix/object1"), vec![1, 2, 3].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("other/path/object2"), vec![4, 5, 6].into())
-            .await
-            .unwrap();
-        store
-            .put(&Path::from("root_object"), vec![7, 8, 9].into())
-            .await
-            .unwrap();
-
-        // Test with None prefix
-        let result = delete_objects_with_prefix(store.clone(), None).await;
-        assert!(result.is_ok());
-
-        // Verify all objects are deleted
-        let list_result = store.list(None).collect::<Vec<_>>().await;
-        assert!(
-            list_result.is_empty(),
-            "Expected all objects to be deleted with None prefix"
-        );
-    }
 }

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -1,14 +1,9 @@
-use crate::clock::SystemClock;
 use crate::config::{CheckpointOptions, CheckpointScope};
 use crate::db::Db;
 use crate::error::SlateDBError;
-use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::mem_table_flush::MemtableFlushMsg;
-use object_store::path::Path;
-use object_store::ObjectStore;
 use serde::Serialize;
-use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use uuid::Uuid;
 
 #[non_exhaustive]
@@ -77,7 +72,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
     use crate::tablestore::TableStore;
-    use crate::{admin, test_utils};
+    use crate::test_utils;
     use bytes::Bytes;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -193,7 +188,7 @@ mod tests {
     async fn test_should_fail_create_checkpoint_from_missing_checkpoint() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_kv_store";
-        let admin = AdminBuilder::new(path.clone(), object_store.clone()).build();
+        let admin = AdminBuilder::new(path, object_store.clone()).build();
         // open and close the db to init the manifest and trigger another write
         let _ = Db::builder(path, object_store.clone())
             .with_settings(Settings::default())
@@ -219,7 +214,7 @@ mod tests {
     async fn test_should_fail_create_checkpoint_no_manifest() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_kv_store";
-        let admin = AdminBuilder::new(path.clone(), object_store.clone()).build();
+        let admin = AdminBuilder::new(path, object_store.clone()).build();
         let result = admin.create_checkpoint(&CheckpointOptions::default()).await;
 
         assert!(result.is_err());

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -93,6 +93,7 @@ use tokio::runtime::Handle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use crate::admin::Admin;
 use crate::cached_object_store::stats::CachedObjectStoreStats;
 use crate::cached_object_store::CachedObjectStore;
 use crate::cached_object_store::FsCacheStorage;
@@ -483,5 +484,40 @@ impl<P: Into<Path>> DbBuilder<P> {
             garbage_collector: Mutex::new(garbage_collector),
             cancellation_token: self.cancellation_token,
         })
+    }
+}
+
+/// Builder for creating new Admin instances.
+///
+/// This provides a fluent API for configuring an Admin object.
+pub struct AdminBuilder<P: Into<Path>> {
+    path: P,
+    object_store: Arc<dyn ObjectStore>,
+    system_clock: Arc<dyn SystemClock>,
+}
+
+impl<P: Into<Path>> AdminBuilder<P> {
+    /// Creates a new AdminBuilder with the given path and object store.
+    pub fn new(path: P, object_store: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            path,
+            object_store,
+            system_clock: Arc::new(DefaultSystemClock::new()),
+        }
+    }
+
+    /// Sets the system clock to use for administrative functions.
+    pub fn with_system_clock(mut self, system_clock: Arc<dyn SystemClock>) -> Self {
+        self.system_clock = system_clock;
+        self
+    }
+
+    /// Builds and returns an Admin instance.
+    pub fn build(self) -> Admin {
+        Admin {
+            path: self.path.into(),
+            object_store: self.object_store,
+            system_clock: self.system_clock,
+        }
     }
 }


### PR DESCRIPTION
I found that our public facing static functions are a real pain to work with while working on #606 and #609. I initially thought using a `DbContext` that held just normally static stuff (rng, clock, etc) would be helpful. After working through it, I felt the right thing to do was get rid of `DbContext` and implement proper builders for user-facing stuff. That includes:

- admin.rs
- compactor.rs (and related compactor stuff)
- garbage_collector.rs

Each of these builders will allow us to do `_with_system_clock` and `_with_logical_clock` if/when needed. As we add an RNG and filesystem for DST, they'll also have `_with_*` methods for the appropriate builders.

Internally, we'll pass actual `impl SystemClock`, `impl LogicalClock`, and so on to the structs and functions that need them.

This PR currently:

- implements `Admin` and`AdminBuilder` to show what the improved UX will be.
- moves `delete_objects_with_prefix` to the bencher `main.rs` file since it's only used there and has nothing to do with SlateDB.
- updates main.rs files to use the new `Admin` client.
- moves `refresh_checkpoint` and `delete_checkpoint` out of `Db` (`checkpoint.rs`) and into `Admin.

@hachikuji I would like your feedback on the refresh/delete changes. They weren't used in our codebase; it appears we have separate refresh logic in the manifest store?

