### PR TITLE
Add `DbRand` to allow injectable randomness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2973,6 +2973,7 @@ dependencies = [
  "snap",
  "tempfile",
  "thiserror 1.0.69",
+ "thread_local",
  "tokio",
  "tokio-test",
  "tokio-util",

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -49,6 +49,7 @@ uuid = { version = "1.12.0", features = ["v4", "serde"] }
 walkdir = "2.3.3"
 zstd = { version = "0.13.2", optional = true }
 tokio-util = { version = "0.7.15", default-features = false, features = ["rt"] }
+thread_local = "1.1.8"
 
 [dev-dependencies]
 bincode = "1"

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -304,6 +304,33 @@ impl Admin {
         .await?;
         Ok(())
     }
+
+    /// Creates a new builder for an admin client at the given path.
+    ///
+    /// ## Arguments
+    /// - `path`: the path to the database
+    /// - `object_store`: the object store to use for the database
+    ///
+    /// ## Returns
+    /// - `AdminBuilder`: the builder to initialize the admin client
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::admin::Admin;
+    /// use slatedb::SlateDBError;
+    /// use slatedb::object_store::memory::InMemory;
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let object_store = Arc::new(InMemory::new());
+    ///     let admin = Admin::builder("/tmp/test_db", object_store).build();
+    /// }
+    /// ```
+    pub fn builder<P: Into<Path>>(path: P, object_store: Arc<dyn ObjectStore>) -> AdminBuilder<P> {
+        AdminBuilder::new(path, object_store)
+    }
 }
 
 /// Loads an object store from configured environment variables.

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -447,11 +447,12 @@ mod tests {
     use crate::cached_object_store::storage_fs::FsCacheStorage;
     use crate::cached_object_store::{storage::PartID, storage_fs::FsCacheEntry};
     use crate::clock::DefaultSystemClock;
+    use crate::rand::DbRand;
     use crate::stats::StatRegistry;
     use crate::test_utils::gen_rand_bytes;
 
     fn new_test_cache_folder() -> std::path::PathBuf {
-        let mut rng = crate::rand::thread_rng();
+        let mut rng = rand::thread_rng();
         let dir_name: String = (0..10)
             .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
             .collect();
@@ -482,6 +483,7 @@ mod tests {
             None,
             stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
 
         let part_size = 1024;
@@ -553,6 +555,7 @@ mod tests {
             None,
             stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
 
         let cached_store =
@@ -597,6 +600,7 @@ mod tests {
             None,
             stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
 
         let cached_store =
@@ -686,6 +690,7 @@ mod tests {
             None,
             stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
         let cached_store =
             CachedObjectStore::new(object_store, cache_storage, 1024, stats).unwrap();
@@ -708,6 +713,7 @@ mod tests {
             None,
             stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
         let cached_store =
             CachedObjectStore::new(object_store, cache_storage, 1024, stats).unwrap();
@@ -738,6 +744,7 @@ mod tests {
             None,
             stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
         let cached_store =
             CachedObjectStore::new(object_store.clone(), cache_storage, 1024, stats).unwrap();

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -41,11 +41,8 @@ impl CompactionExecuteBench {
     pub fn new(path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
         Self::new_with_rand(path, object_store, Arc::new(DbRand::default()))
     }
-    pub fn new_with_rand(
-        path: Path,
-        object_store: Arc<dyn ObjectStore>,
-        rand: Arc<DbRand>,
-    ) -> Self {
+
+    fn new_with_rand(path: Path, object_store: Arc<dyn ObjectStore>, rand: Arc<DbRand>) -> Self {
         Self {
             path,
             object_store,

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -24,6 +24,7 @@ use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::object_stores::ObjectStores;
+use crate::rand::DbRand;
 use crate::sst::SsTableFormat;
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
@@ -33,11 +34,23 @@ use crate::types::ValueDeletable;
 pub struct CompactionExecuteBench {
     path: Path,
     object_store: Arc<dyn ObjectStore>,
+    rand: Arc<DbRand>,
 }
 
 impl CompactionExecuteBench {
     pub fn new(path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
-        Self { path, object_store }
+        Self::new_with_rand(path, object_store, Arc::new(DbRand::default()))
+    }
+    pub fn new_with_rand(
+        path: Path,
+        object_store: Arc<dyn ObjectStore>,
+        rand: Arc<DbRand>,
+    ) -> Self {
+        Self {
+            path,
+            object_store,
+            rand,
+        }
     }
 
     fn sst_id(id: u32) -> SsTableId {
@@ -64,8 +77,8 @@ impl CompactionExecuteBench {
         ));
         let num_keys = sst_bytes / (val_bytes + key_bytes);
         let mut key_start = vec![0u8; key_bytes - mem::size_of::<u32>()];
-        let mut rng = crate::rand::thread_rng();
-        rng.fill_bytes(key_start.as_mut_slice());
+        let rand = self.rand.clone();
+        rand.thread_rng().fill_bytes(key_start.as_mut_slice());
         let mut futures = FuturesUnordered::<JoinHandle<Result<(), SlateDBError>>>::new();
         for i in 0..num_ssts {
             while futures.len() >= 4 {
@@ -83,6 +96,7 @@ impl CompactionExecuteBench {
                 key_start_copy,
                 num_keys,
                 val_bytes,
+                self.rand.clone(),
             ));
             futures.push(jh)
         }
@@ -102,6 +116,7 @@ impl CompactionExecuteBench {
         key_start: Vec<u8>,
         num_keys: usize,
         val_bytes: usize,
+        rand: Arc<DbRand>,
     ) -> Result<(), SlateDBError> {
         let mut retries = 0;
         loop {
@@ -111,6 +126,7 @@ impl CompactionExecuteBench {
                 key_start.clone(),
                 num_keys,
                 val_bytes,
+                rand.clone(),
             )
             .await;
             match result {
@@ -134,8 +150,8 @@ impl CompactionExecuteBench {
         key_start: Vec<u8>,
         num_keys: usize,
         val_bytes: usize,
+        rand: Arc<DbRand>,
     ) -> Result<(), SlateDBError> {
-        let mut rng = crate::rand::thread_rng();
         let start = tokio::time::Instant::now();
         let mut suffix = Vec::<u8>::new();
         suffix.put_u32(i);
@@ -144,7 +160,7 @@ impl CompactionExecuteBench {
         let mut sst_writer = table_store.table_writer(CompactionExecuteBench::sst_id(i));
         for _ in 0..num_keys {
             let mut val = vec![0u8; val_bytes];
-            rng.fill_bytes(val.as_mut_slice());
+            rand.thread_rng().fill_bytes(val.as_mut_slice());
             let key = key_gen.next();
             let row_entry = RowEntry::new(key, ValueDeletable::Value(val.into()), 0, None, None);
             sst_writer.add(row_entry).await?;

--- a/slatedb/src/comparable_range.rs
+++ b/slatedb/src/comparable_range.rs
@@ -337,7 +337,7 @@ pub(crate) mod tests {
         ];
         let mut shuffled_ranges = ranges.clone();
         // Shuffle the ranges to ensure the order is random
-        shuffled_ranges.shuffle(&mut crate::rand::thread_rng());
+        shuffled_ranges.shuffle(&mut rand::thread_rng());
         // Sort the ranges to ensure the order is deterministic
         shuffled_ranges.sort();
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -982,6 +982,7 @@ mod tests {
     use crate::object_stores::ObjectStores;
     use crate::proptest_util::arbitrary;
     use crate::proptest_util::sample;
+    use crate::rand::DbRand;
     use crate::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
@@ -1505,6 +1506,7 @@ mod tests {
             None,
             cache_stats.clone(),
             Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
         ));
 
         let cached_object_store = CachedObjectStore::new(

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     fn build_block() -> CachedEntry {
-        let mut rng = crate::rand::thread_rng();
+        let mut rng = rand::thread_rng();
         let mut builder = BlockBuilder::new(1024);
         loop {
             let mut k = vec![0u8; 32];

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -3,7 +3,8 @@
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]
 #![allow(clippy::result_large_err)]
-#![deny(clippy::disallowed_types)]
+// Disallow non-approved non-deterministic types and functions in production code
+#![cfg_attr(not(test), deny(clippy::disallowed_types, clippy::disallowed_methods))]
 
 /// Re-export the bytes crate.
 ///

--- a/slatedb/src/proptest_util.rs
+++ b/slatedb/src/proptest_util.rs
@@ -208,7 +208,7 @@ pub(crate) mod rng {
 
     pub(crate) fn new_test_rng(seed: Option<[u8; 32]>) -> TestRng {
         let seed = seed.unwrap_or_else(|| {
-            let mut thread_rng = crate::rand::thread_rng();
+            let mut thread_rng = rand::thread_rng();
             let random_bytes: [u8; 32] = thread_rng.gen();
             random_bytes
         });

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -12,68 +12,13 @@
 
 use std::cell::RefCell;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, OnceLock};
 
-use rand::{RngCore, SeedableRng};
+use rand::RngCore;
+use rand::SeedableRng;
 use rand_xoshiro::Xoroshiro128PlusPlus;
 use thread_local::ThreadLocal;
 
 type RngAlg = Xoroshiro128PlusPlus;
-
-static ROOT_RNG: OnceLock<Mutex<RngAlg>> = OnceLock::new();
-
-/// Seed the root random number generator.
-///
-/// This function can only be called once. If it is called multiple times, it will panic.
-pub(crate) fn seed(seed: u64) {
-    let rng = RngAlg::seed_from_u64(seed);
-    ROOT_RNG
-        .set(Mutex::new(rng))
-        .expect("rand::seed() can only be called once");
-}
-
-thread_local! {
-    /// Per-thread RNG state, stored by value in a Cell.
-    static THREAD_RNG: RefCell<RngAlg> = {
-        let mut guard = ROOT_RNG
-            .get_or_init(|| Mutex::new(RngAlg::from_entropy()))
-            .lock()
-            .expect("root rng poisoned");
-        let child_seed = guard.next_u64();
-        RefCell::new(RngAlg::seed_from_u64(child_seed))
-    };
-}
-
-/// A thread-local random number generator.
-pub(crate) struct ThreadRng;
-
-impl RngCore for ThreadRng {
-    #[inline(always)]
-    fn next_u32(&mut self) -> u32 {
-        THREAD_RNG.with(|cell| cell.borrow_mut().next_u32())
-    }
-
-    #[inline(always)]
-    fn next_u64(&mut self) -> u64 {
-        THREAD_RNG.with(|cell| cell.borrow_mut().next_u64())
-    }
-
-    #[inline(always)]
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        THREAD_RNG.with(|cell| cell.borrow_mut().fill_bytes(dest))
-    }
-
-    #[inline(always)]
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        THREAD_RNG.with(|cell| cell.borrow_mut().try_fill_bytes(dest))
-    }
-}
-
-/// Returns a handle to the thread-local random number generator.
-#[inline]
-pub(crate) fn thread_rng() -> ThreadRng {
-    ThreadRng
-}
 
 /// A shareable, lock-free random number generator (RNG).
 ///
@@ -90,27 +35,28 @@ pub(crate) fn thread_rng() -> ThreadRng {
 /// ## Usage
 ///
 /// ```ignore
-/// use slate_db::rand::DbRng;
+/// use slate_db::rand::DbRand;
 ///
-/// let rng = DbRng::new(42);
+/// let rng = DbRand::new(42);
 /// let _ = rng.next_u64();
 /// ```
-pub struct DbRng {
+#[derive(Debug)]
+pub struct DbRand {
     seed_counter: AtomicU64,
     thread_rng: ThreadLocal<RefCell<RngAlg>>,
 }
 
-impl DbRng {
-    /// Create a new `DbRng` with the given 64-bit seed.
+impl DbRand {
+    /// Create a new `DbRand` with the given 64-bit seed.
     pub fn new(seed: u64) -> Self {
-        DbRng {
+        DbRand {
             seed_counter: AtomicU64::new(seed),
             thread_rng: ThreadLocal::new(),
         }
     }
 
-    /// Grab (or initialize) this thread’s RNG
-    fn thread_rng(&self) -> std::cell::RefMut<'_, RngAlg> {
+    /// Grab this thread’s RNG. Initializes the RNG if it hasn't been initialized yet.
+    pub fn thread_rng(&self) -> std::cell::RefMut<'_, impl RngCore> {
         self.thread_rng
             .get_or(|| {
                 let seed = self.seed_counter.fetch_add(1, Ordering::Relaxed);
@@ -121,72 +67,8 @@ impl DbRng {
     }
 }
 
-impl RngCore for DbRng {
-    /// Generate a random u64
-    fn next_u64(&mut self) -> u64 {
-        self.thread_rng().next_u64()
-    }
-
-    /// Generate a random u32
-    fn next_u32(&mut self) -> u32 {
-        self.thread_rng().next_u32()
-    }
-
-    /// Fill bytes
-    fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.thread_rng().fill_bytes(dest)
-    }
-
-    /// Try to fill bytes
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.thread_rng().try_fill_bytes(dest)
-    }
-}
-
-impl Default for DbRng {
+impl Default for DbRand {
     fn default() -> Self {
-        #![allow(clippy::disallowed_methods)]
         Self::new(rand::random())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    // Force a thread-local RNG to use a specific seed so we can test deterministically.
-    fn seed_local(seed: u64) {
-        THREAD_RNG.with(|cell| {
-            *cell.borrow_mut() = RngAlg::seed_from_u64(seed);
-        });
-    }
-
-    #[test]
-    fn test_rng() {
-        std::thread::spawn(move || {
-            seed_local(42);
-            let rand_u64 = thread_rng().next_u64();
-            assert_eq!(rand_u64, 16756476715040848931);
-        })
-        .join()
-        .unwrap();
-    }
-
-    #[test]
-    fn test_rng_thread_local() {
-        std::thread::spawn(move || {
-            seed_local(42);
-            let outer_u64 = thread_rng().next_u64();
-            let inner_u64 = std::thread::spawn(move || {
-                seed_local(64);
-                thread_rng().next_u64()
-            })
-            .join()
-            .unwrap();
-            assert_eq!(inner_u64, 12172458793332410705);
-            assert_eq!(outer_u64, 16756476715040848931);
-        })
-        .join()
-        .unwrap();
     }
 }

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_types)]
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 //! SlateDB's module for generating random data.
 //!

--- a/slatedb/src/rand.rs
+++ b/slatedb/src/rand.rs
@@ -18,7 +18,7 @@ use rand::SeedableRng;
 use rand_xoshiro::Xoroshiro128PlusPlus;
 use thread_local::ThreadLocal;
 
-type RngAlg = Xoroshiro128PlusPlus;
+pub(crate) type RngAlg = Xoroshiro128PlusPlus;
 
 /// A shareable, lock-free random number generator (RNG).
 ///
@@ -41,14 +41,14 @@ type RngAlg = Xoroshiro128PlusPlus;
 /// let _ = rng.next_u64();
 /// ```
 #[derive(Debug)]
-pub struct DbRand {
+pub(crate) struct DbRand {
     seed_counter: AtomicU64,
     thread_rng: ThreadLocal<RefCell<RngAlg>>,
 }
 
 impl DbRand {
     /// Create a new `DbRand` with the given 64-bit seed.
-    pub fn new(seed: u64) -> Self {
+    pub(crate) fn new(seed: u64) -> Self {
         DbRand {
             seed_counter: AtomicU64::new(seed),
             thread_rng: ThreadLocal::new(),
@@ -56,7 +56,7 @@ impl DbRand {
     }
 
     /// Grab this thread’s RNG. Initializes the RNG if it hasn't been initialized yet.
-    pub fn thread_rng(&self) -> std::cell::RefMut<'_, impl RngCore> {
+    pub(crate) fn thread_rng(&self) -> std::cell::RefMut<'_, impl RngCore> {
         self.thread_rng
             .get_or(|| {
                 let seed = self.seed_counter.fetch_add(1, Ordering::Relaxed);

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -116,7 +116,7 @@ impl LogicalClock for TestClock {
 }
 
 pub(crate) fn gen_rand_bytes(n: usize) -> Bytes {
-    let mut rng = crate::rand::thread_rng();
+    let mut rng = rand::thread_rng();
     let random_bytes: Vec<u8> = (0..n).map(|_| rng.gen()).collect();
     Bytes::from(random_bytes)
 }
@@ -248,7 +248,7 @@ pub(crate) async fn seed_database(
 }
 
 pub(crate) fn build_test_sst(format: &SsTableFormat, num_blocks: usize) -> EncodedSsTable {
-    let mut rng = crate::rand::thread_rng();
+    let mut rng = rand::thread_rng();
     let mut keygen = OrderedBytesGenerator::new_with_suffix(&[], &[0u8; 16]);
     let mut encoded_sst_builder = format.table_builder();
     while encoded_sst_builder.num_blocks() < num_blocks {

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -250,7 +250,7 @@ fn compute_lower_bound(prev_block_last_key: &Bytes, this_block_first_key: &Bytes
 }
 
 // TODO replace this with our rand module
-#[allow(clippy::disallowed_methods)]
+#[allow(clippy::disallowed_methods, clippy::disallowed_types)]
 pub(crate) fn uuid() -> Uuid {
     let mut random_bytes = [0; 16];
     rand::thread_rng().fill_bytes(&mut random_bytes);

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -249,15 +249,18 @@ fn compute_lower_bound(prev_block_last_key: &Bytes, this_block_first_key: &Bytes
     this_block_first_key.slice(..prev_block_last_key.len() + 1)
 }
 
-#[allow(clippy::disallowed_types)]
+// TODO replace this with our rand module
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn uuid() -> Uuid {
     let mut random_bytes = [0; 16];
-    crate::rand::thread_rng().fill_bytes(&mut random_bytes);
+    rand::thread_rng().fill_bytes(&mut random_bytes);
     uuid::Builder::from_random_bytes(random_bytes).into_uuid()
 }
 
+// TODO replace this with our rand module
+#[allow(clippy::disallowed_methods)]
 pub(crate) fn ulid() -> Ulid {
-    Ulid::with_source(&mut crate::rand::thread_rng())
+    Ulid::with_source(&mut rand::thread_rng())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR is a follow-on to #610. I've added a `DbRand` struct to `rand.rs`. The intent is to provide the equivalent to `rand::thread_ng()`, but in an object that can be put in an Arc to share everywhere, and which doesn't use locking. The code achieves this using the `thread_local` crate; we create a new random number generator (RNG) once for each thread. To seed the thread RNGs, we use an AtomicU64, which we increment after each use.

The `RngAlg` uses `Xoroshiro128PlusPlus`, which is portable (runs deterministically across environments and OS's). `Xoroshiro128PlusPlus` also uses splitmix to safely randomize the u64 and maintain entropy.

This PR does _not_ update the UUID/ULID generation to use `DbRand`. I plan to do that in the next PR. I'm trying to keep things readable.