### PR TITLE
Update `benchmark-db.sh` location

### DIFF
--- a/slatedb-bencher/README.md
+++ b/slatedb-bencher/README.md
@@ -66,7 +66,7 @@ a set of benchmarks suitable for your task. The script should be run from
 the repository root:
 
 ```bash
-./src/bencher/benchmark-db.sh
+./slatedb-bencher/benchmark-db.sh
 ```
 
 The command above will produce results at `target/bencher/results` directory. The results include:


### PR DESCRIPTION
## PR Summary
This small PR simply updates the `benchmark-db.sh` location in `slatedb-bencher/README.md`.