### PR TITLE
Add `GarbageCollectorBuilder` and make `GarbageCollector` non-static

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -3,11 +3,8 @@ use crate::clock::SystemClock;
 use crate::config::{CheckpointOptions, GarbageCollectorOptions};
 use crate::db::builder::GarbageCollectorBuilder;
 use crate::error::SlateDBError;
-use crate::garbage_collector::stats::GcStats;
-use crate::garbage_collector::GarbageCollector;
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::sst::SsTableFormat;
-use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
 
 use crate::clone;

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -274,7 +274,7 @@ mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::clock::DefaultSystemClock;
     use crate::config::{GarbageCollectorDirectoryOptions, GarbageCollectorOptions};
-    use crate::db::builder::GarbageCollectorBuilder;
+    
     use crate::error::SlateDBError;
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;


### PR DESCRIPTION
This is the next follow-on after #610. In this PR, I introduce a `GarbageCollectorBuilder` and make the `GarbageCollector` non-static. I feel it's much cleaner. It also lays the groundwork to be able to use `DbRand` to generate `Uuid`s and `Ulid`s. When I started doing that work, I found that there were a ton of invasive changes in admin/compaction/gc because of all these static methods passing params around.