### PR TITLE
Add `CompactorBuilder` and make `Compactor` async

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -133,7 +133,7 @@ impl Admin {
         .build();
 
         tracker.spawn(async move {
-            gc.start_async_task().await;
+            gc.run_async_task().await;
         });
         tracker.close();
         tracker.wait().await;

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -109,13 +109,13 @@ impl Compactor {
     /// Unlike [`start_in_bg_thread`](Compactor::start_in_bg_thread), this method
     /// uses the current Tokio runtime instead of creating a new thread. This is useful
     /// when you want to run the compactor within an existing async runtime.
-    pub async fn run_async_task(&self) -> Result<(), SlateDBError> {
+    pub async fn run_async_task(&self, compactor_runtime: Handle) -> Result<(), SlateDBError> {
         let mut db_runs_log_ticker = tokio::time::interval(Duration::from_secs(10));
         let mut manifest_poll_ticker = tokio::time::interval(self.options.poll_interval);
         let (worker_tx, mut worker_rx) = tokio::sync::mpsc::unbounded_channel();
         let scheduler = self.scheduler_supplier.compaction_scheduler();
         let executor = Box::new(TokioCompactionExecutor::new(
-            Handle::current(),
+            compactor_runtime,
             self.options.clone(),
             worker_tx,
             self.table_store.clone(),

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -149,7 +149,7 @@ impl Compactor {
         // `worker_rx` messages have been drained.
         while !(self.cancellation_token.is_cancelled() && worker_rx.is_empty()) {
             fail_point!(Arc::clone(&self.fp_registry), "compactor-main-loop", |_| {
-                return Err(SlateDBError::InvalidCompaction);
+                Err(SlateDBError::InvalidCompaction)
             });
 
             tokio::select! {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -73,6 +73,7 @@ pub(crate) struct Compactor {
     stats: Arc<CompactionStats>,
     system_clock: Arc<dyn SystemClock>,
     cancellation_token: CancellationToken,
+    #[allow(dead_code)]
     fp_registry: Arc<FailPointRegistry>,
 }
 

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -120,7 +120,7 @@ impl Compactor {
         cleanup_fn: impl FnOnce(&Result<(), SlateDBError>) + Send + 'static,
     ) {
         let this = self.clone();
-        let compactor_main = move || tokio_handle.block_on(this.start_async_task());
+        let compactor_main = move || tokio_handle.block_on(this.run_async_task());
         spawn_bg_thread("slatedb-compactor", cleanup_fn, compactor_main);
     }
 
@@ -132,7 +132,7 @@ impl Compactor {
     /// Unlike [`start_in_bg_thread`](Compactor::start_in_bg_thread), this method
     /// uses the current Tokio runtime instead of creating a new thread. This is useful
     /// when you want to run the compactor within an existing async runtime.
-    pub async fn start_async_task(&self) -> Result<(), SlateDBError> {
+    pub async fn run_async_task(&self) -> Result<(), SlateDBError> {
         let mut db_runs_log_ticker = tokio::time::interval(Duration::from_secs(10));
         let mut manifest_poll_ticker = tokio::time::interval(self.options.poll_interval);
         let (worker_tx, mut worker_rx) = tokio::sync::mpsc::unbounded_channel();

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -151,11 +151,6 @@ impl Compactor {
 
         Ok(())
     }
-
-    /// Notify the compactor to terminate.
-    pub async fn terminate_background_task(self) {
-        self.cancellation_token.cancel();
-    }
 }
 
 struct CompactorEventHandler {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -45,16 +45,15 @@ pub(crate) enum WorkerToOrchestratorMsg {
 /// and read amplification (by reducing the number of sorted runs that need to be searched on
 /// a read). It's made up of a few different components:
 ///
-/// The Orchestrator is responsible for orchestrating the ongoing process of compacting
-/// the db. It periodically polls the manifest for changes, calls into the Scheduler
-/// to discover compactions that should be performed, schedules those compactions on the
-/// Executor, and when they are completed, updates the manifest. The Orchestrator is made
-/// up of [`CompactorOrchestrator`] and [`CompactorEventHandler`]. [`CompactorOrchestrator`]
-/// runs the main event loop on a background thread. The event loop listens on the manifest
-/// poll ticker to react to manifest poll ticks, the executor worker channel to react to
-/// updates about running compactions, and the shutdown channel to discover when it should
-/// terminate. It doesn't actually implement the logic for reacting to these events. This
-/// is implemented by [`CompactorEventHandler`].
+/// - [`Compactor`]: The main event loop that orchestrates the compaction process.
+/// - [`CompactorEventHandler`]: The event handler that handles events from the compactor.
+/// - [`CompactionScheduler`]: The scheduler that discovers compactions that should be performed.
+/// - [`CompactionExecutor`]: The executor that runs the compaction tasks.
+///
+/// The main event loop listens on the manifest poll ticker to react to manifest poll ticks, the
+/// executor worker channel to react to updates about running compactions, and the shutdown
+/// channel to discover when it should terminate. It doesn't actually implement the logic for
+/// reacting to these events. This is implemented by [`CompactorEventHandler`].
 ///
 /// The Scheduler is responsible for deciding what sorted runs should be compacted together.
 /// It implements the [`CompactionScheduler`] trait. The implementation is specified by providing

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -544,7 +544,10 @@ mod tests {
         db.put(&[b'a'; 16], &[b'a'; 32]).await.unwrap();
         db.put(&[b'b'; 16], &[b'a'; 32]).await.unwrap();
         db.flush().await.unwrap();
-        scheduler.scheduler.should_compact.store(true, Ordering::SeqCst);
+        scheduler
+            .scheduler
+            .should_compact
+            .store(true, Ordering::SeqCst);
         let db_state = await_compaction(&db, manifest_store.clone()).await.unwrap();
         assert_eq!(db_state.compacted.len(), 1);
         assert_eq!(db_state.l0.len(), 0, "{:?}", db_state.l0);
@@ -576,7 +579,10 @@ mod tests {
         let tombstone = iter.next_entry().await.unwrap();
         assert!(tombstone.unwrap().value.is_tombstone());
 
-        scheduler.scheduler.should_compact.store(true, Ordering::SeqCst);
+        scheduler
+            .scheduler
+            .should_compact
+            .store(true, Ordering::SeqCst);
         let db_state = await_compacted_compaction(manifest_store.clone(), db_state.compacted)
             .await
             .unwrap();

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -48,7 +48,7 @@ impl TokioCompactionExecutor {
     pub(crate) fn new(
         handle: tokio::runtime::Handle,
         options: Arc<CompactorOptions>,
-        worker_tx: crossbeam_channel::Sender<WorkerToOrchestratorMsg>,
+        worker_tx: tokio::sync::mpsc::UnboundedSender<WorkerToOrchestratorMsg>,
         table_store: Arc<TableStore>,
         stats: Arc<CompactionStats>,
     ) -> Self {
@@ -87,7 +87,7 @@ struct TokioCompactionTask {
 pub(crate) struct TokioCompactionExecutorInner {
     options: Arc<CompactorOptions>,
     handle: tokio::runtime::Handle,
-    worker_tx: crossbeam_channel::Sender<WorkerToOrchestratorMsg>,
+    worker_tx: tokio::sync::mpsc::UnboundedSender<WorkerToOrchestratorMsg>,
     table_store: Arc<TableStore>,
     tasks: Arc<Mutex<HashMap<u32, TokioCompactionTask>>>,
     stats: Arc<CompactionStats>,

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -602,6 +602,8 @@ mod tests {
     fn build_db(os: Arc<dyn ObjectStore>, tokio_handle: &Handle) -> Db {
         let opts = Settings {
             l0_sst_size_bytes: 256,
+            // Disable compactor to prevent it from compacting L0s unpredictably
+            compactor_options: None,
             ..Default::default()
         };
         tokio_handle

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -67,7 +67,6 @@ pub(crate) struct DbInner {
     pub(crate) stat_registry: Arc<StatRegistry>,
     pub(crate) mono_clock: Arc<MonotonicClock>,
     pub(crate) reader: Reader,
-
     pub(crate) wal_enabled: bool,
 }
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -460,7 +460,7 @@ impl Db {
             let mut maybe_compactor = self.compactor.lock();
             maybe_compactor.take()
         } {
-            compactor.close().await;
+            compactor.terminate_background_task().await;
         }
 
         if let Some(gc) = {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2893,7 +2893,7 @@ mod tests {
         assert!(neg_lookup.unwrap().is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_should_read_from_compacted_db() {
         do_test_should_read_compacted_db(test_db_options(
             0,
@@ -2908,7 +2908,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_should_read_from_compacted_db_no_filters() {
         do_test_should_read_compacted_db(test_db_options(
             u32::MAX,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -582,7 +582,6 @@ pub struct GarbageCollectorBuilder<P: Into<Path>> {
     stat_registry: Arc<StatRegistry>,
     cancellation_token: CancellationToken,
     system_clock: Arc<dyn SystemClock>,
-    fp_registry: Arc<FailPointRegistry>,
 }
 
 impl<P: Into<Path>> GarbageCollectorBuilder<P> {
@@ -595,7 +594,6 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             stat_registry: Arc::new(StatRegistry::new()),
             cancellation_token: CancellationToken::new(),
             system_clock: Arc::new(DefaultSystemClock::default()),
-            fp_registry: Arc::new(FailPointRegistry::new()),
         }
     }
 
@@ -621,13 +619,6 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
     /// Sets the cancellation token to use for the garbage collector.
     pub fn with_cancellation_token(mut self, cancellation_token: CancellationToken) -> Self {
         self.cancellation_token = cancellation_token;
-        self
-    }
-
-    /// Sets the fail point registry to use for the garbage collector.
-    #[allow(unused)]
-    pub fn with_fp_registry(mut self, fp_registry: Arc<FailPointRegistry>) -> Self {
-        self.fp_registry = fp_registry;
         self
     }
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -123,6 +123,7 @@ use crate::clock::SystemClock;
 use crate::compactor::SizeTieredCompactionSchedulerSupplier;
 use crate::compactor::{CompactionSchedulerSupplier, Compactor};
 use crate::config::default_block_cache;
+use crate::config::CompactorOptions;
 use crate::config::GarbageCollectorOptions;
 use crate::config::{Settings, SstBlockSize};
 use crate::db::Db;
@@ -445,9 +446,6 @@ impl<P: Into<Path>> DbBuilder<P> {
             inner.spawn_memtable_flush_task(manifest, memtable_flush_rx, &tokio_handle);
         let write_task = inner.spawn_write_task(write_rx, &tokio_handle);
 
-        // Setup compactor if needed
-        let mut compactor = None;
-
         // Not to pollute the cache during compaction or GC
         let uncached_table_store = Arc::new(TableStore::new_with_fp_registry(
             ObjectStores::new(
@@ -462,7 +460,8 @@ impl<P: Into<Path>> DbBuilder<P> {
 
         // To keep backwards compatibility, check if the compaction_scheduler_supplier or compactor_options are set.
         // If either are set, we need to initialize the compactor.
-        if self.compaction_scheduler_supplier.is_some() || self.settings.compactor_options.is_some()
+        let compactor = if self.compaction_scheduler_supplier.is_some()
+            || self.settings.compactor_options.is_some()
         {
             let compactor_options = self.settings.compactor_options.unwrap_or_default();
             let compaction_handle = self.compaction_runtime.unwrap_or_else(|| Handle::current());
@@ -470,25 +469,28 @@ impl<P: Into<Path>> DbBuilder<P> {
                 .compaction_scheduler_supplier
                 .unwrap_or_else(|| Arc::new(SizeTieredCompactionSchedulerSupplier::default()));
             let cleanup_inner = inner.clone();
-            compactor = Some(
-                Compactor::new(
-                    manifest_store.clone(),
-                    uncached_table_store.clone(),
-                    compactor_options.clone(),
-                    scheduler_supplier,
-                    compaction_handle,
-                    inner.stat_registry.as_ref(),
-                    move |result: &Result<(), SlateDBError>| {
-                        let err = bg_task_result_into_err(result);
-                        warn!("compactor thread exited with {:?}", err);
-                        let mut state = cleanup_inner.state.write();
-                        state.record_fatal_error(err.clone())
-                    },
-                    system_clock.clone(),
-                )
-                .await?,
-            )
-        }
+            let compactor = Compactor::new(
+                manifest_store.clone(),
+                uncached_table_store.clone(),
+                compactor_options.clone(),
+                scheduler_supplier,
+                inner.stat_registry.as_ref(),
+                system_clock.clone(),
+                self.cancellation_token.clone(),
+            );
+            compactor.start_in_bg_thread(
+                compaction_handle,
+                move |result: &Result<(), SlateDBError>| {
+                    let err = bg_task_result_into_err(result);
+                    warn!("compactor thread exited with {:?}", err);
+                    let mut state = cleanup_inner.state.write();
+                    state.record_fatal_error(err.clone())
+                },
+            );
+            Some(compactor)
+        } else {
+            None
+        };
 
         // To keep backwards compatibility, check if the gc_runtime or garbage_collector_options are set.
         // If either are set, we need to initialize the garbage collector.
@@ -650,6 +652,88 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             manifest_store,
             table_store,
             self.options,
+            self.stat_registry,
+            self.system_clock,
+            self.cancellation_token,
+        )
+    }
+}
+
+/// Builder for creating new Compactor instances.
+///
+/// This provides a fluent API for configuring a Compactor object.
+pub struct CompactorBuilder<P: Into<Path>> {
+    path: P,
+    main_object_store: Arc<dyn ObjectStore>,
+    tokio_handle: Handle,
+    options: CompactorOptions,
+    scheduler_supplier: Arc<dyn CompactionSchedulerSupplier>,
+    stat_registry: Arc<StatRegistry>,
+    cancellation_token: CancellationToken,
+    system_clock: Arc<dyn SystemClock>,
+}
+
+impl<P: Into<Path>> CompactorBuilder<P> {
+    pub fn new(path: P, main_object_store: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            path,
+            main_object_store,
+            tokio_handle: Handle::current(),
+            options: CompactorOptions::default(),
+            scheduler_supplier: Arc::new(SizeTieredCompactionSchedulerSupplier::default()),
+            stat_registry: Arc::new(StatRegistry::new()),
+            cancellation_token: CancellationToken::new(),
+            system_clock: Arc::new(DefaultSystemClock::default()),
+        }
+    }
+
+    /// Sets the tokio handle to use for background tasks.
+    #[allow(unused)]
+    pub fn with_tokio_handle(mut self, tokio_handle: Handle) -> Self {
+        self.tokio_handle = tokio_handle;
+        self
+    }
+
+    /// Sets the options to use for the garbage collector.
+    pub fn with_options(mut self, options: CompactorOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    /// Sets the stats registry to use for the garbage collector.
+    #[allow(unused)]
+    pub fn with_stat_registry(mut self, stat_registry: Arc<StatRegistry>) -> Self {
+        self.stat_registry = stat_registry;
+        self
+    }
+
+    /// Sets the system clock to use for the garbage collector.
+    pub fn with_system_clock(mut self, system_clock: Arc<dyn SystemClock>) -> Self {
+        self.system_clock = system_clock;
+        self
+    }
+
+    /// Sets the cancellation token to use for the garbage collector.
+    pub fn with_cancellation_token(mut self, cancellation_token: CancellationToken) -> Self {
+        self.cancellation_token = cancellation_token;
+        self
+    }
+
+    /// Builds and returns a Compactor instance.
+    pub fn build(self) -> Compactor {
+        let path: Path = self.path.into();
+        let manifest_store = Arc::new(ManifestStore::new(&path, self.main_object_store.clone()));
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(self.main_object_store.clone(), None),
+            SsTableFormat::default(), // read only SSTs can use default
+            path,
+            None, // no need for cache in GC
+        ));
+        Compactor::new(
+            manifest_store,
+            table_store,
+            self.options,
+            self.scheduler_supplier,
             self.stat_registry,
             self.system_clock,
             self.cancellation_token,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -477,7 +477,6 @@ impl<P: Into<Path>> DbBuilder<P> {
                 inner.stat_registry.clone(),
                 system_clock.clone(),
                 self.cancellation_token.clone(),
-                self.fp_registry.clone(),
             );
             let this_compactor = compactor.clone();
             // Spawn the compactor on the compaction runtime
@@ -667,7 +666,6 @@ pub struct CompactorBuilder<P: Into<Path>> {
     stat_registry: Arc<StatRegistry>,
     cancellation_token: CancellationToken,
     system_clock: Arc<dyn SystemClock>,
-    fp_registry: Arc<FailPointRegistry>,
 }
 
 #[allow(unused)]
@@ -682,7 +680,6 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             stat_registry: Arc::new(StatRegistry::new()),
             cancellation_token: CancellationToken::new(),
             system_clock: Arc::new(DefaultSystemClock::default()),
-            fp_registry: Arc::new(FailPointRegistry::new()),
         }
     }
 
@@ -718,12 +715,6 @@ impl<P: Into<Path>> CompactorBuilder<P> {
         self
     }
 
-    /// Sets the fail point registry to use for the compactor.
-    pub fn with_fp_registry(mut self, fp_registry: Arc<FailPointRegistry>) -> Self {
-        self.fp_registry = fp_registry;
-        self
-    }
-
     /// Builds and returns a Compactor instance.
     pub fn build(self) -> Compactor {
         let path: Path = self.path.into();
@@ -742,7 +733,6 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             self.stat_registry,
             self.system_clock,
             self.cancellation_token,
-            self.fp_registry,
         )
     }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -673,6 +673,7 @@ pub struct CompactorBuilder<P: Into<Path>> {
     system_clock: Arc<dyn SystemClock>,
 }
 
+#[allow(unused)]
 impl<P: Into<Path>> CompactorBuilder<P> {
     pub fn new(path: P, main_object_store: Arc<dyn ObjectStore>) -> Self {
         Self {

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -464,7 +464,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             || self.settings.compactor_options.is_some()
         {
             let compactor_options = self.settings.compactor_options.unwrap_or_default();
-            let compaction_handle = self.compaction_runtime.unwrap_or_else(|| Handle::current());
+            let compaction_handle = self.compaction_runtime.unwrap_or_else(|| tokio_handle.clone());
             let scheduler_supplier = self
                 .compaction_scheduler_supplier
                 .unwrap_or_else(|| Arc::new(SizeTieredCompactionSchedulerSupplier::default()));

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -140,6 +140,7 @@ use crate::sst::SsTableFormat;
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
 use crate::utils::bg_task_result_into_err;
+use crate::utils::spawn_bg_task;
 
 /// A builder for creating a new Db instance.
 ///
@@ -507,12 +508,18 @@ impl<P: Into<Path>> DbBuilder<P> {
                     system_clock.clone(),
                     self.cancellation_token.clone(),
                 );
-                gc.start_in_bg_thread(gc_handle, move |result| {
-                    let err = bg_task_result_into_err(result);
-                    warn!("GC thread exited with {:?}", err);
-                    let mut state = cleanup_inner.state.write();
-                    state.record_fatal_error(err.clone())
-                });
+                let this_gc = gc.clone();
+                let fut = async move { this_gc.run_async_task().await };
+                spawn_bg_task(
+                    &gc_handle,
+                    move |result| {
+                        let err = bg_task_result_into_err(result);
+                        warn!("GC thread exited with {:?}", err);
+                        let mut state = cleanup_inner.state.write();
+                        state.record_fatal_error(err.clone())
+                    },
+                    fut,
+                );
                 Some(gc)
             } else {
                 None

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -474,7 +474,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                 uncached_table_store.clone(),
                 compactor_options.clone(),
                 scheduler_supplier,
-                inner.stat_registry.as_ref(),
+                inner.stat_registry.clone(),
                 system_clock.clone(),
                 self.cancellation_token.clone(),
             );

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -480,9 +480,11 @@ impl<P: Into<Path>> DbBuilder<P> {
                 self.fp_registry.clone(),
             );
             let this_compactor = compactor.clone();
-            let fut = async move { this_compactor.run_async_task().await };
+            // Spawn the compactor on the compaction runtime
+            let fut = async move { this_compactor.run_async_task(compaction_handle).await };
+            // Spawn the main event loop on the main tokio runtime
             spawn_bg_task(
-                &compaction_handle,
+                &tokio_handle,
                 move |result: &Result<(), SlateDBError>| {
                     let err = bg_task_result_into_err(result);
                     warn!("compactor thread exited with {:?}", err);

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -117,6 +117,7 @@ impl GarbageCollector {
     ///
     /// # Arguments
     ///
+    /// * `tokio_handle` - The tokio handle to use in the background thread.
     /// * `cleanup_fn` - A function that will be called when the garbage collector
     ///   thread completes, with the final result (success or error).
     pub fn start_in_bg_thread(
@@ -133,10 +134,12 @@ impl GarbageCollector {
     }
 
     /// Starts the garbage collector. This method performs the actual garbage collection.
-    /// The garbage collector runs until the cancellation token is cancelled.
+    /// The garbage collector runs until the cancellation token is cancelled. Use
+    /// [`terminate_background_task`](GarbageCollector::terminate_background_task) to stop the
+    /// garbage collector.
     ///
     /// Unlike [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread), this method
-    /// uses the provided Tokio runtime instead of creating a new thread. This is useful
+    /// uses the current Tokio runtime instead of creating a new thread. This is useful
     /// when you want to run the garbage collector within an existing async runtime.
     pub async fn start_async_task(&self) {
         let mut log_ticker = tokio::time::interval(Duration::from_secs(60));

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -58,7 +58,7 @@ trait GcTask {
 /// The garbage collector can run in three modes:
 ///
 /// - As a background thread with [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread)
-/// - As an async task with [`start_async_task`](GarbageCollector::start_async_task)
+/// - As an async task with [`run_async_task`](GarbageCollector::run_async_task)
 /// - As a one-time operation with [`run_gc_once`](GarbageCollector::run_gc_once)
 ///
 /// The garbage collector uses configurable intervals and minimum age thresholds for each
@@ -127,7 +127,7 @@ impl GarbageCollector {
     ) {
         let this = self.clone();
         let gc_main = move || {
-            tokio_handle.block_on(this.start_async_task());
+            tokio_handle.block_on(this.run_async_task());
             Ok(())
         };
         spawn_bg_thread("slatedb-gc", cleanup_fn, gc_main);
@@ -141,7 +141,7 @@ impl GarbageCollector {
     /// Unlike [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread), this method
     /// uses the current Tokio runtime instead of creating a new thread. This is useful
     /// when you want to run the garbage collector within an existing async runtime.
-    pub async fn start_async_task(&self) {
+    pub async fn run_async_task(&self) {
         let mut log_ticker = tokio::time::interval(Duration::from_secs(60));
 
         let (mut wal_gc_task, mut compacted_gc_task, mut manifest_gc_task) = self.gc_tasks();

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -19,14 +19,12 @@ use crate::garbage_collector::stats::GcStats;
 use crate::manifest::store::{DirtyManifest, ManifestStore, StoredManifest};
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
-use crate::utils::spawn_bg_thread;
 use chrono::{DateTime, Utc};
 use compacted_gc::CompactedGcTask;
 use manifest_gc::ManifestGcTask;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::runtime::Handle;
 use tokio::time::Interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
@@ -108,31 +106,6 @@ impl GarbageCollector {
         }
     }
 
-    /// Starts the garbage collector in a background thread.
-    ///
-    /// This method launches the garbage collector in a dedicated background thread
-    /// and returns immediately. The garbage collector will run until its cancellation
-    /// token is cancelled. Use [`terminate_background_task`](GarbageCollector::terminate_background_task)
-    /// to stop the garbage collector.
-    ///
-    /// # Arguments
-    ///
-    /// * `tokio_handle` - The tokio handle to use in the background thread.
-    /// * `cleanup_fn` - A function that will be called when the garbage collector
-    ///   thread completes, with the final result (success or error).
-    pub fn start_in_bg_thread(
-        &self,
-        tokio_handle: Handle,
-        cleanup_fn: impl FnOnce(&Result<(), SlateDBError>) + Send + 'static,
-    ) {
-        let this = self.clone();
-        let gc_main = move || {
-            tokio_handle.block_on(this.run_async_task());
-            Ok(())
-        };
-        spawn_bg_thread("slatedb-gc", cleanup_fn, gc_main);
-    }
-
     /// Starts the garbage collector. This method performs the actual garbage collection.
     /// The garbage collector runs until the cancellation token is cancelled. Use
     /// [`terminate_background_task`](GarbageCollector::terminate_background_task) to stop the
@@ -141,7 +114,7 @@ impl GarbageCollector {
     /// Unlike [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread), this method
     /// uses the current Tokio runtime instead of creating a new thread. This is useful
     /// when you want to run the garbage collector within an existing async runtime.
-    pub async fn run_async_task(&self) {
+    pub async fn run_async_task(&self) -> Result<(), SlateDBError> {
         let mut log_ticker = tokio::time::interval(Duration::from_secs(60));
 
         let (mut wal_gc_task, mut compacted_gc_task, mut manifest_gc_task) = self.gc_tasks();
@@ -185,6 +158,8 @@ impl GarbageCollector {
             self.stats.gc_wal_count.value.load(Ordering::SeqCst),
             self.stats.gc_compacted_count.value.load(Ordering::SeqCst)
         );
+
+        Ok(())
     }
 
     /// Run the garbage collector once.
@@ -286,6 +261,7 @@ mod tests {
 
     use chrono::{DateTime, Utc};
     use object_store::{local::LocalFileSystem, path::Path};
+    use tokio::runtime::Handle;
     use uuid::Uuid;
 
     use crate::checkpoint::Checkpoint;
@@ -295,6 +271,7 @@ mod tests {
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::types::RowEntry;
+    use crate::utils::spawn_bg_task;
     use crate::{
         db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId},
         manifest::store::{ManifestStore, StoredManifest},
@@ -1118,7 +1095,12 @@ mod tests {
             cancellation_token.clone(),
         );
 
-        gc.start_in_bg_thread(Handle::current(), |result| assert!(result.is_ok()));
+        let this_gc = gc.clone();
+        spawn_bg_task(
+            &Handle::current(),
+            |result| assert!(result.is_ok()),
+            async move { this_gc.run_async_task().await },
+        );
         gc.terminate_background_task().await;
 
         tokio::time::sleep(Duration::from_secs(2)).await;

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -324,7 +324,7 @@ impl SizeTieredCompactionSchedulerSupplier {
 }
 
 impl CompactionSchedulerSupplier for SizeTieredCompactionSchedulerSupplier {
-    fn compaction_scheduler(&self) -> Box<dyn CompactionScheduler> {
+    fn compaction_scheduler(&self) -> Box<dyn CompactionScheduler + Send + Sync> {
         Box::new(SizeTieredCompactionScheduler::new(self.options.clone()))
     }
 }


### PR DESCRIPTION
This is the next DST PR after #613. The compactor was originally a mixture of sync and async code. The event loop was synchronous and ran in a thread. This differs from the GC, which has an async event loop. This PR unifies the design of the compactor and the garbage collector. My hope is that this will make it easier for us to do DST since we can have the compactor run on the same single threaded tokio runtime as everything else.

- Replace crossbeam with tokio
- Remove `CompactorOrchestator` (it seemed like an unneeded layer of abstraction)
- Replace the thread in `Compactor::new` with `start_async_task` and `start_in_bg_thread`
- Add `CompactorBuilder` to `builder.rs`
- Get rid of err_*x and replace `CompactorMainMsg` with a `CancellationToken`
- Update a bunch of tests

Notes:

1. I opted to leave the `CompactionExecutor` trait synchronous. The `TokioCompactionExecutor` remains as it was before: it receives a tokio runtime handle, which it uses for async code. I'm open to making it async, but not in this PR. Would be interested in everyone's thoughts.
2. I found some flaky tests. The first were a group in `compactor_state.rs`; these were fixed in #619. The second was `test_should_read_from_compacted_db` in `db.rs`. This one also appeared to be depending on compactor timing. I added a failpoint to pause the compactor loop until all data is written and everything works. I did some debugging and it seems like the compactor was running fast enough now that it was compacting stuff in such a way that it would get some L0's compacted and into an SR and then reach a steady state. **Please pay special attention to this test. I want to make sure I didn't break any assumptions in my refactoring.**