### PR TITLE
Only add the pyo3/extension-module feature for non-Mac arch's

### DIFF
--- a/slatedb-py/.cargo/config.toml
+++ b/slatedb-py/.cargo/config.toml
@@ -1,0 +1,15 @@
+# Can't directly depend on pyo3 on macs due to:
+#
+# - https://github.com/PyO3/pyo3/issues/2521
+# - https://github.com/PyO3/pyo3/issues/340
+#
+# Work around this using:
+#
+# https://github.com/PyO3/pyo3/blob/main/guide/src/faq.md#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror
+#
+# But rather than define the feature for all architectures (which causes Macs
+# to fail when using --all-features), we define it only for non-macOS and
+# non-iOS targets.
+# I think you need the default to be all(not(x), not(y)) or not(any(x, y)).
+[target.'cfg(all(not(target_os = "macos"), not(target_os = "ios")))'.features]
+extension-module = ["pyo3/extension-module"]

--- a/slatedb-py/Cargo.toml
+++ b/slatedb-py/Cargo.toml
@@ -14,19 +14,10 @@ crate-type = ["cdylib"]
 doc = false
 
 [dependencies]
+# See .cargo/config.toml for details on why pyo3/extension-module is only
+# enabled on non-macOS and non-iOS targets.
 pyo3 = { version = "0.25.1" }
 pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 slatedb = { path = "../slatedb" }
 once_cell = "1.19"
 tokio = { version = "1.40.0", features = ["fs", "macros", "sync", "rt", "rt-multi-thread", "signal"] }
-
-# Can't directly depend on pyo3 due to:
-#
-# - https://github.com/PyO3/pyo3/issues/2521
-# - https://github.com/PyO3/pyo3/issues/340
-#
-# Work around this using:
-#
-# https://github.com/PyO3/pyo3/blob/main/guide/src/faq.md#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror
-[features]
-extension-module = ["pyo3/extension-module"]


### PR DESCRIPTION
I found it annoying that I couldn't do `--all-features` on my mac because it would still pull in the `pyo3/extension-module` features. I moved it to `slatedb-py/.cargo/config.toml` so I could use the `cfg` stuff to filter it out completely from Mac architectures.