### PR TITLE
Add more functions to the Python binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 
 *.pyc
 *.so
+slatedb-py/dist

--- a/slatedb-py/python/slatedb/slatedb.pyi
+++ b/slatedb-py/python/slatedb/slatedb.pyi
@@ -4,7 +4,7 @@ Python stub file for slatedb module.
 This module provides a Python interface to SlateDB, a key-value database built in Rust.
 """
 
-from typing import Optional
+from typing import Optional, List, Tuple
 
 class SlateDB:
     """
@@ -14,7 +14,7 @@ class SlateDB:
     and is built with Rust for safety and performance.
     """
     
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, env_file: Optional[str] = None, **kwargs) -> None:
         """
         Create a new SlateDB instance.
         
@@ -38,6 +38,7 @@ class SlateDB:
             ValueError: If the key is empty or there's a database error
         """
         ...
+
     
     def get(self, key: bytes) -> Optional[bytes]:
         """
@@ -51,6 +52,24 @@ class SlateDB:
             
         Raises:
             ValueError: If the key is empty or there's a database error
+        """
+        ...
+
+    
+    def scan(self, start: bytes, end: Optional[bytes] = None) -> List[Tuple[bytes, bytes]]:
+        """
+        Scan the database for key-value pairs with a given prefix.
+
+        Args:
+            start: The start key to scan from as bytes (cannot be empty)
+            end: The end key to stop at as bytes, exclusive (optional, defaults to None)
+                 if None, scan until the end of start+0xFF
+
+        Raises:
+            ValueError: If the start key is empty or there's a database error
+
+        Returns:
+            A list of tuples containing the key and value as bytes, sorted by key
         """
         ...
     

--- a/slatedb-py/tests/test_basic_operations.py
+++ b/slatedb-py/tests/test_basic_operations.py
@@ -63,6 +63,13 @@ def test_empty_values(db):
     with pytest.raises(ValueError, match="key cannot be empty"):
         db.delete(b"")
 
+    with pytest.raises(ValueError, match="start cannot be empty"):
+        db.scan(b"", b"key3")
+
+    with pytest.raises(ValueError, match="start cannot be empty"):
+        db.scan(b"", None)
+
+        
 def test_large_values(db):
     """Test operations with large values."""
     large_value = b"x" * 1024 * 1024  # 1MB
@@ -74,6 +81,17 @@ def test_binary_data(db):
     binary_data = bytes(range(256))
     db.put(b"binary", binary_data)
     assert db.get(b"binary") == binary_data
+
+def test_scan(db):
+    """Test scan operations."""
+    db.put(b"key1", b"value1")
+    db.put(b"key2", b"value2")
+    db.put(b"key3", b"value3")
+    assert list(db.scan(b"key1", b"key4")) == [(b"key1", b"value1"), (b"key2", b"value2"), (b"key3", b"value3")]
+    assert list(db.scan(b"key1", b"key3")) == [(b"key1", b"value1"), (b"key2", b"value2")]
+    assert list(db.scan(b"key1", b"key2")) == [(b"key1", b"value1")]
+    assert list(db.scan(b"key1", None)) == [(b"key1", b"value1")]
+    assert list(db.scan(b"key")) == [(b"key1", b"value1"), (b"key2", b"value2"), (b"key3", b"value3")]
 
 def test_invalid_inputs(db):
     """Test invalid inputs."""


### PR DESCRIPTION
Added the scan function, as the iterator pattern was too difficult to write, a simple version was implemented first.

Added put_xxx, get_xxx, etc., functions to simplify usage.

@calavera please review