### PR TITLE
Use DB's fatal error state if it's set when a channel send fails

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -239,9 +239,7 @@ impl DbInner {
         // TODO: this can be modified as awaiting the last_durable_seq watermark & fatal error.
         let mut durable_watcher = rx
             .await?
-            .map_slatedb_err(self.state.read().error_reader(), |_| {
-                SlateDBError::BackgroundTaskShutdown
-            })?;
+            .map_slatedb_err(self.state.read().error_reader(), |e| e)?;
         if options.await_durable {
             durable_watcher.await_value().await?;
         }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3448,10 +3448,10 @@ mod tests {
         ttl: Option<u64>,
     ) -> Settings {
         Settings {
-            flush_interval: Some(Duration::from_millis(100)),
+            flush_interval: Some(Duration::from_millis(1)),
             #[cfg(feature = "wal_disable")]
             wal_enabled: true,
-            manifest_poll_interval: Duration::from_millis(100),
+            manifest_poll_interval: Duration::from_millis(1),
             manifest_update_timeout: Duration::from_secs(300),
             max_unflushed_bytes: 134_217_728,
             l0_max_ssts: 8,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3454,10 +3454,10 @@ mod tests {
         ttl: Option<u64>,
     ) -> Settings {
         Settings {
-            flush_interval: Some(Duration::from_millis(1)),
+            flush_interval: Some(Duration::from_millis(100)),
             #[cfg(feature = "wal_disable")]
             wal_enabled: true,
-            manifest_poll_interval: Duration::from_millis(1),
+            manifest_poll_interval: Duration::from_millis(100),
             manifest_update_timeout: Duration::from_secs(300),
             max_unflushed_bytes: 134_217_728,
             l0_max_ssts: 8,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2973,7 +2973,11 @@ mod tests {
 
         // assert that db1 can no longer write.
         let err = do_put(&db1, b"1", b"1").await;
-        assert!(matches!(err, Err(SlateDBError::Fenced)));
+        assert!(
+            matches!(err, Err(SlateDBError::Fenced)),
+            "got non-fenced error: {:?}",
+            err
+        );
 
         do_put(&db2, b"2", b"2").await.unwrap();
         assert_eq!(db2.inner.state.read().state().core().next_wal_sst_id, 5);

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -37,7 +37,7 @@ impl DbInner {
         guard.freeze_memtable(wal_id)?;
         self.memtable_flush_notifier
             .send(MemtableFlushMsg::FlushImmutableMemtables { sender: None })
-            .map_slatedb_err(self.state.read().error_reader(), |_| {
+            .map_slatedb_err(guard.error_reader(), |_| {
                 SlateDBError::MemtableFlushChannelError
             })?;
         Ok(())

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -129,7 +129,7 @@ where
             cleanup_fn(&result);
             result
         })
-        .expect("failed to spawn monitored thread")
+        .expect("failed to spawn thread")
 }
 
 pub(crate) fn system_time_to_millis(system_time: SystemTime) -> i64 {

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -215,6 +215,7 @@ impl WalBufferManager {
                 .expect("flush_tx not initialized, please call start_background first.")
                 .send(WalFlushWork { result_tx: None })
                 .await
+                // TODO use map_slatedb_err
                 .map_err(|_| SlateDBError::BackgroundTaskShutdown)?;
         }
         Ok(current_wal)
@@ -242,6 +243,7 @@ impl WalBufferManager {
                 result_tx: Some(result_tx),
             })
             .await
+            // TODO use map_slatedb_err
             .map_err(|_| SlateDBError::BackgroundTaskShutdown)?;
         let mut quit_rx = self.quit_once.reader();
         // TODO: it's good to have a timeout here.


### PR DESCRIPTION
#519 introduced a WAL buffer. Shortly after that PR was merged, we began noticing sporadic failures in `test_empty_wal_should_fence_old_writer`. After some debugging, we traced it down to a race condition where the `mem_table_flush.rs` event loop gets fenced, closes its receiving channel (in `drain_messages`), drops the channel, and _then_ sets the DB error state.

This behavior was resulting in the empty WAL fence test failing because `db1` has a manifest poller set to 100ms. The mem table flusher would _very occasionally_ see that the manifest had been fenced, and shut itself down (using the sequence of steps listed above). There was a brief window of time where `do_put` for `db1` could still go through because `check_error` would be empty even though the mem table flusher channel had been closed. There is a more detailed write-up of this in #623.

This PR fixes this issue in three ways:

1. Rewrites the spawn* tasks in utils so they're not using nested monitor threads/tasks anymore. This keeps the variables in the `f`/`fut` alive until `cleanup_fn` has finished running. Previously, the channels were getting dropped before `cleanup_fn` was running (so the channel was closed but the state was not fatal yet).
2. Set the state to fatal in `mem_table_flush.rs`'s `fut` just after the `core_flush_loop` returns. I had to do this because `drain_messages` closes the channel explicitly (not just dropped at the end of the lifetime of the `fut`). Doing so would _again_ create a condition where the channel is closed but the fatal error is not yet set.
3. Added a `map_slatedb_err` method that will behave like `map_err`, except it will use the DB's error state if it's set. Otherwise, it falls back to normal map_err logic.

These three things _should_ fix the problem. I took a pass at updating the code to use `map_slatedb_err` where appropriate. I might have missed some, but I suppose we can fix those up as we find them.

I ran the test many times and it's working now. I also ran the entire test suite in a loop many times and didn't find any errors.

TBH, I find the solution quite brittle, but I couldn't think of a better way to handle this. There's simply a fundamental race between setting the error state (shutting down the DB) and sending messages over channels that might be closed or dropped. I would love it if there was some alternative someone is aware of?