### PR TITLE
fix: flaky test case test_should_recover_imm_from_wal_after_flush_error

### DIFF
--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -355,6 +355,9 @@ impl WalBufferManager {
         for (wal_id, wal) in flushing_wals.iter() {
             let result = self.do_flush_one_wal(*wal_id, wal.clone()).await;
             if let Err(e) = &result {
+                // a KV table can be retried to flush multiple times, but WatchableOnceCell is only set once.
+                // we do NOT call `wal.notify_durable` as soon as encountered any error here, but notify
+                // the error when we're sure enters fatal state in `do_cleanup`.
                 return Err(e.clone());
             }
 
@@ -367,9 +370,7 @@ impl WalBufferManager {
                 }
             }
 
-            // a kv table can be retried to flush multiple times, but WatchableOnceCell is only set once.
-            // let's notify Ok(()) as soon as possible, while the error will be notified when it goes into
-            // fatal state.
+            // notify durable only when the flush is successful.
             wal.notify_durable(result.clone());
         }
 


### PR DESCRIPTION
this test case asserts `recent_flushed_wal_id()` after `await_flush()`

```
        // write a few keys that will result in memtable flushes
        let key1 = [b'a'; 32];
        let value1 = [b'b'; 96];
        let result = db.put(&key1, &value1).await;
        db.await_flush().await.unwrap();
        assert!(result.is_ok(), "Failed to write key1");
        assert_eq!(db.inner.wal_buffer.recent_flushed_wal_id(), 2);
```

and the current implementation of `await_flush()` is calling `await_durable()` on the `current_wal` when the method is called. 

```

    // await the pending wals to be flushed to remote storage.
    pub async fn await_flush(&self) -> Result<(), SlateDBError> {
        let current_wal = self.inner.read().current_wal.clone();
        if current_wal.is_empty() {
            return Ok(());
        }
        current_wal.await_durable().await
    }
```

in do_flush, i found a race condition where `wal.notify_durable` is called before incrementing `recent_flushed_wal_id`. this means there's a brief window where the wal is notified as durable, but `recent_flushed_wal_id` hasn't been updated yet. this race is what's causing the `test_should_recover_imm_from_wal_after_flush_error` test to fail.

i believe this race condition isn't critical for production use, `recent_flushed_wal_id` doesn't need to be strictly accurate in the current assumption. reading a stale `recent_flushed_wal_id` won't affect correctness since we filter entries by sequence number anyway. still, it makes more sense to update `recent_flushed_wal_id` after the wal is notified as durable.

i've looped this test cases for 10+ minutes on this pr and still not get reproduced yet, while it can be reproduced on main branch after 1~2 minutes.