### PR TITLE
fix(wal): track db fatal when wal flusher got unrecoverable error

### DIFF
--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -233,7 +233,7 @@ pub struct ReadOptions {
 impl Default for ReadOptions {
     fn default() -> Self {
         Self {
-            durability_filter: DurabilityLevel::Remote,
+            durability_filter: DurabilityLevel::Memory,
             dirty: false,
         }
     }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -121,12 +121,9 @@ impl DbInner {
         };
 
         let recent_flushed_wal_id = state.read().state().core().replay_after_wal_id;
-        let state_clone = state.clone();
         let wal_buffer = Arc::new(WalBufferManager::new(
             state.clone(),
-            Box::new(move |err| {
-                state_clone.write().record_fatal_error(err);
-            }),
+            Some(state.clone()),
             recent_flushed_wal_id,
             oracle.clone(),
             table_store.clone(),

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -73,6 +73,7 @@ struct WalBufferManagerInner {
 }
 
 impl WalBufferManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         wal_id_incrementor: Arc<dyn WalIdStore + Send + Sync>,
         db_state: Option<Arc<RwLock<DbState>>>,

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -46,6 +46,7 @@ use crate::{
 pub(crate) struct WalBufferManager {
     inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
     wal_id_incrementor: Arc<dyn WalIdStore + Send + Sync>,
+    // If set, WAL buffer will call `record_fatal_error` if it fails
     db_state: Option<Arc<RwLock<DbState>>>,
     quit_once: WatchableOnceCell<Result<(), SlateDBError>>,
     mono_clock: Arc<MonotonicClock>,


### PR DESCRIPTION
this is another try of having fatal state to get propogated when wal flushing got unrecoverable error.

this `handle_fatal` is kinda ugly, i suppose another way is directly expose `db.state.error` to underlying components like `WalBufferManager`, as it can be considered as a globally coordinated primitive, instead of an inner state of db state.