### PR TITLE
Remove `GarbageCollector::start_in_bg_thread`

### DIFF
--- a/slatedb/clippy.toml
+++ b/slatedb/clippy.toml
@@ -39,6 +39,7 @@ disallowed-types   = [
     { path = "uuid::Builder", reason = "Only our utils.rs may touch this" },
     { path = "ulid::Generator", reason = "Only our utils.rs may touch this" },
     { path = "std::time::Instant", reason = "Use tokio::time::Instant instead" },
+    { path = "std::thread::Builder", reason = "Use tokio::task::Builder instead" },
 ]
 disallowed-methods = [
     { path = "rand::random", reason = "Only our rand.rs may touch this" },
@@ -55,4 +56,7 @@ disallowed-methods = [
     { path = "uuid::Uuid::new_v6", reason = "Only our utils.rs may touch this" },
     { path = "uuid::Uuid::new_v7", reason = "Only our utils.rs may touch this" },
     { path = "uuid::Uuid::new_v8", reason = "Only our utils.rs may touch this" },
+    { path = "std::thread::spawn", reason = "Use tokio::spawn instead" },
+    { path = "std::thread::spawn_blocking", reason = "Use tokio::spawn_blocking instead" },
+    { path = "std::thread::sleep", reason = "Use tokio::time::sleep instead" },
 ]

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -132,13 +132,12 @@ impl Admin {
         .with_cancellation_token(ct)
         .build();
 
-        tracker.spawn(async move {
-            gc.run_async_task().await;
+        let jh = tracker.spawn(async move {
+            gc.run_async_task().await
         });
         tracker.close();
         tracker.wait().await;
-
-        Ok(())
+        jh.await.unwrap().map_err(Into::into)
     }
 
     /// Creates a checkpoint of the db stored in the object store at the specified path using the

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -132,9 +132,7 @@ impl Admin {
         .with_cancellation_token(ct)
         .build();
 
-        let jh = tracker.spawn(async move {
-            gc.run_async_task().await
-        });
+        let jh = tracker.spawn(async move { gc.run_async_task().await });
         tracker.close();
         tracker.wait().await;
         jh.await.unwrap().map_err(Into::into)

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -41,7 +41,6 @@ use crate::db_iter::DbIterator;
 use crate::db_state::{DbState, SsTableId};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
-use crate::garbage_collector::GarbageCollector;
 use crate::manifest::store::{DirtyManifest, FenceableManifest};
 use crate::mem_table::WritableKVTable;
 use crate::mem_table_flush::MemtableFlushMsg;
@@ -386,7 +385,7 @@ pub struct Db {
     memtable_flush_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
     write_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
     compactor_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
-    garbage_collector: Mutex<Option<GarbageCollector>>,
+    garbage_collector_task: Mutex<Option<tokio::task::JoinHandle<Result<(), SlateDBError>>>>,
     cancellation_token: CancellationToken,
 }
 
@@ -485,11 +484,14 @@ impl Db {
             info!("compactor task exited with: {:?}", result);
         }
 
-        if let Some(gc) = {
-            let mut maybe_gc = self.garbage_collector.lock();
-            maybe_gc.take()
+        if let Some(garbage_collector_task) = {
+            let mut maybe_garbage_collector_task = self.garbage_collector_task.lock();
+            maybe_garbage_collector_task.take()
         } {
-            gc.terminate_background_task().await;
+            let result = garbage_collector_task
+                .await
+                .expect("Failed to join garbage collector task");
+            info!("garbage collector task exited with: {:?}", result);
         }
 
         // Shutdown the write batch thread.

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -478,9 +478,8 @@ impl<P: Into<Path>> DbBuilder<P> {
                 system_clock.clone(),
                 self.cancellation_token.clone(),
             );
-            // Spawn the compactor on the compaction runtime
-            // Spawn the main event loop on the main tokio runtime
             let compactor_task = spawn_bg_task(
+                // Spawn the main event loop on the main tokio runtime
                 &tokio_handle,
                 move |result: &Result<(), SlateDBError>| {
                     let err = bg_task_result_into_err(result);
@@ -488,6 +487,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                     let mut state = cleanup_inner.state.write();
                     state.record_fatal_error(err.clone())
                 },
+                // Spawn the compactor on the compaction runtime
                 async move { compactor.run_async_task(compaction_handle).await },
             );
             Some(compactor_task)
@@ -497,7 +497,7 @@ impl<P: Into<Path>> DbBuilder<P> {
 
         // To keep backwards compatibility, check if the gc_runtime or garbage_collector_options are set.
         // If either are set, we need to initialize the garbage collector.
-        let garbage_collector =
+        let garbage_collector_task =
             if self.settings.garbage_collector_options.is_some() || self.gc_runtime.is_some() {
                 let gc_options = self.settings.garbage_collector_options.unwrap_or_default();
                 let gc_handle = self.gc_runtime.unwrap_or_else(|| tokio_handle.clone());
@@ -510,13 +510,17 @@ impl<P: Into<Path>> DbBuilder<P> {
                     system_clock.clone(),
                     self.cancellation_token.clone(),
                 );
-                gc.start_in_bg_thread(gc_handle, move |result| {
-                    let err = bg_task_result_into_err(result);
-                    warn!("GC thread exited with {:?}", err);
-                    let mut state = cleanup_inner.state.write();
-                    state.record_fatal_error(err.clone())
-                });
-                Some(gc)
+                let garbage_collector_task = spawn_bg_task(
+                    &gc_handle,
+                    move |result| {
+                        let err = bg_task_result_into_err(result);
+                        warn!("GC thread exited with {:?}", err);
+                        let mut state = cleanup_inner.state.write();
+                        state.record_fatal_error(err.clone())
+                    },
+                    async move { gc.run_async_task().await },
+                );
+                Some(garbage_collector_task)
             } else {
                 None
             };
@@ -527,7 +531,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             memtable_flush_task: Mutex::new(memtable_flush_task),
             write_task: Mutex::new(write_task),
             compactor_task: Mutex::new(compactor_task),
-            garbage_collector: Mutex::new(garbage_collector),
+            garbage_collector_task: Mutex::new(garbage_collector_task),
             cancellation_token: self.cancellation_token,
         })
     }

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -53,9 +53,8 @@ trait GcTask {
 /// - Compacted SSTs that are no longer referenced by active manifests or checkpoints
 /// - Old manifests that are not needed for recovery or checkpoints
 ///
-/// The garbage collector can run in three modes:
+/// The garbage collector can run in two modes:
 ///
-/// - As a background thread with [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread)
 /// - As an async task with [`run_async_task`](GarbageCollector::run_async_task)
 /// - As a one-time operation with [`run_gc_once`](GarbageCollector::run_gc_once)
 ///
@@ -107,13 +106,7 @@ impl GarbageCollector {
     }
 
     /// Starts the garbage collector. This method performs the actual garbage collection.
-    /// The garbage collector runs until the cancellation token is cancelled. Use
-    /// [`terminate_background_task`](GarbageCollector::terminate_background_task) to stop the
-    /// garbage collector.
-    ///
-    /// Unlike [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread), this method
-    /// uses the current Tokio runtime instead of creating a new thread. This is useful
-    /// when you want to run the garbage collector within an existing async runtime.
+    /// The garbage collector runs until the cancellation token is cancelled.
     pub async fn run_async_task(&self) -> Result<(), SlateDBError> {
         let (mut wal_gc_task, mut compacted_gc_task, mut manifest_gc_task) = self.gc_tasks();
         let mut compacted_ticker = compacted_gc_task.ticker();

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -952,7 +952,7 @@ mod tests {
         // Always sleep 1ms to make sure we get ULIDs that are sortable.
         // Without this, the ULIDs could have the same millisecond timestamp
         // and then ULID sorting is based on the random part.
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
         let sst_id = SsTableId::Compacted(crate::utils::ulid());
         let mut sst = table_store.table_builder();

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -108,31 +108,6 @@ impl GarbageCollector {
         }
     }
 
-    /// Starts the garbage collector in a background thread.
-    ///
-    /// This method launches the garbage collector in a dedicated background thread
-    /// and returns immediately. The garbage collector will run until its cancellation
-    /// token is cancelled. Use [`terminate_background_task`](GarbageCollector::terminate_background_task)
-    /// to stop the garbage collector.
-    ///
-    /// # Arguments
-    ///
-    /// * `tokio_handle` - The tokio handle to use in the background thread.
-    /// * `cleanup_fn` - A function that will be called when the garbage collector
-    ///   thread completes, with the final result (success or error).
-    pub fn start_in_bg_thread(
-        &self,
-        tokio_handle: Handle,
-        cleanup_fn: impl FnOnce(&Result<(), SlateDBError>) + Send + 'static,
-    ) {
-        let this = self.clone();
-        let gc_main = move || {
-            tokio_handle.block_on(this.run_async_task());
-            Ok(())
-        };
-        spawn_bg_thread("slatedb-gc", cleanup_fn, gc_main);
-    }
-
     /// Starts the garbage collector. This method performs the actual garbage collection.
     /// The garbage collector runs until the cancellation token is cancelled. Use
     /// [`terminate_background_task`](GarbageCollector::terminate_background_task) to stop the
@@ -141,14 +116,12 @@ impl GarbageCollector {
     /// Unlike [`start_in_bg_thread`](GarbageCollector::start_in_bg_thread), this method
     /// uses the current Tokio runtime instead of creating a new thread. This is useful
     /// when you want to run the garbage collector within an existing async runtime.
-    pub async fn run_async_task(&self) {
-        let mut log_ticker = tokio::time::interval(Duration::from_secs(60));
-
+    pub async fn run_async_task(&self) -> Result<(), SlateDBError> {
         let (mut wal_gc_task, mut compacted_gc_task, mut manifest_gc_task) = self.gc_tasks();
-
         let mut compacted_ticker = compacted_gc_task.ticker();
         let mut wal_ticker = wal_gc_task.ticker();
         let mut manifest_ticker = manifest_gc_task.ticker();
+        let mut log_ticker = tokio::time::interval(Duration::from_secs(60));
 
         info!(
             "Starting Garbage Collector with [manifest: {:#?}], [wal: {:#?}], [compacted: {:#?}]",
@@ -185,6 +158,8 @@ impl GarbageCollector {
             self.stats.gc_wal_count.value.load(Ordering::SeqCst),
             self.stats.gc_compacted_count.value.load(Ordering::SeqCst)
         );
+
+        Ok(())
     }
 
     /// Run the garbage collector once.
@@ -202,11 +177,6 @@ impl GarbageCollector {
         self.run_gc_task(&mut compacted_gc_task).await;
 
         self.stats.gc_count.inc();
-    }
-
-    /// Notify the garbage collector to terminate.
-    pub async fn terminate_background_task(self) {
-        self.cancellation_token.cancel();
     }
 
     fn gc_tasks(&self) -> (WalGcTask, CompactedGcTask, ManifestGcTask) {
@@ -295,6 +265,7 @@ mod tests {
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::types::RowEntry;
+    use crate::utils::spawn_bg_task;
     use crate::{
         db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId},
         manifest::store::{ManifestStore, StoredManifest},
@@ -1118,8 +1089,10 @@ mod tests {
             cancellation_token.clone(),
         );
 
-        gc.start_in_bg_thread(Handle::current(), |result| assert!(result.is_ok()));
-        gc.terminate_background_task().await;
+        let fut = async move { gc.run_async_task().await };
+        let jh = spawn_bg_task(&Handle::current(), |result| assert!(result.is_ok()), fut);
+        cancellation_token.cancel();
+        jh.await.unwrap();
 
         tokio::time::sleep(Duration::from_secs(2)).await;
         assert!(cancellation_token.is_cancelled());


### PR DESCRIPTION
This is a fast follow-on for #620. While making the `Compactor` async, I noticed that some improvements could be made to the GC:

- Update `Db` to use `garbage_collector_task` rather than `GarbageCollector`
- Update `DbBuilder` to use `spawn_bg_task` for the GC
- Remove unused `spawn_bg_thread` in `utils.rs`
- Detect thread usage now that we're fully async
- Update some docs

I opted not to add a `garbage_collector_runtime` param to `run_async_task`. The current behavior remains as it was: the GC event loop and GcTasks both run on the same GC runtime. I started down that path, but it felt like overkill. If a GC goes slow, I think it's far less consequential than a slow compactor. We can always add it later if we deem it necessary.