### PR TITLE
Use `DbRand` to generate UUIDs and ULIDs

### DIFF
--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -196,7 +196,7 @@ mod tests {
             .await
             .unwrap();
 
-        let source_checkpoint_id = crate::utils::uuid();
+        let source_checkpoint_id = uuid::Uuid::new_v4();
         let result = admin
             .create_checkpoint(&CheckpointOptions {
                 source: Some(source_checkpoint_id),
@@ -280,7 +280,7 @@ mod tests {
             .unwrap();
 
         let result = admin
-            .refresh_checkpoint(crate::utils::uuid(), Some(Duration::from_secs(1000)))
+            .refresh_checkpoint(uuid::Uuid::new_v4(), Some(Duration::from_secs(1000)))
             .await;
 
         assert!(matches!(result, Err(SlateDBError::InvalidDBState)));

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -430,7 +430,7 @@ mod tests {
 
         // Create an uninitialized manifest with an invalid checkpoint id
         let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-        let non_existent_source_checkpoint_id = crate::utils::uuid();
+        let non_existent_source_checkpoint_id = uuid::Uuid::new_v4();
         StoredManifest::create_uninitialized_clone(
             clone_manifest_store,
             &Manifest::initial(CoreDbState::new()),
@@ -517,7 +517,7 @@ mod tests {
             Arc::clone(&clone_manifest_store),
             &parent_manifest,
             original_parent_path.to_string(),
-            crate::utils::uuid(),
+            uuid::Uuid::new_v4(),
         )
         .await
         .unwrap();

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -241,9 +241,10 @@ impl CompactorEventHandler {
     async fn write_manifest(&mut self) -> Result<(), SlateDBError> {
         // write the checkpoint first so that it points to the manifest with the ssts
         // being removed
+        let checkpoint_id = self.rand.thread_rng().gen_uuid();
         self.manifest
             .write_checkpoint(
-                None,
+                checkpoint_id,
                 &CheckpointOptions {
                     // TODO(rohan): for now, just write a checkpoint with 15-minute expiry
                     //              so that it's extremely unlikely for the gc to delete ssts

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -14,6 +14,7 @@ use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::merge_iterator::MergeIterator;
+use crate::rand::DbRand;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
@@ -21,7 +22,7 @@ use crate::tablestore::TableStore;
 use crate::compactor::stats::CompactionStats;
 use crate::types::RowEntry;
 use crate::types::ValueDeletable::Tombstone;
-use crate::utils::spawn_bg_task;
+use crate::utils::{spawn_bg_task, IdGenerator};
 use tracing::error;
 use uuid::Uuid;
 
@@ -50,6 +51,7 @@ impl TokioCompactionExecutor {
         options: Arc<CompactorOptions>,
         worker_tx: tokio::sync::mpsc::UnboundedSender<WorkerToOrchestratorMsg>,
         table_store: Arc<TableStore>,
+        rand: Arc<DbRand>,
         stats: Arc<CompactionStats>,
     ) -> Self {
         Self {
@@ -58,6 +60,7 @@ impl TokioCompactionExecutor {
                 handle,
                 worker_tx,
                 table_store,
+                rand,
                 tasks: Arc::new(Mutex::new(HashMap::new())),
                 stats,
                 is_stopped: AtomicBool::new(false),
@@ -90,6 +93,7 @@ pub(crate) struct TokioCompactionExecutorInner {
     worker_tx: tokio::sync::mpsc::UnboundedSender<WorkerToOrchestratorMsg>,
     table_store: Arc<TableStore>,
     tasks: Arc<Mutex<HashMap<u32, TokioCompactionTask>>>,
+    rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     is_stopped: AtomicBool,
 }
@@ -136,7 +140,7 @@ impl TokioCompactionExecutorInner {
         let mut output_ssts = Vec::new();
         let mut current_writer = self
             .table_store
-            .table_writer(SsTableId::Compacted(crate::utils::ulid()));
+            .table_writer(SsTableId::Compacted(self.rand.thread_rng().gen_ulid()));
         let mut current_size = 0usize;
 
         while let Some(raw_kv) = all_iter.next_entry().await? {
@@ -174,7 +178,7 @@ impl TokioCompactionExecutorInner {
                 let finished_writer = mem::replace(
                     &mut current_writer,
                     self.table_store
-                        .table_writer(SsTableId::Compacted(crate::utils::ulid())),
+                        .table_writer(SsTableId::Compacted(self.rand.thread_rng().gen_ulid())),
                 );
                 output_ssts.push(finished_writer.close().await?);
                 self.stats.bytes_compacted.add(current_size as u64);

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -521,7 +521,7 @@ mod tests {
         // mimic an externally added checkpoint
         let mut dirty = new_dirty_manifest();
         let checkpoint = Checkpoint {
-            id: crate::utils::uuid(),
+            id: uuid::Uuid::new_v4(),
             manifest_id: 1,
             expire_time: None,
             create_time: DefaultSystemClock::default().now(),

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -46,6 +46,7 @@ use crate::manifest::store::{DirtyManifest, FenceableManifest};
 use crate::mem_table::WritableKVTable;
 use crate::mem_table_flush::MemtableFlushMsg;
 use crate::oracle::Oracle;
+use crate::rand::DbRand;
 use crate::reader::Reader;
 use crate::sst_iter::SstIteratorOptions;
 use crate::stats::StatRegistry;
@@ -69,6 +70,7 @@ pub(crate) struct DbInner {
     /// A clock which is guaranteed to be monotonic. it's previous value is
     /// stored in the manifest and WAL, will be updated after WAL replay.
     pub(crate) mono_clock: Arc<MonotonicClock>,
+    pub(crate) rand: Arc<DbRand>,
     pub(crate) oracle: Arc<Oracle>,
     pub(crate) reader: Reader,
     /// [`wal_buffer`] manages the in-memory WAL buffer, it manages the flushing
@@ -84,6 +86,7 @@ impl DbInner {
         logical_clock: Arc<dyn LogicalClock>,
         // TODO replace all system clock usage with this
         _system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
         table_store: Arc<TableStore>,
         manifest: DirtyManifest,
         memtable_flush_notifier: UnboundedSender<MemtableFlushMsg>,
@@ -141,6 +144,7 @@ impl DbInner {
             write_notifier,
             db_stats,
             mono_clock,
+            rand,
             stat_registry,
             reader,
         };

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -543,6 +543,7 @@ pub struct AdminBuilder<P: Into<Path>> {
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     system_clock: Arc<dyn SystemClock>,
+    rand: Arc<DbRand>,
 }
 
 impl<P: Into<Path>> AdminBuilder<P> {
@@ -553,6 +554,7 @@ impl<P: Into<Path>> AdminBuilder<P> {
             main_object_store,
             wal_object_store: None,
             system_clock: Arc::new(DefaultSystemClock::new()),
+            rand: Arc::new(DbRand::default()),
         }
     }
 
@@ -562,12 +564,19 @@ impl<P: Into<Path>> AdminBuilder<P> {
         self
     }
 
+    /// Sets the random number generator to use for randomness.
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.rand = Arc::new(DbRand::new(seed));
+        self
+    }
+
     /// Builds and returns an Admin instance.
     pub fn build(self) -> Admin {
         Admin {
             path: self.path.into(),
             object_stores: ObjectStores::new(self.main_object_store, self.wal_object_store),
             system_clock: self.system_clock,
+            rand: self.rand,
         }
     }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -475,6 +475,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                 uncached_table_store.clone(),
                 compactor_options.clone(),
                 scheduler_supplier,
+                rand.clone(),
                 inner.stat_registry.clone(),
                 system_clock.clone(),
                 self.cancellation_token.clone(),
@@ -662,6 +663,7 @@ pub struct CompactorBuilder<P: Into<Path>> {
     tokio_handle: Handle,
     options: CompactorOptions,
     scheduler_supplier: Arc<dyn CompactionSchedulerSupplier>,
+    rand: Arc<DbRand>,
     stat_registry: Arc<StatRegistry>,
     cancellation_token: CancellationToken,
     system_clock: Arc<dyn SystemClock>,
@@ -676,6 +678,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             tokio_handle: Handle::current(),
             options: CompactorOptions::default(),
             scheduler_supplier: Arc::new(SizeTieredCompactionSchedulerSupplier::default()),
+            rand: Arc::new(DbRand::default()),
             stat_registry: Arc::new(StatRegistry::new()),
             cancellation_token: CancellationToken::new(),
             system_clock: Arc::new(DefaultSystemClock::default()),
@@ -689,28 +692,34 @@ impl<P: Into<Path>> CompactorBuilder<P> {
         self
     }
 
-    /// Sets the options to use for the garbage collector.
+    /// Sets the options to use for the compactor.
     pub fn with_options(mut self, options: CompactorOptions) -> Self {
         self.options = options;
         self
     }
 
-    /// Sets the stats registry to use for the garbage collector.
+    /// Sets the stats registry to use for the compactor.
     #[allow(unused)]
     pub fn with_stat_registry(mut self, stat_registry: Arc<StatRegistry>) -> Self {
         self.stat_registry = stat_registry;
         self
     }
 
-    /// Sets the system clock to use for the garbage collector.
+    /// Sets the system clock to use for the compactor.
     pub fn with_system_clock(mut self, system_clock: Arc<dyn SystemClock>) -> Self {
         self.system_clock = system_clock;
         self
     }
 
-    /// Sets the cancellation token to use for the garbage collector.
+    /// Sets the cancellation token to use for the compactor.
     pub fn with_cancellation_token(mut self, cancellation_token: CancellationToken) -> Self {
         self.cancellation_token = cancellation_token;
+        self
+    }
+
+    /// Sets the random number generator to use for the compactor.
+    pub fn with_rand(mut self, rand: Arc<DbRand>) -> Self {
+        self.rand = rand;
         self
     }
 
@@ -729,6 +738,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             table_store,
             self.options,
             self.scheduler_supplier,
+            self.rand,
             self.stat_registry,
             self.system_clock,
             self.cancellation_token,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -417,6 +417,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                 self.settings.clone(),
                 logical_clock,
                 system_clock.clone(),
+                rand.clone(),
                 table_store.clone(),
                 manifest.prepare_dirty()?,
                 memtable_flush_tx,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -958,7 +958,7 @@ mod tests {
 
         let parent_manifest = Manifest::initial(CoreDbState::new());
         let parent_path = "/tmp/parent_store".to_string();
-        let source_checkpoint_id = crate::utils::uuid();
+        let source_checkpoint_id = uuid::Uuid::new_v4();
 
         let _ = StoredManifest::create_uninitialized_clone(
             Arc::clone(&manifest_store),

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -11,12 +11,13 @@ use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::Manifest;
 use crate::mem_table::{ImmutableMemtable, KVTable};
 use crate::oracle::Oracle;
+use crate::rand::DbRand;
 use crate::reader::{ReadSnapshot, Reader};
 use crate::sst_iter::SstIteratorOptions;
 use crate::stats::StatRegistry;
 use crate::store_provider::{DefaultStoreProvider, StoreProvider};
 use crate::tablestore::TableStore;
-use crate::utils::{MonotonicSeq, WatchableOnceCell};
+use crate::utils::{IdGenerator, MonotonicSeq, WatchableOnceCell};
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{utils, Checkpoint, DbIterator};
 use bytes::Bytes;
@@ -50,6 +51,7 @@ struct DbReaderInner {
     oracle: Arc<Oracle>,
     reader: Reader,
     error_watcher: WatchableOnceCell<SlateDBError>,
+    rand: Arc<DbRand>,
 }
 
 struct ManifestPoller {
@@ -94,6 +96,7 @@ impl DbReaderInner {
         checkpoint_id: Option<Uuid>,
         logical_clock: Arc<dyn LogicalClock>,
         system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
     ) -> Result<Self, SlateDBError> {
         let mut manifest = StoredManifest::load(Arc::clone(&manifest_store)).await?;
         if !manifest.db_state().initialized {
@@ -101,7 +104,8 @@ impl DbReaderInner {
         }
 
         let checkpoint =
-            Self::get_or_create_checkpoint(&mut manifest, checkpoint_id, &options).await?;
+            Self::get_or_create_checkpoint(&mut manifest, checkpoint_id, &options, rand.clone())
+                .await?;
 
         let replay_new_wals = checkpoint_id.is_none();
         let initial_state = Arc::new(
@@ -147,6 +151,7 @@ impl DbReaderInner {
             oracle,
             reader,
             error_watcher: WatchableOnceCell::new(),
+            rand,
         })
     }
 
@@ -154,6 +159,7 @@ impl DbReaderInner {
         manifest: &mut StoredManifest,
         checkpoint_id: Option<Uuid>,
         options: &DbReaderOptions,
+        rand: Arc<DbRand>,
     ) -> Result<Checkpoint, SlateDBError> {
         let checkpoint = if let Some(checkpoint_id) = checkpoint_id {
             manifest
@@ -166,7 +172,9 @@ impl DbReaderInner {
                 lifetime: Some(options.checkpoint_lifetime),
                 ..CheckpointOptions::default()
             };
-            manifest.write_checkpoint(None, &options).await?
+            manifest
+                .write_checkpoint(rand.thread_rng().gen_uuid(), &options)
+                .await?
         };
         Ok(checkpoint)
     }
@@ -212,8 +220,9 @@ impl DbReaderInner {
             lifetime: Some(self.options.checkpoint_lifetime),
             ..CheckpointOptions::default()
         };
+        let new_checkpoint_id = self.rand.thread_rng().gen_uuid();
         stored_manifest
-            .replace_checkpoint(current_checkpoint_id, &options)
+            .replace_checkpoint(current_checkpoint_id, new_checkpoint_id, &options)
             .await
     }
 
@@ -537,6 +546,7 @@ impl DbReader {
             options,
             Arc::new(DefaultLogicalClock::default()),
             Arc::new(DefaultSystemClock::default()),
+            Arc::new(DbRand::new(rand::random())),
         )
         .await
     }
@@ -547,6 +557,7 @@ impl DbReader {
         options: DbReaderOptions,
         logical_clock: Arc<dyn LogicalClock>,
         system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
     ) -> Result<Self, SlateDBError> {
         Self::validate_options(&options)?;
 
@@ -560,6 +571,7 @@ impl DbReader {
                 checkpoint_id,
                 logical_clock,
                 system_clock,
+                rand,
             )
             .await?,
         );
@@ -838,6 +850,7 @@ mod tests {
     use crate::paths::PathResolver;
     use crate::proptest_util::rng::new_test_rng;
     use crate::proptest_util::sample;
+    use crate::rand::DbRand;
     use crate::sst::SsTableFormat;
     use crate::store_provider::StoreProvider;
     use crate::tablestore::TableStore;
@@ -906,6 +919,7 @@ mod tests {
             DbReaderOptions::default(),
             test_provider.logical_clock.clone(),
             test_provider.system_clock.clone(),
+            test_provider.rand.clone(),
         )
         .await
         .unwrap();
@@ -965,6 +979,7 @@ mod tests {
             &parent_manifest,
             parent_path,
             source_checkpoint_id,
+            Arc::new(DbRand::default()),
         )
         .await
         .unwrap();
@@ -1153,18 +1168,21 @@ mod tests {
         fp_registry: Arc<FailPointRegistry>,
         logical_clock: Arc<dyn LogicalClock>,
         system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
     }
 
     impl TestProvider {
         fn new(path: Path, object_store: Arc<dyn ObjectStore>) -> Self {
             let logical_clock = Arc::new(DefaultLogicalClock::new());
             let system_clock = Arc::new(DefaultSystemClock::new());
+            let rand = Arc::new(DbRand::default());
             TestProvider {
                 object_store,
                 path,
                 fp_registry: Arc::new(FailPointRegistry::new()),
                 logical_clock,
                 system_clock,
+                rand,
             }
         }
     }
@@ -1188,6 +1206,7 @@ mod tests {
                 options,
                 self.logical_clock.clone() as Arc<dyn LogicalClock>,
                 self.system_clock.clone() as Arc<dyn SystemClock>,
+                self.rand.clone(),
             )
             .await
         }

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -602,7 +602,7 @@ mod tests {
         let mut updated_state = new_dirty_manifest();
         updated_state.core = db_state.state.core().clone();
         let checkpoint = Checkpoint {
-            id: crate::utils::uuid(),
+            id: uuid::Uuid::new_v4(),
             manifest_id: 1,
             expire_time: None,
             create_time: DefaultSystemClock::default().now(),
@@ -659,10 +659,8 @@ mod tests {
                 .freeze_memtable(i as u64)
                 .expect("db in error state");
             let imm = db_state.state.imm_memtable.back().unwrap().clone();
-            let handle = SsTableHandle::new(
-                SsTableId::Compacted(crate::utils::ulid()),
-                dummy_info.clone(),
-            );
+            let handle =
+                SsTableHandle::new(SsTableId::Compacted(ulid::Ulid::new()), dummy_info.clone());
             db_state.move_imm_memtable_to_l0(imm, handle).unwrap();
         }
     }
@@ -719,7 +717,7 @@ mod tests {
 
     fn create_compacted_sst_handle(first_key: Option<Bytes>) -> SsTableHandle {
         let sst_info = create_sst_info(first_key);
-        let sst_id = SsTableId::Compacted(crate::utils::ulid());
+        let sst_id = SsTableId::Compacted(ulid::Ulid::new());
         SsTableHandle::new(sst_id, sst_info.clone())
     }
 

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -582,13 +582,13 @@ mod tests {
         let mut core = CoreDbState::new();
         core.checkpoints = vec![
             checkpoint::Checkpoint {
-                id: crate::utils::uuid(),
+                id: uuid::Uuid::new_v4(),
                 manifest_id: 1,
                 expire_time: None,
                 create_time: SystemTime::UNIX_EPOCH + Duration::from_secs(100),
             },
             checkpoint::Checkpoint {
-                id: crate::utils::uuid(),
+                id: uuid::Uuid::new_v4(),
                 manifest_id: 2,
                 expire_time: Some(SystemTime::UNIX_EPOCH + Duration::from_secs(1000)),
                 create_time: SystemTime::UNIX_EPOCH + Duration::from_secs(200),
@@ -612,18 +612,18 @@ mod tests {
         manifest.external_dbs = vec![
             ExternalDb {
                 path: "/path/to/external/first".to_string(),
-                source_checkpoint_id: crate::utils::uuid(),
-                final_checkpoint_id: Some(crate::utils::uuid()),
+                source_checkpoint_id: uuid::Uuid::new_v4(),
+                final_checkpoint_id: Some(uuid::Uuid::new_v4()),
                 sst_ids: vec![
-                    SsTableId::Compacted(crate::utils::ulid()),
-                    SsTableId::Compacted(crate::utils::ulid()),
+                    SsTableId::Compacted(ulid::Ulid::new()),
+                    SsTableId::Compacted(ulid::Ulid::new()),
                 ],
             },
             ExternalDb {
                 path: "/path/to/external/second".to_string(),
-                source_checkpoint_id: crate::utils::uuid(),
-                final_checkpoint_id: Some(crate::utils::uuid()),
-                sst_ids: vec![SsTableId::Compacted(crate::utils::ulid())],
+                source_checkpoint_id: uuid::Uuid::new_v4(),
+                final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+                sst_ids: vec![SsTableId::Compacted(ulid::Ulid::new())],
             },
         ];
         let codec = FlatBufferManifestCodec {};
@@ -640,7 +640,7 @@ mod tests {
     fn test_should_encode_decode_ssts_with_visible_ranges() {
         fn new_sst_handle(first_key: &[u8], visible_range: Option<BytesRange>) -> SsTableHandle {
             SsTableHandle::new_compacted(
-                SsTableId::Compacted(crate::utils::ulid()),
+                SsTableId::Compacted(ulid::Ulid::new()),
                 SsTableInfo {
                     first_key: Some(Bytes::copy_from_slice(first_key)),
                     ..Default::default()

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -376,7 +376,7 @@ mod tests {
 
     fn new_checkpoint(manifest_id: u64, expire_time: Option<SystemTime>) -> Checkpoint {
         Checkpoint {
-            id: crate::utils::uuid(),
+            id: uuid::Uuid::new_v4(),
             manifest_id,
             expire_time,
             create_time: DefaultSystemClock::default().now(),
@@ -984,7 +984,7 @@ mod tests {
         // and then ULID sorting is based on the random part.
         std::thread::sleep(std::time::Duration::from_millis(1));
 
-        let sst_id = SsTableId::Compacted(crate::utils::ulid());
+        let sst_id = SsTableId::Compacted(ulid::Ulid::new());
         let mut sst = table_store.table_builder();
         sst.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
         let table = sst.build().unwrap();

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1166,7 +1166,10 @@ mod tests {
             ..CheckpointOptions::default()
         };
 
-        let checkpoint = sm.write_checkpoint(uuid::Uuid::new_v4(), &options).await.unwrap();
+        let checkpoint = sm
+            .write_checkpoint(uuid::Uuid::new_v4(), &options)
+            .await
+            .unwrap();
         let expire_time = checkpoint.expire_time.unwrap();
 
         let refreshed_checkpoint = sm
@@ -1216,7 +1219,11 @@ mod tests {
             .unwrap();
 
         let replaced_checkpoint = sm
-            .replace_checkpoint(checkpoint.id, uuid::Uuid::new_v4(), &CheckpointOptions::default())
+            .replace_checkpoint(
+                checkpoint.id,
+                uuid::Uuid::new_v4(),
+                &CheckpointOptions::default(),
+            )
             .await
             .unwrap();
         assert_ne!(checkpoint.id, replaced_checkpoint.id);
@@ -1237,7 +1244,11 @@ mod tests {
 
         let missing_checkpoint_id = uuid::Uuid::new_v4();
         let replaced_checkpoint = sm
-            .replace_checkpoint(uuid::Uuid::new_v4(), missing_checkpoint_id, &CheckpointOptions::default())
+            .replace_checkpoint(
+                uuid::Uuid::new_v4(),
+                missing_checkpoint_id,
+                &CheckpointOptions::default(),
+            )
             .await
             .unwrap();
 

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1066,7 +1066,7 @@ mod tests {
 
     fn new_checkpoint(manifest_id: u64) -> Checkpoint {
         Checkpoint {
-            id: crate::utils::uuid(),
+            id: uuid::Uuid::new_v4(),
             manifest_id,
             expire_time: None,
             create_time: now_rounded_to_nearest_sec(),
@@ -1190,7 +1190,7 @@ mod tests {
             .await
             .unwrap();
 
-        let checkpoint_id = crate::utils::uuid();
+        let checkpoint_id = uuid::Uuid::new_v4();
         let result = sm
             .refresh_checkpoint(checkpoint_id, Duration::from_secs(100))
             .await;
@@ -1235,7 +1235,7 @@ mod tests {
             .await
             .unwrap();
 
-        let missing_checkpoint_id = crate::utils::uuid();
+        let missing_checkpoint_id = uuid::Uuid::new_v4();
         let replaced_checkpoint = sm
             .replace_checkpoint(missing_checkpoint_id, &CheckpointOptions::default())
             .await
@@ -1272,7 +1272,7 @@ mod tests {
             .await
             .unwrap();
 
-        let checkpoint_id = crate::utils::uuid();
+        let checkpoint_id = uuid::Uuid::new_v4();
         let manifest_id = sm.id;
         sm.delete_checkpoint(checkpoint_id).await.unwrap();
         sm.refresh().await.unwrap();

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -72,7 +72,7 @@ mod tests {
             &main_store
         ));
         assert!(Arc::ptr_eq(
-            &stores.store_for(&SsTableId::Compacted(crate::utils::ulid())),
+            &stores.store_for(&SsTableId::Compacted(ulid::Ulid::new())),
             &main_store
         ));
     }
@@ -97,7 +97,7 @@ mod tests {
             &wal_store
         ));
         assert!(Arc::ptr_eq(
-            &stores.store_for(&SsTableId::Compacted(crate::utils::ulid())),
+            &stores.store_for(&SsTableId::Compacted(ulid::Ulid::new())),
             &main_store
         ));
     }

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -467,7 +467,7 @@ mod tests {
             ],
         ));
         state
-            .submit_compaction(create_sr_compaction(vec![3, 2, 1, 0]))
+            .submit_compaction(uuid::Uuid::new_v4(), create_sr_compaction(vec![3, 2, 1, 0]))
             .unwrap();
 
         // when:
@@ -551,7 +551,7 @@ mod tests {
             ],
         ));
         state
-            .submit_compaction(create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
+            .submit_compaction(uuid::Uuid::new_v4(), create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
             .unwrap();
 
         // when:
@@ -581,7 +581,7 @@ mod tests {
             ],
         ));
         state
-            .submit_compaction(create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
+            .submit_compaction(uuid::Uuid::new_v4(), create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
             .unwrap();
 
         // when:

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -633,7 +633,7 @@ mod tests {
             filter_len: 0,
             compression_codec: None,
         };
-        SsTableHandle::new(SsTableId::Compacted(crate::utils::ulid()), info)
+        SsTableHandle::new(SsTableId::Compacted(ulid::Ulid::new()), info)
     }
 
     fn create_sr2(id: u32, size: u64) -> SortedRun {

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -551,7 +551,10 @@ mod tests {
             ],
         ));
         state
-            .submit_compaction(uuid::Uuid::new_v4(), create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
+            .submit_compaction(
+                uuid::Uuid::new_v4(),
+                create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]),
+            )
             .unwrap();
 
         // when:
@@ -581,7 +584,10 @@ mod tests {
             ],
         ));
         state
-            .submit_compaction(uuid::Uuid::new_v4(), create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]))
+            .submit_compaction(
+                uuid::Uuid::new_v4(),
+                create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]),
+            )
             .unwrap();
 
         // when:

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -186,7 +186,7 @@ mod tests {
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
         builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
         let encoded = builder.build().unwrap();
-        let id = SsTableId::Compacted(crate::utils::ulid());
+        let id = SsTableId::Compacted(ulid::Ulid::new());
         let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
@@ -229,12 +229,12 @@ mod tests {
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
         builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
         let encoded = builder.build().unwrap();
-        let id1 = SsTableId::Compacted(crate::utils::ulid());
+        let id1 = SsTableId::Compacted(ulid::Ulid::new());
         let handle1 = table_store.write_sst(&id1, encoded, false).await.unwrap();
         let mut builder = table_store.table_builder();
         builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
         let encoded = builder.build().unwrap();
-        let id2 = SsTableId::Compacted(crate::utils::ulid());
+        let id2 = SsTableId::Compacted(ulid::Ulid::new());
         let handle2 = table_store.write_sst(&id2, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
@@ -448,7 +448,7 @@ mod tests {
             }
 
             let encoded = builder.build().unwrap();
-            let id = SsTableId::Compacted(crate::utils::ulid());
+            let id = SsTableId::Compacted(ulid::Ulid::new());
             let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
             ssts.push(handle);
         }
@@ -465,7 +465,7 @@ mod tests {
     ) -> SortedRun {
         let mut ssts = Vec::<SsTableHandle>::new();
         for _ in 0..n {
-            let mut writer = table_store.table_writer(SsTableId::Compacted(crate::utils::ulid()));
+            let mut writer = table_store.table_writer(SsTableId::Compacted(ulid::Ulid::new()));
             for _ in 0..keys_per_sst {
                 let entry =
                     RowEntry::new_value(key_gen.next().as_ref(), val_gen.next().as_ref(), 0);

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -633,7 +633,7 @@ mod tests {
             Path::from(ROOT),
             None,
         ));
-        let id = SsTableId::Compacted(crate::utils::ulid());
+        let id = SsTableId::Compacted(ulid::Ulid::new());
 
         // when:
         let mut writer = ts.table_writer(id);
@@ -805,7 +805,7 @@ mod tests {
         ));
 
         // Create and write SST
-        let id = SsTableId::Compacted(crate::utils::ulid());
+        let id = SsTableId::Compacted(ulid::Ulid::new());
         let mut writer = ts.table_writer(id);
         let mut expected_data = Vec::with_capacity(20);
         for i in 0..20 {
@@ -929,7 +929,7 @@ mod tests {
             Path::from("/root"),
             Some(wrapper),
         ));
-        let id = SsTableId::Compacted(crate::utils::ulid());
+        let id = SsTableId::Compacted(ulid::Ulid::new());
         let sst = build_test_sst(&ts.sst_format, 3);
         let sst_bytes = sst.remaining_as_bytes();
         let sst_info = sst.info.clone();
@@ -965,7 +965,7 @@ mod tests {
             Path::from("/root"),
             Some(wrapper),
         ));
-        let id = SsTableId::Compacted(crate::utils::ulid());
+        let id = SsTableId::Compacted(ulid::Ulid::new());
         let sst = build_test_sst(&ts.sst_format, 3);
         let sst_bytes = sst.remaining_as_bytes();
         let sst_info = sst.info.clone();
@@ -1025,7 +1025,7 @@ mod tests {
         // Create id1, id2, and i3 as three random UUIDs that have been sorted ascending.
         // Need to do this because the Ulids are sometimes generated in the same millisecond
         // and the random suffix is used to break the tie, which might be out of order.
-        let mut ulids = (0..3).map(|_| crate::utils::ulid()).collect::<Vec<Ulid>>();
+        let mut ulids = (0..3).map(|_| ulid::Ulid::new()).collect::<Vec<Ulid>>();
         ulids.sort();
         let (id1, id2, id3) = (
             SsTableId::Compacted(ulids[0]),
@@ -1169,8 +1169,8 @@ mod tests {
             None,
         ));
 
-        let id1 = SsTableId::Compacted(crate::utils::ulid());
-        let id2 = SsTableId::Compacted(crate::utils::ulid());
+        let id1 = SsTableId::Compacted(ulid::Ulid::new());
+        let id2 = SsTableId::Compacted(ulid::Ulid::new());
         let path1 = ts.path(&id1);
         let path2 = ts.path(&id2);
         main_store.put(&path1, Bytes::new().into()).await.unwrap();

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -279,18 +279,28 @@ impl MonotonicSeq {
     }
 }
 
-// TODO replace this with our rand module
-#[allow(clippy::disallowed_methods, clippy::disallowed_types)]
-pub(crate) fn uuid() -> Uuid {
-    let mut random_bytes = [0; 16];
-    rand::thread_rng().fill_bytes(&mut random_bytes);
-    uuid::Builder::from_random_bytes(random_bytes).into_uuid()
+/// Trait for generating UUIDs and ULIDs from a random number generator.
+pub trait IdGenerator {
+    fn gen_uuid(&mut self) -> Uuid;
+    fn gen_ulid(&mut self) -> Ulid;
 }
 
-// TODO replace this with our rand module
-#[allow(clippy::disallowed_methods)]
-pub(crate) fn ulid() -> Ulid {
-    Ulid::with_source(&mut rand::thread_rng())
+impl<R: RngCore> IdGenerator for R {
+    /// Generates a random UUID using the provided RNG.
+    fn gen_uuid(&mut self) -> Uuid {
+        let mut bytes = [0u8; 16];
+        self.fill_bytes(&mut bytes);
+        // set version = 4
+        bytes[6] = (bytes[6] & 0x0f) | 0x40;
+        // set variant = RFC4122
+        bytes[8] = (bytes[8] & 0x3f) | 0x80;
+        Uuid::from_bytes(bytes)
+    }
+
+    /// Generates a random ULID using the provided RNG.
+    fn gen_ulid(&mut self) -> Ulid {
+        Ulid::with_source(self)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is the next PR after #620 in the enable-DST series. Here, we replace static UUID and ULID generation with implementations that use `DbRand`. This will make UUID and ULID generation deterministic if we seed the DB.

This work depended on the compactor refactoring in #620 because the compactor used ULIDs and UUIDs a lot. Prior to #620, it had no builder and was mostly static. Updating each static method bled the parameter updates everywhere. Now that the compactor has a `self` it can reference for most methods, adding `DbRand` is much simpler.

We now have `gen_uuid` and `gen_ulid` methods that are automatically added to any `RngCore` when `utils::IdGenerator` is imported. Both methods use the `RngCore` it's attached to for ULID/UUID generation.

Most of the changes are fairly mechanical. A couple of things to watch out for:

- I replaced `FenceableManifest ::write_checkpoint`'s `Option<Uuid>` with a required `Uuid`. This moved random number generation out of the `write_checkpoint` method, which seemed much cleaner than passing in a `DbRand`.
- `CompactorState::submit_compaction` now requires that a `Uuid` is passed in. Previously, it was doing UUID creation itself. Again, this seemed cleaner.
- It seems to me that the `Compaction` ID is also used as the `CompactionJob` id in `CompactorEventHandler::submit_compaction`. I maintained that logic, but it would be nice to confirm this what's supposed to happen.