### PR TITLE
Insulate compactor from executor async runtimes

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -142,7 +142,7 @@ impl Compactor {
                     // Stop the executor. Don't return because there might
                     // still be messages in `worker_rx`. Let the loop continue
                     // to drain them until empty.
-                    handler.stop_executor().await;
+                    handler.stop_executor().await?;
                 }
                 _ = db_runs_log_ticker.tick() => {
                     handler.handle_log_ticker();
@@ -224,7 +224,7 @@ impl CompactorEventHandler {
         }
     }
 
-    async fn stop_executor(&self) {
+    async fn stop_executor(&self) -> Result<(), SlateDBError> {
         let this_executor = self.executor.clone();
         tokio::task::spawn_blocking(move || {
             this_executor.stop();

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -112,8 +112,8 @@ impl Compactor {
         let mut db_runs_log_ticker = tokio::time::interval(Duration::from_secs(10));
         let mut manifest_poll_ticker = tokio::time::interval(self.options.poll_interval);
         let (worker_tx, mut worker_rx) = tokio::sync::mpsc::unbounded_channel();
-        let scheduler = self.scheduler_supplier.compaction_scheduler();
-        let executor = Box::new(TokioCompactionExecutor::new(
+        let scheduler = Arc::from(self.scheduler_supplier.compaction_scheduler());
+        let executor = Arc::new(TokioCompactionExecutor::new(
             compactor_runtime,
             self.options.clone(),
             worker_tx,
@@ -142,7 +142,7 @@ impl Compactor {
                     // Stop the executor. Don't return because there might
                     // still be messages in `worker_rx`. Let the loop continue
                     // to drain them until empty.
-                    handler.stop_executor();
+                    handler.stop_executor().await;
                 }
                 _ = db_runs_log_ticker.tick() => {
                     handler.handle_log_ticker();
@@ -164,8 +164,8 @@ struct CompactorEventHandler {
     state: CompactorState,
     manifest: FenceableManifest,
     options: Arc<CompactorOptions>,
-    scheduler: Box<dyn CompactionScheduler + Send + Sync>,
-    executor: Box<dyn CompactionExecutor + Send + Sync>,
+    scheduler: Arc<dyn CompactionScheduler + Send + Sync>,
+    executor: Arc<dyn CompactionExecutor + Send + Sync>,
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     system_clock: Arc<dyn SystemClock>,
@@ -175,8 +175,8 @@ impl CompactorEventHandler {
     async fn new(
         manifest_store: Arc<ManifestStore>,
         options: Arc<CompactorOptions>,
-        scheduler: Box<dyn CompactionScheduler + Send + Sync>,
-        executor: Box<dyn CompactionExecutor + Send + Sync>,
+        scheduler: Arc<dyn CompactionScheduler + Send + Sync>,
+        executor: Arc<dyn CompactionExecutor + Send + Sync>,
         rand: Arc<DbRand>,
         stats: Arc<CompactionStats>,
         system_clock: Arc<dyn SystemClock>,
@@ -224,8 +224,11 @@ impl CompactorEventHandler {
         }
     }
 
-    fn stop_executor(&self) {
-        self.executor.stop();
+    async fn stop_executor(&self) {
+        let this_executor = self.executor.clone();
+        tokio::task::spawn_blocking(move || {
+            this_executor.stop();
+        });
     }
 
     fn is_executor_stopped(&self) -> bool {
@@ -234,7 +237,7 @@ impl CompactorEventHandler {
 
     async fn load_manifest(&mut self) -> Result<(), SlateDBError> {
         self.manifest.refresh().await?;
-        self.refresh_db_state()?;
+        self.refresh_db_state().await?;
         Ok(())
     }
 
@@ -276,7 +279,7 @@ impl CompactorEventHandler {
         }
     }
 
-    fn maybe_schedule_compactions(&mut self) -> Result<(), SlateDBError> {
+    async fn maybe_schedule_compactions(&mut self) -> Result<(), SlateDBError> {
         let compactions = self.scheduler.maybe_schedule_compaction(&self.state);
         for compaction in compactions.iter() {
             if self.state.num_compactions() >= self.options.max_concurrent_compactions {
@@ -288,12 +291,16 @@ impl CompactorEventHandler {
                 );
                 break;
             }
-            self.submit_compaction(compaction.clone())?;
+            self.submit_compaction(compaction.clone()).await?;
         }
         Ok(())
     }
 
-    fn start_compaction(&mut self, id: Uuid, compaction: Compaction) {
+    async fn start_compaction(
+        &mut self,
+        id: Uuid,
+        compaction: Compaction,
+    ) -> Result<(), SlateDBError> {
         self.log_compaction_state();
         let db_state = self.state.db_state();
         let compacted_sst_iter = db_state.compacted.iter().flat_map(|sr| sr.ssts.iter());
@@ -323,14 +330,20 @@ impl CompactorEventHandler {
                 .compacted
                 .last()
                 .is_some_and(|sr| compaction.destination == sr.id);
-        self.executor.start_compaction(CompactionJob {
+        let job = CompactionJob {
             id,
             destination: compaction.destination,
             ssts,
             sorted_runs,
             compaction_ts: db_state.last_l0_clock_tick,
             is_dest_last_run,
-        });
+        };
+        let this_executor = self.executor.clone();
+        tokio::task::spawn_blocking(move || {
+            this_executor.start_compaction(job);
+        })
+        .await
+        .map_err(|_| SlateDBError::CompactionExecutorFailed)
     }
 
     // state writers
@@ -346,7 +359,7 @@ impl CompactorEventHandler {
         self.state.finish_compaction(id, output_sr);
         self.log_compaction_state();
         self.write_manifest_safely().await?;
-        self.maybe_schedule_compactions()?;
+        self.maybe_schedule_compactions().await?;
         self.stats.last_compaction_ts.set(
             self.system_clock
                 .now()
@@ -357,12 +370,12 @@ impl CompactorEventHandler {
         Ok(())
     }
 
-    fn submit_compaction(&mut self, compaction: Compaction) -> Result<(), SlateDBError> {
+    async fn submit_compaction(&mut self, compaction: Compaction) -> Result<(), SlateDBError> {
         let id = self.rand.thread_rng().gen_uuid();
         let result = self.state.submit_compaction(id, compaction.clone());
         match result {
             Ok(_) => {
-                self.start_compaction(id, compaction);
+                self.start_compaction(id, compaction).await?;
             }
             Err(err) => {
                 warn!("invalid compaction: {:?}", err);
@@ -371,10 +384,10 @@ impl CompactorEventHandler {
         Ok(())
     }
 
-    fn refresh_db_state(&mut self) -> Result<(), SlateDBError> {
+    async fn refresh_db_state(&mut self) -> Result<(), SlateDBError> {
         self.state
             .merge_remote_manifest(self.manifest.prepare_dirty()?);
-        self.maybe_schedule_compactions()?;
+        self.maybe_schedule_compactions().await?;
         Ok(())
     }
 
@@ -746,9 +759,9 @@ mod tests {
         manifest_store: Arc<ManifestStore>,
         options: Settings,
         db: Db,
-        scheduler: Box<MockScheduler>,
-        executor: Box<MockExecutor>,
-        real_executor: Box<dyn CompactionExecutor>,
+        scheduler: Arc<MockScheduler>,
+        executor: Arc<MockExecutor>,
+        real_executor: Arc<dyn CompactionExecutor>,
         real_executor_rx: tokio::sync::mpsc::UnboundedReceiver<WorkerToOrchestratorMsg>,
         stats_registry: Arc<StatRegistry>,
         handler: CompactorEventHandler,
@@ -767,13 +780,13 @@ mod tests {
                 .await
                 .unwrap();
 
-            let scheduler = Box::new(MockScheduler::new());
-            let executor = Box::new(MockExecutor::new());
+            let scheduler = Arc::new(MockScheduler::new());
+            let executor = Arc::new(MockExecutor::new());
             let (real_executor_tx, real_executor_rx) = tokio::sync::mpsc::unbounded_channel();
             let rand = Arc::new(DbRand::default());
             let stats_registry = Arc::new(StatRegistry::new());
             let compactor_stats = Arc::new(CompactionStats::new(stats_registry.clone()));
-            let real_executor = Box::new(TokioCompactionExecutor::new(
+            let real_executor = Arc::new(TokioCompactionExecutor::new(
                 Handle::current(),
                 compactor_options.clone(),
                 real_executor_tx,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -228,7 +228,9 @@ impl CompactorEventHandler {
         let this_executor = self.executor.clone();
         tokio::task::spawn_blocking(move || {
             this_executor.stop();
-        });
+        })
+        .await
+        .map_err(|_| SlateDBError::CompactionExecutorFailed)
     }
 
     fn is_executor_stopped(&self) -> bool {

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -54,6 +54,9 @@ pub enum SlateDBError {
     #[error("Invalid Compaction")]
     InvalidCompaction,
 
+    #[error("Compaction executor failed")]
+    CompactionExecutorFailed,
+
     #[error(
         "Invalid clock tick, most be monotonic. Last tick: {}, Next tick: {}",
         last_tick,


### PR DESCRIPTION
While working on #640, I found the compactor fails when stop() is called. I introduced the issue when I made the compactor async in #620. `Compactor`'s event loop (async) calls `CompactorEventHandler`'s `stop_executor`. The call stack eventually reaches `CompactionExecutor`'s `stop()` method. Everything from the `stop_executor` call on down is sync. Then, in `stop()`, I had the `TokioCompactionExecutor `'s `stop()` method call `this.handle.spawn_blocking()`. Tokio doesn't allow this because, though `stop()` is sync, it detects it's inside another runtime (the `Compactor`'s).

I fixed the issue by making the remaining `CompactorEventHandler` functions async (minus a couple of little helpers). This is mostly for clarity since it seemed to call `spawn_blocking` on our own `CompactorEventHandler`. Then, I updated `stop_executor` in the handler to spawn a blocking thread from within its own runtime (`Compactor`'s). This is safe and Tokio accepts it.

Finally, I noticed the same issue exists with `start_compaction()`, so I updated the handler's `start_compaction()` method to call the executor's `start_compaction()` from a `spawn_blocking`. We weren't seeing failures here because `start_compaction()` in our executor was calling `spawn_bg_task`, which is safe from within the runtime (since it doesn't block runtime threads).

I opted to make the `scheduler` variable an `Arc` instead of a `Box` simply because it felt more intuitive to have it the same as the executor, which we needed to change to `Arc` to pass into sync blocks.

I also added a new error type: `CompactionExecutorFailed`. This is to signal when the `spawn_blocking` calls fail. Our `CompactionExecutor` trait doesn't return error types, so I decided to simply signal that the calls had failed.