### PR TITLE
Disable cache for WAL replay iterator

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -363,7 +363,7 @@ impl DbInner {
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 1,
             blocks_to_fetch: 256,
-            cache_blocks: true,
+            cache_blocks: false,
             eager_spawn: true,
         };
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -432,9 +432,6 @@ impl<P: Into<Path>> DbBuilder<P> {
             inner.fence_writers(&mut manifest, next_wal_id).await?;
         }
 
-        // Replay WAL
-        inner.replay_wal().await?;
-
         // Setup background tasks
         let tokio_handle = Handle::current();
         if inner.wal_enabled {
@@ -522,6 +519,9 @@ impl<P: Into<Path>> DbBuilder<P> {
             } else {
                 None
             };
+
+        // Replay WAL
+        inner.replay_wal().await?;
 
         // Create and return the Db instance
         Ok(Db {


### PR DESCRIPTION
I noticed that we're still using `cache_blocks` in `replay_wal`. This will cache the WAL's blocks in the in-memory block cache. Since #519, we don't read from the WAL anymore (except during replay). Caching its blocks during WAL replay is useless.

Fixes #646