### PR TITLE
feat(disk_cache): implement extensible cache admission framework

### DIFF
--- a/slatedb/src/cached_object_store/admission/mod.rs
+++ b/slatedb/src/cached_object_store/admission/mod.rs
@@ -1,0 +1,38 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Copy)]
+pub enum AdmitResult {
+    /// The object was admitted to the disk cache.
+    Admitted,
+    /// The object was rejected
+    Rejected,
+}
+
+impl AdmitResult {
+    pub fn admitted(&self) -> bool {
+        matches!(self, AdmitResult::Admitted)
+    }
+
+    pub fn rejected(&self) -> bool {
+        matches!(self, AdmitResult::Rejected)
+    }
+}
+
+impl From<bool> for AdmitResult {
+    fn from(value: bool) -> Self {
+        if value {
+            AdmitResult::Admitted
+        } else {
+            AdmitResult::Rejected
+        }
+    }
+}
+
+pub trait AdmissionPolicy: Send + Sync + 'static + Debug {}
+
+/// The admission picker is responsible for deciding whether an object should be admitted to the disk cache or not.
+#[derive(Debug, Clone)]
+pub struct AdmissionPicker {
+    pub policies: Vec<Arc<dyn AdmissionPolicy>>,
+}

--- a/slatedb/src/cached_object_store/admission/mod.rs
+++ b/slatedb/src/cached_object_store/admission/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::Debug;
 use std::sync::Arc;
 
+use crate::cached_object_store::LocalCacheEntry;
+
 #[derive(Debug, Clone, Copy)]
 pub enum AdmitResult {
     /// The object was admitted to the disk cache.
@@ -14,6 +16,7 @@ impl AdmitResult {
         matches!(self, AdmitResult::Admitted)
     }
 
+    #[allow(unused)]
     pub fn rejected(&self) -> bool {
         matches!(self, AdmitResult::Rejected)
     }
@@ -29,10 +32,61 @@ impl From<bool> for AdmitResult {
     }
 }
 
-pub trait AdmissionPolicy: Send + Sync + 'static + Debug {}
+pub trait AdmissionPolicy: Send + Sync + 'static + Debug {
+    /// Determines whether the given entry should be admitted to the disk cache.
+    fn pick(&self, entry: &dyn LocalCacheEntry) -> AdmitResult;
+
+    /// A human-readable name for the policy
+    #[allow(unused)]
+    fn name(&self) -> &str;
+}
+
+/// A policy that admits all objects to the disk cache without any checks.
+#[derive(Debug, Clone)]
+pub struct AdmitAll;
+
+impl AdmissionPolicy for AdmitAll {
+    fn pick(&self, _: &dyn LocalCacheEntry) -> AdmitResult {
+        AdmitResult::Admitted
+    }
+
+    fn name(&self) -> &str {
+        "AdmitAll"
+    }
+}
 
 /// The admission picker is responsible for deciding whether an object should be admitted to the disk cache or not.
 #[derive(Debug, Clone)]
 pub struct AdmissionPicker {
-    pub policies: Vec<Arc<dyn AdmissionPolicy>>,
+    policies: Vec<Arc<dyn AdmissionPolicy>>,
+}
+
+impl AdmissionPicker {
+    pub fn new() -> Self {
+        Self {
+            policies: vec![Arc::new(AdmitAll)],
+        }
+    }
+
+    #[allow(unused)]
+    pub fn build_with_policies(policies: Vec<Arc<dyn AdmissionPolicy>>) -> Self {
+        Self { policies }
+    }
+
+    pub fn pick(&self, entry: &dyn LocalCacheEntry) -> AdmitResult {
+        for policy in self.policies.iter() {
+            match policy.pick(entry) {
+                AdmitResult::Admitted => {}
+                AdmitResult::Rejected => return AdmitResult::Rejected,
+            }
+        }
+
+        AdmitResult::Admitted
+    }
+}
+
+impl Default for AdmissionPicker {
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/slatedb/src/cached_object_store/mod.rs
+++ b/slatedb/src/cached_object_store/mod.rs
@@ -5,6 +5,7 @@ pub use storage_fs::FsCacheStorage;
 
 pub mod stats;
 
+mod admission;
 mod object_store;
 mod storage;
 mod storage_fs;


### PR DESCRIPTION
This is the first step towards a solution for #198, which implements a extensible cache admission framework. We introduced an `AdmissionPicker` to manage all admission policies.

Users can customize `AdmissionPolicy` or directly use the admission policies we provide. Currently we have implemented an admission policy that accepts all cache entries, so this will not affect the current disk cache write process.