### PR TITLE
test: let test_get_after_put to use explicit options instead of defaults

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1067,12 +1067,27 @@ mod tests {
                 |(key, value)| {
                     runtime.block_on(async {
                         if !key.is_empty() {
-                            db.put(&key, &value).await.unwrap();
+                            db.put_with_options(
+                                &key,
+                                &value,
+                                &PutOptions::default(),
+                                &WriteOptions {
+                                    await_durable: false,
+                                },
+                            )
+                            .await
+                            .unwrap();
                             assert_eq!(
                                 Some(value),
-                                db.get_with_options(&key, &ReadOptions::default())
-                                    .await
-                                    .unwrap()
+                                db.get_with_options(
+                                    &key,
+                                    &ReadOptions {
+                                        durability_filter: Memory,
+                                        dirty: false,
+                                    }
+                                )
+                                .await
+                                .unwrap()
                             );
                         }
                     });


### PR DESCRIPTION
related: #647

this pr uses explicit options on write options and read options, to test over the case about a `get()` should always get the committed data with `dirty: false`. 

(currently the `sync` field is not supported yet. all the writes' sync level are considered as memory, this should be added in a pr).