### PR TITLE
Default to Foyer cache and 256MiB `max_sst_size`

### DIFF
--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -66,10 +66,10 @@ tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 tokio-test = "0.4.4"
 
 [features]
-default = ["aws", "moka"]
+default = ["aws", "foyer"]
 aws = ["object_store/aws"]
 azure = ["object_store/azure"]
-bencher = ["aws", "azure", "wal_disable", "moka"]
+bencher = ["aws", "azure", "wal_disable", "foyer"]
 compression = ["snappy"]
 snappy = ["dep:snap"]
 zlib = ["dep:flate2"]

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -823,13 +823,13 @@ pub struct CompactorOptions {
 /// Default options for the compactor. Currently, only a
 /// `SizeTieredCompactionScheduler` compaction strategy is implemented.
 impl Default for CompactorOptions {
-    /// Returns a `CompactorOptions` with a 5 second poll interval and a 1GB max
+    /// Returns a `CompactorOptions` with a 5 second poll interval and a 256MiB max
     /// SSTable size.
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(5),
             manifest_update_timeout: Duration::from_secs(300),
-            max_sst_size: 1024 * 1024 * 1024,
+            max_sst_size: 256 * 1024 * 1024,
             max_concurrent_compactions: 4,
         }
     }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -581,7 +581,6 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
     use crate::stats::StatRegistry;
-    #[cfg(feature = "moka")]
     use crate::tablestore::TableStore;
     use crate::test_utils::{assert_iterator, build_test_sst};
     use crate::types::{RowEntry, ValueDeletable};


### PR DESCRIPTION
@Barre discovered that Moka could get into a ton of contention under his workload. It's not immediately apparent what the issue is with Moka, but switching to Foyer fixed the problem immediately.

@Barre also discovered that the 1GiB default for compacted SSTs can lead to a lot of write amplification and slow things down. 256MiB was a much better default for him.  In general, I think that makes sense for others, too. The cost is 4x the number of SSTs listed in the manifest and on list() calls to `compacted`. If that's an issue for users, they can set their SST size to 1GiB.

Fixes #602, #646
