### PR TITLE
Update RELEASE.md with Python binding instructions

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -7,6 +7,10 @@ name: Publish Release (Python)
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of the release (e.g., 1.0.0)"
+        required: true
 
 permissions:
   contents: read
@@ -31,6 +35,8 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -70,6 +76,8 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -98,6 +106,8 @@ jobs:
   #           target: x86
   #   steps:
   #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: "v${{ github.event.inputs.version }}"
   #     - uses: actions/setup-python@v5
   #       with:
   #         python-version: 3.x
@@ -126,6 +136,8 @@ jobs:
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -146,6 +158,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,12 +19,6 @@ SlateDB releases are published using a Github release action defined in `.github
 1. Go to the [release action page](https://github.com/slatedb/slatedb/actions/workflows/release.yaml)
 2. Input a version value in the format `X.Y.Z` and click `Run workflow`.
 
- To create a patch release for an existing version:
-
-1. If it doesn't already exist, create a <major>.<minor>.x branch from the release tag. So for example, for the v0.6.0 release, run `git checkout -b 0.6.x v0.6.0`.
-2. Cherry-pick the desired changes onto the release branch and push it.
-3. Run the release workflow against the release branch and specify the desired release version (e.g. v0.6.1)
-
 The release action will do the following:
 
 1. Verify that the version adheres to the semantic versioning format.
@@ -33,3 +27,22 @@ The release action will do the following:
 4. Commit the changes and push to the `main` branch.
 5. Create a Github release with the specified version and auto-generated release notes.
 6. Publish a release to crates.io.
+
+### Patch releases
+
+To create a patch release for an existing version:
+
+1. If it doesn't already exist, create a <major>.<minor>.x branch from the release tag. So for example, for the v0.6.0 release, run `git checkout -b 0.6.x v0.6.0`.
+2. Cherry-pick the desired changes onto the release branch and push it.
+3. Run the release workflow against the release branch and specify the desired release version (e.g. v0.6.1)
+
+### Bindings
+
+#### Python Bindings
+
+SlateDB Python bindings are published using a Github release action defined in `.github/workflows/python.yml`. To create a new release:
+
+1. Go to the [python release action page](https://github.com/slatedb/slatedb/actions/workflows/python.yaml)
+2. Input a version value in the format `X.Y.Z` and click `Run workflow`.
+
+Python releases can only run after a crate release has been published to crates.io using the Rust publication process shown above. This is because the Python release action can only run against a release tag in the git repo (not on main).


### PR DESCRIPTION
After jumping through man hoops, I've gotten 0.7.0 published to PyPI. I've updated the release documentation to describe how to do this.

I also decided to make the Python release run against a tag, not main. This seems safer and will keep Python releases in lock-step with the Rust crate.