### PR TITLE
Add compactor progress

### DIFF
--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -341,18 +341,15 @@ impl CompactionExecuteBench {
         info!("start compaction job");
         tokio::task::spawn_blocking(move || executor.start_compaction(job));
         while let Some(msg) = rx.recv().await {
-            match msg {
-                WorkerToOrchestratorMsg::CompactionFinished { id: _, result } => match result {
+            if let WorkerToOrchestratorMsg::CompactionFinished { id: _, result } = msg {
+                match result {
                     Ok(_) => {
                         info!(elapsed = ?start.elapsed(), "compaction finished");
                     }
                     Err(err) => return Err(err),
-                },
-                // Ignore compactor progress reports
-                _ => {}
+                }
             }
         }
-
         Ok(())
     }
 

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -15,6 +15,7 @@ use tracing::{error, info};
 use ulid::Ulid;
 
 use crate::bytes_generator::OrderedBytesGenerator;
+use crate::clock::DefaultSystemClock;
 use crate::compactor::stats::CompactionStats;
 use crate::compactor::WorkerToOrchestratorMsg;
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
@@ -308,6 +309,7 @@ impl CompactionExecuteBench {
             table_store.clone(),
             self.rand.clone(),
             stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
         );
         let os = self.object_store.clone();
         info!("load compaction job");

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -53,8 +53,13 @@ impl CompactionProgressTracker {
         }
     }
 
-    pub fn add_job(&mut self, id: Uuid, bytes: u64) {
-        self.processed_bytes.insert(id, (0, bytes));
+    /// Adds a new compaction job to the tracker.
+    ///
+    /// # Arguments
+    /// * `id` - The ID of the compaction job.
+    /// * `total_bytes` - The total number of bytes to be processed for the compaction job.
+    pub fn add_job(&mut self, id: Uuid, total_bytes: u64) {
+        self.processed_bytes.insert(id, (0, total_bytes));
     }
 
     pub fn remove_job(&mut self, id: Uuid) {
@@ -62,6 +67,10 @@ impl CompactionProgressTracker {
     }
 
     /// Overwrites the progress for a compaction job with the latest processed bytes.
+    ///
+    /// # Arguments
+    /// * `id` - The ID of the compaction job.
+    /// * `bytes_processed` - The total number of bytes processed so far.
     pub fn update_progress(&mut self, id: Uuid, bytes_processed: u64) {
         if let Some((_, total_bytes)) = self.processed_bytes.get(&id).map(|entry| *entry.value()) {
             self.processed_bytes

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -66,7 +66,7 @@ impl CompactionProgressLogger {
         if let Some((_, total_bytes)) = self
             .processed_bytes
             .get(&id)
-            .map(|entry| entry.value().clone())
+            .map(|entry| *entry.value())
         {
             self.processed_bytes
                 .insert(id, (bytes_processed, total_bytes));

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -62,6 +62,10 @@ impl CompactionProgressTracker {
         self.processed_bytes.insert(id, (0, total_bytes));
     }
 
+    /// Removes a compaction job from the tracker.
+    ///
+    /// # Arguments
+    /// * `id` - The ID of the compaction job.
     pub fn remove_job(&mut self, id: Uuid) {
         self.processed_bytes.remove(&id);
     }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -63,11 +63,7 @@ impl CompactionProgressLogger {
 
     /// Overwrites the progress for a compaction job with the latest processed bytes.
     pub fn update_progress(&mut self, id: Uuid, bytes_processed: u64) {
-        if let Some((_, total_bytes)) = self
-            .processed_bytes
-            .get(&id)
-            .map(|entry| *entry.value())
-        {
+        if let Some((_, total_bytes)) = self.processed_bytes.get(&id).map(|entry| *entry.value()) {
             self.processed_bytes
                 .insert(id, (bytes_processed, total_bytes));
         } else {
@@ -191,6 +187,7 @@ impl Compactor {
             self.table_store.clone(),
             self.rand.clone(),
             self.stats.clone(),
+            self.system_clock.clone(),
         ));
         let mut handler = CompactorEventHandler::new(
             self.manifest_store.clone(),
@@ -883,6 +880,7 @@ mod tests {
                 table_store,
                 rand.clone(),
                 compactor_stats.clone(),
+                Arc::new(DefaultSystemClock::new()),
             ));
             let handler = CompactorEventHandler::new(
                 manifest_store.clone(),

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -200,10 +200,10 @@ impl TokioCompactionExecutorInner {
                 _ => raw_kv,
             };
 
-            let key_len = kv.key.len() as u64;
-            let value_len = kv.value.len() as u64;
+            let key_len = kv.key.len();
+            let value_len = kv.value.len();
 
-            total_bytes_processed += key_len + value_len;
+            total_bytes_processed += key_len as u64 + value_len as u64;
             let duration_since_last_report = self
                 .clock
                 .now()
@@ -229,7 +229,7 @@ impl TokioCompactionExecutorInner {
             }
 
             current_writer.add(kv).await?;
-            current_size += key_len as usize + value_len as usize;
+            current_size += key_len + value_len;
 
             if current_size > self.options.max_sst_size {
                 current_size = 0;

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -37,13 +37,6 @@ pub(crate) struct CompactionJob {
 
 impl std::fmt::Debug for CompactionJob {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let estimated_sst_size = self.ssts.iter().map(|sst| sst.estimate_size()).sum::<u64>();
-        let estimated_sr_size = self
-            .sorted_runs
-            .iter()
-            .map(|sr| sr.estimate_size())
-            .sum::<u64>();
-        let estimated_total_size = estimated_sst_size + estimated_sr_size;
         f.debug_struct("CompactionJob")
             .field("id", &self.id)
             .field("destination", &self.destination)
@@ -51,8 +44,21 @@ impl std::fmt::Debug for CompactionJob {
             .field("sorted_runs", &self.sorted_runs)
             .field("compaction_ts", &self.compaction_ts)
             .field("is_dest_last_run", &self.is_dest_last_run)
-            .field("estimated_source_bytes", &estimated_total_size)
+            .field("estimated_source_bytes", &self.estimated_source_bytes())
             .finish()
+    }
+}
+
+impl CompactionJob {
+    /// Estimates the total size of the source SSTs and sorted runs.
+    pub(crate) fn estimated_source_bytes(&self) -> u64 {
+        let sst_size = self.ssts.iter().map(|sst| sst.estimate_size()).sum::<u64>();
+        let sr_size = self
+            .sorted_runs
+            .iter()
+            .map(|sr| sr.estimate_size())
+            .sum::<u64>();
+        sst_size + sr_size
     }
 }
 

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -243,16 +243,17 @@ impl TokioCompactionExecutorInner {
                 _ => raw_kv,
             };
 
+            // Update progress
+            let key_len = kv.key.len() as u64;
+            let value_len = kv.value.len() as u64;
+            progress_logger.log_progress(key_len + value_len, false);
+
             if compaction.is_dest_last_run && kv.value.is_tombstone() {
                 continue;
             }
 
-            // Add to SST
-            let key_len = kv.key.len() as u64;
-            let value_len = kv.value.len() as u64;
             current_writer.add(kv).await?;
             current_size += key_len as usize + value_len as usize;
-            progress_logger.log_progress(key_len + value_len, false);
 
             if current_size > self.options.max_sst_size {
                 current_size = 0;

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -153,7 +153,7 @@ impl CompactionProgressLogger {
     pub fn log_progress(&mut self, bytes_processed: u64, is_done: bool) {
         self.total_processed_bytes += bytes_processed;
 
-        if self.estimated_total_bytes > 0 && self.last_log_print.elapsed() >= self.log_interval {
+        if is_done || self.last_log_print.elapsed() >= self.log_interval {
             self.last_log_print = Instant::now();
             let current_percentage =
                 (self.total_processed_bytes * 100 / self.estimated_total_bytes) as u32;

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -126,49 +126,6 @@ pub(crate) struct TokioCompactionExecutorInner {
     is_stopped: AtomicBool,
 }
 
-/// Struct responsible for tracking and logging compaction progress
-pub(crate) struct CompactionProgressLogger {
-    /// Total estimated bytes to be processed
-    estimated_total_bytes: u64,
-    /// Total bytes processed so far
-    total_processed_bytes: u64,
-    /// Last time a log message was printed
-    last_log_print: Instant,
-    /// Minimum interval between log messages
-    log_interval: Duration,
-}
-
-impl CompactionProgressLogger {
-    /// Creates a new progress logger
-    pub fn new(estimated_total_bytes: u64, log_interval: Duration) -> Self {
-        Self {
-            estimated_total_bytes,
-            total_processed_bytes: 0,
-            last_log_print: Instant::now(),
-            log_interval,
-        }
-    }
-
-    /// Updates progress by the given amount of bytes and logs if necessary
-    pub fn log_progress(&mut self, bytes_processed: u64, is_done: bool) {
-        self.total_processed_bytes += bytes_processed;
-
-        if is_done || self.last_log_print.elapsed() >= self.log_interval {
-            self.last_log_print = Instant::now();
-            let current_percentage =
-                (self.total_processed_bytes * 100 / self.estimated_total_bytes) as u32;
-
-            debug!(
-                current_percentage = format!("{current_percentage}%"),
-                processed_bytes = self.total_processed_bytes,
-                estimated_total_bytes = self.estimated_total_bytes,
-                is_done,
-                "compaction progress"
-            );
-        }
-    }
-}
-
 impl TokioCompactionExecutorInner {
     async fn load_iterators<'a>(
         &self,
@@ -215,12 +172,8 @@ impl TokioCompactionExecutorInner {
             .table_store
             .table_writer(SsTableId::Compacted(self.rand.thread_rng().gen_ulid()));
         let mut current_size = 0usize;
-
-        // Initialize the progress logger
-        let mut progress_logger = CompactionProgressLogger::new(
-            compaction.estimated_source_bytes(),
-            Duration::from_secs(10),
-        );
+        let mut total_bytes_processed = 0u64;
+        let mut last_progress_report = Instant::now();
 
         while let Some(raw_kv) = all_iter.next_entry().await? {
             // filter out any expired entries -- eventually we can consider
@@ -243,10 +196,26 @@ impl TokioCompactionExecutorInner {
                 _ => raw_kv,
             };
 
-            // Update progress
             let key_len = kv.key.len() as u64;
             let value_len = kv.value.len() as u64;
-            progress_logger.log_progress(key_len + value_len, false);
+
+            total_bytes_processed += key_len + value_len;
+            if last_progress_report.elapsed() > Duration::from_secs(1) {
+                self.worker_tx
+                    .send(WorkerToOrchestratorMsg::CompactionProgress {
+                        id: compaction.id,
+                        bytes_processed: total_bytes_processed,
+                    })
+                    .expect("failed to send compaction progress");
+                last_progress_report = Instant::now();
+            }
+
+            self.worker_tx
+                .send(WorkerToOrchestratorMsg::CompactionProgress {
+                    id: compaction.id,
+                    bytes_processed: total_bytes_processed,
+                })
+                .expect("failed to send compaction progress");
 
             if compaction.is_dest_last_run && kv.value.is_tombstone() {
                 continue;
@@ -266,8 +235,6 @@ impl TokioCompactionExecutorInner {
                 self.stats.bytes_compacted.add(current_size as u64);
             }
         }
-
-        progress_logger.log_progress(0, true);
 
         if current_size > 0 {
             output_ssts.push(current_writer.close().await?);

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -6,7 +6,7 @@ use tokio::{
     sync::{mpsc, oneshot},
     task::JoinHandle,
 };
-use tracing::{debug, instrument, trace};
+use tracing::{instrument, trace};
 
 use crate::{
     clock::MonotonicClock,
@@ -487,8 +487,10 @@ impl WalBufferManager {
             }
         }
 
-        debug!("draining immutable wals: ..{}", releaseable_count);
-        inner.immutable_wals.drain(..releaseable_count);
+        if releaseable_count > 0 {
+            trace!("draining immutable wals: ..{}", releaseable_count);
+            inner.immutable_wals.drain(..releaseable_count);
+        }
     }
 
     pub async fn close(&self) -> Result<(), SlateDBError> {


### PR DESCRIPTION
I added a `CompactionProgressTracker` to `compactor.rs`. I updated the compactor to log the compaction progress along with the compaction state when the ticker fires in the event loop.

Here's what it looks like:

```
2025-07-02T22:42:44.903438Z DEBUG slatedb::compactor: compaction progress id=0a1e6fbe-c117-4c52-b9cf-6f9af317bb96 current_percentage="2%" processed_bytes=13802880 estimated_total_bytes=540058533
```

This will give wildly inaccurate results when compression is used since we're using compressed bytes when estimating size, but uncompressed bytes when getting the size of key/value pairs. IMO, it's still useful for tracking raw byte progress. Once we store actual byte or row count information in metadata, we can use it here to calculate accurate progress.
