### PR TITLE
Add some project ideas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,14 @@ the rights to use your contribution.
 When you submit a pull request, a CLA bot will automatically determine whether you need to provide
 a CLA and decorate the PR appropriately (e.g., status check, comment). Simply follow the instructions
 provided by the bot. You will only need to do this once across all repos using our CLA.
+
+## Project Ideas
+
+Here are some fun projects that would be fun (and useful) to work on:
+
+- Integrate SlateDB into [Kine](https://github.com/k3s-io/kine)
+- A Redis-compatible server on SlateDB.
+- A `pg_slatedb` PostgreSQL extension.
+- A [TiKV](https://github.com/tikv/tikv)-compatible [RawKV](https://tikv.org/docs/dev/develop/rawkv/introduction/) or TxnKV storage layer on SlateDB.
+- A multi-writer storage service on SlateDB using [Chitchat](https://github.com/quickwit-oss/chitchat).
+- SlateDB bindings in other languages.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Visit [slatedb.io](https://slatedb.io) to learn more.
 - [ ] Merge operator ([#328](https://github.com/slatedb/slatedb/issues/328))
 - [x] Clones ([#49](https://github.com/slatedb/slatedb/issues/49))
 
+## Projects
+
+Check out [CONTRIBUTING.md](CONTRIBUTING.md) for fun (and useful) projects to work on.
+
 ## Adopters
 
 See who's using SlateDB.


### PR DESCRIPTION
I've had some project ideas rattling around in the back of my head. I want to get them written down so people can find them. I considered GH issues, GH discussions, an `awesome-slatedb` repo, or adding to the docs. Ultimately, I settled on a quick little section in `CONTRIBUTING.md` and a reference in the `README.md` If the list grows or we add more detail, we can move it elsewhere. `CONTRIBUTING.md` seemed most expedient.