### PR TITLE
feat(db_cache): divide in-memory cache into data block cache and meta cache

### DIFF
--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -63,6 +63,7 @@ mod tests {
     use crate::clock::SystemClock;
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::SsTableId;
     use crate::error::SlateDBError;
     use crate::iter::KeyValueIterator;
@@ -72,6 +73,7 @@ mod tests {
     use crate::proptest_util::{rng, sample};
     use crate::sst::SsTableFormat;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
+    use crate::stats::StatRegistry;
     use crate::tablestore::TableStore;
     use crate::test_utils;
     use bytes::Bytes;
@@ -379,7 +381,7 @@ mod tests {
             ObjectStores::new(Arc::clone(&object_store), None),
             SsTableFormat::default(),
             path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let sst_handle = table_store.open_sst(table_id).await.unwrap();
 

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -21,6 +21,7 @@ use crate::compactor::WorkerToOrchestratorMsg;
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
 use crate::config::{CompactorOptions, CompressionCodec};
+use crate::db_cache::DbCacheWrapper;
 use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -72,7 +73,7 @@ impl CompactionExecuteBench {
             ObjectStores::new(self.object_store.clone(), None),
             sst_format,
             self.path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let num_keys = sst_bytes / (val_bytes + key_bytes);
         let mut key_start = vec![0u8; key_bytes - mem::size_of::<u32>()];
@@ -290,7 +291,7 @@ impl CompactionExecuteBench {
             ObjectStores::new(self.object_store.clone(), None),
             sst_format,
             self.path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let compaction = source_sr_ids.map(|source_sr_ids| {
             Compaction::new(

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -558,6 +558,7 @@ mod tests {
         PutOptions, Settings, SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
     };
     use crate::db::Db;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::{CoreDbState, SortedRun};
     use crate::iter::KeyValueIterator;
     use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -1145,7 +1146,7 @@ mod tests {
             ObjectStores::new(os.clone(), None),
             sst_format,
             Path::from(PATH),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         (manifest_store, table_store)
     }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -737,6 +737,9 @@ pub struct DbReaderOptions {
 
     #[serde(skip)]
     pub block_cache: Option<Arc<dyn DbCache>>,
+
+    #[serde(skip)]
+    pub meta_cache: Option<Arc<dyn DbCache>>,
 }
 
 impl Default for DbReaderOptions {
@@ -746,6 +749,7 @@ impl Default for DbReaderOptions {
             checkpoint_lifetime: Duration::from_secs(10 * 60),
             max_memtable_bytes: 64 * 1024 * 1024,
             block_cache: default_block_cache(),
+            meta_cache: default_meta_cache(),
         }
     }
 }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -162,9 +162,11 @@ use std::sync::Arc;
 use std::{str::FromStr, time::Duration};
 use uuid::Uuid;
 
+use crate::db_cache::foyer::FoyerCacheOptions;
+use crate::db_cache::moka::MokaCacheOptions;
 use crate::error::{SettingsError, SlateDBError};
 
-use crate::db_cache::DbCache;
+use crate::db_cache::{DbCache, DEFAULT_BLOCK_CACHE_CAPACITY, DEFAULT_META_CACHE_CAPACITY};
 use crate::garbage_collector::{DEFAULT_INTERVAL, DEFAULT_MIN_AGE};
 
 /// Enum representing valid SST block sizes
@@ -752,11 +754,44 @@ impl Default for DbReaderOptions {
 pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "moka")]
     {
-        return Some(Arc::new(crate::db_cache::moka::MokaCache::new()));
+        return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
+            MokaCacheOptions {
+                max_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
+                time_to_live: None,
+                time_to_idle: None,
+            },
+        )));
     }
     #[cfg(feature = "foyer")]
     {
-        return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new()));
+        return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
+            FoyerCacheOptions {
+                max_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
+            },
+        )));
+    }
+    None
+}
+
+#[allow(unreachable_code)]
+pub(crate) fn default_meta_cache() -> Option<Arc<dyn DbCache>> {
+    #[cfg(feature = "moka")]
+    {
+        return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
+            MokaCacheOptions {
+                max_capacity: DEFAULT_META_CACHE_CAPACITY,
+                time_to_live: None,
+                time_to_idle: None,
+            },
+        )));
+    }
+    #[cfg(feature = "foyer")]
+    {
+        return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
+            FoyerCacheOptions {
+                max_capacity: DEFAULT_META_CACHE_CAPACITY,
+            },
+        )));
     }
     None
 }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -162,8 +162,6 @@ use std::sync::Arc;
 use std::{str::FromStr, time::Duration};
 use uuid::Uuid;
 
-use crate::db_cache::foyer::FoyerCacheOptions;
-use crate::db_cache::moka::MokaCacheOptions;
 use crate::error::{SettingsError, SlateDBError};
 
 use crate::db_cache::{DbCache, DEFAULT_BLOCK_CACHE_CAPACITY, DEFAULT_META_CACHE_CAPACITY};
@@ -759,7 +757,7 @@ pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "moka")]
     {
         return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
-            MokaCacheOptions {
+            crate::db_cache::moka::MokaCacheOptions {
                 max_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
                 time_to_live: None,
                 time_to_idle: None,
@@ -769,7 +767,7 @@ pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "foyer")]
     {
         return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
-            FoyerCacheOptions {
+            crate::db_cache::foyer::FoyerCacheOptions {
                 max_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
             },
         )));
@@ -782,7 +780,7 @@ pub(crate) fn default_meta_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "moka")]
     {
         return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
-            MokaCacheOptions {
+            crate::db_cache::moka::MokaCacheOptions {
                 max_capacity: DEFAULT_META_CACHE_CAPACITY,
                 time_to_live: None,
                 time_to_idle: None,
@@ -792,7 +790,7 @@ pub(crate) fn default_meta_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "foyer")]
     {
         return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
-            FoyerCacheOptions {
+            crate::db_cache::foyer::FoyerCacheOptions {
                 max_capacity: DEFAULT_META_CACHE_CAPACITY,
             },
         )));

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -164,7 +164,7 @@ use uuid::Uuid;
 
 use crate::error::{SettingsError, SlateDBError};
 
-use crate::db_cache::{DbCache, DEFAULT_BLOCK_CACHE_CAPACITY, DEFAULT_META_CACHE_CAPACITY};
+use crate::db_cache::DbCache;
 use crate::garbage_collector::{DEFAULT_INTERVAL, DEFAULT_MIN_AGE};
 
 /// Enum representing valid SST block sizes
@@ -758,7 +758,7 @@ pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
     {
         return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
             crate::db_cache::moka::MokaCacheOptions {
-                max_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
+                max_capacity: crate::db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
                 time_to_live: None,
                 time_to_idle: None,
             },
@@ -768,7 +768,7 @@ pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
     {
         return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
             crate::db_cache::foyer::FoyerCacheOptions {
-                max_capacity: DEFAULT_BLOCK_CACHE_CAPACITY,
+                max_capacity: crate::db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
             },
         )));
     }
@@ -781,7 +781,7 @@ pub(crate) fn default_meta_cache() -> Option<Arc<dyn DbCache>> {
     {
         return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
             crate::db_cache::moka::MokaCacheOptions {
-                max_capacity: DEFAULT_META_CACHE_CAPACITY,
+                max_capacity: crate::db_cache::DEFAULT_META_CACHE_CAPACITY,
                 time_to_live: None,
                 time_to_idle: None,
             },
@@ -791,7 +791,7 @@ pub(crate) fn default_meta_cache() -> Option<Arc<dyn DbCache>> {
     {
         return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
             crate::db_cache::foyer::FoyerCacheOptions {
-                max_capacity: DEFAULT_META_CACHE_CAPACITY,
+                max_capacity: crate::db_cache::DEFAULT_META_CACHE_CAPACITY,
             },
         )));
     }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1024,6 +1024,7 @@ mod tests {
         CompactorOptions, ObjectStoreCacheOptions, Settings, SizeTieredCompactionSchedulerOptions,
         Ttl,
     };
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::CoreDbState;
     use crate::db_stats::IMMUTABLE_MEMTABLE_FLUSHES;
     use crate::iter::KeyValueIterator;
@@ -2107,7 +2108,7 @@ mod tests {
     #[cfg(feature = "wal_disable")]
     #[tokio::test]
     async fn test_wal_disabled() {
-        use crate::{test_utils::assert_iterator, types::RowEntry};
+        use crate::{db_cache::DbCacheWrapper, test_utils::assert_iterator, types::RowEntry};
 
         let clock = Arc::new(TestClock::new());
         let mut options = test_db_options(0, 256, None);
@@ -2119,7 +2120,7 @@ mod tests {
             ObjectStores::new(object_store.clone(), None),
             sst_format,
             path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let db = Db::builder(path.clone(), object_store.clone())
             .with_settings(options)
@@ -2206,7 +2207,7 @@ mod tests {
             ObjectStores::new(object_store.clone(), None),
             sst_format,
             path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
 
         // Write data a few times such that each loop results in a memtable flush
@@ -2882,7 +2883,7 @@ mod tests {
             ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
             path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
 
         // Get the next WAL SST ID based on what's currently in the object store

--- a/slatedb/src/db_cache/foyer.rs
+++ b/slatedb/src/db_cache/foyer.rs
@@ -91,24 +91,24 @@ impl Default for FoyerCache {
 
 #[async_trait]
 impl DbCache for FoyerCache {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
-        Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
+    async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(key).map(|entry| entry.value().clone()))
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
-        Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
+    async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(key).map(|entry| entry.value().clone()))
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
-        Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
+    async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(key).map(|entry| entry.value().clone()))
     }
 
     async fn insert(&self, key: CachedKey, value: CachedEntry) {
         self.inner.insert(key, value);
     }
 
-    async fn remove(&self, key: CachedKey) {
-        self.inner.remove(&key);
+    async fn remove(&self, key: &CachedKey) {
+        self.inner.remove(key);
     }
 
     fn entry_count(&self) -> u64 {

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -60,9 +60,9 @@ impl FoyerHybridCache {
 }
 
 impl FoyerHybridCache {
-    async fn get(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         self.inner
-            .get(&key)
+            .get(key)
             .await
             .map_err(|e| DbCacheError { msg: e.to_string() })
             .map(|maybe_v| maybe_v.map(|v| v.value().clone()))
@@ -71,15 +71,15 @@ impl FoyerHybridCache {
 
 #[async_trait]
 impl DbCache for FoyerHybridCache {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         self.get(key).await
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         self.get(key).await
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         self.get(key).await
     }
 
@@ -87,8 +87,8 @@ impl DbCache for FoyerHybridCache {
         self.inner.insert(key, value);
     }
 
-    async fn remove(&self, key: CachedKey) {
-        self.inner.remove(&key);
+    async fn remove(&self, key: &CachedKey) {
+        self.inner.remove(key);
     }
 
     fn entry_count(&self) -> u64 {
@@ -125,7 +125,7 @@ mod tests {
         let mut found = 0;
         let mut notfound = 0;
         for (k, v) in items {
-            let cached_v = cache.get_block(k).await.unwrap();
+            let cached_v = cache.get_block(&k).await.unwrap();
             if let Some(cached_v) = cached_v {
                 assert!(v.block().unwrap().as_ref() == cached_v.block().unwrap().as_ref());
                 found += 1;

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -78,19 +78,19 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 ///
 /// #[async_trait]
 /// impl DbCache for MyCache {
-///     async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+///     async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
 ///         let guard = self.inner.lock().unwrap();
-///         Ok(guard.data.get(&key).cloned())
+///         Ok(guard.data.get(key).cloned())
 ///     }
 ///
-///     async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+///     async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
 ///         let guard = self.inner.lock().unwrap();
-///         Ok(guard.data.get(&key).cloned())
+///         Ok(guard.data.get(key).cloned())
 ///     }
 ///
-///     async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+///     async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
 ///         let guard = self.inner.lock().unwrap();
-///         Ok(guard.data.get(&key).cloned())
+///         Ok(guard.data.get(key).cloned())
 ///     }
 ///
 ///     async fn insert(&self, key: CachedKey, value: CachedEntry) {
@@ -101,9 +101,9 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 ///         }
 ///     }
 ///
-///     async fn remove(&self, key: CachedKey) {
+///     async fn remove(&self, key: &CachedKey) {
 ///         let mut guard = self.inner.lock().unwrap();
-///         if let Some(v) = guard.data.remove(&key) {
+///         if let Some(v) = guard.data.remove(key) {
 ///             guard.usage -= v.size() as u64;
 ///         }
 ///     }
@@ -126,12 +126,12 @@ pub const DEFAULT_MAX_CAPACITY: u64 = 64 * 1024 * 1024;
 /// ```
 #[async_trait]
 pub trait DbCache: Send + Sync {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
+    async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
+    async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
+    async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError>;
     async fn insert(&self, key: CachedKey, value: CachedEntry);
     #[allow(dead_code)]
-    async fn remove(&self, key: CachedKey);
+    async fn remove(&self, key: &CachedKey);
     #[allow(dead_code)]
     fn entry_count(&self) -> u64;
 }
@@ -286,7 +286,7 @@ impl DbCacheWrapper {
 
 #[async_trait]
 impl DbCache for DbCacheWrapper {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         let entry = match self.cache.get_block(key).await {
             Ok(e) => e,
             Err(err) => {
@@ -302,7 +302,7 @@ impl DbCache for DbCacheWrapper {
         Ok(entry)
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         let entry = match self.cache.get_index(key).await {
             Ok(e) => e,
             Err(err) => {
@@ -318,7 +318,7 @@ impl DbCache for DbCacheWrapper {
         Ok(entry)
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
         let entry = match self.cache.get_filter(key).await {
             Ok(e) => e,
             Err(err) => {
@@ -339,7 +339,7 @@ impl DbCache for DbCacheWrapper {
     }
 
     #[allow(dead_code)]
-    async fn remove(&self, key: CachedKey) {
+    async fn remove(&self, key: &CachedKey) {
         self.cache.remove(key).await
     }
 
@@ -421,19 +421,19 @@ pub(crate) mod test_utils {
 
     #[async_trait]
     impl DbCache for TestCache {
-        async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
             let guard = self.items.lock().unwrap();
-            Ok(guard.get(&key).cloned())
+            Ok(guard.get(key).cloned())
         }
 
-        async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
             let guard = self.items.lock().unwrap();
-            Ok(guard.get(&key).cloned())
+            Ok(guard.get(key).cloned())
         }
 
-        async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
             let guard = self.items.lock().unwrap();
-            Ok(guard.get(&key).cloned())
+            Ok(guard.get(key).cloned())
         }
 
         async fn insert(&self, key: CachedKey, value: CachedEntry) {
@@ -441,9 +441,9 @@ pub(crate) mod test_utils {
             guard.insert(key, value);
         }
 
-        async fn remove(&self, key: CachedKey) {
+        async fn remove(&self, key: &CachedKey) {
             let mut guard = self.items.lock().unwrap();
-            guard.remove(&key);
+            guard.remove(key);
         }
 
         fn entry_count(&self) -> u64 {
@@ -485,7 +485,7 @@ mod tests {
 
         for i in 1..4 {
             // when:
-            let _ = cache.get_filter(key.clone()).await;
+            let _ = cache.get_filter(&key).await;
 
             // then:
             assert_eq!(0, cache.stats.filter_miss.get());
@@ -501,7 +501,7 @@ mod tests {
 
         for i in 1..4 {
             // when:
-            let _ = cache.get_filter(key.clone()).await;
+            let _ = cache.get_filter(&key).await;
 
             // then:
             assert_eq!(i, cache.stats.filter_miss.get());
@@ -523,7 +523,7 @@ mod tests {
 
         for i in 1..4 {
             // when:
-            let _ = cache.get_index(key.clone()).await;
+            let _ = cache.get_index(&key).await;
 
             // then:
             assert_eq!(0, cache.stats.index_miss.get());
@@ -547,7 +547,7 @@ mod tests {
             .await;
 
         // when:
-        let cached = cache.get_index(key).await.unwrap().unwrap();
+        let cached = cache.get_index(&key).await.unwrap().unwrap();
 
         // then:
         assert_index_clamped(index.as_ref(), cached.sst_index().unwrap().as_ref());
@@ -561,7 +561,7 @@ mod tests {
 
         for i in 1..4 {
             // when:
-            let _ = cache.get_index(key.clone()).await;
+            let _ = cache.get_index(&key).await;
 
             // then:
             assert_eq!(i, cache.stats.index_miss.get());
@@ -588,7 +588,7 @@ mod tests {
 
         for i in 1..4 {
             // when:
-            let _ = cache.get_block(key.clone()).await;
+            let _ = cache.get_block(&key).await;
 
             // then:
             assert_eq!(0, cache.stats.data_block_miss.get());
@@ -604,7 +604,7 @@ mod tests {
 
         for i in 1..4 {
             // when:
-            let _ = cache.get_block(key.clone()).await;
+            let _ = cache.get_block(&key).await;
 
             // then:
             assert_eq!(i, cache.stats.data_block_miss.get());

--- a/slatedb/src/db_cache/moka.rs
+++ b/slatedb/src/db_cache/moka.rs
@@ -107,24 +107,24 @@ impl Default for MokaCache {
 
 #[async_trait]
 impl DbCache for MokaCache {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
-        Ok(self.inner.get(&key).await)
+    async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(key).await)
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
-        Ok(self.inner.get(&key).await)
+    async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(key).await)
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
-        Ok(self.inner.get(&key).await)
+    async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+        Ok(self.inner.get(key).await)
     }
 
     async fn insert(&self, key: CachedKey, value: CachedEntry) {
         self.inner.insert(key, value).await;
     }
 
-    async fn remove(&self, key: CachedKey) {
-        self.inner.remove(&key).await;
+    async fn remove(&self, key: &CachedKey) {
+        self.inner.remove(key).await;
     }
 
     fn entry_count(&self) -> u64 {

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -250,6 +250,7 @@ mod tests {
     use crate::checkpoint::Checkpoint;
     use crate::clock::DefaultSystemClock;
     use crate::config::{GarbageCollectorDirectoryOptions, GarbageCollectorOptions};
+    use crate::db_cache::DbCacheWrapper;
     use crate::error::SlateDBError;
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
@@ -927,7 +928,7 @@ mod tests {
             ObjectStores::new(local_object_store.clone(), None),
             sst_format,
             path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
 
         (manifest_store, table_store, local_object_store)

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -532,6 +532,8 @@ mod tests {
     async fn test_level_get_handles_expire(
         #[case] test_case: LevelGetExpireTestCase,
     ) -> Result<(), SlateDBError> {
+        use crate::db_cache::DbCacheWrapper;
+
         let mock_read_snapshot = mock_read_snapshot();
         let stat_registry = StatRegistry::new();
         let get = LevelGet {
@@ -542,7 +544,7 @@ mod tests {
                 ObjectStores::new(Arc::new(InMemory::new()), None),
                 SsTableFormat::default(),
                 Path::from(""),
-                None,
+                Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
             )),
             db_stats: DbStats::new(&stat_registry),
             now: 10000,

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -151,10 +151,12 @@ impl KeyValueIterator for SortedRunIterator<'_> {
 mod tests {
     use super::*;
     use crate::bytes_generator::OrderedBytesGenerator;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::SsTableId;
     use crate::proptest_util;
     use crate::proptest_util::sample;
     use crate::sst::SsTableFormat;
+    use crate::stats::StatRegistry;
     use crate::test_utils::{assert_kv, gen_attrs};
 
     use crate::object_stores::ObjectStores;
@@ -179,7 +181,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -223,7 +225,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -275,7 +277,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&[b'a'; 16], b'a', b'z');
         let mut test_case_key_gen = key_gen.clone();
@@ -319,7 +321,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&[b'a'; 16], b'a', b'z');
         let mut expected_key_gen = key_gen.clone();
@@ -357,7 +359,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&[b'a'; 16], b'a', b'z');
         let val_gen = OrderedBytesGenerator::new_with_byte_range(&[0u8; 16], 0u8, 26u8);
@@ -383,7 +385,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             SsTableFormat::default(),
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
 
         let mut rng = proptest_util::rng::new_test_rng(None);

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -722,11 +722,13 @@ mod tests {
     use super::*;
     use crate::block_iterator::BlockIterator;
     use crate::bytes_range::BytesRange;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::SsTableId;
     use crate::filter::filter_hash;
     use crate::iter::IterationOrder::Ascending;
     use crate::object_stores::ObjectStores;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
+    use crate::stats::StatRegistry;
     use crate::tablestore::TableStore;
     use crate::test_utils::{assert_iterator, build_test_sst, gen_attrs, gen_empty_attrs};
 
@@ -778,7 +780,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder
@@ -829,7 +831,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format.clone(),
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder
@@ -915,7 +917,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format.clone(),
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         for k in 1..=8 {
@@ -996,7 +998,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -1055,7 +1057,7 @@ mod tests {
             ObjectStores::new(object_store.clone(), None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -1076,7 +1078,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
         let index = table_store.read_index(&sst_handle).await.unwrap();
@@ -1132,7 +1134,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format.clone(),
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder
@@ -1180,7 +1182,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -1242,7 +1244,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format.clone(),
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         );
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -1291,7 +1293,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path,
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let mut builder = table_store.table_builder();
         for key in 'a'..='z' {

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -389,9 +389,11 @@ impl KeyValueIterator for SstIterator<'_> {
 mod tests {
     use super::*;
     use crate::bytes_generator::OrderedBytesGenerator;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::SsTableId;
     use crate::object_stores::ObjectStores;
     use crate::sst::SsTableFormat;
+    use crate::stats::StatRegistry;
     use crate::test_utils::{assert_kv, gen_attrs};
     use object_store::path::Path;
     use object_store::{memory::InMemory, ObjectStore};
@@ -409,7 +411,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let mut builder = table_store.table_builder();
         builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
@@ -463,7 +465,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let mut builder = table_store.table_builder();
 
@@ -521,7 +523,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let first_key = [b'a'; 16];
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'z');
@@ -571,7 +573,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let first_key = [b'b'; 16];
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'y');
@@ -615,7 +617,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let first_key = [b'b'; 16];
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'y');
@@ -649,7 +651,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             format,
             root_path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let first_key = [b'b'; 16];
         let key_gen = OrderedBytesGenerator::new_with_byte_range(&first_key, b'a', b'y');

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -15,7 +15,7 @@ pub(crate) trait StoreProvider: Send + Sync {
 pub(crate) struct DefaultStoreProvider {
     pub(crate) path: Path,
     pub(crate) object_store: Arc<dyn ObjectStore>,
-    pub(crate) block_cache: Option<Arc<dyn DbCache>>,
+    pub(crate) cache: Arc<dyn DbCache>,
 }
 
 impl StoreProvider for DefaultStoreProvider {
@@ -24,7 +24,7 @@ impl StoreProvider for DefaultStoreProvider {
             ObjectStores::new(Arc::clone(&self.object_store), None),
             SsTableFormat::default(),
             self.path.clone(),
-            self.block_cache.clone(),
+            self.cache.clone(),
         ))
     }
 

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -796,7 +796,12 @@ mod tests {
 
         let stat_registry = StatRegistry::new();
         let block_cache = Arc::new(MokaCache::new());
-        let wrapper = Arc::new(DbCacheWrapper::new(block_cache.clone(), &stat_registry));
+        let meta_cache = Arc::new(MokaCache::new());
+        let wrapper = Arc::new(DbCacheWrapper::new(
+            Some(block_cache.clone()),
+            Some(meta_cache.clone()),
+            &stat_registry,
+        ));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             format,
@@ -921,8 +926,13 @@ mod tests {
     async fn test_write_sst_should_write_cache() {
         let os = Arc::new(InMemory::new());
         let stat_registry = StatRegistry::new();
-        let cache = Arc::new(TestCache::new());
-        let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry));
+        let block_cache = Arc::new(TestCache::new());
+        let meta_cache = Arc::new(TestCache::new());
+        let wrapper = Arc::new(DbCacheWrapper::new(
+            Some(block_cache.clone()),
+            Some(meta_cache.clone()),
+            &stat_registry,
+        ));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             SsTableFormat::default(),
@@ -944,7 +954,7 @@ mod tests {
                 .sst_format
                 .read_block_raw(&sst_info, &index, i, &sst_bytes)
                 .unwrap();
-            let cached_block = cache
+            let cached_block = block_cache
                 .get_block(&(id, block_meta.offset()).into())
                 .await
                 .unwrap();
@@ -957,8 +967,13 @@ mod tests {
     async fn test_write_sst_should_not_write_cache() {
         let os = Arc::new(InMemory::new());
         let stat_registry = StatRegistry::new();
-        let cache = Arc::new(TestCache::new());
-        let wrapper = Arc::new(DbCacheWrapper::new(cache.clone(), &stat_registry));
+        let block_cache = Arc::new(TestCache::new());
+        let meta_cache = Arc::new(TestCache::new());
+        let wrapper = Arc::new(DbCacheWrapper::new(
+            Some(block_cache.clone()),
+            Some(meta_cache.clone()),
+            &stat_registry,
+        ));
         let ts = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             SsTableFormat::default(),
@@ -976,7 +991,7 @@ mod tests {
         let block_metas = index.borrow().block_meta();
         for i in 0..block_metas.len() {
             let block_meta = block_metas.get(i);
-            let cached_block = cache
+            let cached_block = block_cache
                 .get_block(&(id, block_meta.offset()).into())
                 .await
                 .unwrap();

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -317,7 +317,7 @@ impl TableStore {
     ) -> Result<Option<Arc<BloomFilter>>, SlateDBError> {
         if let Some(cache) = &self.block_cache {
             if let Some(filter) = cache
-                .get_filter((handle.id, handle.info.filter_offset).into())
+                .get_filter(&(handle.id, handle.info.filter_offset).into())
                 .await
                 .unwrap_or(None)
                 .and_then(|e| e.bloom_filter())
@@ -348,7 +348,7 @@ impl TableStore {
     ) -> Result<Arc<SsTableIndexOwned>, SlateDBError> {
         if let Some(cache) = &self.block_cache {
             if let Some(index) = cache
-                .get_index((handle.id, handle.info.index_offset).into())
+                .get_index(&(handle.id, handle.info.index_offset).into())
                 .await
                 .unwrap_or(None)
                 .and_then(|e| e.sst_index())
@@ -415,7 +415,7 @@ impl TableStore {
                 let block_meta = index_borrow.block_meta().get(block_num);
                 let offset = block_meta.offset();
                 cache
-                    .get_block((handle.id, offset).into())
+                    .get_block(&(handle.id, offset).into())
                     .await
                     .unwrap_or(None)
                     .and_then(|entry| entry.block())
@@ -838,7 +838,7 @@ mod tests {
             let offset = index.borrow().block_meta().get(i).offset();
             assert!(
                 block_cache
-                    .get_block((handle.id, offset).into())
+                    .get_block(&(handle.id, offset).into())
                     .await
                     .unwrap_or(None)
                     .is_some(),
@@ -850,11 +850,11 @@ mod tests {
         // Partially clear the cache (remove blocks 5..10 and 15..20)
         for i in 5..10 {
             let offset = index.borrow().block_meta().get(i).offset();
-            block_cache.remove((handle.id, offset).into()).await;
+            block_cache.remove(&(handle.id, offset).into()).await;
         }
         for i in 15..20 {
             let offset = index.borrow().block_meta().get(i).offset();
-            block_cache.remove((handle.id, offset).into()).await;
+            block_cache.remove(&(handle.id, offset).into()).await;
         }
 
         // Test 2: Partial cache hit, everything should be returned since missing blocks are returned from sst
@@ -869,7 +869,7 @@ mod tests {
             let offset = index.borrow().block_meta().get(i).offset();
             assert!(
                 block_cache
-                    .get_block((handle.id, offset).into())
+                    .get_block(&(handle.id, offset).into())
                     .await
                     .unwrap_or(None)
                     .is_some(),
@@ -894,7 +894,7 @@ mod tests {
             let offset = index.borrow().block_meta().get(i).offset();
             assert!(
                 block_cache
-                    .get_block((handle.id, offset).into())
+                    .get_block(&(handle.id, offset).into())
                     .await
                     .unwrap_or(None)
                     .is_some(),
@@ -945,7 +945,7 @@ mod tests {
                 .read_block_raw(&sst_info, &index, i, &sst_bytes)
                 .unwrap();
             let cached_block = cache
-                .get_block((id, block_meta.offset()).into())
+                .get_block(&(id, block_meta.offset()).into())
                 .await
                 .unwrap();
             assert!(cached_block.is_some());
@@ -977,7 +977,7 @@ mod tests {
         for i in 0..block_metas.len() {
             let block_meta = block_metas.get(i);
             let cached_block = cache
-                .get_block((id, block_meta.offset()).into())
+                .get_block(&(id, block_meta.offset()).into())
                 .await
                 .unwrap();
             assert!(cached_block.is_none());

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -515,6 +515,7 @@ struct WalFlushWork {
 mod tests {
     use super::*;
     use crate::clock::MonotonicClock;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::CoreDbState;
     use crate::manifest::store::DirtyManifest;
     use crate::manifest::Manifest;
@@ -551,7 +552,7 @@ mod tests {
             ObjectStores::new(object_store, None),
             SsTableFormat::default(),
             Path::from("/root"),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ));
         let test_clock = Arc::new(TestClock::new());
         let mono_clock = Arc::new(MonotonicClock::new(test_clock.clone(), 0));

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -278,12 +278,14 @@ impl WalReplayIterator<'_> {
 mod tests {
     use super::{WalReplayIterator, WalReplayOptions};
     use crate::bytes_range::BytesRange;
+    use crate::db_cache::DbCacheWrapper;
     use crate::db_state::{CoreDbState, SsTableId};
     use crate::iter::{IterationOrder, KeyValueIterator};
     use crate::mem_table::WritableKVTable;
     use crate::object_stores::ObjectStores;
     use crate::proptest_util::{rng, sample};
     use crate::sst::SsTableFormat;
+    use crate::stats::StatRegistry;
     use crate::tablestore::TableStore;
     use crate::types::RowEntry;
     use crate::{test_utils, SlateDBError};
@@ -557,7 +559,7 @@ mod tests {
             ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
             path.clone(),
-            None,
+            Arc::new(DbCacheWrapper::new(None, None, &StatRegistry::new())),
         ))
     }
 


### PR DESCRIPTION
This PR will close #651. 

The contribution of this PR is as follows:
1. The in-memory cache is now divided into a data block cache and a meta cache.
2. `trait DbCache` interface has been modified to avoid unnecessary clone of `CachedKey`.
3. Changes `Option<Arc<dyn DbCache>>` in `TableStore` to `Arc<dyn DbCache>`, thus hiding the details inside `DbCache`.

I considered some bigger refactorings, such as using static dispatch, but I finally decided to minimize the impact on the original code.