### PR TITLE
docs(db_cache): add comments to `foyer_hybrid.rs`

### DIFF
--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -14,17 +14,17 @@
 //!
 //! ## Notes
 //! Foyer HybridCache manages its own memory and disk cache, so when it coexists with `CachedObjectStore`
-//! there may be some duplication of cached data. In other words, disk cache may suffer from write 
-//! amplification. If you don't want to suffer from write amplification, then we recommend that you do not 
+//! there may be some duplication of cached data. In other words, disk cache may suffer from write
+//! amplification. If you don't want to suffer from write amplification, then we recommend that you do not
 //! coexist Foyer HybridCache with `CachedObjectStore`.
-//! 
+//!
 //! Benefits of coexistence:
-//! `CachedObjectStore` provides prefetching, which may speed up your read performance and 
+//! `CachedObjectStore` provides prefetching, which may speed up your read performance and
 //! reduce unnecessary object store accesses.
-//! 
+//!
 //! Drawbacks of coexistence:
-//! Disk may suffer from write amplification. Data will first be written to `CachedObjectStore`, then 
-//! flow into the memory part of Foyer HybridCache, and finally written back to the disk area managed 
+//! Disk may suffer from write amplification. Data will first be written to `CachedObjectStore`, then
+//! flow into the memory part of Foyer HybridCache, and finally written back to the disk area managed
 //! by Foyer HybridCache itself. slateDB cannot control Foyer HybridCache to write data to its disk area.
 //!
 //! ## Examples


### PR DESCRIPTION
This PR adds some comments for foyer `HybridCache`, mentioning possible issues when it coexists with `CachedObjectStore`.