### PR TITLE
Record bytes_compacted correctly.

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,6 +86,10 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.98
+      - name: Install gdb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb
       - name: Run Tests
         run: cargo nextest run --workspace --all-features --profile ci
       - name: Run Doc Tests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,8 +86,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.98
-      - name: Install gdb
-        run: sudo apt-get install -y gdb
       - name: Run Tests
         run: cargo nextest run --workspace --all-features --profile ci
       - name: Run Doc Tests

--- a/scripts/backtrace-on-timeout.sh
+++ b/scripts/backtrace-on-timeout.sh
@@ -6,19 +6,6 @@
 # Fail on errors.
 set -eu
 
-# Install gdb if it's not already installed
-if ! command -v gdb &> /dev/null; then
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        brew install gdb
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        sudo apt-get update
-        sudo apt-get install -y gdb
-    else
-        echo "Error: `gdb` is not installed, please install it manually"
-        exit 1
-    fi
-fi
-
 # Run background jobs in separate process groups, so that the SIGTERM from
 # nextest doesn't hit the test job until we're ready.
 set -m

--- a/scripts/backtrace-on-timeout.sh
+++ b/scripts/backtrace-on-timeout.sh
@@ -6,6 +6,19 @@
 # Fail on errors.
 set -eu
 
+# Install gdb if it's not already installed
+if ! command -v gdb &> /dev/null; then
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install gdb
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update
+        sudo apt-get install -y gdb
+    else
+        echo "Error: `gdb` is not installed, please install it manually"
+        exit 1
+    fi
+fi
+
 # Run background jobs in separate process groups, so that the SIGTERM from
 # nextest doesn't hit the test job until we're ready.
 set -m

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -232,7 +232,6 @@ impl TokioCompactionExecutorInner {
             current_size += key_len + value_len;
 
             if current_size > self.options.max_sst_size {
-                current_size = 0;
                 let finished_writer = mem::replace(
                     &mut current_writer,
                     self.table_store
@@ -240,6 +239,7 @@ impl TokioCompactionExecutorInner {
                 );
                 output_ssts.push(finished_writer.close().await?);
                 self.stats.bytes_compacted.add(current_size as u64);
+                current_size = 0;
             }
         }
 


### PR DESCRIPTION
When a writer is finished, the compaction process is recording 0 as the size, instead of the size of the current bytes processed until that point.

I was looking at these two lines while trying to implement #676, and it seems wrong. Since this is a small change, I rather get it out while I try to figure out how to implement #676 correctly.