### PR TITLE
feat: add snapshot api

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -38,6 +38,7 @@ use crate::clock::MonotonicClock;
 use crate::clock::{LogicalClock, SystemClock};
 use crate::config::{PutOptions, ReadOptions, ScanOptions, Settings, WriteOptions};
 use crate::db_iter::DbIterator;
+use crate::db_snapshot::DbSnapshot;
 use crate::db_state::{DbState, SsTableId};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
@@ -583,6 +584,46 @@ impl Db {
         }
 
         Ok(())
+    }
+
+    /// Create a snapshot of the database.
+    ///
+    /// ## Returns
+    /// - `Result<DbSnapshot, SlateDBError>`: the snapshot of the database, it represents
+    ///   a consistent view of the database at the time of the snapshot.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), SlateDBError> {
+    ///     let object_store = Arc::new(InMemory::new());
+    ///     let db = Db::open("test_db", object_store).await?;
+    ///     
+    ///     // Write some data and create a snapshot
+    ///     db.put(b"key1", b"value1").await?;
+    ///     let snapshot = db.snapshot().await?;
+    ///     
+    ///     // Snapshot provides read-only access to database state
+    ///     let value = snapshot.get(b"key1").await?;
+    ///     assert_eq!(value, Some(b"value1".as_slice()));
+    ///     
+    ///     // Write more data to original database
+    ///     db.put(b"key2", b"value2").await?;
+    ///     
+    ///     // Snapshot still sees old state, original db sees new data
+    ///     assert_eq!(snapshot.get(b"key2").await?, None);
+    ///     assert_eq!(db.get(b"key2").await?, Some(b"value2".as_slice()));
+    ///     
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn snapshot(&self) -> Result<DbSnapshot, SlateDBError> {
+        todo!()
     }
 
     /// Get a value from the database with default read options.

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -1,0 +1,78 @@
+use bytes::Bytes;
+use std::ops::RangeBounds;
+use std::sync::Arc;
+
+use crate::config::{ReadOptions, ScanOptions};
+use crate::db_iter::DbIterator;
+use crate::error::SlateDBError;
+use crate::Db;
+
+pub struct DbSnapshot {}
+
+impl DbSnapshot {
+    pub(crate) fn new(db: Arc<Db>) -> Self {
+        todo!()
+    }
+
+    /// Get a value from the snapshot with default read options.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to get
+    ///
+    /// ## Returns
+    /// - `Result<Option<Bytes>, SlateDBError>`: the value if it exists, None otherwise
+    pub async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, SlateDBError> {
+        todo!()
+    }
+
+    /// Get a value from the snapshot with custom read options.
+    ///
+    /// ## Arguments
+    /// - `key`: the key to get
+    /// - `options`: the read options to use
+    ///
+    /// ## Returns
+    /// - `Result<Option<Bytes>, SlateDBError>`: the value if it exists, None otherwise
+    pub async fn get_with_options<K: AsRef<[u8]> + Send>(
+        &self,
+        key: K,
+        options: &ReadOptions,
+    ) -> Result<Option<Bytes>, SlateDBError> {
+        todo!()
+    }
+
+    /// Scan a range of keys using the default scan options.
+    ///
+    /// ## Arguments
+    /// - `range`: the range of keys to scan
+    ///
+    /// ## Returns
+    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
+    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, SlateDBError>
+    where
+        K: AsRef<[u8]> + Send,
+        T: RangeBounds<K> + Send,
+    {
+        todo!()
+    }
+
+    /// Scan a range of keys with the provided options.
+    ///
+    /// ## Arguments
+    /// - `range`: the range of keys to scan
+    /// - `options`: the scan options to use
+    ///
+    /// ## Returns
+    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
+    pub async fn scan_with_options<K, T>(
+        &self,
+        range: T,
+        options: &ScanOptions,
+    ) -> Result<DbIterator, SlateDBError>
+    where
+        K: AsRef<[u8]> + Send,
+        T: RangeBounds<K> + Send,
+    {
+        todo!()
+    }
+}

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -69,6 +69,7 @@ mod db;
 mod db_common;
 mod db_iter;
 mod db_reader;
+mod db_snapshot;
 mod db_state;
 mod error;
 mod filter;


### PR DESCRIPTION
this pr aims to add the API for creating snapshot.

a `DbSnapshot` contains all the read-only operations in a `Db` object. it records the seqnum at the moment when the `DbSnapshot` is created, and always making a consistent view as long as this `DbSnapshot` object lives.

in the current design, `DbSnapshot` is not expected to work on the db read instance.

we can divide this pr into the following subtasks:

1. [ ] exposing the API
2. [ ] scan() get() with `seq` passed
3. [ ] track all the living `DbSnapshot` objects
4. [ ] extract the `min_retention_seq` from living `DbSnapshot` objects, and persist it in manifest
5. [ ] let the compactor handle the `min_retention_seq` by RetentionIterator

(during the implementation, these tasks might be splitted in different PRs if we could figure out any self-contained changeset for easier to review.)