### PR TITLE
Implement the Public Error API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arc-swap"
@@ -3145,6 +3145,7 @@ dependencies = [
 name = "slatedb"
 version = "0.7.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "atomic",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lto = true
 [workspace.dependencies]
 
 # dependencies
+anyhow = "1.0.98"
 async-trait = "0.1.82"
 atomic = "0.6.0"
 bitflags = "2.6.0"

--- a/rfcs/0007-api-errors.md
+++ b/rfcs/0007-api-errors.md
@@ -10,7 +10,7 @@
 
 # SlateDB Error API
 
-Status: Draft
+Status: Accepted
 
 Authors:
 
@@ -43,8 +43,12 @@ into the error message, which will not be considered part of the public API.
 
 ## Public API
 
-Publicly exposed errors will be maintained in `slatedb::Error`. Each new error type must be documented
-in this RFC. All public APIs will document the complete set of errors that may be returned. 
+All public APIs will document the complete set of errors that may be returned.
+
+All public errors are exposed through the `slatedb::Error` struct. This struct includes an
+enum describing the kind of error that it represents, `slatedb::ErrorKind`. New error
+representations can be added to `slatedb::ErrorKind` only when the current representations
+don't cover a general problem in the database.
 
 Each exposed error type will expose documentation which contains a general description
 of the error and contains any prescriptive guidance (such as indicating whether a failed 
@@ -55,48 +59,85 @@ instance of the error that was encountered. Unlike the error type, the message i
 public API and can be changed without notice. The intent is to pack as much detail into the message
 for someone to understand the root cause, and if possible, what they should do to resolve it.
 
-The complete set of public error types are listed below:
-
-```rust
-mod slatedb {
-  use std::time::Duration;
-
-  #[derive(Clone, Debug, Error)]
-  pub enum Error {
-    /// The application attempted an invalid operation or an operation with an
-    /// invalid parameter (including misconfiguration).
-    #[error("Operation Error: {msg}")]
-    OperationError { msg: String },
-
-    /// Unexpected internal error. This error is fatal (i.e. the database must be closed).
-    #[error("System Error: {msg}")]
-    SystemError { msg: String },
-
-    /// Invalid persistent state (e.g. corrupted data files). The state must 
-    /// be repaired before the database can be restarted.
-    #[error("Persistent Error: {msg}")]
-    PersistentError { msg: String },
-
-    /// Failed access database resources (e.g. remote storage) due to some 
-    /// kind of authentication or authorization error. The operation can be 
-    /// retried after the permission issue is resolved.
-    #[error("Permission Error: {msg}")]
-    PermissionError { msg: String },
-
-    /// The operation failed due to a transient error (such as IO unavailability). 
-    /// The operation can be retried after backing off.
-    #[error("Transient Error: {msg}. Backoff {backoff} before retrying.")]
-    TransientError { msg: String, backoff: Duration },
-
-    /// An operation failed during a transaction. The transaction can be aborted
-    /// and the operation can be retried.
-    #[error("Transaction Error: {msg}")]
-    TransactionError { msg: String },
-  }
-}
-```
-
 New errors can be added by updating this RFC. Existing errors can be removed through semantic 
 versioning. Typically, the need to remove an error suggests that some part of the internal 
 implementation has been inadvertently leaked, so such cases should be rare if the exposed 
 errors follow the principles above.
+
+These are the currently supported `slatedb::ErrorKind`:
+
+```rust
+/// Represents the kind of public errors that can be returned to the user.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The database attempted to use an invalid configuration.
+    Configuration,
+
+    /// The database attempted an invalid operation or an operation with an
+    /// invalid parameter (including misconfiguration).
+    Operation,
+
+    /// Unexpected internal error. This error is fatal (i.e. the database must be closed).
+    System,
+
+    /// Invalid persistent state (e.g. corrupted data files). The state must
+    /// be repaired before the database can be restarted.
+    PersistentState,
+
+    /// Failed access database resources (e.g. remote storage) due to some
+    /// kind of authentication or authorization error. The operation can be
+    /// retried after the permission issue is resolved.
+    Permission,
+
+    /// The operation failed due to a transient error (such as IO unavailability).
+    /// The operation can be retried after backing off.
+    Transient(Duration),
+}
+```
+
+### Constructing public errors
+
+The `slatedb::Error` struct includes functions to construct public errors. Each one of those
+functions is identified by the name variant that they represent. `slatedb::Error::system` creates
+`slatedb::ErrorKind::System` errors and so on.
+
+If you want to propagate another error into a public error, you have to use the `with_source` function
+after constructing an error. For example if you want to propagate an `std::io::IOError`:
+
+```rust
+let error = slatedb::Error::operation("failed connection".to_string()).with_source(my_ioerror)
+```
+
+In general, you should not construct public errors directly. It's recommended to use the internal `slatedb::SlateDBError`
+which is then transformed into a public error. This gives you more flexibility to construct your errors.
+
+## Internal errors vs External errors
+
+Internal errors can continue being described through `slatedb::SlateDBError`. This error
+type can be transformed into an `slatedb::Error` through the `From` trait.
+
+### Internal errors message format
+
+`SlateDbError` uses [thiserror](https://docs.rs/thiserror) to define internal errors. This crate gives you flexibility
+in the formatting of error messages, as well as other errors that are bubling up from the database.
+
+We follow some conventions to generate message to ensure they are all consistent. This is the list of conventions:
+
+- Try to be specific when you create an internal error. Instead of creating an error that can take multiple messages, create different errors that can be formatted following these rules.
+- Write messages in lowercase: `read channel error` instead of `Read Channel Error`.
+- If an error message includes variables, they're added at the end of the message in KEY=`VALUE` format. `unexpected range key. key=\`foo\`, range=\`[..]\`` instead of `unexpected key \`foo\` in range \`[..]\``.
+- Errors that propagate other errors don't include the propagated errors in the message. They will be included automatically when the internal error is translated into a public error. See the example below:
+```rust
+// DO THIS
+enum SlateDBError {
+  #[error("io error")]
+  IOError(#[from] std::io::Error)
+}
+
+// **DO NOT** DO THIS
+enum SlateDBError {
+  #[error("io error: #{0}")]
+  IOError(#[from] std::io::Error)
+}
+```
+

--- a/rfcs/0007-api-errors.md
+++ b/rfcs/0007-api-errors.md
@@ -119,7 +119,7 @@ type can be transformed into an `slatedb::Error` through the `From` trait.
 ### Internal errors message format
 
 `SlateDbError` uses [thiserror](https://docs.rs/thiserror) to define internal errors. This crate gives you flexibility
-in the formatting of error messages, as well as other errors that are bubling up from the database.
+in the formatting of error messages, as well as other errors that are bubbling up from the database.
 
 We follow some conventions to generate message to ensure they are all consistent. This is the list of conventions:
 

--- a/slatedb-bencher/src/args.rs
+++ b/slatedb-bencher/src/args.rs
@@ -11,7 +11,7 @@ use slatedb::{
         moka::{MokaCache, MokaCacheOptions},
         DbCache,
     },
-    SettingsError,
+    Error,
 };
 use tracing::info;
 
@@ -68,7 +68,7 @@ pub(crate) struct DbArgs {
 
 impl DbArgs {
     /// Returns a `(Settings, Option<Arc<dyn DbCache>>)` struct based on DbArgs's arguments.
-    pub(crate) fn config(&self) -> Result<(Settings, Option<Arc<dyn DbCache>>), SettingsError> {
+    pub(crate) fn config(&self) -> Result<(Settings, Option<Arc<dyn DbCache>>), Error> {
         let settings = if let Some(path) = &self.db_options_path {
             Settings::from_file(path)?
         } else {

--- a/slatedb-py/src/lib.rs
+++ b/slatedb-py/src/lib.rs
@@ -4,7 +4,7 @@ use ::slatedb::object_store::memory::InMemory;
 use ::slatedb::object_store::ObjectStore;
 use ::slatedb::Db;
 use ::slatedb::DbReader;
-use ::slatedb::{KeyValue, SlateDBError};
+use ::slatedb::{Error, KeyValue};
 use once_cell::sync::OnceCell;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -417,7 +417,7 @@ impl PySlateDBAdmin {
     }
 }
 
-type IteratorReceiver = Arc<Mutex<mpsc::UnboundedReceiver<Result<Option<KeyValue>, SlateDBError>>>>;
+type IteratorReceiver = Arc<Mutex<mpsc::UnboundedReceiver<Result<Option<KeyValue>, Error>>>>;
 
 #[pyclass(name = "DbIterator")]
 pub struct PyDbIterator {
@@ -473,7 +473,7 @@ impl PyDbIterator {
                         }
                     }
                     let _ = sender.send(Ok(None)); // End of iteration
-                    Ok::<(), SlateDBError>(())
+                    Ok::<(), Error>(())
                 }
                 .await;
 
@@ -494,7 +494,7 @@ impl PyDbIterator {
                         }
                     }
                     let _ = sender.send(Ok(None)); // End of iteration
-                    Ok::<(), SlateDBError>(())
+                    Ok::<(), Error>(())
                 }
                 .await;
 

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 homepage.workspace = true
 
 [dependencies]
+anyhow = { workspace = true, optional = true }
 async-trait = { workspace = true }
 atomic = { workspace = true }
 bitflags = { workspace = true }
@@ -82,7 +83,7 @@ lz4 = ["dep:lz4_flex"]
 zstd = ["dep:zstd"]
 wal_disable = []
 moka = ["dep:moka"]
-foyer = ["dep:foyer"]
+foyer = ["dep:foyer", "dep:anyhow"]
 test-util = ["tokio/test-util"]
 
 [lib]

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -182,7 +182,7 @@ impl Admin {
     pub async fn create_detached_checkpoint(
         &self,
         options: &CheckpointOptions,
-    ) -> Result<CheckpointCreateResult, SlateDBError> {
+    ) -> Result<CheckpointCreateResult, crate::Error> {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
@@ -209,7 +209,7 @@ impl Admin {
         &self,
         id: Uuid,
         lifetime: Option<Duration>,
-    ) -> Result<(), SlateDBError> {
+    ) -> Result<(), crate::Error> {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
@@ -231,10 +231,11 @@ impl Admin {
                 Ok(Some(dirty))
             })
             .await
+            .map_err(Into::into)
     }
 
     /// Deletes the checkpoint with the specified id.
-    pub async fn delete_checkpoint(&self, id: Uuid) -> Result<(), SlateDBError> {
+    pub async fn delete_checkpoint(&self, id: Uuid) -> Result<(), crate::Error> {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
@@ -254,6 +255,7 @@ impl Admin {
                 Ok(Some(dirty))
             })
             .await
+            .map_err(Into::into)
     }
 
     /// Clone a database. If no db already exists at the specified path, then this will create
@@ -324,7 +326,6 @@ impl Admin {
     ///
     /// ```
     /// use slatedb::admin::Admin;
-    /// use slatedb::SlateDBError;
     /// use slatedb::object_store::memory::InMemory;
     /// use std::sync::Arc;
     ///

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -14,7 +14,7 @@ use bytes::Bytes;
 ///
 /// # Examples
 /// ```rust
-/// # async fn run() -> Result<(), slatedb::SlateDBError> {
+/// # async fn run() -> Result<(), slatedb::Error> {
 /// #     use std::sync::Arc;
 /// #     use slatedb::object_store::memory::InMemory;
 ///     use slatedb::Db;

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -15,8 +15,8 @@ use std::{
 };
 
 use crate::{
+    error::SlateDBError,
     utils::{self, system_time_from_millis, system_time_to_millis},
-    SlateDBError,
 };
 use tracing::info;
 

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -65,7 +65,7 @@ impl CompactionExecuteBench {
         key_bytes: usize,
         val_bytes: usize,
         compression_codec: Option<CompressionCodec>,
-    ) -> Result<(), SlateDBError> {
+    ) -> Result<(), crate::Error> {
         let sst_format = SsTableFormat {
             compression_codec,
             ..SsTableFormat::default()
@@ -183,7 +183,7 @@ impl CompactionExecuteBench {
     }
 
     #[allow(clippy::panic)]
-    pub async fn run_clear(&self, num_ssts: usize) -> Result<(), SlateDBError> {
+    pub async fn run_clear(&self, num_ssts: usize) -> Result<(), crate::Error> {
         let mut del_tasks = Vec::new();
         for i in 0u32..num_ssts as u32 {
             let os = self.object_store.clone();
@@ -198,7 +198,7 @@ impl CompactionExecuteBench {
         for result in results {
             match result {
                 Ok(Ok(())) => {}
-                Ok(Err(err)) => return Err(err.into()),
+                Ok(Err(err)) => return Err(SlateDBError::from(err).into()),
                 Err(err) => panic!("task failed: {:?}", err),
             }
         }
@@ -295,7 +295,7 @@ impl CompactionExecuteBench {
         source_sr_ids: Option<Vec<u32>>,
         destination_sr_id: u32,
         compression_codec: Option<CompressionCodec>,
-    ) -> Result<(), SlateDBError> {
+    ) -> Result<(), crate::Error> {
         let sst_format = SsTableFormat {
             compression_codec,
             ..SsTableFormat::default()
@@ -366,7 +366,7 @@ impl CompactionExecuteBench {
                             .as_millis();
                         info!(elapsed_ms, "compaction finished");
                     }
-                    Err(err) => return Err(err),
+                    Err(err) => return Err(err.into()),
                 }
             }
         }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -565,6 +565,7 @@ mod tests {
     };
     use crate::db::Db;
     use crate::db_state::{CoreDbState, SortedRun};
+    use crate::error::SlateDBError;
     use crate::iter::KeyValueIterator;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::object_stores::ObjectStores;
@@ -576,7 +577,6 @@ mod tests {
     use crate::tablestore::TableStore;
     use crate::test_utils::{assert_iterator, TestClock};
     use crate::types::RowEntry;
-    use crate::SlateDBError;
 
     const PATH: &str = "/test/db";
 

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -577,7 +577,7 @@ impl Settings {
     /// # Returns
     ///
     /// * `Ok(Settings)` if the file was successfully read and parsed.
-    /// * `Err(SettingsError)` if there was an error reading or parsing the file.
+    /// * `Err(Error)` if there was an error reading or parsing the file.
     ///
     /// # Errors
     ///
@@ -593,10 +593,10 @@ impl Settings {
     ///
     /// let config = Settings::from_file("config.toml").expect("Failed to load options from file");
     /// ```
-    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Settings, SettingsError> {
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Settings, crate::Error> {
         let path = path.as_ref();
         let Some(ext) = path.extension() else {
-            return Err(SettingsError::UnknownFormat(path.into()));
+            return Err(SettingsError::UnknownFormat(path.into()).into());
         };
 
         let mut builder = Figment::from(Settings::default());
@@ -604,11 +604,11 @@ impl Settings {
             "json" => builder = builder.merge(Json::file(path)),
             "toml" => builder = builder.merge(Toml::file(path)),
             "yaml" | "yml" => builder = builder.merge(Yaml::file(path)),
-            _ => return Err(SettingsError::UnknownFormat(path.into())),
+            _ => return Err(SettingsError::UnknownFormat(path.into()).into()),
         }
         builder
             .extract()
-            .map_err(|e| SettingsError::InvalidFormat(Box::new(e)))
+            .map_err(|e| SettingsError::InvalidFormat(Box::new(e)).into())
     }
 
     /// Loads Settings from environment variables with a specified prefix.
@@ -628,7 +628,7 @@ impl Settings {
     /// # Returns
     ///
     /// * `Ok(Settings)` if the environment variables were successfully read and parsed.
-    /// * `Err(SettingsError)` if there was an error reading or parsing the environment variables.
+    /// * `Err(Error)` if there was an error reading or parsing the environment variables.
     ///
     /// # Examples
     ///
@@ -638,11 +638,11 @@ impl Settings {
     /// // Assuming environment variables like SLATEDB_FLUSH_INTERVAL, SLATEDB_WAL_ENABLED, etc. are set
     /// let config = Settings::from_env("SLATEDB_").expect("Failed to load options from env");
     /// ```
-    pub fn from_env(prefix: &str) -> Result<Settings, SettingsError> {
+    pub fn from_env(prefix: &str) -> Result<Settings, crate::Error> {
         Figment::from(Settings::default())
             .merge(Env::prefixed(prefix))
             .extract()
-            .map_err(|e| SettingsError::InvalidFormat(Box::new(e)))
+            .map_err(|e| SettingsError::InvalidFormat(Box::new(e)).into())
     }
 
     /// Loads Settings from multiple configuration sources in a specific order.
@@ -660,7 +660,7 @@ impl Settings {
     /// # Returns
     ///
     /// * `Ok(Settings)` if the configuration was successfully loaded and parsed.
-    /// * `Err(SettingsError)` if there was an error reading or parsing the configuration.
+    /// * `Err(Error)` if there was an error reading or parsing the configuration.
     ///
     /// # Examples
     ///
@@ -669,7 +669,7 @@ impl Settings {
     ///
     /// let config = Settings::load().expect("Failed to load options");
     /// ```
-    pub fn load() -> Result<Settings, SettingsError> {
+    pub fn load() -> Result<Settings, crate::Error> {
         Figment::from(Settings::default())
             .merge(Json::file("SlateDb.json"))
             .merge(Toml::file("SlateDb.toml"))
@@ -677,7 +677,7 @@ impl Settings {
             .merge(Yaml::file("SlateDb.yml"))
             .admerge(Env::prefixed("SLATEDB_"))
             .extract()
-            .map_err(|e| SettingsError::InvalidFormat(Box::new(e)))
+            .map_err(|e| SettingsError::InvalidFormat(Box::new(e)).into())
     }
 }
 
@@ -780,7 +780,7 @@ pub enum CompressionCodec {
 }
 
 impl FromStr for CompressionCodec {
-    type Err = SlateDBError;
+    type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -792,7 +792,7 @@ impl FromStr for CompressionCodec {
             "lz4" => Ok(Self::Lz4),
             #[cfg(feature = "zstd")]
             "zstd" => Ok(Self::Zstd),
-            _ => Err(SlateDBError::InvalidCompressionCodec),
+            _ => Err(SlateDBError::InvalidCompressionCodec.into()),
         }
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8,12 +8,12 @@
 //! Basic usage of the `Db` struct:
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::open("test_db", object_store).await?;
 //!     Ok(())
@@ -446,17 +446,17 @@ impl Db {
     /// - `Db`: the database
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error opening the database
+    /// - `Error`: if there was an error opening the database
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::memory::InMemory;
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     Ok(())
@@ -465,7 +465,7 @@ impl Db {
     pub async fn open<P: Into<Path>>(
         path: P,
         object_store: Arc<dyn ObjectStore>,
-    ) -> Result<Self, SlateDBError> {
+    ) -> Result<Self, crate::Error> {
         // Use the builder API internally
         Self::builder(path, object_store).build().await
     }
@@ -482,12 +482,12 @@ impl Db {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::memory::InMemory;
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store = Arc::new(InMemory::new());
     ///     let db = Db::builder("/tmp/test_db", object_store)
     ///         .build()
@@ -502,24 +502,24 @@ impl Db {
     /// Close the database.
     ///
     /// ## Returns
-    /// - `Result<(), SlateDBError>`: if there was an error closing the database
+    /// - `Result<(), Error>`: if there was an error closing the database
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.close().await?;
     ///     Ok(())
     /// }
     /// ```
-    pub async fn close(&self) -> Result<(), SlateDBError> {
+    pub async fn close(&self) -> Result<(), crate::Error> {
         self.cancellation_token.cancel();
 
         if let Some(compactor_task) = {
@@ -597,22 +597,22 @@ impl Db {
     /// - `key`: the key to get
     ///
     /// ## Returns
-    /// - `Result<Option<Bytes>, SlateDBError>`:
+    /// - `Result<Option<Bytes>, Error>`:
     ///     - `Some(Bytes)`: the value if it exists
     ///     - `None`: if the value does not exist
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error getting the value
+    /// - `Error`: if there was an error getting the value
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.put(b"key", b"value").await?;
@@ -620,7 +620,7 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, SlateDBError> {
+    pub async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, crate::Error> {
         self.get_with_options(key, &ReadOptions::default()).await
     }
 
@@ -637,22 +637,22 @@ impl Db {
     ///   can only observe committed state).
     ///
     /// ## Returns
-    /// - `Result<Option<Bytes>, SlateDBError>`:
+    /// - `Result<Option<Bytes>, Error>`:
     ///   - `Some(Bytes)`: the value if it exists
     ///   - `None`: if the value does not exist
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error getting the value
+    /// - `Error`: if there was an error getting the value
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, config::ReadOptions, SlateDBError};
+    /// use slatedb::{Db, config::ReadOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.put(b"key", b"value").await?;
@@ -664,8 +664,11 @@ impl Db {
         &self,
         key: K,
         options: &ReadOptions,
-    ) -> Result<Option<Bytes>, SlateDBError> {
-        self.inner.get_with_options(key, options).await
+    ) -> Result<Option<Bytes>, crate::Error> {
+        self.inner
+            .get_with_options(key, options)
+            .await
+            .map_err(Into::into)
     }
 
     /// Scan a range of keys using the default scan options.
@@ -673,20 +676,20 @@ impl Db {
     /// returns a `DbIterator`
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error scanning the range of keys
+    /// - `Error`: if there was an error scanning the range of keys
     ///
     /// ## Returns
-    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
+    /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.put(b"a", b"a_value").await?;
@@ -698,7 +701,7 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, SlateDBError>
+    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -711,17 +714,17 @@ impl Db {
     /// returns a `DbIterator`
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error scanning the range of keys
+    /// - `Error`: if there was an error scanning the range of keys
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, config::ScanOptions, config::DurabilityLevel, SlateDBError};
+    /// use slatedb::{Db, config::ScanOptions, config::DurabilityLevel, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.put(b"a", b"a_value").await?;
@@ -740,7 +743,7 @@ impl Db {
         &self,
         range: T,
         options: &ScanOptions,
-    ) -> Result<DbIterator, SlateDBError>
+    ) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -755,6 +758,7 @@ impl Db {
         self.inner
             .scan_with_options(BytesRange::from(range), options)
             .await
+            .map_err(Into::into)
     }
 
     /// Write a value into the database with default `WriteOptions`.
@@ -764,24 +768,24 @@ impl Db {
     /// - `value`: the value to write
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error writing the value.
+    /// - `Error`: if there was an error writing the value.
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.put(b"key", b"value").await?;
     ///     Ok(())
     /// }
     /// ```
-    pub async fn put<K, V>(&self, key: K, value: V) -> Result<(), SlateDBError>
+    pub async fn put<K, V>(&self, key: K, value: V) -> Result<(), crate::Error>
     where
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
@@ -800,17 +804,17 @@ impl Db {
     /// - `write_opts`: the write options to use
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error writing the value.
+    /// - `Error`: if there was an error writing the value.
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, config::{PutOptions, WriteOptions}, SlateDBError};
+    /// use slatedb::{Db, config::{PutOptions, WriteOptions}, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.put_with_options(b"key", b"value", &PutOptions::default(), &WriteOptions::default()).await?;
@@ -823,7 +827,7 @@ impl Db {
         value: V,
         put_opts: &PutOptions,
         write_opts: &WriteOptions,
-    ) -> Result<(), SlateDBError>
+    ) -> Result<(), crate::Error>
     where
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
@@ -839,24 +843,24 @@ impl Db {
     /// - `key`: the key to delete
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error deleting the key.
+    /// - `Error`: if there was an error deleting the key.
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.delete(b"key").await?;
     ///     Ok(())
     /// }
     /// ```
-    pub async fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), SlateDBError> {
+    pub async fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), crate::Error> {
         let mut batch = WriteBatch::new();
         batch.delete(key.as_ref());
         self.write(batch).await
@@ -869,17 +873,17 @@ impl Db {
     /// - `options`: the write options to use
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error deleting the key.
+    /// - `Error`: if there was an error deleting the key.
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, config::WriteOptions, SlateDBError};
+    /// use slatedb::{Db, config::WriteOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.delete_with_options(b"key", &WriteOptions::default()).await?;
@@ -890,7 +894,7 @@ impl Db {
         &self,
         key: K,
         options: &WriteOptions,
-    ) -> Result<(), SlateDBError> {
+    ) -> Result<(), crate::Error> {
         let mut batch = WriteBatch::new();
         batch.delete(key);
         self.write_with_options(batch, options).await
@@ -904,17 +908,17 @@ impl Db {
     /// - `batch`: the batch of put/delete operations to write
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error writing the batch.
+    /// - `Error`: if there was an error writing the batch.
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{WriteBatch, Db, SlateDBError};
+    /// use slatedb::{WriteBatch, Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///
@@ -927,7 +931,7 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn write(&self, batch: WriteBatch) -> Result<(), SlateDBError> {
+    pub async fn write(&self, batch: WriteBatch) -> Result<(), crate::Error> {
         self.write_with_options(batch, &WriteOptions::default())
             .await
     }
@@ -941,17 +945,17 @@ impl Db {
     /// - `options`: the write options to use
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error writing the batch.
+    /// - `Error`: if there was an error writing the batch.
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{WriteBatch, Db, config::WriteOptions, SlateDBError};
+    /// use slatedb::{WriteBatch, Db, config::WriteOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///
@@ -968,8 +972,11 @@ impl Db {
         &self,
         batch: WriteBatch,
         options: &WriteOptions,
-    ) -> Result<(), SlateDBError> {
-        self.inner.write_with_options(batch, options).await
+    ) -> Result<(), crate::Error> {
+        self.inner
+            .write_with_options(batch, options)
+            .await
+            .map_err(Into::into)
     }
 
     /// Flush the database to disk.
@@ -977,28 +984,28 @@ impl Db {
     /// If WAL is disabled, flushes the memtables to disk.
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error flushing the database
+    /// - `Error`: if there was an error flushing the database
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, SlateDBError};
+    /// use slatedb::{Db, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store).await?;
     ///     db.flush().await?;
     ///     Ok(())
     /// }
     /// ```
-    pub async fn flush(&self) -> Result<(), SlateDBError> {
+    pub async fn flush(&self) -> Result<(), crate::Error> {
         if self.inner.wal_enabled {
-            self.inner.flush_wals().await
+            self.inner.flush_wals().await.map_err(Into::into)
         } else {
-            self.inner.flush_memtables().await
+            self.inner.flush_memtables().await.map_err(Into::into)
         }
     }
 
@@ -1013,7 +1020,7 @@ impl DbRead for Db {
         &self,
         key: K,
         options: &ReadOptions,
-    ) -> Result<Option<Bytes>, SlateDBError> {
+    ) -> Result<Option<Bytes>, crate::Error> {
         self.get_with_options(key, options).await
     }
 
@@ -1021,7 +1028,7 @@ impl DbRead for Db {
         &self,
         range: T,
         options: &ScanOptions,
-    ) -> Result<DbIterator, SlateDBError>
+    ) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -1700,12 +1707,12 @@ mod tests {
 
         #[async_trait]
         trait IteratorTrait {
-            async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError>;
+            async fn next(&mut self) -> Result<Option<KeyValue>, crate::Error>;
         }
 
         #[async_trait]
         impl IteratorTrait for DbIterator<'_> {
-            async fn next(&mut self) -> Result<Option<KeyValue>, SlateDBError> {
+            async fn next(&mut self) -> Result<Option<KeyValue>, crate::Error> {
                 DbIterator::next(self).await
             }
         }
@@ -1820,10 +1827,13 @@ mod tests {
 
             let lower_bounded_range = BytesRange::from(arbitrary_key.clone()..);
             let value = sample::bytes_in_range(rng, &lower_bounded_range);
-            assert!(matches!(
-                iter.seek(value).await,
-                Err(SlateDBError::InvalidArgument { msg: _ })
-            ));
+            let err = iter.seek(value.clone()).await.unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("cannot seek to a key outside the iterator range"),
+                "{}",
+                err
+            );
 
             let mut iter = db
                 .scan_with_options(arbitrary_key.clone().., &ScanOptions::default())
@@ -1832,10 +1842,13 @@ mod tests {
 
             let upper_bounded_range = BytesRange::from(..arbitrary_key.clone());
             let value = sample::bytes_in_range(rng, &upper_bounded_range);
-            assert!(matches!(
-                iter.seek(value).await,
-                Err(SlateDBError::InvalidArgument { msg: _ })
-            ));
+            let err = iter.seek(value.clone()).await.unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("cannot seek to a key outside the iterator range"),
+                "{}",
+                err
+            );
         }
     }
 
@@ -2846,8 +2859,8 @@ mod tests {
         );
 
         fail_parallel::cfg(fp_registry.clone(), "write-wal-sst-io-error", "panic").unwrap();
-        let result = db.put(b"foo", b"bar").await;
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskPanic(_))));
+        let result = db.put(b"foo", b"bar").await.unwrap_err();
+        assert!(result.to_string().contains("background task panic'd"));
     }
 
     #[tokio::test]
@@ -2867,8 +2880,11 @@ mod tests {
         fail_parallel::cfg(fp_registry.clone(), "write-wal-sst-io-error", "panic").unwrap();
 
         // Trigger a WAL write, which should not advance the manifest WAL ID
-        let result = db.put(b"foo", b"bar").await;
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskPanic(_))));
+        let result = db.put(b"foo", b"bar").await.unwrap_err();
+        assert_eq!(
+            result.to_string(),
+            "System error: background task panic'd (failpoint write-wal-sst-io-error panic)"
+        );
 
         // Close, which flushes the latest manifest to the object store
         // TODO: it might make sense to return an error if there're unflushed wals in memory
@@ -3049,7 +3065,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_kv_store";
 
-        async fn do_put(db: &Db, key: &[u8], val: &[u8]) -> Result<(), SlateDBError> {
+        async fn do_put(db: &Db, key: &[u8], val: &[u8]) -> Result<(), crate::Error> {
             db.put_with_options(
                 key,
                 val,
@@ -3077,11 +3093,10 @@ mod tests {
             .unwrap();
 
         // assert that db1 can no longer write.
-        let err = do_put(&db1, b"1", b"1").await;
-        assert!(
-            matches!(err, Err(SlateDBError::Fenced)),
-            "got non-fenced error: {:?}",
-            err
+        let err = do_put(&db1, b"1", b"1").await.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Permission error: detected newer DB client"
         );
 
         do_put(&db2, b"2", b"2").await.unwrap();
@@ -3112,11 +3127,7 @@ mod tests {
         clock.ticker.store(5, Ordering::SeqCst);
         match db.put(b"1", b"1").await {
             Ok(_) => panic!("expected an error on inserting backwards time"),
-            Err(e) => assert!(
-                e.to_string().contains("Last tick: 10, Next tick: 5"),
-                "{}",
-                e.to_string()
-            ),
+            Err(e) => assert_eq!(e.to_string(), "Operation error: invalid clock tick, must be monotonic. last_tick=`10`, next_tick=`5`"),
         }
     }
 
@@ -3149,11 +3160,7 @@ mod tests {
         clock.ticker.store(5, Ordering::SeqCst);
         match db2.put(b"1", b"1").await {
             Ok(_) => panic!("expected an error on inserting backwards time"),
-            Err(e) => assert!(
-                e.to_string().contains("Last tick: 10, Next tick: 5"),
-                "{}",
-                e.to_string()
-            ),
+            Err(e) => assert_eq!(e.to_string(), "Operation error: invalid clock tick, must be monotonic. last_tick=`10`, next_tick=`5`"),
         }
     }
 
@@ -3474,7 +3481,12 @@ mod tests {
             .with_settings(test_db_options(0, 1024, None))
             .build()
             .await;
-        assert!(matches!(result, Err(SlateDBError::Unsupported(..))));
+        match result {
+            Err(err) => {
+                assert!(err.to_string().contains("unsupported"));
+            }
+            _ => panic!("expected Unsupported error"),
+        }
     }
 
     #[test]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -8,12 +8,12 @@
 //! Basic usage of the `DbBuilder` struct:
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
 //!         .build()
@@ -25,12 +25,12 @@
 //! Example with custom settings:
 //!
 //! ```
-//! use slatedb::{Db, config::Settings, SlateDBError};
+//! use slatedb::{Db, config::Settings, Error};
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
 //!         .with_settings(Settings {
@@ -46,13 +46,13 @@
 //! Example with a custom block cache:
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::object_store::memory::InMemory;
 //! use slatedb::db_cache::moka::MokaCache;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
 //!         .with_block_cache(Arc::new(MokaCache::new()))
@@ -65,13 +65,13 @@
 //! Example with a custom clock:
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::clock::DefaultLogicalClock;
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let clock = Arc::new(DefaultLogicalClock::new());
 //!     let db = Db::builder("test_db", object_store)
@@ -85,13 +85,13 @@
 //! Example with a custom SST block size:
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::config::SstBlockSize;
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
 //!         .with_sst_block_size(SstBlockSize::Block8Kib) // 8KiB blocks
@@ -283,7 +283,7 @@ impl<P: Into<Path>> DbBuilder<P> {
     }
 
     /// Builds and opens the database.
-    pub async fn build(self) -> Result<Db, SlateDBError> {
+    pub async fn build(self) -> Result<Db, crate::Error> {
         let path = self.path.into();
         // TODO: proper URI generation, for now it works just as a flag
         let wal_object_store_uri = self.wal_object_store.as_ref().map(|_| String::new());
@@ -356,7 +356,8 @@ impl<P: Into<Path>> DbBuilder<P> {
             if latest_manifest.db_state().wal_object_store_uri != wal_object_store_uri {
                 return Err(SlateDBError::Unsupported(String::from(
                     "WAL object store reconfiguration is not supported",
-                )));
+                ))
+                .into());
             }
         }
 

--- a/slatedb/src/db_cache/foyer.rs
+++ b/slatedb/src/db_cache/foyer.rs
@@ -14,13 +14,13 @@
 //!
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::db_cache::foyer::FoyerCache;
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
 //!         .with_block_cache(Arc::new(FoyerCache::new()))
@@ -32,7 +32,6 @@
 //!
 
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
-use crate::SlateDBError;
 use async_trait::async_trait;
 
 /// The options for the Foyer cache.
@@ -91,15 +90,15 @@ impl Default for FoyerCache {
 
 #[async_trait]
 impl DbCache for FoyerCache {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         Ok(self.inner.get(&key).map(|entry| entry.value().clone()))
     }
 

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -59,9 +59,10 @@
 //! ```
 //!
 
+use std::sync::Arc;
+
 use crate::db_cache::{CachedEntry, CachedKey, DbCache};
-use crate::SlateDBError;
-use crate::SlateDBError::DbCacheError;
+use crate::error::SlateDBError::FoyerCacheReadingError;
 use async_trait::async_trait;
 
 pub struct FoyerHybridCache {
@@ -75,26 +76,26 @@ impl FoyerHybridCache {
 }
 
 impl FoyerHybridCache {
-    async fn get(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         self.inner
             .get(&key)
             .await
-            .map_err(|e| DbCacheError { msg: e.to_string() })
+            .map_err(|e| FoyerCacheReadingError(Arc::new(e)).into())
             .map(|maybe_v| maybe_v.map(|v| v.value().clone()))
     }
 }
 
 #[async_trait]
 impl DbCache for FoyerHybridCache {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         self.get(key).await
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         self.get(key).await
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         self.get(key).await
     }
 

--- a/slatedb/src/db_cache/moka.rs
+++ b/slatedb/src/db_cache/moka.rs
@@ -13,13 +13,13 @@
 //! ## Examples
 //!
 //! ```
-//! use slatedb::{Db, SlateDBError};
+//! use slatedb::{Db, Error};
 //! use slatedb::db_cache::moka::MokaCache;
 //! use slatedb::object_store::memory::InMemory;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
-//! async fn main() -> Result<(), SlateDBError> {
+//! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
 //!         .with_block_cache(Arc::new(MokaCache::new()))
@@ -30,7 +30,6 @@
 //! ```
 //!
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
-use crate::SlateDBError;
 use async_trait::async_trait;
 use std::time::Duration;
 
@@ -107,15 +106,15 @@ impl Default for MokaCache {
 
 #[async_trait]
 impl DbCache for MokaCache {
-    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_block(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         Ok(self.inner.get(&key).await)
     }
 
-    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_index(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         Ok(self.inner.get(&key).await)
     }
 
-    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, SlateDBError> {
+    async fn get_filter(&self, key: CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
         Ok(self.inner.get(&key).await)
     }
 

--- a/slatedb/src/db_cache/serde.rs
+++ b/slatedb/src/db_cache/serde.rs
@@ -7,9 +7,9 @@
 use crate::block::Block;
 use crate::db_cache::{CachedEntry, CachedItem, CachedKey};
 use crate::db_state::SsTableId;
+use crate::error::SlateDBError;
 use crate::filter::BloomFilter;
 use crate::flatbuffer_types::SsTableIndexOwned;
-use crate::SlateDBError;
 use bytes::Bytes;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/slatedb/src/db_read.rs
+++ b/slatedb/src/db_read.rs
@@ -1,6 +1,5 @@
 use crate::{
     config::{ReadOptions, ScanOptions},
-    error::SlateDBError,
     DbIterator,
 };
 use bytes::Bytes;
@@ -27,13 +26,13 @@ pub trait DbRead {
     /// - `key`: the key to get
     ///
     /// ## Returns
-    /// - `Result<Option<Bytes>, SlateDBError>`:
+    /// - `Result<Option<Bytes>, Error>`:
     ///     - `Some(Bytes)`: the value if it exists
     ///     - `None`: if the value does not exist
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error getting the value
-    async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, SlateDBError> {
+    /// - `Error`: if there was an error getting the value
+    async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, crate::Error> {
         self.get_with_options(key, &ReadOptions::default()).await
     }
 
@@ -49,17 +48,17 @@ pub trait DbRead {
     /// - `options`: the read options to use
     ///
     /// ## Returns
-    /// - `Result<Option<Bytes>, SlateDBError>`:
+    /// - `Result<Option<Bytes>, Error>`:
     ///   - `Some(Bytes)`: the value if it exists
     ///   - `None`: if the value does not exist
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error getting the value
+    /// - `Error`: if there was an error getting the value
     async fn get_with_options<K: AsRef<[u8]> + Send>(
         &self,
         key: K,
         options: &ReadOptions,
-    ) -> Result<Option<Bytes>, SlateDBError>;
+    ) -> Result<Option<Bytes>, crate::Error>;
 
     /// Scan a range of keys using the default scan options.
     ///
@@ -69,11 +68,11 @@ pub trait DbRead {
     /// - `range`: the range of keys to scan
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error scanning the range of keys
+    /// - `Error`: if there was an error scanning the range of keys
     ///
     /// ## Returns
-    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    async fn scan<K, T>(&self, range: T) -> Result<DbIterator, SlateDBError>
+    /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
+    async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -90,15 +89,15 @@ pub trait DbRead {
     /// - `options`: the scan options to use
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error scanning the range of keys
+    /// - `Error`: if there was an error scanning the range of keys
     ///
     /// ## Returns
-    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
+    /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
     async fn scan_with_options<K, T>(
         &self,
         range: T,
         options: &ScanOptions,
-    ) -> Result<DbIterator, SlateDBError>
+    ) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send;

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -502,22 +502,18 @@ impl DbReaderInner {
 impl DbReader {
     fn validate_options(options: &DbReaderOptions) -> Result<(), SlateDBError> {
         if options.checkpoint_lifetime.as_millis() < 1000 {
-            return Err(SlateDBError::InvalidArgument {
-                msg: "Checkpoint lifetime must be at least 1s".to_string(),
-            });
+            return Err(SlateDBError::InvalidCheckpointLifetime(
+                options.checkpoint_lifetime,
+            ));
         }
 
-        let double_poll_interval =
-            options
-                .manifest_poll_interval
-                .checked_mul(2)
-                .ok_or(SlateDBError::InvalidArgument {
-                    msg: "Manifest poll interval is too large".to_string(),
-                })?;
+        let double_poll_interval = options.manifest_poll_interval.checked_mul(2).ok_or(
+            SlateDBError::InvalidManifestPollInterval(options.manifest_poll_interval),
+        )?;
         if options.checkpoint_lifetime < double_poll_interval {
-            return Err(SlateDBError::InvalidArgument {
-                msg: "Checkpoint lifetime must be at least double the manifest poll interval"
-                    .to_string(),
+            return Err(SlateDBError::CheckpointLifetimeTooShort {
+                lifetime: options.checkpoint_lifetime,
+                interval: double_poll_interval,
             });
         }
         Ok(())
@@ -534,7 +530,7 @@ impl DbReader {
         object_store: Arc<dyn ObjectStore>,
         checkpoint_id: Option<Uuid>,
         options: DbReaderOptions,
-    ) -> Result<Self, SlateDBError> {
+    ) -> Result<Self, crate::Error> {
         let path = path.into();
         let store_provider = DefaultStoreProvider {
             path,
@@ -551,6 +547,7 @@ impl DbReader {
             Arc::new(DbRand::default()),
         )
         .await
+        .map_err(Into::into)
     }
 
     async fn open_internal(
@@ -604,22 +601,22 @@ impl DbReader {
     /// - `key`: the key to get
     ///
     /// ## Returns
-    /// - `Result<Option<Bytes>, SlateDBError>`:
+    /// - `Result<Option<Bytes>, Error>`:
     ///     - `Some(Bytes)`: the value if it exists
     ///     - `None`: if the value does not exist
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error getting the value
+    /// - `Error`: if there was an error getting the value
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, config::DbReaderOptions, SlateDBError};
+    /// use slatedb::{Db, DbReader, config::DbReaderOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", Arc::clone(&object_store)).await?;
     ///     db.put(b"key", b"value").await?;
@@ -635,7 +632,7 @@ impl DbReader {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, SlateDBError> {
+    pub async fn get<K: AsRef<[u8]> + Send>(&self, key: K) -> Result<Option<Bytes>, crate::Error> {
         self.get_with_options(key, &ReadOptions::default()).await
     }
 
@@ -652,22 +649,22 @@ impl DbReader {
     ///   for readers, which can only observe committed state).
     ///
     /// ## Returns
-    /// - `Result<Option<Bytes>, SlateDBError>`:
+    /// - `Result<Option<Bytes>, Error>`:
     ///     - `Some(Bytes)`: the value if it exists
     ///     - `None`: if the value does not exist
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error getting the value
+    /// - `Error`: if there was an error getting the value
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, config::DbReaderOptions, config::ReadOptions, SlateDBError};
+    /// use slatedb::{Db, DbReader, config::DbReaderOptions, config::ReadOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", Arc::clone(&object_store)).await?;
     ///     db.put(b"key", b"value").await?;
@@ -687,8 +684,11 @@ impl DbReader {
         &self,
         key: K,
         options: &ReadOptions,
-    ) -> Result<Option<Bytes>, SlateDBError> {
-        self.inner.get_with_options(key, options).await
+    ) -> Result<Option<Bytes>, crate::Error> {
+        self.inner
+            .get_with_options(key, options)
+            .await
+            .map_err(Into::into)
     }
 
     /// Scan a range of keys using the default scan options.
@@ -699,20 +699,20 @@ impl DbReader {
     /// - `range`: the range of keys to scan
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error scanning the range of keys
+    /// - `Error`: if there was an error scanning the range of keys
     ///
     /// ## Returns
-    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
+    /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, config::DbReaderOptions, SlateDBError};
+    /// use slatedb::{Db, DbReader, config::DbReaderOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", Arc::clone(&object_store)).await?;
     ///     db.put(b"a", b"a_value").await?;
@@ -731,7 +731,7 @@ impl DbReader {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, SlateDBError>
+    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -749,20 +749,20 @@ impl DbReader {
     ///   for readers, which can only observe committed state).
     ///
     /// ## Errors
-    /// - `SlateDBError`: if there was an error scanning the range of keys
+    /// - `Error`: if there was an error scanning the range of keys
     ///
     /// ## Returns
-    /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
+    /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, config::DbReaderOptions, config::ScanOptions, config::DurabilityLevel, SlateDBError};
+    /// use slatedb::{Db, DbReader, config::DbReaderOptions, config::ScanOptions, config::DurabilityLevel, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", Arc::clone(&object_store)).await?;
     ///     db.put(b"a", b"a_value").await?;
@@ -787,7 +787,7 @@ impl DbReader {
         &self,
         range: T,
         options: &ScanOptions,
-    ) -> Result<DbIterator, SlateDBError>
+    ) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -799,23 +799,26 @@ impl DbReader {
             .end_bound()
             .map(|b| Bytes::copy_from_slice(b.as_ref()));
         let range = BytesRange::from((start, end));
-        self.inner.scan_with_options(range, options).await
+        self.inner
+            .scan_with_options(range, options)
+            .await
+            .map_err(Into::into)
     }
 
     /// Close the database reader.
     ///
     /// ## Returns
-    /// - `Result<(), SlateDBError>`: if there was an error closing the reader
+    /// - `Result<(), Error>`: if there was an error closing the reader
     ///
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, config::DbReaderOptions, SlateDBError};
+    /// use slatedb::{Db, DbReader, config::DbReaderOptions, Error};
     /// use slatedb::object_store::{ObjectStore, memory::InMemory};
     /// use std::sync::Arc;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), SlateDBError> {
+    /// async fn main() -> Result<(), Error> {
     ///     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     ///     let db = Db::open("test_db", object_store.clone()).await?;
     ///     let options = DbReaderOptions::default();
@@ -825,7 +828,7 @@ impl DbReader {
     /// }
     /// ```
     ///
-    pub async fn close(&self) -> Result<(), SlateDBError> {
+    pub async fn close(&self) -> Result<(), crate::Error> {
         if let Some(poller) = &self.manifest_poller {
             poller
                 .thread_tx
@@ -849,7 +852,7 @@ impl DbRead for DbReader {
         &self,
         key: K,
         options: &ReadOptions,
-    ) -> Result<Option<Bytes>, SlateDBError> {
+    ) -> Result<Option<Bytes>, crate::Error> {
         self.get_with_options(key, options).await
     }
 
@@ -857,7 +860,7 @@ impl DbRead for DbReader {
         &self,
         range: T,
         options: &ScanOptions,
-    ) -> Result<DbIterator, SlateDBError>
+    ) -> Result<DbIterator, crate::Error>
     where
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
@@ -882,7 +885,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::store_provider::StoreProvider;
     use crate::tablestore::TableStore;
-    use crate::{test_utils, Db, SlateDBError};
+    use crate::{error::SlateDBError, test_utils, Db};
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -1183,11 +1186,9 @@ mod tests {
         )
         .unwrap();
         tokio::time::sleep(Duration::from_millis(20)).await;
-        let result = reader.get(b"key").await;
-        let Err(err) = result else {
-            panic!("Expected an error");
-        };
-        assert!(matches!(err, SlateDBError::IoError(_)));
+        let result = reader.get(b"key").await.unwrap_err();
+        dbg!(&result);
+        assert_eq!(result.to_string(), "System error: io error (oops)");
     }
 
     struct TestProvider {
@@ -1216,7 +1217,7 @@ mod tests {
     }
 
     impl TestProvider {
-        async fn new_db(&self, options: Settings) -> Result<Db, SlateDBError> {
+        async fn new_db(&self, options: Settings) -> Result<Db, crate::Error> {
             Db::builder(self.path.clone(), self.object_store.clone())
                 .with_settings(options)
                 .build()

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -1,85 +1,94 @@
+use object_store::path::Path;
 use std::any::Any;
+use std::ops::Bound;
 use std::sync::Mutex;
+use std::time::Duration;
 use std::{path::PathBuf, sync::Arc};
-use thiserror::Error;
+use thiserror::Error as ThisError;
 use uuid::Uuid;
 
+use crate::bytes_range::BytesRange;
 use crate::merge_operator::MergeOperatorError;
 
 #[non_exhaustive]
-#[derive(Clone, Debug, Error)]
-pub enum SlateDBError {
-    #[error("IO error: {0}")]
+#[derive(Clone, Debug, ThisError)]
+pub(crate) enum SlateDBError {
+    #[error("io error")]
     IoError(#[from] Arc<std::io::Error>),
 
-    #[error("Checksum mismatch")]
+    #[error("checksum mismatch")]
     ChecksumMismatch,
 
-    #[error("Empty SSTable")]
+    #[error("empty SSTable")]
     EmptySSTable,
 
-    #[error("Empty block metadata")]
+    #[error("empty block metadata")]
     EmptyBlockMeta,
 
-    #[error("Empty block")]
+    #[error("empty block")]
     EmptyBlock,
 
-    #[error("Empty manifest")]
+    #[error("empty manifest")]
     EmptyManifest,
 
-    #[error("Object store error: {0}")]
+    #[error("object store error")]
     ObjectStoreError(#[from] Arc<object_store::Error>),
 
-    #[error("Manifest file already exists")]
+    #[error("manifest file already exists")]
     ManifestVersionExists,
 
-    #[error("Failed to find manifest with id {0}")]
+    #[error("failed to find manifest with id. id=`{0}`")]
     ManifestMissing(u64),
 
-    #[error("Failed to find latest manifest")]
+    #[error("failed to find latest manifest")]
     LatestManifestMissing,
 
-    #[error("Invalid deletion")]
+    #[error("invalid deletion")]
     InvalidDeletion,
 
-    #[error("Invalid sst error: {0}")]
+    #[error("invalid sst error")]
     InvalidFlatbuffer(#[from] flatbuffers::InvalidFlatbuffer),
 
-    #[error("Invalid DB state error")]
+    #[error("invalid DB state error")]
     InvalidDBState,
 
-    #[error("Unsupported operation: {0}")]
+    #[error("unsupported operation. operation=`{0}`")]
     Unsupported(String),
 
-    #[error("Invalid Compaction")]
+    #[error("invalid compaction")]
     InvalidCompaction,
 
-    #[error("Compaction executor failed")]
+    #[error("compaction executor failed")]
     CompactionExecutorFailed,
 
     #[error(
-        "Invalid clock tick, most be monotonic. Last tick: {}, Next tick: {}",
-        last_tick,
-        next_tick
+        "invalid clock tick, must be monotonic. last_tick=`{last_tick}`, next_tick=`{next_tick}`"
     )]
     InvalidClockTick { last_tick: i64, next_tick: i64 },
 
-    #[error("Detected newer DB client")]
+    #[error("detected newer DB client")]
     Fenced,
 
-    #[error("Invalid cache part size bytes, it must be multiple of 1024 and greater than 0")]
+    #[error("invalid cache part size bytes, it must be multiple of 1024 and greater than 0")]
     InvalidCachePartSize,
 
-    #[error("Invalid Compression Codec")]
+    #[error("invalid compression codec")]
     InvalidCompressionCodec,
 
-    #[error("Error Decompressing Block")]
+    #[cfg(any(
+        feature = "snappy",
+        feature = "zlib",
+        feature = "lz4",
+        feature = "zstd"
+    ))]
+    #[error("error decompressing block")]
     BlockDecompressionError,
 
-    #[error("Error Compressing Block")]
+    #[cfg(any(feature = "snappy", feature = "zlib", feature = "zstd"))]
+    #[error("error compressing block")]
     BlockCompressionError,
 
-    #[error("Invalid RowFlags (encoded_bits: {encoded_bits:#b}, known_bits: {known_bits:#b}): {message}"
+    #[error("Invalid RowFlags. #{message}. encoded_bits=`{encoded_bits:#b}`, known_bits=`{known_bits:#b}`"
     )]
     InvalidRowFlags {
         encoded_bits: u8,
@@ -87,14 +96,11 @@ pub enum SlateDBError {
         message: String,
     },
 
-    #[error("Read channel error: {0}")]
+    #[error("read channel error")]
     ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
 
-    #[error("Iterator invalidated after unexpected error {0}")]
+    #[error("iterator invalidated after unexpected error")]
     InvalidatedIterator(#[from] Box<SlateDBError>),
-
-    #[error("Invalid Argument: {msg}")]
-    InvalidArgument { msg: String },
 
     #[error("background task panic'd")]
     // we need to wrap the panic args in an Arc so SlateDbError is Clone
@@ -104,29 +110,74 @@ pub enum SlateDBError {
     #[error("background task shutdown")]
     BackgroundTaskShutdown,
 
-    #[error("Merge Operator error: {0}")]
+    #[error("merge operator error")]
     MergeOperatorError(#[from] MergeOperatorError),
 
-    #[error("Checkpoint {0} missing")]
+    #[error("checkpoint missing. checkpoint_id=`{0}`")]
     CheckpointMissing(Uuid),
 
-    #[error("Database already exists: {msg}")]
-    DatabaseAlreadyExists { msg: String },
-
-    #[error("Byte format version mismatch: expected {expected_version}, actual {actual_version}")]
+    #[error(
+        "byte format version mismatch. expected_version=`{expected_version}`, actual_version=`{actual_version}`"
+    )]
     InvalidVersion {
         expected_version: u16,
         actual_version: u16,
     },
 
-    #[error("Db Cache error: {msg}")]
-    DbCacheError { msg: String },
+    #[error("foyer cache reading error")]
+    #[cfg(feature = "foyer")]
+    FoyerCacheReadingError(#[from] Arc<anyhow::Error>),
 
-    #[error("Timeout: {msg}")]
-    Timeout { msg: String },
+    #[error("operation timed out. operation=`{op}`")]
+    Timeout { op: &'static str, backoff: Duration },
 
-    #[error("Unexpected error: {msg}")]
-    UnexpectedError { msg: String },
+    #[error("wal buffer already started")]
+    WalBufferAlreadyStarted,
+
+    #[error("cannot seek to a key outside the iterator range. key=`{key:?}`, range=`{range:?}`")]
+    SeekKeyOutOfRange { key: Vec<u8>, range: BytesRange },
+
+    #[error("cannot seek to a key less than the last returned key")]
+    SeekKeyLessThanLastReturnedKey,
+
+    #[error(
+        "parent path must be different from the clone's path. parent_path=`{0}`, clone_path=`{0}`"
+    )]
+    IdenticalClonePaths(Path),
+
+    #[error("invalid checkpoint lifetime. lifetime=`{0:?}`")]
+    InvalidCheckpointLifetime(Duration),
+
+    #[error("invalid manifest poll interval. interval=`{0:?}`")]
+    InvalidManifestPollInterval(Duration),
+
+    #[error("checkpoint lifetime must be at least double the manifest poll interval. lifetime=`{lifetime:?}`, interval=`{interval:?}`")]
+    CheckpointLifetimeTooShort {
+        lifetime: Duration,
+        interval: Duration,
+    },
+
+    #[error("invalid sst batch size. size=`{0}`")]
+    InvalidSSTBatchSize(usize),
+
+    #[error("cannot seek to a key outside the iterator range. key=`{key:?}`, start_key=`{start_key:?}`, end_key=`{end_key:?}`")]
+    SeekKeyOutOfKeyRange {
+        key: Vec<u8>,
+        start_key: Bound<Vec<u8>>,
+        end_key: Bound<Vec<u8>>,
+    },
+
+    #[error("the cloned database is not attached to any external database")]
+    CloneExternalDbMissing,
+
+    #[error("the cloned database is not attached to external database with a valid checkpoint. path=`{path}`, checkpoint_id=`{checkpoint_id:?}`")]
+    CloneIncorrectExternalDbCheckpoint {
+        path: String,
+        checkpoint_id: Option<Uuid>,
+    },
+
+    #[error("the final checkpoint for the cloned database no longer exists in the manifest. path=`{path}`, checkpoint_id=`{checkpoint_id}`")]
+    CloneIncorrectFinalCheckpoint { path: String, checkpoint_id: Uuid },
 }
 
 impl From<std::io::Error> for SlateDBError {
@@ -146,11 +197,256 @@ impl From<object_store::Error> for SlateDBError {
 /// This enum encapsulates various error conditions that may arise
 /// when parsing or processing database configuration options.
 #[non_exhaustive]
-#[derive(Error, Debug)]
-pub enum SettingsError {
-    #[error("Unknown configuration file format: {0}")]
+#[derive(ThisError, Debug)]
+pub(crate) enum SettingsError {
+    #[error("Unknown configuration file format `{0}`")]
     UnknownFormat(PathBuf),
 
-    #[error("Invalid configuration format: {0}")]
+    #[error("Invalid configuration format")]
     InvalidFormat(#[from] Box<figment::Error>),
+}
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Represents the kind of public errors that can be returned to the user.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The database attempted to use an invalid configuration.
+    Configuration,
+
+    /// The database attempted an invalid operation or an operation with an
+    /// invalid parameter (including misconfiguration).
+    Operation,
+
+    /// Unexpected internal error. This error is fatal (i.e. the database must be closed).
+    System,
+
+    /// Invalid persistent state (e.g. corrupted data files). The state must
+    /// be repaired before the database can be restarted.
+    PersistentState,
+
+    /// Failed access database resources (e.g. remote storage) due to some
+    /// kind of authentication or authorization error. The operation can be
+    /// retried after the permission issue is resolved.
+    Permission,
+
+    /// The operation failed due to a transient error (such as IO unavailability).
+    /// The operation can be retried after backing off.
+    Transient(Duration),
+}
+
+impl std::fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorKind::Configuration => write!(f, "Configuration error"),
+            ErrorKind::Operation => write!(f, "Operation error"),
+            ErrorKind::System => write!(f, "System error"),
+            ErrorKind::PersistentState => write!(f, "Persistent state error"),
+            ErrorKind::Permission => write!(f, "Permission error"),
+            ErrorKind::Transient(backoff) => {
+                write!(f, "Transient error (retry after: {backoff:?})")
+            }
+        }
+    }
+}
+
+/// Represents a public error that can be returned to the user.
+#[derive(Debug)]
+pub struct Error {
+    msg: String,
+    kind: ErrorKind,
+    source: Option<BoxError>,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.kind, self.msg)?;
+        if let Some(source) = self.source.as_ref() {
+            write!(f, " ({source})")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.source
+            .as_ref()
+            .map(|e| e.as_ref() as &(dyn std::error::Error + 'static))
+    }
+}
+
+impl Error {
+    /// Creates a new public configuration error.
+    pub fn configuration(msg: String) -> Self {
+        Self {
+            msg,
+            kind: ErrorKind::Configuration,
+            source: None,
+        }
+    }
+
+    /// Creates a new public operation error.
+    pub fn operation(msg: String) -> Self {
+        Self {
+            msg,
+            kind: ErrorKind::Operation,
+            source: None,
+        }
+    }
+
+    /// Creates a new public system error.
+    pub fn system(msg: String) -> Self {
+        Self {
+            msg,
+            kind: ErrorKind::System,
+            source: None,
+        }
+    }
+
+    /// Creates a new public persistent state error.
+    pub fn persistent_state(msg: String) -> Self {
+        Self {
+            msg,
+            kind: ErrorKind::PersistentState,
+            source: None,
+        }
+    }
+
+    /// Creates a new public permission error.
+    pub fn permission(msg: String) -> Self {
+        Self {
+            msg,
+            kind: ErrorKind::Permission,
+            source: None,
+        }
+    }
+
+    /// Creates a new public transient error.
+    pub fn transient(msg: String, backoff: Duration) -> Self {
+        Self {
+            msg,
+            kind: ErrorKind::Transient(backoff),
+            source: None,
+        }
+    }
+
+    /// Adds a source to the error.
+    pub fn with_source(mut self, source: BoxError) -> Self {
+        self.source = Some(source);
+        self
+    }
+}
+
+impl From<SlateDBError> for Error {
+    fn from(err: SlateDBError) -> Self {
+        let msg = err.to_string();
+        match err {
+            SlateDBError::IoError(err) => Error::system(msg).with_source(Box::new(err)),
+            SlateDBError::ObjectStoreError(err) => Error::operation(msg).with_source(Box::new(err)),
+            SlateDBError::InvalidFlatbuffer(err) => {
+                Error::persistent_state(msg).with_source(Box::new(err))
+            }
+            SlateDBError::InvalidDeletion => Error::operation(msg),
+            SlateDBError::InvalidDBState => Error::persistent_state(msg),
+            SlateDBError::InvalidCompaction => Error::operation(msg),
+            SlateDBError::CompactionExecutorFailed => Error::system(msg),
+            SlateDBError::InvalidClockTick { .. } => Error::operation(msg),
+            SlateDBError::Fenced => Error::permission(msg),
+            SlateDBError::InvalidCachePartSize => Error::operation(msg),
+            SlateDBError::InvalidCompressionCodec => Error::operation(msg),
+            #[cfg(any(
+                feature = "snappy",
+                feature = "zlib",
+                feature = "lz4",
+                feature = "zstd"
+            ))]
+            SlateDBError::BlockDecompressionError => Error::operation(msg),
+            #[cfg(any(feature = "snappy", feature = "zlib", feature = "zstd"))]
+            SlateDBError::BlockCompressionError => Error::operation(msg),
+            SlateDBError::InvalidRowFlags { .. } => Error::operation(msg),
+            SlateDBError::ReadChannelError(err) => Error::system(msg).with_source(Box::new(err)),
+            SlateDBError::InvalidatedIterator(err) => {
+                Error::operation(msg).with_source(Box::new(err))
+            }
+            SlateDBError::BackgroundTaskPanic(err) => {
+                Error::system(msg).with_source(Box::new(PanicError(err)))
+            }
+            SlateDBError::BackgroundTaskShutdown => Error::system(msg),
+            SlateDBError::MergeOperatorError(err) => {
+                Error::operation(msg).with_source(Box::new(err))
+            }
+            SlateDBError::CheckpointMissing(_) => Error::persistent_state(msg),
+            SlateDBError::InvalidVersion { .. } => Error::persistent_state(msg),
+            #[cfg(feature = "foyer")]
+            SlateDBError::FoyerCacheReadingError(err) => {
+                Error::persistent_state(msg).with_source(Box::new(AnyhowError(err)))
+            }
+            SlateDBError::Timeout { backoff, .. } => Error::transient(msg, backoff),
+            SlateDBError::WalBufferAlreadyStarted => Error::system(msg),
+            SlateDBError::ManifestMissing(_) => Error::persistent_state(msg),
+            SlateDBError::LatestManifestMissing => Error::persistent_state(msg),
+            SlateDBError::ManifestVersionExists => Error::persistent_state(msg),
+            SlateDBError::EmptyManifest => Error::persistent_state(msg),
+            SlateDBError::EmptyBlock => Error::persistent_state(msg),
+            SlateDBError::EmptyBlockMeta => Error::persistent_state(msg),
+            SlateDBError::EmptySSTable => Error::persistent_state(msg),
+            SlateDBError::Unsupported(_) => Error::operation(msg),
+            SlateDBError::ChecksumMismatch => Error::persistent_state(msg),
+            SlateDBError::SeekKeyOutOfRange { .. } => Error::operation(msg),
+            SlateDBError::SeekKeyLessThanLastReturnedKey => Error::operation(msg),
+            SlateDBError::IdenticalClonePaths { .. } => Error::operation(msg),
+            SlateDBError::InvalidCheckpointLifetime(_) => Error::operation(msg),
+            SlateDBError::InvalidManifestPollInterval(_) => Error::operation(msg),
+            SlateDBError::CheckpointLifetimeTooShort { .. } => Error::operation(msg),
+            SlateDBError::InvalidSSTBatchSize(_) => Error::operation(msg),
+            SlateDBError::SeekKeyOutOfKeyRange { .. } => Error::operation(msg),
+            SlateDBError::CloneExternalDbMissing => Error::persistent_state(msg),
+            SlateDBError::CloneIncorrectExternalDbCheckpoint { .. } => Error::persistent_state(msg),
+            SlateDBError::CloneIncorrectFinalCheckpoint { .. } => Error::persistent_state(msg),
+        }
+    }
+}
+
+impl From<SettingsError> for Error {
+    fn from(err: SettingsError) -> Self {
+        let msg = err.to_string();
+        match err {
+            SettingsError::UnknownFormat(_) => Error::configuration(msg),
+            SettingsError::InvalidFormat(err) => {
+                Error::configuration(msg).with_source(Box::new(err))
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PanicError(Arc<Mutex<Box<dyn Any + Send>>>);
+impl std::error::Error for PanicError {}
+impl std::fmt::Display for PanicError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let guard = self.0.lock().unwrap();
+        if let Some(err) = guard.downcast_ref::<SlateDBError>() {
+            write!(f, "{err}")?;
+        } else if let Some(err) = guard.downcast_ref::<Box<dyn std::error::Error>>() {
+            write!(f, "{err}")?;
+        } else if let Some(err) = guard.downcast_ref::<String>() {
+            write!(f, "{err}")?;
+        } else {
+            write!(f, "irrecoverable panic")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+#[cfg(feature = "foyer")]
+struct AnyhowError(Arc<anyhow::Error>);
+#[cfg(feature = "foyer")]
+impl std::error::Error for AnyhowError {}
+#[cfg(feature = "foyer")]
+impl std::fmt::Display for AnyhowError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }

--- a/slatedb/src/filter_iterator.rs
+++ b/slatedb/src/filter_iterator.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
 
+use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::types::RowEntry;
 use crate::utils::is_not_expired;
-use crate::SlateDBError;
 
 pub(crate) type FilterPredicate = Box<dyn Fn(&RowEntry) -> bool + Send + Sync>;
 

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -565,7 +565,7 @@ mod tests {
     use crate::db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::flatbuffer_types::{FlatBufferManifestCodec, SsTableIndexOwned};
     use crate::manifest::{ExternalDb, Manifest, ManifestCodec};
-    use crate::{checkpoint, SlateDBError};
+    use crate::{checkpoint, error::SlateDBError};
     use std::collections::VecDeque;
     use std::time::{Duration, SystemTime};
 

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -1,6 +1,6 @@
 use crate::{
-    config::GarbageCollectorDirectoryOptions, db_state::SsTableId, manifest::store::ManifestStore,
-    tablestore::TableStore, SlateDBError,
+    config::GarbageCollectorDirectoryOptions, db_state::SsTableId, error::SlateDBError,
+    manifest::store::ManifestStore, tablestore::TableStore,
 };
 use chrono::{DateTime, Utc};
 use std::collections::HashSet;

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::GarbageCollectorDirectoryOptions, manifest::store::ManifestStore, SlateDBError,
+    config::GarbageCollectorDirectoryOptions, error::SlateDBError, manifest::store::ManifestStore,
 };
 use chrono::{DateTime, Utc};
 use std::collections::HashSet;

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -1,8 +1,8 @@
 use crate::manifest::Manifest;
 use crate::tablestore::SstFileMetadata;
 use crate::{
-    config::GarbageCollectorDirectoryOptions, manifest::store::ManifestStore,
-    tablestore::TableStore, SlateDBError,
+    config::GarbageCollectorDirectoryOptions, error::SlateDBError, manifest::store::ManifestStore,
+    tablestore::TableStore,
 };
 use chrono::{DateTime, Utc};
 use std::collections::BTreeMap;

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -35,7 +35,7 @@ pub use db_cache::stats as db_cache_stats;
 pub use db_iter::DbIterator;
 pub use db_read::DbRead;
 pub use db_reader::DbReader;
-pub use error::{SettingsError, SlateDBError};
+pub use error::{Error, ErrorKind};
 pub use garbage_collector::stats as garbage_collector_stats;
 pub use merge_operator::{MergeOperator, MergeOperatorError};
 pub use types::KeyValue;

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -15,7 +15,7 @@ use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::types::{RowEntry, ValueDeletable};
 use crate::utils::{get_now_for_read, is_not_expired};
-use crate::{filter, DbIterator, SlateDBError};
+use crate::{error::SlateDBError, filter, DbIterator};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::FutureExt;

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -346,9 +346,10 @@ impl KeyValueIterator for SstIterator<'_> {
 
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
         if !self.view.contains(next_key) {
-            return Err(SlateDBError::InvalidArgument {
-                msg: format!("Cannot seek to a key '{:?}' which is outside the iterator range (start: {:?}, end: {:?})",
-                             next_key, self.view.start_key(), self.view.end_key())
+            return Err(SlateDBError::SeekKeyOutOfKeyRange {
+                key: next_key.to_vec(),
+                start_key: self.view.start_key().map(|b| b.to_vec()),
+                end_key: self.view.end_key().map(|b| b.to_vec()),
             });
         }
         if !self.state.is_finished() {

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -240,7 +240,7 @@ pub(crate) async fn seed_database(
     db: &Db,
     table: &BTreeMap<Bytes, Bytes>,
     await_durable: bool,
-) -> Result<(), SlateDBError> {
+) -> Result<(), crate::Error> {
     let put_options = PutOptions::default();
     let write_options = WriteOptions { await_durable };
 

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -15,6 +15,7 @@ use crate::{
     clock::{MonotonicClock, SystemClock},
     db_state::{DbState, SsTableId},
     db_stats::DbStats,
+    error::SlateDBError,
     iter::KeyValueIterator,
     mem_table::KVTable,
     oracle::Oracle,
@@ -22,7 +23,6 @@ use crate::{
     types::RowEntry,
     utils::{spawn_bg_task, WatchableOnceCell, WatchableOnceCellReader},
     wal_id::WalIdStore,
-    SlateDBError,
 };
 
 /// [`WalBufferManager`] buffers write operations in memory before flushing them to persistent storage.
@@ -121,9 +121,7 @@ impl WalBufferManager {
 
     pub async fn start_background(self: &Arc<Self>) -> Result<(), SlateDBError> {
         if self.inner.read().background_task.is_some() {
-            return Err(SlateDBError::UnexpectedError {
-                msg: "wal_buffer already started".to_string(),
-            });
+            return Err(SlateDBError::WalBufferAlreadyStarted);
         }
 
         let (flush_tx, flush_rx) = mpsc::channel(128);

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -1,11 +1,10 @@
 use crate::db_state::{CoreDbState, SsTableId};
+use crate::error::SlateDBError;
 use crate::iter::KeyValueIterator;
 use crate::mem_table::WritableKVTable;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::types::RowEntry;
-use crate::SlateDBError;
-use crate::SlateDBError::InvalidArgument;
 use std::collections::VecDeque;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
@@ -95,9 +94,7 @@ impl WalReplayIterator<'_> {
     ) -> Result<Self, SlateDBError> {
         let sst_batch_size = options.sst_batch_size;
         if sst_batch_size < 1 {
-            return Err(InvalidArgument {
-                msg: "Replay batch size must be at least 1".to_string(),
-            });
+            return Err(SlateDBError::InvalidSSTBatchSize(sst_batch_size));
         }
 
         // load the last seq number from manifest, and use it as the starting seq number to avoid
@@ -286,7 +283,7 @@ mod tests {
     use crate::sst::SsTableFormat;
     use crate::tablestore::TableStore;
     use crate::types::RowEntry;
-    use crate::{test_utils, SlateDBError};
+    use crate::{error::SlateDBError, test_utils};
     use bytes::Bytes;
     use object_store::memory::InMemory;
     use object_store::path::Path;


### PR DESCRIPTION
This is an implementation of RFC 7, but with caveats.

When I started implementing it, I realized that it lacked some details on the design itself. I opted for changing the `Error` type definition to match what I've seen in other very popular crates, instead of using an enum to define all the errors, the `Error` type is a generic error that includes a `ErrorKind` enum with the different error variants. This is similar to the implementation that the AWS SDK follows, for example.

I also added a section to the RFC about internal vs external errors, and how to format errors to be consistent across the board. We can use that as a guideline when we introduce new errors, I noticed that there were a lot of variations in format, and I think it's better to constraint ourselves to some clear guidelines.

This is a short summary of what this massive PR includes:

- Update the RFC with more information about error types and formatting.
- Create the new public Error type.
- Create a transformation between SlateDBError and the new Error type.
- Update all public endpoint to use the new Error type.
- Update abstract internal errors to be more specific.

Fixes #508 