### PR TITLE
Add `gen_ulid` clock param

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -184,9 +184,9 @@ impl TokioCompactionExecutorInner {
         debug!(?compaction, "executing compaction");
         let mut all_iter = self.load_iterators(&compaction).await?;
         let mut output_ssts = Vec::new();
-        let mut current_writer = self
-            .table_store
-            .table_writer(SsTableId::Compacted(self.rand.rng().gen_ulid()));
+        let mut current_writer = self.table_store.table_writer(SsTableId::Compacted(
+            self.rand.rng().gen_ulid(self.clock.as_ref()),
+        ));
 
         let mut bytes_written = 0usize;
         let mut last_progress_report = self.clock.now();
@@ -219,8 +219,9 @@ impl TokioCompactionExecutorInner {
             if bytes_written > self.options.max_sst_size {
                 let finished_writer = mem::replace(
                     &mut current_writer,
-                    self.table_store
-                        .table_writer(SsTableId::Compacted(self.rand.rng().gen_ulid())),
+                    self.table_store.table_writer(SsTableId::Compacted(
+                        self.rand.rng().gen_ulid(self.clock.as_ref()),
+                    )),
                 );
                 let sst = finished_writer.close().await?;
 

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -104,7 +104,12 @@ impl MemtableFlusher {
                 rguard.state().imm_memtable.back().cloned()
             }
         } {
-            let id = SsTableId::Compacted(self.db_inner.rand.rng().gen_ulid());
+            let id = SsTableId::Compacted(
+                self.db_inner
+                    .rand
+                    .rng()
+                    .gen_ulid(self.db_inner.system_clock.as_ref()),
+            );
             let sst_handle = self
                 .db_inner
                 .flush_imm_table(&id, imm_memtable.table(), true)

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -6,7 +6,7 @@ use crate::error::SlateDBError::BackgroundTaskPanic;
 use crate::types::RowEntry;
 use bytes::{BufMut, Bytes};
 use futures::FutureExt;
-use rand::RngCore;
+use rand::{Rng, RngCore};
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::atomic::AtomicU64;
@@ -281,7 +281,7 @@ impl<T> SendSafely<T> for UnboundedSender<T> {
 /// Trait for generating UUIDs and ULIDs from a random number generator.
 pub trait IdGenerator {
     fn gen_uuid(&mut self) -> Uuid;
-    fn gen_ulid(&mut self) -> Ulid;
+    fn gen_ulid(&mut self, clock: &dyn SystemClock) -> Ulid;
 }
 
 impl<R: RngCore> IdGenerator for R {
@@ -296,9 +296,13 @@ impl<R: RngCore> IdGenerator for R {
         Uuid::from_bytes(bytes)
     }
 
-    /// Generates a random ULID using the provided RNG.
-    fn gen_ulid(&mut self) -> Ulid {
-        Ulid::with_source(self)
+    /// Generates a random ULID using the provided RNG. The clock is used to generate
+    /// the timestamp component of the ULID.
+    fn gen_ulid(&mut self, clock: &dyn SystemClock) -> Ulid {
+        let now = u64::try_from(system_time_to_millis(clock.now()))
+            .expect("timestamp outside u64 range in gen_ulid");
+        let random_bytes = self.random::<u128>();
+        Ulid::from_parts(now, random_bytes)
     }
 }
 


### PR DESCRIPTION
I found that our current ULID generator is non-deterministic because it uses the `ulid` crate to get time, which always uses system time, not our `SystemClock`. Fixed this by adding a param to take our clock.

I considered separating ULID and UUID generation out so we can have a ULID struct that contains a clock, but it felt clunky to have two different ways to generate IDs. This way, the ULID and UUID generation continue to piggyback off of any `RngCore`, and we only need to pass a clock when we're generating ULIDs, which is relatively limited.