### PR TITLE
Consume log events into tracing (including structured logs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,6 +3195,7 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "ulid",
  "uuid",
@@ -3217,6 +3218,7 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -3233,6 +3235,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,8 @@ thiserror = "1.0.63"
 tokio = "1.40.0"
 tokio-util = { version = "0.7.15", default-features = false }
 tracing = "0.1.40"
-tracing-subscriber = "0.3"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", default-features = false }
 thread_local = "1.1.8"
 ulid = "1.2.1"
 uuid = "1.17.0"

--- a/slatedb-bencher/Cargo.toml
+++ b/slatedb-bencher/Cargo.toml
@@ -27,5 +27,6 @@ rand_xorshift = { workspace = true }
 slatedb = { workspace = true, features = ["aws", "azure", "bencher", "wal_disable", "moka"] }
 tokio = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
+tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 sysinfo = { workspace = true }

--- a/slatedb-cli/Cargo.toml
+++ b/slatedb-cli/Cargo.toml
@@ -17,6 +17,7 @@ slatedb = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util = { workspace = true, default-features = false, features = ["rt"] }
 tracing = { workspace = true, features = ["log"] }
+tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -14,6 +14,7 @@ mod args;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_log::LogTracer::init().expect("failed to initialize tracing");
     tracing_subscriber::fmt::init();
 
     let args: CliArgs = parse_args();

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -68,6 +68,7 @@ rstest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-test = { workspace = true }
+tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 [features]

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -344,6 +344,7 @@ static INIT_LOGGING: Once = Once::new();
 fn init_tracing() {
     INIT_LOGGING.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+        tracing_log::LogTracer::init().expect("failed to initialize tracing");
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)


### PR DESCRIPTION
When I converted `tracing::` logs to `log::` logs, I ported the structured logging as well, assuming it would work. It turns out the default tracing_subscriber configuration does not properly consume the key-value pairs from the `log` library by default. We need to use `LogTracer` from the `tracing_log` crate (provided by the tracing library) to have these key-value pairs properly consumed. This PR updates accordingly.

See https://github.com/tokio-rs/tracing/discussions/2875 for some more notes.