### PR TITLE
[refactor] make modifying COW state easier

### DIFF
--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -59,7 +59,7 @@ impl DbInner {
         self.freeze_memtable(&mut guard, recent_flushed_wal_id)?;
 
         let last_wal = replayed_memtable.last_wal_id;
-        guard.set_next_wal_id(last_wal + 1);
+        guard.modify(|modifier| modifier.state.manifest.core.next_wal_sst_id = last_wal + 1);
 
         // update seqs and clock
         self.oracle.last_seq.store(replayed_memtable.last_seq);

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -10,7 +10,6 @@ use crate::wal_id::WalIdStore;
 use bytes::Bytes;
 use log::debug;
 use serde::Serialize;
-use std::cmp;
 use std::collections::VecDeque;
 use std::fmt::{Debug, Formatter};
 use std::ops::Bound::{Excluded, Included, Unbounded};
@@ -441,7 +440,6 @@ impl DbState {
         self.error.reader()
     }
 
-    // mutations
     pub fn record_fatal_error(&mut self, error: SlateDBError) {
         self.error.write(error);
     }
@@ -450,27 +448,20 @@ impl DbState {
         &mut self.memtable
     }
 
-    fn state_copy(&self) -> COWDbState {
-        self.state.as_ref().clone()
-    }
-
-    fn update_state(&mut self, state: COWDbState) {
-        self.state = Arc::new(state);
-    }
-
     pub fn freeze_memtable(&mut self, recent_flushed_wal_id: u64) -> Result<(), SlateDBError> {
         if let Some(err) = self.error.reader().read() {
             return Err(err.clone());
         }
         let old_memtable = std::mem::replace(&mut self.memtable, WritableKVTable::new());
-        let mut state = self.state_copy();
-        state
-            .imm_memtable
-            .push_front(Arc::new(ImmutableMemtable::new(
-                old_memtable,
-                recent_flushed_wal_id,
-            )));
-        self.update_state(state);
+        self.modify(|modifier| {
+            modifier
+                .state
+                .imm_memtable
+                .push_front(Arc::new(ImmutableMemtable::new(
+                    old_memtable,
+                    recent_flushed_wal_id,
+                )))
+        });
         Ok(())
     }
 
@@ -486,52 +477,31 @@ impl DbState {
         Ok(())
     }
 
-    pub fn move_imm_memtable_to_l0(
-        &mut self,
-        imm_memtable: Arc<ImmutableMemtable>,
-        sst_handle: SsTableHandle,
-    ) -> Result<(), SlateDBError> {
-        let mut state = self.state_copy();
-        let popped = state
-            .imm_memtable
-            .pop_back()
-            .expect("expected imm memtable");
-        assert!(Arc::ptr_eq(&popped, &imm_memtable));
-        state.manifest.core.l0.push_front(sst_handle);
-        state.manifest.core.replay_after_wal_id = imm_memtable.recent_flushed_wal_id();
-
-        // ensure the persisted manifest tick never goes backwards in time
-        let memtable_tick = imm_memtable.table().last_tick();
-        state.manifest.core.last_l0_clock_tick =
-            cmp::max(state.manifest.core.last_l0_clock_tick, memtable_tick);
-        if state.manifest.core.last_l0_clock_tick != memtable_tick {
-            return Err(SlateDBError::InvalidClockTick {
-                last_tick: state.manifest.core.last_l0_clock_tick,
-                next_tick: memtable_tick,
-            });
-        }
-        // update the persisted manifest last_l0_seq as the latest seq in the imm.
-        if let Some(seq) = imm_memtable.table().last_seq() {
-            state.manifest.core.last_l0_seq = seq;
-        }
-
-        self.update_state(state);
-        Ok(())
+    pub fn merge_remote_manifest(&mut self, remote_manifest: DirtyManifest) {
+        self.modify(|modifier| modifier.merge_remote_manifest(remote_manifest));
     }
 
-    /// increment the next wal id, and return the previous value.
-    pub fn increment_next_wal_id(&mut self) -> u64 {
-        let mut state = self.state_copy();
-        let next_wal_id = state.manifest.core.next_wal_sst_id;
-        state.manifest.core.next_wal_sst_id += 1;
-        self.update_state(state);
-        next_wal_id
+    pub fn modify<F, R>(&mut self, fun: F) -> R
+    where
+        F: FnOnce(&mut StateModifier<'_>) -> R,
+    {
+        let mut modifier = StateModifier::new(self);
+        let result = fun(&mut modifier);
+        modifier.finish();
+        result
     }
+}
 
-    pub fn set_next_wal_id(&mut self, next_wal_id: u64) {
-        let mut state = self.state_copy();
-        state.manifest.core.next_wal_sst_id = next_wal_id;
-        self.update_state(state);
+pub(crate) struct StateModifier<'a> {
+    db_state: &'a mut DbState,
+    pub state: COWDbState,
+}
+
+impl<'a> StateModifier<'a> {
+    /// Create a new state modifier
+    fn new(db_state: &'a mut DbState) -> Self {
+        let state = db_state.state.as_ref().clone();
+        Self { db_state, state }
     }
 
     pub fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyManifest) {
@@ -551,8 +521,7 @@ impl DbState {
             self.state.manifest.core.l0.iter().cloned().collect()
         };
 
-        let mut state = self.state_copy();
-        let my_db_state = state.core();
+        let my_db_state = self.state.core();
         remote_manifest.core = CoreDbState {
             initialized: my_db_state.initialized,
             l0_last_compacted: remote_manifest.core.l0_last_compacted,
@@ -566,8 +535,11 @@ impl DbState {
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
             recent_snapshot_min_seq: my_db_state.recent_snapshot_min_seq,
         };
-        state.manifest = remote_manifest;
-        self.update_state(state);
+        self.state.manifest = remote_manifest;
+    }
+
+    fn finish(self) {
+        self.db_state.state = Arc::new(self.state);
     }
 }
 
@@ -575,7 +547,15 @@ impl WalIdStore for parking_lot::RwLock<DbState> {
     /// increment the next wal id, and return the previous value.
     fn next_wal_id(&self) -> u64 {
         let mut state = self.write();
-        state.increment_next_wal_id()
+
+        // not sure why, but it doesn't compile without the return
+        // statement -- probably some generic inference bug
+        #[allow(clippy::needless_return)]
+        return state.modify(|modifier| {
+            let next_wal_id = modifier.state.manifest.core.next_wal_sst_id;
+            modifier.state.manifest.core.next_wal_sst_id += 1;
+            next_wal_id
+        });
     }
 }
 
@@ -661,7 +641,10 @@ mod tests {
             let imm = db_state.state.imm_memtable.back().unwrap().clone();
             let handle =
                 SsTableHandle::new(SsTableId::Compacted(ulid::Ulid::new()), dummy_info.clone());
-            db_state.move_imm_memtable_to_l0(imm, handle).unwrap();
+            db_state.modify(|modifier| {
+                modifier.state.manifest.core.l0.push_front(handle);
+                modifier.state.manifest.core.replay_after_wal_id = imm.recent_flushed_wal_id();
+            });
         }
     }
 

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -7,6 +7,7 @@ use crate::error::SlateDBError::BackgroundTaskShutdown;
 use crate::manifest::store::FenceableManifest;
 use crate::utils::{bg_task_result_into_err, spawn_bg_task, IdGenerator};
 use log::{error, info, warn};
+use std::cmp;
 use std::sync::Arc;
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -117,7 +118,37 @@ impl MemtableFlusher {
                 .await?;
             {
                 let mut guard = self.db_inner.state.write();
-                guard.move_imm_memtable_to_l0(imm_memtable.clone(), sst_handle)?;
+                guard.modify(|modifier| {
+                    let popped = modifier
+                        .state
+                        .imm_memtable
+                        .pop_back()
+                        .expect("expected imm memtable");
+                    assert!(Arc::ptr_eq(&popped, &imm_memtable));
+                    modifier.state.manifest.core.l0.push_front(sst_handle);
+                    modifier.state.manifest.core.replay_after_wal_id =
+                        imm_memtable.recent_flushed_wal_id();
+
+                    // ensure the persisted manifest tick never goes backwards in time
+                    let memtable_tick = imm_memtable.table().last_tick();
+                    modifier.state.manifest.core.last_l0_clock_tick = cmp::max(
+                        modifier.state.manifest.core.last_l0_clock_tick,
+                        memtable_tick,
+                    );
+                    if modifier.state.manifest.core.last_l0_clock_tick != memtable_tick {
+                        return Err(SlateDBError::InvalidClockTick {
+                            last_tick: modifier.state.manifest.core.last_l0_clock_tick,
+                            next_tick: memtable_tick,
+                        });
+                    }
+
+                    // update the persisted manifest last_l0_seq as the latest seq in the imm.
+                    if let Some(seq) = imm_memtable.table().last_seq() {
+                        modifier.state.manifest.core.last_l0_seq = seq;
+                    };
+
+                    Ok(())
+                })?;
             }
             imm_memtable.notify_flush_to_l0(Ok(()));
             match self.write_manifest_safely().await {


### PR DESCRIPTION
This PR makes modifying the COW state a little easier by returning a handle that allows you to make/chain multiple modifications. The usage pattern is now:

```rs
let mut guard = self.db_inner.state.write();
guard.modify(|modifier| {
  // make modifications to the state accessed via
  // the modifier.state
});
```

The `modify` method ensure the state is copied on write when the modify block ends.

The motivation for this PR is that while implementing #685 I needed to make some modifications to the COWDbState but I didn't want to pipe details into the `db_state.rs` file that it really has no business knowing about.