### PR TITLE
feat(snapshot): allow saving recent_snapshot_min_seq to manifest

### DIFF
--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -481,6 +481,10 @@ impl DbState {
         self.modify(|modifier| modifier.merge_remote_manifest(remote_manifest));
     }
 
+    pub fn set_recent_snapshot_min_seq(&mut self, seq: u64) {
+        self.modify(|modifier| modifier.state.manifest.core.recent_snapshot_min_seq = Some(seq));
+    }
+
     pub fn modify<F, R>(&mut self, fun: F) -> R
     where
         F: FnOnce(&mut StateModifier<'_>) -> R,
@@ -502,12 +506,6 @@ impl<'a> StateModifier<'a> {
     fn new(db_state: &'a mut DbState) -> Self {
         let state = db_state.state.as_ref().clone();
         Self { db_state, state }
-    }
-
-    pub fn set_recent_snapshot_min_seq(&mut self, seq: u64) {
-        let mut state = self.state_copy();
-        state.manifest.core.recent_snapshot_min_seq = Some(seq);
-        self.update_state(state);
     }
 
     pub fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyManifest) {

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -481,10 +481,6 @@ impl DbState {
         self.modify(|modifier| modifier.merge_remote_manifest(remote_manifest));
     }
 
-    pub fn set_recent_snapshot_min_seq(&mut self, seq: u64) {
-        self.modify(|modifier| modifier.state.manifest.core.recent_snapshot_min_seq = Some(seq));
-    }
-
     pub fn modify<F, R>(&mut self, fun: F) -> R
     where
         F: FnOnce(&mut StateModifier<'_>) -> R,

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -534,6 +534,12 @@ impl DbState {
         self.update_state(state);
     }
 
+    pub fn set_recent_snapshot_min_seq(&mut self, seq: u64) {
+        let mut state = self.state_copy();
+        state.manifest.core.recent_snapshot_min_seq = Some(seq);
+        self.update_state(state);
+    }
+
     pub fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyManifest) {
         // The compactor removes tables from l0_last_compacted, so we
         // only want to keep the tables up to there.

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -22,6 +22,7 @@ pub(crate) enum MemtableFlushMsg {
         options: CheckpointOptions,
         sender: Sender<Result<CheckpointCreateResult, SlateDBError>>,
     },
+    #[allow(dead_code)]
     WriteRecentSnapshotMinSeq {
         seq: u64,
     },
@@ -223,7 +224,9 @@ impl DbInner {
                                 }
                             },
                             MemtableFlushMsg::WriteRecentSnapshotMinSeq { seq } => {
-                                flusher.write_recent_snapshot_min_seq(seq).await?;
+                                if let Err(err) = flusher.write_recent_snapshot_min_seq(seq).await {
+                                    error!("error writing recent snapshot min seq: {err}");
+                                }
                             }
                         }
                     },

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -22,6 +22,10 @@ pub(crate) enum MemtableFlushMsg {
         options: CheckpointOptions,
         sender: Sender<Result<CheckpointCreateResult, SlateDBError>>,
     },
+    // TODO: Consider factoring out manifest operations into a dedicated component like called `ManifestFlusher`.
+    // The current `MemtableFlusher` handles both memtable flushing and manifest operations (checkpoints, manifest
+    // updates, snapshot sequence writes). A separate `ManifestFlusher` might be good to improve separation of
+    // concerns and allow independent management of the manifest operations, making it easier to test.
     #[allow(dead_code)]
     WriteRecentSnapshotMinSeq {
         seq: u64,

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -92,7 +92,9 @@ impl MemtableFlusher {
     ) -> Result<(), SlateDBError> {
         {
             let mut state_guard = self.db_inner.state.write();
-            state_guard.set_recent_snapshot_min_seq(seq);
+            state_guard.modify(|modifier| {
+                modifier.state.manifest.core.recent_snapshot_min_seq = Some(seq);
+            });
         }
         self.write_manifest_safely().await
     }


### PR DESCRIPTION
this pr is also a subtask extracted from #688, and a follow up of #701.

we are planning to periodically flush the min active snapshot's min seq to manifest, to inform the compactor a safe seq on retention.

this pr is kinda not elegant in my opinion... iiuc, `mem_table_flush.rs` is the unified place for the db writer to update the manifest in the current design. it might be good to factor out a dedicated component like `ManifestFlusher` to manage manifest writes in a single place.

but right now, it seems to be a too big change for implementing #688, i think we can open an issue to track this and refactor after the feature is implemented.