### PR TITLE
Remove structured logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,6 @@ dependencies = [
  "tokio-test",
  "tokio-util",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "ulid",
  "uuid",
@@ -3218,7 +3217,6 @@ dependencies = [
  "sysinfo",
  "tokio",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -3235,7 +3233,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
  "uuid",
 ]
@@ -3254,7 +3251,6 @@ dependencies = [
  "slatedb",
  "tokio",
  "tracing",
- "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ thiserror = "1.0.63"
 tokio = "1.40.0"
 tokio-util = { version = "0.7.15", default-features = false }
 tracing = "0.1.40"
-tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false }
 thread_local = "1.1.8"
 ulid = "1.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ thiserror = "1.0.63"
 tokio = "1.40.0"
 tokio-util = { version = "0.7.15", default-features = false }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3", default-features = false }
+tracing-subscriber = { version = "0.3" }
 thread_local = "1.1.8"
 ulid = "1.2.1"
 uuid = "1.17.0"

--- a/slatedb-bencher/Cargo.toml
+++ b/slatedb-bencher/Cargo.toml
@@ -27,6 +27,5 @@ rand_xorshift = { workspace = true }
 slatedb = { workspace = true, features = ["aws", "azure", "bencher", "wal_disable", "moka"] }
 tokio = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 sysinfo = { workspace = true }

--- a/slatedb-bencher/Cargo.toml
+++ b/slatedb-bencher/Cargo.toml
@@ -27,5 +27,5 @@ rand_xorshift = { workspace = true }
 slatedb = { workspace = true, features = ["aws", "azure", "bencher", "wal_disable", "moka"] }
 tokio = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-tracing-subscriber = { workspace = true, features = ["fmt"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 sysinfo = { workspace = true }

--- a/slatedb-bencher/src/db.rs
+++ b/slatedb-bencher/src/db.rs
@@ -294,7 +294,7 @@ impl Task {
                         puts += 1;
                         puts_bytes += self.val_len as u64;
                     }
-                    Err(e) => warn!("put failed: {}", e),
+                    Err(e) => warn!("put failed [error={}]", e),
                 }
             } else {
                 let key = if random.random_range(0..100) < self.get_hit_percentage {
@@ -308,7 +308,7 @@ impl Task {
                         gets_hits += val.is_some() as u64;
                         gets_bytes += key.len() as u64 + val.map(|v| v.len() as u64).unwrap_or(0);
                     }
-                    Err(e) => warn!("get failed: {}", e),
+                    Err(e) => warn!("get failed [error={}]", e),
                 }
             }
             if last_report.elapsed() >= REPORT_INTERVAL {

--- a/slatedb-bencher/src/main.rs
+++ b/slatedb-bencher/src/main.rs
@@ -20,6 +20,8 @@ use std::error::Error;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info, warn};
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::EnvFilter;
 
 mod args;
 mod db;
@@ -29,7 +31,12 @@ const CLEANUP_NAME: &str = ".clean_benchmark_data";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    tracing_subscriber::fmt::init();
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_test_writer()
+        .init();
 
     let args = BencherArgs::parse();
     let path = Path::from(args.path);

--- a/slatedb-bencher/src/system_monitor.rs
+++ b/slatedb-bencher/src/system_monitor.rs
@@ -31,11 +31,11 @@ impl SystemMonitor {
     /// Starts the system monitoring in a background thread.
     pub fn start(&mut self) {
         if self.handle.is_some() {
-            info!("System monitoring is already running");
+            info!("system monitoring is already running");
             return;
         }
 
-        info!("Starting system resource monitoring");
+        info!("starting system resource monitoring");
         self.running.store(true, Ordering::SeqCst);
         let running = Arc::clone(&self.running);
 
@@ -151,20 +151,20 @@ impl SystemMonitor {
                 }
             }
 
-            info!("System resource monitoring stopped");
+            info!("system resource monitoring stopped");
         }));
     }
 
     /// Stops the system monitoring and waits for the thread to finish.
     pub fn stop(&mut self) {
         if let Some(handle) = self.handle.take() {
-            info!("Stopping system resource monitoring");
+            info!("stopping system resource monitoring");
             self.running.store(false, Ordering::SeqCst);
             if let Err(e) = handle.join() {
-                info!("Error joining system monitor thread: {:?}", e);
+                info!("error joining system monitor thread [error={:?}]", e);
             }
         } else {
-            info!("System monitoring is not running");
+            info!("system monitoring is not running");
         }
     }
 }

--- a/slatedb-cli/Cargo.toml
+++ b/slatedb-cli/Cargo.toml
@@ -17,7 +17,6 @@ slatedb = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util = { workspace = true, default-features = false, features = ["rt"] }
 tracing = { workspace = true, features = ["log"] }
-tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 

--- a/slatedb-cli/Cargo.toml
+++ b/slatedb-cli/Cargo.toml
@@ -17,7 +17,7 @@ slatedb = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util = { workspace = true, default-features = false, features = ["rt"] }
 tracing = { workspace = true, features = ["log"] }
-tracing-subscriber = { workspace = true, features = ["fmt"] }
+tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -14,7 +14,6 @@ mod args;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    tracing_log::LogTracer::init().expect("failed to initialize tracing");
     tracing_subscriber::fmt::init();
 
     let args: CliArgs = parse_args();

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -33,8 +33,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tokio::spawn(async move {
         tokio::signal::ctrl_c()
             .await
-            .expect("Failed to install CTRL+C signal handler");
-        debug!("Intercepted SIGINT ... shutting down background processes");
+            .expect("failed to install CTRL+C signal handler");
+        debug!("intercepted SIGINT ... shutting down background processes");
         // if we cant send a shutdown message it's probably because it's already closed
         ct.cancel();
     });
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn exec_read_manifest(admin: &Admin, id: Option<u64>) -> Result<(), Box<dyn Error>> {
     match admin.read_manifest(id).await? {
         None => {
-            println!("No manifest file found.")
+            println!("no manifest file found")
         }
         Some(manifest) => {
             println!("{}", manifest);

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -8,13 +8,20 @@ use std::error::Error;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
 
 mod args;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    tracing_subscriber::fmt::init();
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
+        .with_test_writer()
+        .init();
 
     let args: CliArgs = parse_args();
     let path = Path::from(args.path.as_str());

--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -20,7 +20,6 @@ rand = { workspace = true }
 slatedb = { workspace = true, features = ["lz4", "snappy", "test-util", "wal_disable", "zlib", "zstd"] }
 tokio = { workspace = true, features = ["macros", "test-util", "rt"] }
 tracing = { workspace = true }
-tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 [dev-dependencies]

--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 chrono = { workspace = true }
 ctor = { workspace = true }
 futures = { workspace = true }
-log = { workspace = true, features = ["kv"] }
+log = { workspace = true }
 object_store = { workspace = true }
 rand = { workspace = true }
 slatedb = { workspace = true, features = ["lz4", "snappy", "test-util", "wal_disable", "zlib", "zstd"] }

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -507,12 +507,12 @@ impl Dst {
         for (step_count, _) in (0..iterations).enumerate() {
             let step_action = self.action_sampler.sample_action(&self.state);
             info!(
+                "run_simulation [step_count={}, simulated_time={}, btree_size={}, btree_entries={}, step_action={}]",
                 step_count,
-                simulated_time:% = self.system_clock.now().signed_duration_since(start_time),
-                btree_size:% = utils::pretty_bytes(self.state.size_bytes),
-                btree_entries = self.state.len(),
-                step_action:% = step_action;
-                "run_simulation"
+                self.system_clock.now().signed_duration_since(start_time),
+                utils::pretty_bytes(self.state.size_bytes),
+                self.state.len(),
+                step_action,
             );
             match step_action {
                 DstAction::Write(write_ops, write_options) => {
@@ -607,7 +607,7 @@ impl Dst {
     }
 
     async fn advance_time(&self, duration: Duration) {
-        debug!(duration:?; "advance_time");
+        debug!("advance_time [duration={:?}]", duration);
         self.system_clock.clone().advance(duration).await;
     }
 

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -190,7 +190,6 @@ static INIT_LOGGING: Once = Once::new();
 fn init_tracing() {
     INIT_LOGGING.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-        tracing_log::LogTracer::init().expect("failed to initialize tracing");
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -151,7 +151,7 @@ pub async fn run_simulation(
     dst_opts: DstOptions,
 ) -> Result<(), Error> {
     let seed = rand.seed();
-    info!("running simulation with seed {}", seed);
+    info!("running simulation [seed={}]", seed);
     let mut dst = build_dst(
         system_clock.clone(),
         logical_clock.clone(),
@@ -162,7 +162,7 @@ pub async fn run_simulation(
     match dst.run_simulation(iterations).await {
         Ok(_) => Ok(()),
         Err(e) => {
-            error!("simulation failed with seed {}: {}", seed, e);
+            error!("simulation failed [seed={}, error={}]", seed, e);
             Err(e)
         }
     }

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -114,7 +114,7 @@ fn test_dst_is_deterministic(
                     if let Some(expected_u64) = expected_u64 {
                         assert_eq!(
                             next_u64, expected_u64,
-                            "non-determinism detected: seed={}, simulation_count={}, next_u64={}, expected_u64={}",
+                            "non-determinism detected [seed={}, simulation_count={}, next_u64={}, expected_u64={}]",
                             seed, simulation_count, next_u64, expected_u64
                         );
                     }
@@ -122,7 +122,7 @@ fn test_dst_is_deterministic(
                         assert_eq!(
                             next_time,
                             expected_time,
-                            "non-determinism detected: seed={}, simulation_count={}, next_time={:?}, expected_time={:?}",
+                            "non-determinism detected [seed={}, simulation_count={}, next_time={:?}, expected_time={:?}]",
                             seed,
                             simulation_count,
                             next_time,
@@ -135,7 +135,7 @@ fn test_dst_is_deterministic(
                     Ok(())
                 }
                 Err(e) => {
-                    error!("simulation failed with seed {}: {}", seed, e);
+                    error!("simulation failed [seed={}, error={}]", seed, e);
                     Err(e)
                 }
             }

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -27,7 +27,7 @@ flate2 = { workspace = true, optional = true }
 flatbuffers = { workspace = true }
 foyer = { workspace = true, features = ["serde"], optional = true }
 futures = { workspace = true }
-log = { workspace = true, features = ["kv"] }
+log = { workspace = true }
 lz4_flex = { workspace = true, optional = true }
 moka = { workspace = true, features = ["future"], optional = true }
 object_store = { workspace = true }

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -68,7 +68,6 @@ rstest = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-test = { workspace = true }
-tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 [features]

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -172,7 +172,7 @@ impl DbInner {
                         SlateDBError::BackgroundTaskShutdown
                     }
                     Err(err) => {
-                        warn!("write task exited with {:?}", err);
+                        warn!("write task exited [error={}]", err);
                         err.clone()
                     }
                 };

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -492,7 +492,7 @@ impl FsCacheEvictorInner {
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(err) => {
-                    warn!("evictor: failed to walk the cache folder: {}", err);
+                    warn!("evictor failed to walk the cache folder [error={}]", err);
                     continue;
                 }
             };
@@ -504,7 +504,8 @@ impl FsCacheEvictorInner {
                 Ok(metadata) => metadata,
                 Err(err) => {
                     warn!(
-                        "evictor: failed to get the metadata of the cache file: {}",
+                        "evictor failed to get the metadata of the cache file [path={:?}, error={}]",
+                        entry.path(),
                         err
                     );
                     continue;
@@ -589,14 +590,14 @@ impl FsCacheEvictorInner {
         // if the file is not found, still try to remove it from the cache_entries, and decrease the cache_size_bytes.
         // this might happen when the file is removed by other processes, but the cache_entries is not updated yet.
         if let Err(err) = tokio::fs::remove_file(&target).await {
-            warn!("evictor: failed to remove the cache file: {}", err);
+            warn!("evictor failed to remove the cache file [error={}]", err);
             if err.kind() != std::io::ErrorKind::NotFound {
                 return 0;
             }
         }
 
         debug!(
-            "evictor: evicted cache file: {:?}, bytes: {}",
+            "evictor evicted cache file [path={:?}, bytes={}]",
             target, target_bytes
         );
 

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -365,7 +365,7 @@ impl CompactionExecuteBench {
                             .now()
                             .signed_duration_since(start)
                             .num_milliseconds();
-                        info!(elapsed_ms; "compaction finished");
+                        info!("compaction finished [elapsed_ms={}]", elapsed_ms);
                     }
                     Err(err) => return Err(err.into()),
                 }

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -138,7 +138,7 @@ impl CompactionExecuteBench {
                     if retries >= 3 {
                         return Err(err);
                     } else {
-                        error!("error loading sst: {:?}", err)
+                        error!("error loading sst [retry={}]: {:?}", retries, err)
                     }
                 }
             }
@@ -177,7 +177,7 @@ impl CompactionExecuteBench {
             .now()
             .signed_duration_since(start)
             .num_milliseconds();
-        info!("wrote sst with id: {:?} {:?}ms", &sst.id, elapsed_ms);
+        info!("wrote sst [id={:?}, elapsed_ms={}]", &sst.id, elapsed_ms);
         Ok(())
     }
 
@@ -198,7 +198,7 @@ impl CompactionExecuteBench {
             match result {
                 Ok(Ok(())) => {}
                 Ok(Err(err)) => return Err(SlateDBError::from(err).into()),
-                Err(err) => panic!("task failed: {:?}", err),
+                Err(err) => panic!("task failed [error={:?}]", err),
             }
         }
         Ok(())

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -306,7 +306,7 @@ impl CompactorEventHandler {
                     .await
                     .expect("fatal error finishing compaction"),
                 Err(err) => {
-                    error!("error executing compaction: {:#?}", err);
+                    error!("error executing compaction [error={:#?}]", err);
                     self.finish_failed_compaction(id);
                 }
             },
@@ -505,7 +505,7 @@ impl CompactorEventHandler {
                 self.start_compaction(id, compaction).await?;
             }
             Err(err) => {
-                warn!("invalid compaction: {:?}", err);
+                warn!("invalid compaction [error={:?}]", err);
             }
         }
         Ok(())
@@ -522,7 +522,7 @@ impl CompactorEventHandler {
         self.state.db_state().log_db_runs();
         let compactions = self.state.compactions();
         for compaction in compactions.iter() {
-            info!("in-flight compaction: {}", compaction);
+            info!("in-flight compaction [compaction={}]", compaction);
         }
     }
 }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -81,7 +81,7 @@ impl CompactionProgressTracker {
             self.processed_bytes
                 .insert(id, (bytes_processed, total_bytes));
         } else {
-            warn!(id:%; "compaction progress tracker missing for job");
+            warn!("compaction progress tracker missing for job [id={}]", id);
         }
     }
 
@@ -92,11 +92,11 @@ impl CompactionProgressTracker {
             let (processed_bytes, total_bytes) = entry.value();
             let percentage = (processed_bytes * 100 / total_bytes) as u32;
             debug!(
-                id:%,
-                current_percentage:% = format!("{percentage}%"),
+                "compaction progress [id={}, current_percentage={}%, processed_bytes={}, estimated_total_bytes={}]",
+                id,
+                percentage,
                 processed_bytes,
-                estimated_total_bytes = total_bytes;
-                "compaction progress"
+                total_bytes,
             );
         }
     }

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -297,7 +297,7 @@ impl TokioCompactionExecutorInner {
             for result in results {
                 match result {
                     Err(e) if !e.is_cancelled() => {
-                        error!("Shutdown error in compaction task: {:?}", e);
+                        error!("shutdown error in compaction task [error={:?}]", e);
                     }
                     _ => {}
                 }

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -184,7 +184,7 @@ impl TokioCompactionExecutorInner {
         &self,
         compaction: CompactionJob,
     ) -> Result<SortedRun, SlateDBError> {
-        debug!(compaction:?; "executing compaction");
+        debug!("executing compaction [compaction={:?}]", compaction);
         let mut all_iter = self.load_iterators(&compaction).await?;
         let mut output_ssts = Vec::new();
         let mut current_writer = self.table_store.table_writer(SsTableId::Compacted(

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -145,7 +145,7 @@ impl CompactorState {
                 return Err(SlateDBError::InvalidCompaction);
             }
         }
-        info!("accepted submitted compaction: {:?}", compaction);
+        info!("accepted submitted compaction [compaction={}]", compaction);
         self.compactions.insert(id, compaction);
         Ok(id)
     }
@@ -195,7 +195,7 @@ impl CompactorState {
 
     pub(crate) fn finish_compaction(&mut self, id: Uuid, output_sr: SortedRun) {
         if let Some(compaction) = self.compactions.get(&id) {
-            info!("finished compaction: {:?}", compaction);
+            info!("finished compaction [compaction={}]", compaction);
             // reconstruct l0
             let compaction_l0s: HashSet<Ulid> = compaction
                 .sources

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -287,21 +287,21 @@ impl DbInner {
             let total_mem_size_bytes = wal_size_bytes + imm_memtable_size_bytes;
 
             trace!(
+                "checking backpressure [total_mem_size_bytes={}, wal_size_bytes={}, imm_memtable_size_bytes={}, max_unflushed_bytes={}]",
                 total_mem_size_bytes,
                 wal_size_bytes,
                 imm_memtable_size_bytes,
-                max_unflushed_bytes = self.settings.max_unflushed_bytes;
-                "checking backpressure",
+                self.settings.max_unflushed_bytes,
             );
 
             if total_mem_size_bytes >= self.settings.max_unflushed_bytes {
                 self.db_stats.backpressure_count.inc();
                 warn!(
+                    "unflushed memtable size exceeds max_unflushed_bytes. applying backpressure. [total_mem_size_bytes={}, wal_size_bytes={}, imm_memtable_size_bytes={}, max_unflushed_bytes={}]",
                     total_mem_size_bytes,
                     wal_size_bytes,
                     imm_memtable_size_bytes,
-                    max_unflushed_bytes = self.settings.max_unflushed_bytes;
-                    "Unflushed memtable size exceeds max_unflushed_bytes. Applying backpressure.",
+                    self.settings.max_unflushed_bytes,
                 );
 
                 let maybe_oldest_unflushed_memtable = {
@@ -344,7 +344,7 @@ impl DbInner {
                     result = await_flush_memtable => result?,
                     result = await_flush_wal => result?,
                     _ = timeout_fut => {
-                        warn!("Backpressure timeout: waited 30s, no memtable/WAL flushed yet");
+                        warn!("backpressure timeout: waited 30s, no memtable/WAL flushed yet");
                     }
                 };
             } else {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -528,8 +528,8 @@ impl Db {
             let mut maybe_compactor_task = self.compactor_task.lock();
             maybe_compactor_task.take()
         } {
-            let result = compactor_task.await.expect("Failed to join compactor task");
-            info!("compactor task exited with: {:?}", result);
+            let result = compactor_task.await.expect("failed to join compactor task");
+            info!("compactor task exited [result={:?}]", result);
         }
 
         if let Some(garbage_collector_task) = {
@@ -538,8 +538,8 @@ impl Db {
         } {
             let result = garbage_collector_task
                 .await
-                .expect("Failed to join garbage collector task");
-            info!("garbage collector task exited with: {:?}", result);
+                .expect("failed to join garbage collector task");
+            info!("garbage collector task exited [result={:?}]", result);
         }
 
         // Shutdown the write batch thread.
@@ -555,8 +555,8 @@ impl Db {
             let mut write_task = self.write_task.lock();
             write_task.take()
         } {
-            let result = write_task.await.expect("Failed to join write thread");
-            info!("write task exited with {:?}", result);
+            let result = write_task.await.expect("failed to join write thread");
+            info!("write task exited [result={:?}]", result);
         }
 
         // Shutdown the WAL flush thread.
@@ -564,7 +564,7 @@ impl Db {
             .wal_buffer
             .close()
             .await
-            .expect("Failed to close WAL buffer");
+            .expect("failed to close WAL buffer");
 
         // Shutdown the memtable flush thread.
         self.inner
@@ -581,8 +581,8 @@ impl Db {
         } {
             let result = memtable_flush_task
                 .await
-                .expect("Failed to join memtable flush thread");
-            info!("mem table flush task exited with: {:?}", result);
+                .expect("failed to join memtable flush thread");
+            info!("mem table flush task exited [result={:?}]", result);
         }
 
         Ok(())

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -497,7 +497,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                 &tokio_handle,
                 move |result: &Result<(), SlateDBError>| {
                     let err = bg_task_result_into_err(result);
-                    warn!("compactor thread exited with {:?}", err);
+                    warn!("compactor thread exited [error={}]", err);
                     let mut state = cleanup_inner.state.write();
                     state.record_fatal_error(err.clone())
                 },
@@ -528,7 +528,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                     &gc_handle,
                     move |result| {
                         let err = bg_task_result_into_err(result);
-                        warn!("GC thread exited with {:?}", err);
+                        warn!("GC thread exited [error={}]", err);
                         let mut state = cleanup_inner.state.write();
                         state.record_fatal_error(err.clone())
                     },

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -290,9 +290,15 @@ impl<P: Into<Path>> DbBuilder<P> {
 
         // Log the database opening
         if let Ok(settings_json) = self.settings.to_json_string() {
-            info!(path:?, settings:? = settings_json; "Opening SlateDB database");
+            info!(
+                "opening SlateDB database [path={}, settings={}]",
+                path, settings_json
+            );
         } else {
-            info!(path:?, settings:? = self.settings; "Opening SlateDB database");
+            info!(
+                "opening SlateDB database [path={}, settings={:?}]",
+                path, self.settings
+            );
         }
 
         let rand = Arc::new(self.seed.map(DbRand::new).unwrap_or_default());

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -281,9 +281,15 @@ impl DbCacheWrapper {
             }
         };
         if log_at_err {
-            error!("error getting {} from cache: {}", block_type, err);
+            error!(
+                "error getting block from cache [block_type={} error={:?}]",
+                block_type, err
+            );
         } else {
-            debug!("error getting {} from cache: {}", block_type, err);
+            debug!(
+                "error getting block from cache [block_type={} error={:?}]",
+                block_type, err
+            );
         }
         self.stats.get_error.inc();
     }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -358,7 +358,7 @@ impl DbReaderInner {
                 .refresh_checkpoint(checkpoint.id, self.options.checkpoint_lifetime)
                 .await?;
             info!(
-                "Refreshed checkpoint {} to expire at {:?}",
+                "refreshed checkpoint [checkpoint_id={}, expire_time={:?}]",
                 checkpoint.id, refreshed_checkpoint.expire_time
             )
         }
@@ -399,7 +399,7 @@ impl DbReaderInner {
                                 ).await?;
                                 let checkpoint_id = this.state.read().checkpoint.id;
                                 if Some(checkpoint_id) != this.user_checkpoint_id {
-                                    info!("Deleting reader established checkpoint {} for shutdown", checkpoint_id);
+                                    info!("deleting reader established checkpoint for shutdown [checkpoint_id={}]", checkpoint_id);
                                     manifest.delete_checkpoint(checkpoint_id).await?;
                                 }
                                 Ok(())
@@ -413,7 +413,7 @@ impl DbReaderInner {
         let (thread_tx, mut thread_rx) = tokio::sync::mpsc::unbounded_channel();
         let fut = async move {
             let result = core_poll_loop(this, &mut thread_rx).await;
-            info!("Manifest poll thread exiting with result {:?}", result);
+            info!("manifest poll thread exiting [result={:?}]", result);
             result
         };
 
@@ -421,7 +421,7 @@ impl DbReaderInner {
         let join_handle = utils::spawn_bg_task(
             &Handle::current(),
             move |result| {
-                warn!("manifest polling thread exited with {:?}", result);
+                warn!("manifest polling thread exited [result={:?}]", result);
                 if let Err(err) = result {
                     this.error_watcher.write(err.clone());
                 }
@@ -838,8 +838,8 @@ impl DbReader {
                 let mut guard = poller.join_handle.lock();
                 guard.take()
             } {
-                let result = join_handle.await.expect("Failed to join manifest poller");
-                info!("Manifest poller exited with {:?}", result);
+                let result = join_handle.await.expect("failed to join manifest poller");
+                info!("manifest poller exited [result={:?}]", result);
             }
         }
         Ok(())

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -193,9 +193,9 @@ impl GarbageCollector {
     #[instrument(level = "debug", skip_all, fields(resource = task.resource()))]
     async fn run_gc_task<T: GcTask + std::fmt::Debug>(&self, task: &mut T) {
         if let Err(e) = self.remove_expired_checkpoints().await {
-            error!("Error removing expired checkpoints: {}", e);
+            error!("error removing expired checkpoints [error={}]", e);
         } else if let Err(e) = task.collect(self.system_clock.now()).await {
-            error!("Error collecting compacted garbage: {}", e);
+            error!("error collecting compacted garbage [error={}]", e);
         }
     }
 

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -84,7 +84,7 @@ impl GcTask for CompactedGcTask {
 
         for id in sst_ids_to_delete {
             if let Err(e) = self.table_store.delete_sst(&id).await {
-                error!("Error deleting SST: {}", e);
+                error!("error deleting SST [id={:?}, error={}]", id, e);
             } else {
                 self.stats.gc_compacted_count.inc();
             }

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -79,7 +79,10 @@ impl GcTask for ManifestGcTask {
                     .delete_manifest(manifest_metadata.id)
                     .await
                 {
-                    error!("Error deleting manifest: {}", e);
+                    error!(
+                        "error deleting manifest [id={:?}, error={}]",
+                        manifest_metadata.id, e
+                    );
                 } else {
                     self.stats.gc_manifest_count.inc();
                 }

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -99,7 +99,7 @@ impl GcTask for WalGcTask {
 
         for id in sst_ids_to_delete {
             if let Err(e) = self.table_store.delete_sst(&id).await {
-                error!("Error deleting WAL SST: {}", e);
+                error!("error deleting WAL SST [id={:?}, error={}]", id, e);
             } else {
                 self.stats.gc_wal_count.inc();
             }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -131,7 +131,7 @@ impl Manifest {
                 if let Some(range) = range {
                     ranges.push((manifest, range));
                 } else {
-                    warn!("Manifest {:?} has no SST files", manifest);
+                    warn!("manifest has no SST files [manifest={:?}]", manifest);
                 }
             }
             ranges.sort_by_key(|(_, range)| range.comparable_start_bound().cloned());
@@ -141,7 +141,7 @@ impl Manifest {
             for (_, range) in ranges.iter() {
                 if let Some(previous_range) = previous_range {
                     if range.intersect(previous_range).is_some() {
-                        unreachable!("Overlapping ranges found");
+                        unreachable!("overlapping ranges found");
                     }
                 }
                 previous_range = Some(range);

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -609,7 +609,7 @@ impl ManifestStore {
         }
 
         let manifest_path = &self.get_manifest_path(id);
-        debug!(manifest_path:%; "deleting manifest");
+        debug!("deleting manifest [manifest_path={}]", manifest_path);
         self.object_store.delete(manifest_path).await?;
         Ok(())
     }

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -639,7 +639,10 @@ impl ManifestStore {
                         size: file.size as u32,
                     });
                 }
-                Err(_) => warn!("Unknown file in manifest directory: {:?}", file.location),
+                Err(_) => warn!(
+                    "unknown file in manifest directory [location={:?}]",
+                    file.location
+                ),
                 _ => {}
             }
         }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -208,7 +208,7 @@ impl TableStore {
             .map_err(|e| match e {
                 object_store::Error::AlreadyExists { path: _, source: _ } => match id {
                     SsTableId::Wal(_) => {
-                        debug!("Path {path} already exists");
+                        debug!("path already exists [path={}]", path);
                         SlateDBError::Fenced
                     }
                     SsTableId::Compacted(_) => SlateDBError::from(e),
@@ -288,11 +288,14 @@ impl TableStore {
                     }
                 }
                 Err(e) => {
-                    warn!("Error while parsing file id: {}", e);
+                    warn!(
+                        "error while parsing file id [location={}, error={}]",
+                        file.location, e
+                    );
                 }
                 _ => {
                     warn!(
-                        "Unexpected file found in compacted directory: {:?}",
+                        "unexpected file found in compacted directory [location={}]",
                         file.location
                     );
                 }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -253,7 +253,7 @@ impl TableStore {
     pub(crate) async fn delete_sst(&self, id: &SsTableId) -> Result<(), SlateDBError> {
         let object_store = self.object_stores.store_for(id);
         let path = self.path(id);
-        debug!(path:%; "deleting SST");
+        debug!("deleting SST [path={}]", path);
         object_store.delete(&path).await.map_err(SlateDBError::from)
     }
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -343,7 +343,6 @@ static INIT_LOGGING: Once = Once::new();
 fn init_tracing() {
     INIT_LOGGING.call_once(|| {
         let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("debug"));
-        tracing_log::LogTracer::init().expect("failed to initialize tracing");
         tracing_subscriber::fmt()
             .with_env_filter(filter)
             .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -497,7 +497,10 @@ impl WalBufferManager {
         }
 
         if releaseable_count > 0 {
-            trace!("draining immutable wals: ..{}", releaseable_count);
+            trace!(
+                "draining immutable wals [releaseable_count={}]",
+                releaseable_count
+            );
             inner.immutable_wals.drain(..releaseable_count);
         }
     }

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -218,9 +218,9 @@ impl WalBufferManager {
                 inner.current_wal.metadata().entries_size_in_bytes,
             );
             trace!(
-                current_wal_size:?,
-                max_wal_bytes_size:? = self.max_wal_bytes_size;
-                "checking flush trigger",
+                "checking flush trigger [current_wal_size={}, max_wal_bytes_size={}]",
+                current_wal_size,
+                self.max_wal_bytes_size,
             );
             let need_flush = current_wal_size >= self.max_wal_bytes_size;
             (
@@ -408,7 +408,7 @@ impl WalBufferManager {
                 // a KV table can be retried to flush multiple times, but WatchableOnceCell is only set once.
                 // we do NOT call `wal.notify_durable` as soon as encountered any error here, but notify
                 // the error when we're sure enters fatal state in `do_cleanup`.
-                error!(wal_id:% = wal_id; "failed to flush WAL");
+                error!("failed to flush WAL [wal_id={}]", wal_id);
                 return Err(e.clone());
             }
 

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -129,12 +129,13 @@ async fn test_concurrent_writers_and_readers() {
 
                         if current_value != last_seen_value {
                             log::info!(
+                                "progress [reader_id={}, iterations={}, sample_key={}, last_seen_value={}, current_value={}]",
                                 reader_id,
                                 iterations,
-                                sample_key = key,
+                                key,
                                 last_seen_value,
-                                current_value;
-                                "progress");
+                                current_value
+                            );
                         }
                     }
                 }

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -72,7 +72,7 @@ async fn test_concurrent_writers_and_readers() {
                     .expect("Failed to write value");
 
                     if i % 10 == 0 {
-                        log::info!("Writer {} wrote {} values", writer_id, i);
+                        log::info!("wrote values [writer_id={}, write_count={}]", writer_id, i);
                     }
                 }
             })


### PR DESCRIPTION
I thought #706 would fix our structured logging problems. The issue began when I migrated to `log` for all logging (#702). After doing so, we couldn't see structured log fields using `tracing_subscriber`. I thought I fixed the issue in #706, but the structured log k-v fields were still not visible (I misread the log output). After #706, I dug into the code and realized that `tracing_log` does not use `log::Record::key_values()` at all; they're just dropped.

I opened https://github.com/tokio-rs/tracing/issues/3355 to see if we can get structured log support for the `log` crate into `tracing_log`. In the meantime, I've replaced all structured logging with normal string interpolation style logs.

I also took the opportunity to do some minor log standardization as I came across it (lowercase case letters, wrap params in `[]` at end of file (e.g. `some error happened [path={:?}, error={}]`. This loosely aligns with the `error.rs` guidance that @calavera outlined. My changes are not exhaustive, but clean up things quite a bit already.

The alternative I considered was just going back to `tracing` for logs. I'm not strongly opposed to this, but it doesn't seem ideal since SlateDB is a library that's meant to be unopinionated about the environment/application it runs in.