### PR TITLE
Add a nightly DST test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,6 @@
 experimental = ["wrapper-scripts"]
 
+# PR unit/CI profile
 [profile.ci]
 slow-timeout = { period = "30s", terminate-after = 4 }
 
@@ -10,10 +11,20 @@ command = "../scripts/backtrace-on-timeout.sh"
 filter = "all()"
 run-wrapper = "backtrace-on-timeout"
 
+# PR DST profile
 [profile.dst]
 slow-timeout = { period = "30m", terminate-after = 1 }
-default-filter = "package(slatedb-dst) & test(dst)"
+default-filter = "package(slatedb-dst) & test(test_dst)"
 
 [[profile.dst.scripts]]
+filter = "all()"
+run-wrapper = "backtrace-on-timeout"
+
+# Nightly DST profile
+[profile.dst-nightly]
+slow-timeout = { period = "90m", terminate-after = 1 }
+default-filter = "package(slatedb-dst) & test(test_dst_nightly)"
+
+[[profile.dst-nightly.scripts]]
 filter = "all()"
 run-wrapper = "backtrace-on-timeout"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -161,6 +161,22 @@ jobs:
           git commit -m "Update microbenchmark pprof for job id ${GITHUB_RUN_ID}"
           git push
 
+  deterministic-simulation-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.98
+      - name: Install gdb
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gdb
+      - name: Run DST Tests
+        run: cargo nextest run -p slatedb-dst --all-features --profile dst-nightly
+        env:
+          RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
+
   # This is an integration test that makes sure SlateDB works with ZeroFS.
   # ZeroFS has discovered some issues with SlateDB so we want to make sure
   # we catch them early. Moreover, ZeroFS is an important project in the

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -173,7 +173,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gdb
       - name: Run DST Tests
-        run: cargo nextest run -p slatedb-dst --all-features --profile dst-nightly
+        run: cargo nextest run test_dst_nightly -p slatedb-dst --all-features --profile dst-nightly
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -162,7 +162,9 @@ jobs:
           git push
 
   deterministic-simulation-test:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-x64-16x
+    # Stop running tests at 57m to stay within the 1 hour warp build billing window
+    timeout-minutes: 57
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3252,6 +3252,7 @@ dependencies = [
  "rand 0.9.1",
  "rstest",
  "slatedb",
+ "sysinfo",
  "tokio",
  "tracing",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,4 +88,12 @@ tempfile = "3.3"
 tokio-test = "0.4.4"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(dst)', 'cfg(tokio_unstable)'] }
+unexpected_cfgs = { level = "allow", check-cfg = [
+    # Enables deterministic simulation tests in slatedb-dst
+    'cfg(dst)',
+    # Enables slow tests
+    'cfg(slow)',
+    # Enables tokio unstable features, which are required for DST
+    # (see slatedb-dst/src/utils.rs for details)
+    'cfg(tokio_unstable)'
+] }

--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter"] }
 
 [dev-dependencies]
 rstest = { workspace = true }
+sysinfo = { workspace = true }
 
 [lints]
 workspace = true

--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -37,3 +37,19 @@ $ RUSTFLAGS="--cfg dst --cfg tokio_unstable" \
   RUSTDOCFLAGS="--cfg tokio_unstable" \
   cargo nextest run -p slatedb-dst --profile dst
 ```
+
+## Nightly
+
+This crate also contains a longer-running test that's meant to be run every
+night. It is only run when `slow`, `dst`, and `tokio_unstable` cfgs are all set.
+
+The `.github/workflows/nightly.yaml` is configured to run this test.
+
+To run it locally, you must set the `RUSTFLAGS` environment variable to include
+`--cfg dst --cfg tokio_unstable --cfg slow`.
+
+```bash
+$ RUSTFLAGS="--cfg dst --cfg tokio_unstable --cfg slow" \
+  RUSTDOCFLAGS="--cfg tokio_unstable" \
+  cargo test test_dst_nightly -p slatedb-dst --all-features
+```

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -471,7 +471,7 @@ impl DstDuration {
     pub fn should_run(&self, current_iteration: u32, start_time: std::time::Instant) -> bool {
         match self {
             DstDuration::Iterations(max_iterations) => current_iteration < *max_iterations,
-            DstDuration::WallClock(max_duration) => *max_duration < start_time.elapsed(),
+            DstDuration::WallClock(max_duration) => start_time.elapsed() < *max_duration,
         }
     }
 }
@@ -519,6 +519,10 @@ impl Dst {
         let simulated_time = self.system_clock.now();
         let actual_start_time = std::time::Instant::now();
         let mut step_count = 0;
+        eprintln!(
+            "running simulation [step_count={}, dst_duration={:?}]",
+            step_count, dst_duration
+        );
         while dst_duration.should_run(step_count, actual_start_time) {
             let step_action = self.action_sampler.sample_action(&self.state);
             info!(

--- a/slatedb-dst/src/lib.rs
+++ b/slatedb-dst/src/lib.rs
@@ -4,4 +4,6 @@ mod dst;
 pub mod utils;
 
 #[allow(unused_imports)]
-pub use dst::{DefaultDstDistribution, Dst, DstAction, DstDistribution, DstOptions, DstWriteOp};
+pub use dst::{
+    DefaultDstDistribution, Dst, DstAction, DstDistribution, DstDuration, DstOptions, DstWriteOp,
+};

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -21,6 +21,7 @@ use tracing::{error, info};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
+use crate::dst::DstDuration;
 use crate::DefaultDstDistribution;
 use crate::Dst;
 use crate::DstOptions;
@@ -143,7 +144,7 @@ pub async fn run_simulation(
     system_clock: Arc<dyn SystemClock>,
     logical_clock: Arc<dyn LogicalClock>,
     rand: Rc<DbRand>,
-    iterations: u32,
+    dst_duration: DstDuration,
     dst_opts: DstOptions,
 ) -> Result<(), Error> {
     let seed = rand.seed();
@@ -155,7 +156,7 @@ pub async fn run_simulation(
         dst_opts,
     )
     .await;
-    match dst.run_simulation(iterations).await {
+    match dst.run_simulation(dst_duration).await {
         Ok(_) => Ok(()),
         Err(e) => {
             error!("simulation failed with seed {}: {}", seed, e);

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -169,7 +169,7 @@ fn test_dst_nightly() -> Result<(), Error> {
             let runtime = build_runtime(rand.seed());
             let system_clock = Arc::new(MockSystemClock::new());
             let logical_clock = Arc::new(MockLogicalClock::new());
-            let duration = DstDuration::WallClock(std::time::Duration::from_secs(3_600));
+            let duration = DstDuration::WallClock(std::time::Duration::from_secs(3_000)); // 50m
             runtime.block_on(async move {
                 run_simulation(
                     system_clock,


### PR DESCRIPTION
This PR integrates the DST into the nightly Github workflow.

- Adds a `test_dst_nightly` test to simulation.rs.
- Adds a `slow` cfg to `Cargo.toml` to signal slow tests should be run.
- Updates `nightly.yaml` to run the DST on a WarpBuild instance.
- Adds a `DstDuration` param that can be either `Iterations` or `Duration` (wall-clock time) to the `run_simulation`. This allows us to run simulations for a set amount of time rather than a set number of iterations.
- Update `nextest.toml` to include a new `dst-nightly` profile.
- Update docs and README.md

`test_dst_nightly` runs a separate DST on each core of the host machine. The tests run in parallel for 50 minutes.

Future improvements:

- Fail as soon as a handle finishes rather than joining them sequentially.
- Make `test_dst_nightly` use an environment variable so the 50m duration isn't hard-coded.