### PR TITLE
Cap DST nightly at 90% CPU usage

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -163,8 +163,7 @@ jobs:
 
   deterministic-simulation-test:
     runs-on: warp-ubuntu-latest-x64-16x
-    # Stop running tests at 57m to stay within the 1 hour warp build billing window
-    timeout-minutes: 57
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -519,10 +519,6 @@ impl Dst {
         let simulated_time = self.system_clock.now();
         let actual_start_time = std::time::Instant::now();
         let mut step_count = 0;
-        eprintln!(
-            "running simulation [step_count={}, dst_duration={:?}]",
-            step_count, dst_duration
-        );
         while dst_duration.should_run(step_count, actual_start_time) {
             let step_action = self.action_sampler.sample_action(&self.state);
             info!(

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -171,6 +171,8 @@ fn test_dst_nightly() -> Result<(), Error> {
             let logical_clock = Arc::new(MockLogicalClock::new());
             let duration = DstDuration::WallClock(std::time::Duration::from_secs(3_000)); // 50m
             runtime.block_on(async move {
+                let span = tracing::info_span!("run_simulation", core = core, seed = seed);
+                let _enter = span.enter();
                 run_simulation(
                     system_clock,
                     logical_clock,

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -5,7 +5,7 @@
 //! These tests can only be run when DST is enabled. Use one of the following commands to run them:
 //!
 //! - `RUSTFLAGS="--cfg dst --cfg tokio_unstable" cargo test test_dst --all-features`
-//! - `RUSTFLAGS="--cfg dst --cfg tokio_unstable" cargo nextest run test_dst  --profile dst`
+//! - `RUSTFLAGS="--cfg dst --cfg tokio_unstable" cargo nextest run test_dst --profile dst`
 //!
 //! This module also contains a slow test that's meant to be run nightly. It is only run when
 //! `slow`, `dst`, and `tokio_unstable` cfgs are all set.
@@ -159,7 +159,8 @@ fn test_dst_nightly() -> Result<(), Error> {
     let mut handles = Vec::new();
     let mut system = System::new();
     system.refresh_cpu_all();
-    let num_cores = system.cpus().len() as u64;
+    // 90% of the cores because GH actions were being killed at 100%
+    let num_cores = (system.cpus().len() as f64 * 0.9).floor() as u64;
     info!("running nightly [num_cores={}]", num_cores);
     for core in 0..num_cores {
         let handle = std::thread::spawn(move || {

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -164,7 +164,6 @@ fn test_dst_nightly() -> Result<(), Error> {
     for core in 0..num_cores {
         let handle = std::thread::spawn(move || {
             let seed = rand::rng().random::<u64>();
-            info!("running simulation [core={}, seed={}]", core, seed);
             let rand = Rc::new(DbRand::new(seed));
             let runtime = build_runtime(rand.seed());
             let system_clock = Arc::new(MockSystemClock::new());


### PR DESCRIPTION
The GH action runner is killing our DST tests for some reason. I'm not totally clear why, but I'm attempting to give it some headroom.