### PR TITLE
Run nightly DST on ubuntu-latest

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -162,7 +162,7 @@ jobs:
           git push
 
   deterministic-simulation-test:
-    runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Nightly DSTs are still failing on WarpBuild with the core usage dropped to 90%. It ran a lot longer (16m instead of 5m), but still got killed. I'm switching to GH action runners to see if it's an issue with WarpBuild (or Hetzner) machines.