### PR TITLE
[2/4] implementation of gorilla-based single tier sequence tracker

### DIFF
--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -103,6 +103,7 @@ mod rand;
 mod reader;
 mod retention_iterator;
 mod row_codec;
+mod seq_tracker;
 mod sorted_run_iterator;
 mod sst;
 mod sst_iter;

--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -1,0 +1,480 @@
+use std::cmp;
+
+use chrono::{DateTime, Utc};
+use serde::de::{self};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::utils::{sign_extend, BitReader, BitWriter};
+
+#[derive(PartialEq, Clone, Copy)]
+pub(crate) struct TrackedSeq {
+    pub(crate) seq: u64,
+    pub(crate) ts: DateTime<Utc>,
+}
+
+#[allow(dead_code)]
+#[derive(PartialEq)]
+pub(crate) enum FindOption {
+    RoundUp,
+    RoundDown,
+}
+
+/// Tracks sequence number ↔ timestamp relationships with bounded memory using tiered storage.
+///
+/// Uses a multi-tiered approach where each tier stores data at different resolutions (step sizes).
+/// When a tier reaches capacity, it downsamples by doubling the step size and keeping every other
+/// timestamp. This maintains bounded memory while preserving recent data at higher resolution.
+///
+/// Timestamps are compressed using Gorilla encoding (delta-of-deltas) for efficient storage.
+/// Supports bidirectional queries with rounding options for approximate matches.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct TieredSequenceTracker {
+    /// The data, tiered by step size where the step size
+    /// indicates the granularity at which the sequence
+    /// numbers are tracked. The tiers are ordered by the
+    /// granularity (i.e. `tiers[0]` has the lowest step)
+    pub(crate) tiers: Vec<Tier>,
+}
+
+#[allow(dead_code)]
+impl TieredSequenceTracker {
+    pub(crate) fn new(num_tiers: u32, capacity: u32) -> Self {
+        // only support a single tier for now because the
+        // downsampling algorithm for fixed size multi-tiered
+        // sequence tracking is a little more complicated, but
+        // we model it with multiple tiers so that the serialization
+        // format will be compatible with a multi-tiered tracker
+        assert!(num_tiers == 1, "todo! implement multi-tiers");
+
+        let tier_capacity = capacity / num_tiers;
+        let tiers = (0..num_tiers)
+            .map(|i| Tier::new(1 << i, tier_capacity))
+            .collect();
+
+        Self { tiers }
+    }
+
+    pub(crate) fn insert(&mut self, seq: TrackedSeq) {
+        self.tiers[0].insert(seq.seq, seq.ts.timestamp());
+    }
+
+    pub(crate) fn find_ts(&self, seq: u64, find_opt: FindOption) -> Option<DateTime<Utc>> {
+        if let Some(ts) = self.tiers[0].find_ts(seq, find_opt) {
+            DateTime::from_timestamp(ts, 0)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn find_seq(&self, ts: DateTime<Utc>, find_opt: FindOption) -> Option<u64> {
+        self.tiers[0].find_seq(ts.timestamp(), find_opt)
+    }
+}
+
+/// A tier contains a mapping from sequence numbers to
+/// timestamps at a given "resolution", defined by a
+/// step parameter which is how spaced apart the timestamps
+/// are. A tier with step `4` and a start sequence number
+/// of 10, for example, would contain the timestamps for
+/// sequence numbers 10, 14, 16, ... until the capacity
+/// of the tier
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub(crate) struct Tier {
+    /// distance between stored sequence numbers
+    pub(crate) step: u64,
+    /// the first sequence number for which a timestamp is stored
+    pub(crate) first_seq: u64,
+    /// the last sequence number stored in this tier
+    pub(crate) last_seq: u64,
+    /// how many elements can fit in this tier
+    pub(crate) capacity: u32,
+    /// the actual timestamps, the value at `timestamps[i]` is the
+    /// timestamp for the sequence number `first_seq + i * step`
+    #[serde(
+        serialize_with = "serialize_timestamps",
+        deserialize_with = "deserialize_timestamps"
+    )]
+    pub(crate) timestamps: Vec<i64>,
+}
+
+impl Tier {
+    fn new(step: u64, capacity: u32) -> Self {
+        Self {
+            step,
+            first_seq: 0,
+            last_seq: 0,
+            capacity,
+            timestamps: Vec::with_capacity(capacity as usize),
+        }
+    }
+
+    fn insert(&mut self, seq: u64, ts: i64) {
+        assert!(seq >= self.last_seq);
+        assert!(ts >= *self.timestamps.last().unwrap_or(&ts));
+
+        if seq % self.step != 0 {
+            return;
+        }
+
+        if self.timestamps.is_empty() {
+            self.first_seq = seq;
+        }
+
+        self.last_seq = seq;
+        self.timestamps.push(ts);
+
+        // if we've exceeded the capacity then downsample the
+        // sequence numbers and double the step size
+        if self.timestamps.len() as u32 > self.capacity {
+            let old = std::mem::take(&mut self.timestamps);
+            let mut downsampled = Vec::with_capacity(self.capacity as usize);
+            for (i, &ts) in old.iter().enumerate() {
+                if i % 2 == 0 {
+                    downsampled.push(ts);
+                }
+            }
+            self.timestamps = downsampled;
+            self.step *= 2;
+        }
+    }
+
+    /// finds the timestamp associated with `seq`, rounding up or down
+    /// as specified by the find option if the sequence number does not
+    /// exist in this tier
+    fn find_ts(&self, seq: u64, find_opt: FindOption) -> Option<i64> {
+        let len = (self.timestamps.len()) as u64;
+        let max = self.first_seq + self.step * len;
+        let diff = seq - self.first_seq;
+        if let Some(offset) = match find_opt {
+            FindOption::RoundUp if seq <= self.last_seq => Some(cmp::max(0, diff)),
+            FindOption::RoundDown if seq >= self.first_seq => Some(cmp::min(diff, max)),
+            _ => None,
+        } {
+            let mut idx = offset.div_euclid(self.step);
+            let remainder = offset.rem_euclid(self.step);
+
+            if remainder != 0 && find_opt == FindOption::RoundUp {
+                idx += 1;
+            }
+
+            idx = idx.clamp(0, len - 1);
+            return Some(self.timestamps[idx as usize]);
+        }
+
+        None
+    }
+
+    /// finds the sequence number associated with `ts`
+    fn find_seq(&self, ts: i64, find_opt: FindOption) -> Option<u64> {
+        if self.timestamps.is_empty() {
+            return None;
+        }
+
+        match self.timestamps.binary_search(&ts) {
+            Ok(idx) => Some(self.first_seq + (idx as u64) * self.step),
+            Err(idx) => match find_opt {
+                FindOption::RoundUp if idx < self.timestamps.len() => {
+                    Some(self.first_seq + (idx as u64) * self.step)
+                }
+                FindOption::RoundDown if idx > 0 => {
+                    Some(self.first_seq + ((idx - 1) as u64) * self.step)
+                }
+                _ => None,
+            },
+        }
+    }
+}
+
+/// Custom serialization function for timestamps that uses the Gorilla
+/// encoding scheme, which is appropriate for timeseries data
+fn serialize_timestamps<S>(timestamps: &[i64], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encoded = encode_timestamps_to_bytes(timestamps);
+    serializer.serialize_bytes(&encoded)
+}
+
+pub(crate) fn encode_timestamps_to_bytes(timestamps: &[i64]) -> Vec<u8> {
+    let mut w = BitWriter::new();
+    w.push32(timestamps.len() as u32, 32);
+
+    if !timestamps.is_empty() {
+        // first encode the full initial timestamp
+        w.push64(timestamps[0] as u64, 64);
+
+        // for each subsequent encode the delta-of-deltas
+        let mut prev_ts = timestamps[0];
+        let mut prev_delta: i64 = 0;
+
+        for &ts in &timestamps[1..] {
+            let delta = ts - prev_ts;
+            let dod = delta - prev_delta;
+
+            // this is the gorilla encoding scheme, you can see
+            // [this paper](https://www.vldb.org/pvldb/vol8/p1816-teller.pdf)
+            // on page 1820 for the full algorithm
+            match dod {
+                0 => w.push(false),
+                -63..=64 => {
+                    w.push32(0b10, 2);
+                    w.push32((dod as u32) & 0x7F, 7);
+                }
+                -255..=256 => {
+                    w.push32(0b110, 3);
+                    w.push32((dod as u32) & 0x1FF, 9);
+                }
+                -2047..=2048 => {
+                    w.push32(0b1110, 4);
+                    w.push32((dod as u32) & 0xFFF, 12);
+                }
+                _ => {
+                    w.push32(0b1111, 4);
+                    w.push32(dod as u32, 32);
+                }
+            }
+
+            prev_ts = ts;
+            prev_delta = delta;
+        }
+    }
+
+    w.finish()
+}
+
+/// Indicates how many bytes to read given the Gorilla prefix,
+/// where the valid prefixes are 0, 10, 110, 1110, 1111
+const GORILLA_PREFIX_BYTES: [u8; 5] = [0, 7, 9, 12, 32];
+
+/// Custom serialization function for timestamps that uses the Gorilla
+/// encoding scheme, which is appropriate for timeseries data
+fn deserialize_timestamps<'de, D>(deserializer: D) -> Result<Vec<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let buf: Vec<u8> = Vec::deserialize(deserializer)?;
+    decode_timestamps_from_bytes(&buf).map_err(<D::Error as de::Error>::custom)
+}
+
+pub(crate) fn decode_timestamps_from_bytes(buf: &[u8]) -> Result<Vec<i64>, String> {
+    let mut timestamps = Vec::new();
+    let mut reader = BitReader::new(buf);
+
+    let mut remaining = reader.read32(32).ok_or("Expected count first")?;
+
+    if remaining > 0 {
+        let first_ts_bits = reader
+            .read64(64)
+            .ok_or("Unexpected EOF: first ts should be 64 bit")?;
+        let first = first_ts_bits as i64;
+
+        remaining -= 1;
+        timestamps.push(first);
+
+        let mut prev_ts = first;
+        let mut prev_delta: i32 = 0;
+
+        while let Some(prefix) = reader.read_bit() {
+            let dod = if !prefix {
+                0
+            } else {
+                let mut count = 1;
+                while count < 4 {
+                    match reader.read_bit() {
+                        Some(true) => count += 1,
+                        Some(false) => break,
+                        None => {
+                            return Err("Unexpected EOF decoding Gorilla prefix".to_string());
+                        }
+                    }
+                }
+
+                let bits = GORILLA_PREFIX_BYTES[count];
+                let raw = reader
+                    .read32(bits)
+                    .ok_or_else(|| format!("Unexpected EOF reading {}-bit delta-of-delta", bits))?;
+
+                sign_extend(raw, bits)
+            };
+
+            let delta = prev_delta + dod;
+            let ts = prev_ts + (delta as i64);
+            timestamps.push(ts);
+
+            prev_delta = delta;
+            prev_ts = ts;
+
+            // there may be some padding at the end of the [u8]
+            // so we track how many we've read / still need to read
+            remaining -= 1;
+
+            if remaining == 0 {
+                break;
+            }
+        }
+    }
+
+    Ok(timestamps)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_ignore_insert_for_non_step_aligned_sequence_number() {
+        // given
+        let mut tier = Tier::new(4, 10);
+
+        // when
+        tier.insert(5, 100);
+
+        // then
+        assert!(tier.timestamps.is_empty());
+        assert_eq!(tier.last_seq, 0);
+    }
+
+    #[test]
+    fn should_find_exact_timestamp_for_sequence_number() {
+        // given
+        let mut tier = Tier::new(4, 10);
+        tier.insert(4, 100);
+        tier.insert(8, 200);
+        tier.insert(12, 300);
+
+        // when
+        let result_down = tier.find_ts(8, FindOption::RoundDown);
+        let result_up = tier.find_ts(8, FindOption::RoundUp);
+
+        // then
+        assert_eq!(result_down, Some(200));
+        assert_eq!(result_up, Some(200));
+    }
+
+    #[test]
+    fn should_round_up_to_next_timestamp() {
+        // given
+        let mut tier = Tier::new(4, 10);
+        tier.insert(4, 100);
+        tier.insert(8, 200);
+
+        // when
+        let result = tier.find_ts(6, FindOption::RoundUp);
+
+        // then
+        assert_eq!(result, Some(200));
+    }
+
+    #[test]
+    fn should_round_down_to_previous_timestamp() {
+        // given
+        let mut tier = Tier::new(4, 10);
+        tier.insert(4, 100);
+        tier.insert(8, 200);
+
+        // when
+        let result = tier.find_ts(6, FindOption::RoundDown);
+
+        // then
+        assert_eq!(result, Some(100));
+    }
+
+    #[test]
+    fn should_find_exact_sequence_number_for_timestamp() {
+        // given
+        let mut tier = Tier::new(4, 10);
+        tier.insert(4, 100);
+        tier.insert(8, 200);
+        tier.insert(12, 300);
+
+        // when
+        let result_down = tier.find_seq(200, FindOption::RoundDown);
+        let result_up = tier.find_seq(200, FindOption::RoundUp);
+
+        // then
+        assert_eq!(result_down, Some(8));
+        assert_eq!(result_up, Some(8));
+    }
+
+    #[test]
+    fn should_round_up_to_next_sequence_number() {
+        // given
+        let mut tier = Tier::new(4, 10);
+        tier.insert(4, 100);
+        tier.insert(8, 200);
+
+        // when
+        let result = tier.find_seq(150, FindOption::RoundUp);
+
+        // then
+        assert_eq!(result, Some(8));
+    }
+
+    #[test]
+    fn should_round_down_to_previous_sequence_number() {
+        // given
+        let mut tier = Tier::new(4, 10);
+        tier.insert(4, 100);
+        tier.insert(8, 200);
+
+        // when
+        let result = tier.find_seq(150, FindOption::RoundDown);
+
+        // then
+        assert_eq!(result, Some(4));
+    }
+
+    #[test]
+    fn should_downsample_when_capacity_exceeded() {
+        // given
+        let mut tier = Tier::new(2, 3);
+        tier.insert(2, 100);
+        tier.insert(4, 200);
+        tier.insert(6, 300);
+
+        // when
+        tier.insert(8, 400);
+
+        // then
+        assert_eq!(tier.step, 4); // step doubled
+        assert_eq!(tier.timestamps, vec![100, 300]); // downsampled
+        assert_eq!(tier.last_seq, 8);
+    }
+
+    #[test]
+    fn round_trip_empty_timestamps() {
+        let timestamps: Vec<i64> = vec![];
+        let encoded = encode_timestamps_to_bytes(&timestamps);
+        let decoded = decode_timestamps_from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, timestamps);
+    }
+
+    #[test]
+    fn round_trip_single_timestamp() {
+        let timestamps = vec![1234567890];
+        let encoded = encode_timestamps_to_bytes(&timestamps);
+        let decoded = decode_timestamps_from_bytes(&encoded).unwrap();
+        assert_eq!(decoded, timestamps);
+    }
+
+    #[test]
+    fn round_trip_timestamps_with_various_deltas() {
+        // Given timestamps that will exercise each branch of the Gorilla encoding:
+        // Using real Unix timestamps (seconds since epoch) that don't fit in i32
+        // to test the encoding dods using i32s
+        let timestamps = vec![
+            2145916800, 2145916900, 2145916900, 2145916950, 2145918950, 2146018950,
+        ];
+        let encoded = encode_timestamps_to_bytes(&timestamps);
+
+        // When:
+        let decoded = decode_timestamps_from_bytes(&encoded).unwrap();
+
+        // Then:
+        assert_eq!(decoded, timestamps);
+
+        // a naive encoding of 8 bytes per timestamp would be 48 bytes
+        // but this should fit in 23
+        assert_eq!(encoded.len(), 23);
+    }
+}

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -316,6 +316,133 @@ pub async fn timeout<T>(
     }
 }
 
+/// A simple bit-level writer that packs bits into a `[u8]`
+pub(crate) struct BitWriter {
+    buf: Vec<u8>,
+    cur: u8, // the currently assembling byte
+    n: u8,   // the number of "filled" bytes in `cur`
+}
+
+impl BitWriter {
+    pub(crate) fn new() -> Self {
+        BitWriter {
+            buf: Vec::new(),
+            cur: 0,
+            n: 0,
+        }
+    }
+
+    /// Push a single bit into the buffer
+    pub(crate) fn push(&mut self, bit: bool) {
+        if bit {
+            self.cur |= 1 << (7 - self.n);
+        }
+        self.n += 1;
+        if self.n == 8 {
+            self.flush_byte();
+        }
+    }
+
+    /// Push up to a u32 into the buffer, only considering
+    /// the first `bits` number of bits
+    pub(crate) fn push32(&mut self, value: u32, bits: u8) {
+        // writes the lowest `bits` bits from `value` into
+        // the current buffer (most significant bits first)
+        for i in (0..bits).rev() {
+            let bit = ((value >> i) & 1) != 0;
+            self.push(bit);
+        }
+    }
+
+    /// Push up to a u32 into the buffer, only considering
+    /// the first `bits` number of bits
+    pub(crate) fn push64(&mut self, value: u64, bits: u8) {
+        for i in (0..bits).rev() {
+            let bit = ((value >> i) & 1) != 0;
+            self.push(bit);
+        }
+    }
+
+    fn flush_byte(&mut self) {
+        self.buf.push(self.cur);
+        self.cur = 0;
+        self.n = 0;
+    }
+
+    /// Extrat the finalized buffer from the writer
+    pub(crate) fn finish(mut self) -> Vec<u8> {
+        if self.n > 0 {
+            self.buf.push(self.cur);
+        }
+        self.buf
+    }
+}
+
+pub(crate) struct BitReader<'a> {
+    buf: &'a [u8],
+    byte_pos: usize,
+    bit_pos: u8, // 0..8; next bit to read is at (7 - bit_pos)
+}
+
+impl<'a> BitReader<'a> {
+    pub(crate) fn new(buf: &'a [u8]) -> Self {
+        BitReader {
+            buf,
+            byte_pos: 0,
+            bit_pos: 0,
+        }
+    }
+
+    /// Read one bit, or None if we've exhausted the buffer.
+    pub(crate) fn read_bit(&mut self) -> Option<bool> {
+        if self.byte_pos >= self.buf.len() {
+            return None;
+        }
+        let byte = self.buf[self.byte_pos];
+        let bit = ((byte >> (7 - self.bit_pos)) & 1) != 0;
+        self.bit_pos += 1;
+        if self.bit_pos == 8 {
+            self.bit_pos = 0;
+            self.byte_pos += 1;
+        }
+        Some(bit)
+    }
+
+    /// Read `bits` bits, MSB first, returning them as the low `bits` of a u32.
+    pub(crate) fn read32(&mut self, bits: u8) -> Option<u32> {
+        let mut val = 0u32;
+        for _ in 0..bits {
+            val <<= 1;
+            match self.read_bit() {
+                Some(true) => val |= 1,
+                Some(false) => (),
+                None => return None,
+            }
+        }
+        Some(val)
+    }
+
+    /// Read `bits` bits, MSB first, returning them as the low `bits` of a u64.
+    pub(crate) fn read64(&mut self, bits: u8) -> Option<u64> {
+        let mut val = 0u64;
+        for _ in 0..bits {
+            val <<= 1;
+            match self.read_bit() {
+                Some(true) => val |= 1,
+                Some(false) => (),
+                None => return None,
+            }
+        }
+        Some(val)
+    }
+}
+
+/// Sign‐extend the low `bits` of `val` into a full i32.
+pub(crate) fn sign_extend(val: u32, bits: u8) -> i32 {
+    let shift = 32 - bits;
+    ((val << shift) as i32) >> shift
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -325,7 +452,7 @@ mod tests {
     use crate::test_utils::TestClock;
     use crate::utils::{
         bytes_into_minimal_vec, clamp_allocated_size_bytes, compute_index_key, spawn_bg_task,
-        WatchableOnceCell,
+        BitWriter, WatchableOnceCell,
     };
     use bytes::{BufMut, Bytes, BytesMut};
     use parking_lot::Mutex;
@@ -654,5 +781,49 @@ mod tests {
         // rather than timing out, even though both are ready
         let result = timeout_future.await;
         assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_should_write_bits_and_flush_bytes() {
+        // Given: a new BitWriter
+        let mut writer = BitWriter::new();
+
+        // When: we push alternating bits to create a full byte
+        for i in 0..8 {
+            writer.push(i % 2 == 0);
+        }
+        let result = writer.finish();
+
+        // Then: it should return a vector with one byte containing 0xAA (10101010)
+        assert_eq!(result, vec![0xAA]);
+    }
+
+    #[test]
+    fn test_should_push_bits_from_u64_value() {
+        // Given: a new BitWriter
+        let mut writer = BitWriter::new();
+
+        // When: we push 8 bits from a u64 value
+        writer.push32(0xAB, 8);
+        let result = writer.finish();
+
+        // Then: it should return a vector with one byte containing 0xAB
+        assert_eq!(result, vec![0xAB]);
+    }
+
+    #[test]
+    fn test_should_handle_partial_bytes_and_multiple_bytes() {
+        // Given: a new BitWriter
+        let mut writer = BitWriter::new();
+
+        // When: we push individual bits and then push_bits to create partial and full bytes
+        writer.push(true);
+        writer.push(false);
+        writer.push32(0x3F, 6); // 111111
+        writer.push32(0xCD, 8); // Full second byte
+        let result = writer.finish();
+
+        // Then: it should return a vector with two bytes: 0xBF (10111111) and 0xCD
+        assert_eq!(result, vec![0xBF, 0xCD]);
     }
 }


### PR DESCRIPTION
See #710 for the full context and how this is wired in.

This PR adds a data structure that can help track a map of sequence number -> timestamp with lossy granularity. 

Some notes:

1. It encodes using the Gorilla encoding strategy. Unfortunately I couldn't find a well maintained rust implementation of it, and it isn't too much code to just vendor it so I implemented it here. 
2. Gorilla recommends storing timestamps with second granularity to reduce the delta-of-deltas. I do that here by converting all timestamps to seconds. This is probably fine as this map is intended to be used for operational use cases.
3. The current implementation only supports a single tier with even spacing. When it fills up it downsamples everything. This is likely not the ideal final behavior as we likely want newer datapoints to be stored with higher granularity, which is what I'm intending to do with the tiered approach.