### PR TITLE
Use LocalFileSystem for nightly DST

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -177,6 +177,7 @@ jobs:
         run: cargo nextest run test_dst_nightly -p slatedb-dst --all-features --profile dst-nightly --no-capture
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
+          SLATEDB_DST_ROOT: "/tmp/slatedb-dst"
 
   # This is an integration test that makes sure SlateDB works with ZeroFS.
   # ZeroFS has discovered some issues with SlateDB so we want to make sure

--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -51,5 +51,6 @@ To run it locally, you must set the `RUSTFLAGS` environment variable to include
 ```bash
 $ RUSTFLAGS="--cfg dst --cfg tokio_unstable --cfg slow" \
   RUSTDOCFLAGS="--cfg tokio_unstable" \
+  SLATEDB_DST_ROOT="/tmp/slatedb-dst" \
   cargo test test_dst_nightly -p slatedb-dst --all-features
 ```

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -75,7 +75,7 @@
 //!         distr,
 //!         dst_opts,
 //!     );
-//!     dst.run_simulation(10).await.unwrap();
+//!     dst.run_simulation(DstDuration::Iterations(10)).await.unwrap();
 //! });
 //! # }
 //! ```

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -11,6 +11,7 @@
 //! `slow`, `dst`, and `tokio_unstable` cfgs are all set.
 #![cfg(all(dst, tokio_unstable))]
 
+use object_store::memory::InMemory;
 use rand::Rng;
 use rstest::rstest;
 use slatedb::clock::MockLogicalClock;
@@ -59,10 +60,19 @@ fn test_dst(
     #[case] dst_duration: DstDuration,
     #[case] dst_opts: DstOptions,
 ) -> Result<(), Error> {
+    let object_store = Arc::new(InMemory::new());
     let runtime = build_runtime(rand.seed());
     let logical_clock = Arc::new(MockLogicalClock::new());
     runtime.block_on(async move {
-        run_simulation(system_clock, logical_clock, rand, dst_duration, dst_opts).await
+        run_simulation(
+            object_store,
+            system_clock,
+            logical_clock,
+            rand,
+            dst_duration,
+            dst_opts,
+        )
+        .await
     })
 }
 
@@ -103,12 +113,13 @@ fn test_dst_is_deterministic(
     let mut expected_time: Option<DateTime<Utc>> = None;
 
     for simulation_count in 0..simulations {
+        let object_store = Arc::new(InMemory::new());
         let rand = Rc::new(DbRand::new(seed));
         let system_clock = Arc::new(MockSystemClock::new());
         let logical_clock = Arc::new(MockLogicalClock::new());
         let runtime = build_runtime(rand.rng().random::<u64>());
         runtime.block_on(async {
-            let mut dst = build_dst(system_clock.clone(), logical_clock.clone(), rand.clone(), DstOptions::default()).await;
+            let mut dst = build_dst(object_store.clone(), system_clock.clone(), logical_clock.clone(), rand.clone(), DstOptions::default()).await;
             info!(seed, simulation_count, "running simulation");
             match dst.run_simulation(dst_duration).await {
                 Ok(()) => {
@@ -147,15 +158,27 @@ fn test_dst_is_deterministic(
     Ok(())
 }
 
-/// Runs one DST per-core for a long time on all available CPU cores.
+/// Runs one DST per-core for a long time on all available CPU cores. Tests run for
+/// 50 minutes. Each core runs a DST with a different seed, and its own `Db`. Each
+/// `Db` uses a `LocalFileSystem` for its object store. The test will create a
+/// subdirectory for each object store inside the directory specified by the
+/// `SLATEDB_DST_ROOT` environment variable.
 ///
-/// This test only runs when `slow`, `dst`, and `tokio_unstable` cfgs are set.
+/// Set the following environment variables to run this test:
+///
+/// - `RUSTFLAGS="--cfg dst --cfg slow --cfg tokio_unstable"`
+/// - `SLATEDB_DST_ROOT` must be set to a directory to store test data.
 #[test]
 #[cfg(slow)]
 fn test_dst_nightly() -> Result<(), Error> {
+    use object_store::local::LocalFileSystem;
     use slatedb_dst::DstDuration;
+    use std::path::PathBuf;
     use sysinfo::System;
 
+    let test_root: PathBuf = std::env::var("SLATEDB_DST_ROOT")
+        .expect("SLATEDB_DST_ROOT must be set to a directory to store test data")
+        .into();
     let mut handles = Vec::new();
     let mut system = System::new();
     system.refresh_cpu_all();
@@ -163,7 +186,14 @@ fn test_dst_nightly() -> Result<(), Error> {
     let num_cores = (system.cpus().len() as f64 * 0.9).floor() as u64;
     info!("running nightly [num_cores={}]", num_cores);
     for core in 0..num_cores {
+        let test_dir = test_root.join(format!("core-{}", core));
+        std::fs::create_dir_all(&test_dir).expect("failed to create test root");
         let handle = std::thread::spawn(move || {
+            let object_store = Arc::new(
+                LocalFileSystem::new_with_prefix(test_dir)
+                    .expect("failed to create object store")
+                    .with_automatic_cleanup(true),
+            );
             let seed = rand::rng().random::<u64>();
             let rand = Rc::new(DbRand::new(seed));
             let runtime = build_runtime(rand.seed());
@@ -174,6 +204,7 @@ fn test_dst_nightly() -> Result<(), Error> {
                 let span = tracing::info_span!("run_simulation", core = core, seed = seed);
                 let _enter = span.enter();
                 run_simulation(
+                    object_store,
                     system_clock,
                     logical_clock,
                     rand,


### PR DESCRIPTION
This PR adds a new environment variable for DSTs called `SLATEDB_DST_ROOT`. The `slow` DST uses this as the root to create a `LocalFileSystem` `object_store` for each `Db`. Previously, we were using `InMemory`, which was accruing a ton of memory because GC wasn't running very frequently and we were creating a ton of garbage in the test.