### PR TITLE
Update action versions to release the website.

### DIFF
--- a/.github/workflows/release-website.yaml
+++ b/.github/workflows/release-website.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v1
-      - uses: actions/setup-node@v3
+        uses: actions/configure-pages@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
       - name: Build website


### PR DESCRIPTION
I just realized that the versions I configured are quite old. They throw some warnings because of deprecated GHA features.

@criccomini 