### PR TITLE
Disable bench for CLIs, libs, and examples

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,41 +13,49 @@ publish = false
 name = "azure-blob-storage"
 path = "src/azure_blob_storage.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "create-checkpoint"
 path = "src/create_checkpoint.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "delete-checkpoint"
 path = "src/delete_checkpoint.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "full-example"
 path = "src/full_example.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "refresh-checkpoint"
 path = "src/refresh_checkpoint.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "s3-compatible"
 path = "src/s3_compatible.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "simple-example"
 path = "src/simple_example.rs"
 test = false
+bench = false
 
 [[bin]]
 name = "tracing-subscriber"
 path = "src/tracing_subscriber.rs"
 test = false
+bench = false
 
 [dependencies]
 anyhow.workspace = true

--- a/slatedb-cli/Cargo.toml
+++ b/slatedb-cli/Cargo.toml
@@ -26,3 +26,4 @@ rstest = { workspace = true }
 [[bin]]
 name = "slatedb"
 path = "src/main.rs"
+bench = false

--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -10,6 +10,11 @@ homepage.workspace = true
 # Skipping publication for this test crate for now. We can publish if users want.
 publish = false
 
+[lib]
+# Disable `libtest` harness because it fights with Criterion's `--output-format bencher`
+# See https://bheisler.github.io/criterion.rs/book/faq.html
+bench = false
+
 [dependencies]
 chrono = { workspace = true }
 ctor = { workspace = true }

--- a/slatedb-py/Cargo.toml
+++ b/slatedb-py/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 name = "slatedb"
 crate-type = ["cdylib"]
 doc = false
+# Disable `libtest` harness because it fights with Criterion's `--output-format bencher`
+# See https://bheisler.github.io/criterion.rs/book/faq.html
+bench = false
 
 [dependencies]
 # See .cargo/config.toml for details on why pyo3/extension-module is only


### PR DESCRIPTION
The `microbenchmarks` test in `pr.yaml` began failing after #731. I don't believe that PR has anything to do with the failures. I'm able to reproduce them on the commit prior (1fe578c). I think something in the toolchain changed. I've updated the various crates to disable `bench` so it doesn't fight with the criterion output harness (as the `slatedb/Cargo.toml` file already did).