### PR TITLE
Fix documentation issue for garbage collection: "poll_interval" -> "interval"

### DIFF
--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -65,15 +65,15 @@
 //! scan_interval = "3600s"
 //!
 //! [garbage_collector_options.manifest_options]
-//! poll_interval = "300s"
+//! interval = "300s"
 //! min_age = "86400s"
 //!
 //! [garbage_collector_options.wal_options]
-//! poll_interval = "60s"
+//! interval = "60s"
 //! min_age = "60s"
 //!
 //! [garbage_collector_options.compacted_options]
-//! poll_interval = "300s"
+//! interval = "300s"
 //! min_age = "86400s"
 //! ```
 //!
@@ -104,15 +104,15 @@
 //!  },
 //!  "garbage_collector_options": {
 //!    "manifest_options": {
-//!      "poll_interval": "300s",
+//!      "interval": "300s",
 //!      "min_age": "86400s"
 //!    },
 //!    "wal_options": {
-//!      "poll_interval": "60s",
+//!      "interval": "60s",
 //!      "min_age": "60s"
 //!    },
 //!    "compacted_options": {
-//!      "poll_interval": "300s",
+//!      "interval": "300s",
 //!      "min_age": "86400s"
 //!    }
 //!  }
@@ -143,13 +143,13 @@
 //!   scan_interval: '3600s'
 //! garbage_collector_options:
 //!   manifest_options:
-//!     poll_interval: '300s'
+//!     interval: '300s'
 //!     min_age: '86400s'
 //!   wal_options:
-//!     poll_interval: '60s'
+//!     interval: '60s'
 //!     min_age: '60s'
 //!   compacted_options:
-//!     poll_interval: '300s'
+//!     interval: '300s'
 //!     min_age: '86400s'
 //! ```
 //!

--- a/website/src/content/docs/docs/architecture.md
+++ b/website/src/content/docs/docs/architecture.md
@@ -96,4 +96,4 @@ SlateDB garbage collects old manifests and SSTables. The collector runs in the c
 - WAL SSTables older than `min_age` and older than `wal_id_last_compacted`.
 - L0 SSTables older than `min_age` and not referenced by the current manifest or any active snapshot.
 
-Each of these three file types (manifest, WAL SSTable, and L0 SSTable) can be configured with its own `min_age` and `poll_interval` parameters. Garbage collection can also be disabled for each file type by setting the corresponding `GarbageCollectorOptions` attribute to `None`.
+Each of these three file types (manifest, WAL SSTable, and L0 SSTable) can be configured with its own `min_age` and `interval` parameters. Garbage collection can also be disabled for each file type by setting the corresponding `GarbageCollectorOptions` attribute to `None`.


### PR DESCRIPTION
It looks like the garbage collector options were changed from "poll_interval" to just "interval", but docs were not updated to reflect.

The compactor still uses "poll_interval", so care was taken to _not_ update the docs. Searched through code for instances of `poll_interval`, determined if it was for the garbage collector or compactor, and replaced as appropriate.