### PR TITLE
Hide the website's theme selector on mobile views.

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -18,3 +18,8 @@
 .sl-markdown-content img {
     background-color: var(--sl-image-bg-color);
 }
+
+/* Hide the theme selector */
+starlight-theme-select {
+    display: none;
+}


### PR DESCRIPTION
The theme selector in the mobile menu was showing when you opened the menu.

Before:

<img width="561" height="622" alt="image" src="https://github.com/user-attachments/assets/5dc9ac7d-8c0b-408d-9b4d-6ebbfb7ae1af" />


After:

<img width="512" height="596" alt="image" src="https://github.com/user-attachments/assets/f0edc6d5-a1cc-4374-b0f0-37c3e1fe9314" />

/cc @criccomini 
