### PR TITLE
Use `cwd` for `SLATEDB_DST_ROOT` in DST tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -201,7 +201,7 @@ jobs:
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
           RUST_LOG: "warn"
-          SLATEDB_DST_ROOT: "/tmp/slatedb-dst"
+          SLATEDB_DST_ROOT: "./"
 
   # This is an integration test that makes sure SlateDB works with ZeroFS.
   # ZeroFS has discovered some issues with SlateDB so we want to make sure

--- a/slatedb-bencher/benchmark-db.sh
+++ b/slatedb-bencher/benchmark-db.sh
@@ -76,6 +76,10 @@ generate_mermaid () {
     local put_percentage=$(echo "$filename" | cut -d'_' -f1)
     local concurrency=$(echo "$filename" | cut -d'_' -f2)
 
+    # Calculate max value for y-axis scaling
+    local max_value=$(echo "$put_value $get_value" | tr ' ' '\n' | sort -nr | head -n1)
+    local y_max=$(echo "$max_value * 1.2" | bc -l | cut -d'.' -f1)
+
     if [ ! -f "$mermaid_file" ]; then
         # Create new mermaid file
         cat > "$mermaid_file" << EOF
@@ -88,6 +92,7 @@ config:
 xychart-beta
     title "SlateDB [puts=${put_percentage}%, threads=${concurrency}, 🔵=puts, 🟠=get]"
     x-axis ["$x_entry"]
+    y-axis "requests/s" 0 --> $y_max
     line [$put_value]
     line [$get_value]
 EOF
@@ -166,6 +171,11 @@ EOF
         done
         new_get_line="$new_get_line]"
 
+        # Calculate max value for y-axis scaling from all values
+        local all_values="${put_array[*]} ${get_array[*]}"
+        local max_value=$(echo "$all_values" | tr ' ' '\n' | sort -nr | head -n1)
+        local y_max=$(echo "$max_value * 1.2" | bc -l | cut -d'.' -f1)
+
         # Write updated mermaid file
         cat > "$mermaid_file" << EOF
 ---
@@ -177,6 +187,7 @@ config:
 xychart-beta
     $title_line
     $new_x_axis
+    y-axis "requests/s" 0 --> $y_max
     $new_put_line
     $new_get_line
 EOF

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -182,8 +182,7 @@ fn test_dst_nightly() -> Result<(), Error> {
     let mut handles = Vec::new();
     let mut system = System::new();
     system.refresh_cpu_all();
-    // 90% of the cores because GH actions were being killed at 100%
-    let num_cores = (system.cpus().len() as f64 * 0.9).floor() as u64;
+    let num_cores = system.cpus().len();
     info!("running nightly [num_cores={}]", num_cores);
     for core in 0..num_cores {
         let test_dir = test_root.join(format!("core-{}", core));


### PR DESCRIPTION
Attempts to prevent out-of-disk-space errors when running `nightly.yaml` DSTs.