### PR TITLE
Disable clippy disallow's for example crate

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -63,6 +63,3 @@ object_store = { workspace = true, features = ["azure"] }
 slatedb.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing-subscriber.workspace = true
-
-[lints]
-clippy = { disallowed_macros = "allow", disallowed_types = "allow", disallowed_methods = "allow" }

--- a/examples/src/azure_blob_storage.rs
+++ b/examples/src/azure_blob_storage.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use object_store::azure::MicrosoftAzureBuilder;
 use slatedb::{config::PutOptions, Db};
 use std::sync::Arc;

--- a/examples/src/create_checkpoint.rs
+++ b/examples/src/create_checkpoint.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use slatedb::admin::AdminBuilder;
 use slatedb::config::CheckpointOptions;
 use slatedb::object_store::memory::InMemory;

--- a/examples/src/delete_checkpoint.rs
+++ b/examples/src/delete_checkpoint.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use slatedb::admin::AdminBuilder;
 use slatedb::config::CheckpointOptions;
 use slatedb::object_store::memory::InMemory;

--- a/examples/src/full_example.rs
+++ b/examples/src/full_example.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use slatedb::{object_store::memory::InMemory, Db, Error};
 use std::sync::Arc;
 

--- a/examples/src/refresh_checkpoint.rs
+++ b/examples/src/refresh_checkpoint.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use slatedb::admin::AdminBuilder;
 use slatedb::config::CheckpointOptions;
 use slatedb::object_store::memory::InMemory;

--- a/examples/src/s3_compatible.rs
+++ b/examples/src/s3_compatible.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use object_store::aws::S3ConditionalPut;
 use slatedb::Db;
 use std::sync::Arc;

--- a/examples/src/simple_example.rs
+++ b/examples/src/simple_example.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use slatedb::object_store::memory::InMemory;
 use slatedb::{Db, Error};
 use std::sync::Arc;

--- a/examples/src/tracing_subscriber.rs
+++ b/examples/src/tracing_subscriber.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods, clippy::disallowed_macros)]
 use slatedb::{bytes::Bytes, object_store::memory::InMemory, Db};
 use std::sync::Arc;
 


### PR DESCRIPTION
I noticed `cargo clippy --all-features` was catching the `examples` crate after #731. I've updated that crate's Clippy configs to skip our Clippy disallow-* stuff since those are meant to be public examples that are allowed to use whatever methods/types/macros.