### PR TITLE
Limit nightly DST to 12 minutes

### DIFF
--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -198,7 +198,7 @@ fn test_dst_nightly() -> Result<(), Error> {
             let runtime = build_runtime(rand.seed());
             let system_clock = Arc::new(MockSystemClock::new());
             let logical_clock = Arc::new(MockLogicalClock::new());
-            let duration = DstDuration::WallClock(std::time::Duration::from_secs(3_000)); // 50m
+            let duration = DstDuration::WallClock(std::time::Duration::from_secs(720)); // 12 minutes
             runtime.block_on(async move {
                 let span = tracing::info_span!("run_simulation", core = core, seed = seed);
                 let _enter = span.enter();


### PR DESCRIPTION
We are running out of disk space in our nightly DSTs. The reason appears to be that the `LocalFilesystem` `object_store` uses the actual timestamps from the machine time. Our DST mock system clock starts at the UTC epoch, though. Consequently, all the files have a last modified time _way_ ahead of our mock system clock. This causes the GC not to ever remove anything.

I plan to open a GH issue to figure out what to do about this. In the meantime, I'm limiting the nightly DST execution time to 12 minutes so we don't run out of disk on the WarpBuild machine.