### PR TITLE
Remove extra clone creating a DbIterator.

### DIFF
--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -165,7 +165,7 @@ impl Reader {
             sr_iters.push_back(iter);
         }
 
-        DbIterator::new(range.clone(), memtable_iters, l0_iters, sr_iters, max_seq).await
+        DbIterator::new(range, memtable_iters, l0_iters, sr_iters, max_seq).await
     }
 }
 


### PR DESCRIPTION
The range to scan the database can be owned by the DbIterator since it's not used later.