### PR TITLE
fix(wal): ensure batch wal append in atomic

### DIFF
--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -61,8 +61,11 @@ impl DbInner {
     ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
         let now = self.mono_clock.now().await?;
         let seq = self.oracle.last_seq.next();
-        for op in batch.ops {
-            let row_entry = match op {
+
+        let entries = batch
+            .ops
+            .into_iter()
+            .map(|op| match op {
                 WriteOp::Put(key, value, opts) => RowEntry {
                     key,
                     value: ValueDeletable::Value(value),
@@ -77,16 +80,16 @@ impl DbInner {
                     expire_ts: None,
                     seq,
                 },
-            };
+            })
+            .collect::<Vec<_>>();
 
-            if self.wal_enabled {
-                self.wal_buffer.append(&[row_entry.clone()]).await?;
-            }
-            // we do not need to lock the memtable in the middle of the commit pipeline.
-            // the writes will not visible to the reader until the last_committed_seq
-            // is updated.
-            self.state.write().memtable().put(row_entry);
+        if self.wal_enabled {
+            // we should ensure that the WAL entries are appended into wal buffer in atomic.
+            // otherwise, the WAL buffer may flush the entries in the middle of the batch,
+            // which would violate the atomicity guarantee.
+            self.wal_buffer.append(&entries).await?;
         }
+        self.state.write().memtable().put_batch(&entries);
 
         // update the last_applied_seq to wal buffer. if a chunk of WAL entries are applied to the memtable
         // and flushed to the remote storage, WAL buffer manager will recycle these WAL entries.

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -213,6 +213,10 @@ impl WritableKVTable {
         self.table.put(row);
     }
 
+    pub(crate) fn put_batch(&mut self, rows: &[RowEntry]) {
+        self.table.put_batch(rows);
+    }
+
     pub(crate) fn metadata(&self) -> KVTableMetadata {
         self.table.metadata()
     }
@@ -308,6 +312,12 @@ impl KVTable {
         .build();
         iterator.next_entry_sync();
         iterator
+    }
+
+    pub(crate) fn put_batch(&self, rows: &[RowEntry]) {
+        for row in rows {
+            self.put(row.clone());
+        }
     }
 
     pub(crate) fn put(&self, row: RowEntry) {

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -198,7 +198,7 @@ impl WalBufferManager {
     pub async fn append(&self, entries: &[RowEntry]) -> Result<Option<u64>, SlateDBError> {
         // TODO: check if the wal buffer is in a fatal error state.
 
-        let inner = self.inner.read();
+        let inner = self.inner.write();
         for entry in entries {
             inner.current_wal.put(entry.clone());
         }


### PR DESCRIPTION
this pr addes a write lock for batch write operations for WAL appends.

this lock may help us ensure the wal flushing always happen in the write batch boundary.

fixes #762