### PR TITLE
refactor(wal): remove avoidable `clone` in WriteBatch operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2065,7 +2065,6 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml 0.38.1",
- "rand 0.9.1",
  "rand 0.9.2",
  "reqwest",
  "ring",

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -213,10 +213,6 @@ impl WritableKVTable {
         self.table.put(row);
     }
 
-    pub(crate) fn put_batch(&mut self, rows: &[RowEntry]) {
-        self.table.put_batch(rows);
-    }
-
     pub(crate) fn metadata(&self) -> KVTableMetadata {
         self.table.metadata()
     }
@@ -312,12 +308,6 @@ impl KVTable {
         .build();
         iterator.next_entry_sync();
         iterator
-    }
-
-    pub(crate) fn put_batch(&self, rows: &[RowEntry]) {
-        for row in rows {
-            self.put(row.clone());
-        }
     }
 
     pub(crate) fn put(&self, row: RowEntry) {


### PR DESCRIPTION
Close #767 
Considering that `put_batch` will only be used in `write_batch.rs`, I deleted it. I think there is no need to introduce such an interface.