### PR TITLE
Set `RUST_LOG` to info for nightly benchmark

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -104,6 +104,7 @@ jobs:
           AWS_REGION: auto
           AWS_ENDPOINT: https://t3.storage.dev
           SLATEDB_BENCH_CLEAN: true
+          RUST_LOG: info
         run: |
           aws s3 rm --endpoint-url $AWS_ENDPOINT s3://${{ secrets.TIGRIS_AWS_BUCKET_BENCHER }} --recursive
           ./slatedb-bencher/benchmark-db.sh


### PR DESCRIPTION
The nightly benchmark was filled with a lot of chatty debug logs from the WAL buffer. Disabling debug so I can see the logs more clearly.