### PR TITLE
 fix: return Ok(()) for clean background task shutdowns

### DIFF
--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -142,7 +142,6 @@ use crate::rand::DbRand;
 use crate::sst::SsTableFormat;
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
-use crate::utils::bg_task_result_into_err;
 use crate::utils::spawn_bg_task;
 
 /// A builder for creating a new Db instance.
@@ -516,10 +515,16 @@ impl<P: Into<Path>> DbBuilder<P> {
                 // Spawn the main event loop on the main tokio runtime
                 &tokio_handle,
                 move |result: &Result<(), SlateDBError>| {
-                    let err = bg_task_result_into_err(result);
-                    warn!("compactor thread exited [error={}]", err);
-                    let mut state = cleanup_inner.state.write();
-                    state.record_fatal_error(err.clone())
+                    match result {
+                        Ok(()) => {
+                            info!("compactor thread exited cleanly");
+                        }
+                        Err(err) => {
+                            warn!("compactor thread exited [error={}]", err);
+                            let mut state = cleanup_inner.state.write();
+                            state.record_fatal_error(err.clone())
+                        }
+                    }
                 },
                 // Spawn the compactor on the compaction runtime
                 async move { compactor.run_async_task(compaction_handle).await },
@@ -547,10 +552,16 @@ impl<P: Into<Path>> DbBuilder<P> {
                 let garbage_collector_task = spawn_bg_task(
                     &gc_handle,
                     move |result| {
-                        let err = bg_task_result_into_err(result);
-                        warn!("GC thread exited [error={}]", err);
-                        let mut state = cleanup_inner.state.write();
-                        state.record_fatal_error(err.clone())
+                        match result {
+                            Ok(()) => {
+                                info!("GC thread exited cleanly");
+                            }
+                            Err(err) => {
+                                warn!("GC thread exited [error={}]", err);
+                                let mut state = cleanup_inner.state.write();
+                                state.record_fatal_error(err.clone())
+                            }
+                        }
                     },
                     async move { gc.run_async_task().await },
                 );

--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -57,7 +57,7 @@
 //!         result: Result<(), SlateDBError>,
 //!     ) -> Result<(), SlateDBError> {
 //!         match result {
-//!             Ok(_) | Err(SlateDBError::BackgroundTaskShutdown) => {
+//!             Ok(_) => {
 //!                 messages.for_each(|m| self.handle(m)).await;
 //!             },
 //!             // skipping drain messages on unclean shutdown
@@ -225,16 +225,16 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
     /// flow:
     ///
     /// 1. Break immediately if we're in an error state or cancelled, and return
-    ///    [SlateDBError::BackgroundTaskShutdown].
+    ///    `Ok(())`.
     /// 2. Else, if there is a message, read it and invoke [MessageHandler::handle].
     /// 3. Else, if there is a ticker event, read it and invoke [MessageHandler::handle].
     ///
     /// If there is an uncaught error at any point, the error is returned immediately (in
-    /// lieu of [SlateDBError::BackgroundTaskShutdown] on a clean shutdown).
+    /// lieu of `Ok(())` on a clean shutdown).
     ///
     /// ## Returns
     ///
-    /// A [Result] containing [SlateDBError::BackgroundTaskShutdown] on clean shutdown,
+    /// A [Result] containing `Ok(())` on clean shutdown,
     /// or an uncaught error.
     async fn run_loop(&mut self) -> Result<(), SlateDBError> {
         let cancellation_token = self.cancellation_token.clone();
@@ -277,7 +277,7 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
                 },
             }
         }
-        Err(SlateDBError::BackgroundTaskShutdown)
+        Ok(())
     }
 
     /// Handles the result of [MessageDispatcher::run_loop] using the following logic:
@@ -312,7 +312,7 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
     /// * `maybe_error`: An optional error to pass to the handler. Setting this argument
     ///   signals to the [MessageHandler] that the database is in an error state during
     ///   shutdown. An option is used instead of `Result`` because we convert
-    ///   [SlateDBError::BackgroundTaskShutdown] to None, so handlers handle messages
+    ///   `Ok(())` to None, so handlers handle messages
     ///   cleanly during shutdown when the database is not in an error state.
     ///
     /// ## Returns
@@ -578,17 +578,17 @@ mod test {
             .expect("join failed");
 
         // Verify final state
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
+        assert!(matches!(result, Ok(())));
         assert!(matches!(
             error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
+            None
         ));
         assert!(matches!(
             cleanup_called
                 .reader()
                 .read()
                 .expect("cleanup result not set"),
-            Err(SlateDBError::BackgroundTaskShutdown)
+            Ok(())
         ));
         let messages = log.lock().unwrap().clone();
         assert_eq!(
@@ -749,14 +749,14 @@ mod test {
             .expect("join failed");
 
         // Verify final state
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
+        assert!(matches!(result, Ok(())));
         assert!(matches!(
             error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
+            None
         ));
         assert!(matches!(
             cleanup_called.reader().read(),
-            Some(Err(SlateDBError::BackgroundTaskShutdown))
+            Some(Ok(()))
         ));
         let messages = log.lock().unwrap().clone();
         assert_eq!(
@@ -845,10 +845,10 @@ mod test {
             .expect("join failed");
 
         // Verify final state
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
+        assert!(matches!(result, Ok(())));
         assert!(matches!(
             error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
+            None
         ));
         assert!(matches!(cleanup_called.reader().read(), Some(Err(_))));
         assert_eq!(log.lock().unwrap().len(), 9);
@@ -938,10 +938,10 @@ mod test {
             .await
             .expect("dispatcher did not stop in time")
             .expect("join failed");
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
+        assert!(matches!(result, Ok(())));
         assert!(matches!(
             error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
+            None
         ));
         assert!(matches!(cleanup_called.reader().read(), Some(Err(_))));
         assert_eq!(log.lock().unwrap().len(), 10);
@@ -1017,10 +1017,10 @@ mod test {
             .await
             .expect("dispatcher did not stop in time")
             .expect("join failed");
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
+        assert!(matches!(result, Ok(())));
         assert!(matches!(
             error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
+            None
         ));
         assert!(matches!(cleanup_called.reader().read(), Some(Err(_))));
         assert_eq!(log.lock().unwrap().len(), 16);

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -107,8 +107,6 @@ pub(crate) enum SlateDBError {
     // we need to wrap the panic args in a mutex so that SlateDbError is Sync
     BackgroundTaskPanic(Arc<Mutex<Box<dyn Any + Send>>>),
 
-    #[error("background task shutdown")]
-    BackgroundTaskShutdown,
 
     #[error("merge operator error")]
     MergeOperatorError(#[from] MergeOperatorError),
@@ -190,6 +188,9 @@ pub(crate) enum SlateDBError {
 
     #[error("invalid object store URL. url=`{0}`")]
     InvalidObjectStoreURL(String, #[source] url::ParseError),
+
+    #[error("operation cancelled due to shutdown")]
+    Shutdown,
 }
 
 impl From<std::io::Error> for SlateDBError {
@@ -370,7 +371,6 @@ impl From<SlateDBError> for Error {
             SlateDBError::BackgroundTaskPanic(err) => {
                 Error::system(msg).with_source(Box::new(PanicError(err)))
             }
-            SlateDBError::BackgroundTaskShutdown => Error::system(msg),
             SlateDBError::MergeOperatorError(err) => {
                 Error::operation(msg).with_source(Box::new(err))
             }
@@ -410,6 +410,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::InvalidObjectStoreURL(_, err) => {
                 Error::configuration(msg).with_source(Box::new(err))
             }
+            SlateDBError::Shutdown => Error::system(msg),
         }
     }
 }

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -3,9 +3,8 @@ use crate::config::CheckpointOptions;
 use crate::db::DbInner;
 use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
-use crate::error::SlateDBError::BackgroundTaskShutdown;
 use crate::manifest::store::FenceableManifest;
-use crate::utils::{bg_task_result_into_err, spawn_bg_task, IdGenerator};
+use crate::utils::{spawn_bg_task, IdGenerator};
 use log::{debug, error, info, warn};
 use std::cmp;
 use std::sync::Arc;
@@ -276,7 +275,7 @@ impl DbInner {
             }
 
             // respond to any pending msgs
-            let pending_error = result.clone().err().unwrap_or(BackgroundTaskShutdown);
+            let pending_error = result.clone().err().unwrap_or(SlateDBError::Shutdown);
             Self::drain_messages(&mut flush_rx, &pending_error).await;
 
             if let Err(err) = flusher.write_manifest_safely().await {
@@ -291,20 +290,26 @@ impl DbInner {
         Some(spawn_bg_task(
             tokio_handle,
             move |result| {
-                let err = bg_task_result_into_err(result);
-                warn!("memtable flush task exited with error [error={}]", err);
-                let mut state = this.state.write();
-                state.record_fatal_error(err.clone());
-                info!("notifying in-memory memtable of error");
-                state.memtable().table().notify_durable(Err(err.clone()));
-                for imm_table in state.state().imm_memtable.iter() {
-                    info!(
-                        "notifying imm memtable of error [last_wal_id={}, error={}]",
-                        imm_table.recent_flushed_wal_id(),
-                        err,
-                    );
-                    imm_table.notify_flush_to_l0(Err(err.clone()));
-                    imm_table.table().notify_durable(Err(err.clone()));
+                match result {
+                    Ok(()) => {
+                        info!("memtable flush task exited cleanly");
+                    }
+                    Err(err) => {
+                        warn!("memtable flush task exited with error [error={}]", err);
+                        let mut state = this.state.write();
+                        state.record_fatal_error(err.clone());
+                        info!("notifying in-memory memtable of error");
+                        state.memtable().table().notify_durable(Err(err.clone()));
+                        for imm_table in state.state().imm_memtable.iter() {
+                            info!(
+                                "notifying imm memtable of error [last_wal_id={}, error={}]",
+                                imm_table.recent_flushed_wal_id(),
+                                err,
+                            );
+                            imm_table.notify_flush_to_l0(Err(err.clone()));
+                            imm_table.table().notify_durable(Err(err.clone()));
+                        }
+                    }
                 }
             },
             fut,

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -133,12 +133,6 @@ pub(crate) fn is_not_expired(entry: &RowEntry, now: i64) -> bool {
     }
 }
 
-pub(crate) fn bg_task_result_into_err(result: &Result<(), SlateDBError>) -> SlateDBError {
-    match result {
-        Ok(_) => SlateDBError::BackgroundTaskShutdown,
-        Err(err) => err.clone(),
-    }
-}
 
 /// Merge two options using the provided function.
 pub(crate) fn merge_options<T>(


### PR DESCRIPTION
Fixes: https://github.com/slatedb/slatedb/issues/817

Remove BackgroundTaskShutdown error and return Ok(()) instead when background tasks shut down cleanly via CancellationToken.