### PR TITLE
Configure ReadTheDocs for Python bindings

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+
+sphinx:
+  configuration: slatedb-py/docs/conf.py
+
+python:
+  install:
+    - path: slatedb-py
+      extra_requirements:
+        - docs

--- a/slatedb-py/docs/conf.py
+++ b/slatedb-py/docs/conf.py
@@ -1,0 +1,13 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../python'))
+
+project = 'SlateDB Python API'
+extensions = [
+    'autoapi.extension',
+    'sphinx.ext.napoleon',
+]
+autoapi_type = 'python'
+autoapi_dirs = ['../python']
+autoapi_root = 'api'
+html_theme = 'sphinx_rtd_theme'

--- a/slatedb-py/docs/index.rst
+++ b/slatedb-py/docs/index.rst
@@ -1,0 +1,7 @@
+SlateDB Python API
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   api/index

--- a/slatedb-py/pyproject.toml
+++ b/slatedb-py/pyproject.toml
@@ -19,6 +19,11 @@ test = [
     "pytest>=8.3",
     "pytest-asyncio>=0.25.0",
 ]
+docs = [
+    "sphinx>=7.4",
+    "sphinx-rtd-theme>=3.0",
+    "sphinx-autoapi>=3.0",
+]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
## Summary
- add docs extra dependencies
- configure Sphinx and autoapi docs for slatedb-py
- add ReadTheDocs config to build API reference

## Testing
- `sphinx-build -b html slatedb-py/docs slatedb-py/docs/_build/html`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0adf00c208329861eaebfb91eee7b