### PR TITLE
Add subdirectory to go meta url

### DIFF
--- a/website/src/pages/slatedb-go.astro
+++ b/website/src/pages/slatedb-go.astro
@@ -2,7 +2,7 @@
 ---
 <html lang="en">
   <head>
-    <meta name="go-import" content="slatedb.io/slatedb-go git https://github.com/slatedb/slatedb">
+    <meta name="go-import" content="slatedb.io/slatedb-go git https://github.com/slatedb/slatedb slatedb-go/go">
     <meta name="go-source" content="slatedb.io/slatedb-go https://github.com/slatedb/slatedb https://github.com/slatedb/slatedb/tree/main/slatedb-go/go{/dir} https://github.com/slatedb/slatedb/blob/main/slatedb-go/go{/dir}/{file}#L{line}" />
     <title>SlateDB Go module</title>
   </head>


### PR DESCRIPTION
According to this:

https://go.dev/ref/mod#vcs-find

We need to specify a subdirectory in our meta for Go module vanity URLs.