### PR TITLE
Add Go module tag to release process

### DIFF
--- a/.github/workflows/release-website.yaml
+++ b/.github/workflows/release-website.yaml
@@ -1,4 +1,4 @@
-name: Deploy documentation
+name: Deploy website
 
 on:
   # `workflow_dispatch` allows to update the website with minor changes between releases.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,5 +85,15 @@ jobs:
             cargo publish
           fi
 
+      - name: Create Go module tag
+        run: |
+          TAG="slatedb-go/go/v${{ github.event.inputs.version }}"
+          if git ls-remote --tags origin "${TAG}" | grep -q "refs/tags/${TAG}$"; then
+            echo "✔ ${TAG} already exists, skipping"
+          else
+            git tag -a "${TAG}" -m "Release Go module ${TAG}"
+            git push origin "${TAG}"
+          fi
+
       - name: Publish website
         uses: ./.github/workflows/release-website.yaml

--- a/website/src/pages/slatedb-go.astro
+++ b/website/src/pages/slatedb-go.astro
@@ -14,3 +14,15 @@
     </p>
   </main>
 </html>
+
+{/*
+  This page is required to make `go get` work with SlateDB's Go binding.
+  The module is in `slatedb-go/go`, which means a normal import path would be
+  `github.com/slatedb/slatedb/slatedb-go/go`. This is a bit ugly, so we use
+  `slatedb.io/slatedb-go` instead. See https://go.dev/ref/mod#vcs-find for
+  details.
+
+  NOTE: We are using the `subdir` field in `go-import`, which is a new feature
+  in Go 1.25.0. This means SlateDB's Go binding requires Go 1.25.0 or higher.
+  See https://go.dev/doc/go1.25#go-command for details.
+*/}


### PR DESCRIPTION
Go module tagging for subdirectories requires the format `subdir/v0.0.0`. I'm adding a `slatedb-go/go/v0.0.0` tag to the release process so users will be able to `go get slatedb.io/slatedb-go`.