### PR TITLE
Add title header to SlateDB Error API document

### DIFF
--- a/rfcs/0007-api-errors.md
+++ b/rfcs/0007-api-errors.md
@@ -1,3 +1,5 @@
+# SlateDB Error API
+
 <!-- TOC start (generated with https://github.com/derlin/bitdowntoc) -->
 
 - [SlateDB Error API](#slatedb-error-api)
@@ -7,8 +9,6 @@
    * [Public API](#public-api)
 
 <!-- TOC end -->
-
-# SlateDB Error API
 
 Status: Accepted
 


### PR DESCRIPTION
Having the TOC before the header was causing issues with RFC website generation.