### PR TITLE
Remove README.md doc attribute in lib.rs

### DIFF
--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc = include_str!("../../README.md")]
 #![cfg_attr(test, allow(clippy::unwrap_used))]
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]


### PR DESCRIPTION
It appears that  `#![doc = include_str!("../../README.md")]` in `lib.rs` does not work now that we have workspaced packages. It works fine during development, but when building and publishing releases, we get:

```
   Compiling slatedb v0.8.0 (/home/runner/work/slatedb/slatedb/target/package/slatedb-0.8.0)
error: couldn't read `src/../../README.md`: No such file or directory (os error 2)
 --> src/lib.rs:1:10
  |
1 | #![doc = include_str!("../../README.md")]
  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
help: there is a file with the same name in a different directory
  |
1 | #![doc = include_str!("../../../../README.md")]
  |                              ++++++
```

This can be replicated locally with:

```
cargo publish --dry-run -p slatedb
```

It seems that we removed the doc include after 0.6.1. I re-added it here (assuming it would work):

https://github.com/slatedb/slatedb/commit/82847c76d07c4701cc63994091bcf087bb113c68

Turns out that was a bad assumption. I fiddled with things for an hour but couldn't figure out how to get it to work both in the IDE/dev environment and also at build time.