### PR TITLE
Set github action bot name and email

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -88,6 +88,8 @@ jobs:
       - name: Create Go module tag
         run: |
           TAG="slatedb-go/go/v${{ github.event.inputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git ls-remote --tags origin "${TAG}" | grep -q "refs/tags/${TAG}$"; then
             echo "✔ ${TAG} already exists, skipping"
           else


### PR DESCRIPTION
The most recent (0.8.0) release failed because the release.yaml does not set a github bot name or email. This PR fixes that.