### PR TITLE
Add memtable flush logs

### DIFF
--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -167,7 +167,7 @@ impl MemtableFlusher {
                     if matches!(err, SlateDBError::Fenced) {
                         if let Err(delete_err) = self.db_inner.table_store.delete_sst(&id).await {
                             warn!(
-                                "failed to delete fenced SST [id={:?}, error={}]",
+                                "failed to delete fenced SST [id={:?}, error={:?}]",
                                 id, delete_err
                             );
                         }
@@ -224,7 +224,7 @@ impl DbInner {
                     }
                     _ = manifest_poll_interval.tick() => {
                         if let Err(err) = flusher.load_manifest().await {
-                            error!("error loading manifest [error={}]", err);
+                            error!("error loading manifest [error={:?}]", err);
                             return Err(err);
                         }
                         this.flush_and_record(flusher).await?
@@ -240,14 +240,14 @@ impl DbInner {
                                 if let Some(rsp_sender) = sender {
                                     let res = rsp_sender.send(Ok(()));
                                     if let Err(Err(err)) = res {
-                                        error!("error sending flush response [error={}]", err);
+                                        error!("error sending flush response [error={:?}]", err);
                                     }
                                 }
                             },
                             MemtableFlushMsg::CreateCheckpoint { options, sender } => {
                                 let write_result = flusher.write_checkpoint_safely(&options).await;
                                 if let Err(Err(e)) = sender.send(write_result) {
-                                    error!("Failed to send checkpoint error [error={}]", e);
+                                    error!("Failed to send checkpoint error [error={:?}]", e);
                                 }
                             }
                         }
@@ -292,14 +292,14 @@ impl DbInner {
             tokio_handle,
             move |result| {
                 let err = bg_task_result_into_err(result);
-                warn!("memtable flush task exited with error [error={}]", err);
+                warn!("memtable flush task exited with error [error={:?}]", err);
                 let mut state = this.state.write();
                 state.record_fatal_error(err.clone());
                 info!("notifying in-memory memtable of error");
                 state.memtable().table().notify_durable(Err(err.clone()));
                 for imm_table in state.state().imm_memtable.iter() {
                     info!(
-                        "notifying imm memtable of error [last_wal_id={}, error={}]",
+                        "notifying imm memtable of error [last_wal_id={}, error={:?}]",
                         imm_table.recent_flushed_wal_id(),
                         err,
                     );

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -190,7 +190,7 @@ impl DbInner {
     ) -> Result<(), SlateDBError> {
         let result = flusher.flush_imm_memtables_to_l0().await;
         if let Err(err) = &result {
-            error!("error from memtable flush [error={}]", err);
+            error!("error from memtable flush [error={:?}]", err);
         } else {
             self.db_stats.immutable_memtable_flushes.inc();
         }


### PR DESCRIPTION
We're logging display info, not debug info, when logging errors in the memtable flusher.