### PR TITLE
DST should use at least `l0_max_ssts` for its compactor

### DIFF
--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -527,11 +527,10 @@ impl Dst {
         while dst_duration.should_run(step_count, actual_start_time) {
             let step_action = self.action_sampler.sample_action(&self.state);
             info!(
-                "run_simulation [simulated_time={}, state={:?}, step_count={}, step_action={}]",
+                "run_simulation [simulated_time={}, step_count={}, step_action={}]",
                 self.system_clock
                     .now()
                     .signed_duration_since(simulated_time),
-                &self.state,
                 step_count,
                 step_action,
             );


### PR DESCRIPTION
Last night's deterministic simulation tests got stuck. After some investigation, I discovered that one of the seeds resulted in an `l0_max_ssts=2` setting. The default `SizeTieredCompactionSchedulerOptions` uses `min_compaction_sources: 4`. When the DST hit 2 L0 SSTs it began blocking future writes, but the compactor never kicked in to clear L0 because it hadn't yet reached 4 L0 SSTs. This results in a deadlock.

This PR fixes the immediate problem by ensuring the DST always takes the max of min_compaction_sources and l0_max_ssts. I ran the test with the same seed locally after this change (and verified it still used `l0_max_ssts=0`) and the test now passes.

Fixes #854