### PR TITLE
Add `ClockedObjectStore` to mock times in DST

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -207,7 +207,7 @@ jobs:
         run: cargo nextest run test_dst_nightly -p slatedb-dst --all-features --profile dst-nightly --no-capture
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
-          RUST_LOG: "warn"
+          RUST_LOG: "info"
           SLATEDB_DST_ROOT: "./"
 
   notify:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,6 +3325,7 @@ dependencies = [
 name = "slatedb-dst"
 version = "0.8.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "ctor",
  "futures",

--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 bench = false
 
 [dependencies]
+async-trait = { workspace = true }
 chrono = { workspace = true }
 ctor = { workspace = true }
 futures = { workspace = true }

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -547,6 +547,8 @@ impl Dst {
             }
             step_count += 1;
         }
+        self.run_flush().await?;
+        self.db.close().await?;
         Ok(())
     }
 

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -318,9 +318,9 @@ impl DefaultDstDistribution {
     }
 
     /// Generates an advance time action. The duration is sampled using a log-uniform
-    /// distribution. The range is hard coded as 1..10_000_000 (1ms to 100 seconds).
+    /// distribution. The range is hard coded as 1..10_000_000 (1ms to 10 seconds).
     fn sample_advance_time(&self) -> DstAction {
-        let sleep_micros = self.sample_log10_uniform(1..100_000_000).into();
+        let sleep_micros = self.sample_log10_uniform(1..10_000_000).into();
         DstAction::AdvanceTime(Duration::from_micros(sleep_micros))
     }
 

--- a/slatedb-dst/src/dst.rs
+++ b/slatedb-dst/src/dst.rs
@@ -318,9 +318,9 @@ impl DefaultDstDistribution {
     }
 
     /// Generates an advance time action. The duration is sampled using a log-uniform
-    /// distribution. The range is hard coded as 1..10_000_000 (1ms to 10 seconds).
+    /// distribution. The range is hard coded as 1..10_000_000 (1ms to 100 seconds).
     fn sample_advance_time(&self) -> DstAction {
-        let sleep_micros = self.sample_log10_uniform(1..10_000_000).into();
+        let sleep_micros = self.sample_log10_uniform(1..100_000_000).into();
         DstAction::AdvanceTime(Duration::from_micros(sleep_micros))
     }
 

--- a/slatedb-dst/src/lib.rs
+++ b/slatedb-dst/src/lib.rs
@@ -2,9 +2,9 @@
 
 mod dst;
 mod error;
+pub mod object_store;
 mod state;
 pub mod utils;
-pub mod object_store;
 
 #[allow(unused_imports)]
 pub use dst::{

--- a/slatedb-dst/src/lib.rs
+++ b/slatedb-dst/src/lib.rs
@@ -4,6 +4,7 @@ mod dst;
 mod error;
 mod state;
 pub mod utils;
+pub mod object_store;
 
 #[allow(unused_imports)]
 pub use dst::{

--- a/slatedb-dst/src/object_store.rs
+++ b/slatedb-dst/src/object_store.rs
@@ -1,0 +1,431 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, RwLock};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+};
+use slatedb::clock::SystemClock;
+
+#[derive(Debug, Clone)]
+struct FileTimes {
+    created: DateTime<Utc>,
+    modified: DateTime<Utc>,
+}
+
+/// ObjectStore wrapper that overrides metadata times using a provided SystemClock.
+/// - Records timestamps for mutating operations (put, copy, rename, delete).
+/// - Uses recorded timestamps for `last_modified` in ObjectMeta returned by `head` and `list`.
+#[derive(Clone)]
+pub struct ClockedObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    clock: Arc<dyn SystemClock>,
+    times: Arc<RwLock<HashMap<Path, FileTimes>>>,
+}
+
+impl ClockedObjectStore {
+    pub fn new(inner: Arc<dyn ObjectStore>, clock: Arc<dyn SystemClock>) -> Self {
+        Self {
+            inner,
+            clock,
+            times: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Record a modification for the given path. If the path doesn't exist in the map,
+    /// initialize both created and modified to now().
+    fn record_modified(&self, path: &Path) -> DateTime<Utc> {
+        let now = self.clock.now();
+        let mut guard = self
+            .times
+            .write()
+            .expect("ClockedObjectStore.times poisoned");
+        guard
+            .entry(path.clone())
+            .and_modify(|t| t.modified = now)
+            .or_insert_with(|| FileTimes {
+                created: now,
+                modified: now,
+            });
+        now
+    }
+
+    /// Record a creation for the given path. If the path already exists in the map,
+    /// leaves created unchanged and updates modified to now().
+    fn record_created(&self, path: &Path) -> DateTime<Utc> {
+        self.record_modified(path)
+    }
+
+    /// Remove any tracked times for this path (after a successful delete or rename).
+    fn remove(&self, path: &Path) {
+        let mut guard = self
+            .times
+            .write()
+            .expect("ClockedObjectStore.times poisoned");
+        guard.remove(path);
+    }
+
+    /// Apply recorded last_modified to ObjectMeta if available.
+    fn with_recorded_times(&self, meta: ObjectMeta) -> ObjectMeta {
+        if let Ok(guard) = self.times.read() {
+            if let Some(t) = guard.get(&meta.location) {
+                return ObjectMeta {
+                    last_modified: t.modified,
+                    ..meta
+                };
+            }
+        }
+        meta
+    }
+}
+
+impl fmt::Debug for ClockedObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ClockedObjectStore({})", self.inner)
+    }
+}
+
+impl fmt::Display for ClockedObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ClockedObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ClockedObjectStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        let meta = self.inner.head(location).await?;
+        Ok(self.with_recorded_times(meta))
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        let res = self.inner.put_opts(location, payload, opts).await?;
+        // Record a modification timestamp; initializes created on first observation
+        self.record_modified(location);
+        Ok(res)
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        // Delegate directly; times will be recorded if caller completes via put_opts path elsewhere.
+        // If multipart is used, last_modified won't be tracked unless a following copy/rename occurs.
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        self.inner.delete(location).await?;
+        self.remove(location);
+        Ok(())
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        let times = self.times.clone();
+        self.inner
+            .list(prefix)
+            .map(move |res| match res {
+                Ok(meta) => {
+                    if let Ok(guard) = times.read() {
+                        if let Some(t) = guard.get(&meta.location) {
+                            return Ok(ObjectMeta {
+                                last_modified: t.modified,
+                                ..meta
+                            });
+                        }
+                    }
+                    Ok(meta)
+                }
+                Err(e) => Err(e),
+            })
+            .boxed()
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        let times = self.times.clone();
+        self.inner
+            .list_with_offset(prefix, offset)
+            .map(move |res| match res {
+                Ok(meta) => {
+                    if let Ok(guard) = times.read() {
+                        if let Some(t) = guard.get(&meta.location) {
+                            return Ok(ObjectMeta {
+                                last_modified: t.modified,
+                                ..meta
+                            });
+                        }
+                    }
+                    Ok(meta)
+                }
+                Err(e) => Err(e),
+            })
+            .boxed()
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        let mut result = self.inner.list_with_delimiter(prefix).await?;
+        // Map times for each object
+        let guard = self
+            .times
+            .read()
+            .expect("ClockedObjectStore.times poisoned");
+        result.objects = result
+            .objects
+            .into_iter()
+            .map(|meta| {
+                if let Some(t) = guard.get(&meta.location) {
+                    ObjectMeta {
+                        last_modified: t.modified,
+                        ..meta
+                    }
+                } else {
+                    meta
+                }
+            })
+            .collect();
+        Ok(result)
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy(from, to).await?;
+        self.record_created(to);
+        Ok(())
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.rename(from, to).await?;
+        self.remove(from);
+        self.record_created(to);
+        Ok(())
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await?;
+        self.record_created(to);
+        Ok(())
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.rename_if_not_exists(from, to).await?;
+        self.remove(from);
+        self.record_created(to);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::TryStreamExt;
+    use object_store::memory::InMemory;
+    use object_store::PutPayload;
+    use slatedb::clock::MockSystemClock;
+
+    fn p(s: &str) -> Path {
+        Path::from(s)
+    }
+
+    #[tokio::test]
+    async fn test_put_and_head_use_clock_time() {
+        let clock = Arc::new(MockSystemClock::new());
+        clock.set(1_234);
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        let path = p("foo");
+        store
+            .put(&path, PutPayload::from(b"data".as_slice()))
+            .await
+            .unwrap();
+
+        let meta = store.head(&path).await.unwrap();
+        assert_eq!(meta.last_modified.timestamp_millis(), 1_234);
+    }
+
+    #[tokio::test]
+    async fn test_list_overrides_times() {
+        let clock = Arc::new(MockSystemClock::new());
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        clock.set(1_000);
+        store
+            .put(&p("a"), PutPayload::from(b"a".as_slice()))
+            .await
+            .unwrap();
+
+        clock.set(2_000);
+        store
+            .put(&p("b"), PutPayload::from(b"b".as_slice()))
+            .await
+            .unwrap();
+
+        let items: Vec<_> = store
+            .list(None)
+            .try_collect()
+            .await
+            .expect("listing should succeed");
+
+        let mut map = std::collections::HashMap::new();
+        for m in items {
+            map.insert(m.location.to_string(), m.last_modified.timestamp_millis());
+        }
+        assert_eq!(map.get("a"), Some(&1_000));
+        assert_eq!(map.get("b"), Some(&2_000));
+    }
+
+    #[tokio::test]
+    async fn test_delete_removes_entry() {
+        let clock = Arc::new(MockSystemClock::new());
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        clock.set(3_000);
+        let path = p("todel");
+        store
+            .put(&path, PutPayload::from(b"x".as_slice()))
+            .await
+            .unwrap();
+        let meta = store.head(&path).await.unwrap();
+        assert_eq!(meta.last_modified.timestamp_millis(), 3_000);
+
+        store.delete(&path).await.unwrap();
+        let head_res = store.head(&path).await;
+        assert!(head_res.is_err(), "deleted object should not have head");
+    }
+
+    #[tokio::test]
+    async fn test_rename_updates_target_and_removes_source() {
+        let clock = Arc::new(MockSystemClock::new());
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        clock.set(4_000);
+        store
+            .put(&p("src"), PutPayload::from(b"x".as_slice()))
+            .await
+            .unwrap();
+        let meta = store.head(&p("src")).await.unwrap();
+        assert_eq!(meta.last_modified.timestamp_millis(), 4_000);
+
+        clock.set(5_000);
+        store.rename(&p("src"), &p("dst")).await.unwrap();
+
+        // Source should be gone
+        assert!(store.head(&p("src")).await.is_err());
+        // Dest should have new timestamp
+        let meta = store.head(&p("dst")).await.unwrap();
+        assert_eq!(meta.last_modified.timestamp_millis(), 5_000);
+    }
+
+    #[tokio::test]
+    async fn test_copy_updates_target_time() {
+        let clock = Arc::new(MockSystemClock::new());
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        clock.set(6_000);
+        store
+            .put(&p("a"), PutPayload::from(b"x".as_slice()))
+            .await
+            .unwrap();
+        let meta = store.head(&p("a")).await.unwrap();
+        assert_eq!(meta.last_modified.timestamp_millis(), 6_000);
+
+        clock.set(7_000);
+        store.copy(&p("a"), &p("b")).await.unwrap();
+        let meta_b = store.head(&p("b")).await.unwrap();
+        assert_eq!(meta_b.last_modified.timestamp_millis(), 7_000);
+    }
+
+    #[tokio::test]
+    async fn test_list_with_delimiter_overrides_times() {
+        let clock = Arc::new(MockSystemClock::new());
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        clock.set(8_000);
+        store
+            .put(&p("dir/a"), PutPayload::from(b"x".as_slice()))
+            .await
+            .unwrap();
+        clock.set(9_000);
+        store
+            .put(&p("dir/b"), PutPayload::from(b"y".as_slice()))
+            .await
+            .unwrap();
+
+        let res = store
+            .list_with_delimiter(Some(&p("dir/")))
+            .await
+            .expect("list_with_delimiter should succeed");
+        assert_eq!(res.common_prefixes.len(), 0);
+        let mut map = std::collections::HashMap::new();
+        for m in res.objects {
+            map.insert(m.location.to_string(), m.last_modified.timestamp_millis());
+        }
+        assert_eq!(map.get("dir/a"), Some(&8_000));
+        assert_eq!(map.get("dir/b"), Some(&9_000));
+    }
+
+    #[tokio::test]
+    async fn test_list_with_offset_overrides_times() {
+        let clock = Arc::new(MockSystemClock::new());
+        let inner = Arc::new(InMemory::new());
+        let store = ClockedObjectStore::new(inner, clock.clone());
+
+        clock.set(10_000);
+        store
+            .put(&p("a"), PutPayload::from(b"x".as_slice()))
+            .await
+            .unwrap();
+        clock.set(11_000);
+        store
+            .put(&p("b"), PutPayload::from(b"y".as_slice()))
+            .await
+            .unwrap();
+
+        let items: Vec<_> = store
+            .list_with_offset(None, &p("a"))
+            .try_collect()
+            .await
+            .expect("list_with_offset should succeed");
+        // Should include at least "b" with its timestamp
+        let mut map = std::collections::HashMap::new();
+        for m in items {
+            map.insert(m.location.to_string(), m.last_modified.timestamp_millis());
+        }
+        assert_eq!(map.get("b"), Some(&11_000));
+    }
+}

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -1,6 +1,6 @@
 //! This module contains helper functions to simplify deterministic simulation (DST).
 
-use log::{error, warn};
+use log::{info, error};
 use rand::Rng;
 use slatedb::clock::LogicalClock;
 use slatedb::clock::SystemClock;
@@ -189,7 +189,7 @@ pub async fn run_simulation(
     dst_opts: DstOptions,
 ) -> Result<(), Error> {
     let seed = rand.seed();
-    warn!("running simulation [seed={}]", seed);
+    info!("running simulation [seed={}]", seed);
     let mut dst = build_dst(
         object_store,
         system_clock.clone(),

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -124,18 +124,15 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
         compression_codec,
         garbage_collector_options: Some(GarbageCollectorOptions {
             manifest_options: Some(GarbageCollectorDirectoryOptions {
-                min_age: Duration::from_secs(60),
-                interval: Some(Duration::from_secs(60)),
+                min_age: Duration::from_secs(300),
                 ..Default::default()
             }),
             wal_options: Some(GarbageCollectorDirectoryOptions {
-                min_age: Duration::from_secs(60),
-                interval: Some(Duration::from_secs(60)),
+                min_age: Duration::from_secs(300),
                 ..Default::default()
             }),
             compacted_options: Some(GarbageCollectorDirectoryOptions {
-                min_age: Duration::from_secs(60),
-                interval: Some(Duration::from_secs(60)),
+                min_age: Duration::from_secs(3600),
                 ..Default::default()
             }),
         }),

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -124,15 +124,18 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
         compression_codec,
         garbage_collector_options: Some(GarbageCollectorOptions {
             manifest_options: Some(GarbageCollectorDirectoryOptions {
-                min_age: Duration::from_secs(300),
+                min_age: Duration::from_secs(60),
+                interval: Some(Duration::from_secs(60)),
                 ..Default::default()
             }),
             wal_options: Some(GarbageCollectorDirectoryOptions {
-                min_age: Duration::from_secs(300),
+                min_age: Duration::from_secs(60),
+                interval: Some(Duration::from_secs(60)),
                 ..Default::default()
             }),
             compacted_options: Some(GarbageCollectorDirectoryOptions {
-                min_age: Duration::from_secs(3600),
+                min_age: Duration::from_secs(60),
+                interval: Some(Duration::from_secs(60)),
                 ..Default::default()
             }),
         }),

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -1,6 +1,6 @@
 //! This module contains helper functions to simplify deterministic simulation (DST).
 
-use log::{info, error};
+use log::{error, info};
 use rand::Rng;
 use slatedb::clock::LogicalClock;
 use slatedb::clock::SystemClock;
@@ -25,6 +25,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
 use crate::dst::DstDuration;
+use crate::object_store::ClockedObjectStore;
 use crate::DefaultDstDistribution;
 use crate::Dst;
 use crate::DstOptions;
@@ -78,6 +79,7 @@ pub async fn build_db(
     logical_clock: Arc<dyn LogicalClock>,
     rand: &DbRand,
 ) -> Db {
+    let object_store = Arc::new(ClockedObjectStore::new(object_store, system_clock.clone()));
     let settings = build_settings(rand).await;
     let compaction_scheduler_supplier = build_compaction_scheduler_supplier(rand, &settings).await;
     let mut builder = DbBuilder::new("test_db", object_store);

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -198,7 +198,7 @@ fn test_dst_nightly() -> Result<(), Error> {
             let runtime = build_runtime(rand.seed());
             let system_clock = Arc::new(MockSystemClock::new());
             let logical_clock = Arc::new(MockLogicalClock::new());
-            let duration = DstDuration::WallClock(std::time::Duration::from_secs(720)); // 12 minutes
+            let duration = DstDuration::WallClock(std::time::Duration::from_secs(900)); // 15 minutes
             runtime.block_on(async move {
                 let span = tracing::info_span!("run_simulation", core = core, seed = seed);
                 let _enter = span.enter();

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -198,7 +198,7 @@ fn test_dst_nightly() -> Result<(), Error> {
             let runtime = build_runtime(rand.seed());
             let system_clock = Arc::new(MockSystemClock::new());
             let logical_clock = Arc::new(MockLogicalClock::new());
-            let duration = DstDuration::WallClock(std::time::Duration::from_secs(720)); // 12 minutes
+            let duration = DstDuration::WallClock(std::time::Duration::from_secs(60)); // 12 minutes
             runtime.block_on(async move {
                 let span = tracing::info_span!("run_simulation", core = core, seed = seed);
                 let _enter = span.enter();

--- a/slatedb-dst/tests/simulation.rs
+++ b/slatedb-dst/tests/simulation.rs
@@ -198,7 +198,7 @@ fn test_dst_nightly() -> Result<(), Error> {
             let runtime = build_runtime(rand.seed());
             let system_clock = Arc::new(MockSystemClock::new());
             let logical_clock = Arc::new(MockLogicalClock::new());
-            let duration = DstDuration::WallClock(std::time::Duration::from_secs(60)); // 12 minutes
+            let duration = DstDuration::WallClock(std::time::Duration::from_secs(720)); // 12 minutes
             runtime.block_on(async move {
                 let span = tracing::info_span!("run_simulation", core = core, seed = seed);
                 let _enter = span.enter();

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -48,6 +48,7 @@ impl Admin {
         let manifest_store = ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.system_clock.clone(),
         );
         let id_manifest = if let Some(id) = maybe_id {
             manifest_store
@@ -72,6 +73,7 @@ impl Admin {
         let manifest_store = ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.system_clock.clone(),
         );
         let manifests = manifest_store.list_manifests(range).await?;
         Ok(serde_json::to_string(&manifests)?)
@@ -82,6 +84,7 @@ impl Admin {
         let manifest_store = ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.system_clock.clone(),
         );
         let (_, manifest) = manifest_store.read_latest_manifest().await?;
         Ok(manifest.core.checkpoints)
@@ -188,6 +191,7 @@ impl Admin {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.system_clock.clone(),
         ));
         manifest_store
             .validate_no_wal_object_store_configured()
@@ -215,6 +219,7 @@ impl Admin {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.system_clock.clone(),
         ));
         let mut stored_manifest = StoredManifest::load(manifest_store).await?;
         stored_manifest
@@ -241,6 +246,7 @@ impl Admin {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.system_clock.clone(),
         ));
         let mut stored_manifest = StoredManifest::load(manifest_store).await?;
         stored_manifest
@@ -309,6 +315,7 @@ impl Admin {
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
             parent_checkpoint,
             Arc::new(FailPointRegistry::new()),
+            self.system_clock.clone(),
             self.rand.clone(),
         )
         .await?;

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -90,7 +90,11 @@ mod tests {
         // open and close the db to init the manifest and trigger another write
         let db = Db::open(path.clone(), object_store.clone()).await.unwrap();
         db.close().await.unwrap();
-        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let manifest_store = ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let (_, before_checkpoint) = manifest_store.read_latest_manifest().await.unwrap();
 
         let CheckpointCreateResult {
@@ -125,7 +129,11 @@ mod tests {
             .await
             .unwrap();
         db.close().await.unwrap();
-        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let manifest_store = ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let checkpoint_time = DefaultSystemClock::default().now();
 
         let CheckpointCreateResult {
@@ -249,7 +257,11 @@ mod tests {
             })
             .await
             .unwrap();
-        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let manifest_store = ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         let checkpoint = manifest
             .core
@@ -315,7 +327,11 @@ mod tests {
 
         admin.delete_checkpoint(id).await.unwrap();
 
-        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let manifest_store = ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         assert!(!manifest.core.checkpoints.iter().any(|c| c.id == id));
     }
@@ -363,7 +379,11 @@ mod tests {
             .await
             .unwrap();
 
-        let manifest_store = ManifestStore::new(&path, object_store.clone());
+        let manifest_store = ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let manifest = manifest_store
             .read_manifest(checkpoint.manifest_id)
             .await

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -1,4 +1,5 @@
 use crate::checkpoint::Checkpoint;
+use crate::clock::SystemClock;
 use crate::config::CheckpointOptions;
 use crate::db_state::{CoreDbState, SsTableId};
 use crate::error::SlateDBError;
@@ -20,6 +21,7 @@ pub(crate) async fn create_clone<P: Into<Path>>(
     object_store: Arc<dyn ObjectStore>,
     parent_checkpoint: Option<Uuid>,
     fp_registry: Arc<FailPointRegistry>,
+    system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
 ) -> Result<(), SlateDBError> {
     let clone_path = clone_path.into();
@@ -29,8 +31,16 @@ pub(crate) async fn create_clone<P: Into<Path>>(
         return Err(SlateDBError::IdenticalClonePaths(parent_path));
     }
 
-    let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-    let parent_manifest_store = Arc::new(ManifestStore::new(&parent_path, object_store.clone()));
+    let clone_manifest_store = Arc::new(ManifestStore::new(
+        &clone_path,
+        object_store.clone(),
+        system_clock.clone(),
+    ));
+    let parent_manifest_store = Arc::new(ManifestStore::new(
+        &parent_path,
+        object_store.clone(),
+        system_clock.clone(),
+    ));
     parent_manifest_store
         .validate_no_wal_object_store_configured()
         .await?;
@@ -41,6 +51,7 @@ pub(crate) async fn create_clone<P: Into<Path>>(
         parent_path.to_string(),
         parent_checkpoint,
         object_store.clone(),
+        system_clock.clone(),
         rand,
         fp_registry.clone(),
     )
@@ -70,6 +81,7 @@ async fn create_clone_manifest(
     parent_path: String,
     parent_checkpoint_id: Option<Uuid>,
     object_store: Arc<dyn ObjectStore>,
+    system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
     #[allow(unused)] fp_registry: Arc<FailPointRegistry>,
 ) -> Result<StoredManifest, SlateDBError> {
@@ -85,6 +97,7 @@ async fn create_clone_manifest(
                 parent_path.clone(),
                 &initialized_clone_manifest,
                 object_store.clone(),
+                system_clock.clone(),
             )
             .await?;
             return Ok(initialized_clone_manifest);
@@ -137,6 +150,7 @@ async fn create_clone_manifest(
             Arc::new(ManifestStore::new(
                 &external_db.path.clone().into(),
                 object_store.clone(),
+                system_clock.clone(),
             ))
         };
         let mut external_db_manifest =
@@ -223,6 +237,7 @@ async fn validate_external_dbs_contain_final_checkpoint(
     parent_path: String,
     clone_manifest: &StoredManifest,
     object_store: Arc<dyn ObjectStore>,
+    system_clock: Arc<dyn SystemClock>,
 ) -> Result<(), SlateDBError> {
     // Validate external dbs all contain the final checkpoint
     for external_db in &clone_manifest.manifest().external_dbs {
@@ -236,6 +251,7 @@ async fn validate_external_dbs_contain_final_checkpoint(
             Arc::new(ManifestStore::new(
                 &external_db.path.clone().into(),
                 object_store.clone(),
+                system_clock.clone(),
             ))
         };
         let external_manifest = external_manifest_store.read_latest_manifest().await?.1;
@@ -298,6 +314,7 @@ async fn copy_wal_ssts(
 
 #[cfg(test)]
 mod tests {
+    use crate::clock::DefaultSystemClock;
     use crate::clone::create_clone;
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
@@ -339,6 +356,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::new(FailPointRegistry::new()),
+            Arc::new(DefaultSystemClock::new()),
             Arc::new(DbRand::default()),
         )
         .await
@@ -403,6 +421,7 @@ mod tests {
             object_store.clone(),
             Some(checkpoint.id),
             Arc::new(FailPointRegistry::new()),
+            Arc::new(DefaultSystemClock::new()),
             Arc::new(DbRand::default()),
         )
         .await
@@ -424,6 +443,7 @@ mod tests {
         let parent_path = Path::from("/tmp/test_parent");
         let clone_path = Path::from("/tmp/test_clone");
         let rand = Arc::new(DbRand::default());
+        let system_clock = Arc::new(DefaultSystemClock::new());
 
         // Create the parent with empty state
         let parent_db = Db::open(parent_path.clone(), object_store.clone())
@@ -432,7 +452,11 @@ mod tests {
         parent_db.close().await.unwrap();
 
         // Create an uninitialized manifest with an invalid checkpoint id
-        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_manifest_store = Arc::new(ManifestStore::new(
+            &clone_path,
+            object_store.clone(),
+            system_clock.clone(),
+        ));
         let non_existent_source_checkpoint_id = uuid::Uuid::new_v4();
         StoredManifest::create_uninitialized_clone(
             clone_manifest_store,
@@ -451,6 +475,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -467,10 +492,14 @@ mod tests {
         let parent_path = Path::from("/tmp/test_parent");
         let clone_path = Path::from("/tmp/test_clone");
         let rand = Arc::new(DbRand::default());
+        let system_clock = Arc::new(DefaultSystemClock::new());
 
         // Create the parent with empty state
-        let parent_manifest_store =
-            Arc::new(ManifestStore::new(&parent_path, object_store.clone()));
+        let parent_manifest_store = Arc::new(ManifestStore::new(
+            &parent_path,
+            object_store.clone(),
+            system_clock.clone(),
+        ));
         let mut parent_sm =
             StoredManifest::create_new_db(parent_manifest_store, CoreDbState::new())
                 .await
@@ -487,7 +516,11 @@ mod tests {
             .unwrap();
 
         // Create an uninitialized manifest referring to the first checkpoint
-        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_manifest_store = Arc::new(ManifestStore::new(
+            &clone_path,
+            object_store.clone(),
+            system_clock.clone(),
+        ));
         StoredManifest::create_uninitialized_clone(
             clone_manifest_store,
             &Manifest::initial(CoreDbState::new()),
@@ -505,6 +538,7 @@ mod tests {
             object_store.clone(),
             Some(checkpoint_2.id),
             Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -523,10 +557,15 @@ mod tests {
         let updated_parent_path = Path::from("/tmp/test_parent/new");
         let clone_path = Path::from("/tmp/test_clone");
         let rand = Arc::new(DbRand::default());
+        let system_clock = Arc::new(DefaultSystemClock::new());
 
         // Setup an uninitialized manifest pointing to a different parent
         let parent_manifest = Manifest::initial(CoreDbState::new());
-        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_manifest_store = Arc::new(ManifestStore::new(
+            &clone_path,
+            object_store.clone(),
+            system_clock.clone(),
+        ));
         StoredManifest::create_uninitialized_clone(
             Arc::clone(&clone_manifest_store),
             &parent_manifest,
@@ -550,6 +589,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -567,6 +607,7 @@ mod tests {
         let parent_path = "/tmp/test_parent";
         let clone_path = "/tmp/test_clone";
         let rand = Arc::new(DbRand::default());
+        let system_clock = Arc::new(DefaultSystemClock::new());
 
         let parent_db = Db::open(parent_path, object_store.clone()).await.unwrap();
         parent_db.close().await.unwrap();
@@ -577,13 +618,17 @@ mod tests {
             object_store.clone(),
             None,
             Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
         .unwrap();
 
-        let clone_manifest_store =
-            ManifestStore::new(&Path::from(clone_path), object_store.clone());
+        let clone_manifest_store = ManifestStore::new(
+            &Path::from(clone_path),
+            object_store.clone(),
+            system_clock.clone(),
+        );
         let (manifest_id, _) = clone_manifest_store.read_latest_manifest().await.unwrap();
 
         create_clone(
@@ -592,6 +637,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
             rand.clone(),
         )
         .await?;
@@ -611,6 +657,7 @@ mod tests {
         let parent_path = Path::from("/tmp/test_parent");
         let clone_path = Path::from("/tmp/test_clone");
         let rand = Arc::new(DbRand::default());
+        let system_clock = Arc::new(DefaultSystemClock::new());
 
         let parent_db = Db::open(parent_path.clone(), object_store.clone())
             .await
@@ -640,6 +687,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::clone(&fp_registry),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -653,6 +701,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::clone(&fp_registry),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -666,6 +715,7 @@ mod tests {
         let parent_path = Path::from("/tmp/test_parent");
         let clone_path = Path::from("/tmp/test_clone");
         let rand = Arc::new(DbRand::default());
+        let system_clock = Arc::new(DefaultSystemClock::new());
 
         let parent_db = Db::open(parent_path.clone(), object_store.clone()).await?;
         let mut rng = rng::new_test_rng(None);
@@ -688,6 +738,7 @@ mod tests {
             object_store.clone(),
             Some(checkpoint.id),
             Arc::clone(&fp_registry),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -702,8 +753,11 @@ mod tests {
         .unwrap();
 
         // Delete the checkpoint from the parent database
-        let parent_manifest_store =
-            Arc::new(ManifestStore::new(&parent_path, object_store.clone()));
+        let parent_manifest_store = Arc::new(ManifestStore::new(
+            &parent_path,
+            object_store.clone(),
+            system_clock.clone(),
+        ));
         let mut parent_manifest = StoredManifest::load(parent_manifest_store).await?;
         parent_manifest.delete_checkpoint(checkpoint.id).await?;
 
@@ -714,6 +768,7 @@ mod tests {
             object_store.clone(),
             Some(checkpoint.id),
             Arc::clone(&fp_registry),
+            system_clock.clone(),
             rand.clone(),
         )
         .await
@@ -743,6 +798,7 @@ mod tests {
             object_store.clone(),
             None,
             Arc::new(FailPointRegistry::new()),
+            Arc::new(DefaultSystemClock::new()),
             Arc::new(DbRand::default()),
         )
         .await;

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -324,11 +324,15 @@ impl CompactionExecuteBench {
             table_store.clone(),
             self.rand.clone(),
             stats.clone(),
-            Arc::new(DefaultSystemClock::new()),
+            self.system_clock.clone(),
         );
         let os = self.object_store.clone();
         info!("load compaction job");
-        let manifest_store = Arc::new(ManifestStore::new(&self.path, os.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &self.path,
+            os.clone(),
+            self.system_clock.clone(),
+        ));
         let manifest = StoredManifest::load(manifest_store).await?;
 
         let job = match &compaction {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1222,7 +1222,11 @@ mod tests {
             min_filter_keys: 10,
             ..SsTableFormat::default()
         };
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(PATH),
+            os.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             sst_format,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -90,7 +90,8 @@ impl CompactionProgressTracker {
         for entry in self.processed_bytes.iter() {
             let id = entry.key();
             let (processed_bytes, total_bytes) = entry.value();
-            let percentage = (processed_bytes * 100 / total_bytes) as u32;
+            // max() to avoid division by zero
+            let percentage = (processed_bytes * 100 / (total_bytes.max(&1))) as u32;
             debug!(
                 "compaction progress [id={}, current_percentage={}%, processed_bytes={}, estimated_total_bytes={}]",
                 id,

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -814,7 +814,11 @@ mod tests {
                 .unwrap();
         }
         tokio_handle.block_on(db.close()).unwrap();
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(PATH),
+            os.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let stored_manifest = tokio_handle
             .block_on(StoredManifest::load(manifest_store))
             .unwrap();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2373,7 +2373,11 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let mut stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
         let write_options = WriteOptions {
             await_durable: false,
@@ -2441,8 +2445,12 @@ mod tests {
             .build()
             .await
             .unwrap();
-
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let clock = Arc::new(DefaultSystemClock::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            clock.clone(),
+        ));
         let mut stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
         let sst_format = SsTableFormat {
             min_filter_keys: 10,
@@ -2519,7 +2527,11 @@ mod tests {
             .await
             .unwrap();
 
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let mut stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
         let sst_format = SsTableFormat {
             min_filter_keys: 10,
@@ -2993,7 +3005,11 @@ mod tests {
         kv_store_restored.close().await.unwrap();
 
         // validate that the manifest file exists.
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let stored_manifest = StoredManifest::load(manifest_store).await.unwrap();
         let db_state = stored_manifest.db_state();
         assert_eq!(db_state.next_wal_sst_id, next_wal_id);
@@ -3398,7 +3414,11 @@ mod tests {
         // on close().
         db.close().await.unwrap();
 
-        let manifest_store = ManifestStore::new(&Path::from(path), object_store.clone());
+        let manifest_store = ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
@@ -3429,7 +3449,11 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let ms = ManifestStore::new(&Path::from(path), object_store.clone());
+        let ms = ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        );
         let mut sm = StoredManifest::load(Arc::new(ms)).await.unwrap();
 
         // write enough to fill up a few l0 SSTs
@@ -3739,7 +3763,11 @@ mod tests {
 
         // check the last_l0_clock_tick persisted in the manifest, it should be
         // i64::MIN because no WAL SST has yet made its way into L0
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let stored_manifest = StoredManifest::load(manifest_store).await.unwrap();
         let db_state = stored_manifest.db_state();
         let last_clock_tick = db_state.last_l0_clock_tick;
@@ -3786,7 +3814,11 @@ mod tests {
 
         // check the last_clock_tick persisted in the manifest, it should be
         // i64::MIN because no WAL SST has yet made its way into L0
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let stored_manifest = StoredManifest::load(manifest_store).await.unwrap();
         let db_state = stored_manifest.db_state();
         let last_clock_tick = db_state.last_l0_clock_tick;
@@ -3944,7 +3976,11 @@ mod tests {
         db1.put(b"k", b"v").await.unwrap();
 
         // Fence the db by opening a new one
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(path),
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let stored_manifest = StoredManifest::load(manifest_store.clone()).await.unwrap();
         FenceableManifest::init_writer(
             stored_manifest,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -370,9 +370,10 @@ impl<P: Into<Path>> DbBuilder<P> {
         };
 
         // Setup the manifest store and load latest manifest
-        let manifest_store = Arc::new(ManifestStore::new(
+        let manifest_store = Arc::new(ManifestStore::new_with_clock(
             &path,
             maybe_cached_main_object_store.clone(),
+            system_clock.clone(),
         ));
         let latest_manifest = StoredManifest::try_load(manifest_store.clone()).await?;
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -370,7 +370,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         };
 
         // Setup the manifest store and load latest manifest
-        let manifest_store = Arc::new(ManifestStore::new_with_clock(
+        let manifest_store = Arc::new(ManifestStore::new(
             &path,
             maybe_cached_main_object_store.clone(),
             system_clock.clone(),
@@ -689,7 +689,11 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
     /// Builds and returns a GarbageCollector instance.
     pub fn build(self) -> GarbageCollector {
         let path: Path = self.path.into();
-        let manifest_store = Arc::new(ManifestStore::new(&path, self.main_object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            self.main_object_store.clone(),
+            self.system_clock.clone(),
+        ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(
                 self.main_object_store.clone(),
@@ -790,7 +794,11 @@ impl<P: Into<Path>> CompactorBuilder<P> {
     /// Builds and returns a Compactor instance.
     pub fn build(self) -> Compactor {
         let path: Path = self.path.into();
-        let manifest_store = Arc::new(ManifestStore::new(&path, self.main_object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            self.main_object_store.clone(),
+            self.system_clock.clone(),
+        ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(self.main_object_store.clone(), None),
             SsTableFormat::default(), // read only SSTs can use default

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -532,10 +532,12 @@ impl DbReader {
         options: DbReaderOptions,
     ) -> Result<Self, crate::Error> {
         let path = path.into();
+        let clock = Arc::new(DefaultSystemClock::default());
         let store_provider = DefaultStoreProvider {
             path,
             object_store,
             block_cache: options.block_cache.clone(),
+            system_clock: clock.clone(),
         };
 
         Self::open_internal(
@@ -543,7 +545,7 @@ impl DbReader {
             checkpoint_id,
             options,
             Arc::new(DefaultLogicalClock::default()),
-            Arc::new(DefaultSystemClock::default()),
+            clock,
             Arc::new(DbRand::default()),
         )
         .await
@@ -1253,7 +1255,7 @@ mod tests {
         }
 
         fn manifest_store(&self) -> Arc<ManifestStore> {
-            Arc::new(ManifestStore::new_with_clock(
+            Arc::new(ManifestStore::new(
                 &self.path,
                 Arc::clone(&self.object_store),
                 self.system_clock.clone(),

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -920,7 +920,11 @@ mod tests {
                 .with_automatic_cleanup(true),
         );
         let path = Path::from("/");
-        let manifest_store = Arc::new(ManifestStore::new(&path, local_object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            local_object_store.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let sst_format = SsTableFormat::default();
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(local_object_store.clone(), None),

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -219,6 +219,7 @@ impl Manifest {
 #[cfg(test)]
 mod tests {
     use crate::bytes_range::BytesRange;
+    use crate::clock::DefaultSystemClock;
     use crate::manifest::store::{ManifestStore, StoredManifest};
 
     use crate::config::CheckpointOptions;
@@ -241,8 +242,11 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
 
         let parent_path = Path::from("/tmp/test_parent");
-        let parent_manifest_store =
-            Arc::new(ManifestStore::new(&parent_path, object_store.clone()));
+        let parent_manifest_store = Arc::new(ManifestStore::new(
+            &parent_path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::default()),
+        ));
         let mut parent_manifest =
             StoredManifest::create_new_db(parent_manifest_store, CoreDbState::new())
                 .await
@@ -253,7 +257,11 @@ mod tests {
             .unwrap();
 
         let clone_path = Path::from("/tmp/test_clone");
-        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_manifest_store = Arc::new(ManifestStore::new(
+            &clone_path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::default()),
+        ));
         let clone_stored_manifest = StoredManifest::create_uninitialized_clone(
             Arc::clone(&clone_manifest_store),
             parent_manifest.manifest(),
@@ -294,7 +302,11 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
 
         let path = Path::from("/tmp/test_db");
-        let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            object_store.clone(),
+            Arc::new(DefaultSystemClock::default()),
+        ));
         let mut manifest =
             StoredManifest::create_new_db(Arc::clone(&manifest_store), CoreDbState::new())
                 .await

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1,5 +1,5 @@
 use crate::checkpoint::Checkpoint;
-use crate::clock::{DefaultSystemClock, SystemClock};
+use crate::clock::SystemClock;
 use crate::config::CheckpointOptions;
 use crate::db_state::CoreDbState;
 use crate::error::SlateDBError;
@@ -552,15 +552,7 @@ pub(crate) struct ManifestStore {
 }
 
 impl ManifestStore {
-    pub(crate) fn new(root_path: &Path, object_store: Arc<dyn ObjectStore>) -> Self {
-        Self::new_with_clock(
-            root_path,
-            object_store,
-            Arc::new(DefaultSystemClock::default()),
-        )
-    }
-
-    pub(crate) fn new_with_clock(
+    pub(crate) fn new(
         root_path: &Path,
         object_store: Arc<dyn ObjectStore>,
         clock: Arc<dyn SystemClock>,
@@ -1014,7 +1006,11 @@ mod tests {
     async fn test_should_read_specific_manifest() {
         // Given
         let os = Arc::new(InMemory::new());
-        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let ms = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            os.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
         let state = CoreDbState::new();
         let mut sm = StoredManifest::create_new_db(ms.clone(), state.clone())
             .await
@@ -1036,7 +1032,11 @@ mod tests {
         // Given a flaky store that times out on the first write
         let base = Arc::new(InMemory::new());
         let flaky = Arc::new(FlakyObjectStore::new(base.clone(), 1));
-        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), flaky.clone()));
+        let ms = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            flaky.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ));
 
         // When creating a new DB (initial manifest write under retry)
         let core = CoreDbState::new();
@@ -1119,7 +1119,11 @@ mod tests {
 
     fn new_memory_manifest_store() -> Arc<ManifestStore> {
         let os = Arc::new(InMemory::new());
-        Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()))
+        Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            os.clone(),
+            Arc::new(DefaultSystemClock::new()),
+        ))
     }
 
     fn new_checkpoint(manifest_id: u64) -> Checkpoint {
@@ -1355,7 +1359,11 @@ mod tests {
     #[tokio::test]
     async fn test_should_cretry_epoch_bump_if_manifest_version_exists() {
         let os = Arc::new(InMemory::new());
-        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()));
+        let ms = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            os.clone(),
+            Arc::new(DefaultSystemClock::default()),
+        ));
         let state = CoreDbState::new();
 
         // Mimic two writers A and B that try to bump the epoch at the same time

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,3 +1,4 @@
+use crate::clock::SystemClock;
 use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
 use crate::object_stores::ObjectStores;
@@ -16,6 +17,7 @@ pub(crate) struct DefaultStoreProvider {
     pub(crate) path: Path,
     pub(crate) object_store: Arc<dyn ObjectStore>,
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
+    pub(crate) system_clock: Arc<dyn SystemClock>,
 }
 
 impl StoreProvider for DefaultStoreProvider {
@@ -32,6 +34,7 @@ impl StoreProvider for DefaultStoreProvider {
         Arc::new(ManifestStore::new(
             &self.path,
             Arc::clone(&self.object_store),
+            Arc::clone(&self.system_clock),
         ))
     }
 }


### PR DESCRIPTION
This PR adds `ClockedObjectStore`, which allows the DST to use its `SystemClock` for `last_modified` metadata in the object store. This change allows the garbage collector to see timestamps from the object store that are relative to the mocked DST rather than the actual machine clock. This change was largely vibe coded. I took a pass on it and made a few tweaks; let me know if you spot anything odd.

While testing, I also noticed:

1. We have a divide-by-zero error in the compactor stat logging line.
2. We were not using the system clock when...
   1. making ManifestStore in `builder.rs`,
   2. creating `DbReaders`,
   3. and creating `Checkpoint`s.

I fixed these issues in this PR. All tests pass and the DST now hovers at around 5-6GiB rather than the 50GiB+ it was previously accruing in a few minutes of execution.

Fixes #861
Fixes #754
