### PR TITLE
Separate website release into job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,5 +97,12 @@ jobs:
             git push origin "${TAG}"
           fi
 
-      - name: Publish website
-        uses: ./.github/workflows/release-website.yaml
+  website:
+    name: Deploy website
+    needs: release
+    uses: ./.github/workflows/release-website.yaml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    secrets: inherit


### PR DESCRIPTION
The `release.yaml` workflow is failing with:

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/slatedb/slatedb/.github/workflows/release-website.yaml'. Did you forget to run actions/checkout before running your local action?
```

Apparently, we need to run the release-website.yaml as a job rather than an action. I've done so in this PR.