### PR TITLE
modify seq_tracker implementation to match RFC-12

### DIFF
--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -1,10 +1,17 @@
-use std::cmp;
-
 use chrono::{DateTime, Utc};
 use serde::de::{self};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::utils::{sign_extend, BitReader, BitWriter};
+
+/// Default capacity for the sequence tracker (8192 entries)
+const DEFAULT_CAPACITY: u32 = 8192;
+
+/// Default reporting interval in seconds (60 seconds)
+const DEFAULT_INTERVAL_SECS: u64 = 60;
+
+/// Version number for the serialization format
+const SERIALIZATION_VERSION: u8 = 1;
 
 #[derive(PartialEq, Clone, Copy)]
 pub(crate) struct TrackedSeq {
@@ -22,204 +29,243 @@ pub(crate) enum FindOption {
     RoundDown,
 }
 
-/// Tracks sequence number ↔ timestamp relationships with bounded memory using tiered storage.
+/// Tracks sequence number ↔ timestamp relationships with bounded memory.
 ///
-/// Uses a multi-tiered approach where each tier stores data at different resolutions (step sizes).
-/// When a tier reaches capacity, it downsamples by doubling the step size and keeping every other
-/// timestamp. This maintains bounded memory while preserving recent data at higher resolution.
-///
-/// Timestamps are compressed using Gorilla encoding (delta-of-deltas) for efficient storage.
-/// Supports bidirectional queries with rounding options for approximate matches.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub(crate) struct TieredSequenceTracker {
-    /// The data, tiered by step size where the step size
-    /// indicates the granularity at which the sequence
-    /// numbers are tracked. The tiers are ordered by the
-    /// granularity (i.e. `tiers[0]` has the lowest step)
-    pub(crate) tiers: Vec<Tier>,
+/// Uses two sorted arrays for bi-directional lookup between sequence numbers and timestamps.
+/// When capacity is reached, downsamples by removing every other entry to maintain bounded memory.
+/// Data is compressed using Gorilla encoding (delta-of-deltas) for efficient storage.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SequenceTracker {
+    /// Sorted array of sequence numbers
+    sequence_numbers: Vec<u64>,
+    /// Sorted array of timestamps (as Unix timestamps)
+    timestamps: Vec<i64>,
+    /// Maximum number of entries to store
+    capacity: u32,
+    /// Interval in seconds at which to record timestamps
+    interval_secs: u64,
+    /// Last recorded timestamp to enforce interval
+    last_recorded_ts: Option<i64>,
 }
 
 #[allow(dead_code)]
-impl TieredSequenceTracker {
-    pub(crate) fn new(num_tiers: u32, capacity: u32) -> Self {
-        // only support a single tier for now because the
-        // downsampling algorithm for fixed size multi-tiered
-        // sequence tracking is a little more complicated, but
-        // we model it with multiple tiers so that the serialization
-        // format will be compatible with a multi-tiered tracker
-        assert!(num_tiers == 1, "todo! implement multi-tiers");
-
-        let tier_capacity = capacity / num_tiers;
-        let tiers = (0..num_tiers)
-            .map(|i| Tier::new(1 << i, tier_capacity))
-            .collect();
-
-        Self { tiers }
+impl SequenceTracker {
+    /// Create a new SequenceTracker with default configuration (60s interval, 8192 capacity)
+    pub(crate) fn new() -> Self {
+        Self::with_config(DEFAULT_CAPACITY, DEFAULT_INTERVAL_SECS)
     }
 
-    pub(crate) fn insert(&mut self, seq: TrackedSeq) {
-        self.tiers[0].insert(seq.seq, seq.ts.timestamp());
-    }
-
-    pub(crate) fn find_ts(&self, seq: u64, find_opt: FindOption) -> Option<DateTime<Utc>> {
-        if let Some(ts) = self.tiers[0].find_ts(seq, find_opt) {
-            DateTime::from_timestamp(ts, 0)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn find_seq(&self, ts: DateTime<Utc>, find_opt: FindOption) -> Option<u64> {
-        self.tiers[0].find_seq(ts.timestamp(), find_opt)
-    }
-}
-
-/// A tier contains a mapping from sequence numbers to
-/// timestamps at a given "resolution", defined by a
-/// step parameter which is how spaced apart the timestamps
-/// are. A tier with step `4` and a start sequence number
-/// of 10, for example, would contain the timestamps for
-/// sequence numbers 10, 14, 16, ... until the capacity
-/// of the tier
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub(crate) struct Tier {
-    /// distance between stored sequence numbers
-    pub(crate) step: u64,
-    /// the first sequence number for which a timestamp is stored
-    pub(crate) first_seq: u64,
-    /// the last sequence number stored in this tier
-    pub(crate) last_seq: u64,
-    /// how many elements can fit in this tier
-    pub(crate) capacity: u32,
-    /// the actual timestamps, the value at `timestamps[i]` is the
-    /// timestamp for the sequence number `first_seq + i * step`
-    #[serde(
-        serialize_with = "serialize_timestamps",
-        deserialize_with = "deserialize_timestamps"
-    )]
-    pub(crate) timestamps: Vec<i64>,
-}
-
-impl Tier {
-    fn new(step: u64, capacity: u32) -> Self {
+    /// Create a new SequenceTracker with custom configuration (used for testing)
+    fn with_config(capacity: u32, interval_secs: u64) -> Self {
         Self {
-            step,
-            first_seq: 0,
-            last_seq: 0,
-            capacity,
+            sequence_numbers: Vec::with_capacity(capacity as usize),
             timestamps: Vec::with_capacity(capacity as usize),
+            capacity,
+            interval_secs,
+            last_recorded_ts: None,
         }
     }
 
-    fn insert(&mut self, seq: u64, ts: i64) {
-        assert!(seq >= self.last_seq);
-        assert!(ts >= *self.timestamps.last().unwrap_or(&ts));
+    /// Insert a new sequence number and timestamp pair
+    pub(crate) fn insert(&mut self, seq: TrackedSeq) {
+        let ts_secs = seq.ts.timestamp();
 
-        if seq % self.step != 0 {
-            return;
+        // Only record if enough time has passed since last recording
+        // Discarding insertions instead of only inserting on a timer
+        // makes it easier to manage concurrency and is a pretty cheap
+        // operation.
+        if let Some(last_ts) = self.last_recorded_ts {
+            if (ts_secs - last_ts) < self.interval_secs as i64 {
+                return;
+            }
         }
 
-        if self.timestamps.is_empty() {
-            self.first_seq = seq;
+        // Ensure monotonic ordering
+        if let Some(last_seq) = self.sequence_numbers.last() {
+            assert!(seq.seq >= *last_seq, "Sequence numbers must be monotonic");
+        }
+        if let Some(last_ts) = self.timestamps.last() {
+            assert!(ts_secs >= *last_ts, "Timestamps must be monotonic");
         }
 
-        self.last_seq = seq;
-        self.timestamps.push(ts);
+        self.sequence_numbers.push(seq.seq);
+        self.timestamps.push(ts_secs);
+        self.last_recorded_ts = Some(ts_secs);
 
-        // if we've exceeded the capacity then downsample the
-        // sequence numbers and double the step size
-        if self.timestamps.len() as u32 > self.capacity {
-            let old = std::mem::take(&mut self.timestamps);
-            let mut downsampled = Vec::with_capacity(self.capacity as usize);
-            for (i, &ts) in old.iter().enumerate() {
-                if i % 2 == 0 {
-                    downsampled.push(ts);
+        // Downsample if we exceed capacity
+        if self.sequence_numbers.len() > self.capacity as usize {
+            self.downsample();
+        }
+    }
+
+    /// Downsample by removing every other entry
+    fn downsample(&mut self) {
+        let mut new_seqs = Vec::with_capacity(self.capacity as usize);
+        let mut new_timestamps = Vec::with_capacity(self.capacity as usize);
+
+        for i in (0..self.sequence_numbers.len()).step_by(2) {
+            new_seqs.push(self.sequence_numbers[i]);
+            new_timestamps.push(self.timestamps[i]);
+        }
+
+        self.sequence_numbers = new_seqs;
+        self.timestamps = new_timestamps;
+    }
+
+    /// Find the timestamp for a given sequence number
+    pub(crate) fn find_ts(&self, seq: u64, find_opt: FindOption) -> Option<DateTime<Utc>> {
+        if self.sequence_numbers.is_empty() {
+            return None;
+        }
+
+        match self.sequence_numbers.binary_search(&seq) {
+            Ok(idx) => DateTime::from_timestamp(self.timestamps[idx], 0),
+            Err(idx) => match find_opt {
+                FindOption::RoundUp if idx < self.sequence_numbers.len() => {
+                    DateTime::from_timestamp(self.timestamps[idx], 0)
                 }
-            }
-            self.timestamps = downsampled;
-            self.step *= 2;
-        }
-    }
-
-    /// finds the timestamp associated with `seq`, rounding up or down
-    /// as specified by the find option if the sequence number does not
-    /// exist in this tier
-    fn find_ts(&self, seq: u64, find_opt: FindOption) -> Option<i64> {
-        let len = (self.timestamps.len()) as u64;
-        let max = self.first_seq + self.step * len;
-
-        if let Some(offset) = match find_opt {
-            FindOption::RoundUp if seq <= self.last_seq => {
-                if seq >= self.first_seq {
-                    Some(cmp::max(0, (seq - self.first_seq) as i64))
-                } else {
-                    Some(0)
+                FindOption::RoundDown if idx > 0 => {
+                    DateTime::from_timestamp(self.timestamps[idx - 1], 0)
                 }
-            }
-            FindOption::RoundDown if seq >= self.first_seq => {
-                Some(cmp::min((seq - self.first_seq) as i64, max as i64))
-            }
-            _ => None,
-        } {
-            let mut idx = offset.div_euclid(self.step as i64);
-            let remainder = offset.rem_euclid(self.step as i64);
-
-            if remainder != 0 && find_opt == FindOption::RoundUp {
-                idx += 1;
-            }
-
-            idx = idx.clamp(0, len as i64 - 1);
-            return Some(self.timestamps[idx as usize]);
+                _ => None,
+            },
         }
-
-        None
     }
 
-    /// finds the sequence number associated with `ts`
-    fn find_seq(&self, ts: i64, find_opt: FindOption) -> Option<u64> {
+    /// Find the sequence number for a given timestamp
+    pub(crate) fn find_seq(&self, ts: DateTime<Utc>, find_opt: FindOption) -> Option<u64> {
+        let ts_secs = ts.timestamp();
+
         if self.timestamps.is_empty() {
             return None;
         }
 
-        match self.timestamps.binary_search(&ts) {
-            Ok(idx) => Some(self.first_seq + (idx as u64) * self.step),
+        match self.timestamps.binary_search(&ts_secs) {
+            Ok(idx) => Some(self.sequence_numbers[idx]),
             Err(idx) => match find_opt {
                 FindOption::RoundUp if idx < self.timestamps.len() => {
-                    Some(self.first_seq + (idx as u64) * self.step)
+                    Some(self.sequence_numbers[idx])
                 }
-                FindOption::RoundDown if idx > 0 => {
-                    Some(self.first_seq + ((idx - 1) as u64) * self.step)
-                }
+                FindOption::RoundDown if idx > 0 => Some(self.sequence_numbers[idx - 1]),
                 _ => None,
             },
         }
     }
 }
 
-/// Custom serialization function for timestamps that uses the Gorilla
-/// encoding scheme, which is appropriate for timeseries data
-fn serialize_timestamps<S>(timestamps: &[i64], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let encoded = encode_timestamps_to_bytes(timestamps);
-    serializer.serialize_bytes(&encoded)
+impl Serialize for SequenceTracker {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let encoded = encode_sequence_tracker(self);
+        serializer.serialize_bytes(&encoded)
+    }
 }
 
-pub(crate) fn encode_timestamps_to_bytes(timestamps: &[i64]) -> Vec<u8> {
+impl<'de> Deserialize<'de> for SequenceTracker {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let buf: Vec<u8> = Vec::deserialize(deserializer)?;
+        decode_sequence_tracker(&buf).map_err(<D::Error as de::Error>::custom)
+    }
+}
+
+/// Encode a SequenceTracker to bytes using the format specified in RFC-0012
+fn encode_sequence_tracker(tracker: &SequenceTracker) -> Vec<u8> {
+    let mut result = Vec::new();
+
+    // Write version (u8)
+    result.push(SERIALIZATION_VERSION);
+
+    // Write length (as u32, little-endian)
+    let len = tracker.sequence_numbers.len() as u32;
+    result.extend_from_slice(&len.to_le_bytes());
+
+    // Encode sequence numbers using Gorilla encoding
+    let encoded_seqs = encode_sequence_numbers(&tracker.sequence_numbers);
+    result.extend_from_slice(&encoded_seqs);
+
+    // Encode timestamps using Gorilla encoding
+    let encoded_timestamps = encode_timestamps(&tracker.timestamps);
+    result.extend_from_slice(&encoded_timestamps);
+
+    result
+}
+
+/// Decode a SequenceTracker from bytes
+fn decode_sequence_tracker(buf: &[u8]) -> Result<SequenceTracker, String> {
+    if buf.is_empty() {
+        return Err("Empty buffer".to_string());
+    }
+
+    let mut offset = 0;
+
+    // Read version
+    let version = buf[offset];
+    if version != SERIALIZATION_VERSION {
+        return Err(format!("Unsupported version: {}", version));
+    }
+    offset += 1;
+
+    // Read length
+    if buf.len() < offset + 4 {
+        return Err("Buffer too small for length".to_string());
+    }
+    let len_bytes: [u8; 4] = buf[offset..offset + 4]
+        .try_into()
+        .map_err(|_| "Buffer too small for length".to_string())?;
+    let len = u32::from_le_bytes(len_bytes) as usize;
+    offset += 4;
+
+    // Decode sequence numbers
+    let (encoded_seq_len, sequence_numbers) = decode_sequence_numbers_with_length(&buf[offset..])?;
+    if sequence_numbers.len() != len {
+        return Err(format!(
+            "Expected {} sequence numbers, got {}",
+            len,
+            sequence_numbers.len()
+        ));
+    }
+    offset += encoded_seq_len;
+
+    // Decode timestamps
+    let timestamps = decode_timestamps(&buf[offset..])?;
+    if timestamps.len() != len {
+        return Err(format!(
+            "Expected {} timestamps, got {}",
+            len,
+            timestamps.len()
+        ));
+    }
+
+    // Reconstruct the tracker with default configuration (note that it
+    // is fully backwards compatible to change the interval or the capacity
+    // since this would just trigger different downsampling behavior)
+    let mut tracker = SequenceTracker::with_config(DEFAULT_CAPACITY, DEFAULT_INTERVAL_SECS);
+    tracker.sequence_numbers = sequence_numbers;
+    tracker.timestamps = timestamps;
+
+    Ok(tracker)
+}
+
+/// Generic Gorilla encoding for i64 values (used for both timestamps and sequence numbers)
+fn encode_gorilla_i64(values: &[i64]) -> Vec<u8> {
     let mut w = BitWriter::new();
-    w.push32(timestamps.len() as u32, 32);
+    w.push32(values.len() as u32, 32);
 
-    if !timestamps.is_empty() {
-        // first encode the full initial timestamp
-        w.push64(timestamps[0] as u64, 64);
+    if !values.is_empty() {
+        // First value is encoded in full
+        w.push64(values[0] as u64, 64);
 
-        // for each subsequent encode the delta-of-deltas
-        let mut prev_ts = timestamps[0];
+        // Encode subsequent values using delta-of-deltas
+        let mut prev_val = values[0];
         let mut prev_delta: i64 = 0;
 
-        for &ts in &timestamps[1..] {
-            let delta = ts - prev_ts;
+        for &val in &values[1..] {
+            let delta = val - prev_val;
             let dod = delta - prev_delta;
 
             // this is the gorilla encoding scheme, you can see
@@ -245,7 +291,7 @@ pub(crate) fn encode_timestamps_to_bytes(timestamps: &[i64]) -> Vec<u8> {
                 }
             }
 
-            prev_ts = ts;
+            prev_val = val;
             prev_delta = delta;
         }
     }
@@ -253,50 +299,42 @@ pub(crate) fn encode_timestamps_to_bytes(timestamps: &[i64]) -> Vec<u8> {
     w.finish()
 }
 
-/// Indicates how many bytes to read given the Gorilla prefix,
-/// where the valid prefixes are 0, 10, 110, 1110, 1111
-const GORILLA_PREFIX_BYTES: [u8; 5] = [0, 7, 9, 12, 32];
-
-/// Custom serialization function for timestamps that uses the Gorilla
-/// encoding scheme, which is appropriate for timeseries data
-fn deserialize_timestamps<'de, D>(deserializer: D) -> Result<Vec<i64>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let buf: Vec<u8> = Vec::deserialize(deserializer)?;
-    decode_timestamps_from_bytes(&buf).map_err(<D::Error as de::Error>::custom)
-}
-
-pub(crate) fn decode_timestamps_from_bytes(buf: &[u8]) -> Result<Vec<i64>, String> {
-    let mut timestamps = Vec::new();
+/// Generic Gorilla decoding for i64 values, returning bytes consumed
+fn decode_gorilla_i64_with_length(buf: &[u8]) -> Result<(usize, Vec<i64>), String> {
+    let mut values = Vec::new();
     let mut reader = BitReader::new(buf);
+    let mut bits_read = 0usize;
 
     let mut remaining = reader.read32(32).ok_or("Expected count first")?;
+    bits_read += 32;
 
     if remaining > 0 {
-        let first_ts_bits = reader
+        let first_bits = reader
             .read64(64)
-            .ok_or("Unexpected EOF: first ts should be 64 bit")?;
-        let first = first_ts_bits as i64;
+            .ok_or("Unexpected EOF: first value should be 64 bit")?;
+        let first = first_bits as i64;
+        bits_read += 64;
 
         remaining -= 1;
-        timestamps.push(first);
+        values.push(first);
 
-        let mut prev_ts = first;
-        let mut prev_delta: i32 = 0;
+        let mut prev_val = first;
+        let mut prev_delta: i64 = 0;
 
-        while let Some(prefix) = reader.read_bit() {
+        while remaining > 0 {
+            let prefix = reader.read_bit().ok_or("Unexpected EOF reading prefix")?;
+            bits_read += 1;
+
             let dod = if !prefix {
-                0
+                0i64
             } else {
                 let mut count = 1;
                 while count < 4 {
+                    bits_read += 1;
                     match reader.read_bit() {
                         Some(true) => count += 1,
                         Some(false) => break,
-                        None => {
-                            return Err("Unexpected EOF decoding Gorilla prefix".to_string());
-                        }
+                        None => return Err("Unexpected EOF decoding Gorilla prefix".to_string()),
                     }
                 }
 
@@ -304,34 +342,144 @@ pub(crate) fn decode_timestamps_from_bytes(buf: &[u8]) -> Result<Vec<i64>, Strin
                 let raw = reader
                     .read32(bits)
                     .ok_or_else(|| format!("Unexpected EOF reading {}-bit delta-of-delta", bits))?;
+                bits_read += bits as usize;
 
-                sign_extend(raw, bits)
+                sign_extend(raw, bits) as i64
             };
 
             let delta = prev_delta + dod;
-            let ts = prev_ts + (delta as i64);
-            timestamps.push(ts);
+            let val = prev_val + delta;
+            values.push(val);
 
             prev_delta = delta;
-            prev_ts = ts;
+            prev_val = val;
 
             // there may be some padding at the end of the [u8]
             // so we track how many we've read / still need to read
             remaining -= 1;
-
-            if remaining == 0 {
-                break;
-            }
         }
     }
 
+    // Calculate bytes consumed (rounded up to next byte boundary)
+    let bytes_consumed = bits_read.div_ceil(8);
+
+    Ok((bytes_consumed, values))
+}
+
+/// Encode sequence numbers using Gorilla encoding (delta-of-deltas)
+fn encode_sequence_numbers(sequences: &[u64]) -> Vec<u8> {
+    // Convert u64 to i64 using bit cast (preserves bit pattern)
+    let as_i64: Vec<i64> = sequences.iter().map(|&x| x as i64).collect();
+    encode_gorilla_i64(&as_i64)
+}
+
+/// Decode sequence numbers from Gorilla encoding, returning the number of bytes consumed
+fn decode_sequence_numbers_with_length(buf: &[u8]) -> Result<(usize, Vec<u64>), String> {
+    let (bytes_consumed, values) = decode_gorilla_i64_with_length(buf)?;
+
+    // Convert i64 back to u64 using bit cast (preserves bit pattern)
+    // This correctly handles values that were > i64::MAX
+    let sequences: Vec<u64> = values.into_iter().map(|v| v as u64).collect();
+
+    Ok((bytes_consumed, sequences))
+}
+
+/// Encode timestamps using Gorilla encoding
+fn encode_timestamps(timestamps: &[i64]) -> Vec<u8> {
+    encode_gorilla_i64(timestamps)
+}
+
+/// Decode timestamps from Gorilla encoding
+fn decode_timestamps(buf: &[u8]) -> Result<Vec<i64>, String> {
+    let (_, timestamps) = decode_gorilla_i64_with_length(buf)?;
     Ok(timestamps)
 }
+
+/// Indicates how many bytes to read given the Gorilla prefix
+const GORILLA_PREFIX_BYTES: [u8; 5] = [0, 7, 9, 12, 32];
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use rstest::*;
+
+    #[test]
+    fn should_track_sequence_timestamp_pairs() {
+        // given
+        let mut tracker = SequenceTracker::with_config(10, 1);
+
+        // when
+        tracker.insert(TrackedSeq {
+            seq: 100,
+            ts: DateTime::from_timestamp(1000, 0).unwrap(),
+        });
+        tracker.insert(TrackedSeq {
+            seq: 200,
+            ts: DateTime::from_timestamp(2000, 0).unwrap(),
+        });
+        tracker.insert(TrackedSeq {
+            seq: 300,
+            ts: DateTime::from_timestamp(3000, 0).unwrap(),
+        });
+
+        // then
+        assert_eq!(tracker.sequence_numbers.len(), 3);
+        assert_eq!(
+            tracker.find_seq(
+                DateTime::from_timestamp(2000, 0).unwrap(),
+                FindOption::RoundDown
+            ),
+            Some(200)
+        );
+        assert_eq!(
+            tracker.find_ts(200, FindOption::RoundDown),
+            DateTime::from_timestamp(2000, 0)
+        );
+    }
+
+    #[test]
+    fn should_respect_reporting_interval() {
+        // given
+        let mut tracker = SequenceTracker::with_config(10, 60);
+
+        // when
+        tracker.insert(TrackedSeq {
+            seq: 100,
+            ts: DateTime::from_timestamp(1000, 0).unwrap(),
+        });
+        // This should be ignored (only 30 seconds later)
+        tracker.insert(TrackedSeq {
+            seq: 200,
+            ts: DateTime::from_timestamp(1030, 0).unwrap(),
+        });
+        // This should be recorded (60 seconds after first)
+        tracker.insert(TrackedSeq {
+            seq: 300,
+            ts: DateTime::from_timestamp(1060, 0).unwrap(),
+        });
+
+        // then
+        assert_eq!(tracker.sequence_numbers.len(), 2);
+        assert_eq!(tracker.sequence_numbers, vec![100, 300]);
+    }
+
+    #[test]
+    fn should_downsample_when_exceeding_capacity() {
+        // given
+        let mut tracker = SequenceTracker::with_config(4, 1);
+
+        // when - add entries to exceed capacity
+        for i in 0..6 {
+            tracker.insert(TrackedSeq {
+                seq: (i * 100) as u64,
+                ts: DateTime::from_timestamp((i * 1000) as i64, 0).unwrap(),
+            });
+        }
+
+        // then - should have downsampled to keep every other entry
+        assert!(tracker.sequence_numbers.len() <= 4);
+        assert_eq!(tracker.sequence_numbers[0], 0);
+    }
 
     #[rstest]
     #[case::exact_match(8, FindOption::RoundDown, Some(200))]
@@ -342,18 +490,36 @@ mod tests {
     #[case::after_last_seq(16, FindOption::RoundUp, None)]
     #[case::at_first_seq(4, FindOption::RoundDown, Some(100))]
     #[case::at_last_seq(12, FindOption::RoundUp, Some(300))]
-    fn test_find_ts(#[case] seq: u64, #[case] find_opt: FindOption, #[case] expected: Option<i64>) {
+    fn test_find_timestamp_by_seq(
+        #[case] seq: u64,
+        #[case] find_opt: FindOption,
+        #[case] expected_ts: Option<i64>,
+    ) {
         // given
-        let mut tier = Tier::new(4, 10);
-        tier.insert(4, 100);
-        tier.insert(8, 200);
-        tier.insert(12, 300);
+        let mut tracker = SequenceTracker::with_config(4, 1);
+        if seq != 1 || find_opt != FindOption::RoundDown {
+            tracker.insert(TrackedSeq {
+                seq: 4,
+                ts: DateTime::from_timestamp(100, 0).unwrap(),
+            });
+            tracker.insert(TrackedSeq {
+                seq: 8,
+                ts: DateTime::from_timestamp(200, 0).unwrap(),
+            });
+            tracker.insert(TrackedSeq {
+                seq: 12,
+                ts: DateTime::from_timestamp(300, 0).unwrap(),
+            });
+        }
 
         // when
-        let result = tier.find_ts(seq, find_opt);
+        let result = tracker.find_ts(seq, find_opt);
 
         // then
-        assert_eq!(result, expected);
+        assert_eq!(
+            result,
+            expected_ts.and_then(|ts| DateTime::from_timestamp(ts, 0))
+        );
     }
 
     #[rstest]
@@ -366,21 +532,74 @@ mod tests {
     #[case::at_first_ts(100, FindOption::RoundDown, Some(4))]
     #[case::at_last_ts(300, FindOption::RoundUp, Some(12))]
     #[case::empty_tier(1, FindOption::RoundDown, None)]
-    fn test_find_seq(#[case] ts: i64, #[case] find_opt: FindOption, #[case] expected: Option<u64>) {
+    fn test_find_seq_by_timestamp(
+        #[case] ts: i64,
+        #[case] find_opt: FindOption,
+        #[case] expected: Option<u64>,
+    ) {
         // given
-        let mut tier = Tier::new(4, 10);
+        let mut tracker = SequenceTracker::with_config(4, 1);
         // (ts == 1 is the empty tier case)
         if ts != 1 || find_opt != FindOption::RoundDown {
-            tier.insert(4, 100);
-            tier.insert(8, 200);
-            tier.insert(12, 300);
+            tracker.insert(TrackedSeq {
+                seq: 4,
+                ts: DateTime::from_timestamp(100, 0).unwrap(),
+            });
+            tracker.insert(TrackedSeq {
+                seq: 8,
+                ts: DateTime::from_timestamp(200, 0).unwrap(),
+            });
+            tracker.insert(TrackedSeq {
+                seq: 12,
+                ts: DateTime::from_timestamp(300, 0).unwrap(),
+            });
         }
 
         // when
-        let result = tier.find_seq(ts, find_opt);
+        let result = tracker.find_seq(DateTime::from_timestamp(ts, 0).unwrap(), find_opt);
 
         // then
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_serialize_deserialize_round_trip() {
+        // given
+        let mut tracker = SequenceTracker::with_config(10, 1);
+        for i in 0..5 {
+            tracker.insert(TrackedSeq {
+                seq: (i * 100) as u64,
+                ts: DateTime::from_timestamp((i * 1000) as i64, 0).unwrap(),
+            });
+        }
+
+        // when
+        let encoded = encode_sequence_tracker(&tracker);
+        let decoded = decode_sequence_tracker(&encoded).unwrap();
+
+        // then
+        assert_eq!(decoded.sequence_numbers, tracker.sequence_numbers);
+        assert_eq!(decoded.timestamps, tracker.timestamps);
+    }
+
+    #[rstest]
+    #[case::empty_sequences(vec![])]
+    #[case::single_sequence(vec![1000])]
+    #[case::multiple_sequences(vec![100, 200, 300, 400, 500])]
+    #[case::large_gaps(vec![100, 10000, 20000, 30000])]
+    #[case::small_increments(vec![100, 101, 102, 103, 104])]
+    #[case::max_u64(vec![u64::MAX])]
+    #[case::above_i64_max(vec![i64::MAX as u64 + 1])]
+    #[case::u64_values_that_become_negative(vec![u64::MAX - 100, u64::MAX - 50, u64::MAX])]
+    #[case::large_u64_with_small_deltas(vec![u64::MAX - 10, u64::MAX - 9, u64::MAX - 8, u64::MAX - 7])]
+    #[case::wraparound_sequence(vec![u64::MAX - 1, u64::MAX, 0, 1, 2])]
+    fn test_encode_decode_sequence_numbers(#[case] sequences: Vec<u64>) {
+        // when
+        let encoded = encode_sequence_numbers(&sequences);
+        let (_, decoded) = decode_sequence_numbers_with_length(&encoded).unwrap();
+
+        // then
+        assert_eq!(decoded, sequences);
     }
 
     #[rstest]
@@ -397,13 +616,30 @@ mod tests {
     #[case::mixed_dod(vec![1000, 1000, 1032, 1128, 1512, 50000])] // Tests all branches with values within ranges
     #[case::mixed_dod_boundaries(vec![1000, 1000, 1028, 1255, 2047, 1000000])] // Tests all branches at boundaries
     #[case::large_numbers(vec![i64::MAX - 1000, i64::MAX - 500, i64::MAX])]
-    fn test_serialize_deserialize_round_trip(#[case] timestamps: Vec<i64>) {
+    fn test_encode_decode_timestamps(#[case] timestamps: Vec<i64>) {
         // when
-        let encoded = encode_timestamps_to_bytes(&timestamps);
-        let decoded = decode_timestamps_from_bytes(&encoded).unwrap();
+        let encoded = encode_timestamps(&timestamps);
+        let decoded = decode_timestamps(&encoded).unwrap();
 
         // then
         assert_eq!(decoded, timestamps);
+    }
+
+    #[test]
+    fn test_empty_tracker_queries() {
+        // given
+        let tracker = SequenceTracker::new();
+
+        // then
+        assert_eq!(
+            tracker.find_seq(
+                DateTime::from_timestamp(100, 0).unwrap(),
+                FindOption::RoundDown
+            ),
+            None
+        );
+        assert_eq!(tracker.find_ts(100, FindOption::RoundUp), None);
+        assert!(tracker.sequence_numbers.is_empty());
     }
 
     #[test]
@@ -411,46 +647,45 @@ mod tests {
         use proptest::collection::vec;
         use proptest::prelude::*;
 
-        // Generate timestamp sequences for testing
-        let timestamp_strategy = vec(any::<i32>(), 0..=20).prop_map(|deltas| {
+        // Generate paired sequences and timestamps for testing
+        let tracker_strategy = vec(any::<(u32, u32)>(), 0..=20).prop_map(|pairs| {
+            let mut tracker = SequenceTracker::with_config(100, 1);
+
+            let base_seq = 0u64;
             let base_timestamp = 1_600_000_000i64; // Unix timestamp around 2020
-            let mut timestamps = Vec::new();
+
+            let mut current_seq = base_seq;
             let mut current_ts = base_timestamp;
 
-            for delta in deltas {
-                timestamps.push(current_ts);
-                current_ts =
-                    current_ts.saturating_add(delta.clamp(i32::MIN / 2, i32::MAX / 2) as i64);
+            for (seq_delta, ts_delta) in pairs {
+                // Limit deltas to avoid problematic ranges in Gorilla encoding
+                // Specifically avoid sequence number deltas >= 2^31 that cause sign issues
+                // It is reasonable to assume that production deltas wont exceed these bounds.
+                let safe_seq_delta = (seq_delta % (u32::MAX as u32 / 2)) as u64;
+                let safe_ts_delta = (ts_delta % (u32::MAX as u32 / 2)) as i64;
+
+                current_seq = current_seq.saturating_add(safe_seq_delta);
+                current_ts = current_ts.saturating_add(safe_ts_delta);
+
+                tracker.insert(TrackedSeq {
+                    seq: current_seq,
+                    ts: DateTime::from_timestamp(current_ts, 0).unwrap(),
+                });
             }
 
-            timestamps
+            tracker
         });
 
-        proptest!(|(timestamps in timestamp_strategy)| {
-            let encoded = encode_timestamps_to_bytes(&timestamps);
-            let decoded = decode_timestamps_from_bytes(&encoded).unwrap();
-            assert_eq!(decoded, timestamps);
+        proptest!(|(tracker in tracker_strategy)| {
+            // given a tracker with some data
+
+            // when we encode and decode it
+            let encoded = encode_sequence_tracker(&tracker);
+            let decoded = decode_sequence_tracker(&encoded).unwrap();
+
+            // then the sequence numbers and timestamps should match exactly
+            assert_eq!(decoded.sequence_numbers, tracker.sequence_numbers);
+            assert_eq!(decoded.timestamps, tracker.timestamps);
         });
-    }
-
-    #[test]
-    fn should_downsample_when_capacity_exceeded() {
-        // given
-        let mut tier = Tier::new(2, 3);
-
-        // Insert step-aligned sequences (step=2)
-        tier.insert(2, 100);
-        tier.insert(3, 150); // Should be ignored (not divisible by step=2)
-        tier.insert(4, 200);
-        tier.insert(5, 250); // Should be ignored (not divisible by step=2)
-        tier.insert(6, 300);
-
-        // when - this should trigger downsampling
-        tier.insert(8, 400);
-
-        // then
-        assert_eq!(tier.step, 4); // step doubled
-        assert_eq!(tier.timestamps, vec![100, 300]); // downsampled (only step-aligned sequences)
-        assert_eq!(tier.last_seq, 8);
     }
 }

--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -661,8 +661,8 @@ mod tests {
                 // Limit deltas to avoid problematic ranges in Gorilla encoding
                 // Specifically avoid sequence number deltas >= 2^31 that cause sign issues
                 // It is reasonable to assume that production deltas wont exceed these bounds.
-                let safe_seq_delta = (seq_delta % (u32::MAX as u32 / 2)) as u64;
-                let safe_ts_delta = (ts_delta % (u32::MAX as u32 / 2)) as i64;
+                let safe_seq_delta = (seq_delta % (u32::MAX / 2)) as u64;
+                let safe_ts_delta = (ts_delta % (u32::MAX / 2)) as i64;
 
                 current_seq = current_seq.saturating_add(safe_seq_delta);
                 current_ts = current_ts.saturating_add(safe_ts_delta);

--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -38,7 +38,7 @@ pub(crate) enum FindOption {
 pub(crate) struct SequenceTracker {
     /// Sorted array of sequence numbers
     sequence_numbers: Vec<u64>,
-    /// Sorted array of timestamps (as Unix timestamps)
+    /// Sorted array of timestamps (as Unix timestamp seconds)
     timestamps: Vec<i64>,
     /// Maximum number of entries to store
     capacity: u32,


### PR DESCRIPTION
See RFC-0012 for the implementation details, but it effectively implements the seq_tracker using a simpler (non-tiered) double-array with a simple remove-every-other-entry downsampling strategy.