### PR TITLE
Wrap object stores in `RetryingObjectStore`

### DIFF
--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -141,6 +141,7 @@ use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
 use crate::object_stores::ObjectStores;
 use crate::paths::PathResolver;
 use crate::rand::DbRand;
+use crate::retrying_object_store::RetryingObjectStore;
 use crate::sst::SsTableFormat;
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
@@ -295,6 +296,11 @@ impl<P: Into<Path>> DbBuilder<P> {
         // TODO: proper URI generation, for now it works just as a flag
         let wal_object_store_uri = self.wal_object_store.as_ref().map(|_| String::new());
 
+        let retrying_main_object_store = Arc::new(RetryingObjectStore::new(self.main_object_store));
+        let retrying_wal_object_store: Option<Arc<dyn ObjectStore>> = self
+            .wal_object_store
+            .map(|s| Arc::new(RetryingObjectStore::new(s)) as Arc<dyn ObjectStore>);
+
         // Log the database opening
         if let Ok(settings_json) = self.settings.to_json_string() {
             info!(
@@ -355,7 +361,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                 ));
 
                 let cached_object_store = CachedObjectStore::new(
-                    self.main_object_store.clone(),
+                    retrying_main_object_store.clone(),
                     cache_storage,
                     self.settings.object_store_cache_options.part_size_bytes,
                     self.settings.object_store_cache_options.cache_puts,
@@ -366,9 +372,9 @@ impl<P: Into<Path>> DbBuilder<P> {
             }
         };
 
-        let maybe_cached_main_object_store = match &cached_object_store {
+        let maybe_cached_main_object_store: Arc<dyn ObjectStore> = match &cached_object_store {
             Some(cached_store) => cached_store.clone(),
-            None => self.main_object_store.clone(),
+            None => retrying_main_object_store.clone(),
         };
 
         // Setup the manifest store and load latest manifest
@@ -407,7 +413,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         let table_store = Arc::new(TableStore::new_with_fp_registry(
             ObjectStores::new(
                 maybe_cached_main_object_store.clone(),
-                self.wal_object_store.clone(),
+                retrying_wal_object_store.clone(),
             ),
             sst_format.clone(),
             path_resolver.clone(),
@@ -482,8 +488,8 @@ impl<P: Into<Path>> DbBuilder<P> {
         // Not to pollute the cache during compaction or GC
         let uncached_table_store = Arc::new(TableStore::new_with_fp_registry(
             ObjectStores::new(
-                self.main_object_store.clone(),
-                self.wal_object_store.clone(),
+                retrying_main_object_store.clone(),
+                retrying_wal_object_store.clone(),
             ),
             sst_format,
             path_resolver.clone(),
@@ -617,6 +623,7 @@ impl<P: Into<Path>> AdminBuilder<P> {
 
     /// Builds and returns an Admin instance.
     pub fn build(self) -> Admin {
+        // No retrying object stores here, since we don't want to retry admin operations
         Admin {
             path: self.path.into(),
             object_stores: ObjectStores::new(self.main_object_store, self.wal_object_store),
@@ -679,11 +686,18 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
     /// Builds and returns a GarbageCollector instance.
     pub fn build(self) -> GarbageCollector {
         let path: Path = self.path.into();
-        let manifest_store = Arc::new(ManifestStore::new(&path, self.main_object_store.clone()));
+        let retrying_main_object_store = Arc::new(RetryingObjectStore::new(self.main_object_store));
+        let retrying_wal_object_store = self
+            .wal_object_store
+            .map(|s| Arc::new(RetryingObjectStore::new(s)) as Arc<dyn ObjectStore>);
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            retrying_main_object_store.clone(),
+        ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(
-                self.main_object_store.clone(),
-                self.wal_object_store.clone(),
+                retrying_main_object_store.clone(),
+                retrying_wal_object_store.clone(),
             ),
             SsTableFormat::default(), // read only SSTs can use default
             path,
@@ -779,9 +793,13 @@ impl<P: Into<Path>> CompactorBuilder<P> {
     /// Builds and returns a Compactor instance.
     pub fn build(self) -> Compactor {
         let path: Path = self.path.into();
-        let manifest_store = Arc::new(ManifestStore::new(&path, self.main_object_store.clone()));
+        let retrying_main_object_store = Arc::new(RetryingObjectStore::new(self.main_object_store));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &path,
+            retrying_main_object_store.clone(),
+        ));
         let table_store = Arc::new(TableStore::new(
-            ObjectStores::new(self.main_object_store.clone(), None),
+            ObjectStores::new(retrying_main_object_store.clone(), None),
             SsTableFormat::default(), // read only SSTs can use default
             path,
             None, // no need for cache in GC

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -103,13 +103,13 @@ mod proptest_util;
 mod rand;
 mod reader;
 mod retention_iterator;
+mod retrying_object_store;
 mod row_codec;
 mod seq_tracker;
 mod sorted_run_iterator;
 mod sst;
 mod sst_iter;
 mod store_provider;
-mod retrying_object_store;
 mod tablestore;
 #[cfg(test)]
 mod test_utils;

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -109,6 +109,7 @@ mod sorted_run_iterator;
 mod sst;
 mod sst_iter;
 mod store_provider;
+mod retrying_object_store;
 mod tablestore;
 #[cfg(test)]
 mod test_utils;

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1026,6 +1026,7 @@ mod tests {
         // Given a flaky store that times out on the first write
         let base = Arc::new(InMemory::new());
         let flaky = Arc::new(FlakyObjectStore::new(base.clone(), 1));
+        let retrying = Arc::new(RetryingObjectStore::new(flaky.clone()));
         let ms = Arc::new(ManifestStore::new(
             &Path::from(ROOT),
             retrying.clone(),

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -14,7 +14,6 @@ use crate::transactional_object_store::{
     DelegatingTransactionalObjectStore, TransactionalObjectStore,
 };
 use crate::utils;
-use backon::{ExponentialBuilder, Retryable};
 use chrono::Utc;
 use futures::StreamExt;
 use log::{debug, warn};
@@ -578,14 +577,8 @@ impl ManifestStore {
 
     async fn write_manifest(&self, id: u64, manifest: &Manifest) -> Result<(), SlateDBError> {
         let manifest_path = &self.get_manifest_path(id);
-
-        (|| async {
-            self.write_manifest_in_object_store(manifest_path, manifest)
-                .await
-        })
-        .retry(ExponentialBuilder::default().with_total_delay(Some(Duration::from_secs(300))))
-        .when(utils::should_retry_object_store_operation)
-        .await
+        self.write_manifest_in_object_store(manifest_path, manifest)
+            .await
     }
 
     async fn write_manifest_in_object_store(
@@ -783,6 +776,7 @@ mod tests {
     use crate::error;
     use crate::error::SlateDBError;
     use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
+    use crate::retrying_object_store::RetryingObjectStore;
     use crate::test_utils::FlakyObjectStore;
     use chrono::Timelike;
     use object_store::memory::InMemory;
@@ -1036,7 +1030,8 @@ mod tests {
         // Given a flaky store that times out on the first write
         let base = Arc::new(InMemory::new());
         let flaky = Arc::new(FlakyObjectStore::new(base.clone(), 1));
-        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), flaky.clone()));
+        let retrying = Arc::new(RetryingObjectStore::new(flaky.clone()));
+        let ms = Arc::new(ManifestStore::new(&Path::from(ROOT), retrying.clone()));
 
         // When creating a new DB (initial manifest write under retry)
         let core = CoreDbState::new();

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -66,7 +66,7 @@ impl ObjectStore for RetryingObjectStore {
     ) -> object_store::Result<GetResult> {
         (|| async {
             // Options and location must be owned per-attempt.
-            self.inner.get_opts(&location, options.clone()).await
+            self.inner.get_opts(location, options.clone()).await
         })
         .retry(Self::retry_builder())
         .notify(Self::notify)
@@ -75,7 +75,7 @@ impl ObjectStore for RetryingObjectStore {
     }
 
     async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        (|| async { self.inner.head(&location).await })
+        (|| async { self.inner.head(location).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
             .when(Self::should_retry)
@@ -90,7 +90,7 @@ impl ObjectStore for RetryingObjectStore {
     ) -> object_store::Result<PutResult> {
         (|| async {
             self.inner
-                .put_opts(&location, payload.clone(), opts.clone())
+                .put_opts(location, payload.clone(), opts.clone())
                 .await
         })
         .retry(Self::retry_builder())
@@ -103,7 +103,7 @@ impl ObjectStore for RetryingObjectStore {
         &self,
         location: &Path,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        (|| async { self.inner.put_multipart(&location).await })
+        (|| async { self.inner.put_multipart(location).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
             .when(Self::should_retry)
@@ -115,7 +115,7 @@ impl ObjectStore for RetryingObjectStore {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        (|| async { self.inner.put_multipart_opts(&location, opts.clone()).await })
+        (|| async { self.inner.put_multipart_opts(location, opts.clone()).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
             .when(Self::should_retry)
@@ -123,7 +123,7 @@ impl ObjectStore for RetryingObjectStore {
     }
 
     async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        (|| async { self.inner.delete(&location).await })
+        (|| async { self.inner.delete(location).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
             .when(Self::should_retry)

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -7,8 +7,8 @@ use futures::stream::BoxStream;
 use log::{info, warn};
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOptions,
-    PutOptions, PutPayload, PutResult,
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult,
 };
 
 /// A thin wrapper around an `ObjectStore` that retries transient errors with
@@ -95,11 +95,15 @@ impl ObjectStore for RetryingObjectStore {
         let loc = location.clone();
         let payload = payload.clone();
         let opts = opts.clone();
-        (|| async { self.inner.put_opts(&loc, payload.clone(), opts.clone()).await })
-            .retry(Self::retry_builder())
-            .notify(Self::notify)
-            .when(Self::should_retry_os_error)
-            .await
+        (|| async {
+            self.inner
+                .put_opts(&loc, payload.clone(), opts.clone())
+                .await
+        })
+        .retry(Self::retry_builder())
+        .notify(Self::notify)
+        .when(Self::should_retry_os_error)
+        .await
     }
 
     async fn put_multipart(

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -37,7 +37,7 @@ impl RetryingObjectStore {
     }
 
     #[inline]
-    fn should_retry_os_error(err: &object_store::Error) -> bool {
+    fn should_retry(err: &object_store::Error) -> bool {
         let retry = !matches!(
             err,
             object_store::Error::AlreadyExists { .. }
@@ -70,7 +70,7 @@ impl ObjectStore for RetryingObjectStore {
         })
         .retry(Self::retry_builder())
         .notify(Self::notify)
-        .when(Self::should_retry_os_error)
+        .when(Self::should_retry)
         .await
     }
 
@@ -78,7 +78,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.head(&location).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -95,7 +95,7 @@ impl ObjectStore for RetryingObjectStore {
         })
         .retry(Self::retry_builder())
         .notify(Self::notify)
-        .when(Self::should_retry_os_error)
+        .when(Self::should_retry)
         .await
     }
 
@@ -106,7 +106,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.put_multipart(&location).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -118,7 +118,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.put_multipart_opts(&location, opts.clone()).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -126,7 +126,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.delete(&location).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -148,7 +148,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.list_with_delimiter(prefix).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -156,7 +156,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.copy(from, to).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -164,7 +164,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.rename(from, to).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -172,7 +172,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.copy_if_not_exists(from, to).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 
@@ -180,7 +180,7 @@ impl ObjectStore for RetryingObjectStore {
         (|| async { self.inner.rename_if_not_exists(from, to).await })
             .retry(Self::retry_builder())
             .notify(Self::notify)
-            .when(Self::should_retry_os_error)
+            .when(Self::should_retry)
             .await
     }
 }

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -29,6 +29,11 @@ impl RetryingObjectStore {
     }
 
     #[inline]
+    fn notify(err: &object_store::Error) {
+        info!("retrying object store operation [error={:?}]", err);
+    }
+
+    #[inline]
     fn should_retry_os_error(err: &object_store::Error) -> bool {
         // Mirror the semantics of `utils::should_retry_object_store_operation` for
         // object-store errors (permanent vs transient), and log similarly.
@@ -67,6 +72,7 @@ impl ObjectStore for RetryingObjectStore {
             self.inner.get_opts(&loc, opts.clone()).await
         })
         .retry(Self::retry_builder())
+        .notify(Self::notify)
         .when(Self::should_retry_os_error)
         .await
     }
@@ -75,6 +81,7 @@ impl ObjectStore for RetryingObjectStore {
         let loc = location.clone();
         (|| async { self.inner.head(&loc).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -90,6 +97,7 @@ impl ObjectStore for RetryingObjectStore {
         let opts = opts.clone();
         (|| async { self.inner.put_opts(&loc, payload.clone(), opts.clone()).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -101,6 +109,7 @@ impl ObjectStore for RetryingObjectStore {
         let loc = location.clone();
         (|| async { self.inner.put_multipart(&loc).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -114,6 +123,7 @@ impl ObjectStore for RetryingObjectStore {
         let opts = opts.clone();
         (|| async { self.inner.put_multipart_opts(&loc, opts.clone()).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -122,6 +132,7 @@ impl ObjectStore for RetryingObjectStore {
         let loc = location.clone();
         (|| async { self.inner.delete(&loc).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -143,6 +154,7 @@ impl ObjectStore for RetryingObjectStore {
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
         (|| async { self.inner.list_with_delimiter(prefix).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -152,6 +164,7 @@ impl ObjectStore for RetryingObjectStore {
         let to = to.clone();
         (|| async { self.inner.copy(&from, &to).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -161,6 +174,7 @@ impl ObjectStore for RetryingObjectStore {
         let to = to.clone();
         (|| async { self.inner.rename(&from, &to).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -170,6 +184,7 @@ impl ObjectStore for RetryingObjectStore {
         let to = to.clone();
         (|| async { self.inner.copy_if_not_exists(&from, &to).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }
@@ -179,6 +194,7 @@ impl ObjectStore for RetryingObjectStore {
         let to = to.clone();
         (|| async { self.inner.rename_if_not_exists(&from, &to).await })
             .retry(Self::retry_builder())
+            .notify(Self::notify)
             .when(Self::should_retry_os_error)
             .await
     }

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -1,0 +1,295 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use backon::{ExponentialBuilder, Retryable};
+use futures::stream::BoxStream;
+use log::{info, warn};
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOptions,
+    PutOptions, PutPayload, PutResult,
+};
+
+/// A thin wrapper around an `ObjectStore` that retries transient errors with
+/// exponential backoff for up to 5 minutes.
+#[derive(Debug, Clone)]
+pub(crate) struct RetryingObjectStore {
+    inner: Arc<dyn ObjectStore>,
+}
+
+impl RetryingObjectStore {
+    pub fn new(inner: Arc<dyn ObjectStore>) -> Arc<Self> {
+        Arc::new(Self { inner })
+    }
+
+    #[inline]
+    fn retry_builder() -> ExponentialBuilder {
+        ExponentialBuilder::default().with_total_delay(Some(Duration::from_secs(300)))
+    }
+
+    #[inline]
+    fn should_retry_os_error(err: &object_store::Error) -> bool {
+        // Mirror the semantics of `utils::should_retry_object_store_operation` for
+        // object-store errors (permanent vs transient), and log similarly.
+        let retry = match err {
+            object_store::Error::AlreadyExists { .. }
+            | object_store::Error::Precondition { .. }
+            | object_store::Error::NotImplemented => false,
+            _ => true,
+        };
+        if retry {
+            info!("retrying object store operation [error={:?}]", err);
+        } else {
+            warn!("not retrying object store operation [error={:?}]", err);
+        }
+        retry
+    }
+}
+
+impl std::fmt::Display for RetryingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RetryingObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for RetryingObjectStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        let loc = location.clone();
+        let opts = options.clone();
+        (|| async {
+            // Options and location must be owned per-attempt.
+            self.inner.get_opts(&loc, opts.clone()).await
+        })
+        .retry(Self::retry_builder())
+        .when(Self::should_retry_os_error)
+        .await
+    }
+
+    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        let loc = location.clone();
+        (|| async { self.inner.head(&loc).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        let loc = location.clone();
+        let payload = payload.clone();
+        let opts = opts.clone();
+        (|| async { self.inner.put_opts(&loc, payload.clone(), opts.clone()).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        let loc = location.clone();
+        (|| async { self.inner.put_multipart(&loc).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        let loc = location.clone();
+        let opts = opts.clone();
+        (|| async { self.inner.put_multipart_opts(&loc, opts.clone()).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        let loc = location.clone();
+        (|| async { self.inner.delete(&loc).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        // Delegates directly; listing returns a stream so per-page retry is out of scope here.
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        // Delegates directly; listing returns a stream so per-page retry is out of scope here.
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        (|| async { self.inner.list_with_delimiter(prefix).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let from = from.clone();
+        let to = to.clone();
+        (|| async { self.inner.copy(&from, &to).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let from = from.clone();
+        let to = to.clone();
+        (|| async { self.inner.rename(&from, &to).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let from = from.clone();
+        let to = to.clone();
+        (|| async { self.inner.copy_if_not_exists(&from, &to).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let from = from.clone();
+        let to = to.clone();
+        (|| async { self.inner.rename_if_not_exists(&from, &to).await })
+            .retry(Self::retry_builder())
+            .when(Self::should_retry_os_error)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RetryingObjectStore;
+    use crate::test_utils::FlakyObjectStore;
+    use bytes::Bytes;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::{ObjectStore, PutMode, PutOptions, PutPayload};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_put_opts_retries_transient_until_success() {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 1));
+        let retrying = RetryingObjectStore::new(flaky.clone());
+
+        let path = Path::from("/data/obj");
+        retrying
+            .put_opts(
+                &path,
+                PutPayload::from_bytes(Bytes::from_static(b"hello")),
+                PutOptions::default(),
+            )
+            .await
+            .expect("put should succeed after retries");
+
+        // 1 failure + 1 success
+        assert_eq!(flaky.put_attempts(), 2);
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"hello"));
+    }
+
+    #[tokio::test]
+    async fn test_put_opts_does_not_retry_on_already_exists() {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0));
+        let retrying = RetryingObjectStore::new(flaky.clone());
+        let path = Path::from("/data/obj");
+
+        retrying
+            .put_opts(
+                &path,
+                PutPayload::from_bytes(Bytes::from_static(b"v1")),
+                PutOptions::from(PutMode::Create),
+            )
+            .await
+            .unwrap();
+
+        let attempts_before = flaky.put_attempts();
+        let err = retrying
+            .put_opts(
+                &path,
+                PutPayload::from_bytes(Bytes::from_static(b"v2")),
+                PutOptions::from(PutMode::Create),
+            )
+            .await
+            .expect_err("second put should fail with AlreadyExists");
+
+        // Should be AlreadyExists
+        match err {
+            object_store::Error::AlreadyExists { .. } => {}
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        // Should not retry on AlreadyExists → exactly one new attempt
+        assert_eq!(flaky.put_attempts(), attempts_before + 1);
+    }
+
+    #[tokio::test]
+    async fn test_head_retries_transient_until_success() {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/x");
+        inner
+            .put(&path, PutPayload::from_bytes(Bytes::from_static(b"data")))
+            .await
+            .unwrap();
+
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_head_failures(1));
+        let retrying = RetryingObjectStore::new(flaky.clone());
+
+        let meta = retrying.head(&path).await.expect("head should succeed");
+        assert_eq!(meta.size, 4);
+        assert_eq!(flaky.head_attempts(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_put_opts_does_not_retry_on_precondition() {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let failing = Arc::new(FlakyObjectStore::new(inner, 0).with_put_precondition_always());
+        let retrying = RetryingObjectStore::new(failing.clone());
+        let path = Path::from("/p");
+
+        let err = retrying
+            .put_opts(
+                &path,
+                PutPayload::from_bytes(Bytes::from_static(b"x")),
+                PutOptions::default(),
+            )
+            .await
+            .expect_err("expected precondition error");
+
+        match err {
+            object_store::Error::Precondition { .. } => {}
+            e => panic!("unexpected error: {e:?}"),
+        }
+        assert_eq!(failing.put_attempts(), 1);
+    }
+}

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use backon::{ExponentialBuilder, Retryable};
 use futures::stream::BoxStream;
-use log::{debug, info, warn};
+use log::{debug, info};
 use object_store::path::Path;
 use object_store::{
     GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -29,8 +29,8 @@ impl RetryingObjectStore {
     }
 
     #[inline]
-    fn notify(err: &object_store::Error) {
-        info!("retrying object store operation [error={:?}]", err);
+    fn notify(err: &object_store::Error, duration: Duration) {
+        info!("retrying object store operation [error={:?}, duration={:?}]", err, duration);
     }
 
     #[inline]

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -2,6 +2,7 @@ use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
 use crate::object_stores::ObjectStores;
 use crate::sst::SsTableFormat;
+use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::TableStore;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -21,7 +22,7 @@ pub(crate) struct DefaultStoreProvider {
 impl StoreProvider for DefaultStoreProvider {
     fn table_store(&self) -> Arc<TableStore> {
         Arc::new(TableStore::new(
-            ObjectStores::new(Arc::clone(&self.object_store), None),
+            ObjectStores::new(RetryingObjectStore::new(Arc::clone(&self.object_store)), None),
             SsTableFormat::default(),
             self.path.clone(),
             self.block_cache.clone(),
@@ -31,7 +32,7 @@ impl StoreProvider for DefaultStoreProvider {
     fn manifest_store(&self) -> Arc<ManifestStore> {
         Arc::new(ManifestStore::new(
             &self.path,
-            Arc::clone(&self.object_store),
+            RetryingObjectStore::new(Arc::clone(&self.object_store)),
         ))
     }
 }

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,7 +1,6 @@
 use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
 use crate::object_stores::ObjectStores;
-use crate::retrying_object_store::RetryingObjectStore;
 use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use object_store::path::Path;
@@ -22,10 +21,7 @@ pub(crate) struct DefaultStoreProvider {
 impl StoreProvider for DefaultStoreProvider {
     fn table_store(&self) -> Arc<TableStore> {
         Arc::new(TableStore::new(
-            ObjectStores::new(
-                RetryingObjectStore::new(Arc::clone(&self.object_store)),
-                None,
-            ),
+            ObjectStores::new(Arc::clone(&self.object_store), None),
             SsTableFormat::default(),
             self.path.clone(),
             self.block_cache.clone(),
@@ -35,7 +31,7 @@ impl StoreProvider for DefaultStoreProvider {
     fn manifest_store(&self) -> Arc<ManifestStore> {
         Arc::new(ManifestStore::new(
             &self.path,
-            RetryingObjectStore::new(Arc::clone(&self.object_store)),
+            Arc::clone(&self.object_store),
         ))
     }
 }

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,8 +1,8 @@
 use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
 use crate::object_stores::ObjectStores;
-use crate::sst::SsTableFormat;
 use crate::retrying_object_store::RetryingObjectStore;
+use crate::sst::SsTableFormat;
 use crate::tablestore::TableStore;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -22,7 +22,10 @@ pub(crate) struct DefaultStoreProvider {
 impl StoreProvider for DefaultStoreProvider {
     fn table_store(&self) -> Arc<TableStore> {
         Arc::new(TableStore::new(
-            ObjectStores::new(RetryingObjectStore::new(Arc::clone(&self.object_store)), None),
+            ObjectStores::new(
+                RetryingObjectStore::new(Arc::clone(&self.object_store)),
+                None,
+            ),
             SsTableFormat::default(),
             self.path.clone(),
             self.block_cache.clone(),

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -426,7 +426,11 @@ impl ObjectStore for FlakyObjectStore {
         if self
             .fail_first_head
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
-                if v > 0 { Some(v - 1) } else { None }
+                if v > 0 {
+                    Some(v - 1)
+                } else {
+                    None
+                }
             })
             .is_ok()
         {

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -455,8 +455,7 @@ impl ObjectStore for FlakyObjectStore {
         if self.put_precondition_always.load(Ordering::SeqCst) {
             return Err(object_store::Error::Precondition {
                 path: location.to_string(),
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::Other,
+                source: Box::new(std::io::Error::other(
                     "injected precondition",
                 )),
             });

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -455,9 +455,7 @@ impl ObjectStore for FlakyObjectStore {
         if self.put_precondition_always.load(Ordering::SeqCst) {
             return Err(object_store::Error::Precondition {
                 path: location.to_string(),
-                source: Box::new(std::io::Error::other(
-                    "injected precondition",
-                )),
+                source: Box::new(std::io::Error::other("injected precondition")),
             });
         }
         if self

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -364,8 +364,14 @@ fn init_tracing() {
 #[derive(Debug)]
 pub(crate) struct FlakyObjectStore {
     inner: Arc<dyn ObjectStore>,
+    // Put options: transient failures on first N attempts
     fail_first_put_opts: AtomicUsize,
     put_opts_attempts: AtomicUsize,
+    // Put options: if set, always return Precondition error (non-retryable)
+    put_precondition_always: std::sync::atomic::AtomicBool,
+    // Head: transient failures on first N attempts
+    fail_first_head: AtomicUsize,
+    head_attempts: AtomicUsize,
 }
 
 impl FlakyObjectStore {
@@ -374,11 +380,28 @@ impl FlakyObjectStore {
             inner,
             fail_first_put_opts: AtomicUsize::new(fail_first_put_opts),
             put_opts_attempts: AtomicUsize::new(0),
+            put_precondition_always: std::sync::atomic::AtomicBool::new(false),
+            fail_first_head: AtomicUsize::new(0),
+            head_attempts: AtomicUsize::new(0),
         }
+    }
+
+    pub(crate) fn with_put_precondition_always(self) -> Self {
+        self.put_precondition_always.store(true, Ordering::SeqCst);
+        self
+    }
+
+    pub(crate) fn with_head_failures(self, n: usize) -> Self {
+        self.fail_first_head.store(n, Ordering::SeqCst);
+        self
     }
 
     pub(crate) fn put_attempts(&self) -> usize {
         self.put_opts_attempts.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn head_attempts(&self) -> usize {
+        self.head_attempts.load(Ordering::SeqCst)
     }
 }
 
@@ -399,6 +422,22 @@ impl ObjectStore for FlakyObjectStore {
     }
 
     async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        self.head_attempts.fetch_add(1, Ordering::SeqCst);
+        if self
+            .fail_first_head
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                if v > 0 { Some(v - 1) } else { None }
+            })
+            .is_ok()
+        {
+            return Err(object_store::Error::Generic {
+                store: "flaky_head",
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "injected head timeout",
+                )),
+            });
+        }
         self.inner.head(location).await
     }
 
@@ -409,6 +448,15 @@ impl ObjectStore for FlakyObjectStore {
         opts: OS_PutOptions,
     ) -> object_store::Result<PutResult> {
         self.put_opts_attempts.fetch_add(1, Ordering::SeqCst);
+        if self.put_precondition_always.load(Ordering::SeqCst) {
+            return Err(object_store::Error::Precondition {
+                path: location.to_string(),
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "injected precondition",
+                )),
+            });
+        }
         if self
             .fail_first_put_opts
             .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -7,7 +7,7 @@ use crate::error::SlateDBError::BackgroundTaskPanic;
 use crate::types::RowEntry;
 use bytes::{BufMut, Bytes};
 use futures::FutureExt;
-use log::{info, warn};
+use log::warn;
 use rand::{Rng, RngCore};
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
@@ -535,8 +535,6 @@ pub(crate) fn should_retry_object_store_operation(error: &SlateDBError) -> bool 
     }
     if !retry {
         warn!("not retrying object store operation [error={:?}]", error);
-    } else {
-        info!("retrying object store operation [error={:?}]", error);
     }
     retry
 }


### PR DESCRIPTION
It appears I missed many spots where we interact with the object store. Users are reporting failures for list and get operations:

https://github.com/Barre/ZeroFS/issues/143

Rather than trying to chase all of these down, I created a `RetryingObjectStore`. It uses the same retry logic for all `ObjectStore` operations. All errors are retried except `AlreadyExists`, `Precondition`, and `NotImplemented`. I realized that, with this approach, we no longer need to worry about `ManifestVersionExists` and `Fenced` because the `TableStore` and `ManifestStore` both convert `AlreadyExists` to the appropriate `SlateDBError`.