### PR TITLE
Implement MessageHandler for CompactorEventHandler

### DIFF
--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -17,7 +17,7 @@ use ulid::Ulid;
 use crate::bytes_generator::OrderedBytesGenerator;
 use crate::clock::{DefaultSystemClock, SystemClock};
 use crate::compactor::stats::CompactionStats;
-use crate::compactor::WorkerToOrchestratorMsg;
+use crate::compactor::CompactorMessage;
 use crate::compactor_executor::{CompactionExecutor, CompactionJob, TokioCompactionExecutor};
 use crate::compactor_state::{Compaction, SourceId};
 use crate::config::{CompactorOptions, CompressionCodec};
@@ -361,7 +361,7 @@ impl CompactionExecuteBench {
         #[allow(clippy::disallowed_methods)]
         tokio::task::spawn_blocking(move || executor.start_compaction(job));
         while let Some(msg) = rx.recv().await {
-            if let WorkerToOrchestratorMsg::CompactionFinished { id: _, result } = msg {
+            if let CompactorMessage::CompactionFinished { id: _, result } = msg {
                 match result {
                     Ok(_) => {
                         let elapsed_ms = self

--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -194,6 +194,7 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
     }
 
     /// Runs the dispatcher. This is the primary entry point for running the dispatcher.
+    /// Run blocks until the dispatcher is shutdown or an error occurs.
     ///
     /// [MessageDispatcher::run] is the primary entry point for running the dispatcher;
     /// it is responsible for:


### PR DESCRIPTION
Update the compactor to use `MessageDispatcher`. I tried to do this in the least invasive way possible. The implementation creates the `MessageDispatcher` inside `Compactor::run_async_task`. I like this pattern because it makes it pretty straight-forward to create a Compactor and run it outside of the DB (in a separate process/on a separate machine).

If the PR feels unwieldy, I suggest looking at the changes commit-by-commit.

Part of #776