### PR TITLE
Expose errors' `ErrorKind`

### DIFF
--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -337,6 +337,10 @@ impl Error {
         self.source = Some(source);
         self
     }
+
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
+    }
 }
 
 impl From<SlateDBError> for Error {


### PR DESCRIPTION
Pretty self explanatory. At the moment this returns a reference since `ErrorKind` is not `Copy`. It might also be a good idea to mark it as `non_exhaustive` so adding new error kinds is not a breaking change now that they're exposed.