### PR TITLE
Specify unique name for Python binding's Rust library

### DIFF
--- a/slatedb-py/Cargo.toml
+++ b/slatedb-py/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 homepage.workspace = true
 
 [lib]
-name = "slatedb"
+name = "slatedb_py"
 crate-type = ["cdylib"]
 doc = false
 # Disable `libtest` harness because it fights with Criterion's `--output-format bencher`


### PR DESCRIPTION
Fixes #897

Python tests fail on Windows seemingly due to path construction issues, but that is not related to this fix.