### PR TITLE
Expose fencing errors & mark `ErrorKind` as `non_exhaustive` and `Copy`

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3617,10 +3617,7 @@ mod tests {
 
         // assert that db1 can no longer write.
         let err = do_put(&db1, b"1", b"1").await.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            "Permission error: detected newer DB client"
-        );
+        assert_eq!(err.to_string(), "Fencing error: detected newer DB client");
 
         do_put(&db2, b"2", b"2").await.unwrap();
         assert_eq!(db2.inner.state.read().state().core().next_wal_sst_id, 5);


### PR DESCRIPTION
This does exactly what the title says.

Other options for fencing errors would be to add a `fenced` boolean field to `ErrorKind::Permission`, or to rename that variant or guarantee that it only applies to fencing. In any case users should be able to tell whether an error is due to fencing, and in my opinion it shouldn't be mixed with any other error kinds.

As for the other part of the changes, they were already discussed in #892.

Fixes #881