### PR TITLE
Expose db builder through ffi, remove SlateDBOptions

### DIFF
--- a/slatedb-go/go/batch_test.go
+++ b/slatedb-go/go/batch_test.go
@@ -22,7 +22,7 @@ var _ = Describe("WriteBatch", func() {
 
 		db, err = slatedb.Open(tmpDir, &slatedb.StoreConfig{
 			Provider: slatedb.ProviderLocal,
-		}, nil)
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(db).NotTo(BeNil())
 	})

--- a/slatedb-go/go/config.go
+++ b/slatedb-go/go/config.go
@@ -9,9 +9,15 @@ package slatedb
 import "C"
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 	"unsafe"
 )
+
+// ============================================================================
+// TYPE DEFINITIONS
+// ============================================================================
 
 // Provider types
 type Provider string
@@ -19,19 +25,6 @@ type Provider string
 const (
 	ProviderLocal Provider = "local"
 	ProviderAWS   Provider = "aws"
-)
-
-// SstBlockSize represents SST block size options
-type SstBlockSize uint8
-
-const (
-	SstBlockSize1Kib  = iota + 1 // 1KiB blocks
-	SstBlockSize2Kib             // 2KiB blocks
-	SstBlockSize4Kib             // 4KiB blocks (default)
-	SstBlockSize8Kib             // 8KiB blocks
-	SstBlockSize16Kib            // 16KiB blocks
-	SstBlockSize32Kib            // 32KiB blocks
-	SstBlockSize64Kib            // 64KiB blocks
 )
 
 // AWSConfig contains AWS S3 specific configuration
@@ -42,52 +35,10 @@ type AWSConfig struct {
 	RequestTimeout time.Duration `json:"request_timeout,omitempty"` // HTTP timeout for S3 requests
 }
 
-// CompactorOptions contains configuration for the background compactor
-type CompactorOptions struct {
-	// PollInterval sets how often to check for compaction opportunities
-	// If 0, uses SlateDB default (5s)
-	PollInterval time.Duration `json:"poll_interval,omitempty"`
-
-	// ManifestUpdateTimeout sets timeout for manifest update operations
-	// If 0, uses SlateDB default (300s)
-	ManifestUpdateTimeout time.Duration `json:"manifest_update_timeout,omitempty"`
-
-	// MaxSSTSizeBytes sets the target size for output SSTs during compaction
-	// If 0, uses SlateDB default (256MB)
-	MaxSSTSizeBytes uint64 `json:"max_sst_size_bytes,omitempty"`
-
-	// MaxConcurrentCompactions limits parallel compaction jobs
-	// If 0, uses SlateDB default (4)
-	MaxConcurrentCompactions uint32 `json:"max_concurrent_compactions,omitempty"`
-}
-
 // StoreConfig contains object storage provider configuration
 type StoreConfig struct {
 	Provider Provider   `json:"provider"`
 	AWS      *AWSConfig `json:"aws,omitempty"`
-}
-
-// SlateDBOptions contains optional configuration for opening a SlateDB database
-type SlateDBOptions struct {
-	// L0SstSizeBytes sets the size threshold for L0 SSTable flushes.
-	// If 0, uses default (64MB). Larger values reduce API calls but increase recovery time.
-	L0SstSizeBytes uint64 `json:"l0_sst_size_bytes,omitempty"`
-
-	// FlushInterval sets how often to flush the WAL to object storage.
-	// If 0, uses default (100ms). Lower values reduce latency but increase API costs.
-	FlushInterval time.Duration `json:"flush_interval,omitempty"`
-
-	// CacheFolder specifies the local folder for caching SSTables.
-	// If empty, no cache is used. If set, enables local caching of SSTables.
-	CacheFolder string `json:"cache_folder,omitempty"`
-
-	// SstBlockSize sets the block size for SSTable blocks.
-	// If 0, uses default (4KiB). Blocks are the unit of reading and caching.
-	SstBlockSize SstBlockSize `json:"sst_block_size,omitempty"`
-
-	// CompactorOptions controls background compaction behavior
-	// If nil, uses SlateDB defaults for all compactor settings
-	CompactorOptions *CompactorOptions `json:"compactor_options,omitempty"`
 }
 
 // DurabilityLevel represents the durability filter for scans
@@ -126,9 +77,311 @@ type ReadOptions struct {
 
 // DbReaderOptions controls DbReader behavior
 type DbReaderOptions struct {
-	ManifestPollInterval uint64 // How often to poll for updates (in milliseconds). Default: 5000 (5s) if 0
-	CheckpointLifetime   uint64 // How long checkpoints should live (in milliseconds). Default: 60000 (60s) if 0
-	MaxMemtableBytes     uint64 // Max size of in-memory table for WAL buffering. Default: 1048576 (1MB) if 0
+	ManifestPollInterval uint64 // How often to poll for updates (in milliseconds). Default: 10000 (10s) if 0
+	CheckpointLifetime   uint64 // How long checkpoints should live (in milliseconds). Default: 600000 (10m) if 0
+	MaxMemtableBytes     uint64 // Max size of in-memory table for WAL buffering. Default: 67108864 (64MB) if 0
+}
+
+// Settings represents SlateDB configuration that mirrors Rust's Settings struct exactly
+// Duration fields use strings to match Rust's JSON serialization format
+type Settings struct {
+	FlushInterval         string `json:"flush_interval,omitempty"`
+	ManifestPollInterval  string `json:"manifest_poll_interval,omitempty"`
+	ManifestUpdateTimeout string `json:"manifest_update_timeout,omitempty"`
+	CompressionCodec      string `json:"compression_codec,omitempty"`
+	DefaultTTL            string `json:"default_ttl,omitempty"`
+
+	MinFilterKeys     uint32 `json:"min_filter_keys,omitempty"`
+	FilterBitsPerKey  uint32 `json:"filter_bits_per_key,omitempty"`
+	L0SstSizeBytes    uint64 `json:"l0_sst_size_bytes,omitempty"`
+	L0MaxSsts         uint32 `json:"l0_max_ssts,omitempty"`
+	MaxUnflushedBytes uint64 `json:"max_unflushed_bytes,omitempty"`
+
+	WalEnabled *bool `json:"wal_enabled,omitempty"`
+
+	CompactorOptions        *CompactorOptions        `json:"compactor_options,omitempty"`
+	ObjectStoreCacheOptions *ObjectStoreCacheOptions `json:"object_store_cache_options,omitempty"`
+	GarbageCollectorOptions *GarbageCollectorOptions `json:"garbage_collector_options,omitempty"`
+}
+
+// CompactorOptions represents compaction configuration
+type CompactorOptions struct {
+	PollInterval             string `json:"poll_interval"`
+	ManifestUpdateTimeout    string `json:"manifest_update_timeout"`
+	MaxSstSize               uint64 `json:"max_sst_size"`
+	MaxConcurrentCompactions uint32 `json:"max_concurrent_compactions"`
+}
+
+// ObjectStoreCacheOptions represents object store caching configuration
+type ObjectStoreCacheOptions struct {
+	RootFolder                string `json:"root_folder,omitempty"`
+	ScanInterval              string `json:"scan_interval,omitempty"`
+	MaxCacheSizeBytes         uint64 `json:"max_cache_size_bytes,omitempty"`
+	PartSizeBytes             uint64 `json:"part_size_bytes,omitempty"`
+	CachePuts                 *bool  `json:"cache_puts,omitempty"`
+	PreloadDiskCacheOnStartup *bool  `json:"preload_disk_cache_on_startup,omitempty"`
+}
+
+// GarbageCollectorOptions represents garbage collection configuration
+//
+// Behavior:
+// - nil GarbageCollectorOptions: Garbage collection disabled
+// - Empty GarbageCollectorOptions{}: Garbage collection enabled with Rust defaults
+// - Specific directory options: Garbage collection enabled for all directories, options applied to specific directories
+type GarbageCollectorOptions struct {
+	Manifest  *GarbageCollectorDirectoryOptions `json:"manifest_options,omitempty"`
+	Wal       *GarbageCollectorDirectoryOptions `json:"wal_options,omitempty"`
+	Compacted *GarbageCollectorDirectoryOptions `json:"compacted_options,omitempty"`
+}
+
+// GarbageCollectorDirectoryOptions represents per-directory GC configuration
+//
+// Default values match Rust defaults:
+// - Interval: "300s" (5 minutes)
+// - MinAge: "86400s" (24 hours)
+//
+// Override as needed:
+//
+//	Manifest: &GarbageCollectorDirectoryOptions{Interval: "60s", MinAge: "1h"}
+type GarbageCollectorDirectoryOptions struct {
+	Interval string `json:"interval"` // Default: "300s" (5 minutes)
+	MinAge   string `json:"min_age"`  // Default: "86400s" (24 hours)
+}
+
+// DefaultGarbageCollectorDirectoryOptions returns Rust default values
+func DefaultGarbageCollectorDirectoryOptions() *GarbageCollectorDirectoryOptions {
+	return &GarbageCollectorDirectoryOptions{
+		Interval: "300s",   // 5 minutes
+		MinAge:   "86400s", // 24 hours
+	}
+}
+
+// SstBlockSize represents SST block size options
+type SstBlockSize uint8
+
+const (
+	SstBlockSize1Kib SstBlockSize = iota + 1
+	SstBlockSize2Kib
+	SstBlockSize4Kib
+	SstBlockSize8Kib
+	SstBlockSize16Kib
+	SstBlockSize32Kib
+	SstBlockSize64Kib
+)
+
+// ============================================================================
+// SETTINGS CONSTRUCTORS
+// ============================================================================
+
+// settingsFromJSON converts JSON from Rust FFI into a Settings struct
+// This handles Rust's string durations ("100ms", "1s") transparently
+func settingsFromJSON(jsonStr string) (*Settings, error) {
+	var settings Settings
+	if err := json.Unmarshal([]byte(jsonStr), &settings); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal settings JSON: %w", err)
+	}
+	return &settings, nil
+}
+
+// SettingsDefault creates default Settings
+func SettingsDefault() (*Settings, error) {
+	cJson := C.slatedb_settings_default()
+	if cJson == nil {
+		return nil, errors.New("failed to create default settings")
+	}
+	defer C.free(unsafe.Pointer(cJson))
+
+	jsonStr := C.GoString(cJson)
+	return settingsFromJSON(jsonStr)
+}
+
+// SettingsFromFile loads Settings from a configuration file
+// The result is always merged with defaults, so partial configurations work correctly
+func SettingsFromFile(path string) (*Settings, error) {
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cJson := C.slatedb_settings_from_file(cPath)
+	if cJson == nil {
+		return nil, fmt.Errorf("failed to load settings from file: %s", path)
+	}
+	defer C.free(unsafe.Pointer(cJson))
+
+	jsonStr := C.GoString(cJson)
+	return settingsFromJSON(jsonStr)
+}
+
+// SettingsFromEnv loads Settings from environment variables
+// The result is always merged with defaults, so partial configurations work correctly
+func SettingsFromEnv(prefix string) (*Settings, error) {
+	cPrefix := C.CString(prefix)
+	defer C.free(unsafe.Pointer(cPrefix))
+
+	cJson := C.slatedb_settings_from_env(cPrefix)
+	if cJson == nil {
+		return nil, fmt.Errorf("failed to load settings from environment with prefix: %s", prefix)
+	}
+	defer C.free(unsafe.Pointer(cJson))
+
+	jsonStr := C.GoString(cJson)
+	return settingsFromJSON(jsonStr)
+}
+
+// SettingsLoad loads Settings using auto-detection (files, env vars, etc.)
+// The result is always merged with defaults, so partial configurations work correctly
+func SettingsLoad() (*Settings, error) {
+	cJson := C.slatedb_settings_load()
+	if cJson == nil {
+		return nil, errors.New("failed to load settings using auto-detection")
+	}
+	defer C.free(unsafe.Pointer(cJson))
+
+	jsonStr := C.GoString(cJson)
+	return settingsFromJSON(jsonStr)
+}
+
+// ============================================================================
+// MERGE FUNCTIONS
+// ============================================================================
+
+// MergeSettings merges two Settings structs, with override taking precedence over base
+func MergeSettings(base, override *Settings) *Settings {
+	if base == nil && override == nil {
+		return &Settings{} // Return empty settings instead of nil
+	}
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+
+	result := *base // Copy base
+
+	if override.FlushInterval != "" {
+		result.FlushInterval = override.FlushInterval
+	}
+	if override.ManifestPollInterval != "" {
+		result.ManifestPollInterval = override.ManifestPollInterval
+	}
+	if override.ManifestUpdateTimeout != "" {
+		result.ManifestUpdateTimeout = override.ManifestUpdateTimeout
+	}
+	if override.CompressionCodec != "" {
+		result.CompressionCodec = override.CompressionCodec
+	}
+	if override.DefaultTTL != "" {
+		result.DefaultTTL = override.DefaultTTL
+	}
+
+	if override.MinFilterKeys != 0 {
+		result.MinFilterKeys = override.MinFilterKeys
+	}
+	if override.FilterBitsPerKey != 0 {
+		result.FilterBitsPerKey = override.FilterBitsPerKey
+	}
+	if override.L0SstSizeBytes != 0 {
+		result.L0SstSizeBytes = override.L0SstSizeBytes
+	}
+	if override.L0MaxSsts != 0 {
+		result.L0MaxSsts = override.L0MaxSsts
+	}
+	if override.MaxUnflushedBytes != 0 {
+		result.MaxUnflushedBytes = override.MaxUnflushedBytes
+	}
+
+	if override.WalEnabled != nil {
+		result.WalEnabled = override.WalEnabled
+	}
+	if override.CompactorOptions != nil {
+		if result.CompactorOptions == nil {
+			result.CompactorOptions = override.CompactorOptions
+		} else {
+			// Merge CompactorOptions fields individually
+			merged := *result.CompactorOptions
+			if override.CompactorOptions.PollInterval != "" {
+				merged.PollInterval = override.CompactorOptions.PollInterval
+			}
+			if override.CompactorOptions.ManifestUpdateTimeout != "" {
+				merged.ManifestUpdateTimeout = override.CompactorOptions.ManifestUpdateTimeout
+			}
+			if override.CompactorOptions.MaxSstSize != 0 {
+				merged.MaxSstSize = override.CompactorOptions.MaxSstSize
+			}
+			if override.CompactorOptions.MaxConcurrentCompactions != 0 {
+				merged.MaxConcurrentCompactions = override.CompactorOptions.MaxConcurrentCompactions
+			}
+			result.CompactorOptions = &merged
+		}
+	}
+	if override.ObjectStoreCacheOptions != nil {
+		if result.ObjectStoreCacheOptions == nil {
+			result.ObjectStoreCacheOptions = override.ObjectStoreCacheOptions
+		} else {
+			// Merge ObjectStoreCacheOptions fields individually
+			merged := *result.ObjectStoreCacheOptions
+			if override.ObjectStoreCacheOptions.RootFolder != "" {
+				merged.RootFolder = override.ObjectStoreCacheOptions.RootFolder
+			}
+			if override.ObjectStoreCacheOptions.ScanInterval != "" {
+				merged.ScanInterval = override.ObjectStoreCacheOptions.ScanInterval
+			}
+			if override.ObjectStoreCacheOptions.MaxCacheSizeBytes != 0 {
+				merged.MaxCacheSizeBytes = override.ObjectStoreCacheOptions.MaxCacheSizeBytes
+			}
+			if override.ObjectStoreCacheOptions.PartSizeBytes != 0 {
+				merged.PartSizeBytes = override.ObjectStoreCacheOptions.PartSizeBytes
+			}
+			if override.ObjectStoreCacheOptions.CachePuts != nil {
+				merged.CachePuts = override.ObjectStoreCacheOptions.CachePuts
+			}
+			if override.ObjectStoreCacheOptions.PreloadDiskCacheOnStartup != nil {
+				merged.PreloadDiskCacheOnStartup = override.ObjectStoreCacheOptions.PreloadDiskCacheOnStartup
+			}
+			result.ObjectStoreCacheOptions = &merged
+		}
+	}
+	if override.GarbageCollectorOptions != nil {
+		if result.GarbageCollectorOptions == nil {
+			result.GarbageCollectorOptions = override.GarbageCollectorOptions
+		} else {
+			// Merge GarbageCollectorOptions fields individually
+			merged := *result.GarbageCollectorOptions
+			if override.GarbageCollectorOptions.Manifest != nil {
+				merged.Manifest = mergeGarbageCollectorDirectoryOptions(merged.Manifest, override.GarbageCollectorOptions.Manifest)
+			}
+			if override.GarbageCollectorOptions.Wal != nil {
+				merged.Wal = mergeGarbageCollectorDirectoryOptions(merged.Wal, override.GarbageCollectorOptions.Wal)
+			}
+			if override.GarbageCollectorOptions.Compacted != nil {
+				merged.Compacted = mergeGarbageCollectorDirectoryOptions(merged.Compacted, override.GarbageCollectorOptions.Compacted)
+			}
+			result.GarbageCollectorOptions = &merged
+		}
+	}
+
+	return &result
+}
+
+// Helper functions for nested struct merging
+
+// mergeGarbageCollectorDirectoryOptions merges two GarbageCollectorDirectoryOptions
+func mergeGarbageCollectorDirectoryOptions(base, override *GarbageCollectorDirectoryOptions) *GarbageCollectorDirectoryOptions {
+	if base == nil {
+		return override
+	}
+	if override == nil {
+		return base
+	}
+
+	merged := *base
+	if override.Interval != "" {
+		merged.Interval = override.Interval
+	}
+	if override.MinAge != "" {
+		merged.MinAge = override.MinAge
+	}
+	return &merged
 }
 
 // ScanOptions contains options for scan operations
@@ -139,6 +392,10 @@ type ScanOptions struct {
 	CacheBlocks      bool   // Whether to cache fetched blocks (default: false)
 	MaxFetchTasks    uint64 // Maximum concurrent fetch tasks (default: 1)
 }
+
+// ============================================================================
+// FFI CONVERTER FUNCTIONS
+// ============================================================================
 
 // convertToCScanOptions converts Go ScanOptions to C ScanOptions
 func convertToCScanOptions(opts *ScanOptions) *C.CSdbScanOptions {
@@ -212,22 +469,6 @@ func convertStoreConfigToJSON(config *StoreConfig) (*C.char, unsafe.Pointer) {
 	}
 
 	jsonBytes, err := json.Marshal(config)
-	if err != nil {
-		return nil, nil // Return null on error
-	}
-
-	cStr := C.CString(string(jsonBytes))
-	return cStr, unsafe.Pointer(cStr)
-}
-
-// convertOptionsToJSON converts Go SlateDBOptions to JSON string
-// Returns C string and pointer to free. Caller must free the returned pointer.
-func convertOptionsToJSON(opts *SlateDBOptions) (*C.char, unsafe.Pointer) {
-	if opts == nil {
-		return nil, nil // Pass null to C = use all defaults
-	}
-
-	jsonBytes, err := json.Marshal(opts)
 	if err != nil {
 		return nil, nil // Return null on error
 	}

--- a/slatedb-go/go/config_test.go
+++ b/slatedb-go/go/config_test.go
@@ -1,0 +1,142 @@
+package slatedb_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"slatedb.io/slatedb-go"
+)
+
+var _ = Describe("Configuration", func() {
+	Describe("SettingsDefault", func() {
+		It("should create valid default settings", func() {
+			settings, err := slatedb.SettingsDefault()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(settings).ToNot(BeNil())
+			Expect(settings.FlushInterval).ToNot(BeEmpty())
+			Expect(settings.L0SstSizeBytes).To(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("MergeSettings", func() {
+		var base, override *slatedb.Settings
+
+		BeforeEach(func() {
+			base = &slatedb.Settings{
+				FlushInterval:  "100ms",
+				L0SstSizeBytes: 1048576,
+				MinFilterKeys:  1000,
+				CompactorOptions: &slatedb.CompactorOptions{
+					PollInterval:             "1s",
+					ManifestUpdateTimeout:    "30s",
+					MaxSstSize:               67108864,
+					MaxConcurrentCompactions: 2,
+				},
+				ObjectStoreCacheOptions: &slatedb.ObjectStoreCacheOptions{
+					MaxCacheSizeBytes: 134217728,
+					RootFolder:        "/tmp/base",
+				},
+			}
+		})
+
+		It("should merge with zero-value semantics", func() {
+			override = &slatedb.Settings{
+				FlushInterval:  "200ms", // Override
+				L0SstSizeBytes: 0,       // Zero - preserve base
+				MinFilterKeys:  2000,    // Override
+			}
+
+			merged := slatedb.MergeSettings(base, override)
+
+			Expect(merged.FlushInterval).To(Equal("200ms"))          // Overridden
+			Expect(merged.L0SstSizeBytes).To(Equal(uint64(1048576))) // Preserved from base
+			Expect(merged.MinFilterKeys).To(Equal(uint32(2000)))     // Overridden
+		})
+
+		It("should merge nested structs field-by-field", func() {
+			override = &slatedb.Settings{
+				CompactorOptions: &slatedb.CompactorOptions{
+					PollInterval: "2s", // Override only this field
+					MaxSstSize:   134217728,
+				},
+				ObjectStoreCacheOptions: &slatedb.ObjectStoreCacheOptions{
+					RootFolder: "/tmp/override", // Override only this field
+				},
+			}
+
+			merged := slatedb.MergeSettings(base, override)
+
+			// CompactorOptions: some fields overridden, others preserved
+			Expect(merged.CompactorOptions.PollInterval).To(Equal("2s"))
+			Expect(merged.CompactorOptions.ManifestUpdateTimeout).To(Equal("30s")) // Preserved
+			Expect(merged.CompactorOptions.MaxSstSize).To(Equal(uint64(134217728)))
+			Expect(merged.CompactorOptions.MaxConcurrentCompactions).To(Equal(uint32(2))) // Preserved
+
+			// ObjectStoreCacheOptions: partial override
+			Expect(merged.ObjectStoreCacheOptions.RootFolder).To(Equal("/tmp/override"))
+			Expect(merged.ObjectStoreCacheOptions.MaxCacheSizeBytes).To(Equal(uint64(134217728))) // Preserved
+		})
+
+		It("should handle nil cases", func() {
+			Expect(slatedb.MergeSettings(nil, base)).To(Equal(base))
+			Expect(slatedb.MergeSettings(base, nil)).To(Equal(base))
+			Expect(slatedb.MergeSettings(nil, nil)).ToNot(BeNil())
+		})
+	})
+
+	Describe("GarbageCollectorOptions merging", func() {
+		It("should merge nested GC options correctly", func() {
+			base := &slatedb.Settings{
+				GarbageCollectorOptions: &slatedb.GarbageCollectorOptions{
+					Manifest: &slatedb.GarbageCollectorDirectoryOptions{
+						Interval: "24h",
+						MinAge:   "1h",
+					},
+				},
+			}
+
+			override := &slatedb.Settings{
+				GarbageCollectorOptions: &slatedb.GarbageCollectorOptions{
+					Manifest: &slatedb.GarbageCollectorDirectoryOptions{
+						Interval: "48h",
+						MinAge:   "1h",
+					},
+					Compacted: &slatedb.GarbageCollectorDirectoryOptions{
+						Interval: "6h",
+						MinAge:   "15m",
+					},
+				},
+			}
+
+			merged := slatedb.MergeSettings(base, override)
+
+			Expect(merged.GarbageCollectorOptions.Manifest.Interval).To(Equal("48h"))
+			Expect(merged.GarbageCollectorOptions.Manifest.MinAge).To(Equal("1h"))
+			Expect(merged.GarbageCollectorOptions.Compacted.Interval).To(Equal("6h"))
+			Expect(merged.GarbageCollectorOptions.Compacted.MinAge).To(Equal("15m"))
+		})
+	})
+
+	Describe("JSON serialization", func() {
+		It("should serialize and deserialize correctly", func() {
+			original := &slatedb.Settings{
+				FlushInterval:  "250ms",
+				L0SstSizeBytes: 2097152,
+				MinFilterKeys:  1500,
+			}
+
+			jsonData, err := json.Marshal(original)
+			Expect(err).ToNot(HaveOccurred())
+
+			var deserialized slatedb.Settings
+			err = json.Unmarshal(jsonData, &deserialized)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(deserialized.FlushInterval).To(Equal(original.FlushInterval))
+			Expect(deserialized.L0SstSizeBytes).To(Equal(original.L0SstSizeBytes))
+			Expect(deserialized.MinFilterKeys).To(Equal(original.MinFilterKeys))
+		})
+	})
+})

--- a/slatedb-go/go/iterator_test.go
+++ b/slatedb-go/go/iterator_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Iterator", func() {
 
 		db, err = slatedb.Open(tmpDir, &slatedb.StoreConfig{
 			Provider: slatedb.ProviderLocal,
-		}, nil)
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(db).NotTo(BeNil())
 

--- a/slatedb-go/src/db_reader.rs
+++ b/slatedb-go/src/db_reader.rs
@@ -138,8 +138,7 @@ pub extern "C" fn slatedb_reader_open(
                 parse_store_config(json_str).map_err(|_| CSdbError::InvalidArgument)
             })
             .and_then(|config| {
-                rt.block_on(create_object_store(&config))
-                    .map_err(|_| CSdbError::InvalidArgument)
+                create_object_store(&config).map_err(|_| CSdbError::InvalidArgument)
             });
 
         match store_result {

--- a/slatedb-go/src/object_store.rs
+++ b/slatedb-go/src/object_store.rs
@@ -15,9 +15,7 @@ pub fn create_inmemory_store() -> Result<Arc<dyn ObjectStore>, CSdbResult> {
 }
 
 // Helper function to create AWS S3 object store
-pub async fn create_aws_store(
-    aws_config: &AwsConfigJson,
-) -> Result<Arc<dyn ObjectStore>, CSdbResult> {
+pub fn create_aws_store(aws_config: &AwsConfigJson) -> Result<Arc<dyn ObjectStore>, CSdbResult> {
     let bucket_str = if let Some(bucket) = aws_config.bucket.clone() {
         bucket
     } else if let Ok(bucket) = std::env::var("AWS_BUCKET") {


### PR DESCRIPTION
Using settings json as expected by the rust dbBuilder instead of creating a custom SlateDBOptions. This change makes the ffi/go usage closer to rust usage, and provides configuration options which were previously missing. It also adds missing support for providing settings through file, env, or auto-detection.

Also changes the previous `Open` method to use all defaults, and removed the SlateDBOptions argument. Advanced usage can use the builder methods instead.