### PR TITLE
Fix `test_should_recover_imm_from_wal_after_flush_error`

### DIFF
--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -172,8 +172,6 @@ impl DbInner {
             |_| { Err(SlateDBError::from(std::io::Error::other("oops"))) }
         );
 
-        // get the durable watcher. we'll await on current WAL table to be flushed if wal is enabled.
-        // otherwise, we'll use the memtable's durable watcher.
         if self.wal_enabled {
             self.wal_buffer.maybe_trigger_flush().await?;
             // TODO: handle sync here, if sync is enabled, we can call `flush` here. let's put this

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -17,7 +17,7 @@ pub struct Checkpoint {
 }
 
 #[non_exhaustive]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CheckpointCreateResult {
     /// The id of the created checkpoint.
     pub id: Uuid,

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -228,7 +228,7 @@ impl MessageHandler<MemtableFlushMsg> for MemtableFlusher {
                 if let Err(Err(e)) = sender.send(write_result.clone()) {
                     error!("Failed to send checkpoint error [error={:?}]", e);
                 }
-                write_result.and_then(|_| Ok(()))
+                write_result.map(|_| ())
             }
         }
     }

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -214,21 +214,21 @@ impl MessageHandler<MemtableFlushMsg> for MemtableFlusher {
                 self.flush_and_record().await
             }
             MemtableFlushMsg::FlushImmutableMemtables { sender } => {
-                self.flush_and_record().await?;
+                let result = self.flush_and_record().await;
                 if let Some(rsp_sender) = sender {
-                    let res = rsp_sender.send(Ok(()));
+                    let res = rsp_sender.send(result.clone());
                     if let Err(Err(err)) = res {
                         error!("error sending flush response [error={:?}]", err);
                     }
                 }
-                Ok(())
+                result
             }
             MemtableFlushMsg::CreateCheckpoint { options, sender } => {
                 let write_result = self.write_checkpoint_safely(&options).await;
-                if let Err(Err(e)) = sender.send(write_result) {
+                if let Err(Err(e)) = sender.send(write_result.clone()) {
                     error!("Failed to send checkpoint error [error={:?}]", e);
                 }
-                Ok(())
+                write_result.and_then(|_| Ok(()))
             }
         }
     }

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -200,14 +200,14 @@ impl WalBufferManager {
 
     /// Append row entries to the current WAL. return the last seq number of the WAL.
     /// TODO: validate the seq number is always increasing.
-    pub async fn append(&self, entries: &[RowEntry]) -> Result<Option<u64>, SlateDBError> {
+    pub async fn append(&self, entries: &[RowEntry]) -> Result<Arc<KVTable>, SlateDBError> {
         // TODO: check if the wal buffer is in a fatal error state.
 
         let inner = self.inner.write();
         for entry in entries {
             inner.current_wal.put(entry.clone());
         }
-        Ok(entries.last().map(|entry| entry.seq))
+        Ok(inner.current_wal.clone())
     }
 
     /// Check if we need to flush the wal with considering max_wal_size. the checking over `max_wal_size`


### PR DESCRIPTION
After various dispatcher.rs migrations, several issues surfaced:

1. `mem_table_flush.rs` was always returning `Ok(())` in its event handler (even when `flush_and_record` or `write_checkpoint_safely` failed).
2. A race condition in `batch_write.rs` surfaced. We call `wal_buffer.append()` to add rows, then later we get the `current_wal` to use when notifying durable writes. It's technically possible for `flush_interval` to trigger a WAL flush between these two steps. If that happens, the `current_wal` we return is not the WAL that the rows were written to (it's already been frozen and potentially flushed). This was causing our test to hang indefinitely since the second WAL never gets flushed.
3. We had the test set to a max L0 SST byte size of 128, which we were writing. This led to a race condition where the mem_table_flush.rs event loop _might_ trigger its "oops" error (in table_store.rs) _before_ the put() call gets a clean `Ok(())` response to its WAL write. I fixed this by bumping the max L0 SST byte size up and forcing a flush that includes the current memtable (even if it's < the max l0 size).

Fixes #904 