### PR TITLE
wire in sequence tracker [RFC-0012]

### DIFF
--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -95,6 +95,9 @@ table ManifestV1 {
     // needs this to determine whether it's safe to drop duplicate key writes. If a recent snapshot
     // still references an older version of a key, it should not be dropped.
     recent_snapshot_min_seq: ulong;
+
+    // Serialized sequence tracker data as defined in RFC-0012.
+    sequence_tracker: [ubyte];
 }
 
 table CompactedSstId {

--- a/slatedb-go/go/slatedb.h
+++ b/slatedb-go/go/slatedb.h
@@ -181,6 +181,8 @@ typedef struct CSdbScanResult {
 
 #define ManifestV1_VT_RECENT_SNAPSHOT_MIN_SEQ 32
 
+#define ManifestV1_VT_SEQUENCE_TRACKER 34
+
 #define CompactedSsTable_VT_ID 4
 
 #define CompactedSsTable_VT_INFO 6

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -183,7 +183,7 @@ impl DbInner {
 
         // update the last_committed_seq, so the writes will be visible to the readers.
         self.oracle.last_committed_seq.store(commit_seq);
-        self.oracle.record_sequence(commit_seq, now);
+        self.oracle.record_sequence(commit_seq);
 
         // maybe freeze the memtable.
         {

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -183,6 +183,7 @@ impl DbInner {
 
         // update the last_committed_seq, so the writes will be visible to the readers.
         self.oracle.last_committed_seq.store(commit_seq);
+        self.oracle.record_sequence(commit_seq, now);
 
         // maybe freeze the memtable.
         {

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -183,6 +183,7 @@ impl CompactorState {
             checkpoints: remote_manifest.core.checkpoints.clone(),
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
             recent_snapshot_min_seq: my_db_state.recent_snapshot_min_seq,
+            sequence_tracker: remote_manifest.core.sequence_tracker,
         };
         remote_manifest.core = merged;
         self.manifest = remote_manifest;

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2632,6 +2632,7 @@ mod tests {
         assert!(found_keys.contains(key2.as_slice()));
     }
 
+    #[cfg(feature = "test-util")]
     async fn test_sequence_tracker_persisted_across_flush_and_reload_impl(wal_enabled: bool) {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_sequence_tracker_flush";

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -110,13 +110,15 @@ impl DbInner {
     ) -> Result<Self, SlateDBError> {
         // both last_seq and last_committed_seq will be updated after WAL replay.
         let last_l0_seq = manifest.core.last_l0_seq;
+        let initial_sequence_tracker = manifest.core.sequence_tracker.clone();
         let last_seq = MonotonicSeq::new(last_l0_seq);
         let last_committed_seq = MonotonicSeq::new(last_l0_seq);
         let last_remote_persisted_seq = MonotonicSeq::new(last_l0_seq);
         let oracle = Arc::new(
             Oracle::new(last_committed_seq)
                 .with_last_seq(last_seq)
-                .with_last_remote_persisted_seq(last_remote_persisted_seq),
+                .with_last_remote_persisted_seq(last_remote_persisted_seq)
+                .with_sequence_tracker(initial_sequence_tracker),
         );
 
         let mono_clock = Arc::new(MonotonicClock::new(

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -129,7 +129,9 @@ impl DbReaderInner {
         // to last_l0_seq.
         let last_committed_seq = MonotonicSeq::new(initial_state.core().last_l0_seq);
         last_committed_seq.store_if_greater(initial_state.last_committed_seq);
-        let oracle = Arc::new(Oracle::new(last_committed_seq));
+        let sequence_tracker = initial_state.core().sequence_tracker.clone();
+        let oracle =
+            Arc::new(Oracle::new(last_committed_seq).with_sequence_tracker(sequence_tracker));
 
         let stat_registry = Arc::new(StatRegistry::new());
         let db_stats = DbStats::new(stat_registry.as_ref());

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -130,8 +130,10 @@ impl DbReaderInner {
         let last_committed_seq = MonotonicSeq::new(initial_state.core().last_l0_seq);
         last_committed_seq.store_if_greater(initial_state.last_committed_seq);
         let sequence_tracker = initial_state.core().sequence_tracker.clone();
-        let oracle =
-            Arc::new(Oracle::new(last_committed_seq).with_sequence_tracker(sequence_tracker));
+        let oracle = Arc::new(
+            Oracle::new(last_committed_seq, system_clock.clone())
+                .with_sequence_tracker(sequence_tracker),
+        );
 
         let stat_registry = Arc::new(StatRegistry::new());
         let db_stats = DbStats::new(stat_registry.as_ref());

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -5,6 +5,7 @@ use crate::error::SlateDBError;
 use crate::manifest::store::DirtyManifest;
 use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
 use crate::reader::DbStateReader;
+use crate::seq_tracker::SequenceTracker;
 use crate::utils::{WatchableOnceCell, WatchableOnceCellReader};
 use crate::wal_id::WalIdStore;
 use bytes::Bytes;
@@ -340,6 +341,7 @@ pub(crate) struct CoreDbState {
     /// recent snapshot still references an older version of a key, it should not be
     /// recycled. This field is updated when a new L0 is flushed.
     pub(crate) recent_snapshot_min_seq: u64,
+    pub(crate) sequence_tracker: SequenceTracker,
     pub(crate) checkpoints: Vec<Checkpoint>,
     pub(crate) wal_object_store_uri: Option<String>,
 }
@@ -358,6 +360,7 @@ impl CoreDbState {
             checkpoints: vec![],
             wal_object_store_uri: None,
             recent_snapshot_min_seq: 0,
+            sequence_tracker: SequenceTracker::new(),
         }
     }
 
@@ -532,9 +535,10 @@ impl<'a> StateModifier<'a> {
             replay_after_wal_id: my_db_state.replay_after_wal_id,
             last_l0_clock_tick: my_db_state.last_l0_clock_tick,
             last_l0_seq: my_db_state.last_l0_seq,
+            recent_snapshot_min_seq: my_db_state.recent_snapshot_min_seq,
+            sequence_tracker: remote_manifest.core.sequence_tracker,
             checkpoints: remote_manifest.core.checkpoints,
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
-            recent_snapshot_min_seq: my_db_state.recent_snapshot_min_seq,
         };
         self.state.manifest = remote_manifest;
     }

--- a/slatedb/src/generated/manifest_generated.rs
+++ b/slatedb/src/generated/manifest_generated.rs
@@ -1207,6 +1207,7 @@ impl<'a> ManifestV1<'a> {
   pub const VT_LAST_L0_SEQ: flatbuffers::VOffsetT = 28;
   pub const VT_WAL_OBJECT_STORE_URI: flatbuffers::VOffsetT = 30;
   pub const VT_RECENT_SNAPSHOT_MIN_SEQ: flatbuffers::VOffsetT = 32;
+  pub const VT_SEQUENCE_TRACKER: flatbuffers::VOffsetT = 34;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -1226,6 +1227,7 @@ impl<'a> ManifestV1<'a> {
     builder.add_compactor_epoch(args.compactor_epoch);
     builder.add_writer_epoch(args.writer_epoch);
     builder.add_manifest_id(args.manifest_id);
+    if let Some(x) = args.sequence_tracker { builder.add_sequence_tracker(x); }
     if let Some(x) = args.wal_object_store_uri { builder.add_wal_object_store_uri(x); }
     if let Some(x) = args.checkpoints { builder.add_checkpoints(x); }
     if let Some(x) = args.compacted { builder.add_compacted(x); }
@@ -1342,6 +1344,13 @@ impl<'a> ManifestV1<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<u64>(ManifestV1::VT_RECENT_SNAPSHOT_MIN_SEQ, Some(0)).unwrap()}
   }
+  #[inline]
+  pub fn sequence_tracker(&self) -> Option<flatbuffers::Vector<'a, u8>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(ManifestV1::VT_SEQUENCE_TRACKER, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for ManifestV1<'_> {
@@ -1366,6 +1375,7 @@ impl flatbuffers::Verifiable for ManifestV1<'_> {
      .visit_field::<u64>("last_l0_seq", Self::VT_LAST_L0_SEQ, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<&str>>("wal_object_store_uri", Self::VT_WAL_OBJECT_STORE_URI, false)?
      .visit_field::<u64>("recent_snapshot_min_seq", Self::VT_RECENT_SNAPSHOT_MIN_SEQ, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("sequence_tracker", Self::VT_SEQUENCE_TRACKER, false)?
      .finish();
     Ok(())
   }
@@ -1386,6 +1396,7 @@ pub struct ManifestV1Args<'a> {
     pub last_l0_seq: u64,
     pub wal_object_store_uri: Option<flatbuffers::WIPOffset<&'a str>>,
     pub recent_snapshot_min_seq: u64,
+    pub sequence_tracker: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
 }
 impl<'a> Default for ManifestV1Args<'a> {
   #[inline]
@@ -1406,6 +1417,7 @@ impl<'a> Default for ManifestV1Args<'a> {
       last_l0_seq: 0,
       wal_object_store_uri: None,
       recent_snapshot_min_seq: 0,
+      sequence_tracker: None,
     }
   }
 }
@@ -1476,6 +1488,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV1Builder<'a, 'b, A> {
     self.fbb_.push_slot::<u64>(ManifestV1::VT_RECENT_SNAPSHOT_MIN_SEQ, recent_snapshot_min_seq, 0);
   }
   #[inline]
+  pub fn add_sequence_tracker(&mut self, sequence_tracker: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV1::VT_SEQUENCE_TRACKER, sequence_tracker);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ManifestV1Builder<'a, 'b, A> {
     let start = _fbb.start_table();
     ManifestV1Builder {
@@ -1511,6 +1527,7 @@ impl core::fmt::Debug for ManifestV1<'_> {
       ds.field("last_l0_seq", &self.last_l0_seq());
       ds.field("wal_object_store_uri", &self.wal_object_store_uri());
       ds.field("recent_snapshot_min_seq", &self.recent_snapshot_min_seq());
+      ds.field("sequence_tracker", &self.sequence_tracker());
       ds.finish()
   }
 }

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -41,9 +41,6 @@ impl MemtableFlusher {
         self.manifest.refresh().await?;
         let mut wguard_state = self.db_inner.state.write();
         wguard_state.merge_remote_manifest(self.manifest.prepare_dirty()?);
-        let tracker = wguard_state.state().core().sequence_tracker.clone();
-        drop(wguard_state);
-        self.db_inner.oracle.replace_sequence_tracker(tracker);
         Ok(())
     }
 

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -5,6 +5,7 @@ use crate::db_state::SsTableId;
 use crate::dispatcher::{MessageDispatcher, MessageFactory, MessageHandler};
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
+use crate::seq_tracker::SequenceTracker;
 use crate::utils::IdGenerator;
 use async_trait::async_trait;
 use futures::stream::BoxStream;

--- a/slatedb/src/oracle.rs
+++ b/slatedb/src/oracle.rs
@@ -20,7 +20,12 @@ pub(crate) struct Oracle {
     /// The sequence number of the most recent write that has been fully durable
     /// flushed to the remote storage.
     pub(crate) last_remote_persisted_seq: Arc<MonotonicSeq>,
+    /// A sequence tracker that correlates sequence numbers with system clock ticks.
+    /// The tracker is limited to 8192 entries and downsamples data when it gets full.
     sequence_tracker: Arc<Mutex<SequenceTracker>>,
+    /// The system clock to use when tracking sequence numbers (sequence numbers
+    /// will be associated with the system clock tick and only be recorded every
+    /// 60 seconds worth of ticks to this clock)
     system_clock: Arc<dyn SystemClock>,
 }
 

--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -34,7 +34,7 @@ pub(crate) enum FindOption {
 /// Uses two sorted arrays for bi-directional lookup between sequence numbers and timestamps.
 /// When capacity is reached, downsamples by removing every other entry to maintain bounded memory.
 /// Data is compressed using Gorilla encoding (delta-of-deltas) for efficient storage.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub(crate) struct SequenceTracker {
     /// Sorted array of sequence numbers
     sequence_numbers: Vec<u64>,
@@ -46,6 +46,16 @@ pub(crate) struct SequenceTracker {
     interval_secs: u64,
     /// Last recorded timestamp to enforce interval
     last_recorded_ts: Option<i64>,
+}
+
+impl PartialEq for SequenceTracker {
+    fn eq(&self, other: &Self) -> bool {
+        // Compare only the essential data, ignoring last_recorded_ts which is implementation detail
+        self.sequence_numbers == other.sequence_numbers
+            && self.timestamps == other.timestamps
+            && self.capacity == other.capacity
+            && self.interval_secs == other.interval_secs
+    }
 }
 
 #[allow(dead_code)]

--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -151,6 +151,16 @@ impl SequenceTracker {
             },
         }
     }
+
+    /// Serialize the tracker into bytes using the RFC-0012 format.
+    pub(crate) fn to_bytes(&self) -> Vec<u8> {
+        encode_sequence_tracker(self)
+    }
+
+    /// Deserialize the tracker from bytes using the RFC-0012 format.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        decode_sequence_tracker(bytes)
+    }
 }
 
 impl Serialize for SequenceTracker {

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -360,6 +360,7 @@ mod tests {
 
     use crate::db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::manifest::store::test_utils::new_dirty_manifest;
+    use crate::seq_tracker::SequenceTracker;
     use crate::size_tiered_compaction::SizeTieredCompactionScheduler;
 
     #[test]
@@ -679,6 +680,7 @@ mod tests {
             checkpoints: vec![],
             wal_object_store_uri: None,
             recent_snapshot_min_seq: 0,
+            sequence_tracker: SequenceTracker::new(),
         }
     }
 

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -541,7 +541,8 @@ mod tests {
         ));
         let test_clock = Arc::new(TestClock::new());
         let mono_clock = Arc::new(MonotonicClock::new(test_clock.clone(), 0));
-        let oracle = Arc::new(Oracle::new(MonotonicSeq::new(0)));
+        let system_clock = Arc::new(DefaultSystemClock::new());
+        let oracle = Arc::new(Oracle::new(MonotonicSeq::new(0), system_clock.clone()));
         let db_state = Arc::new(RwLock::new(DbState::new(DirtyManifest::new(
             0,
             Manifest::initial(CoreDbState::new()),
@@ -554,7 +555,7 @@ mod tests {
             oracle,
             table_store.clone(),
             mono_clock,
-            Arc::new(DefaultSystemClock::default()),
+            system_clock,
             1000,                            // max_wal_bytes_size
             Some(Duration::from_millis(10)), // max_flush_interval
         ));


### PR DESCRIPTION
Replaces #773 which was closed in favor of the simpler design.

You can review the commits in order if you'd like, they basically do this:

- Wire the new sequence tracker through the manifest codec, memtable flush, and oracle so every flush persists the latest tracking state and restarts restore it.
- Extend the oracle to own the live tracker, update it on each committed batch, and keep the in-memory copy in sync when manifests change.
- Add an end-to-end test that writes a few batches, flushes to L0, reloads the manifest, and proves the tracker survives a restart.

This is the second to last PR in fixing #685 - the next PR will make sure the iterators use the mapping to filter out records appropriately.