### PR TITLE
map seqnums to system ts for filtering in retention iterator

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -211,6 +211,7 @@ impl Compactor {
             self.rand.clone(),
             self.stats.clone(),
             self.system_clock.clone(),
+            self.manifest_store.clone(),
         ));
         let handler = CompactorEventHandler::new(
             self.manifest_store.clone(),
@@ -472,7 +473,6 @@ impl CompactorEventHandler {
             compaction_ts: db_state.last_l0_clock_tick,
             retention_min_seq: Some(db_state.recent_snapshot_min_seq),
             is_dest_last_run,
-            sequence_tracker: Arc::new(db_state.sequence_tracker.clone()),
         };
         self.progress_tracker
             .add_job(id, job.estimated_source_bytes());
@@ -946,6 +946,7 @@ mod tests {
                 rand.clone(),
                 compactor_stats.clone(),
                 Arc::new(DefaultSystemClock::new()),
+                manifest_store.clone(),
             ));
             let handler = CompactorEventHandler::new(
                 manifest_store.clone(),


### PR DESCRIPTION
fixes #685 

Adds filtering based on the timestamp corresponding to the sequence number of a row if the time window retention is configured. The interesting part is the way it handles rounding, pay close attention to that in your review 🙏 