### PR TITLE
Replace `BackgroundTaskShutdown` with a clean shutdown

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -674,6 +674,7 @@ impl Db {
             info!("mem table flush task exited [result={:?}]", result);
         }
 
+        info!("db closed");
         Ok(())
     }
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -674,6 +674,7 @@ impl Db {
             info!("mem table flush task exited [result={:?}]", result);
         }
 
+        self.inner.state.write().error().write(SlateDBError::Closed);
         info!("db closed");
         Ok(())
     }

--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -603,7 +603,7 @@ mod test {
 
         // Verify final state
         assert!(matches!(result, Ok(())));
-        assert!(matches!(error_state.reader().read(), None));
+        assert!(error_state.reader().read().is_none());
         assert!(matches!(
             cleanup_called
                 .reader()
@@ -771,7 +771,7 @@ mod test {
 
         // Verify final state
         assert!(matches!(result, Ok(())));
-        assert!(matches!(error_state.reader().read(), None));
+        assert!(error_state.reader().read().is_none());
         assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         let messages = log.lock().unwrap().clone();
         assert_eq!(
@@ -861,7 +861,7 @@ mod test {
 
         // Verify final state
         assert!(matches!(result, Ok(())));
-        assert!(matches!(error_state.reader().read(), None));
+        assert!(error_state.reader().read().is_none());
         assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         assert_eq!(log.lock().unwrap().len(), 9);
     }
@@ -951,7 +951,7 @@ mod test {
             .expect("dispatcher did not stop in time")
             .expect("join failed");
         assert!(matches!(result, Ok(())));
-        assert!(matches!(error_state.reader().read(), None));
+        assert!(error_state.reader().read().is_none());
         assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         assert_eq!(log.lock().unwrap().len(), 10);
     }
@@ -1027,7 +1027,7 @@ mod test {
             .expect("dispatcher did not stop in time")
             .expect("join failed");
         assert!(matches!(result, Ok(())));
-        assert!(matches!(error_state.reader().read(), None));
+        assert!(error_state.reader().read().is_none());
         assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         assert_eq!(log.lock().unwrap().len(), 16);
     }

--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -285,7 +285,7 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
                 },
             }
         }
-        Err(SlateDBError::BackgroundTaskShutdown)
+        Ok(())
     }
 
     /// Handles the result of [MessageDispatcher::run_loop] using the following logic:
@@ -602,17 +602,14 @@ mod test {
             .expect("join failed");
 
         // Verify final state
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
-        assert!(matches!(
-            error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
-        ));
+        assert!(matches!(result, Ok(())));
+        assert!(matches!(error_state.reader().read(), None));
         assert!(matches!(
             cleanup_called
                 .reader()
                 .read()
                 .expect("cleanup result not set"),
-            Err(SlateDBError::BackgroundTaskShutdown)
+            Ok(()),
         ));
         let messages = log.lock().unwrap().clone();
         assert_eq!(
@@ -773,15 +770,9 @@ mod test {
             .expect("join failed");
 
         // Verify final state
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
-        assert!(matches!(
-            error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
-        ));
-        assert!(matches!(
-            cleanup_called.reader().read(),
-            Some(Err(SlateDBError::BackgroundTaskShutdown))
-        ));
+        assert!(matches!(result, Ok(())));
+        assert!(matches!(error_state.reader().read(), None));
+        assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         let messages = log.lock().unwrap().clone();
         assert_eq!(
             messages,
@@ -869,12 +860,9 @@ mod test {
             .expect("join failed");
 
         // Verify final state
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
-        assert!(matches!(
-            error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
-        ));
-        assert!(matches!(cleanup_called.reader().read(), Some(Err(_))));
+        assert!(matches!(result, Ok(())));
+        assert!(matches!(error_state.reader().read(), None));
+        assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         assert_eq!(log.lock().unwrap().len(), 9);
     }
 
@@ -962,12 +950,9 @@ mod test {
             .await
             .expect("dispatcher did not stop in time")
             .expect("join failed");
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
-        assert!(matches!(
-            error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
-        ));
-        assert!(matches!(cleanup_called.reader().read(), Some(Err(_))));
+        assert!(matches!(result, Ok(())));
+        assert!(matches!(error_state.reader().read(), None));
+        assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         assert_eq!(log.lock().unwrap().len(), 10);
     }
 
@@ -1041,12 +1026,9 @@ mod test {
             .await
             .expect("dispatcher did not stop in time")
             .expect("join failed");
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
-        assert!(matches!(
-            error_state.reader().read(),
-            Some(SlateDBError::BackgroundTaskShutdown)
-        ));
-        assert!(matches!(cleanup_called.reader().read(), Some(Err(_))));
+        assert!(matches!(result, Ok(())));
+        assert!(matches!(error_state.reader().read(), None));
+        assert!(matches!(cleanup_called.reader().read(), Some(Ok(()))));
         assert_eq!(log.lock().unwrap().len(), 16);
     }
 

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -107,8 +107,8 @@ pub(crate) enum SlateDBError {
     // we need to wrap the panic args in a mutex so that SlateDbError is Sync
     BackgroundTaskPanic(Arc<Mutex<Box<dyn Any + Send>>>),
 
-    #[error("background task shutdown")]
-    BackgroundTaskShutdown,
+    #[error("db is closed")]
+    Closed,
 
     #[error("merge operator error")]
     MergeOperatorError(#[from] MergeOperatorError),
@@ -392,7 +392,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::BackgroundTaskPanic(err) => {
                 Error::system(msg).with_source(Box::new(PanicError(err)))
             }
-            SlateDBError::BackgroundTaskShutdown => Error::system(msg),
+            SlateDBError::Closed => Error::system(msg),
             SlateDBError::MergeOperatorError(err) => {
                 Error::operation(msg).with_source(Box::new(err))
             }

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1170,7 +1170,7 @@ mod tests {
         let jh = tokio::spawn(async move { dispatcher.run().await });
         cancellation_token.cancel();
         let result = jh.await.unwrap();
-        assert!(matches!(result, Err(SlateDBError::BackgroundTaskShutdown)));
+        assert!(matches!(result, Ok(())));
 
         tokio::time::sleep(Duration::from_secs(2)).await;
         assert!(cancellation_token.is_cancelled());

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -264,7 +264,10 @@ impl MessageHandler<MemtableFlushMsg> for MemtableFlusher {
 
         // notify in-memory memtables of error
         let state = self.db_inner.state.read();
-        debug!("notifying in-memory memtable of shutdown [result={:?}]", result);
+        debug!(
+            "notifying in-memory memtable of shutdown [result={:?}]",
+            result
+        );
         state.memtable().table().notify_durable(Err(error.clone()));
         for imm_table in state.state().imm_memtable.iter() {
             debug!(

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -242,10 +242,7 @@ impl MessageHandler<MemtableFlushMsg> for MemtableFlusher {
         mut messages: BoxStream<'async_trait, MemtableFlushMsg>,
         result: Result<(), SlateDBError>,
     ) -> Result<(), SlateDBError> {
-        let error = result
-            .clone()
-            .err()
-            .unwrap_or(SlateDBError::BackgroundTaskShutdown);
+        let error = result.clone().err().unwrap_or(SlateDBError::Closed);
         // drain remaining messages
         while let Some(message) = messages.next().await {
             match message {

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -264,11 +264,11 @@ impl MessageHandler<MemtableFlushMsg> for MemtableFlusher {
 
         // notify in-memory memtables of error
         let state = self.db_inner.state.read();
-        info!("notifying in-memory memtable of error");
+        debug!("notifying in-memory memtable of shutdown [result={:?}]", result);
         state.memtable().table().notify_durable(Err(error.clone()));
         for imm_table in state.state().imm_memtable.iter() {
-            info!(
-                "notifying imm memtable of error [last_wal_id={}, error={:?}]",
+            debug!(
+                "notifying imm memtable of shutdown [last_wal_id={}, error={:?}]",
                 imm_table.recent_flushed_wal_id(),
                 error,
             );

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -484,7 +484,7 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
         }
         // notify all the flushing wals to be finished with fatal error or shutdown error. we need ensure all the wal
         // tables finally get notified.
-        let fatal_or_shutdown = result.err().unwrap_or(SlateDBError::BackgroundTaskShutdown);
+        let fatal_or_shutdown = result.err().unwrap_or(SlateDBError::Closed);
 
         // freeze current WAL to notify writers in the subsequent flushing_wals loop
         self.wal_buffer.freeze_current_wal().await?;


### PR DESCRIPTION
A clean shutdown in SlateDB (`db.close()`) currently sets a `SlateDBError::BackgroundTaskShutdown` in `db_state.rs`'s `error` field. We then special case this error type all over the place to determine when we're shutdown cleanly. This is confusing and brittle.

I've removed `BackgroundTaskShutdown`. `dispatcher.rs` now returns `Ok(())` when it's shutdown cleanly. If a dispatcher run_loop returns with an `Err(...)`, it still sets the `error` field in `db_state.rs`. Doing so immediately halts all other dispatchers and blocks future calls to the DB.

I originally thought we should convert `db_state.rs`'s `error: WatchableOnceCell<SlateDBError>,` to be `shutdown_result: WatchableOnceCell<Result<(), SlateDBError>>`. The idea was that we'd set the field to `Ok(())` on shutdown to signal that the DB should be shutdown. But I found this overlapped with `cancellation_token`'s purpose. I kept `cancellation_token` since it seems idiomatic. I checked if there's a pattern to include a `Result` with a cancellation token in Rust, but there appears not to be. I landed on:

- cancellation_token() is used to request a clean shutdown
- dispatchers never halt unless
  - an error occurred in the dispatcher (it will then halt and set the `error` field)
  - the error field is set by another task (another dispatcher)
  - the cancellation_token is called (Ok(()) is returned and no error is set)

I did find that there were a few places where we were notifying channels that we could no longer handle their request in `cleanup()`. I introduced `SlateDBError::Closed` to signal to those channels that the DB is now closed and their requests couldn't be completed. I did a quick pass and it appears `Closed` is being used exclusively for `send_safely` channel calls, which makes sense.

Before, a clean shutdown looked like this:

```
2025-09-23T21:15:47.488999Z  WARN slatedb::dispatcher: halting message loop because db is in error state [error=BackgroundTaskShutdown]    
2025-09-23T21:15:47.489065Z  WARN slatedb::dispatcher: halting message loop because db is in error state [error=BackgroundTaskShutdown]    
2025-09-23T21:15:47.489137Z  INFO slatedb::db: compactor task exited [result=Err(BackgroundTaskShutdown)]    
2025-09-23T21:15:47.489145Z  INFO slatedb::db: write task exited [result=Err(BackgroundTaskShutdown)]    
2025-09-23T21:15:47.489153Z  INFO slatedb::db: wal buffer task exited [result=Err(BackgroundTaskShutdown)]    
2025-09-23T21:15:47.489159Z  INFO slatedb::db: mem table flush task exited [result=Err(BackgroundTaskShutdown)]    
```

Now it looks like this:

```
2025-09-23T21:19:16.998574Z  INFO slatedb::mem_table_flush: memtable flush thread exiting [result=Ok(())]    
2025-09-23T21:19:16.998725Z  INFO slatedb::db: compactor task exited [result=Ok(())]    
2025-09-23T21:19:16.998734Z  INFO slatedb::db: write task exited [result=Ok(())]    
2025-09-23T21:19:16.998763Z  INFO slatedb::db: wal buffer task exited [result=Ok(())]    
2025-09-23T21:19:16.998771Z  INFO slatedb::db: mem table flush task exited [result=Ok(())]    
```

And the error case now:

```
2025-09-23T21:19:18.115003Z ERROR slatedb::mem_table_flush: error writing manifest on shutdown [err=detected newer DB client]    
2025-09-23T21:19:18.115021Z  INFO slatedb::mem_table_flush: memtable flush thread exiting [result=Err(Fenced)]    
2025-09-23T21:19:18.115030Z  INFO slatedb::db: write task exited [result=Err(Fenced)]    
2025-09-23T21:19:18.115046Z  WARN slatedb::dispatcher: halting message loop because db is in error state [error=Fenced]    
2025-09-23T21:19:18.115067Z  INFO slatedb::db: wal buffer task exited [result=Err(Fenced)]    
2025-09-23T21:19:18.115076Z  INFO slatedb::db: mem table flush task exited [result=Err(Fenced)]    
```

Fixes #817