### PR TITLE
[Minor]Refactor compaction validation to scheduler; replace SlateDBError in trait API

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -467,7 +467,7 @@ impl CompactorEventHandler {
                 break;
             }
             // Validate the candidate compaction; skip invalid ones
-            match self.validate_compaction(&compaction) {
+            match self.validate_compaction(compaction) {
                 Err(e) => {
                     warn!("invalid compaction [error={:?}]", e);
                     continue;

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -466,7 +466,7 @@ impl CompactorEventHandler {
                 );
                 break;
             }
-            self.submit_compaction(compaction.clone()).await?
+            self.submit_compaction(compaction.clone()).await?;
         }
         Ok(())
     }

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -259,8 +259,6 @@ impl CompactorState {
             last_sr_id = sr.id;
         }
     }
-
-    // State-level validation removed; policy validation lives in CompactionScheduler
 }
 
 #[cfg(test)]

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter};
 
-use log::{info, warn};
+use log::info;
 use ulid::Ulid;
 use uuid::Uuid;
 
@@ -121,7 +121,8 @@ impl CompactorState {
         id: Uuid,
         compaction: Compaction,
     ) -> Result<Uuid, SlateDBError> {
-        self.validate_compaction(&compaction)?;
+        // Validation is enforced by the CompactionScheduler. Compactor calls
+        // scheduler.validate_compaction(...) before submitting here.
         if self
             .compactions
             .values()
@@ -261,71 +262,7 @@ impl CompactorState {
         }
     }
 
-    fn validate_compaction(&mut self, compaction: &Compaction) -> Result<(), SlateDBError> {
-        // Logical order of sources: [L0 (newest → oldest), then SRs (highest id → 0)]
-        let sources_logical_order: Vec<SourceId> = self
-            .db_state()
-            .l0
-            .iter()
-            .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
-            .chain(
-                self.db_state()
-                    .compacted
-                    .iter()
-                    .map(|sr| SourceId::SortedRun(sr.id)),
-            )
-            .collect();
-
-        // Validate compaction sources exist
-        if compaction.sources.is_empty() {
-            warn!("submitted compaction is empty: {:?}", compaction.sources);
-            return Err(SlateDBError::InvalidCompaction);
-        }
-
-        // Validate if the compaction sources are strictly consecutive elements in the db_state sources
-        if !sources_logical_order
-            .windows(compaction.sources.len())
-            .any(|w| w == compaction.sources.as_slice())
-        {
-            warn!("submitted compaction is not a consecutive series of sources from db state: {:?} {:?}",
-            compaction.sources, sources_logical_order);
-            return Err(SlateDBError::InvalidCompaction);
-        }
-
-        let has_sr = compaction
-            .sources
-            .iter()
-            .any(|s| matches!(s, SourceId::SortedRun(_)));
-
-        if has_sr {
-            // Must merge into the lowest-id SR among sources
-            let min_sr = compaction
-                .sources
-                .iter()
-                .filter_map(|s| s.maybe_unwrap_sorted_run())
-                .min()
-                .expect("at least one SR in sources");
-            if compaction.destination != min_sr {
-                warn!(
-                    "destination does not match lowest-id SR among sources: {:?} {:?}",
-                    compaction.destination, min_sr
-                );
-                return Err(SlateDBError::InvalidCompaction);
-            }
-        } else {
-            // L0-only: must create new SR with id > highest_existing
-            let highest_id = self.db_state().compacted.first().map_or(0, |sr| sr.id + 1);
-            if compaction.destination < highest_id {
-                warn!(
-                    "compaction destination is lesser than the expected L0-only highest_id: {:?} {:?}",
-                    compaction.destination, highest_id
-                );
-                return Err(SlateDBError::InvalidCompaction);
-            }
-        }
-
-        Ok(())
-    }
+    // State-level validation removed; policy validation lives in CompactionScheduler
 }
 
 #[cfg(test)]
@@ -613,56 +550,6 @@ mod tests {
 
         // then:
         assert_eq!(vec![checkpoint], state.db_state().checkpoints);
-    }
-
-    #[test]
-    fn test_should_submit_invalid_compaction_wrong_order() {
-        // given:
-        let rt = build_runtime();
-        let (_, _, mut state) = build_test_state(rt.handle());
-
-        let l0_sst = &mut state.db_state().l0.clone();
-        let last_sst = l0_sst.pop_back();
-        l0_sst.push_front(last_sst.unwrap());
-        // when:
-        let compaction = build_l0_compaction(l0_sst, 0);
-        let result = state.submit_compaction(uuid::Uuid::new_v4(), compaction);
-
-        // then:
-        assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
-    }
-
-    #[test]
-    fn test_should_submit_invalid_compaction_skipped_sst() {
-        // given:
-        let rt = build_runtime();
-        let (_, _, mut state) = build_test_state(rt.handle());
-
-        let l0_sst = &mut state.db_state().l0.clone();
-        let last_sst = l0_sst.pop_back().unwrap();
-        l0_sst.push_front(last_sst);
-        l0_sst.pop_back();
-        // when:
-        let compaction = build_l0_compaction(l0_sst, 0);
-        let result = state.submit_compaction(uuid::Uuid::new_v4(), compaction);
-
-        // then:
-        assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
-    }
-
-    #[test]
-    fn test_should_submit_invalid_compaction_with_sr() {
-        // given:
-        let rt = build_runtime();
-        let (_, _, mut state) = build_test_state(rt.handle());
-
-        let mut compaction = build_l0_compaction(&state.db_state().l0, 0);
-        compaction.sources.push(SourceId::SortedRun(5));
-        // when:
-        let result = state.submit_compaction(uuid::Uuid::new_v4(), compaction);
-
-        // then:
-        assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
     }
 
     #[test]

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -121,8 +121,6 @@ impl CompactorState {
         id: Uuid,
         compaction: Compaction,
     ) -> Result<Uuid, SlateDBError> {
-        // Validation is enforced by the CompactionScheduler. Compactor calls
-        // scheduler.validate_compaction(...) before submitting here.
         if self
             .compactions
             .values()

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -735,7 +735,9 @@ mod tests {
         l0_sst.push_front(last_sst.unwrap());
         // when:
         let compaction = create_l0_compaction(l0_sst.make_contiguous(), 0);
-        let result = scheduler.validate_compaction(&state, &compaction).map_err(|_e|SlateDBError::InvalidCompaction);
+        let result = scheduler
+            .validate_compaction(&state, &compaction)
+            .map_err(|_e| SlateDBError::InvalidCompaction);
 
         // then:
         assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
@@ -754,7 +756,9 @@ mod tests {
         l0_sst.pop_back();
         // when:
         let compaction = create_l0_compaction(l0_sst.make_contiguous(), 0);
-        let result = scheduler.validate_compaction(&state, &compaction).map_err(|_e|SlateDBError::InvalidCompaction);
+        let result = scheduler
+            .validate_compaction(&state, &compaction)
+            .map_err(|_e| SlateDBError::InvalidCompaction);
 
         // then:
         assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
@@ -771,7 +775,9 @@ mod tests {
         let mut compaction = create_l0_compaction(l0.make_contiguous(), 0);
         compaction.sources.push(SourceId::SortedRun(5));
         // when:
-        let result = scheduler.validate_compaction(&state, &compaction).map_err(|_e|SlateDBError::InvalidCompaction);
+        let result = scheduler
+            .validate_compaction(&state, &compaction)
+            .map_err(|_e| SlateDBError::InvalidCompaction);
 
         // then:
         assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -437,7 +437,6 @@ mod tests {
 
     use crate::compactor::CompactionScheduler;
     use crate::compactor_state::{Compaction, CompactorState, SourceId};
-    use crate::error::SlateDBError;
 
     use crate::db_state::{CoreDbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
     use crate::manifest::store::test_utils::new_dirty_manifest;
@@ -736,11 +735,10 @@ mod tests {
         // when:
         let compaction = create_l0_compaction(l0_sst.make_contiguous(), 0);
         let result = scheduler
-            .validate_compaction(&state, &compaction)
-            .map_err(|_e| SlateDBError::InvalidCompaction);
+            .validate_compaction(&state, &compaction);
 
         // then:
-        assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
+        assert!(result.is_err());
     }
 
     #[test]
@@ -757,11 +755,10 @@ mod tests {
         // when:
         let compaction = create_l0_compaction(l0_sst.make_contiguous(), 0);
         let result = scheduler
-            .validate_compaction(&state, &compaction)
-            .map_err(|_e| SlateDBError::InvalidCompaction);
+            .validate_compaction(&state, &compaction);
 
         // then:
-        assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
+        assert!(result.is_err());
     }
 
     #[test]
@@ -776,11 +773,10 @@ mod tests {
         compaction.sources.push(SourceId::SortedRun(5));
         // when:
         let result = scheduler
-            .validate_compaction(&state, &compaction)
-            .map_err(|_e| SlateDBError::InvalidCompaction);
+            .validate_compaction(&state, &compaction);
 
         // then:
-        assert!(matches!(result, Err(SlateDBError::InvalidCompaction)));
+        assert!(result.is_err());
     }
 
     fn create_sst(size: u64) -> SsTableHandle {

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -734,8 +734,7 @@ mod tests {
         l0_sst.push_front(last_sst.unwrap());
         // when:
         let compaction = create_l0_compaction(l0_sst.make_contiguous(), 0);
-        let result = scheduler
-            .validate_compaction(&state, &compaction);
+        let result = scheduler.validate_compaction(&state, &compaction);
 
         // then:
         assert!(result.is_err());
@@ -754,8 +753,7 @@ mod tests {
         l0_sst.pop_back();
         // when:
         let compaction = create_l0_compaction(l0_sst.make_contiguous(), 0);
-        let result = scheduler
-            .validate_compaction(&state, &compaction);
+        let result = scheduler.validate_compaction(&state, &compaction);
 
         // then:
         assert!(result.is_err());
@@ -772,8 +770,7 @@ mod tests {
         let mut compaction = create_l0_compaction(l0.make_contiguous(), 0);
         compaction.sources.push(SourceId::SortedRun(5));
         // when:
-        let result = scheduler
-            .validate_compaction(&state, &compaction);
+        let result = scheduler.validate_compaction(&state, &compaction);
 
         // then:
         assert!(result.is_err());


### PR DESCRIPTION
### Summary
- Add a provided validation hook to `CompactionScheduler` so each scheduler can validate proposed compactions.
- Move validation responsibility from `CompactorState` to schedulers; keep compactor as the enforcement point.
- Use public `crate::error::Error` at the trait boundary; map to internal `SlateDBError` inside the compactor.
- Relocate/adjust invalid-compaction tests to the size-tiered scheduler, fixing flakiness and type issues.

### Motivation
- Avoid “private type in public API” by not exposing `SlateDBError` in a public trait.
- Let each scheduling policy own its validation logic (policy-specific rules).
- Remove duplicate or conflicting validation paths (state vs. scheduler).
- Keep the compactor policy-agnostic and simply enforce the scheduler’s decision.

### Changes
- `slatedb/src/compactor.rs`
  - `CompactionScheduler` now has a provided method:
    - `fn validate_compaction(&self, state: &CompactorState, compaction: &Compaction) -> Result<(), crate::error::Error> { Ok(()) }`
  - Compactor loop calls `validate_compaction(...)` before submission and maps failures to `SlateDBError::InvalidCompaction`.
  - Import `crate::error::Error` to simplify signatures.
- `slatedb/src/compactor_state.rs`
  - Remove state-level validation logic and the call from `submit_compaction(...)`. It still prevents duplicate destination compactions.
- `slatedb/src/size_tiered_compaction.rs`
  - Implement `validate_compaction(...)` for size-tiered scheduler; return `Error::operation(...)` with clear messages.
  - Move invalid-compaction tests here; build local L0 fixtures and use `make_contiguous()` to avoid borrow/unwrap issues.
  - Update test assertions to target `Result<(), crate::error::Error>` (e.g., `is_err()` or `err().kind() == ErrorKind::Operation`).

### API Surface
- Additive change to public trait `CompactionScheduler` with a provided method (object-safe, no generics).
- Validation errors at the trait boundary are now `crate::error::Error` (public) instead of `SlateDBError` (crate-private).

### Backward Compatibility
- Existing schedulers continue to compile; the provided method defaults to `Ok(())`.
- Rare name conflicts with downstream inherent methods are possible but unlikely.
- External callers that matched on `SlateDBError` in scheduler validation must adjust to `crate::error::Error`.

### Tests
- Moved:
  - `test_should_submit_invalid_compaction_wrong_order`
  - `test_should_submit_invalid_compaction_skipped_sst`
  - `test_should_submit_invalid_compaction_with_sr`
- Tests now exercise scheduler validation directly and avoid mutating state references.
