### PR TITLE
Improve object_store test_save_result_not_aligned

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -647,6 +647,11 @@ mod tests {
             entry.read_part(2, 0..part_size).await?,
             Some(payload.slice(2048..3072))
         );
+        // check that the unaligned part was also cached
+        assert_eq!(
+            entry.read_part(3, 0..32).await?,
+            Some(payload.slice(3072..3104))
+        );
 
         // delete part 2, known_cache_size is still known
         let evict_part_path =


### PR DESCRIPTION
Improve object_store `test_save_result_not_aligned`
- this test asserts that `CachedObjectStore` has the expected behaviors when the object is not aligned with chunked part_size
```
| p0 (1024 bytes) | p1 (1024 bytes) | p2 (1024 bytes) | p3 (32 bytes) | 
```

- before: not asserting the last unaligned part p3
- after: assert that the unaligned part exists in cache also