### PR TITLE
Export DbSnapshot as public

### DIFF
--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -42,6 +42,7 @@ pub use db_cache::stats as db_cache_stats;
 pub use db_iter::DbIterator;
 pub use db_read::DbRead;
 pub use db_reader::DbReader;
+pub use db_snapshot::DbSnapshot;
 pub use db_transaction::DBTransaction;
 pub use error::{Error, ErrorKind};
 pub use garbage_collector::stats as garbage_collector_stats;


### PR DESCRIPTION
Seems this was missed. I tried `DBSnapshot` after this change and it seems to work. 