### PR TITLE
fix ttl filtering with range scans

### DIFF
--- a/slatedb/src/filter_iterator.rs
+++ b/slatedb/src/filter_iterator.rs
@@ -20,7 +20,6 @@ impl<T: KeyValueIterator> FilterIterator<T> {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn new_with_ttl_now(iterator: T, ttl_now: i64) -> Self {
         let predicate = Box::new(move |entry: &RowEntry| is_not_expired(entry, ttl_now));
         Self::new(iterator, predicate)

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -165,6 +165,7 @@ impl Reader {
         range_tracker: Option<Arc<DbIteratorRangeTracker>>,
     ) -> Result<DbIterator<'a>, SlateDBError> {
         let max_seq = self.prepare_max_seq(max_seq, options.durability_filter, options.dirty);
+        let now = get_now_for_read(self.mono_clock.clone(), options.durability_filter).await?;
 
         let mut memtables = VecDeque::new();
         memtables.push_back(db_state.memtable());
@@ -230,6 +231,7 @@ impl Reader {
             sr_iters,
             max_seq,
             range_tracker,
+            now,
         )
         .await
     }


### PR DESCRIPTION
similar to #937 it looks like range scans didn't apply TTL filters to expired elements. this PR changes that (mostly test code)