### PR TITLE
Fix db.rs test failing with SendErr

### DIFF
--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -795,6 +795,7 @@ mod test {
         let task_executor = MessageHandlerExecutor::new(error_state.clone(), clock.clone())
             .with_fp_registry(fp_registry.clone());
         fail_parallel::cfg(fp_registry.clone(), "dispatcher-run-loop", "1*off->return").unwrap();
+        fail_parallel::cfg(fp_registry.clone(), "dispatcher-cleanup", "pause").unwrap();
         task_executor
             .add_handler(
                 "test".to_string(),


### PR DESCRIPTION
I accidentally forgot to pause the cleanup function in `test_executor_propagates_handler_error_drains_messages` before triggering a panic. The test verifies that the second message is processed by the cleanup method. If the cleanup method is not paused, it's possible that the first message in the test triggers the panic, the cleanup function is then called, no messages are in the channel, and the rx is closed/dropped. _Then_ the second message in the test is sent. This can causes a send error.

I was able to reproduce the issue by adding a sleep(1s) before the second message is sent. Pausing the cleanup method fixes the issue.