### PR TITLE
Make SystemClockTicker::new public.

### DIFF
--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -63,7 +63,8 @@ pub struct SystemClockTicker<'a> {
 }
 
 impl<'a> SystemClockTicker<'a> {
-    fn new(clock: &'a dyn SystemClock, duration: Duration) -> Self {
+    /// Creates a new ticker that emits a signal every `duration` interval.
+    pub fn new(clock: &'a dyn SystemClock, duration: Duration) -> Self {
         Self {
             clock,
             duration,


### PR DESCRIPTION
Nobody can implement the SystemClock trait outside this repository because there is no way to initialize a SystemClockTicker.

This change exposes the SystemClockTicker::new function, so people that want to implement their own SystemClock can initialize the ticker.