### PR TITLE
Fix `test_compactor_compacts_l0`

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1475,7 +1475,7 @@ mod tests {
     async fn await_compaction(db: &Db) -> Option<CoreDbState> {
         run_for(Duration::from_secs(10), || async {
             let (empty_wal, empty_memtable, core_db_state) = {
-                let db_state = db.inner.state.write();
+                let db_state = db.inner.state.read();
                 let cow_db_state = db_state.state();
                 (
                     db.inner.wal_buffer.is_empty(),


### PR DESCRIPTION
I noticed a sporadic failure in `test_compactor_compacts_l0` in https://github.com/slatedb/slatedb/pull/968, which was simply an RFC change.

The `await_compaction` is using a split view of the DB state between `db.inner.state` and `get_db_state`, which returns the persisted manifest's view of the state. These two are not necessarily in sync, so we can get into a state where the manifest l0 might be empty but the in-memory l0 might not. This can lead `await_compaction` to think that all data has made it to L1+ when, in fact, it has not. I fixed this by making `await_compaction` use the in-memory view for everything.