### PR TITLE
Peg cargo-edit in release to stable rust

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,9 +33,13 @@ jobs:
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
           ref: ${{ github.ref }}
 
-      # Set up Rust stable
+      # Set up Rust stable for installing cargo-edit
+      - name: Setup Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # Install cargo-edit with locked dependencies using stable toolchain
       - name: Install cargo-edit
-        run: cargo install cargo-edit
+        run: cargo +stable install cargo-edit --locked
 
       # Set Cargo.toml version using cargo-edit
       - name: Set version


### PR DESCRIPTION
Fix for failed release.yaml process:

```
error: failed to compile `cargo-edit v0.13.7`, intermediate artifacts can be found at `/tmp/cargo-installgPGavV`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.88.0-nightly is not supported by the following package:
    smol_str@0.3.4 requires rustc 1.89
  Try re-running `cargo install` with `--locked`
```