### PR TITLE
rename attempt_ts to compaction_clock_tick

### DIFF
--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -252,7 +252,7 @@ impl CompactionExecuteBench {
             destination: 0,
             ssts,
             sorted_runs: vec![],
-            attempt_ts: manifest.db_state().last_l0_clock_tick,
+            compaction_logical_clock_tick: manifest.db_state().last_l0_clock_tick,
             retention_min_seq: Some(manifest.db_state().recent_snapshot_min_seq),
             is_dest_last_run,
         })
@@ -289,7 +289,7 @@ impl CompactionExecuteBench {
             destination: 0,
             ssts: vec![],
             sorted_runs: srs,
-            attempt_ts: state.last_l0_clock_tick,
+            compaction_logical_clock_tick: state.last_l0_clock_tick,
             retention_min_seq: Some(state.recent_snapshot_min_seq),
             is_dest_last_run,
         }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -589,7 +589,7 @@ impl CompactorEventHandler {
             destination: spec.destination(),
             ssts,
             sorted_runs,
-            attempt_ts: db_state.last_l0_clock_tick,
+            compaction_logical_clock_tick: db_state.last_l0_clock_tick,
             retention_min_seq: Some(db_state.recent_snapshot_min_seq),
             is_dest_last_run,
         };


### PR DESCRIPTION
## Summary

Renames attempt_ts to compaction_clock_tick to clarify that this is the logical clock tick associated with compaction rather than the wallclock time that it started

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
