### PR TITLE
Make website buttons responsive

### DIFF
--- a/website/src/components/TerminalContent.astro
+++ b/website/src/components/TerminalContent.astro
@@ -271,5 +271,22 @@ const displayStyle = isDefault ? "" : "display: none;";
         .terminal-features .features.functional-features-grid {
             grid-template-columns: 1fr;
         }
+
+        /* Make action buttons full-width on mobile */
+        .terminal-buttons {
+            flex-direction: column;
+            align-items: stretch;
+            align-self: stretch;
+            width: 100%;
+            gap: 0.75rem;
+        }
+
+        .terminal-buttons > a {
+            display: block;
+            width: 100%;
+            max-width: 100%;
+            text-align: center;
+            box-sizing: border-box; /* include 2px border in width */
+        }
     }
 </style>


### PR DESCRIPTION
## Summary

The terminal buttons were looking a little funky on mobile. I opted to stretch them when viewing in that mode. In desktop mode, they remain as they were. Here's how they look now on mobile:

<img width="377" height="782" alt="Screenshot 2025-11-12 at 9 38 06 PM" src="https://github.com/user-attachments/assets/6e436c51-6db2-4a7a-8d38-ab03f2c182b3" />

## Changes

- Updated the terminal button component to stretch buttons