### PR TITLE
fix flaky l0 sequence tracking test

### DIFF
--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -7,6 +7,7 @@ use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
 use crate::utils::IdGenerator;
 use async_trait::async_trait;
+use fail_parallel::fail_point;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use log::{debug, error, info, warn};
@@ -199,6 +200,10 @@ impl MemtableFlusher {
     }
 
     async fn flush_and_record(&mut self) -> Result<(), SlateDBError> {
+        fail_point!(
+            Arc::clone(&self.db_inner.fp_registry),
+            "flush-memtable-to-l0"
+        );
         let result = self.flush_imm_memtables_to_l0().await;
         if let Err(err) = &result {
             error!("error from memtable flush [error={:?}]", err);


### PR DESCRIPTION
## Summary

Fixes a flaky test

## Changes

the problem was that a manifest poll can trigger an immutable memtable flush -> L0, meaning that the check below would never return true because the `imm_memtables` were empty (because they've already been flushed to L0).

```rs
if !guard.state().imm_memtable.is_empty() {
    froze_memtable = true;
    break;
}
```

This change just moves the failpoint to stop ANY L0 flush from happening, independent of what triggers it.

## Notes for Reviewers

I ran the test 1K times in a tight loop and it didn't fail. Before this it would fail pretty regularly in the first 20 runs. 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
