### PR TITLE
set last_remote_persisted_seq_num after flushing memtable

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -434,6 +434,9 @@ impl DbInner {
 
         // last_committed_seq is updated as WAL is replayed. after replay,
         // the last_committed_seq is considered same as the last_remote_persisted_seq.
+        assert!(
+            self.oracle.last_remote_persisted_seq.load() <= self.oracle.last_committed_seq.load()
+        );
         self.oracle
             .last_remote_persisted_seq
             .store(self.oracle.last_committed_seq.load());
@@ -1424,8 +1427,8 @@ mod tests {
     use crate::clock::MockSystemClock;
     use crate::config::DurabilityLevel::{Memory, Remote};
     use crate::config::{
-        CompactorOptions, ObjectStoreCacheOptions, Settings, SizeTieredCompactionSchedulerOptions,
-        Ttl,
+        CompactorOptions, DurabilityLevel, ObjectStoreCacheOptions, Settings,
+        SizeTieredCompactionSchedulerOptions, Ttl,
     };
     use crate::db_state::CoreDbState;
     use crate::db_stats::IMMUTABLE_MEMTABLE_FLUSHES;
@@ -5063,6 +5066,56 @@ mod tests {
             );
             assert!(recent_min_seq > snapshot_seq);
         }
+    }
+
+    #[tokio::test]
+    async fn test_memtable_flush_updates_last_remote_persisted_seq() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test";
+        let mut opts = test_db_options(0, 256, None);
+        opts.flush_interval = Some(Duration::MAX);
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(opts)
+            .build()
+            .await
+            .unwrap();
+
+        // do a write and flush memtable only (not wal)
+        let write_opts = WriteOptions {
+            await_durable: false,
+        };
+        db.put_with_options(&b"foo", &b"bar", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // check that read with durability level remote returns value
+        let v = db
+            .get_with_options(
+                &b"foo",
+                &ReadOptions {
+                    durability_filter: DurabilityLevel::Memory,
+                    dirty: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(v, Some(Bytes::from(b"bar".as_ref())));
+        let v = db
+            .get_with_options(
+                &b"foo",
+                &ReadOptions {
+                    durability_filter: DurabilityLevel::Remote,
+                    dirty: false,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(v, Some(Bytes::from(b"bar".as_ref())));
     }
 
     // Merge operator test helpers

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -62,7 +62,12 @@ impl DbInner {
         guard.modify(|modifier| modifier.state.manifest.core.next_wal_sst_id = last_wal + 1);
 
         // update seqs and clock
+        // we know these won't move backwards (even though the replayed wal files might contain some
+        // older rows) because the wal replay iterator ignores any entries with seq num lower than
+        // l0_last_seq from the manifest
+        assert!(self.oracle.last_seq.load() <= replayed_memtable.last_seq);
         self.oracle.last_seq.store(replayed_memtable.last_seq);
+        assert!(self.oracle.last_committed_seq.load() <= replayed_memtable.last_seq);
         self.oracle
             .last_committed_seq
             .store(replayed_memtable.last_seq);

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -29,15 +29,6 @@ impl DbInner {
         self.mono_clock
             .fetch_max_last_durable_tick(imm_table.last_tick());
 
-        if !self.wal_enabled {
-            // in no-WAL mode, the last_remote_persisted_seq is only updated when the
-            // imm table is flushed to L0. this is useful for reader to restrict to
-            // only read the persisted data.
-            self.oracle
-                .last_remote_persisted_seq
-                .store_if_greater(self.oracle.last_seq.load());
-        }
-
         Ok(handle)
     }
 }


### PR DESCRIPTION
## Summary

set last_remote_persisted_seq_num after flushing memtable

## Changes

Before this patch the db writer wasn't notifying the oracle about the last seq num in an l0 when the l0 is successfully written and added to the manifest. This is a bug because at this point all contained rows are durably stored to the db. It's also possible for this to occur before those rows are durably written to the WAL, so its important to notify the oracle when this happens so readers using durability level Remote can observe the contained rows.

## Notes for Reviewers

- Review the test case in db.rs
- Review the fix in mem_table_flush.rs
- Review the change to `flush_imm_memtable.rs`. We shouldn't need that branch anymore, plus the seq num
   it was using was not correct.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
