### PR TITLE
split oracle into trait with imples for reader/writer

### DIFF
--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -166,6 +166,7 @@ mod tests {
     use crate::config::{CompactorOptions, PutOptions, Settings, WriteOptions};
     use crate::object_store::memory::InMemory;
     use crate::object_store::ObjectStore;
+    use crate::oracle::Oracle;
     use crate::{Db, Error};
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
@@ -654,7 +655,7 @@ mod tests {
                 .expect("Failed to create test database"),
         );
         db.put(b"key1", b"value1").await?;
-        let recent_committed_seq = db.inner.oracle.last_committed_seq.load();
+        let recent_committed_seq = db.inner.oracle.last_committed_seq();
 
         // Configure the failpoint to "pause", blocking the put after memtable write but before commit
         fail_parallel::cfg(fp_registry.clone(), "write-batch-pre-commit", "pause").unwrap();


### PR DESCRIPTION
I had some trouble tracing through the way the various seq nums were tracked. This is an attempt to make that a bit
easier to follow.

This patch splits the oracle up into DbOracle and DbReaderOracle for Db and DbReader, respectively. It makes the intended relationships between the seq nums for the Db Reader (all seq nums represent same value) and Db a bit more clear. It also makes it a bit easier to trace through what updates the seq nums and what reads them. Finally, this patch also changes the reader to use the term "last remote persisted seq" for its seq num since that's really what the reader is reading - the last persisted state at the time of the checkpoint (vs whats committed which might be in memory in the writer)

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
