### PR TITLE
Update the doc to use Foyer as the custom block cache

### DIFF
--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -47,15 +47,15 @@
 //!
 //! ```
 //! use slatedb::{Db, Error};
+//! use slatedb::db_cache::foyer::FoyerCache;
 //! use slatedb::object_store::memory::InMemory;
-//! use slatedb::db_cache::moka::MokaCache;
 //! use std::sync::Arc;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Error> {
 //!     let object_store = Arc::new(InMemory::new());
 //!     let db = Db::builder("test_db", object_store)
-//!         .with_memory_cache(Arc::new(MokaCache::new()))
+//!         .with_memory_cache(Arc::new(FoyerCache::new()))
 //!         .build()
 //!         .await?;
 //!     Ok(())

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -4,8 +4,8 @@
 //! cached blocks, index and bloom filters associated with SSTable IDs.
 //!
 //! There are currently two built-in cache implementations:
-//! - [Foyer](crate::db_cache::foyer::FoyerCache): Requires the `foyer` feature flag.
-//! - [Moka](crate::db_cache::moka::MokaCache): Requires the `moka` feature flag. (Enabled by default)
+//! - [Foyer](crate::db_cache::foyer::FoyerCache): Requires the `foyer` feature flag. (Enabled by default)
+//! - [Moka](crate::db_cache::moka::MokaCache): Requires the `moka` feature flag.
 //!
 //! ## Usage
 //!


### PR DESCRIPTION
## Summary

The example was using `Moka` before which caused `cargo test -p slatedb` to fail because `Moka` is not enabled by default and we have chosen `Foyer` to be the default block cache.


## Changes

- The example has now been updated to use `Foyer` instead.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
