### PR TITLE
only increment immutable_memtable_flushes when flush happens [MINOR]

### DIFF
--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -179,6 +179,7 @@ impl MemtableFlusher {
                 })?;
             }
             imm_memtable.notify_flush_to_l0(Ok(()));
+            self.db_inner.db_stats.immutable_memtable_flushes.inc();
             match self.write_manifest_safely().await {
                 Ok(_) => {
                     // at this point we know the data in the memtable is durably stored
@@ -216,8 +217,6 @@ impl MemtableFlusher {
         let result = self.flush_imm_memtables_to_l0().await;
         if let Err(err) = &result {
             error!("error from memtable flush [error={:?}]", err);
-        } else {
-            self.db_inner.db_stats.immutable_memtable_flushes.inc();
         }
         result
     }


### PR DESCRIPTION
## Summary

Right now this metric tracks every time `flush_imm_memtables_to_l0` is called, not when a flush actually happens. This PR changes it to only flush when memtables are flushed. 

## Changes

- Moved when the counter was incremented

## Notes for Reviewers

Note that we attempt to flush L0 every time we poll manifests, but it is frequently the case that there are no frozen (immutable) memtables, so this just does nothing but increment the counter.

https://github.com/slatedb/slatedb/blob/4efcef8bfb19c978581da01ee3bd80db311b551c/slatedb/src/mem_table_flush.rs#L235-L250

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
