### PR TITLE
Remove fsync from disk cache writes

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -122,7 +122,6 @@ impl FsCacheEntry {
             .await
             .map_err(wrap_io_err)?;
         file.write_all(&buf).await.map_err(wrap_io_err)?;
-        file.sync_all().await.map_err(wrap_io_err)?;
         fs::rename(tmp_path, path).await.map_err(wrap_io_err)
     }
 


### PR DESCRIPTION
The fsync on every cache part write was pure overhead, especially on non-enterprise SSD drives. Since the disk cache is ephemeral storage with the remote object store as the source of truth, durability is not needed. Atomicity is preserved by the atomic rename operation.

