### PR TITLE
Remove chaos-http-proxy from chaos tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -251,12 +251,6 @@ jobs:
           sudo apt-get install -y jq curl maven
           sudo snap install aws-cli --classic
 
-      - name: Build chaos-http-proxy
-        run: |
-          git clone https://github.com/bouncestorage/chaos-http-proxy
-          cd chaos-http-proxy
-          mvn -q -DskipTests package
-
       - name: Start chaos services (docker compose)
         run: |
           docker compose -f scripts/run_chaos_scenarios.compose.yaml up -d
@@ -300,6 +294,6 @@ jobs:
         if: failure()
         run: |
           echo "--- LocalStack logs ---"; docker logs --tail 500 localstack || true
-          echo "--- chaos-http-proxy logs ---"; docker logs --tail 500 chaos-http-proxy || true
+          echo "--- lowdown logs ---"; docker logs --tail 500 lowdown || true
           echo "--- Toxiproxy logs ---"; docker logs --tail 500 toxiproxy || true
           echo "--- Toxiproxy proxies ---"; curl -sf http://127.0.0.1:8474/proxies || true


### PR DESCRIPTION
## Summary

A couple of references to a defunct `chaos-http-proxy` container/package snuck their way into #1014. I'm removing them. The PR uses [lowdown](https://github.com/criccomini/lowdown) instead now, so there's no need for chaos-http-proxy stuff anymore.

## Changes

- Replace chaos-http-proxy container log dump with lowdown log dump
- Remove manual Maven build for chaos-http-proxy

## Notes for Reviewers

See https://github.com/slatedb/slatedb/pull/1014#discussion_r2557462353 for details.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
