### PR TITLE
Remove unused clock field from ManifestStore struct

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -53,7 +53,6 @@ impl Admin {
         let manifest_store = ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         );
         let id_manifest = if let Some(id) = maybe_id {
             manifest_store
@@ -78,7 +77,6 @@ impl Admin {
         let manifest_store = ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         );
         let manifests = manifest_store.list_manifests(range).await?;
         Ok(serde_json::to_string(&manifests)?)
@@ -97,7 +95,6 @@ impl Admin {
         let manifest_store = ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         );
         let (_, manifest) = manifest_store.read_latest_manifest().await?;
 
@@ -225,7 +222,6 @@ impl Admin {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         ));
         manifest_store
             .validate_no_wal_object_store_configured()
@@ -254,7 +250,6 @@ impl Admin {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         ));
         let mut stored_manifest =
             StoredManifest::load(manifest_store, self.system_clock.clone()).await?;
@@ -282,7 +277,6 @@ impl Admin {
         let manifest_store = Arc::new(ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         ));
         let mut stored_manifest =
             StoredManifest::load(manifest_store, self.system_clock.clone()).await?;
@@ -351,7 +345,6 @@ impl Admin {
         ManifestStore::new(
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.system_clock.clone(),
         )
     }
 

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -91,11 +91,7 @@ mod tests {
         // open and close the db to init the manifest and trigger another write
         let db = Db::open(path.clone(), object_store.clone()).await.unwrap();
         db.close().await.unwrap();
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
         let (_, before_checkpoint) = manifest_store.read_latest_manifest().await.unwrap();
 
         let CheckpointCreateResult {
@@ -130,11 +126,7 @@ mod tests {
             .await
             .unwrap();
         db.close().await.unwrap();
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
         let checkpoint_time = DefaultSystemClock::default().now();
 
         let CheckpointCreateResult {
@@ -258,11 +250,7 @@ mod tests {
             })
             .await
             .unwrap();
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
         let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         let checkpoint = manifest
             .core
@@ -325,11 +313,7 @@ mod tests {
 
         admin.delete_checkpoint(id).await.unwrap();
 
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
         let (_, manifest) = manifest_store.read_latest_manifest().await.unwrap();
         assert!(!manifest.core.checkpoints.iter().any(|c| c.id == id));
     }
@@ -377,11 +361,7 @@ mod tests {
             .await
             .unwrap();
 
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
         let manifest = manifest_store
             .read_manifest(checkpoint.manifest_id)
             .await
@@ -434,11 +414,7 @@ mod tests {
         let admin = AdminBuilder::new(path.clone(), object_store.clone()).build();
         let db = Db::open(path.clone(), object_store.clone()).await.unwrap();
         db.close().await.unwrap();
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
 
         let checkpoint_name = "my_checkpoint".to_string();
         let CheckpointCreateResult {
@@ -469,11 +445,7 @@ mod tests {
         let admin = AdminBuilder::new(path.clone(), object_store.clone()).build();
         let db = Db::open(path.clone(), object_store.clone()).await.unwrap();
         db.close().await.unwrap();
-        let manifest_store = ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
 
         // Create multiple checkpoints without names
         admin

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -327,11 +327,7 @@ impl CompactionExecuteBench {
         let stats = Arc::new(CompactionStats::new(registry.clone()));
         let os = self.object_store.clone();
 
-        let manifest_store = Arc::new(ManifestStore::new(
-            &self.path,
-            os.clone(),
-            self.system_clock.clone(),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&self.path, os.clone()));
 
         let executor = TokioCompactionExecutor::new(
             Handle::current(),

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -2462,11 +2462,7 @@ mod tests {
             min_filter_keys: 10,
             ..SsTableFormat::default()
         };
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(PATH),
-            os.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(os.clone(), None),
             sst_format,

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -418,11 +418,7 @@ mod tests {
             .await
             .unwrap();
         let table_store = db.inner.table_store.clone();
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path.as_str()),
-            os.clone(),
-            clock.clone(),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path.as_str()), os.clone()));
         let executor = TokioCompactionExecutor::new(
             handle,
             options,

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -872,11 +872,7 @@ mod tests {
         let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
         let rand: Arc<DbRand> = Arc::new(DbRand::default());
 
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(PATH),
-            os.clone(),
-            system_clock.clone(),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(PATH), os.clone()));
         let stored_manifest = tokio_handle
             .block_on(StoredManifest::load(
                 manifest_store,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2856,11 +2856,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let manifest_store = Arc::new(ManifestStore::new(
-            &path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
         let mut stored_manifest =
             StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
                 .await
@@ -2935,12 +2931,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let clock = Arc::new(DefaultSystemClock::new());
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            clock.clone(),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let mut stored_manifest =
             StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
                 .await
@@ -3024,11 +3015,7 @@ mod tests {
             .await
             .unwrap();
 
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let mut stored_manifest =
             StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
                 .await
@@ -3168,11 +3155,7 @@ mod tests {
             .await
             .unwrap();
 
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let mut stored_manifest =
             StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
                 .await
@@ -3730,11 +3713,7 @@ mod tests {
         kv_store_restored.close().await.unwrap();
 
         // validate that the manifest file exists.
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let stored_manifest =
             StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
                 .await
@@ -4325,11 +4304,7 @@ mod tests {
         // on close().
         db.close().await.unwrap();
 
-        let manifest_store = ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let manifest_store = ManifestStore::new(&Path::from(path), object_store.clone());
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
@@ -4364,11 +4339,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let ms = ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        );
+        let ms = ManifestStore::new(&Path::from(path), object_store.clone());
         let mut sm = StoredManifest::load(Arc::new(ms), Arc::new(DefaultSystemClock::new()))
             .await
             .unwrap();
@@ -4671,11 +4642,7 @@ mod tests {
 
         // check the last_l0_clock_tick persisted in the manifest, it should be
         // i64::MIN because no WAL SST has yet made its way into L0
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let stored_manifest =
             StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
                 .await
@@ -4725,11 +4692,7 @@ mod tests {
 
         // check the last_clock_tick persisted in the manifest, it should be
         // i64::MIN because no WAL SST has yet made its way into L0
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let stored_manifest =
             StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
                 .await
@@ -4890,11 +4853,7 @@ mod tests {
         db1.put(b"k", b"v").await.unwrap();
 
         // Fence the db by opening a new one
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from(path),
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let stored_manifest =
             StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
                 .await
@@ -5504,8 +5463,7 @@ mod tests {
             .expect("flush failed");
 
         // Read the latest manifest and verify it references the L0 SST.
-        let manifest_store =
-            ManifestStore::new(&path, object_store.clone(), db.inner.system_clock.clone());
+        let manifest_store = ManifestStore::new(&path, object_store.clone());
         let (_, manifest) = manifest_store
             .read_latest_manifest()
             .await

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -401,7 +401,6 @@ impl<P: Into<Path>> DbBuilder<P> {
         let manifest_store = Arc::new(ManifestStore::new(
             &path,
             maybe_cached_main_object_store.clone(),
-            system_clock.clone(),
         ));
         let latest_manifest =
             StoredManifest::try_load(manifest_store.clone(), system_clock.clone()).await?;
@@ -729,7 +728,6 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
         let manifest_store = Arc::new(ManifestStore::new(
             &path,
             retrying_main_object_store.clone(),
-            self.system_clock.clone(),
         ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(
@@ -837,7 +835,6 @@ impl<P: Into<Path>> CompactorBuilder<P> {
         let manifest_store = Arc::new(ManifestStore::new(
             &path,
             retrying_main_object_store.clone(),
-            self.system_clock.clone(),
         ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(retrying_main_object_store.clone(), None),

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -556,7 +556,6 @@ impl DbReader {
             path,
             object_store,
             block_cache: options.block_cache.clone(),
-            system_clock: clock.clone(),
         };
 
         Self::open_internal(
@@ -1270,7 +1269,6 @@ mod tests {
             Arc::new(ManifestStore::new(
                 &self.path,
                 Arc::clone(&self.object_store),
-                self.system_clock.clone(),
             ))
         }
     }

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -962,11 +962,7 @@ mod tests {
                 .with_automatic_cleanup(true),
         );
         let path = Path::from("/");
-        let manifest_store = Arc::new(ManifestStore::new(
-            &path,
-            local_object_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&path, local_object_store.clone()));
         let sst_format = SsTableFormat::default();
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(local_object_store.clone(), None),

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -221,11 +221,7 @@ mod tests {
         ));
 
         // Manifest store and initial manifest
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from("/root"),
-            main_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from("/root"), main_store.clone()));
         let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
             CoreDbState::new(),
@@ -315,11 +311,7 @@ mod tests {
         ));
 
         // Manifest store and initial manifest
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from("/root"),
-            main_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from("/root"), main_store.clone()));
         let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
             CoreDbState::new(),
@@ -411,11 +403,7 @@ mod tests {
         ));
 
         // Manifest store with empty DB
-        let manifest_store = Arc::new(ManifestStore::new(
-            &Path::from("/root"),
-            main_store.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from("/root"), main_store.clone()));
         let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
             CoreDbState::new(),

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -238,11 +238,8 @@ mod tests {
         let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
 
         let parent_path = Path::from("/tmp/test_parent");
-        let parent_manifest_store = Arc::new(ManifestStore::new(
-            &parent_path,
-            object_store.clone(),
-            clock.clone(),
-        ));
+        let parent_manifest_store =
+            Arc::new(ManifestStore::new(&parent_path, object_store.clone()));
         let mut parent_manifest =
             StoredManifest::create_new_db(parent_manifest_store, CoreDbState::new(), clock.clone())
                 .await
@@ -253,11 +250,7 @@ mod tests {
             .unwrap();
 
         let clone_path = Path::from("/tmp/test_clone");
-        let clone_manifest_store = Arc::new(ManifestStore::new(
-            &clone_path,
-            object_store.clone(),
-            Arc::new(DefaultSystemClock::default()),
-        ));
+        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
         let clone_stored_manifest = StoredManifest::create_uninitialized_clone(
             Arc::clone(&clone_manifest_store),
             parent_manifest.manifest(),
@@ -300,11 +293,7 @@ mod tests {
         let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
 
         let path = Path::from("/tmp/test_db");
-        let manifest_store = Arc::new(ManifestStore::new(
-            &path,
-            object_store.clone(),
-            clock.clone(),
-        ));
+        let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
         let mut manifest = StoredManifest::create_new_db(
             Arc::clone(&manifest_store),
             CoreDbState::new(),

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,4 +1,3 @@
-use crate::clock::SystemClock;
 use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
 use crate::object_stores::ObjectStores;
@@ -17,7 +16,6 @@ pub(crate) struct DefaultStoreProvider {
     pub(crate) path: Path,
     pub(crate) object_store: Arc<dyn ObjectStore>,
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
-    pub(crate) system_clock: Arc<dyn SystemClock>,
 }
 
 impl StoreProvider for DefaultStoreProvider {
@@ -34,7 +32,6 @@ impl StoreProvider for DefaultStoreProvider {
         Arc::new(ManifestStore::new(
             &self.path,
             Arc::clone(&self.object_store),
-            Arc::clone(&self.system_clock),
         ))
     }
 }


### PR DESCRIPTION
## Summary

The removal of `ManifestStore::clock` also renders the `DefaultStoreProvider::system_clock` field unused and has been cleaned up as well.

Related to: #924 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
