### PR TITLE
Fix list_checkpoints pyi

### DIFF
--- a/slatedb-py/python/slatedb/slatedb.pyi
+++ b/slatedb-py/python/slatedb/slatedb.pyi
@@ -1846,9 +1846,12 @@ class SlateDBAdmin:
         """
         ...
 
-    def list_checkpoints(self) -> list[Checkpoint]:
+    def list_checkpoints(self, name: str | None = None) -> list[Checkpoint]:
         """
         List known checkpoints for the database path/object store.
+
+        Args:
+            name: Optional checkpoint name. When present, only exact matches will be returned.
 
         Returns:
             A list of :class:`Checkpoint` metadata dicts.
@@ -1859,12 +1862,15 @@ class SlateDBAdmin:
         """
         ...
 
-    async def list_checkpoints_async(self) -> list[Checkpoint]:
+    async def list_checkpoints_async(self, name: str | None = None) -> list[Checkpoint]:
         """
         Async variant of ``list_checkpoints``.
 
         Returns:
             A list of :class:`Checkpoint` metadata dicts.
+
+        Args:
+            name: Optional checkpoint name. When present, only exact matches will be returned.
 
         Examples:
             >>> await admin.list_checkpoints_async()


### PR DESCRIPTION
## Summary

Python interface of admin.list_checkpoints did not have the `name` parameter even tho the implementation and tests use it.
After this change the python linter will not complain.

## Changes

Add `name` parameter to `list_checkpoints()` python interface.

## Notes for Reviewers

- Its a tiny change.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
