### PR TITLE
Print the internal error instead of a pointer

### DIFF
--- a/slatedb-go/go/db.go
+++ b/slatedb-go/go/db.go
@@ -99,16 +99,16 @@ func Open(path string, opts ...Option[DbConfig]) (*DB, error) {
 
 	handle := C.slatedb_open(cPath, cURL, cEnvFile)
 
-	if handle._1.error != C.Success {
-		return nil, resultToError(handle._1)
+	if handle.result.error != C.Success {
+		return nil, resultToError(handle.result)
 	}
 
 	// Check if handle is null (indicates error)
-	if handle._0._0 == nil {
+	if handle.handle._0 == nil {
 		return nil, errors.New("failed to open database")
 	}
 
-	return &DB{handle: handle._0}, nil
+	return &DB{handle: handle.handle}, nil
 }
 
 // Put stores a key-value pair in the database

--- a/slatedb-go/go/db_test.go
+++ b/slatedb-go/go/db_test.go
@@ -18,6 +18,7 @@ var _ = Describe("DB", func() {
 	It("should return error if CLOUD_PROVIDER is undefined", func() {
 		db, err := slatedb.Open("path/to/db")
 		Expect(err).To(HaveOccurred())
+		Expect(err).Should(MatchError(ContainSubstring("undefined environment variable")))
 		Expect(db).To(BeNil())
 	})
 

--- a/slatedb-go/go/slatedb.h
+++ b/slatedb-go/go/slatedb.h
@@ -68,8 +68,8 @@ typedef struct CSdbWriteOptions {
 } CSdbWriteOptions;
 
 typedef struct CSdbHandleResult {
-    struct CSdbHandle _0;
-    struct CSdbResult _1;
+    struct CSdbHandle handle;
+    struct CSdbResult result;
 } CSdbHandleResult;
 
 typedef struct CSdbReadOptions {

--- a/slatedb-go/src/db.rs
+++ b/slatedb-go/src/db.rs
@@ -60,7 +60,13 @@ pub extern "C" fn slatedb_open(
     let object_store = match create_object_store(url_str, env_file_str) {
         Ok(store) => store,
         Err(err) => {
-            return create_handle_error_result(CSdbError::InvalidProvider, &err.to_string())
+            return CSdbHandleResult {
+                handle: CSdbHandle::null(),
+                result: CSdbResult {
+                    error: err.error,
+                    message: err.message,
+                },
+            }
         }
     };
 

--- a/slatedb-go/src/error.rs
+++ b/slatedb-go/src/error.rs
@@ -33,22 +33,28 @@ impl std::fmt::Display for CSdbResult {
 }
 
 #[repr(C)]
-pub struct CSdbHandleResult(CSdbHandle, CSdbResult);
+pub struct CSdbHandleResult {
+    pub handle: CSdbHandle,
+    pub result: CSdbResult,
+}
 
 pub fn create_handle_error_result(error: CSdbError, message: &str) -> CSdbHandleResult {
     let c_message =
         CString::new(message).unwrap_or_else(|_| CString::new("Invalid UTF-8").unwrap());
-    CSdbHandleResult(
-        CSdbHandle::null(),
-        CSdbResult {
+    CSdbHandleResult {
+        handle: CSdbHandle::null(),
+        result: CSdbResult {
             error,
             message: c_message.into_raw(),
         },
-    )
+    }
 }
 
 pub fn create_handle_success_result(handler: CSdbHandle) -> CSdbHandleResult {
-    CSdbHandleResult(handler, create_success_result())
+    CSdbHandleResult {
+        handle: handler,
+        result: create_success_result(),
+    }
 }
 
 // Helper functions for error handling


### PR DESCRIPTION
## Summary

In #1056 I added errors to the Go bindings when calling `slatedb.Open()`. However when an error occurs creating the object store we end up printing the pointer instead of the string like so.
```
    consumer_test.go:74: internal error: InternalError: 0x2dec54b0
```

## Changes

- Made CSdbHandleResult fields public so I could use it in the db module
- Passed the result from create_object_store back to the Go bindings when an error occurs
- Updated go bindings to use struct field names

We now get this result:
```
--- FAIL: TestConsumer (0.00s)
    consumer_test.go:74: internal error: Failed to load object store from environment: undefined environment variable LOCAL_PATH
```

## Notes for Reviewers

I couldn't get the go tests working locally, it hangs for me:
```
      > slatedb.io/slatedb-go.Open({0x8c43a7?, 0x0?}, {0x0, 0x0, 0x460297?})
          /home/patrick/src/mouse/slatedb/slatedb-go/go/db.go:100
            | }
            |
            > handle := C.slatedb_open(cPath, cURL, cEnvFile)
            |
            | if handle.result.error != C.Success {
      > slatedb.io/slatedb-go_test.init.func4.2()
          /home/patrick/src/mouse/slatedb/slatedb-go/go/db_test.go:19
            |
            | It("should return error if CLOUD_PROVIDER is undefined", func() {
            > 	db, err := slatedb.Open("path/to/db")
```

It hangs on main too, even after a `go clean --cache`. It's 1:30am here so I'm just going to open this PR and go to bed :) 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
