### PR TITLE
Silence expected NotFound warnings in disk cache evictor

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -622,10 +622,11 @@ impl FsCacheEvictorInner {
         };
 
         // if the file is not found, still try to remove it from the cache_entries, and decrease the cache_size_bytes.
-        // this might happen when the file is removed by other processes, but the cache_entries is not updated yet.
+        // this might happen when the file is removed by other processes, or due to a race between the background
+        // scan (which collects paths then processes them) and eviction deleting files in between.
         if let Err(err) = tokio::fs::remove_file(&target).await {
-            warn!("evictor failed to remove the cache file [error={}]", err);
             if err.kind() != std::io::ErrorKind::NotFound {
+                warn!("evictor failed to remove the cache file [error={}]", err);
                 return 0;
             }
         }


### PR DESCRIPTION
## Summary

A race between the background directory scan and eviction can cause the evictor to attempt removing files that were already deleted. This is handled correctly but was logging noisy warnings.

## Changes

Make a warning less verbose

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

