### PR TITLE
Fix duplicate "bytes" suffix in compaction progress

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -198,7 +198,7 @@ impl Display for Compaction {
         if self.bytes_processed > 0 {
             let human_bytes_processed = crate::utils::format_bytes_si(self.bytes_processed);
 
-            write!(f, " ({} bytes processed)", human_bytes_processed)?;
+            write!(f, " ({} processed)", human_bytes_processed)?;
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

The current string would result in an output like this:

```
2025-12-16T22:35:32.358329Z  INFO slatedb::compactor: in-flight compaction [compaction=["122", "121", "120", "119"] -> 119 (1.37 GB bytes processed)]
```

This PR removes the extra "bytes":


```
2025-12-16T22:35:32.358329Z  INFO slatedb::compactor: in-flight compaction [compaction=["122", "121", "120", "119"] -> 119 (1.37 GB processed)]
```


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
