### PR TITLE
Factor out common CompactorRuntime in DbBuilder and CompactorBuilder

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -11,6 +11,7 @@ use slatedb::config::GarbageCollectorOptions;
 use slatedb::config::SizeTieredCompactionSchedulerOptions;
 use slatedb::object_store::ObjectStore;
 use slatedb::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
+use slatedb::CompactorRuntime;
 use slatedb::Db;
 use slatedb::DbBuilder;
 use slatedb::DbRand;
@@ -87,7 +88,9 @@ pub async fn build_db(
     builder = builder.with_seed(rand.rng().random_range(0..u64::MAX));
     builder = builder.with_system_clock(system_clock.clone());
     builder = builder.with_logical_clock(logical_clock.clone());
-    builder = builder.with_compaction_scheduler_supplier(compaction_scheduler_supplier);
+    builder = builder.with_compactor_runtime(
+        CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler_supplier),
+    );
     builder.build().await.unwrap()
 }
 

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -968,6 +968,7 @@ mod tests {
     use crate::config::{
         PutOptions, Settings, SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
     };
+    use crate::db::builder::CompactorRuntime;
     use crate::db::Db;
     use crate::db_state::{CoreDbState, SortedRun};
     use crate::error::SlateDBError;
@@ -1020,7 +1021,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .build()
             .await
             .unwrap();
@@ -1094,7 +1097,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(scheduler.clone())
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(scheduler.clone()),
+            )
             .build()
             .await
             .unwrap();
@@ -1192,7 +1197,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(scheduler.clone())
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(scheduler.clone()),
+            )
             .build()
             .await
             .unwrap();
@@ -1283,7 +1290,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1355,7 +1364,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1429,7 +1440,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1497,7 +1510,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1575,7 +1590,7 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(insert_clock.clone())
-            .with_compaction_scheduler_supplier(scheduler)
+            .with_compactor_runtime(CompactorRuntime::new().with_scheduler_supplier(scheduler))
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1653,7 +1668,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1707,7 +1724,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_merge_operator(Arc::new(StringConcatMergeOperator))
             .build()
             .await
@@ -1818,7 +1837,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(insert_clock.clone())
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .build()
             .await
             .unwrap();
@@ -2647,7 +2668,9 @@ mod tests {
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_logical_clock(logical_clock)
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .with_sst_block_size(SstBlockSize::Other(128))
             .build()
             .await

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1520,7 +1520,7 @@ mod tests {
         CompactorOptions, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
         ObjectStoreCacheOptions, Settings, SizeTieredCompactionSchedulerOptions, Ttl,
     };
-    use crate::db::builder::GarbageCollectorBuilder;
+    use crate::db::builder::{CompactorRuntime, GarbageCollectorBuilder};
     use crate::db_state::CoreDbState;
     use crate::db_stats::IMMUTABLE_MEMTABLE_FLUSHES;
     use crate::iter::KeyValueIterator;
@@ -2907,7 +2907,9 @@ mod tests {
                         manifest_update_timeout: Duration::from_secs(300),
                     }),
                 ))
-                .with_compaction_scheduler_supplier(compaction_scheduler)
+                .with_compactor_runtime(
+                    CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+                )
                 .build()
                 .await
                 .unwrap(),
@@ -3957,7 +3959,9 @@ mod tests {
         let db = Db::builder(path, object_store.clone())
             .with_settings(test_db_options(0, 1024 * 1024, None))
             .with_merge_operator(Arc::new(StringConcatMergeOperator {}))
-            .with_compaction_scheduler_supplier(compaction_scheduler)
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler),
+            )
             .build()
             .await
             .unwrap();
@@ -4503,7 +4507,9 @@ mod tests {
 
         let db = Db::builder(path, object_store.clone())
             .with_settings(options)
-            .with_compaction_scheduler_supplier(compaction_scheduler.clone())
+            .with_compactor_runtime(
+                CompactorRuntime::new().with_scheduler_supplier(compaction_scheduler.clone()),
+            )
             .build()
             .await
             .unwrap();

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -37,6 +37,7 @@ pub use cached_object_store::stats as cached_object_store_stats;
 pub use checkpoint::{Checkpoint, CheckpointCreateResult};
 pub use compactor::CompactorBuilder;
 pub use config::{Settings, SstBlockSize};
+pub use db::builder::CompactorRuntime;
 pub use db::{Db, DbBuilder};
 pub use db_cache::stats as db_cache_stats;
 pub use db_iter::DbIterator;

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -12,6 +12,7 @@ use slatedb::config::{
 use slatedb::object_store::memory::InMemory;
 use slatedb::object_store::ObjectStore;
 use slatedb::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
+use slatedb::CompactorRuntime;
 use slatedb::Db;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -131,7 +132,9 @@ async fn test_concurrent_writers_and_readers() {
             let db_path = format!("/tmp/test_concurrent_writers_readers_{}", ts);
             Db::builder(db_path, object_store.clone())
                 .with_settings(config.clone())
-                .with_compaction_scheduler_supplier(supplier.clone())
+                .with_compactor_runtime(
+                    CompactorRuntime::new().with_scheduler_supplier(supplier.clone()),
+                )
                 .build()
                 .await
         })


### PR DESCRIPTION
Addresses https://github.com/slatedb/slatedb/issues/1118. This is the best I could come up with to find some convergence between `DbBuilder` and `CompactorBuilder`.  It is difficult at the moment to hook `CompactorBuilder` directly to `DbBuilder` because they are really building different things. However, they do share some common runtime (loosely termed) considerations, which I've tried to move into a `CompactorRuntime`. In the future, if there are more cases of common runtime needs, they can be added here without additional forwarding logic.