### PR TITLE
Add RFC-0014 new WAL persistence format

### DIFF
--- a/rfcs/0014-wal_on_disk_format.md
+++ b/rfcs/0014-wal_on_disk_format.md
@@ -205,7 +205,7 @@ All integers are in little endian.
 | size of the compressed array of offsets                        |
 | (4-bytes unsigned integer, little endian)                      |
 +----------------------------------------------------------------+
-| compression codec offets                                       |
+| compression codec offsets                                       |
 | (1-byte unsigned integer, little endian)                       |
 +----------------------------------------------------------------+
 | CRC32 checksum (4-bytes, unsigned integer, little endian)      |


### PR DESCRIPTION
## Summary

RFC-0014 proposes a new persistence format for WAL objects.

Related to #1085 

## Changes

Adds RFC-0014 that proposes a new persistence format for WAL objects.

## Notes for Reviewers

- Only RFC for discussion of the proposed format. 
- does not contain any implementation. 

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
