### PR TITLE
Bump sequence tracker test to 60s timeout

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3487,7 +3487,7 @@ mod tests {
         };
 
         let mut froze_memtable = false;
-        for _ in 0..200 {
+        for _ in 0..6000 {
             {
                 let guard = db.inner.state.read();
                 if !guard.state().imm_memtable.is_empty() {


### PR DESCRIPTION
`test_sequence_tracker_not_ahead_of_last_l0_seq_when_flush_races_with_writes` waits a maximum of 2 seconds for the memtable to get frozen. Under extreme load, this isn't enough time. I've bumped the timeout to 60 seconds.

Fixes #1130