### PR TITLE
chore: make `slatedb::Db` derive `Clone`

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -560,6 +560,7 @@ impl DbInner {
     }
 }
 
+#[derive(Clone)]
 pub struct Db {
     pub(crate) inner: Arc<DbInner>,
     task_executor: Arc<MessageHandlerExecutor>,


### PR DESCRIPTION
## Summary

It just has 2 `Arc`s so makes for a cheaply cloneable struct.

## Changes

Derive `Clone` on `slatedb::Db`

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏