### PR TITLE
Upgrade `python.yaml` with Maturin 1.10 and remove Mac 13 x86

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -3,17 +3,14 @@
 #
 #    maturin generate-ci github
 #
-name: CI
+name: Publish Release (Python)
 
 on:
-  push:
-    branches:
-      - main
-      - master
-    tags:
-      - '*'
-  pull_request:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of the release (e.g., 1.0.0)"
+        required: true
 
 permissions:
   contents: read
@@ -38,12 +35,15 @@ jobs:
             target: ppc64le
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          working-directory: ./slatedb-py
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
+          path: ./slatedb-py/dist
 
   musllinux:
     runs-on: ${{ matrix.platform.runner }}
@@ -69,12 +69,15 @@ jobs:
             target: armv7
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          working-directory: ./slatedb-py
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -83,7 +86,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-musllinux-${{ matrix.platform.target }}
-          path: dist
+          path: ./slatedb-py/dist
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -96,6 +99,8 @@ jobs:
             target: x86
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -103,6 +108,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          working-directory: ./slatedb-py
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -110,25 +116,26 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
+          path: ./slatedb-py/dist
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          working-directory: ./slatedb-py
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -136,27 +143,29 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
+          path: ./slatedb-py/dist
 
   sdist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.version }}"
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
+          working-directory: ./slatedb-py
           command: sdist
           args: --out dist
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:
           name: wheels-sdist
-          path: dist
+          path: ./slatedb-py/dist
 
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     needs: [linux, musllinux, windows, macos, sdist]
     permissions:
       # Use to sign the release artifacts
@@ -170,12 +179,12 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: 'wheels-*/*'
+          subject-path: "wheels-*/*"
       - name: Publish to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
         uses: PyO3/maturin-action@v1
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
+          working-directory: ./slatedb-py
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
## Summary

Our 0.10.0 Python release failed:

https://github.com/slatedb/slatedb/actions/runs/20609864311

Github has removed Mac 13 x86 builds. This PR updates python.yaml using the latest Maturin build and removes Mac 13 x86 from the Mac build.

## Changes

- Autogenerate python.yaml using the latest Maturin
- Manually re-add `workflow_dispatch`
- Manually re-add working directory `slatedb-py` paths.
- Add Windows release support