### PR TITLE
Re-add envs for Linux Python release

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -42,6 +42,13 @@ jobs:
           python-version: 3.x
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          CC_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-gcc
+          AR_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-ar
+          RANLIB_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-ranlib
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-unknown-linux-gnu-gcc
+          # ensure the ARM assembler defines __ARM_ARCH
+          CFLAGS_aarch64_unknown_linux_gnu: "-march=armv8-a -D__ARM_ARCH=8"
         with:
           working-directory: ./slatedb-py
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
 Set environment variables (`CC_aarch64_unknown_linux_gnu`, `AR_aarch64_unknown_linux_gnu`, `RANLIB_aarch64_unknown_linux_gnu`, `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER`, and `CFLAGS_aarch64_unknown_linux_gnu`) to ensure the correct cross-compilation tools and flags are used when building ARM64 wheels in the GitHub Actions workflow (`.github/workflows/python.yaml`).

This is required for Linux builds.