### PR TITLE
Remove working-directory in Python release step

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -192,6 +192,5 @@ jobs:
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
-          working-directory: ./slatedb-py
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
## Summary

It's causing failures:

Error: ENOENT: no such file or directory, chdir '/home/runner/work/slatedb/slatedb' -> '/home/runner/work/slatedb/slatedb/slatedb-py'
    at wrappedChdir (node:internal/bootstrap/switches/does_own_process_state:130:14)
    at process.chdir (node:internal/worker:111:5)
    at hostBuild (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:33834:25)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async innerMain (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:33920:20)
    at async main (/home/runner/work/_actions/PyO3/maturin-action/v1/dist/index.js:33928:9) {

https://github.com/slatedb/slatedb/actions/runs/20610424040

## Changes

-

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
