### PR TITLE
Add timeout to Go bindings client

### DIFF
--- a/slatedb-go/go/config.go
+++ b/slatedb-go/go/config.go
@@ -15,7 +15,7 @@ import (
 )
 
 type config interface {
-	DbConfig | DbReaderConfig
+	DbConfig | DbReaderConfig | QueryConfig
 }
 
 type DbConfig struct {
@@ -28,6 +28,10 @@ type DbReaderConfig struct {
 	envFile      *string
 	checkpointId *string
 	opts         *DbReaderOptions
+}
+
+type QueryConfig struct {
+	timeout *int64
 }
 
 type Option[T config] func(*T)
@@ -63,6 +67,12 @@ func WithCheckpointId(checkpointId string) Option[DbReaderConfig] {
 func WithDbReaderOptions(opts DbReaderOptions) Option[DbReaderConfig] {
 	return func(cfg *DbReaderConfig) {
 		cfg.opts = &opts
+	}
+}
+
+func WithQueryTimeout(timeout int64) Option[QueryConfig] {
+	return func(cfg *QueryConfig) {
+		cfg.timeout = &timeout
 	}
 }
 

--- a/slatedb-go/go/db.go
+++ b/slatedb-go/go/db.go
@@ -415,7 +415,7 @@ func (db *DB) Scan(start, end []byte) (*Iterator, error) {
 //	    if err != nil { return err }
 //	    process(kv.Key, kv.Value)
 //	}
-func (db *DB) ScanWithOptions(start, end []byte, opts *ScanOptions) (*Iterator, error) {
+func (db *DB) ScanWithOptions(start, end []byte, scanOpts *ScanOptions, opts ...Option[QueryConfig]) (*Iterator, error) {
 	var startPtr *C.uint8_t
 	var startLen C.uintptr_t
 	if len(start) > 0 {
@@ -430,7 +430,12 @@ func (db *DB) ScanWithOptions(start, end []byte, opts *ScanOptions) (*Iterator, 
 		endLen = C.uintptr_t(len(end))
 	}
 
-	cOpts := convertToCScanOptions(opts)
+	cOpts := convertToCScanOptions(scanOpts)
+
+	cfg := &QueryConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
 
 	var iterPtr *C.CSdbIterator
 	result := C.slatedb_scan_with_options(
@@ -441,6 +446,7 @@ func (db *DB) ScanWithOptions(start, end []byte, opts *ScanOptions) (*Iterator, 
 		endLen,
 		cOpts,
 		&iterPtr,
+		(*C.uint64_t)(unsafe.Pointer(&cfg.timeout)),
 	)
 	defer C.slatedb_free_result(result)
 

--- a/slatedb-go/go/db_test.go
+++ b/slatedb-go/go/db_test.go
@@ -207,6 +207,26 @@ var _ = Describe("DB", func() {
 				Expect(count).To(Equal(3))
 			})
 
+			It("should scan with timeout", func() {
+				opts := &slatedb.ScanOptions{}
+
+				iter, err := db.ScanWithOptions([]byte("item:"), []byte("item:99"), opts, slatedb.WithQueryTimeout(10))
+				Expect(err).NotTo(HaveOccurred())
+				defer func() { Expect(iter.Close()).NotTo(HaveOccurred()) }()
+
+				count := 0
+				for {
+					kv, err := iter.Next()
+					if err == io.EOF {
+						break
+					}
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(kv.Key)).To(HavePrefix("item:"))
+					count++
+				}
+				Expect(count).To(Equal(3))
+			})
+
 			It("should scan by prefix", func() {
 				iter, err := db.ScanPrefix([]byte("item:"))
 				Expect(err).NotTo(HaveOccurred())

--- a/slatedb-go/go/slatedb.h
+++ b/slatedb-go/go/slatedb.h
@@ -345,7 +345,8 @@ struct CSdbResult slatedb_scan_with_options(struct CSdbHandle handle,
                                             const uint8_t *end_key,
                                             uintptr_t end_key_len,
                                             const struct CSdbScanOptions *scan_options,
-                                            struct CSdbIterator **iterator_ptr);
+                                            struct CSdbIterator **iterator_ptr,
+                                            const uint64_t *timeout);
 
 // # Safety
 //

--- a/slatedb-go/src/db.rs
+++ b/slatedb-go/src/db.rs
@@ -1,8 +1,10 @@
 use serde_json;
 use slatedb::Db;
+use slatedb::Error as SlateError;
 use std::collections::HashMap;
 use std::os::raw::c_char;
 use tokio::runtime::Builder;
+use tokio::time::{self, Duration};
 
 use crate::config::{
     convert_put_options, convert_range_bounds, convert_read_options, convert_scan_options,
@@ -276,6 +278,7 @@ pub unsafe extern "C" fn slatedb_scan_with_options(
     end_key_len: usize,
     scan_options: *const CSdbScanOptions,
     iterator_ptr: *mut *mut CSdbIterator,
+    timeout: *const u64,
 ) -> CSdbResult {
     if handle.is_null() {
         return create_error_result(CSdbError::NullPointer, "Database handle is null");
@@ -296,12 +299,25 @@ pub unsafe extern "C" fn slatedb_scan_with_options(
     // Convert scan options
     let scan_opts = convert_scan_options(scan_options);
 
+    async fn sleep(timeout: u64) -> SlateError {
+        time::sleep(Duration::from_millis(timeout)).await;
+        SlateError::unavailable("Query timeout".to_string())
+    }
+    tokio::pin!(sleep);
+
     // Create the iterator using the bounds
-    match db_ffi.block_on(
-        db_ffi
-            .db
-            .scan_with_options((start_bound, end_bound), &scan_opts),
-    ) {
+    match db_ffi.block_on(async {
+        tokio::select! {
+            v = db_ffi
+                .db
+                .scan_with_options((start_bound, end_bound), &scan_opts) => {
+                    v
+                }
+            v = sleep(*timeout), if *timeout > 0 => {
+                Err(v)
+            }
+        }
+    }) {
         Ok(iter) => {
             // Create FFI wrapper
             let iter_ffi = CSdbIterator::new_db(handle_ptr, iter);


### PR DESCRIPTION
## Summary

This is an attempt to add a client timeout option to the Go bindings as discussed in https://github.com/slatedb/slatedb/issues/1148.
I wasn't sure how to implement this, I've not used tokio before. I also wasn't sure how to add the options, I went with variadic arguments as it seemed logical to me versus adding another argument. This is more idiomatic Golang IMO rather than having a `Scan` as well as a `ScanWithOptions`.
I thought I'd raise this as a draft to gain some feedback.

## Changes

- Add query option to ScanWithOptions

## Notes for Reviewers

I'm a Gopher not a Rustacean. I'm looking for feedback before I implement this for the `ScanPrefixWithOptions`

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
