### PR TITLE
Display SR(0), SR(1), etc. on compaction display

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -243,7 +243,12 @@ impl Display for Compaction {
             .iter()
             .map(|s| format!("{}", s))
             .collect();
-        write!(f, "{:?} -> SR({})", displayed_sources, self.spec.destination(),)?;
+        write!(
+            f,
+            "{:?} -> SR({})",
+            displayed_sources,
+            self.spec.destination(),
+        )?;
         if self.bytes_processed > 0 {
             let human_bytes_processed = crate::utils::format_bytes_si(self.bytes_processed);
 


### PR DESCRIPTION
## Summary

Clarified the destination sorted run when Display-printing a `Compaction`.

From:

```
INFO slatedb::compactor_state: accepted submitted compaction [compaction=["l0", "l0", "l0", "l0"] -> 0]
INFO slatedb::compactor: in-flight compaction [compaction=["l0", "l0", "l0", "l0"] -> 0]
INFO slatedb::compactor_state: finished compaction [spec=["l0", "l0", "l0", "l0"] -> 0]
```

To:

```
INFO slatedb::compactor_state: accepted submitted compaction [compaction=["l0", "l0", "l0", "l0"] -> SR(0)]
INFO slatedb::compactor: in-flight compaction [compaction=["l0", "l0", "l0", "l0"] -> SR(0)]
INFO slatedb::compactor_state: finished compaction [spec=["l0", "l0", "l0", "l0"] -> SR(0)]
```


## Changes

Wrapped the destination in `SR()`.

## Notes for Reviewers

Should be a straightfoward review.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
