### PR TITLE
Add BlockTransformer trait for custom block encoding

### DIFF
--- a/slatedb-go/src/config.rs
+++ b/slatedb-go/src/config.rs
@@ -141,6 +141,7 @@ pub(crate) fn convert_reader_options(c_opts: *const CSdbReaderOptions) -> DbRead
         max_memtable_bytes,
         block_cache: defaults.block_cache,
         merge_operator: defaults.merge_operator,
+        block_transformer: defaults.block_transformer,
     }
 }
 

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -428,17 +428,21 @@ mod tests {
         let mut sst_builder = table_store.table_builder();
         sst_builder
             .add(RowEntry::new_merge(b"foo", b"3", 4))
+            .await
             .unwrap();
         sst_builder
             .add(RowEntry::new_merge(b"foo", b"2", 3))
+            .await
             .unwrap();
         sst_builder
             .add(RowEntry::new_merge(b"foo", b"1", 2))
+            .await
             .unwrap();
         sst_builder
             .add(RowEntry::new_merge(b"foo", b"0", 1))
+            .await
             .unwrap();
-        let encoded_sst = sst_builder.build().unwrap();
+        let encoded_sst = sst_builder.build().await.unwrap();
         let id = SsTableId::Compacted(Ulid::new());
         let l0 = table_store
             .write_sst(&id, encoded_sst, false)

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -178,6 +178,7 @@ use crate::error::SlateDBError;
 use crate::db_cache::DbCache;
 use crate::garbage_collector::{DEFAULT_INTERVAL, DEFAULT_MIN_AGE};
 use crate::merge_operator::MergeOperatorType;
+use crate::sst::BlockTransformer;
 
 /// Enum representing different levels of cache preloading on startup
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
@@ -904,6 +905,11 @@ pub struct DbReaderOptions {
 
     #[serde(skip)]
     pub merge_operator: Option<MergeOperatorType>,
+
+    /// An optional block transformer for custom encoding/decoding of blocks.
+    /// Can be used for encryption, custom encoding, etc.
+    #[serde(skip)]
+    pub block_transformer: Option<Arc<dyn BlockTransformer>>,
 }
 
 impl Default for DbReaderOptions {
@@ -914,6 +920,7 @@ impl Default for DbReaderOptions {
             max_memtable_bytes: 64 * 1024 * 1024,
             block_cache: default_block_cache(),
             merge_operator: None,
+            block_transformer: None,
         }
     }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -918,7 +918,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             ObjectStores::new(retrying_main_object_store.clone(), None),
             sst_format,
             path,
-            None,
+            None, // no need for cache in GC
         ));
 
         let scheduler_supplier = self

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -151,7 +151,7 @@ use crate::object_stores::ObjectStores;
 use crate::paths::PathResolver;
 use crate::rand::DbRand;
 use crate::retrying_object_store::RetryingObjectStore;
-use crate::sst::SsTableFormat;
+use crate::sst::{BlockTransformer, SsTableFormat};
 use crate::stats::StatRegistry;
 use crate::tablestore::TableStore;
 use crate::utils::WatchableOnceCell;
@@ -175,6 +175,7 @@ pub struct DbBuilder<P: Into<Path>> {
     seed: Option<u64>,
     sst_block_size: Option<SstBlockSize>,
     merge_operator: Option<MergeOperatorType>,
+    block_transformer: Option<Arc<dyn BlockTransformer>>,
 }
 
 impl<P: Into<Path>> DbBuilder<P> {
@@ -195,6 +196,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             seed: None,
             sst_block_size: None,
             merge_operator: None,
+            block_transformer: None,
         }
     }
 
@@ -309,6 +311,25 @@ impl<P: Into<Path>> DbBuilder<P> {
         self
     }
 
+    /// Sets the block transformer to use for the database. The block transformer
+    /// allows custom encoding/decoding of block data before storage and after
+    /// retrieval. This can be used for encryption or other transformations.
+    ///
+    /// The transformer is applied after compression on write and before
+    /// decompression on read. The checksum is calculated on the transformed data.
+    ///
+    /// # Arguments
+    ///
+    /// * `block_transformer` - An Arc-wrapped block transformer implementation.
+    ///
+    /// # Returns
+    ///
+    /// The builder instance for chaining.
+    pub fn with_block_transformer(mut self, block_transformer: Arc<dyn BlockTransformer>) -> Self {
+        self.block_transformer = Some(block_transformer);
+        self
+    }
+
     /// Builds and opens the database.
     pub async fn build(self) -> Result<Db, crate::Error> {
         let path = self.path.into();
@@ -370,6 +391,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             filter_bits_per_key: self.settings.filter_bits_per_key,
             compression_codec: self.settings.compression_codec,
             block_size: self.sst_block_size.unwrap_or_default().as_bytes(),
+            block_transformer: self.block_transformer.clone(),
             ..SsTableFormat::default()
         };
 
@@ -798,6 +820,7 @@ pub struct CompactorBuilder<P: Into<Path>> {
     system_clock: Arc<dyn SystemClock>,
     closed_result: WatchableOnceCell<Result<(), SlateDBError>>,
     merge_operator: Option<MergeOperatorType>,
+    block_transformer: Option<Arc<dyn BlockTransformer>>,
 }
 
 #[allow(unused)]
@@ -814,6 +837,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             system_clock: Arc::new(DefaultSystemClock::default()),
             closed_result: WatchableOnceCell::new(),
             merge_operator: None,
+            block_transformer: None,
         }
     }
 
@@ -864,6 +888,12 @@ impl<P: Into<Path>> CompactorBuilder<P> {
         self
     }
 
+    /// Sets the block transformer to use for the compactor.
+    pub fn with_block_transformer(mut self, block_transformer: Arc<dyn BlockTransformer>) -> Self {
+        self.block_transformer = Some(block_transformer);
+        self
+    }
+
     /// Builds and returns a Compactor instance.
     pub fn build(self) -> Compactor {
         let path: Path = self.path.into();
@@ -880,11 +910,15 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             &path,
             retrying_main_object_store.clone(),
         ));
+        let sst_format = SsTableFormat {
+            block_transformer: self.block_transformer.clone(),
+            ..SsTableFormat::default()
+        };
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(retrying_main_object_store.clone(), None),
-            SsTableFormat::default(), // read only SSTs can use default
+            sst_format,
             path,
-            None, // no need for cache in GC
+            None,
         ));
 
         let scheduler_supplier = self

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -556,6 +556,7 @@ impl DbReader {
             path,
             object_store,
             block_cache: options.block_cache.clone(),
+            block_transformer: options.block_transformer.clone(),
         };
 
         Self::open_internal(

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -99,6 +99,9 @@ pub(crate) enum SlateDBError {
     #[error("error compressing block")]
     BlockCompressionError,
 
+    #[error("error transforming block")]
+    BlockTransformError,
+
     #[error("Invalid RowFlags. #{message}. encoded_bits=`{encoded_bits:#b}`, known_bits=`{known_bits:#b}`")]
     InvalidRowFlags {
         encoded_bits: u8,
@@ -495,6 +498,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::BlockDecompressionError => Error::data(msg),
             #[cfg(any(feature = "snappy", feature = "zlib", feature = "zstd"))]
             SlateDBError::BlockCompressionError => Error::data(msg),
+            SlateDBError::BlockTransformError => Error::data(msg),
             SlateDBError::InvalidRowFlags { .. } => Error::data(msg),
             SlateDBError::CheckpointMissing(_) => Error::data(msg),
             SlateDBError::InvalidVersion { .. } => Error::data(msg),

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -903,10 +903,10 @@ mod tests {
         assert_eq!(manifest, decoded);
     }
 
-    #[test]
-    fn test_should_clamp_index_alloc() {
+    #[tokio::test]
+    async fn test_should_clamp_index_alloc() {
         let format = SsTableFormat::default();
-        let sst = build_test_sst(&format, 3);
+        let sst = build_test_sst(&format, 3).await;
         let data = sst.remaining_as_bytes();
         let start_off = sst.info.index_offset as usize;
         let end_off = sst.info.index_offset as usize + sst.info.index_len as usize;

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -19,10 +19,10 @@ impl DbInner {
         let mut sst_builder = self.table_store.table_builder();
         let mut iter = self.iter_imm_table(imm_table.clone()).await?;
         while let Some(entry) = iter.next_entry().await? {
-            sst_builder.add(entry)?;
+            sst_builder.add(entry).await?;
         }
 
-        let encoded_sst = sst_builder.build()?;
+        let encoded_sst = sst_builder.build().await?;
         let handle = self
             .table_store
             .write_sst(id, encoded_sst, write_cache)

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -736,8 +736,8 @@ mod tests {
         table_id: &SsTableId,
     ) -> Result<(), SlateDBError> {
         let mut sst = table_store.table_builder();
-        sst.add(RowEntry::new_value(b"key", b"value", 0))?;
-        let table1 = sst.build()?;
+        sst.add(RowEntry::new_value(b"key", b"value", 0)).await?;
+        let table1 = sst.build().await?;
         table_store.write_sst(table_id, table1, false).await?;
         Ok(())
     }
@@ -870,15 +870,19 @@ mod tests {
         // write a wal sst
         let id1 = SsTableId::Wal(1);
         let mut sst1 = table_store.table_builder();
-        sst1.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
+        sst1.add(RowEntry::new_value(b"key", b"value", 0))
+            .await
+            .unwrap();
 
-        let table1 = sst1.build().unwrap();
+        let table1 = sst1.build().await.unwrap();
         table_store.write_sst(&id1, table1, false).await.unwrap();
 
         let id2 = SsTableId::Wal(2);
         let mut sst2 = table_store.table_builder();
-        sst2.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
-        let table2 = sst2.build().unwrap();
+        sst2.add(RowEntry::new_value(b"key", b"value", 0))
+            .await
+            .unwrap();
+        let table2 = sst2.build().await.unwrap();
         table_store.write_sst(&id2, table2, false).await.unwrap();
 
         // Set the both WAL SST file to be a day old
@@ -1190,8 +1194,10 @@ mod tests {
     async fn create_sst(table_store: Arc<TableStore>, ts_ms: u64) -> SsTableHandle {
         let sst_id = SsTableId::Compacted(ulid::Ulid::from_parts(ts_ms, 0));
         let mut sst = table_store.table_builder();
-        sst.add(RowEntry::new_value(b"key", b"value", 0)).unwrap();
-        let table = sst.build().unwrap();
+        sst.add(RowEntry::new_value(b"key", b"value", 0))
+            .await
+            .unwrap();
+        let table = sst.build().await.unwrap();
         table_store.write_sst(&sst_id, table, false).await.unwrap()
     }
 

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -288,9 +288,9 @@ mod tests {
         let id_within_min_age = SsTableId::Compacted(ulid::Ulid::from_parts(7_000, 0));
         let id_active_recent = SsTableId::Compacted(ulid::Ulid::from_parts(8_000, 0));
 
-        let sst_to_delete = build_test_sst(&format, 1);
-        let sst_within_min_age = build_test_sst(&format, 1);
-        let sst_active_recent = build_test_sst(&format, 1);
+        let sst_to_delete = build_test_sst(&format, 1).await;
+        let sst_within_min_age = build_test_sst(&format, 1).await;
+        let sst_active_recent = build_test_sst(&format, 1).await;
 
         table_store
             .write_sst(&id_to_delete, sst_to_delete, false)
@@ -389,9 +389,9 @@ mod tests {
         let id_manifest = SsTableId::Compacted(ulid::Ulid::from_parts(3_000, 0));
         let id_newer = SsTableId::Compacted(ulid::Ulid::from_parts(4_000, 0));
 
-        let sst_to_delete = build_test_sst(&format, 1);
-        let sst_manifest = build_test_sst(&format, 1);
-        let sst_newer = build_test_sst(&format, 1);
+        let sst_to_delete = build_test_sst(&format, 1).await;
+        let sst_manifest = build_test_sst(&format, 1).await;
+        let sst_newer = build_test_sst(&format, 1).await;
 
         table_store
             .write_sst(&id_to_delete, sst_to_delete, false)
@@ -478,9 +478,9 @@ mod tests {
         let id_to_delete = SsTableId::Compacted(ulid::Ulid::from_parts(1_000, 0)); // job 1
         let id_barrier = SsTableId::Compacted(ulid::Ulid::from_parts(2_000, 0)); // job 2
         let id_to_newer = SsTableId::Compacted(ulid::Ulid::from_parts(3_000, 0)); // job 2, too
-        let sst_to_delete = build_test_sst(&format, 1);
-        let sst_barrier = build_test_sst(&format, 1);
-        let sst_to_newer = build_test_sst(&format, 1);
+        let sst_to_delete = build_test_sst(&format, 1).await;
+        let sst_barrier = build_test_sst(&format, 1).await;
+        let sst_to_newer = build_test_sst(&format, 1).await;
         table_store
             .write_sst(&id_to_delete, sst_to_delete, false)
             .await
@@ -583,7 +583,7 @@ mod tests {
         // Newest L0 in the manifest has a later timestamp (9_000ms).
         let l0_id = SsTableId::Compacted(ulid::Ulid::from_parts(9_000, 0));
         let l0_handle = table_store
-            .write_sst(&l0_id, build_test_sst(&format, 1), false)
+            .write_sst(&l0_id, build_test_sst(&format, 1).await, false)
             .await
             .unwrap();
         let mut dirty_manifest = stored_manifest.prepare_dirty().unwrap();
@@ -594,7 +594,11 @@ mod tests {
         // output SST (6_000ms), but hasn't updated the manifest yet.
         let compaction_output_id = SsTableId::Compacted(ulid::Ulid::from_parts(6_000, 0));
         table_store
-            .write_sst(&compaction_output_id, build_test_sst(&format, 1), false)
+            .write_sst(
+                &compaction_output_id,
+                build_test_sst(&format, 1).await,
+                false,
+            )
             .await
             .unwrap();
 

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -50,6 +50,7 @@ pub use garbage_collector::GarbageCollectorBuilder;
 pub use merge_operator::{MergeOperator, MergeOperatorError};
 pub use rand::DbRand;
 pub use seq_tracker::FindOption;
+pub use sst::BlockTransformer;
 pub use transaction_manager::IsolationLevel;
 pub use types::KeyValue;
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -520,10 +520,10 @@ mod tests {
             let mut builder = self.table_store.table_builder();
 
             for entry in entries {
-                builder.add(entry)?;
+                builder.add(entry).await?;
             }
 
-            let encoded = builder.build()?;
+            let encoded = builder.build().await?;
             let id = SsTableId::Compacted(Ulid::new());
             self.table_store.write_sst(&id, encoded, false).await
         }

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -226,10 +226,19 @@ mod tests {
             None,
         ));
         let mut builder = table_store.table_builder();
-        builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
-        builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
-        builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
-        let encoded = builder.build().unwrap();
+        builder
+            .add_value(b"key1", b"value1", gen_attrs(1))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key2", b"value2", gen_attrs(2))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key3", b"value3", gen_attrs(3))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
         let sr = SortedRun {
@@ -274,14 +283,23 @@ mod tests {
             None,
         ));
         let mut builder = table_store.table_builder();
-        builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
-        builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
-        let encoded = builder.build().unwrap();
+        builder
+            .add_value(b"key1", b"value1", gen_attrs(1))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key2", b"value2", gen_attrs(2))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
         let id1 = SsTableId::Compacted(ulid::Ulid::new());
         let handle1 = table_store.write_sst(&id1, encoded, false).await.unwrap();
         let mut builder = table_store.table_builder();
-        builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
-        let encoded = builder.build().unwrap();
+        builder
+            .add_value(b"key3", b"value3", gen_attrs(3))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
         let id2 = SsTableId::Compacted(ulid::Ulid::new());
         let handle2 = table_store.write_sst(&id2, encoded, false).await.unwrap();
         let sr = SortedRun {
@@ -492,10 +510,10 @@ mod tests {
             }
 
             for (key, value) in sst_kvs {
-                builder.add_value(key, value, gen_attrs(0)).unwrap();
+                builder.add_value(key, value, gen_attrs(0)).await.unwrap();
             }
 
-            let encoded = builder.build().unwrap();
+            let encoded = builder.build().await.unwrap();
             let id = SsTableId::Compacted(ulid::Ulid::new());
             let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
             ssts.push(handle);

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -866,11 +866,23 @@ mod tests {
             None,
         ));
         let mut builder = table_store.table_builder();
-        builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
-        builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
-        builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
-        builder.add_value(b"key4", b"value4", gen_attrs(4)).unwrap();
-        let encoded = builder.build().unwrap();
+        builder
+            .add_value(b"key1", b"value1", gen_attrs(1))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key2", b"value2", gen_attrs(2))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key3", b"value3", gen_attrs(3))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key4", b"value4", gen_attrs(4))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
         table_store
             .write_sst(&SsTableId::Wal(0), encoded, false)
             .await
@@ -1029,12 +1041,18 @@ mod tests {
             None,
         );
         let mut builder = writer.table_builder();
-        builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
-        builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
+        builder
+            .add_value(b"key1", b"value1", gen_attrs(1))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key2", b"value2", gen_attrs(2))
+            .await
+            .unwrap();
         let handle = writer
             .write_sst(
                 &SsTableId::Compacted(ulid::Ulid::new()),
-                builder.build().unwrap(),
+                builder.build().await.unwrap(),
                 false,
             )
             .await
@@ -1123,9 +1141,10 @@ mod tests {
             let value = format!("v_{}", String::from_utf8_lossy(key));
             builder
                 .add_value(key, value.as_bytes(), gen_attrs(0))
+                .await
                 .unwrap();
         }
-        let encoded = builder.build().unwrap();
+        let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         table_store.write_sst(&id, encoded, false).await.unwrap()
     }
@@ -1153,10 +1172,11 @@ mod tests {
                     format!("value{}", i).as_bytes(),
                     gen_attrs(i),
                 )
+                .await
                 .unwrap();
         }
 
-        let encoded = builder.build().unwrap();
+        let encoded = builder.build().await.unwrap();
         table_store
             .write_sst(&SsTableId::Wal(0), encoded, false)
             .await
@@ -1438,11 +1458,23 @@ mod tests {
         ));
 
         let mut builder = table_store.table_builder();
-        builder.add_value(b"key1", b"value1", gen_attrs(1)).unwrap();
-        builder.add_value(b"key2", b"value2", gen_attrs(2)).unwrap();
-        builder.add_value(b"key3", b"value3", gen_attrs(3)).unwrap();
-        builder.add_value(b"key4", b"value4", gen_attrs(4)).unwrap();
-        let encoded = builder.build().unwrap();
+        builder
+            .add_value(b"key1", b"value1", gen_attrs(1))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key2", b"value2", gen_attrs(2))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key3", b"value3", gen_attrs(3))
+            .await
+            .unwrap();
+        builder
+            .add_value(b"key4", b"value4", gen_attrs(4))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         table_store.write_sst(&id, encoded, false).await.unwrap();
         let sst_handle = table_store.open_sst(&id).await.unwrap();

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,7 +1,7 @@
 use crate::db_cache::DbCache;
 use crate::manifest::store::ManifestStore;
 use crate::object_stores::ObjectStores;
-use crate::sst::SsTableFormat;
+use crate::sst::{BlockTransformer, SsTableFormat};
 use crate::tablestore::TableStore;
 use object_store::path::Path;
 use object_store::ObjectStore;
@@ -16,13 +16,18 @@ pub(crate) struct DefaultStoreProvider {
     pub(crate) path: Path,
     pub(crate) object_store: Arc<dyn ObjectStore>,
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
+    pub(crate) block_transformer: Option<Arc<dyn BlockTransformer>>,
 }
 
 impl StoreProvider for DefaultStoreProvider {
     fn table_store(&self) -> Arc<TableStore> {
+        let sst_format = SsTableFormat {
+            block_transformer: self.block_transformer.clone(),
+            ..SsTableFormat::default()
+        };
         Arc::new(TableStore::new(
             ObjectStores::new(Arc::clone(&self.object_store), None),
-            SsTableFormat::default(),
+            sst_format,
             self.path.clone(),
             self.block_cache.clone(),
         ))

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -282,7 +282,7 @@ pub(crate) async fn seed_database(
     Ok(())
 }
 
-pub(crate) fn build_test_sst(format: &SsTableFormat, num_blocks: usize) -> EncodedSsTable {
+pub(crate) async fn build_test_sst(format: &SsTableFormat, num_blocks: usize) -> EncodedSsTable {
     let mut rng = rand::rng();
     let mut keygen = OrderedBytesGenerator::new_with_suffix(&[], &[0u8; 16]);
     let mut encoded_sst_builder = format.table_builder();
@@ -292,9 +292,9 @@ pub(crate) fn build_test_sst(format: &SsTableFormat, num_blocks: usize) -> Encod
         val.put_bytes(0u8, 32);
         rng.fill_bytes(&mut val);
         let row = RowEntry::new(k, ValueDeletable::Value(val.freeze()), 0u64, None, None);
-        encoded_sst_builder.add(row).unwrap();
+        encoded_sst_builder.add(row).await.unwrap();
     }
-    encoded_sst_builder.build().unwrap()
+    encoded_sst_builder.build().await.unwrap()
 }
 
 /// A compactor that compacts if there are L0s and `should_compact` returns true.

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -341,10 +341,10 @@ impl WalBufferManager {
         let mut sst_builder = self.table_store.table_builder();
         let mut iter = wal.iter();
         while let Some(entry) = iter.next_entry().await? {
-            sst_builder.add(entry)?;
+            sst_builder.add(entry).await?;
         }
 
-        let encoded_sst = sst_builder.build()?;
+        let encoded_sst = sst_builder.build().await?;
         self.table_store
             .write_sst(&SsTableId::Wal(wal_id), encoded_sst, false)
             .await?;


### PR DESCRIPTION
## Summary

Allows users to provide custom transformations (e.g., encryption) for block data. The transformer is applied after compression on write and before decompression on read, with checksums calculated on transformed data.

## Changes

- Add BlockTransformer trait with encode/decode methods
- Apply transformation to data, filter, and index blocks
- Add with_block_transformer() to DbBuilder
- Export trait publicly for user implementations


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
