### PR TITLE
Fix `unreachable_pub` violations (part 3)

### DIFF
--- a/slatedb/src/iter.rs
+++ b/slatedb/src/iter.rs
@@ -17,7 +17,7 @@ pub(crate) enum IterationOrder {
 /// See: https://github.com/slatedb/slatedb/issues/12
 
 #[async_trait]
-pub trait KeyValueIterator: Send + Sync {
+pub(crate) trait KeyValueIterator: Send + Sync {
     /// Performs any expensive initialization required before regular iteration.
     ///
     /// This method should be idempotent and can be called multiple times, only
@@ -76,7 +76,7 @@ pub trait KeyValueIterator: Send + Sync {
 }
 
 /// Initializes the iterator contained in the option, propagating `None` unchanged.
-pub async fn init_optional_iterator<T: KeyValueIterator>(
+pub(crate) async fn init_optional_iterator<T: KeyValueIterator>(
     iter: Option<T>,
 ) -> Result<Option<T>, SlateDBError> {
     match iter {

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -28,7 +28,7 @@ pub(crate) struct SequencedKey {
 }
 
 impl SequencedKey {
-    pub fn new(user_key: Bytes, seq: u64) -> Self {
+    pub(crate) fn new(user_key: Bytes, seq: u64) -> Self {
         Self { user_key, seq }
     }
 }

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -20,7 +20,7 @@ pub(crate) struct RetryingObjectStore {
 }
 
 impl RetryingObjectStore {
-    pub fn new(inner: Arc<dyn ObjectStore>) -> Self {
+    pub(crate) fn new(inner: Arc<dyn ObjectStore>) -> Self {
         Self { inner }
     }
 

--- a/slatedb/src/row_codec.rs
+++ b/slatedb/src/row_codec.rs
@@ -61,7 +61,7 @@ pub(crate) struct SstRowEntry {
 }
 
 impl SstRowEntry {
-    pub fn new(
+    pub(crate) fn new(
         key_prefix_len: usize,
         key_suffix: Bytes,
         seq: u64,
@@ -93,7 +93,7 @@ impl SstRowEntry {
         }
     }
 
-    pub fn flags(&self) -> RowFlags {
+    pub(crate) fn flags(&self) -> RowFlags {
         let mut flags = match &self.value {
             ValueDeletable::Value(_) => RowFlags::default(),
             ValueDeletable::Merge(_) => RowFlags::MERGE_OPERAND,
@@ -109,7 +109,7 @@ impl SstRowEntry {
     }
 
     #[cfg(test)]
-    pub fn size(&self) -> usize {
+    pub(crate) fn size(&self) -> usize {
         let mut size = 2  // u16 key_prefix_len
         + 2 // u16 key_suffix_len
         + self.key_suffix.len() // key_suffix
@@ -130,7 +130,7 @@ impl SstRowEntry {
 
     /// Keys in a Block are stored with prefix stripped off to compress the storage size. This function
     /// restores the full key by prepending the prefix to the key suffix.
-    pub fn restore_full_key(&self, prefix: &Bytes) -> Bytes {
+    pub(crate) fn restore_full_key(&self, prefix: &Bytes) -> Bytes {
         let mut full_key = BytesMut::with_capacity(self.key_prefix_len + self.key_suffix.len());
         full_key.extend_from_slice(&prefix[..self.key_prefix_len]);
         full_key.extend_from_slice(&self.key_suffix);
@@ -141,12 +141,12 @@ impl SstRowEntry {
 pub(crate) struct SstRowCodecV0 {}
 
 impl SstRowCodecV0 {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {}
     }
 
     /// estimated_entries_size include the size of seqnum,create_ts(if exist),expire_ts(exist),key,value
-    pub fn estimate_encoded_size(entry_num: usize, estimated_entries_size: usize) -> usize {
+    pub(crate) fn estimate_encoded_size(entry_num: usize, estimated_entries_size: usize) -> usize {
         let key_prefix_len_size = std::mem::size_of::<u16>();
         let key_suffix_len_size = std::mem::size_of::<u16>();
         let value_len_size = std::mem::size_of::<u32>();
@@ -156,7 +156,7 @@ impl SstRowCodecV0 {
         ans
     }
 
-    pub fn encode(&self, output: &mut Vec<u8>, row: &SstRowEntry) {
+    pub(crate) fn encode(&self, output: &mut Vec<u8>, row: &SstRowEntry) {
         output.put_u16(row.key_prefix_len.try_into().expect("key_prefix_len > u16"));
         output.put_u16(
             row.key_suffix
@@ -197,7 +197,7 @@ impl SstRowCodecV0 {
         }
     }
 
-    pub fn decode(&self, data: &mut Bytes) -> Result<SstRowEntry, SlateDBError> {
+    pub(crate) fn decode(&self, data: &mut Bytes) -> Result<SstRowEntry, SlateDBError> {
         let key_prefix_len = data.get_u16() as usize;
         let key_suffix_len = data.get_u16() as usize;
         let key_suffix = data.slice(..key_suffix_len);

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -520,7 +520,7 @@ impl EncodedSsTableBuilder<'_> {
     /// Adds an entry to the SSTable and returns the size of the block that was finished if any.
     /// The block size is calculated after applying any compression if enabled.
     /// The block size is None if the builder has not finished compacting a block yet.
-    pub fn add(&mut self, entry: RowEntry) -> Result<Option<usize>, SlateDBError> {
+    pub(crate) fn add(&mut self, entry: RowEntry) -> Result<Option<usize>, SlateDBError> {
         self.num_keys += 1;
 
         let index_key = compute_index_key(self.current_block_max_key.take(), &entry.key);
@@ -546,7 +546,7 @@ impl EncodedSsTableBuilder<'_> {
     }
 
     #[cfg(test)]
-    pub fn add_value(
+    pub(crate) fn add_value(
         &mut self,
         key: &[u8],
         val: &[u8],
@@ -562,7 +562,7 @@ impl EncodedSsTableBuilder<'_> {
         self.add(entry)
     }
 
-    pub fn next_block(&mut self) -> Option<EncodedSsTableBlock> {
+    pub(crate) fn next_block(&mut self) -> Option<EncodedSsTableBlock> {
         self.blocks.pop_front()
     }
 
@@ -652,7 +652,7 @@ impl EncodedSsTableBuilder<'_> {
     /// +---------------------------------------------------+
     /// * Only present if num_keys >= min_filter_keys.
     ///
-    pub fn build(mut self) -> Result<EncodedSsTable, SlateDBError> {
+    pub(crate) fn build(mut self) -> Result<EncodedSsTable, SlateDBError> {
         self.finish_block()?;
         let mut buf = Vec::new();
         let mut maybe_filter = None;

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -24,7 +24,7 @@ use crate::sst::{EncodedSsTable, EncodedSsTableBuilder, SsTableFormat};
 use crate::types::RowEntry;
 use crate::{blob::ReadOnlyBlob, block::Block};
 
-pub struct TableStore {
+pub(crate) struct TableStore {
     object_stores: ObjectStores,
     sst_format: SsTableFormat,
     path_resolver: PathResolver,
@@ -68,7 +68,7 @@ pub(crate) struct SstFileMetadata {
 }
 
 impl TableStore {
-    pub fn new<P: Into<Path>>(
+    pub(crate) fn new<P: Into<Path>>(
         object_stores: ObjectStores,
         sst_format: SsTableFormat,
         root_path: P,
@@ -83,7 +83,7 @@ impl TableStore {
         )
     }
 
-    pub fn new_with_fp_registry(
+    pub(crate) fn new_with_fp_registry(
         object_stores: ObjectStores,
         sst_format: SsTableFormat,
         path_resolver: PathResolver,
@@ -551,13 +551,13 @@ impl EncodedSsTableWriter<'_> {
     /// Adds an entry to the SSTable and returns the size of the block that was finished if any.
     /// The block size is calculated after applying any compression if enabled.
     /// The block size is None if the builder has not finished compacting a block yet.
-    pub async fn add(&mut self, entry: RowEntry) -> Result<Option<usize>, SlateDBError> {
+    pub(crate) async fn add(&mut self, entry: RowEntry) -> Result<Option<usize>, SlateDBError> {
         let block_size = self.builder.add(entry)?;
         self.drain_blocks().await?;
         Ok(block_size)
     }
 
-    pub async fn close(mut self) -> Result<SsTableHandle, SlateDBError> {
+    pub(crate) async fn close(mut self) -> Result<SsTableHandle, SlateDBError> {
         let mut encoded_sst = self.builder.build()?;
         while let Some(block) = encoded_sst.unconsumed_blocks.pop_front() {
             self.writer.write_all(block.encoded_bytes.as_ref()).await?;

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -58,7 +58,7 @@ pub(crate) async fn assert_next_entry<T: KeyValueIterator>(
     assert_eq!(actual_entry, expected_entry.clone())
 }
 
-pub fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
+pub(crate) fn assert_kv(kv: &KeyValue, key: &[u8], val: &[u8]) {
     assert_eq!(kv.key, key);
     assert_eq!(kv.value, val);
 }

--- a/slatedb/src/transaction_manager.rs
+++ b/slatedb/src/transaction_manager.rs
@@ -75,7 +75,7 @@ impl TransactionState {
 /// Manages the lifecycle of transaction states and provides isolation-level-aware conflict detection.
 /// Supports both Snapshot Isolation (SI) and Serializable Snapshot Isolation (SSI).
 /// TODO: have a quota for max active transactions.
-pub struct TransactionManager {
+pub(crate) struct TransactionManager {
     inner: Arc<RwLock<TransactionManagerInner>>,
     /// Random number generator for generating transaction IDs
     db_rand: Arc<DbRand>,
@@ -99,7 +99,7 @@ struct TransactionManagerInner {
 }
 
 impl TransactionManager {
-    pub fn new(db_rand: Arc<DbRand>) -> Self {
+    pub(crate) fn new(db_rand: Arc<DbRand>) -> Self {
         Self {
             inner: Arc::new(RwLock::new(TransactionManagerInner {
                 active_txns: HashMap::new(),
@@ -110,7 +110,7 @@ impl TransactionManager {
     }
 
     /// Register a transaction state
-    pub fn new_txn(&self, seq: u64, read_only: bool) -> Uuid {
+    pub(crate) fn new_txn(&self, seq: u64, read_only: bool) -> Uuid {
         let txn_id = self.db_rand.rng().gen_uuid();
 
         let txn_state = TransactionState {
@@ -132,7 +132,7 @@ impl TransactionManager {
 
     /// Register a transaction state with a specific txn id (for testing only)
     #[cfg(test)]
-    pub fn new_txn_with_id(&self, seq: u64, read_only: bool, txn_id: Uuid) -> Uuid {
+    fn new_txn_with_id(&self, seq: u64, read_only: bool, txn_id: Uuid) -> Uuid {
         let txn_state = TransactionState {
             read_only,
             started_seq: seq,
@@ -155,7 +155,7 @@ impl TransactionManager {
     /// Please note that a committed txn can also run into drop_txn() on `drop()`, this
     /// method does nothing on such case.
     /// Here's a chance to recycle the recent committed txns.
-    pub fn drop_txn(&self, txn_id: &Uuid) {
+    pub(crate) fn drop_txn(&self, txn_id: &Uuid) {
         let mut inner = self.inner.write();
         inner.active_txns.remove(txn_id);
         inner.recycle_recent_committed_txns();
@@ -163,7 +163,7 @@ impl TransactionManager {
 
     /// Track write keys for a transaction. This is used for conflict detection.
     /// Keys should be tracked before calling commit-related methods.
-    pub fn track_write_keys(&self, txn_id: &Uuid, write_keys: &HashSet<Bytes>) {
+    pub(crate) fn track_write_keys(&self, txn_id: &Uuid, write_keys: &HashSet<Bytes>) {
         let mut inner = self.inner.write();
         if let Some(txn_state) = inner.active_txns.get_mut(txn_id) {
             txn_state.track_write_keys(write_keys.iter().cloned());
@@ -171,8 +171,11 @@ impl TransactionManager {
     }
 
     /// Track a key read operation (for SSI)
-    #[allow(unused)]
-    pub fn track_read_keys(&self, txn_id: &Uuid, read_keys: impl IntoIterator<Item = Bytes>) {
+    pub(crate) fn track_read_keys(
+        &self,
+        txn_id: &Uuid,
+        read_keys: impl IntoIterator<Item = Bytes>,
+    ) {
         let mut inner = self.inner.write();
         if let Some(txn_state) = inner.active_txns.get_mut(txn_id) {
             txn_state.track_read_keys(read_keys);
@@ -180,8 +183,7 @@ impl TransactionManager {
     }
 
     /// Track a range scan operation (for SSI)
-    #[allow(unused)]
-    pub fn track_read_range(&self, txn_id: &Uuid, range: BytesRange) {
+    pub(crate) fn track_read_range(&self, txn_id: &Uuid, range: BytesRange) {
         let mut inner = self.inner.write();
         if let Some(txn_state) = inner.active_txns.get_mut(txn_id) {
             txn_state.track_read_range(range);
@@ -193,7 +195,7 @@ impl TransactionManager {
     ///
     /// For Snapshot isolation: Only checks write-write conflicts
     /// For SerializableSnapshot isolation: Checks both write-write and read-write conflicts
-    pub fn check_has_conflict(&self, txn_id: &Uuid) -> bool {
+    pub(crate) fn check_has_conflict(&self, txn_id: &Uuid) -> bool {
         let inner = self.inner.read();
         let txn_state = match inner.active_txns.get(txn_id) {
             None => return false,
@@ -222,7 +224,7 @@ impl TransactionManager {
     ///
     /// The transaction will be moved from active_txns to recent_committed_txns
     /// for future conflict checking with other transactions.
-    pub fn track_recent_committed_txn(&self, txn_id: &Uuid, committed_seq: u64) {
+    pub(crate) fn track_recent_committed_txn(&self, txn_id: &Uuid, committed_seq: u64) {
         // remove the transaction from active_txns, and add it to recent_committed_txns
         let mut inner = self.inner.write();
 
@@ -246,7 +248,11 @@ impl TransactionManager {
     /// Track a write batch for conflict detection. This is used for regular write operations
     /// that are not part of an explicit transaction but still need to be tracked for conflict
     /// detection with concurrent transactions.
-    pub fn track_recent_committed_write_batch(&self, keys: &HashSet<Bytes>, committed_seq: u64) {
+    pub(crate) fn track_recent_committed_write_batch(
+        &self,
+        keys: &HashSet<Bytes>,
+        committed_seq: u64,
+    ) {
         // remove the transaction from active_txns, and add it to recent_committed_txns
         let mut inner = self.inner.write();
 
@@ -273,7 +279,7 @@ impl TransactionManager {
     ///
     /// min_active_seq will be persisted to the `recent_snapshot_min_seq` in the manifest
     /// when a new L0 is flushed.
-    pub fn min_active_seq(&self) -> Option<u64> {
+    pub(crate) fn min_active_seq(&self) -> Option<u64> {
         let inner = self.inner.read();
         inner
             .active_txns

--- a/slatedb/src/types.rs
+++ b/slatedb/src/types.rs
@@ -47,7 +47,7 @@ impl RowEntry {
         }
     }
 
-    pub fn estimated_size(&self) -> usize {
+    pub(crate) fn estimated_size(&self) -> usize {
         let mut size = self.key.len() + self.value.len();
         // Add size for sequence number
         size += std::mem::size_of::<u64>();
@@ -169,11 +169,11 @@ impl ValueDeletable {
         }
     }
 
-    pub fn is_tombstone(&self) -> bool {
+    pub(crate) fn is_tombstone(&self) -> bool {
         matches!(self, ValueDeletable::Tombstone)
     }
 
-    pub fn as_bytes(&self) -> Option<Bytes> {
+    pub(crate) fn as_bytes(&self) -> Option<Bytes> {
         match self {
             ValueDeletable::Value(v) | ValueDeletable::Merge(v) => Some(v.clone()),
             ValueDeletable::Tombstone => None,

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -207,31 +207,31 @@ pub(crate) struct MonotonicSeq {
 }
 
 impl MonotonicSeq {
-    pub fn new(initial_value: u64) -> Self {
+    pub(crate) fn new(initial_value: u64) -> Self {
         Self {
             val: AtomicU64::new(initial_value),
         }
     }
 
-    pub fn next(&self) -> u64 {
+    pub(crate) fn next(&self) -> u64 {
         self.val.fetch_add(1, SeqCst) + 1
     }
 
-    pub fn store(&self, value: u64) {
+    pub(crate) fn store(&self, value: u64) {
         self.val.store(value, SeqCst);
     }
 
-    pub fn load(&self) -> u64 {
+    pub(crate) fn load(&self) -> u64 {
         self.val.load(SeqCst)
     }
 
-    pub fn store_if_greater(&self, value: u64) {
+    pub(crate) fn store_if_greater(&self, value: u64) {
         self.val.fetch_max(value, SeqCst);
     }
 }
 
 /// An extension trait that adds a `.send_safely(...)` method to tokio's `UnboundedSender<T>`.
-pub trait SendSafely<T> {
+pub(crate) trait SendSafely<T> {
     /// Attempts to send a message to the channel, and if the channel is closed, returns the error
     /// in `error_reader` if it is set, otherwise panics.
     ///
@@ -269,7 +269,7 @@ impl<T> SendSafely<T> for UnboundedSender<T> {
 }
 
 /// Trait for generating UUIDs and ULIDs from a random number generator.
-pub trait IdGenerator {
+pub(crate) trait IdGenerator {
     fn gen_uuid(&mut self) -> Uuid;
     fn gen_ulid(&mut self, clock: &dyn SystemClock) -> Ulid;
 }
@@ -308,7 +308,7 @@ impl<R: RngCore> IdGenerator for R {
 /// Returns:
 /// - `Ok(T)`: If the future completes within the specified duration.
 /// - `Err(SlateDBError::Timeout)`: If the future does not complete within the specified duration.
-pub async fn timeout<T, Err>(
+pub(crate) async fn timeout<T, Err>(
     clock: Arc<dyn SystemClock>,
     duration: Duration,
     error_fn: impl FnOnce() -> Err,
@@ -520,8 +520,7 @@ where
 /// - &'static str
 ///
 /// Other panic types are handled by printing a generic message with the type name.
-#[allow(dead_code)]
-pub fn panic_string(panic: &Box<dyn Any + Send>) -> String {
+pub(crate) fn panic_string(panic: &Box<dyn Any + Send>) -> String {
     if let Some(result) = panic.downcast_ref::<Result<(), SlateDBError>>() {
         match result {
             Ok(()) => "ok".to_string(),
@@ -621,7 +620,7 @@ pub(crate) fn split_join_result(
 /// assert_eq!(format_bytes_si(1500), "1.50 KB");
 /// assert_eq!(format_bytes_si(1_000_000), "1.00 MB");
 /// ```
-pub fn format_bytes_si(bytes: u64) -> String {
+pub(crate) fn format_bytes_si(bytes: u64) -> String {
     const UNITS: &[&str] = &["B", "KB", "MB", "GB", "TB", "PB", "EB"];
     const FACTOR: f64 = 1000.0;
 


### PR DESCRIPTION
## Summary

See #1170 for details.

## Changes

- Hid all remaining non-compactor items

## Notes for Reviewers

- I am waiting on #1166 to do the compactor updates and enable `unreachable_pub="warn"` in `Cargo.toml`

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
