### PR TITLE
feat(py): allow sharing ObjectStore across multiple DB instances

### DIFF
--- a/slatedb-py/python/slatedb/slatedb.pyi
+++ b/slatedb-py/python/slatedb/slatedb.pyi
@@ -1551,6 +1551,7 @@ class SlateDBReader:
         url: str | None = None,
         env_file: str | None = None,
         checkpoint_id: str | None = None,
+        object_store: ObjectStore | None = None,
         *,
         merge_operator: Callable[[bytes, bytes | None, bytes], bytes] | None = None,
         manifest_poll_interval: int | None = None,
@@ -1565,6 +1566,8 @@ class SlateDBReader:
             url: Optional object store URL.
             env_file: Optional env file for object store config.
             checkpoint_id: Optional checkpoint UUID string to read at.
+            object_store: Optional shared ObjectStore instance. When provided,
+                reuses the S3 client for faster opens. Takes precedence over url/env_file.
             merge_operator: Optional merge operator for reads.
             manifest_poll_interval: Optional poll interval in milliseconds to refresh manifests and replay new WALs when no explicit checkpoint is supplied. Must be <= checkpoint_lifetime/2.
             checkpoint_lifetime: Optional checkpoint lifetime in milliseconds for implicit reader checkpoints. Must be >= 1000 and > 2x manifest_poll_interval.
@@ -1572,6 +1575,9 @@ class SlateDBReader:
 
         Examples:
             >>> reader = SlateDBReader("/tmp/mydb", env_file=".env")
+            >>> # Or with shared ObjectStore:
+            >>> store = ObjectStore.from_env(".env")
+            >>> reader = SlateDBReader("/tmp/mydb", object_store=store)
         """
         ...
 
@@ -1582,6 +1588,7 @@ class SlateDBReader:
         url: str | None = None,
         env_file: str | None = None,
         checkpoint_id: str | None = None,
+        object_store: ObjectStore | None = None,
         *,
         merge_operator: Callable[[bytes, bytes | None, bytes], bytes] | None = None,
         manifest_poll_interval: int | None = None,
@@ -1596,6 +1603,8 @@ class SlateDBReader:
             url: Optional object store URL.
             env_file: Optional env file for object store config.
             checkpoint_id: Optional checkpoint UUID to read at.
+            object_store: Optional shared ObjectStore instance. When provided,
+                reuses the S3 client for faster opens. Takes precedence over url/env_file.
             merge_operator: Optional merge operator for reads.
             manifest_poll_interval: Optional manifest poll interval (ms).
             checkpoint_lifetime: Optional checkpoint lifetime (ms).
@@ -1606,6 +1615,9 @@ class SlateDBReader:
 
         Examples:
             >>> reader = await SlateDBReader.open_async("/tmp/mydb", env_file=".env")
+            >>> # Or with shared ObjectStore:
+            >>> store = ObjectStore.from_env(".env")
+            >>> reader = await SlateDBReader.open_async("/tmp/mydb", object_store=store)
             >>> await reader.get_async(b"missing")
             None
         """


### PR DESCRIPTION
## Summary

- Add `PyObjectStore` class wrapping `Arc<dyn ObjectStore>` for sharing across DB instances
- Add `ObjectStore.from_env()` and `ObjectStore.from_url()` static methods
- Add optional `object_store` parameter to `SlateDB.open_async()` and `SlateDB()` constructor

## Motivation

When opening multiple SlateDB instances, each `open_async()` creates a new S3 client. This is expensive because S3 client creation involves authentication, connection pool setup, etc.

This PR allows users to create an ObjectStore once and share it:

```python
from slatedb import ObjectStore, SlateDB

# Create shared ObjectStore once
object_store = ObjectStore.from_url("s3://my-bucket")

# Open multiple DBs with shared ObjectStore (fast)
db1 = await SlateDB.open_async("db1", object_store=object_store)
db2 = await SlateDB.open_async("db2", object_store=object_store)
```

## Benchmark Results

Testing with 10 sequential DB opens against S3 Express:

| Metric | Without Sharing | With Sharing |
|--------|----------------|--------------|
| Avg open time | 4544ms | 2969ms |
| Total (10 DBs) | 45.4s | 30.1s |
| **Speedup** | - | **1.51x** |

## Test plan

- [x] Local filesystem benchmark (shows no difference as expected - no S3 overhead)
- [x] S3 Express benchmark (shows 1.51x speedup)
- [ ] Run existing tests to ensure backward compatibility

Fixes #1186

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)