### PR TITLE
fix stuck compactions after restart by persisting recovery state

### DIFF
--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -134,7 +134,7 @@ impl CompactorStateWriter {
     ) -> Result<Self, SlateDBError> {
         let stored_manifest =
             StoredManifest::load(manifest_store.clone(), system_clock.clone()).await?;
-        let (manifest, compactions) = Self::fence(
+        let (manifest, mut compactions) = Self::fence(
             stored_manifest,
             compactions_store,
             system_clock.clone(),
@@ -152,6 +152,8 @@ impl CompactorStateWriter {
             }
         });
         dirty_compactions.value.retain_active_and_last_finished();
+        // Persist recovery state before any refresh() can overwrite it.
+        compactions.update(dirty_compactions.clone()).await?;
         let state = CompactorState::new(dirty_manifest, dirty_compactions);
         Ok(Self {
             state,


### PR DESCRIPTION
## Summary

Fix stuck compactions after restart. Running compactions were marked `Failed` in memory but never persisted. The subsequent `refresh()` call merged remote state, bringing back the Running status. These ghost compactions blocked the scheduler forever since they appeared "in-flight" but had no executor jobs.

Fixes #1192

## Changes

- Persist recovery state immediately after marking `Running` compactions as `Failed`, before any `refresh()` can overwrite it

## Notes for Reviewers

Bug introduced in #1166 (9965bdc). Before that commit, `handle_ticker()` only called `load_manifest()`. After, it calls `refresh()` which also loads compactions and merges remote state. The merge logic preserves local state, but `retain_active_and_last_finished()` removes the newly `Failed` compactions first, so the merge brings back Running status from remote.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
