### PR TITLE
Add `memory` store type to `load_object_store_from_env ` 

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -751,6 +751,8 @@ mod tests {
                 r.unwrap_err().to_string(),
                 "invalid environment variable CLOUD_PROVIDER value `invalid`"
             );
+            // unset since the environment variable loaded in from invalid.env
+            // takes precedence over the memory.env file.
             std::env::remove_var("CLOUD_PROVIDER");
 
             jail.create_file("memory.env", "CLOUD_PROVIDER=memory")


### PR DESCRIPTION
## Summary

I found a few use cases where it would have been handy to specify in-memory rather than having to hard code it. Codex'd a PR to support this.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972bf70e00c8329ab7577545f87323a)