### PR TITLE
[slatedb_go] fix type of `ObjectStoreCacheOptions.PreloadDiskCacheOnStartup` field

### DIFF
--- a/slatedb-go/go/config.go
+++ b/slatedb-go/go/config.go
@@ -78,6 +78,15 @@ const (
 	DurabilityRemote DurabilityLevel = 1 // Only data persisted to object storage
 )
 
+// PreloadLevel represents different levels of cache preloading on startup
+type PreloadLevel string
+
+const (
+	NoPreload PreloadLevel = ""       // Default, no preloading during database startup
+	L0Sst     PreloadLevel = "L0Sst"  // Preload only L0 SSTs (most recently written files)
+	AllSst    PreloadLevel = "AllSst" // Preload all SSTs (both L0 and compacted levels)
+)
+
 // WriteOptions controls write operation behavior
 type WriteOptions struct {
 	AwaitDurable bool // Default: true
@@ -143,12 +152,12 @@ type CompactorOptions struct {
 
 // ObjectStoreCacheOptions represents object store caching configuration
 type ObjectStoreCacheOptions struct {
-	RootFolder                string `json:"root_folder,omitempty"`
-	ScanInterval              string `json:"scan_interval,omitempty"`
-	MaxCacheSizeBytes         uint64 `json:"max_cache_size_bytes,omitempty"`
-	PartSizeBytes             uint64 `json:"part_size_bytes,omitempty"`
-	CachePuts                 *bool  `json:"cache_puts,omitempty"`
-	PreloadDiskCacheOnStartup *bool  `json:"preload_disk_cache_on_startup,omitempty"`
+	RootFolder                string       `json:"root_folder,omitempty"`
+	ScanInterval              string       `json:"scan_interval,omitempty"`
+	MaxCacheSizeBytes         uint64       `json:"max_cache_size_bytes,omitempty"`
+	PartSizeBytes             uint64       `json:"part_size_bytes,omitempty"`
+	CachePuts                 *bool        `json:"cache_puts,omitempty"`
+	PreloadDiskCacheOnStartup PreloadLevel `json:"preload_disk_cache_on_startup,omitempty"`
 }
 
 // GarbageCollectorOptions represents garbage collection configuration
@@ -158,9 +167,9 @@ type ObjectStoreCacheOptions struct {
 // - Empty GarbageCollectorOptions{}: Garbage collection enabled with Rust defaults
 // - Specific directory options: Garbage collection enabled for all directories, options applied to specific directories
 type GarbageCollectorOptions struct {
-	Manifest  *GarbageCollectorDirectoryOptions `json:"manifest_options,omitempty"`
-	Wal       *GarbageCollectorDirectoryOptions `json:"wal_options,omitempty"`
-	Compacted *GarbageCollectorDirectoryOptions `json:"compacted_options,omitempty"`
+	Manifest    *GarbageCollectorDirectoryOptions `json:"manifest_options,omitempty"`
+	Wal         *GarbageCollectorDirectoryOptions `json:"wal_options,omitempty"`
+	Compacted   *GarbageCollectorDirectoryOptions `json:"compacted_options,omitempty"`
 	Compactions *GarbageCollectorDirectoryOptions `json:"compactions_options,omitempty"`
 }
 
@@ -365,7 +374,7 @@ func MergeSettings(base, override *Settings) *Settings {
 			if override.ObjectStoreCacheOptions.CachePuts != nil {
 				merged.CachePuts = override.ObjectStoreCacheOptions.CachePuts
 			}
-			if override.ObjectStoreCacheOptions.PreloadDiskCacheOnStartup != nil {
+			if override.ObjectStoreCacheOptions.PreloadDiskCacheOnStartup != NoPreload {
 				merged.PreloadDiskCacheOnStartup = override.ObjectStoreCacheOptions.PreloadDiskCacheOnStartup
 			}
 			result.ObjectStoreCacheOptions = &merged

--- a/slatedb-go/go/config_test.go
+++ b/slatedb-go/go/config_test.go
@@ -35,8 +35,9 @@ var _ = Describe("Configuration", func() {
 					MaxConcurrentCompactions: 2,
 				},
 				ObjectStoreCacheOptions: &slatedb.ObjectStoreCacheOptions{
-					MaxCacheSizeBytes: 134217728,
-					RootFolder:        "/tmp/base",
+					MaxCacheSizeBytes:         134217728,
+					RootFolder:                "/tmp/base",
+					PreloadDiskCacheOnStartup: slatedb.AllSst,
 				},
 			}
 		})

--- a/slatedb-go/go/db_test.go
+++ b/slatedb-go/go/db_test.go
@@ -358,6 +358,7 @@ var _ = Describe("DB Builder", func() {
 			customSettings := defaults
 			customSettings.FlushInterval = "200ms" // Override flush interval
 			customSettings.MinFilterKeys = 1500    // Override min filter keys
+			customSettings.ObjectStoreCacheOptions.PreloadDiskCacheOnStartup = slatedb.AllSst
 
 			db, err := builder.
 				WithEnvFile(envFile).


### PR DESCRIPTION
## Summary

This field must be a string to match the corresponding field in the Rust struct. Currently, database creation fails if one sets a value for the `PreloadDiskCacheOnStartup` field.

## Changes

I've changed the type of `PreloadDiskCacheOnStartup` to be a string. Few tests were updated to use all sst preloading.

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
