### PR TITLE
Verify compaction inputs exist

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -661,6 +661,7 @@ impl CompactorEventHandler {
     /// checked in this function:
     ///
     /// - Compaction has sources
+    /// - Compaction sources exist in DB state
     /// - Compactions with only L0 sources must have a destination > highest existing SR ID
     fn validate_compaction(&self, compaction: &CompactionSpec) -> Result<(), SlateDBError> {
         // Validate compaction sources exist


### PR DESCRIPTION
## Summary

While working on #1221, I noticed that we are not validating that input SSTs/SRs exist when starting a compaction. Since we update `.compaction` files after `.manifest` files, it's possible the manifest gets updated, then the compactor fails before the compaction file is updated. In such a case, the manifest file will have the compaction's inputs removed and its outputs added, but the .compaction file will still have the compaction status as `Running`, which will trigger a resume. The timeline looks like this:

```
t0, compaction `Submitted`
t1, compaction `Running`
t2, compaction finished
t3, manifest updated with compaction results
t4, compactor fails (before .compaction file is updated)
t5, compactor starts and marks submitted `Submitted` (it is still `Running` from t1)
```

This patch causes the compaction to fail validation since its inputs will be missing.

## Changes

- Add input L0/SR checks in `validate_compaction`

## Notes for Reviewers

- Probably worth reading over this section in the RFC: https://github.com/slatedb/slatedb/pull/1221/files#diff-c4e284e4516af930bf2567500bba968d097998cd182d813f5a540372bba6ecc8R402-R404

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
