### PR TITLE
Fix first_key -> first_entry rename

### DIFF
--- a/slatedb-go/go/slatedb.h
+++ b/slatedb-go/go/slatedb.h
@@ -139,7 +139,7 @@ typedef struct CSdbScanResult {
 
 #define BytesRange_VT_END_BOUND 6
 
-#define SsTableInfo_VT_FIRST_KEY 4
+#define SsTableInfo_VT_FIRST_ENTRY 4
 
 #define SsTableInfo_VT_INDEX_OFFSET 6
 
@@ -152,6 +152,8 @@ typedef struct CSdbScanResult {
 #define SsTableInfo_VT_COMPRESSION_FORMAT 14
 
 #define BlockMeta_VT_OFFSET 4
+
+#define BlockMeta_VT_FIRST_KEY 6
 
 #define SsTableIndex_VT_BLOCK_META 4
 

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -2911,7 +2911,7 @@ mod tests {
         fixture.handler.maybe_start_compactions().await.unwrap();
 
         let sst_info = SsTableInfo {
-            first_key: Some(Bytes::from_static(b"a")),
+            first_entry: Some(Bytes::from_static(b"a")),
             ..SsTableInfo::default()
         };
         let output_sst = SsTableHandle::new(SsTableId::Compacted(Ulid::new()), sst_info);

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -590,7 +590,7 @@ mod tests {
             SsTableHandle::new_compacted(
                 SsTableId::Compacted(Ulid::from_parts(10, 0)),
                 SsTableInfo {
-                    first_key: Some(Bytes::copy_from_slice(b"a")),
+                    first_entry: Some(Bytes::copy_from_slice(b"a")),
                     ..Default::default()
                 },
                 None,
@@ -598,7 +598,7 @@ mod tests {
             SsTableHandle::new_compacted(
                 SsTableId::Compacted(Ulid::from_parts(11, 0)),
                 SsTableInfo {
-                    first_key: Some(Bytes::copy_from_slice(b"m")),
+                    first_entry: Some(Bytes::copy_from_slice(b"m")),
                     ..Default::default()
                 },
                 None,

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -1045,7 +1045,7 @@ mod tests {
             SsTableHandle::new_compacted(
                 SsTableId::Compacted(ulid::Ulid::new()),
                 SsTableInfo {
-                    first_key: Some(Bytes::copy_from_slice(first_key)),
+                    first_entry: Some(Bytes::copy_from_slice(first_key)),
                     ..Default::default()
                 },
                 visible_range,

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -737,7 +737,7 @@ mod tests {
 
     fn make_compacted_sst(start_key: &str, size: u64) -> SsTableHandle {
         let info = SsTableInfo {
-            first_key: Some(Bytes::from(start_key.as_bytes().to_vec())),
+            first_entry: Some(Bytes::from(start_key.as_bytes().to_vec())),
             index_offset: size.saturating_sub(1),
             index_len: 1,
             ..Default::default()


### PR DESCRIPTION
## Summary

It appears a couple of `first_entry` renames were missed somewhere around #1193. It's causing main to break.

## Changes

- Rename `first_key` where needed