### PR TITLE
Remove unnecessary clones

### DIFF
--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -256,10 +256,7 @@ fn parse_gc_schedule(s: &str) -> Result<GcSchedule, String> {
         .ok_or_else(|| "Missing or invalid 'min_age'".to_string())
         .and_then(|v| {
             humantime::parse_duration(v).map_err(|e| {
-                "Could not parse min_age as duration: "
-                    .to_string()
-                    .to_owned()
-                    + e.to_string().as_str()
+                "Could not parse min_age as duration: ".to_string() + e.to_string().as_str()
             })
         })?;
     let period = parts

--- a/slatedb-common/src/clock.rs
+++ b/slatedb-common/src/clock.rs
@@ -224,7 +224,7 @@ mod tests {
 
         // Test positive timestamp
         let positive_ts = 1625097600000i64; // 2021-07-01T00:00:00Z in milliseconds
-        clock.clone().set(positive_ts);
+        clock.set(positive_ts);
         assert_eq!(
             clock.now().timestamp_millis(),
             positive_ts,
@@ -233,7 +233,7 @@ mod tests {
 
         // Test negative timestamp (before Unix epoch)
         let negative_ts = -1625097600000; // Before Unix epoch
-        clock.clone().set(negative_ts);
+        clock.set(negative_ts);
         assert_eq!(
             clock.now().timestamp_millis(),
             negative_ts,

--- a/slatedb-py/src/lib.rs
+++ b/slatedb-py/src/lib.rs
@@ -1915,7 +1915,7 @@ impl PySlateDBReader {
         checkpoint_lifetime: Option<u64>,
         max_memtable_bytes: Option<u64>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let object_store = resolve_object_store_py(url.as_deref(), env_file.clone())?;
+        let object_store = resolve_object_store_py(url.as_deref(), env_file)?;
         let merge_operator = parse_merge_operator(merge_operator)?;
         future_into_py(py, async move {
             let mut options = DbReaderOptions {

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -258,11 +258,7 @@ impl WriteBatch {
         let key = Bytes::copy_from_slice(key.as_ref());
         self.ops.insert(
             SequencedKey::new(key.clone(), self.write_idx),
-            WriteOp::Merge(
-                key.clone(),
-                Bytes::copy_from_slice(value.as_ref()),
-                options.clone(),
-            ),
+            WriteOp::Merge(key, Bytes::copy_from_slice(value.as_ref()), options.clone()),
         );
 
         self.write_idx += 1;

--- a/slatedb/src/block.rs
+++ b/slatedb/src/block.rs
@@ -309,7 +309,7 @@ mod tests {
     fn test_block(#[case] test_case: BlockTestCase) {
         let block = build_block(&test_case);
         let encoded = block.encode();
-        let decoded = Block::decode(encoded.clone());
+        let decoded = Block::decode(encoded);
         let block_data = &block.data;
         let block_offsets = &block.offsets;
         // Decode the block data using offsets and validate each decoded entry

--- a/slatedb/src/bytes_range.rs
+++ b/slatedb/src/bytes_range.rs
@@ -231,7 +231,7 @@ pub(crate) mod tests {
             suffix in arbitrary::bytes(8)
         )| {
             let range = BytesRange::from_prefix(&prefix);
-            let mut combined = prefix.clone().to_vec();
+            let mut combined = prefix.to_vec();
             combined.extend_from_slice(&suffix);
             let key = Bytes::from(combined);
             prop_assert!(range.contains(&key));
@@ -255,13 +255,13 @@ pub(crate) mod tests {
             let range = BytesRange::from_prefix(&prefix);
 
             // Any key starting with the prefix should be contained.
-            let mut prefixed = prefix.clone().to_vec();
+            let mut prefixed = prefix.to_vec();
             prefixed.extend_from_slice(&suffix);
             let prefixed = Bytes::from(prefixed);
             prop_assert!(range.contains(&prefixed));
 
             // A key with a different first byte should be rejected.
-            let mut non_prefixed = prefix.clone().to_vec();
+            let mut non_prefixed = prefix.to_vec();
             non_prefixed[0] = non_prefixed[0].wrapping_add(1);
             let non_prefixed = Bytes::from(non_prefixed);
             prop_assert!(!range.contains(&non_prefixed));

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -735,7 +735,7 @@ mod tests {
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
         let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder.clone(),
+            test_cache_folder,
             None,
             None,
             stats.clone(),
@@ -825,7 +825,7 @@ mod tests {
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
         let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder.clone(),
+            test_cache_folder,
             None,
             None,
             stats.clone(),
@@ -848,7 +848,7 @@ mod tests {
         let stats_registry = StatRegistry::new();
         let stats = Arc::new(CachedObjectStoreStats::new(&stats_registry));
         let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder.clone(),
+            test_cache_folder,
             None,
             None,
             stats.clone(),

--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -484,7 +484,7 @@ mod tests {
 
     fn new_memory_compactions_store() -> Arc<CompactionsStore> {
         let os = Arc::new(InMemory::new());
-        Arc::new(CompactionsStore::new(&Path::from(ROOT), os.clone()))
+        Arc::new(CompactionsStore::new(&Path::from(ROOT), os))
     }
 
     fn new_compaction() -> Compaction {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -279,7 +279,7 @@ impl Compactor {
     ) -> Self {
         let stats = Arc::new(CompactionStats::new(stat_registry));
         let task_executor = Arc::new(MessageHandlerExecutor::new(
-            closed_result.clone(),
+            closed_result,
             system_clock.clone(),
         ));
         Self {
@@ -2562,7 +2562,7 @@ mod tests {
         };
         core.l0 = VecDeque::from(vec![
             SsTableHandle::new(SsTableId::Compacted(l0_first), l0_info.clone()),
-            SsTableHandle::new(SsTableId::Compacted(l0_second), l0_info.clone()),
+            SsTableHandle::new(SsTableId::Compacted(l0_second), l0_info),
         ]);
         core.compacted = vec![
             SortedRun {
@@ -2576,7 +2576,7 @@ mod tests {
                 id: 2,
                 ssts: vec![SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(11, 0)),
-                    sr_info.clone(),
+                    sr_info,
                 )],
             },
         ];

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -666,7 +666,7 @@ impl CompactorState {
                 }
             }
             if !inserted {
-                new_compacted.push(output_sr.clone());
+                new_compacted.push(output_sr);
             }
             Self::assert_compacted_srs_in_id_order(&new_compacted);
             let first_source = spec
@@ -885,12 +885,12 @@ mod tests {
         // when:
         let compaction = Compaction::new(compaction_id, spec.clone());
         state
-            .add_compaction(compaction.clone())
+            .add_compaction(compaction)
             .expect("failed to add compaction");
 
         // then:
         let mut compactions = state.active_compactions();
-        let expected = Compaction::new(compaction_id, spec.clone());
+        let expected = Compaction::new(compaction_id, spec);
         assert_eq!(compactions.next().expect("compaction not found"), &expected);
         assert!(compactions.next().is_none());
     }
@@ -905,7 +905,7 @@ mod tests {
         let spec = build_l0_compaction(&before_compaction.l0, 0);
         let compaction = Compaction::new(compaction_id, spec);
         state
-            .add_compaction(compaction.clone())
+            .add_compaction(compaction)
             .expect("failed to add compaction");
 
         // when:
@@ -954,7 +954,7 @@ mod tests {
         let spec = build_l0_compaction(&before_compaction.l0, 0);
         let compaction = Compaction::new(compaction_id, spec);
         state
-            .add_compaction(compaction.clone())
+            .add_compaction(compaction)
             .expect("failed to add compaction");
 
         // when:
@@ -963,7 +963,7 @@ mod tests {
             id: 0,
             ssts: compacted_ssts,
         };
-        state.finish_compaction(compaction_id, sr.clone());
+        state.finish_compaction(compaction_id, sr);
 
         // then:
         assert_eq!(state.active_compactions().count(), 0)
@@ -1015,7 +1015,7 @@ mod tests {
         );
         let compaction = Compaction::new(compaction_id, spec);
         state
-            .add_compaction(compaction.clone())
+            .add_compaction(compaction)
             .expect("failed to add compaction");
         state.finish_compaction(
             compaction_id,
@@ -1085,7 +1085,7 @@ mod tests {
         );
         let compaction = Compaction::new(compaction_id, spec);
         state
-            .add_compaction(compaction.clone())
+            .add_compaction(compaction)
             .expect("failed to add compaction");
         state.finish_compaction(
             compaction_id,
@@ -1166,7 +1166,7 @@ mod tests {
             0,
         );
         let compaction = Compaction::new(compaction_id, spec);
-        let result = state.add_compaction(compaction.clone());
+        let result = state.add_compaction(compaction);
 
         // then:
         assert!(result.is_ok());
@@ -1197,7 +1197,7 @@ mod tests {
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
         let spec = CompactionSpec::new(sources, 0);
         let compaction = Compaction::new(compaction_id, spec);
-        let result = state.add_compaction(compaction.clone());
+        let result = state.add_compaction(compaction);
 
         // or simply:
         assert!(result.is_ok());

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -556,7 +556,7 @@ impl DbInner {
         if let Some(result) = closed_result_reader.read() {
             return match result {
                 Ok(()) => Err(SlateDBError::Closed),
-                Err(e) => Err(e.clone()),
+                Err(e) => Err(e),
             };
         }
         Ok(())

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -772,7 +772,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
         ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(
-                retrying_main_object_store.clone(),
+                retrying_main_object_store,
                 retrying_wal_object_store.clone(),
             ),
             SsTableFormat::default(), // read only SSTs can use default
@@ -899,7 +899,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             ..SsTableFormat::default()
         };
         let table_store = Arc::new(TableStore::new(
-            ObjectStores::new(retrying_main_object_store.clone(), None),
+            ObjectStores::new(retrying_main_object_store, None),
             sst_format,
             path,
             None, // no need for cache in GC

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -137,7 +137,7 @@ impl DbReaderInner {
         let state = RwLock::new(initial_state);
         let reader = Reader {
             table_store: Arc::clone(&table_store),
-            db_stats: db_stats.clone(),
+            db_stats,
             mono_clock: Arc::clone(&mono_clock),
             oracle: oracle.clone(),
             merge_operator: options.merge_operator.clone(),
@@ -455,7 +455,7 @@ impl DbReaderInner {
         if let Some(result) = closed_result_reader.read() {
             return match result {
                 Ok(()) => Err(SlateDBError::Closed),
-                Err(e) => Err(e.clone()),
+                Err(e) => Err(e),
             };
         }
         Ok(())

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -73,7 +73,7 @@ impl SsTableHandle {
     ) -> Self {
         let mut effective_range = match info.first_entry.clone() {
             Some(physical_first_entry) => {
-                BytesRange::new(Included(physical_first_entry.clone()), Unbounded)
+                BytesRange::new(Included(physical_first_entry), Unbounded)
             }
             None => {
                 unreachable!("SST always has a first entry.")
@@ -529,7 +529,7 @@ impl DbState {
         if let Some(result) = self.closed_result.reader().read() {
             return match result {
                 Ok(()) => Err(SlateDBError::Closed),
-                Err(e) => Err(e.clone()),
+                Err(e) => Err(e),
             };
         }
         let old_memtable = std::mem::replace(&mut self.memtable, WritableKVTable::new());
@@ -552,7 +552,7 @@ impl DbState {
         if let Some(result) = self.closed_result.reader().read() {
             return match result {
                 Ok(()) => Err(SlateDBError::Closed),
-                Err(e) => Err(e.clone()),
+                Err(e) => Err(e),
             };
         }
         assert!(self.memtable.is_empty());
@@ -799,7 +799,7 @@ mod tests {
     fn create_compacted_sst_handle(first_entry: Option<Bytes>) -> SsTableHandle {
         let sst_info = create_sst_info(first_entry);
         let sst_id = SsTableId::Compacted(ulid::Ulid::new());
-        SsTableHandle::new(sst_id, sst_info.clone())
+        SsTableHandle::new(sst_id, sst_info)
     }
 
     fn create_sst_info(first_entry: Option<Bytes>) -> SsTableInfo {

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -166,7 +166,7 @@ impl GarbageCollector {
         stat_registry: Arc<StatRegistry>,
         system_clock: Arc<dyn SystemClock>,
     ) -> Self {
-        let stats = Arc::new(GcStats::new(stat_registry.clone()));
+        let stats = Arc::new(GcStats::new(stat_registry));
         let wal_gc_task = WalGcTask::new(
             manifest_store.clone(),
             table_store.clone(),
@@ -176,12 +176,12 @@ impl GarbageCollector {
         let compacted_gc_task = CompactedGcTask::new(
             manifest_store.clone(),
             compactions_store.clone(),
-            table_store.clone(),
+            table_store,
             stats.clone(),
             options.compacted_options,
         );
         let compactions_gc_task = CompactionsGcTask::new(
-            compactions_store.clone(),
+            compactions_store,
             stats.clone(),
             options.compactions_options,
         );
@@ -1175,7 +1175,7 @@ mod tests {
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(local_object_store.clone(), None),
             sst_format,
-            path.clone(),
+            path,
             None,
         ));
 

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1046,7 +1046,7 @@ mod tests {
 
     fn new_memory_manifest_store() -> Arc<ManifestStore> {
         let os = Arc::new(InMemory::new());
-        Arc::new(ManifestStore::new(&Path::from(ROOT), os.clone()))
+        Arc::new(ManifestStore::new(&Path::from(ROOT), os))
     }
 
     fn new_checkpoint(manifest_id: u64) -> Checkpoint {

--- a/slatedb/src/proptest_util.rs
+++ b/slatedb/src/proptest_util.rs
@@ -5,7 +5,7 @@ pub(crate) mod runner {
 
     pub(crate) fn new(source_file: &'static str, rng_seed: Option<[u8; 32]>) -> TestRunner {
         let rng = rng::new_test_rng(rng_seed);
-        let mut config = proptest::test_runner::contextualize_config(Config::default().clone());
+        let mut config = proptest::test_runner::contextualize_config(Config::default());
         config.source_file = Some(source_file);
         TestRunner::new_with_rng(config, rng)
     }
@@ -72,10 +72,7 @@ pub(crate) mod arbitrary {
                         Included(start.clone()),
                         Excluded(end.clone())
                     )),
-                    Just(BytesRange::new(
-                        Excluded(start.clone()),
-                        Included(end.clone())
-                    )),
+                    Just(BytesRange::new(Excluded(start), Included(end))),
                 ]
             })
     }
@@ -86,7 +83,7 @@ pub(crate) mod arbitrary {
                 Just(BytesRange::new(Unbounded, Included(a.clone()))),
                 Just(BytesRange::new(Unbounded, Excluded(a.clone()))),
                 Just(BytesRange::new(Included(a.clone()), Unbounded)),
-                Just(BytesRange::new(Excluded(a.clone()), Unbounded)),
+                Just(BytesRange::new(Excluded(a), Unbounded)),
             ]
         })
     }
@@ -106,10 +103,7 @@ pub(crate) mod arbitrary {
                     Included(a.clone()),
                     Excluded(a_extended.clone())
                 )),
-                Just(BytesRange::new(
-                    Excluded(a.clone()),
-                    Included(a_extended.clone())
-                )),
+                Just(BytesRange::new(Excluded(a), Included(a_extended))),
             ]
         })
     }
@@ -141,7 +135,7 @@ pub(crate) mod arbitrary {
             prop_oneof![
                 Just(BytesRange::new(Excluded(a.clone()), Excluded(a.clone()))),
                 Just(BytesRange::new(Included(a.clone()), Excluded(a.clone()))),
-                Just(BytesRange::new(Excluded(a.clone()), Included(a.clone()))),
+                Just(BytesRange::new(Excluded(a.clone()), Included(a))),
             ]
         })
     }
@@ -172,11 +166,11 @@ pub(crate) mod arbitrary {
                 ),
                 (
                     Just(range1.clone()),
-                    Just(BytesRange::new(Unbounded, Included(end.clone())))
+                    Just(BytesRange::new(Unbounded, Included(end)))
                 ),
                 (
                     Just(range1.clone()),
-                    Just(BytesRange::new(Included(start.clone()), Unbounded))
+                    Just(BytesRange::new(Included(start), Unbounded))
                 ),
                 (
                     Just(range1.clone()),

--- a/slatedb/src/retention_iterator.rs
+++ b/slatedb/src/retention_iterator.rs
@@ -1124,11 +1124,11 @@ mod tests {
         let filtered = RetentionIterator::<TestIterator>::apply_retention_filter(
             versions,
             0,
-            system_clock.clone(),
+            system_clock,
             Some(timeout),
             None,
             false,
-            tracker.clone(),
+            tracker,
         );
 
         let derived_ts = sorted_points

--- a/slatedb/src/row_codec.rs
+++ b/slatedb/src/row_codec.rs
@@ -446,7 +446,7 @@ mod tests {
                 test_case.key_prefix_len,
                 Bytes::from(test_case.key_suffix),
                 test_case.seq,
-                value.clone(),
+                value,
                 test_case.create_ts,
                 test_case.expire_ts,
             ),

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -601,7 +601,7 @@ mod tests {
         let compactor_job = Compaction::new(job_id, request);
 
         state
-            .add_compaction(compactor_job.clone())
+            .add_compaction(compactor_job)
             .expect("failed to add job");
 
         // when:
@@ -686,7 +686,7 @@ mod tests {
         let request = create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]);
         let compactor_job = Compaction::new(compaction_id, request);
         state
-            .add_compaction(compactor_job.clone())
+            .add_compaction(compactor_job)
             .expect("failed to add job");
 
         // when:
@@ -723,7 +723,7 @@ mod tests {
             create_sr_compaction(vec![7, 6, 5, 4, 3, 2, 1, 0]),
         );
         state
-            .add_compaction(compactor_job.clone())
+            .add_compaction(compactor_job)
             .expect("failed to add job");
 
         // when:
@@ -775,7 +775,7 @@ mod tests {
         let l0 = VecDeque::from(vec![create_sst(1), create_sst(1), create_sst(1)]);
         let state = &create_compactor_state(create_db_state(l0.clone(), Vec::new()));
 
-        let mut l0_sst = l0.clone();
+        let mut l0_sst = l0;
         let last_sst = l0_sst.pop_back();
         l0_sst.push_front(last_sst.unwrap());
         // when:
@@ -793,7 +793,7 @@ mod tests {
         let l0 = VecDeque::from(vec![create_sst(1), create_sst(1), create_sst(1)]);
         let state = &create_compactor_state(create_db_state(l0.clone(), Vec::new()));
 
-        let mut l0_sst = l0.clone();
+        let mut l0_sst = l0;
         let last_sst = l0_sst.pop_back().unwrap();
         l0_sst.push_front(last_sst);
         l0_sst.pop_back();

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -38,11 +38,7 @@ impl<'a> SortedRunView<'a> {
         sst_iterator_options: SstIteratorOptions,
     ) -> Result<Option<SstIterator<'a>>, SlateDBError> {
         let next_iter = if let Some(view) = self.pop_sst() {
-            Some(SstIterator::new(
-                view,
-                table_store.clone(),
-                sst_iterator_options,
-            )?)
+            Some(SstIterator::new(view, table_store, sst_iterator_options)?)
         } else {
             None
         };

--- a/slatedb/src/sst.rs
+++ b/slatedb/src/sst.rs
@@ -508,7 +508,7 @@ impl SsTableInfo {
         if raw_info.len() <= 4 {
             return Err(SlateDBError::EmptyBlockMeta);
         }
-        let data = raw_info.slice(..raw_info.len() - 4).clone();
+        let data = raw_info.slice(..raw_info.len() - 4);
         let checksum = raw_info.slice(raw_info.len() - 4..).get_u32();
         if checksum != crc32fast::hash(&data) {
             return Err(SlateDBError::ChecksumMismatch);

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1494,7 +1494,7 @@ mod tests {
         ) {
             let os = Arc::new(InMemory::new());
             let format = SsTableFormat { block_size, ..SsTableFormat::default() };
-            let ts = Arc::new(TableStore::new(ObjectStores::new(os.clone(), None),
+            let ts = Arc::new(TableStore::new(ObjectStores::new(os, None),
                 format, Path::from(ROOT), None));
             if let Some(bytes) = block_size.checked_mul(num_blocks) {
                 assert_eq!(num_blocks, ts.bytes_to_blocks(bytes));

--- a/slatedb/src/transaction_manager.rs
+++ b/slatedb/src/transaction_manager.rs
@@ -1270,7 +1270,7 @@ mod tests {
                     TxnOperation::TrackReadRange {
                         txn_id,
                         start_key: start_key.clone().min(end_key.clone()),
-                        end_key: start_key.max(end_key).to_string(),
+                        end_key: start_key.max(end_key),
                     }
                 }),
             // recycle

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -614,7 +614,7 @@ pub(crate) fn split_unwind_result(
     Option<Box<dyn std::any::Any + Send>>,
 ) {
     match unwind_result {
-        Ok(result) => (result.clone(), None),
+        Ok(result) => (result, None),
         Err(payload) => (Err(SlateDBError::BackgroundTaskPanic(name)), Some(payload)),
     }
 }
@@ -643,7 +643,7 @@ pub(crate) fn split_join_result(
     Option<Box<dyn std::any::Any + Send>>,
 ) {
     match join_result {
-        Ok(task_result) => (task_result.clone(), None),
+        Ok(task_result) => (task_result, None),
         Err(join_error) => {
             if join_error.is_cancelled() {
                 (Err(SlateDBError::BackgroundTaskCancelled(name)), None)

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -561,7 +561,7 @@ mod tests {
         Arc::new(TableStore::new(
             ObjectStores::new(object_store.clone(), None),
             SsTableFormat::default(),
-            path.clone(),
+            path,
             None,
         ))
     }


### PR DESCRIPTION
## Summary

Hey, awesome project!

I'm running a custom version of slate and was debugging some memory consumption issues (100% on my end), but while testing I ran the command below and realized that mostly of the fixes were on slate's side, so decided to upstream :) 

Uses clippy's automatic fix feature to remove unnecessary clones and copies with:

```bash
cargo clippy --fix --allow-dirty --all-features -- \
 -W clippy::clone_on_copy \ 
 -W clippy::needless_clone \ 
 -W clippy::map_clone \ 
 -W clippy::redundant_clone
```

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

