### PR TITLE
Add `all` feature to give all features to py/go bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3415,7 +3415,6 @@ dependencies = [
  "cbindgen",
  "env_logger",
  "log",
- "object_store",
  "once_cell",
  "rand 0.9.2",
  "serde",

--- a/slatedb-go/Cargo.toml
+++ b/slatedb-go/Cargo.toml
@@ -15,8 +15,7 @@ doc = false
 bench = false
 
 [dependencies]
-slatedb = { workspace = true }
-object_store = { workspace = true, features = ["aws"] }
+slatedb = { workspace = true, features = ["all"] }
 tokio = { workspace = true, features = ["fs", "macros", "sync", "rt", "rt-multi-thread", "signal"] }
 once_cell = { workspace = true }
 log = { workspace = true }

--- a/slatedb-py/Cargo.toml
+++ b/slatedb-py/Cargo.toml
@@ -21,7 +21,7 @@ bench = false
 # enabled on non-macOS and non-iOS targets.
 pyo3 = { workspace = true }
 pyo3-async-runtimes = { workspace = true, features = ["tokio-runtime"] }
-slatedb = { workspace = true }
+slatedb = { workspace = true, features = ["all"] }
 once_cell = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "sync", "rt", "rt-multi-thread", "signal"] }
 uuid = { workspace = true, features = ["v4", "serde"] }

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -107,6 +107,20 @@ wal_disable = []
 moka = ["dep:moka"]
 foyer = ["dep:foyer", "dep:anyhow"]
 test-util = ["tokio/test-util", "slatedb-common/test-util", "slatedb-txn-obj/test-util"]
+all = [
+    "aws",
+    "azure",
+    "compression",
+    "opendal",
+    "snappy",
+    "zlib",
+    "lz4",
+    "zstd",
+    "wal_disable",
+    "moka",
+    "foyer",
+    "test-util",
+]
 
 [lib]
 # Disable `libtest` harness because it fights with Criterion's `--output-format bencher`


### PR DESCRIPTION
## Summary

We weren't giving the Python/Go bindings the Azure/GCP object_store features. Now we are. I also added the various compression options and wal_disabled as well. To do this, I just created an `all` feature and enabled it for both bindings.

Fixes #1217