### PR TITLE
fix test_basic_restore

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -4090,7 +4090,8 @@ mod tests {
         let path = "/tmp/test_kv_store";
         let mut next_wal_id = 1;
         let kv_store = Db::builder(path, object_store.clone())
-            .with_settings(test_db_options(0, 512, None))
+            // with l0_sst_size_bytes = 600 all large puts should be flushed in one L0 SST
+            .with_settings(test_db_options(0, 600, None))
             .with_system_clock(Arc::new(MockSystemClock::new()))
             .build()
             .await
@@ -4149,7 +4150,7 @@ mod tests {
 
         // recover and validate that sst files are loaded on recovery.
         let kv_store_restored = Db::builder(path, object_store.clone())
-            .with_settings(test_db_options(0, 512, None))
+            .with_settings(test_db_options(0, 128, None))
             .with_system_clock(Arc::new(MockSystemClock::new()))
             .build()
             .await


### PR DESCRIPTION
## Summary

Fixes unit test `test_basic_restore()`. The test was stuck because it used a MockSystemClock which did not advance. While the test put key-value pairs and waited for durability, the flush interval was never exceeded since the clock did not advance.

Related to https://github.com/slatedb/slatedb/issues/1235

## Changes
- Disabled `await_durable`
- Trigger flushes manually
- Set a L0 SST size so that all large puts go into one L0 SST and some of the small puts are not flushed to L0  

## Notes for Reviewers
Nothing

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
