### PR TITLE
Add commonhaus to websdite footer

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -8,7 +8,11 @@ import SocialIcons from './SocialIcons.astro';
             <SocialIcons />
         </div>
         <div class="copyright-wrapper sl-flex">
-            Copyright © 2025 SlateDB Authors. All rights reserved.
+            <p>
+                <img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_default.svg" height="20"/><br />
+                Copyright © <a href="https://slatedb.io">SlateDB</a>. All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>.<br/>
+                Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.
+            </p>
         </div>
     </div>
 </div>
@@ -18,7 +22,7 @@ import SocialIcons from './SocialIcons.astro';
     .footer {
 		z-index: var(--sl-z-index-navbar);
 		width: 100%;
-		height: var(--sl-nav-height);
+		height: calc(1.5 * var(--sl-nav-height));
 		border-top: 1px solid var(--sl-color-hairline-shade);
 		padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
 		padding-inline-end: var(--sl-nav-pad-x);
@@ -43,10 +47,13 @@ import SocialIcons from './SocialIcons.astro';
 	}
 
     .copyright-wrapper {
-        font-size: clamp(var(--sl-text-xs),calc(0.5rem + 1vw),var(--sl-text-xs));
+        font-size: .75rem;
 		font-family: monospace;
 		order: 2;
 		text-align: center;
+		line-height: 140%;
+		color: #999;
+		a { color: #999; }
 	}
 
 	@media (min-width: 50rem) {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -110,7 +110,11 @@ import timesIcon from '@hackernoon/pixel-icon-library/icons/SVG/regular/times.sv
 						<SocialIcons />
 					</div>
 					<div class="copyright-wrapper">
-						Copyright © 2025 SlateDB Authors. All rights reserved.
+            <p>
+                <img src="https://raw.githubusercontent.com/commonhaus/artwork/main/foundation/brand/svg/CF_logo_horizontal_single_default.svg" height="20"/><br />
+                Copyright © <a href="https://slatedb.io">SlateDB</a>. All rights reserved. For details on our trademarks, please visit our <a href="https://www.commonhaus.org/policies/trademark-policy/">Trademark Policy</a> and <a href="https://www.commonhaus.org/trademarks/">Trademark List</a>.<br/>
+                Trademarks of third parties are owned by their respective holders and their mention here does not suggest any endorsement or association.
+            </p>
 					</div>
 				</div>
 			</footer>
@@ -562,7 +566,7 @@ import timesIcon from '@hackernoon/pixel-icon-library/icons/SVG/regular/times.sv
 		flex-direction: column;
 		gap: 1rem;
 		align-items: center;
-		height: 100%;
+		height: calc(1.5 * var(--sl-nav-height));
 		width: 100%;
 		max-width: 100%;
 		box-sizing: border-box;
@@ -577,10 +581,13 @@ import timesIcon from '@hackernoon/pixel-icon-library/icons/SVG/regular/times.sv
 	}
 
 	.copyright-wrapper {
-		font-size: 0.875rem;
+		font-size: .75rem;
 		font-family: monospace;
 		order: 2;
 		text-align: center;
+		line-height: 140%;
+		color: #999;
+		a { color: #999; }
 	}
 
 	@media (min-width: 50rem) {


### PR DESCRIPTION
## Summary

We need to add commonhaus boilerplate to website footers to comply with trademark policy:

https://github.com/commonhaus/foundation/blob/main/templates/website-footer.md

## Changes

- Update Footer.astro and index.astro to include Commonhaus trademark boilerplate
<img width="1576" height="1056" alt="Screenshot 2026-01-30 at 11 25 48 AM" src="https://github.com/user-attachments/assets/8c3e7e87-a0cb-45eb-b764-d387fd07bf50" />
<img width="1576" height="1056" alt="Screenshot 2026-01-30 at 11 25 44 AM" src="https://github.com/user-attachments/assets/c1ec341d-d74a-4b5b-8964-bcebbfcf5c0b" />

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
