### PR TITLE
Expose multi_clone() API

### DIFF
--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -227,6 +227,9 @@ pub(crate) enum SlateDBError {
 
     #[error("invalid environment variable {key} value `{value}`")]
     InvalidEnvironmentVariable { key: String, value: String },
+
+    #[error("invalid argument: {msg}")]
+    InvalidArgument { msg: String },
 }
 
 impl From<TransactionalObjectError> for SlateDBError {
@@ -501,6 +504,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::InvalidSequenceOrder { .. } => Error::data(msg),
             SlateDBError::UndefinedEnvironmentVariable { .. } => Error::invalid(msg),
             SlateDBError::InvalidEnvironmentVariable { .. } => Error::invalid(msg),
+            SlateDBError::InvalidArgument { .. } => Error::invalid(msg),
 
             // Data errors
             SlateDBError::InvalidFlatbuffer(err) => Error::data(msg).with_source(Box::new(err)),


### PR DESCRIPTION
## Summary

This PR continues the [work](https://github.com/slatedb/slatedb/pull/618) by @dmvk to cloning from multiple source databases - and exposes it to the clients.

## Changes

- add `SourceDatabase` to `admin.rs`
- add `create_multi_clone()` to `admin.rs`
- implement `create_multi_clone()` in `clone.rs`

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
