### PR TITLE
Add `DbTransaction::unmark_write` to skip conflict checks on write

### DIFF
--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -1549,7 +1549,7 @@ mod tests {
                         .begin(IsolationLevel::SerializableSnapshot)
                         .await
                         .unwrap();
-                    txn.merge(b"counter", &MERGE_INCREMENT).unwrap();
+                    txn.merge(b"counter", MERGE_INCREMENT).unwrap();
                     txn.unmark_write([b"counter"]).unwrap();
                     txn.commit().await.unwrap();
                 }));


### PR DESCRIPTION
## Summary

Adds `DbTransaction::unmark_write`. This method allows users to include a write in a transaction, but to exclude it from conflict checks for both reads and writes in other transactions. See the Rustdocs in the PR for details on the semantics.

This PR was written with Codex, but I reviewed and tweaked it as needed.

Fixes #1254

## Changes

- Add `unmark_write` to mirror `mark_read`
- Add tests

## Notes for Reviewers

Marking uses a lock. I figure that's OK.

Several different API approaches to this were discussed:

1. Add `put_untracked`/`write_untracked`/`merge_untracked` APIs [similar to RocksDB](https://github.com/facebook/rocksdb/blob/c2fab4629b2e531f65d05613bf5390f62f48eff7/include/rocksdb/utilities/transaction.h#L564-L599). I rejected this approach because I felt it introduced far too many new APIs (against CLEAN_SLATE.md)
2. Add a `CommitOptions` with a `untracked_write_keys` field. Users would then call `txn.commit_with_options(options)` to set untracked keys. This was rejected because it separates the write being untracked from where it is actually marked untracked. @airhorns (rightly) felt it was too dangerous/confusing.
3. Add a `unmark_write` API (this PR). I opted for this because it felt the cleanest (least API expansion) and matched the `mark_read` API.
4. Add `untracked` to `PutOptions`/`WriteOptions`/`MergeOptions`. I rejected this because `untracked` would be meaningless outside of transactions; it would pollute the normal `Db` APIs.
5. Add a `TransactionWriteOptions` to replace `WriteOptions` for transactions. This is a pretty clean alternative to this PR. I decided against it because I felt it would be confusing to call a put with "untracked" set, then a subsequent with "untracked" unset, and still have that second put be untracked. The API in this PR separates the puts from the untracking so this cardinality mismatch doesn't occur.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
