### PR TITLE
Serialize Tigris-based benchmarks

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -136,6 +136,12 @@ jobs:
 
   transaction-benchmarks:
     runs-on: warp-ubuntu-latest-x64-16x
+    # Must run after `benchmarks` because both jobs clear the same bucket prefix;
+    # running concurrently can delete each other's manifest/object files mid-run.
+    # This also reduces noise between the two tests since the bucket's resources
+    # (network, disk, etc) should be used by only one test at a time, giving more
+    # stable results.
+    needs: benchmarks
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

We've been experiencing occasional timeouts with `transaction-benchmark` in `nightly.yaml`. The timeout appears to be caused by a race condition. Both `benchmark` and `transaction-benchmark` recursively remove all data in the Tigris bucket we're using. If they run simultaneously, they can corrupt each other's state. The result is that the `transaction-benchmark` can go into an infinite loop spewing "begin transaction failed":

https://github.com/slatedb/slatedb/actions/runs/21795107408/job/62881243796

This PR forces `transaction-benchmark` to always run after `benchmark`. An alternative approach would be to prefix the `aws s3 rm` call with the appropriate subdirectory to isolate the tests. Doing so would still allow the tests to run in parallel. Since the tests run against the same bucket, though, I was concerned they might saturate the network to the bucket and give misleading results. Serializing the tests gives all bucket resources to one benchmark at a time.

## Changes

- Make `transaction-benchmark` depend on `benchmark`.

## Notes for Reviewers

Nope!

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
