### PR TITLE
fix(cache): skip write cache if backpressure

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -127,6 +127,7 @@ impl FsCacheEntry {
             .await
             .map_err(wrap_io_err)?;
         file.write_all(&buf).await.map_err(wrap_io_err)?;
+        file.sync_all().await.map_err(wrap_io_err)?;
         fs::rename(tmp_path, path).await.map_err(wrap_io_err)
     }
 


### PR DESCRIPTION
## Summary

currently `track_entry_accessed` sends a message to a background evictor task for tracking whether to evict or not.

when files reaches the threshold of eviction, this background evictor task may busy cleaning up files, without polling this channel. as a result, the calls to `track_entry_accessed` risks to be blocked.

## Changes

this pr adds for a backpressure handling: when `track_entry_accessed`'s channel full, it skip the write operation on put cache.

i'm not 100% confident about this is indeed the root cause of #1266, but it's highly likely to be, for it looks like hangs on channels.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
