### PR TITLE
[slatedb-java] change type of key and value to `ByteBuffer`

### DIFF
--- a/slatedb-java/src/main/java/io/slatedb/SlateDb.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDb.java
@@ -3,6 +3,7 @@ package io.slatedb;
 import io.slatedb.SlateDbConfig.*;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /// Java bindings for SlateDB backed by the `slatedb-c` FFI library.
@@ -35,7 +36,8 @@ import java.util.Objects;
 /// import io.slatedb.SlateDb;
 /// import io.slatedb.SlateDbWriteBatch;
 ///
-/// import java.nio.charset.StandardCharsets;
+/// import import java.nio.ByteBuffer;
+/// import static java.nio.charset.StandardCharsets.UTF_8;
 /// import java.nio.file.Files;
 /// import java.nio.file.Path;
 ///
@@ -55,29 +57,24 @@ import java.util.Objects;
 ///         Path objectStoreRoot = Files.createTempDirectory("slatedb-java-store");
 ///         String objectStoreUrl = "file://" + objectStoreRoot.toAbsolutePath();
 ///
-///         byte[] key = "hello-key".getBytes(StandardCharsets.UTF_8);
-///         byte[] value = "hello-value".getBytes(StandardCharsets.UTF_8);
+///         ByteByffer key = ByteBuffer.wrap("hello-key".getBytes(UTF_8));
+///         ByteByffer value = ByteBuffer.wrap("hello-value".getBytes(UTF_8));
 ///
 ///         try (SlateDb db = SlateDb.open(dbPath.toString(), objectStoreUrl, null)) {
 ///             db.put(key, value);
-///             byte[] loaded = db.get(key);
-///             System.out.println(new String(loaded, StandardCharsets.UTF_8));
+///             ByteByffer loaded = db.get(key);
+///             System.out.println(new String(loaded.array(), UTF_8));
 ///
 ///             try (SlateDbWriteBatch batch = SlateDb.newWriteBatch()) {
-///                 batch.put("hello-a".getBytes(StandardCharsets.UTF_8),
-///                     "value-a".getBytes(StandardCharsets.UTF_8));
-///                 batch.put("hello-b".getBytes(StandardCharsets.UTF_8),
-///                     "value-b".getBytes(StandardCharsets.UTF_8));
+///                 batch.put("hello-a".getBytes(UTF_8), "value-a".getBytes(UTF_8));
+///                 batch.put("hello-b".getBytes(UTF_8), "value-b".getBytes(UTF_8));
 ///                 db.write(batch);
 ///             }
 ///
-///             try (SlateDbScanIterator iter = db.scanPrefix("hello-".getBytes(StandardCharsets.UTF_8))) {
+///             try (SlateDbScanIterator iter = db.scanPrefix("hello-".getBytes(UTF_8))) {
 ///                 SlateDbKeyValue kv;
 ///                 while ((kv = iter.next()) != null) {
-///                     System.out.println(
-///                         new String(kv.key(), StandardCharsets.UTF_8) + "=" +
-///                         new String(kv.value(), StandardCharsets.UTF_8)
-///                     );
+///                     System.out.println(new String(kv.key(), UTF_8) + "=" + new String(kv.value(), UTF_8));
 ///                 }
 ///             }
 ///         }
@@ -238,9 +235,9 @@ public final class SlateDb implements SlateDbReadable {
     /// @throws SlateDbException if the write fails.
     /// ### Example
     /// ```java
-    /// db.put("key".getBytes(StandardCharsets.UTF_8), "value".getBytes(StandardCharsets.UTF_8));
+    /// db.put(ByteBuffer.wrap("key".getBytes(StandardCharsets.UTF_8)), ByteBuffer.wrap("value".getBytes(StandardCharsets.UTF_8)));
     /// ```
-    public void put(byte[] key, byte[] value) {
+    public void put(final ByteBuffer key, final ByteBuffer value) {
         Native.put(handle, key, value);
     }
 
@@ -251,7 +248,12 @@ public final class SlateDb implements SlateDbReadable {
     /// @param putOptions put options or `null` for defaults.
     /// @param writeOptions write options or `null` for defaults.
     /// @throws SlateDbException if the write fails.
-    public void put(byte[] key, byte[] value, PutOptions putOptions, WriteOptions writeOptions) {
+    public void put(
+        final ByteBuffer key,
+        final ByteBuffer value,
+        final PutOptions putOptions,
+        final WriteOptions writeOptions
+    ) {
         Native.put(handle, key, value, putOptions, writeOptions);
     }
 
@@ -264,7 +266,7 @@ public final class SlateDb implements SlateDbReadable {
     /// ```java
     /// byte[] value = db.get("key".getBytes(StandardCharsets.UTF_8));
     /// ```
-    public byte[] get(byte[] key) {
+    public ByteBuffer get(final ByteBuffer key) {
         return Native.get(handle, key);
     }
 
@@ -274,7 +276,7 @@ public final class SlateDb implements SlateDbReadable {
     /// @param options read options or `null` for defaults.
     /// @return The value for the key, or `null` if the key does not exist.
     /// @throws SlateDbException if the read fails.
-    public byte[] get(byte[] key, ReadOptions options) {
+    public ByteBuffer get(final ByteBuffer key, ReadOptions options) {
         return Native.get(handle, key, options);
     }
 
@@ -282,7 +284,7 @@ public final class SlateDb implements SlateDbReadable {
     ///
     /// @param key key to delete.
     /// @throws SlateDbException if the delete fails.
-    public void delete(byte[] key) {
+    public void delete(final ByteBuffer key) {
         delete(key, WriteOptions.DEFAULT);
     }
 
@@ -291,7 +293,7 @@ public final class SlateDb implements SlateDbReadable {
     /// @param key key to delete.
     /// @param options write options or `null` for defaults.
     /// @throws SlateDbException if the delete fails.
-    public void delete(byte[] key, WriteOptions options) {
+    public void delete(final ByteBuffer key, final WriteOptions options) {
         Native.delete(handle, key, options);
     }
 
@@ -357,7 +359,7 @@ public final class SlateDb implements SlateDbReadable {
     ///     }
     /// }
     /// ```
-    public SlateDbScanIterator scan(byte[] startKey, byte[] endKey) {
+    public SlateDbScanIterator scan(final ByteBuffer startKey, final ByteBuffer endKey) {
         return scan(startKey, endKey, ScanOptions.DEFAULT);
     }
 
@@ -369,7 +371,7 @@ public final class SlateDb implements SlateDbReadable {
     /// @param options scan options or `null` for defaults.
     /// @return A [SlateDbScanIterator] over the range. Always close it.
     /// @throws SlateDbException if the scan fails.
-    public SlateDbScanIterator scan(byte[] startKey, byte[] endKey, ScanOptions options) {
+    public SlateDbScanIterator scan(final ByteBuffer startKey, final ByteBuffer endKey, final ScanOptions options) {
         return new SlateDbScanIterator(Native.scan(handle, startKey, endKey, options));
     }
 
@@ -378,7 +380,7 @@ public final class SlateDb implements SlateDbReadable {
     /// @param prefix key prefix to scan.
     /// @return A [SlateDbScanIterator] over the prefix. Always close it.
     /// @throws SlateDbException if the scan fails.
-    public SlateDbScanIterator scanPrefix(byte[] prefix) {
+    public SlateDbScanIterator scanPrefix(final ByteBuffer prefix) {
         return scanPrefix(prefix, ScanOptions.DEFAULT);
     }
 
@@ -388,7 +390,7 @@ public final class SlateDb implements SlateDbReadable {
     /// @param options scan options or `null` for defaults.
     /// @return A [SlateDbScanIterator] over the prefix. Always close it.
     /// @throws SlateDbException if the scan fails.
-    public SlateDbScanIterator scanPrefix(byte[] prefix, ScanOptions options) {
+    public SlateDbScanIterator scanPrefix(final ByteBuffer prefix, final ScanOptions options) {
         return new SlateDbScanIterator(Native.scanPrefix(handle, prefix, options));
     }
 

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbKeyValue.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbKeyValue.java
@@ -1,4 +1,6 @@
 package io.slatedb;
 
+import java.nio.ByteBuffer;
+
 /// Key/value pair returned by scan iterators.
-public record SlateDbKeyValue(byte[] key, byte[] value) {}
+public record SlateDbKeyValue(ByteBuffer key, ByteBuffer value) {}

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbReadable.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbReadable.java
@@ -3,6 +3,8 @@ package io.slatedb;
 import io.slatedb.SlateDbConfig.ReadOptions;
 import io.slatedb.SlateDbConfig.ScanOptions;
 
+import java.nio.ByteBuffer;
+
 /// Shared read-only interface for SlateDb and SlateDbReader.
 ///
 /// Enables passing either type to read paths without additional wrappers.
@@ -11,21 +13,21 @@ public interface SlateDbReadable extends AutoCloseable {
     ///
     /// @param key key to read.
     /// @return The value for the key, or `null` if the key does not exist.
-    byte[] get(byte[] key);
+    ByteBuffer get(ByteBuffer key);
 
     /// Reads a value with custom read options.
     ///
     /// @param key key to read.
     /// @param options read options or `null` for defaults.
     /// @return The value for the key, or `null` if the key does not exist.
-    byte[] get(byte[] key, ReadOptions options);
+    ByteBuffer get(ByteBuffer key, ReadOptions options);
 
     /// Creates a scan iterator over the range `[startKey, endKey)` using default scan options.
     ///
     /// @param startKey inclusive lower bound, or `null`.
     /// @param endKey exclusive upper bound, or `null`.
     /// @return A [SlateDbScanIterator]. Always close it.
-    SlateDbScanIterator scan(byte[] startKey, byte[] endKey);
+    SlateDbScanIterator scan(ByteBuffer startKey, ByteBuffer endKey);
 
     /// Creates a scan iterator over the range `[startKey, endKey)` using custom scan options.
     ///
@@ -33,20 +35,20 @@ public interface SlateDbReadable extends AutoCloseable {
     /// @param endKey exclusive upper bound, or `null`.
     /// @param options scan options or `null` for defaults.
     /// @return A [SlateDbScanIterator]. Always close it.
-    SlateDbScanIterator scan(byte[] startKey, byte[] endKey, ScanOptions options);
+    SlateDbScanIterator scan(ByteBuffer startKey, ByteBuffer endKey, ScanOptions options);
 
     /// Creates a scan iterator for the provided key prefix using default scan options.
     ///
     /// @param prefix key prefix to scan.
     /// @return A [SlateDbScanIterator]. Always close it.
-    SlateDbScanIterator scanPrefix(byte[] prefix);
+    SlateDbScanIterator scanPrefix(ByteBuffer prefix);
 
     /// Creates a scan iterator for the provided key prefix using custom scan options.
     ///
     /// @param prefix key prefix to scan.
     /// @param options scan options or `null` for defaults.
     /// @return A [SlateDbScanIterator]. Always close it.
-    SlateDbScanIterator scanPrefix(byte[] prefix, ScanOptions options);
+    SlateDbScanIterator scanPrefix(ByteBuffer prefix, ScanOptions options);
 
     /// Closes the underlying handle.
     ///

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbReader.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbReader.java
@@ -4,6 +4,7 @@ import io.slatedb.SlateDbConfig.ReadOptions;
 import io.slatedb.SlateDbConfig.ScanOptions;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
 
 /// Read-only SlateDB handle.
 ///
@@ -20,7 +21,7 @@ public final class SlateDbReader implements SlateDbReadable {
     ///
     /// @param key key to read.
     /// @return The value for the key, or `null` if the key does not exist.
-    public byte[] get(byte[] key) {
+    public ByteBuffer get(final ByteBuffer key) {
         return get(key, null);
     }
 
@@ -29,7 +30,7 @@ public final class SlateDbReader implements SlateDbReadable {
     /// @param key key to read.
     /// @param options read options or `null` for defaults.
     /// @return The value for the key, or `null` if the key does not exist.
-    public byte[] get(byte[] key, ReadOptions options) {
+    public ByteBuffer get(final ByteBuffer key, final ReadOptions options) {
         return Native.readerGet(handle, key, options);
     }
 
@@ -38,7 +39,7 @@ public final class SlateDbReader implements SlateDbReadable {
     /// @param startKey inclusive lower bound, or `null`.
     /// @param endKey exclusive upper bound, or `null`.
     /// @return A [SlateDbScanIterator]. Always close it.
-    public SlateDbScanIterator scan(byte[] startKey, byte[] endKey) {
+    public SlateDbScanIterator scan(final ByteBuffer startKey, final ByteBuffer endKey) {
         return scan(startKey, endKey, null);
     }
 
@@ -48,7 +49,7 @@ public final class SlateDbReader implements SlateDbReadable {
     /// @param endKey exclusive upper bound, or `null`.
     /// @param options scan options or `null` for defaults.
     /// @return A [SlateDbScanIterator]. Always close it.
-    public SlateDbScanIterator scan(byte[] startKey, byte[] endKey, ScanOptions options) {
+    public SlateDbScanIterator scan(final ByteBuffer startKey, final ByteBuffer endKey, final ScanOptions options) {
         return new SlateDbScanIterator(Native.readerScan(handle, startKey, endKey, options));
     }
 
@@ -56,7 +57,7 @@ public final class SlateDbReader implements SlateDbReadable {
     ///
     /// @param prefix key prefix to scan.
     /// @return A [SlateDbScanIterator]. Always close it.
-    public SlateDbScanIterator scanPrefix(byte[] prefix) {
+    public SlateDbScanIterator scanPrefix(final ByteBuffer prefix) {
         return scanPrefix(prefix, null);
     }
 
@@ -65,7 +66,7 @@ public final class SlateDbReader implements SlateDbReadable {
     /// @param prefix key prefix to scan.
     /// @param options scan options or `null` for defaults.
     /// @return A [SlateDbScanIterator]. Always close it.
-    public SlateDbScanIterator scanPrefix(byte[] prefix, ScanOptions options) {
+    public SlateDbScanIterator scanPrefix(final ByteBuffer prefix, final ScanOptions options) {
         return new SlateDbScanIterator(Native.readerScanPrefix(handle, prefix, options));
     }
 

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbScanIterator.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbScanIterator.java
@@ -1,6 +1,7 @@
 package io.slatedb;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
 
 /// Iterator over scan results. Always close after use.
 public final class SlateDbScanIterator implements AutoCloseable {
@@ -21,7 +22,7 @@ public final class SlateDbScanIterator implements AutoCloseable {
     /// Seeks to the first entry whose key is greater than or equal to the provided key.
     ///
     /// @param key key to seek to.
-    public void seek(byte[] key) {
+    public void seek(final ByteBuffer key) {
         Native.iteratorSeek(iterPtr, key);
     }
 

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbWriteBatch.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbWriteBatch.java
@@ -3,6 +3,7 @@ package io.slatedb;
 import io.slatedb.SlateDbConfig.PutOptions;
 
 import java.lang.foreign.MemorySegment;
+import java.nio.ByteBuffer;
 
 /// A batch of write operations that can be executed atomically.
 ///
@@ -20,7 +21,7 @@ public final class SlateDbWriteBatch implements AutoCloseable {
     ///
     /// @param key key to write (non-empty).
     /// @param value value to write.
-    public void put(byte[] key, byte[] value) {
+    public void put(final ByteBuffer key, final ByteBuffer value) {
         Native.writeBatchPut(batchPtr, key, value);
     }
 
@@ -29,14 +30,14 @@ public final class SlateDbWriteBatch implements AutoCloseable {
     /// @param key key to write (non-empty).
     /// @param value value to write.
     /// @param options put options or `null` for defaults.
-    public void put(byte[] key, byte[] value, PutOptions options) {
+    public void put(final ByteBuffer key, final ByteBuffer value, PutOptions options) {
         Native.writeBatchPutWithOptions(batchPtr, key, value, options);
     }
 
     /// Adds a delete operation to the batch.
     ///
     /// @param key key to delete.
-    public void delete(byte[] key) {
+    public void delete(final ByteBuffer key) {
         Native.writeBatchDelete(batchPtr, key);
     }
 

--- a/slatedb-java/src/test/java/io/slatedb/SlateDbReaderTest.java
+++ b/slatedb-java/src/test/java/io/slatedb/SlateDbReaderTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.nio.ByteBuffer;
+import static java.nio.ByteBuffer.wrap;
 import java.time.Duration;
 
 class SlateDbReaderTest {
@@ -18,8 +20,8 @@ class SlateDbReaderTest {
     private static void createSlateDB(
         final TestSupport.DbContext context,
         final String url,
-        final byte[] key,
-        final byte[] value
+        final ByteBuffer key,
+        final ByteBuffer value
     ) {
         try (SlateDb db = SlateDb.open(context.dbPath().toAbsolutePath().toString(), url, null)) {
             db.put(key, value);
@@ -33,8 +35,8 @@ class SlateDbReaderTest {
         final var context = TestSupport.createDbContext();
         final var readerObjectStoreUrl = "file://" + context.objectStoreRoot().toAbsolutePath();
 
-        final var key = "reader-key".getBytes(UTF_8);
-        final var value = "reader-value".getBytes(UTF_8);
+        final var key = wrap("reader-key".getBytes(UTF_8));
+        final var value = wrap("reader-value".getBytes(UTF_8));
         createSlateDB(context, readerObjectStoreUrl, key, value);
 
         try (final var reader = SlateDb.openReader(
@@ -44,13 +46,13 @@ class SlateDbReaderTest {
             null,
             DEFAULT_READER_OPTIONS
         )) {
-            assertArrayEquals(value, reader.get(key));
+            assertEquals(value, reader.get(key));
 
-            try (SlateDbScanIterator iter = reader.scanPrefix("reader-".getBytes(UTF_8))) {
+            try (SlateDbScanIterator iter = reader.scanPrefix(wrap("reader-".getBytes(UTF_8)))) {
                 final var kv = iter.next();
                 assertNotNull(kv);
-                assertArrayEquals(key, kv.key());
-                assertArrayEquals(value, kv.value());
+                assertEquals(key, kv.key());
+                assertEquals(value, kv.value());
             }
         }
     }
@@ -61,7 +63,7 @@ class SlateDbReaderTest {
         final var context = TestSupport.createDbContext();
         final var readerObjectStoreUrl = "file://" + context.objectStoreRoot().toAbsolutePath();
 
-        createSlateDB(context, readerObjectStoreUrl, "key".getBytes(UTF_8), "value".getBytes(UTF_8));
+        createSlateDB(context, readerObjectStoreUrl, wrap("key".getBytes(UTF_8)), wrap("value".getBytes(UTF_8)));
 
         try (final var reader = SlateDb.openReader(
             context.dbPath().toAbsolutePath().toString(),
@@ -70,7 +72,7 @@ class SlateDbReaderTest {
             null,
             DEFAULT_READER_OPTIONS
         )) {
-            assertNull(reader.get("missing".getBytes(UTF_8)));
+            assertNull(reader.get(wrap("missing".getBytes(UTF_8))));
         }
     }
 
@@ -80,8 +82,8 @@ class SlateDbReaderTest {
         final var context = TestSupport.createDbContext();
         final var readerObjectStoreUrl = "file://" + context.objectStoreRoot().toAbsolutePath();
 
-        final var key = "reader-close-key".getBytes(UTF_8);
-        final var value = "reader-close-value".getBytes(UTF_8);
+        final var key = wrap("reader-close-key".getBytes(UTF_8));
+        final var value = wrap("reader-close-value".getBytes(UTF_8));
         createSlateDB(context, readerObjectStoreUrl, key, value);
 
         final var reader = SlateDb.openReader(
@@ -93,7 +95,7 @@ class SlateDbReaderTest {
         );
 
         try {
-            assertArrayEquals(value, reader.get(key));
+            assertEquals(value, reader.get(key));
             reader.close();
             assertDoesNotThrow(reader::close);
         } finally {

--- a/slatedb-java/src/test/java/io/slatedb/SlateDbTest.java
+++ b/slatedb-java/src/test/java/io/slatedb/SlateDbTest.java
@@ -1,15 +1,15 @@
 package io.slatedb;
 
 import org.junit.jupiter.api.Assertions;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
+import static java.nio.ByteBuffer.wrap;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class SlateDbTest {
     private static final int ERROR_INTERNAL = 5;
@@ -18,8 +18,8 @@ class SlateDbTest {
         TestSupport.ensureNativeReady();
         TestSupport.DbContext context = TestSupport.createDbContext();
 
-        byte[] key = "smoke-key".getBytes(StandardCharsets.UTF_8);
-        byte[] value = "smoke-value".getBytes(StandardCharsets.UTF_8);
+        final var key = wrap("smoke-key".getBytes(StandardCharsets.UTF_8));
+        final var value = wrap("smoke-value".getBytes(StandardCharsets.UTF_8));
 
         try (SlateDb db = SlateDb.open(
             context.dbPath().toAbsolutePath().toString(),
@@ -27,8 +27,7 @@ class SlateDbTest {
             null
         )) {
             db.put(key, value);
-            byte[] loaded = db.get(key);
-            Assertions.assertArrayEquals(value, loaded);
+            assertEquals(value, db.get(key));
         }
     }
 
@@ -37,8 +36,8 @@ class SlateDbTest {
         TestSupport.ensureNativeReady();
         TestSupport.DbContext context = TestSupport.createDbContext();
 
-        byte[] key = "close-key".getBytes(StandardCharsets.UTF_8);
-        byte[] value = "close-value".getBytes(StandardCharsets.UTF_8);
+        final var key = wrap("close-key".getBytes(StandardCharsets.UTF_8));
+        final var value = wrap("close-value".getBytes(StandardCharsets.UTF_8));
 
         SlateDb db = SlateDb.open(context.dbPath().toAbsolutePath().toString(), context.objectStoreUrl(), null);
         try {
@@ -104,10 +103,10 @@ class SlateDbTest {
             builder.withSettingsJson(settingsJson)
                 .withSstBlockSize(SlateDbConfig.SstBlockSize.KIB_4);
             try (SlateDb db = builder.build()) {
-                byte[] key = "builder-key".getBytes(StandardCharsets.UTF_8);
-                byte[] value = "builder-value".getBytes(StandardCharsets.UTF_8);
+                final var key = wrap("builder-key".getBytes(StandardCharsets.UTF_8));
+                final var value = wrap("builder-value".getBytes(StandardCharsets.UTF_8));
                 db.put(key, value);
-                Assertions.assertArrayEquals(value, db.get(key));
+                assertEquals(value, db.get(key));
             }
         }
     }
@@ -187,16 +186,16 @@ class SlateDbTest {
         final var value = "opts-value".getBytes(StandardCharsets.UTF_8);
 
         try (final SlateDb db = SlateDb.open(context.dbPath().toAbsolutePath().toString(), context.objectStoreUrl(), null)) {
-            db.put(key, value, SlateDbConfig.PutOptions.noExpiry(), new SlateDbConfig.WriteOptions(false));
+            db.put(wrap(key), wrap(value), SlateDbConfig.PutOptions.noExpiry(), new SlateDbConfig.WriteOptions(false));
             final var readOptions = SlateDbConfig.ReadOptions.builder()
                 .durabilityFilter(SlateDbConfig.Durability.MEMORY)
                 .dirty(false)
                 .cacheBlocks(true)
                 .build();
-            assertArrayEquals(value, db.get(key, readOptions));
+            assertEquals(ByteBuffer.wrap(value), db.get(ByteBuffer.wrap(key), readOptions));
 
-            db.delete(key, new SlateDbConfig.WriteOptions(false));
-            assertNull(db.get(key));
+            db.delete(wrap(key), new SlateDbConfig.WriteOptions(false));
+            assertNull(db.get(ByteBuffer.wrap(key)));
 
             final var metrics = db.metrics();
             assertNotNull(metrics);


### PR DESCRIPTION
## Summary

Primitive types like `byte[]` cannot be used with generics. With `ByteBuffer`, we can make some APIs (get) return `Optional`.

Perhaps we can also use ByteBuffer to avoid copying values that slatedb-c returns.

## Changes

Type for all `key` and `value` was changed to `ByteBuffer`.

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
