### PR TITLE
[slatedb-java] refactor `get` to return `Optional<SlateDbKeyValue>`

### DIFF
--- a/slatedb-java/src/main/java/io/slatedb/SlateDb.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDb.java
@@ -4,6 +4,7 @@ import io.slatedb.SlateDbConfig.*;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
+import java.util.Optional;
 
 /// Java bindings for SlateDB backed by the `slatedb-c` FFI library.
 ///
@@ -258,24 +259,24 @@ public final class SlateDb implements SlateDbReadable {
     /// Reads a value from the database using default read options.
     ///
     /// @param key key to read.
-    /// @return The value for the key, or `null` if the key does not exist.
+    /// @return The optional for {@link SlateDbKeyValue}.
     /// @throws SlateDbException if the read fails.
     /// ### Example
     /// ```java
-    /// byte[] value = db.get("key".getBytes(StandardCharsets.UTF_8));
+    /// Optional<SlateDbKeyValue> kv = db.get("key".getBytes(StandardCharsets.UTF_8));
     /// ```
-    public byte[] get(byte[] key) {
-        return Native.get(handle, key);
+    public Optional<SlateDbKeyValue> get(byte[] key) {
+        return Optional.ofNullable(Native.get(handle, key)).map(value -> new SlateDbKeyValue(key, value));
     }
 
     /// Reads a value from the database with custom read options.
     ///
     /// @param key key to read.
     /// @param options read options or `null` for defaults.
-    /// @return The value for the key, or `null` if the key does not exist.
+    /// @return The optional for {@link SlateDbKeyValue}.
     /// @throws SlateDbException if the read fails.
-    public byte[] get(byte[] key, ReadOptions options) {
-        return Native.get(handle, key, options);
+    public Optional<SlateDbKeyValue> get(byte[] key, ReadOptions options) {
+        return Optional.ofNullable(Native.get(handle, key, options)).map(value -> new SlateDbKeyValue(key, value));
     }
 
     /// Deletes a key using default write options.

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbReadable.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbReadable.java
@@ -3,6 +3,8 @@ package io.slatedb;
 import io.slatedb.SlateDbConfig.ReadOptions;
 import io.slatedb.SlateDbConfig.ScanOptions;
 
+import java.util.Optional;
+
 /// Shared read-only interface for SlateDb and SlateDbReader.
 ///
 /// Enables passing either type to read paths without additional wrappers.
@@ -10,15 +12,15 @@ public interface SlateDbReadable extends AutoCloseable {
     /// Reads a value using default read options.
     ///
     /// @param key key to read.
-    /// @return The value for the key, or `null` if the key does not exist.
-    byte[] get(byte[] key);
+    /// @return The optional for {@link SlateDbKeyValue}.
+    Optional<SlateDbKeyValue> get(byte[] key);
 
     /// Reads a value with custom read options.
     ///
     /// @param key key to read.
     /// @param options read options or `null` for defaults.
-    /// @return The value for the key, or `null` if the key does not exist.
-    byte[] get(byte[] key, ReadOptions options);
+    /// @return The optional for {@link SlateDbKeyValue}.
+    Optional<SlateDbKeyValue> get(byte[] key, ReadOptions options);
 
     /// Creates a scan iterator over the range `[startKey, endKey)` using default scan options.
     ///

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbReader.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbReader.java
@@ -4,6 +4,7 @@ import io.slatedb.SlateDbConfig.ReadOptions;
 import io.slatedb.SlateDbConfig.ScanOptions;
 
 import java.lang.foreign.MemorySegment;
+import java.util.Optional;
 
 /// Read-only SlateDB handle.
 ///
@@ -19,8 +20,8 @@ public final class SlateDbReader implements SlateDbReadable {
     /// Reads a value using default read options.
     ///
     /// @param key key to read.
-    /// @return The value for the key, or `null` if the key does not exist.
-    public byte[] get(byte[] key) {
+    /// @return The optional for {@link SlateDbKeyValue}.
+    public Optional<SlateDbKeyValue> get(byte[] key) {
         return get(key, null);
     }
 
@@ -28,9 +29,9 @@ public final class SlateDbReader implements SlateDbReadable {
     ///
     /// @param key key to read.
     /// @param options read options or `null` for defaults.
-    /// @return The value for the key, or `null` if the key does not exist.
-    public byte[] get(byte[] key, ReadOptions options) {
-        return Native.readerGet(handle, key, options);
+    /// @return The optional for {@link SlateDbKeyValue}.
+    public Optional<SlateDbKeyValue> get(byte[] key, ReadOptions options) {
+        return Optional.ofNullable(Native.readerGet(handle, key, options)).map(value -> new SlateDbKeyValue(key, value));
     }
 
     /// Creates a scan iterator over the range `[startKey, endKey)` using default scan options.

--- a/slatedb-java/src/test/java/io/slatedb/SlateDbReaderTest.java
+++ b/slatedb-java/src/test/java/io/slatedb/SlateDbReaderTest.java
@@ -44,7 +44,7 @@ class SlateDbReaderTest {
             null,
             DEFAULT_READER_OPTIONS
         )) {
-            assertArrayEquals(value, reader.get(key));
+            assertArrayEquals(value, reader.get(key).orElseThrow().value());
 
             try (SlateDbScanIterator iter = reader.scanPrefix("reader-".getBytes(UTF_8))) {
                 final var kv = iter.next();
@@ -70,7 +70,7 @@ class SlateDbReaderTest {
             null,
             DEFAULT_READER_OPTIONS
         )) {
-            assertNull(reader.get("missing".getBytes(UTF_8)));
+            assertTrue(reader.get("missing".getBytes(UTF_8)).isEmpty());
         }
     }
 
@@ -93,7 +93,7 @@ class SlateDbReaderTest {
         );
 
         try {
-            assertArrayEquals(value, reader.get(key));
+            assertArrayEquals(value, reader.get(key).orElseThrow().value());
             reader.close();
             assertDoesNotThrow(reader::close);
         } finally {

--- a/slatedb-java/src/test/java/io/slatedb/SlateDbTest.java
+++ b/slatedb-java/src/test/java/io/slatedb/SlateDbTest.java
@@ -2,7 +2,7 @@ package io.slatedb;
 
 import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ class SlateDbTest {
             null
         )) {
             db.put(key, value);
-            byte[] loaded = db.get(key);
+            byte[] loaded = db.get(key).orElseThrow().value();
             Assertions.assertArrayEquals(value, loaded);
         }
     }
@@ -107,7 +107,7 @@ class SlateDbTest {
                 byte[] key = "builder-key".getBytes(StandardCharsets.UTF_8);
                 byte[] value = "builder-value".getBytes(StandardCharsets.UTF_8);
                 db.put(key, value);
-                Assertions.assertArrayEquals(value, db.get(key));
+                Assertions.assertArrayEquals(value, db.get(key).orElseThrow().value());
             }
         }
     }
@@ -193,10 +193,10 @@ class SlateDbTest {
                 .dirty(false)
                 .cacheBlocks(true)
                 .build();
-            assertArrayEquals(value, db.get(key, readOptions));
+            assertArrayEquals(value, db.get(key, readOptions).orElseThrow().value());
 
             db.delete(key, new SlateDbConfig.WriteOptions(false));
-            assertNull(db.get(key));
+            assertTrue(db.get(key).isEmpty());
 
             final var metrics = db.metrics();
             assertNotNull(metrics);

--- a/slatedb-java/src/test/java/io/slatedb/SlateDbWriteBatchTest.java
+++ b/slatedb-java/src/test/java/io/slatedb/SlateDbWriteBatchTest.java
@@ -25,8 +25,8 @@ class SlateDbWriteBatchTest {
 
             db.write(batch);
 
-            Assertions.assertNull(db.get(key1));
-            Assertions.assertArrayEquals(value2, db.get(key2));
+            Assertions.assertTrue(db.get(key1).isEmpty());
+            Assertions.assertArrayEquals(value2, db.get(key2).orElseThrow().value());
         }
     }
 
@@ -46,7 +46,7 @@ class SlateDbWriteBatchTest {
             batch.put(key, value, putOptions);
             db.write(batch, writeOptions);
 
-            Assertions.assertArrayEquals(value, db.get(key));
+            Assertions.assertArrayEquals(value, db.get(key).orElseThrow().value());
         }
     }
 


### PR DESCRIPTION
## Summary

This change ensures that users will handle missing values correctly. It's a Java version of rust `Option` enum,

## Changes

Return type of slatedb java get functions was changed to `Optional<SlateDbKeyValue>`.

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
