### PR TITLE
(Reference PR) Rescaling: update RFC and correct union/projected implementation

### DIFF
--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -679,7 +679,9 @@ The union process works as follows:
      via projection, so their `sst_ids` lists are merged (unioned). Entries with different keys for the same
      path represent distinct checkpoints and must be kept separate. Without this deduplication, repeated
      cycles of projection and union cause exponential growth of duplicated entries: projecting into N parts
-     and unioning back multiplies the entry count by N each cycle.
+     and unioning back multiplies the entry count by N each cycle. New `final_checkpoint_id` values are
+     generated for all entries — the old ones belong to the source databases' clone relationships and are
+     not valid for the new database.
    - L0 SSTs are merged and deduplicated by SST ID. Because L0 SSTs span the full key space and overlap
      with each other, projection typically includes the same L0 SST in multiple projected manifests — each
      with a `visible_range` restricting it to that projection's key range. When these projected manifests are

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -642,6 +642,11 @@ The projection process works as follows:
    effective range.
 4. For each SST that has a non-empty intersection with the projection range, create a new handle with the
    `visible_range` set to the intersection. SSTs with an empty intersection are excluded from the result.
+5. Sorted runs whose SSTs were all excluded are removed entirely. Note that removing sorted runs may leave
+   gaps in sorted run IDs (e.g., `[5, 3, 1]` if SR 4 and 2 were removed). This is acceptable because the
+   compactor does not assume contiguous IDs — it matches sorted runs by ID, not by position. Preserving
+   original IDs is important so that union can correctly match the same logical tier across projected
+   manifests.
 
 The `visible_range` on an `SsTableHandle` constrains the keys that are visible when reading the SST. The
 `effective_range` is the intersection of the SST's physical range (derived from its first key) and its

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -700,7 +700,9 @@ The union process works as follows:
 4. Sorted run IDs are preserved from the source manifests. The compactor does not assume contiguous IDs, so
    gaps left by projection (where empty sorted runs were removed) are acceptable. Preserving original IDs
    maintains tier identity across projection and union. The descending order is preserved to maintain compactor invariant
-5. Each source database is added as an `external_dbs` entry in the resulting manifest, with a new
+5. The resulting manifest has `initialized` set to `false`. The caller must complete setup (e.g., creating
+   final checkpoints in source databases) before setting `initialized` to `true`.
+6. Each source database is added as an `external_dbs` entry in the resulting manifest, with a new
    `final_checkpoint_id` and its owned SST IDs recorded so that the new database can resolve SST paths
    and maintain checkpoints on the source databases to prevent their SSTs from being garbage collected.
    Owned SST IDs are those in the source manifest that are not already tracked by its own `external_dbs`

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -700,6 +700,11 @@ The union process works as follows:
 4. Sorted run IDs are preserved from the source manifests. The compactor does not assume contiguous IDs, so
    gaps left by projection (where empty sorted runs were removed) are acceptable. Preserving original IDs
    maintains tier identity across projection and union. The descending order is preserved to maintain compactor invariant
+5. Each source database is added as an `external_dbs` entry in the resulting manifest, with a new
+   `final_checkpoint_id` and its owned SST IDs recorded so that the new database can resolve SST paths
+   and maintain checkpoints on the source databases to prevent their SSTs from being garbage collected.
+   Owned SST IDs are those in the source manifest that are not already tracked by its own `external_dbs`
+   (i.e., SSTs physically stored under the source's path).
 
 Apart from the above union process, cloning from multiple source databases is the same as clone (see [Clones](#clones)),
 including creation of final checkpoints in source databases (and their source databases, recursively).

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -647,6 +647,9 @@ The projection process works as follows:
    compactor does not assume contiguous IDs — it matches sorted runs by ID, not by position. Preserving
    original IDs is important so that union can correctly match the same logical tier across projected
    manifests.
+6. Remove excluded SST IDs from `external_dbs` entries so that the external database's checkpoint can be released
+   and the SSTs garbage collected once no other manifest references them. Entries whose `sst_ids` list becomes
+   empty are removed entirely, allowing their checkpoint on the external database to be released.
 
 The `visible_range` on an `SsTableHandle` constrains the keys that are visible when reading the SST. The
 `effective_range` is the intersection of the SST's physical range (derived from its first key) and its

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -671,8 +671,8 @@ performing a union.
 The union process works as follows:
 
 1. Sort the input manifests by the start bound of their key ranges.
-2. Validate that the manifests are non-overlapping. If any two manifests have intersecting key ranges, the operation
-   fails.
+2. Validate that the manifests are non-overlapping. Each manifest's key range is computed from the effective ranges
+   of all its L0 and compacted SSTs. If any two manifests have intersecting key ranges, the operation fails.
 3. Concatenate the contents of all input manifests:
    - All `external_dbs` entries are merged into a single list.
    - All L0 SSTs from each manifest are appended to the result's L0 list.

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -686,9 +686,10 @@ The union process works as follows:
      with each other, projection typically includes the same L0 SST in multiple projected manifests — each
      with a `visible_range` restricting it to that projection's key range. When these projected manifests are
      unioned, the duplicate entries must be combined back into a single L0 entry per SST ID. For each unique
-     SST ID, the `visible_range`s from all input manifests are merged into a single contiguous range. If the
-     ranges for a given SST ID are not contiguous (i.e., there is a gap between them), the union operation
-     fails. After deduplication, the L0 list must be sorted by ULID descending (newest first) to preserve
+     SST ID, the `visible_range`s from all input manifests are combined. The ranges for a given SST ID are not 
+     necessarily contiguous (i.e., there might be a gap between them) due to compaction; it's important to preserve
+     these gap so that the old values don't override new ones or deletions.
+     After deduplication, the L0 list must be sorted by ULID descending (newest first) to preserve
      temporal ordering. Without this sort, newer L0 SSTs from one input manifest could appear after older
      L0 SSTs from another, causing point lookups to return stale values — since the read path stops at the
      first matching L0 entry.

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -626,10 +626,10 @@ introduce two operations on manifests to support this: **projection** and **unio
 
 #### Projection
 
-Projection creates a filtered view of a manifest restricted to a specific key range. Given a source manifest and a
-target range, projection returns a new manifest containing only the SSTs whose key ranges overlap with the target
-range. SSTs that fall entirely outside the target range are excluded, and SSTs that partially overlap are annotated
-with a `visible_range` that constrains which keys are accessible.
+Projection creates a filtered view of a manifest restricted to a specific key range specified by the client. Given a 
+source manifest and a target range, projection returns a new manifest containing only the SSTs whose key ranges overlap 
+with the target range. SSTs that fall entirely outside the target range are excluded, and SSTs that partially overlap 
+are annotated with a `visible_range` that constrains which keys are accessible.
 
 The projection process works as follows:
 

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -667,6 +667,9 @@ combined key space.
 
 Union does not support merging WAL state at the moment. Input manifests must have their WAL fully compacted before
 performing a union.
+This can be achieved for example by calling `db.flush_with_options(... FlushOptions { flush_type: FlushType::MemTable });` 
+to force a flush to L0 (all writes prior to that flush will be guaranteed to be in L0+ and in the manifest); or setting 
+`wal_enabled: false` from the beginning.
 
 The union process works as follows:
 

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -663,7 +663,7 @@ projection are treated as if they no longer exist.
 
 Union combines multiple non-overlapping manifests into a single manifest. This is the inverse of projection: given
 a set of manifests that each cover a distinct portion of the key space, union produces a manifest that covers the
-combined key space.
+combined key space. The source databases don't have to share the root database (e.g. they can be independent shards).
 
 Union does not support merging WAL state at the moment. Input manifests must have their WAL fully compacted before
 performing a union.
@@ -685,6 +685,9 @@ The union process works as follows:
      and unioning back multiplies the entry count by N each cycle. New `final_checkpoint_id` values are
      generated for all entries — the old ones belong to the source databases' clone relationships and are
      not valid for the new database.
+   - L0 SSTs with the same ID but __originating__ from different source databases are deduplicated by assigning a new ID
+     (this might happen because ULID is not guaranteed to be globally unique). To preserve the order of L0 ULIDs
+     within the same database, subsequent SSTs might require new IDs as well.
    - L0 SSTs are merged and deduplicated by SST ID. Because L0 SSTs span the full key space and overlap
      with each other, projection typically includes the same L0 SST in multiple projected manifests — each
      with a `visible_range` restricting it to that projection's key range. When these projected manifests are

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -689,10 +689,22 @@ The union process works as follows:
      SST ID, the `visible_range`s from all input manifests are combined. The ranges for a given SST ID are not 
      necessarily contiguous (i.e., there might be a gap between them) due to compaction; it's important to preserve
      these gap so that the old values don't override new ones or deletions.
-     After deduplication, the L0 list must be sorted by ULID descending (newest first) to preserve
-     temporal ordering. Without this sort, newer L0 SSTs from one input manifest could appear after older
+   - After deduplication, the L0 list must be sorted to satisfy the following requirements:
+       1. SSTs from parent databases must precede SSTs from child databases (if there's key space overlap)
+       2. SSTs created within the same database should preserve their relative order
+       3. SSTs created within different databases must have no overlap and don't need to be ordered
+       4. In particular, physically overlapping L0 SSTs that have non-overlapping visible ranges don't require ordering. 
+        For example, if a projected database completely drops inherited L0 after compaction and then creates a new L0 
+        with newer values; the order between this new L0 and the dropped one is not important (the old L0 might still be
+        used by its sibling databases and therefore included in union)
+
+     Without this sort, newer L0 SSTs from one input manifest could appear after older
      L0 SSTs from another, causing point lookups to return stale values — since the read path stops at the
      first matching L0 entry.
+     
+     Due to potential wall clock difference between different database hosts, ULID is not sufficient to satisfy (1). 
+     Instead, SSTs are sorted in topological order and then by ULID; with topological dependencies defined by the 
+     order of SSTs in the input manifests.
    - Sorted runs are merged by tier: sorted runs with the same ID across input manifests are combined
      into a single sorted run by concatenating their SSTs. Since the source manifests cover non-overlapping key
      ranges, the SSTs within each merged run remain non-overlapping. If source manifests have different numbers

--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -631,6 +631,9 @@ source manifest and a target range, projection returns a new manifest containing
 with the target range. SSTs that fall entirely outside the target range are excluded, and SSTs that partially overlap 
 are annotated with a `visible_range` that constrains which keys are accessible.
 
+Write requests fully or partially outside the `visible_range` must fail, as well as read requests completely outside the
+`visible_range`.
+
 The projection process works as follows:
 
 1. Clone the source manifest.

--- a/slatedb/src/bytes_range.rs
+++ b/slatedb/src/bytes_range.rs
@@ -142,6 +142,12 @@ impl BytesRange {
             .map(|inner| Self { inner })
     }
 
+    /// Compute the union of two ranges. Returns `None` if the ranges are not
+    /// contiguous (neither intersecting nor adjacent).
+    pub(crate) fn union(&self, other: &Self) -> Option<Self> {
+        self.inner.union(&other.inner).map(|inner| Self { inner })
+    }
+
     pub(crate) fn is_start_bound_included_or_unbounded(&self) -> bool {
         !matches!(self.start_bound(), Excluded(_))
     }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -206,7 +206,12 @@ impl Manifest {
     fn range(&self) -> Option<BytesRange> {
         let mut start_bound = None;
         let mut end_bound = None;
-        for sst in &self.core.l0 {
+        let all_ssts = self
+            .core
+            .l0
+            .iter()
+            .chain(self.core.compacted.iter().flat_map(|sr| sr.ssts.iter()));
+        for sst in all_ssts {
             let range = sst.compacted_effective_range();
             start_bound = start_bound
                 .map(|b| min(b, range.comparable_start_bound()))

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -178,12 +178,34 @@ impl Manifest {
             }
 
             // Merge the contents of all input manifests
-            let mut external_dbs = vec![];
             let mut core = ManifestCore::new();
 
+            // Deduplicate external_dbs by (path, source_checkpoint_id), merging
+            // sst_ids. Without dedup, repeated projection/union cycles cause
+            // exponential growth of duplicated entries.
+            let mut external_db_map: HashMap<(String, Uuid), ExternalDb> = HashMap::new();
             for (manifest, _) in &ranges {
-                external_dbs.extend_from_slice(&manifest.external_dbs);
+                for db in &manifest.external_dbs {
+                    let key = (db.path.clone(), db.source_checkpoint_id);
+                    match external_db_map.get_mut(&key) {
+                        Some(existing) => {
+                            let existing_ids: HashSet<SsTableId> =
+                                existing.sst_ids.iter().copied().collect();
+                            let new_ids: Vec<SsTableId> = db
+                                .sst_ids
+                                .iter()
+                                .filter(|id| !existing_ids.contains(id))
+                                .copied()
+                                .collect();
+                            existing.sst_ids.extend(new_ids);
+                        }
+                        None => {
+                            external_db_map.insert(key, db.clone());
+                        }
+                    }
+                }
             }
+            let external_dbs: Vec<ExternalDb> = external_db_map.into_values().collect();
 
             // Deduplicate L0 SSTs by ID, merging visible_ranges. Projection
             // includes the same L0 SST in multiple projected manifests with
@@ -1090,5 +1112,85 @@ mod tests {
             .find(|db| db.path == "db_mixed")
             .expect("ExternalDb with some in-range SSTs should be present");
         assert_eq!(mixed_entry.sst_ids, vec![sst_mixed_in]);
+    }
+
+    /// Helper to create a manifest with a single compacted sorted run containing
+    /// a single SST with a given first_entry key. The visible_range pins the SST
+    /// to a specific key range so that multiple manifests can be non-overlapping
+    /// (required by `union`).
+    fn manifest_with_one_compacted_sst(
+        sst_id: SsTableId,
+        first_entry: &'static [u8],
+        visible_range: BytesRange,
+    ) -> Manifest {
+        let mut core = ManifestCore::new();
+        core.compacted.push(SortedRun {
+            id: 0,
+            ssts: vec![SsTableHandle::new_compacted(
+                sst_id,
+                SsTableInfo {
+                    first_entry: Some(Bytes::from_static(first_entry)),
+                    ..SsTableInfo::default()
+                },
+                Some(visible_range),
+            )],
+        });
+        Manifest::initial(core)
+    }
+
+    #[test]
+    fn test_union_deduplicates_external_dbs() {
+        use super::ExternalDb;
+        use std::collections::HashSet;
+
+        let shared_path = "shared_ancestor".to_string();
+        let shared_source_cp = Uuid::new_v4();
+        let original_final_cp = Uuid::new_v4();
+
+        let sst_a = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let sst_b = SsTableId::Compacted(Ulid::from_parts(1001, 0));
+        let sst_c = SsTableId::Compacted(Ulid::from_parts(1002, 0));
+
+        // Manifest 1: has sst_a, sst_b from the shared ancestor, owns sst_own1
+        let sst_own1 = SsTableId::Compacted(Ulid::from_parts(2000, 0));
+        let mut m1 =
+            manifest_with_one_compacted_sst(sst_own1, b"a", BytesRange::from_ref("a".."m"));
+        m1.external_dbs.push(ExternalDb {
+            path: shared_path.clone(),
+            source_checkpoint_id: shared_source_cp,
+            final_checkpoint_id: Some(original_final_cp),
+            sst_ids: vec![sst_a, sst_b],
+        });
+
+        // Manifest 2: has sst_b, sst_c from same shared ancestor, owns sst_own2
+        let sst_own2 = SsTableId::Compacted(Ulid::from_parts(3000, 0));
+        let mut m2 = manifest_with_one_compacted_sst(sst_own2, b"m", BytesRange::from_ref("m"..));
+        m2.external_dbs.push(ExternalDb {
+            path: shared_path.clone(),
+            source_checkpoint_id: shared_source_cp,
+            final_checkpoint_id: Some(original_final_cp),
+            sst_ids: vec![sst_b, sst_c],
+        });
+
+        let sources = vec![m1, m2];
+
+        let result = Manifest::union(sources);
+
+        // Find the entry for the shared ancestor
+        let shared_entries: Vec<_> = result
+            .external_dbs
+            .iter()
+            .filter(|db| db.path == shared_path && db.source_checkpoint_id == shared_source_cp)
+            .collect();
+        assert_eq!(
+            shared_entries.len(),
+            1,
+            "Should have exactly one entry for the shared (path, source_checkpoint_id)"
+        );
+
+        // The merged sst_ids should be the union of {sst_a, sst_b} and {sst_b, sst_c}
+        let merged_ids: HashSet<SsTableId> = shared_entries[0].sst_ids.iter().copied().collect();
+        let expected_ids: HashSet<SsTableId> = [sst_a, sst_b, sst_c].iter().copied().collect();
+        assert_eq!(merged_ids, expected_ids);
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -909,7 +909,7 @@ mod tests {
     #[test]
     fn test_union_fails_on_non_contiguous_l0_ranges() {
         let mut sst_ids: HashMap<String, SsTableId> = HashMap::new();
-        let manifests = vec![
+        let manifests = [
             SimpleManifest {
                 l0: vec![SstEntry::projected("foo", "a", "a".."m")],
                 sorted_runs: vec![],

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -151,7 +151,7 @@ impl Manifest {
     }
 
     #[allow(unused)]
-    pub(crate) fn union(manifests: Vec<Manifest>) -> Manifest {
+    pub(crate) fn union(manifests: Vec<Manifest>, rand: Arc<DbRand>) -> Manifest {
         if manifests.len() == 1 {
             manifests[0].clone()
         } else {
@@ -200,7 +200,18 @@ impl Manifest {
                             existing.sst_ids.extend(new_ids);
                         }
                         None => {
-                            external_db_map.insert(key, db.clone());
+                            // Generate new final_checkpoint_ids — the old ones
+                            // belong to the source databases' clone relationships,
+                            // not to the new database.
+                            external_db_map.insert(
+                                key,
+                                ExternalDb {
+                                    path: db.path.clone(),
+                                    source_checkpoint_id: db.source_checkpoint_id,
+                                    final_checkpoint_id: Some(rand.rng().gen_uuid()),
+                                    sst_ids: db.sst_ids.clone(),
+                                },
+                            );
                         }
                     }
                 }
@@ -830,7 +841,7 @@ mod tests {
         let expected_manifest =
             build_manifest(&test_case.expected, |alias| *sst_ids.get(alias).unwrap());
 
-        let union = Manifest::union(manifests);
+        let union = Manifest::union(manifests, Arc::new(DbRand::default()));
 
         assert_manifest_equal(&union, &expected_manifest, &sst_ids);
     }
@@ -865,7 +876,7 @@ mod tests {
             })
             .collect();
 
-        Manifest::union(manifests);
+        Manifest::union(manifests, Arc::new(DbRand::default()));
     }
 
     fn build_manifest<F>(manifest: &SimpleManifest, mut sst_id_fn: F) -> Manifest
@@ -1174,7 +1185,7 @@ mod tests {
 
         let sources = vec![m1, m2];
 
-        let result = Manifest::union(sources);
+        let result = Manifest::union(sources, Arc::new(DbRand::default()));
 
         // Find the entry for the shared ancestor
         let shared_entries: Vec<_> = result
@@ -1192,5 +1203,62 @@ mod tests {
         let merged_ids: HashSet<SsTableId> = shared_entries[0].sst_ids.iter().copied().collect();
         let expected_ids: HashSet<SsTableId> = [sst_a, sst_b, sst_c].iter().copied().collect();
         assert_eq!(merged_ids, expected_ids);
+
+        // The final_checkpoint_id should differ from the original
+        assert_ne!(
+            shared_entries[0].final_checkpoint_id,
+            Some(original_final_cp),
+            "final_checkpoint_id should be regenerated"
+        );
+        assert!(
+            shared_entries[0].final_checkpoint_id.is_some(),
+            "final_checkpoint_id should not be None"
+        );
+    }
+
+    #[test]
+    fn test_union_regenerates_checkpoint_id_for_unique_external_db() {
+        use super::ExternalDb;
+
+        let original_final_cp = Uuid::new_v4();
+        let ancestor_path = "ancestor".to_string();
+        let ancestor_source_cp = Uuid::new_v4();
+
+        let sst_own1 = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let sst_own2 = SsTableId::Compacted(Ulid::from_parts(2000, 0));
+        let sst_ext = SsTableId::Compacted(Ulid::from_parts(3000, 0));
+
+        // Only m1 has the external_db entry — it won't be deduplicated,
+        // but union should still regenerate its final_checkpoint_id.
+        let mut m1 =
+            manifest_with_one_compacted_sst(sst_own1, b"a", BytesRange::from_ref("a".."m"));
+        m1.external_dbs.push(ExternalDb {
+            path: ancestor_path.clone(),
+            source_checkpoint_id: ancestor_source_cp,
+            final_checkpoint_id: Some(original_final_cp),
+            sst_ids: vec![sst_ext],
+        });
+
+        let m2 = manifest_with_one_compacted_sst(sst_own2, b"m", BytesRange::from_ref("m"..));
+
+        let sources = vec![m1, m2];
+
+        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+
+        let entry = result
+            .external_dbs
+            .iter()
+            .find(|db| db.path == ancestor_path && db.source_checkpoint_id == ancestor_source_cp)
+            .expect("External db entry should be present");
+
+        assert_ne!(
+            entry.final_checkpoint_id,
+            Some(original_final_cp),
+            "final_checkpoint_id should be regenerated even for non-deduplicated entries"
+        );
+        assert!(
+            entry.final_checkpoint_id.is_some(),
+            "final_checkpoint_id should not be None"
+        );
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -183,10 +183,44 @@ impl Manifest {
 
             for (manifest, _) in &ranges {
                 external_dbs.extend_from_slice(&manifest.external_dbs);
+            }
+
+            // Deduplicate L0 SSTs by ID, merging visible_ranges. Projection
+            // includes the same L0 SST in multiple projected manifests with
+            // different visible_ranges, so duplicates must be combined.
+            let mut l0_by_id: HashMap<SsTableId, SsTableHandle> = HashMap::new();
+            for (manifest, _) in &ranges {
                 for sst in &manifest.core.l0 {
-                    core.l0.push_back(sst.clone());
+                    match l0_by_id.get(&sst.id) {
+                        Some(existing) => {
+                            let merged_range = match (&existing.visible_range, &sst.visible_range) {
+                                (Some(a), Some(b)) => Some(a.union(b).unwrap_or_else(|| {
+                                    panic!("L0 SST {:?} has non-contiguous visible_ranges", sst.id)
+                                })),
+                                // If either has no visible_range, the merged result covers everything
+                                _ => None,
+                            };
+                            l0_by_id.insert(
+                                sst.id,
+                                SsTableHandle::new_compacted(
+                                    sst.id,
+                                    sst.info.clone(),
+                                    merged_range,
+                                ),
+                            );
+                        }
+                        None => {
+                            l0_by_id.insert(sst.id, sst.clone());
+                        }
+                    }
                 }
             }
+
+            // Sort L0 SSTs by ULID descending (newest first) to preserve
+            // temporal ordering for correct point-lookup behavior.
+            let mut l0_list: Vec<SsTableHandle> = l0_by_id.into_values().collect();
+            l0_list.sort_by(|a, b| b.id.unwrap_compacted_id().cmp(&a.id.unwrap_compacted_id()));
+            core.l0 = l0_list.into();
 
             // Merge sorted runs by tier: sorted runs with the same ID across
             // input manifests are combined into a single sorted run. We use
@@ -545,7 +579,11 @@ mod tests {
     }
 
     #[rstest]
-    #[case::non_overlapping_l0s(UnionTestCase {
+    #[case::l0_deduplicated_and_sorted(UnionTestCase {
+        // Same L0 SSTs appear in both manifests with adjacent visible_ranges.
+        // After dedup, they're merged into single entries and sorted by ULID
+        // descending. ULIDs are created in order foo < bar < baz, so descending
+        // gives baz, bar, foo.
         manifests: vec![
             SimpleManifest {
                 l0: vec![
@@ -566,48 +604,39 @@ mod tests {
         ],
         expected: SimpleManifest {
             l0: vec![
-                SstEntry::projected("foo", "a", "a".."m"),
-                SstEntry::projected("bar", "f", "a".."m"),
-                SstEntry::projected("baz", "j", "a".."m"),
-                SstEntry::projected("foo", "a", "m"..),
-                SstEntry::projected("bar", "f", "m"..),
-                SstEntry::projected("baz", "j", "m"..)
-                // This is not optimal, but it's a good start from correctness point of view. Eventually we want the manifest to look as follows:
-                //
-                // SstEntry::projected("foo", "a", "a"..),
-                // SstEntry::projected("bar", "f", "a"..),
-                // SstEntry::projected("baz", "j", "a"..),
+                SstEntry::projected("baz", "j", "a"..),
+                SstEntry::projected("bar", "f", "a"..),
+                SstEntry::projected("foo", "a", "a"..),
             ],
             sorted_runs: vec![]
         },
     })]
-    #[case::non_overlapping_l0s_with_gap(UnionTestCase {
+    #[case::l0_unique_per_manifest(UnionTestCase {
+        // L0 SSTs are unique to each manifest (no dedup needed), just sorted
+        // by ULID descending. ULIDs created in order: foo, bar (manifest 1),
+        // then baz, qux (manifest 2). Descending: qux, baz, bar, foo.
         manifests: vec![
             SimpleManifest {
                 l0: vec![
                     SstEntry::projected("foo", "a", "a".."m"),
                     SstEntry::projected("bar", "f", "a".."m"),
-                    SstEntry::projected("baz", "j", "a".."m")
                 ],
                 sorted_runs: vec![]
             },
             SimpleManifest {
                 l0: vec![
-                    SstEntry::projected("foo", "a", "o"..),
-                    SstEntry::projected("bar", "f", "o"..),
-                    SstEntry::projected("baz", "j", "o"..)
+                    SstEntry::projected("baz", "m", "m"..),
+                    SstEntry::projected("qux", "p", "m"..),
                 ],
                 sorted_runs: vec![]
             }
         ],
         expected: SimpleManifest {
             l0: vec![
-                SstEntry::projected("foo", "a", "a".."m"),
+                SstEntry::projected("qux", "p", "m"..),
+                SstEntry::projected("baz", "m", "m"..),
                 SstEntry::projected("bar", "f", "a".."m"),
-                SstEntry::projected("baz", "j", "a".."m"),
-                SstEntry::projected("foo", "a", "o"..),
-                SstEntry::projected("bar", "f", "o"..),
-                SstEntry::projected("baz", "j", "o"..)
+                SstEntry::projected("foo", "a", "a".."m"),
             ],
             sorted_runs: vec![]
         },
@@ -755,8 +784,51 @@ mod tests {
     })]
     fn test_union(#[case] test_case: UnionTestCase) {
         let mut sst_ids: HashMap<String, SsTableId> = HashMap::new();
+        // Use monotonically increasing timestamps for deterministic ULID ordering.
+        // ULIDs created with Ulid::new() within the same millisecond have random
+        // ordering, which makes test assertions on L0 sort order non-deterministic.
+        let mut next_ts: u64 = 1000;
         let manifests: Vec<Manifest> = test_case
             .manifests
+            .iter()
+            .map(|m| {
+                build_manifest(m, |alias| {
+                    if let Some(sst_id) = sst_ids.get(alias) {
+                        *sst_id
+                    } else {
+                        let sst_id = SsTableId::Compacted(Ulid::from_parts(next_ts, 0));
+                        next_ts += 1;
+                        sst_ids.insert(alias.to_string(), sst_id);
+                        sst_id
+                    }
+                })
+            })
+            .collect();
+
+        let expected_manifest =
+            build_manifest(&test_case.expected, |alias| *sst_ids.get(alias).unwrap());
+
+        let union = Manifest::union(manifests);
+
+        assert_manifest_equal(&union, &expected_manifest, &sst_ids);
+    }
+
+    #[test]
+    #[should_panic(expected = "non-contiguous visible_ranges")]
+    fn test_union_fails_on_non_contiguous_l0_ranges() {
+        let mut sst_ids: HashMap<String, SsTableId> = HashMap::new();
+        let manifests = vec![
+            SimpleManifest {
+                l0: vec![SstEntry::projected("foo", "a", "a".."m")],
+                sorted_runs: vec![],
+            },
+            SimpleManifest {
+                // Gap between "m" and "o" -- not contiguous with "a".."m"
+                l0: vec![SstEntry::projected("foo", "a", "o"..)],
+                sorted_runs: vec![],
+            },
+        ];
+        let manifests: Vec<Manifest> = manifests
             .iter()
             .map(|m| {
                 build_manifest(m, |alias| {
@@ -771,12 +843,7 @@ mod tests {
             })
             .collect();
 
-        let expected_manifest =
-            build_manifest(&test_case.expected, |alias| *sst_ids.get(alias).unwrap());
-
-        let union = Manifest::union(manifests);
-
-        assert_manifest_equal(&union, &expected_manifest, &sst_ids);
+        Manifest::union(manifests);
     }
 
     fn build_manifest<F>(manifest: &SimpleManifest, mut sst_id_fn: F) -> Manifest

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -151,136 +151,171 @@ impl Manifest {
     }
 
     #[allow(unused)]
-    pub(crate) fn union(manifests: Vec<Manifest>, rand: Arc<DbRand>) -> Manifest {
-        if manifests.len() == 1 {
-            manifests[0].clone()
-        } else {
-            let mut ranges = vec![];
-            for manifest in &manifests {
-                let range = manifest.range();
-                if let Some(range) = range {
-                    ranges.push((manifest, range));
-                } else {
-                    warn!("manifest has no SST files [manifest={:?}]", manifest);
+    pub(crate) fn union(sources: Vec<(Manifest, String, Uuid)>, rand: Arc<DbRand>) -> Manifest {
+        let mut ranges = vec![];
+        for (manifest, path, source_checkpoint_id) in &sources {
+            let range = manifest.range();
+            if let Some(range) = range {
+                ranges.push((manifest, path, source_checkpoint_id, range));
+            } else {
+                warn!("manifest has no SST files [manifest={:?}]", manifest);
+            }
+        }
+        ranges.sort_by_key(|(_, _, _, range)| range.comparable_start_bound().cloned());
+
+        // Ensure manifests are non-overlapping
+        let mut previous_range = None;
+        for (_, _, _, range) in ranges.iter() {
+            if let Some(previous_range) = previous_range {
+                if range.intersect(previous_range).is_some() {
+                    unreachable!("overlapping ranges found");
                 }
             }
-            ranges.sort_by_key(|(_, range)| range.comparable_start_bound().cloned());
+            previous_range = Some(range);
+        }
 
-            // Ensure manifests are non-overlapping
-            let mut previous_range = None;
-            for (_, range) in ranges.iter() {
-                if let Some(previous_range) = previous_range {
-                    if range.intersect(previous_range).is_some() {
-                        unreachable!("overlapping ranges found");
+        // Merge the contents of all input manifests
+        let mut core = ManifestCore::new();
+
+        // Deduplicate external_dbs by (path, source_checkpoint_id), merging
+        // sst_ids. Without dedup, repeated projection/union cycles cause
+        // exponential growth of duplicated entries.
+        let mut external_db_map: HashMap<(String, Uuid), ExternalDb> = HashMap::new();
+
+        for (manifest, _, _, _) in &ranges {
+            for db in &manifest.external_dbs {
+                let key = (db.path.clone(), db.source_checkpoint_id);
+                match external_db_map.get_mut(&key) {
+                    Some(existing) => {
+                        let existing_ids: HashSet<SsTableId> =
+                            existing.sst_ids.iter().copied().collect();
+                        let new_ids: Vec<SsTableId> = db
+                            .sst_ids
+                            .iter()
+                            .filter(|id| !existing_ids.contains(id))
+                            .copied()
+                            .collect();
+                        existing.sst_ids.extend(new_ids);
                     }
-                }
-                previous_range = Some(range);
-            }
-
-            // Merge the contents of all input manifests
-            let mut core = ManifestCore::new();
-
-            // Deduplicate external_dbs by (path, source_checkpoint_id), merging
-            // sst_ids. Without dedup, repeated projection/union cycles cause
-            // exponential growth of duplicated entries.
-            let mut external_db_map: HashMap<(String, Uuid), ExternalDb> = HashMap::new();
-            for (manifest, _) in &ranges {
-                for db in &manifest.external_dbs {
-                    let key = (db.path.clone(), db.source_checkpoint_id);
-                    match external_db_map.get_mut(&key) {
-                        Some(existing) => {
-                            let existing_ids: HashSet<SsTableId> =
-                                existing.sst_ids.iter().copied().collect();
-                            let new_ids: Vec<SsTableId> = db
-                                .sst_ids
-                                .iter()
-                                .filter(|id| !existing_ids.contains(id))
-                                .copied()
-                                .collect();
-                            existing.sst_ids.extend(new_ids);
-                        }
-                        None => {
-                            // Generate new final_checkpoint_ids — the old ones
-                            // belong to the source databases' clone relationships,
-                            // not to the new database.
-                            external_db_map.insert(
-                                key,
-                                ExternalDb {
-                                    path: db.path.clone(),
-                                    source_checkpoint_id: db.source_checkpoint_id,
-                                    final_checkpoint_id: Some(rand.rng().gen_uuid()),
-                                    sst_ids: db.sst_ids.clone(),
-                                },
-                            );
-                        }
+                    None => {
+                        // Generate new final_checkpoint_ids — the old ones
+                        // belong to the source databases' clone relationships,
+                        // not to the new database.
+                        external_db_map.insert(
+                            key,
+                            ExternalDb {
+                                path: db.path.clone(),
+                                source_checkpoint_id: db.source_checkpoint_id,
+                                final_checkpoint_id: Some(rand.rng().gen_uuid()),
+                                sst_ids: db.sst_ids.clone(),
+                            },
+                        );
                     }
                 }
             }
-            let external_dbs: Vec<ExternalDb> = external_db_map.into_values().collect();
+        }
+        // Add each source database as an external_dbs entry. The owned SST IDs
+        // are the SSTs in the source manifest that are not already tracked by its
+        // own external_dbs (i.e., SSTs physically stored under the source's path).
+        for (manifest, path, source_checkpoint_id, _) in &ranges {
+            let ancestor_sst_ids: HashSet<SsTableId> = manifest
+                .external_dbs
+                .iter()
+                .flat_map(|db| db.sst_ids.iter().copied())
+                .collect();
+            let owned_sst_ids: Vec<SsTableId> = manifest
+                .core
+                .compacted
+                .iter()
+                .flat_map(|sr| sr.ssts.iter().map(|s| s.id))
+                .chain(manifest.core.l0.iter().map(|s| s.id))
+                .filter(|id| !ancestor_sst_ids.contains(id))
+                .collect();
+            let key = ((*path).clone(), **source_checkpoint_id);
+            match external_db_map.get_mut(&key) {
+                Some(existing) => {
+                    let existing_ids: HashSet<SsTableId> =
+                        existing.sst_ids.iter().copied().collect();
+                    let new_ids: Vec<SsTableId> = owned_sst_ids
+                        .into_iter()
+                        .filter(|id| !existing_ids.contains(id))
+                        .collect();
+                    existing.sst_ids.extend(new_ids);
+                }
+                None => {
+                    external_db_map.insert(
+                        key,
+                        ExternalDb {
+                            path: (*path).clone(),
+                            source_checkpoint_id: **source_checkpoint_id,
+                            final_checkpoint_id: Some(rand.rng().gen_uuid()),
+                            sst_ids: owned_sst_ids,
+                        },
+                    );
+                }
+            }
+        }
 
-            // Deduplicate L0 SSTs by ID, merging visible_ranges. Projection
-            // includes the same L0 SST in multiple projected manifests with
-            // different visible_ranges, so duplicates must be combined.
-            let mut l0_by_id: HashMap<SsTableId, SsTableHandle> = HashMap::new();
-            for (manifest, _) in &ranges {
-                for sst in &manifest.core.l0 {
-                    match l0_by_id.get(&sst.id) {
-                        Some(existing) => {
-                            let merged_range = match (&existing.visible_range, &sst.visible_range) {
-                                (Some(a), Some(b)) => Some(a.union(b).unwrap_or_else(|| {
-                                    panic!("L0 SST {:?} has non-contiguous visible_ranges", sst.id)
-                                })),
-                                // If either has no visible_range, the merged result covers everything
-                                _ => None,
-                            };
-                            l0_by_id.insert(
-                                sst.id,
-                                SsTableHandle::new_compacted(
-                                    sst.id,
-                                    sst.info.clone(),
-                                    merged_range,
-                                ),
-                            );
-                        }
-                        None => {
-                            l0_by_id.insert(sst.id, sst.clone());
-                        }
+        let external_dbs: Vec<ExternalDb> = external_db_map.into_values().collect();
+
+        // Deduplicate L0 SSTs by ID, merging visible_ranges. Projection
+        // includes the same L0 SST in multiple projected manifests with
+        // different visible_ranges, so duplicates must be combined.
+        let mut l0_by_id: HashMap<SsTableId, SsTableHandle> = HashMap::new();
+        for (manifest, _, _, _) in &ranges {
+            for sst in &manifest.core.l0 {
+                match l0_by_id.get(&sst.id) {
+                    Some(existing) => {
+                        let merged_range = match (&existing.visible_range, &sst.visible_range) {
+                            (Some(a), Some(b)) => Some(a.union(b).unwrap_or_else(|| {
+                                panic!("L0 SST {:?} has non-contiguous visible_ranges", sst.id)
+                            })),
+                            // If either has no visible_range, the merged result covers everything
+                            _ => None,
+                        };
+                        l0_by_id.insert(
+                            sst.id,
+                            SsTableHandle::new_compacted(sst.id, sst.info.clone(), merged_range),
+                        );
+                    }
+                    None => {
+                        l0_by_id.insert(sst.id, sst.clone());
                     }
                 }
             }
+        }
 
-            // Sort L0 SSTs by ULID descending (newest first) to preserve
-            // temporal ordering for correct point-lookup behavior.
-            let mut l0_list: Vec<SsTableHandle> = l0_by_id.into_values().collect();
-            l0_list.sort_by(|a, b| b.id.unwrap_compacted_id().cmp(&a.id.unwrap_compacted_id()));
-            core.l0 = l0_list.into();
+        // Sort L0 SSTs by ULID descending (newest first) to preserve
+        // temporal ordering for correct point-lookup behavior.
+        let mut l0_list: Vec<SsTableHandle> = l0_by_id.into_values().collect();
+        l0_list.sort_by(|a, b| b.id.unwrap_compacted_id().cmp(&a.id.unwrap_compacted_id()));
+        core.l0 = l0_list.into();
 
-            // Merge sorted runs by tier: sorted runs with the same ID across
-            // input manifests are combined into a single sorted run. We use
-            // the SR ID (not position) to match tiers, since projection can
-            // remove sorted runs and shift positions.
-            let mut merged_by_id: BTreeMap<u32, Vec<SsTableHandle>> = BTreeMap::new();
-            for (manifest, _) in &ranges {
-                for sorted_run in &manifest.core.compacted {
-                    merged_by_id
-                        .entry(sorted_run.id)
-                        .or_default()
-                        .extend(sorted_run.ssts.iter().cloned());
-                }
+        // Merge sorted runs by tier: sorted runs with the same ID across
+        // input manifests are combined into a single sorted run. We use
+        // the SR ID (not position) to match tiers, since projection can
+        // remove sorted runs and shift positions.
+        let mut merged_by_id: BTreeMap<u32, Vec<SsTableHandle>> = BTreeMap::new();
+        for (manifest, _, _, _) in &ranges {
+            for sorted_run in &manifest.core.compacted {
+                merged_by_id
+                    .entry(sorted_run.id)
+                    .or_default()
+                    .extend(sorted_run.ssts.iter().cloned());
             }
+        }
 
-            // Collect sorted runs ordered by ID descending (newest first),
-            // preserving the original IDs.
-            for (id, ssts) in merged_by_id.into_iter().rev() {
-                core.compacted.push(SortedRun { id, ssts });
-            }
+        // Collect sorted runs ordered by ID descending (newest first),
+        // preserving the original IDs.
+        for (id, ssts) in merged_by_id.into_iter().rev() {
+            core.compacted.push(SortedRun { id, ssts });
+        }
 
-            Self {
-                external_dbs,
-                core,
-                writer_epoch: 0,
-                compactor_epoch: 0,
-            }
+        Self {
+            external_dbs,
+            core,
+            writer_epoch: 0,
+            compactor_epoch: 0,
         }
     }
 
@@ -821,11 +856,12 @@ mod tests {
         // ULIDs created with Ulid::new() within the same millisecond have random
         // ordering, which makes test assertions on L0 sort order non-deterministic.
         let mut next_ts: u64 = 1000;
-        let manifests: Vec<Manifest> = test_case
+        let manifests: Vec<(Manifest, String, Uuid)> = test_case
             .manifests
             .iter()
-            .map(|m| {
-                build_manifest(m, |alias| {
+            .enumerate()
+            .map(|(i, m)| {
+                let manifest = build_manifest(m, |alias| {
                     if let Some(sst_id) = sst_ids.get(alias) {
                         *sst_id
                     } else {
@@ -834,7 +870,8 @@ mod tests {
                         sst_ids.insert(alias.to_string(), sst_id);
                         sst_id
                     }
-                })
+                });
+                (manifest, format!("source_{}", i), Uuid::new_v4())
             })
             .collect();
 
@@ -861,10 +898,11 @@ mod tests {
                 sorted_runs: vec![],
             },
         ];
-        let manifests: Vec<Manifest> = manifests
+        let manifests: Vec<(Manifest, String, Uuid)> = manifests
             .iter()
-            .map(|m| {
-                build_manifest(m, |alias| {
+            .enumerate()
+            .map(|(i, m)| {
+                let manifest = build_manifest(m, |alias| {
                     if let Some(sst_id) = sst_ids.get(alias) {
                         *sst_id
                     } else {
@@ -872,7 +910,8 @@ mod tests {
                         sst_ids.insert(alias.to_string(), sst_id);
                         sst_id
                     }
-                })
+                });
+                (manifest, format!("source_{}", i), Uuid::new_v4())
             })
             .collect();
 
@@ -1183,7 +1222,10 @@ mod tests {
             sst_ids: vec![sst_b, sst_c],
         });
 
-        let sources = vec![m1, m2];
+        let sources = vec![
+            (m1, "path1".to_string(), Uuid::new_v4()),
+            (m2, "path2".to_string(), Uuid::new_v4()),
+        ];
 
         let result = Manifest::union(sources, Arc::new(DbRand::default()));
 
@@ -1241,7 +1283,10 @@ mod tests {
 
         let m2 = manifest_with_one_compacted_sst(sst_own2, b"m", BytesRange::from_ref("m"..));
 
-        let sources = vec![m1, m2];
+        let sources = vec![
+            (m1, "path1".to_string(), Uuid::new_v4()),
+            (m2, "path2".to_string(), Uuid::new_v4()),
+        ];
 
         let result = Manifest::union(sources, Arc::new(DbRand::default()));
 
@@ -1260,5 +1305,42 @@ mod tests {
             entry.final_checkpoint_id.is_some(),
             "final_checkpoint_id should not be None"
         );
+    }
+
+    #[test]
+    fn test_union_tracks_sources_as_external_dbs() {
+        let sst1 = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let sst2 = SsTableId::Compacted(Ulid::from_parts(2000, 0));
+
+        let m1 = manifest_with_one_compacted_sst(sst1, b"a", BytesRange::from_ref("a".."m"));
+        let m2 = manifest_with_one_compacted_sst(sst2, b"m", BytesRange::from_ref("m"..));
+
+        let path1 = "source_db_1".to_string();
+        let path2 = "source_db_2".to_string();
+        let cp1 = Uuid::new_v4();
+        let cp2 = Uuid::new_v4();
+
+        let sources = vec![(m1, path1.clone(), cp1), (m2, path2.clone(), cp2)];
+
+        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+
+        // Should have 2 external_dbs entries (one per source)
+        assert_eq!(result.external_dbs.len(), 2);
+
+        let entry1 = result
+            .external_dbs
+            .iter()
+            .find(|db| db.path == path1 && db.source_checkpoint_id == cp1)
+            .expect("Should have external_dbs entry for source 1");
+        assert_eq!(entry1.sst_ids, vec![sst1]);
+        assert!(entry1.final_checkpoint_id.is_some());
+
+        let entry2 = result
+            .external_dbs
+            .iter()
+            .find(|db| db.path == path2 && db.source_checkpoint_id == cp2)
+            .expect("Should have external_dbs entry for source 2");
+        assert_eq!(entry2.sst_ids, vec![sst2]);
+        assert!(entry2.final_checkpoint_id.is_some());
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -177,6 +177,11 @@ impl Manifest {
         // Merge the contents of all input manifests
         let mut core = ManifestCore::new();
 
+        // The resulting manifest is not yet initialized; the caller must
+        // complete setup (e.g. creating final checkpoints) before setting
+        // initialized to true.
+        core.initialized = false;
+
         // Deduplicate external_dbs by (path, source_checkpoint_id), merging
         // sst_ids. Without dedup, repeated projection/union cycles cause
         // exponential growth of duplicated entries.
@@ -1342,5 +1347,30 @@ mod tests {
             .expect("Should have external_dbs entry for source 2");
         assert_eq!(entry2.sst_ids, vec![sst2]);
         assert!(entry2.final_checkpoint_id.is_some());
+    }
+
+    #[test]
+    fn test_union_sets_initialized_false() {
+        let sst1 = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let sst2 = SsTableId::Compacted(Ulid::from_parts(2000, 0));
+
+        let m1 = manifest_with_one_compacted_sst(sst1, b"a", BytesRange::from_ref("a".."m"));
+        let m2 = manifest_with_one_compacted_sst(sst2, b"m", BytesRange::from_ref("m"..));
+
+        // Both manifests start with initialized=true (from ManifestCore::new())
+        assert!(m1.core.initialized);
+        assert!(m2.core.initialized);
+
+        let sources = vec![
+            (m1, "path1".to_string(), Uuid::new_v4()),
+            (m2, "path2".to_string(), Uuid::new_v4()),
+        ];
+
+        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+
+        assert!(
+            !result.core.initialized,
+            "Union result should have initialized=false"
+        );
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -96,6 +96,32 @@ impl Manifest {
         sorter_runs_filtered.retain(|sr| !sr.ssts.is_empty());
         projected.core.compacted = sorter_runs_filtered;
         projected.core.l0 = Self::filter_sst_handles(&projected.core.l0, true, &range).into();
+
+        // Collect all SST IDs that remain after projection
+        let remaining_sst_ids: HashSet<SsTableId> = projected
+            .core
+            .l0
+            .iter()
+            .chain(
+                projected
+                    .core
+                    .compacted
+                    .iter()
+                    .flat_map(|sr| sr.ssts.iter()),
+            )
+            .map(|h| h.id)
+            .collect();
+
+        // Filter external_dbs entries to only include SST IDs still referenced,
+        // and remove entries with no remaining SSTs so their checkpoints can be
+        // released and the external database's SSTs garbage collected.
+        for external_db in &mut projected.external_dbs {
+            external_db
+                .sst_ids
+                .retain(|id| remaining_sst_ids.contains(id));
+        }
+        projected.external_dbs.retain(|db| !db.sst_ids.is_empty());
+
         projected
     }
 
@@ -728,5 +754,114 @@ mod tests {
             Bound::Unbounded => "".to_string(),
         };
         format!("{}..{}", start, end)
+    }
+
+    #[test]
+    fn test_projected_filters_external_dbs() {
+        use super::ExternalDb;
+
+        // Build a manifest with 3 SSTs in a sorted run spanning a..z
+        let sst_in_range = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let sst_out_of_range = SsTableId::Compacted(Ulid::from_parts(1001, 0));
+        let sst_mixed_in = SsTableId::Compacted(Ulid::from_parts(1002, 0));
+        let sst_mixed_out = SsTableId::Compacted(Ulid::from_parts(1003, 0));
+
+        let mut core = ManifestCore::new();
+        core.compacted.push(SortedRun {
+            id: 0,
+            ssts: vec![
+                SsTableHandle::new_compacted(
+                    sst_in_range,
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::from_static(b"d")),
+                        ..SsTableInfo::default()
+                    },
+                    None,
+                ),
+                SsTableHandle::new_compacted(
+                    sst_mixed_in,
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::from_static(b"h")),
+                        ..SsTableInfo::default()
+                    },
+                    None,
+                ),
+                SsTableHandle::new_compacted(
+                    sst_mixed_out,
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::from_static(b"p")),
+                        ..SsTableInfo::default()
+                    },
+                    None,
+                ),
+                SsTableHandle::new_compacted(
+                    sst_out_of_range,
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::from_static(b"u")),
+                        ..SsTableInfo::default()
+                    },
+                    None,
+                ),
+            ],
+        });
+
+        let mut manifest = Manifest::initial(core);
+
+        // ExternalDb fully in range
+        let ext_in_range = ExternalDb {
+            path: "db_in".to_string(),
+            source_checkpoint_id: uuid::Uuid::new_v4(),
+            final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+            sst_ids: vec![sst_in_range],
+        };
+        // ExternalDb fully out of range
+        let ext_out_of_range = ExternalDb {
+            path: "db_out".to_string(),
+            source_checkpoint_id: uuid::Uuid::new_v4(),
+            final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+            sst_ids: vec![sst_out_of_range],
+        };
+        // ExternalDb with mixed SSTs (one in range, one out)
+        let ext_mixed = ExternalDb {
+            path: "db_mixed".to_string(),
+            source_checkpoint_id: uuid::Uuid::new_v4(),
+            final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+            sst_ids: vec![sst_mixed_in, sst_mixed_out],
+        };
+
+        manifest.external_dbs = vec![
+            ext_in_range.clone(),
+            ext_out_of_range.clone(),
+            ext_mixed.clone(),
+        ];
+
+        // Project to range d..p (keeps sst_in_range and sst_mixed_in)
+        let projected = Manifest::projected(&manifest, BytesRange::from_ref("d".."p"));
+
+        // The fully-out-of-range entry should be gone
+        assert!(
+            !projected.external_dbs.iter().any(|db| db.path == "db_out"),
+            "ExternalDb with all SSTs out of range should be removed"
+        );
+
+        // The fully-in-range entry should be unchanged
+        let in_range_entry = projected
+            .external_dbs
+            .iter()
+            .find(|db| db.path == "db_in")
+            .expect("ExternalDb fully in range should be present");
+        assert_eq!(in_range_entry.sst_ids, vec![sst_in_range]);
+
+        // The mixed entry should only retain the in-range SST
+        let mixed_entry = projected
+            .external_dbs
+            .iter()
+            .find(|db| db.path == "db_mixed")
+            .expect("ExternalDb with some in-range SSTs should be present");
+        assert_eq!(mixed_entry.sst_ids, vec![sst_mixed_in]);
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -5,6 +5,7 @@ use std::ops::Bound;
 use std::sync::Arc;
 
 use crate::bytes_range::BytesRange;
+use crate::error::SlateDBError;
 use crate::rand::DbRand;
 use crate::utils::IdGenerator;
 use bytes::Bytes;
@@ -151,7 +152,10 @@ impl Manifest {
     }
 
     #[allow(unused)]
-    pub(crate) fn union(sources: Vec<(Manifest, String, Uuid)>, rand: Arc<DbRand>) -> Manifest {
+    pub(crate) fn union(
+        sources: Vec<(Manifest, String, Uuid)>,
+        rand: Arc<DbRand>,
+    ) -> Result<Manifest, SlateDBError> {
         let mut ranges = vec![];
         for (manifest, path, source_checkpoint_id) in &sources {
             let range = manifest.range();
@@ -168,7 +172,7 @@ impl Manifest {
         for (_, _, _, range) in ranges.iter() {
             if let Some(previous_range) = previous_range {
                 if range.intersect(previous_range).is_some() {
-                    unreachable!("overlapping ranges found");
+                    return Err(SlateDBError::InvalidDBState);
                 }
             }
             previous_range = Some(range);
@@ -280,9 +284,9 @@ impl Manifest {
                 match l0_by_id.get(&sst.id) {
                     Some(existing) => {
                         let merged_range = match (&existing.visible_range, &sst.visible_range) {
-                            (Some(a), Some(b)) => Some(a.union(b).unwrap_or_else(|| {
-                                panic!("L0 SST {:?} has non-contiguous visible_ranges", sst.id)
-                            })),
+                            (Some(a), Some(b)) => {
+                                Some(a.union(b).ok_or(SlateDBError::InvalidDBState)?)
+                            }
                             // If either has no visible_range, the merged result covers everything
                             _ => None,
                         };
@@ -301,6 +305,11 @@ impl Manifest {
         // Sort L0 SSTs by ULID descending (newest first) to preserve
         // temporal ordering for correct point-lookup behavior.
         let mut l0_list: Vec<SsTableHandle> = l0_by_id.into_values().collect();
+        for sst in &l0_list {
+            if matches!(sst.id, SsTableId::Wal(_)) {
+                return Err(SlateDBError::InvalidDBState);
+            }
+        }
         l0_list.sort_by(|a, b| b.id.unwrap_compacted_id().cmp(&a.id.unwrap_compacted_id()));
         core.l0 = l0_list.into();
 
@@ -324,12 +333,12 @@ impl Manifest {
             core.compacted.push(SortedRun { id, ssts });
         }
 
-        Self {
+        Ok(Self {
             external_dbs,
             core,
             writer_epoch: 0,
             compactor_epoch: 0,
-        }
+        })
     }
 
     fn range(&self) -> Option<BytesRange> {
@@ -394,6 +403,7 @@ mod tests {
     use super::Manifest;
     use crate::config::CheckpointOptions;
     use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::error::SlateDBError;
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::rand::DbRand;
     use bytes::Bytes;
@@ -891,13 +901,12 @@ mod tests {
         let expected_manifest =
             build_manifest(&test_case.expected, |alias| *sst_ids.get(alias).unwrap());
 
-        let union = Manifest::union(manifests, Arc::new(DbRand::default()));
+        let union = Manifest::union(manifests, Arc::new(DbRand::default())).unwrap();
 
         assert_manifest_equal(&union, &expected_manifest, &sst_ids);
     }
 
     #[test]
-    #[should_panic(expected = "non-contiguous visible_ranges")]
     fn test_union_fails_on_non_contiguous_l0_ranges() {
         let mut sst_ids: HashMap<String, SsTableId> = HashMap::new();
         let manifests = vec![
@@ -928,7 +937,10 @@ mod tests {
             })
             .collect();
 
-        Manifest::union(manifests, Arc::new(DbRand::default()));
+        assert!(matches!(
+            Manifest::union(manifests, Arc::new(DbRand::default())),
+            Err(SlateDBError::InvalidDBState)
+        ));
     }
 
     fn build_manifest<F>(manifest: &SimpleManifest, mut sst_id_fn: F) -> Manifest
@@ -1240,7 +1252,7 @@ mod tests {
             (m2, "path2".to_string(), Uuid::new_v4()),
         ];
 
-        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+        let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
 
         // Find the entry for the shared ancestor
         let shared_entries: Vec<_> = result
@@ -1301,7 +1313,7 @@ mod tests {
             (m2, "path2".to_string(), Uuid::new_v4()),
         ];
 
-        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+        let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
 
         let entry = result
             .external_dbs
@@ -1335,7 +1347,7 @@ mod tests {
 
         let sources = vec![(m1, path1.clone(), cp1), (m2, path2.clone(), cp2)];
 
-        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+        let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
 
         // Should have 2 external_dbs entries (one per source)
         assert_eq!(result.external_dbs.len(), 2);
@@ -1374,7 +1386,7 @@ mod tests {
             (m2, "path2".to_string(), Uuid::new_v4()),
         ];
 
-        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+        let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
 
         assert!(
             !result.core.initialized,
@@ -1398,7 +1410,7 @@ mod tests {
             (m2, "path2".to_string(), Uuid::new_v4()),
         ];
 
-        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+        let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
 
         assert_eq!(
             result.core.last_l0_seq, 100,

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -93,8 +93,9 @@ impl Manifest {
                 ssts: Self::filter_sst_handles(&sorter_run.ssts, false, &range),
             });
         }
-        projected.core.l0 = Self::filter_sst_handles(&projected.core.l0, true, &range).into();
+        sorter_runs_filtered.retain(|sr| !sr.ssts.is_empty());
         projected.core.compacted = sorter_runs_filtered;
+        projected.core.l0 = Self::filter_sst_handles(&projected.core.l0, true, &range).into();
         projected
     }
 
@@ -359,9 +360,24 @@ mod tests {
         }
     }
 
+    struct SimpleSortedRun {
+        id: Option<u32>,
+        ssts: Vec<SstEntry>,
+    }
+
+    impl SimpleSortedRun {
+        fn new(ssts: Vec<SstEntry>) -> Self {
+            Self { id: None, ssts }
+        }
+
+        fn with_id(id: u32, ssts: Vec<SstEntry>) -> Self {
+            Self { id: Some(id), ssts }
+        }
+    }
+
     struct SimpleManifest {
         l0: Vec<SstEntry>,
-        sorted_runs: Vec<Vec<SstEntry>>,
+        sorted_runs: Vec<SimpleSortedRun>,
     }
 
     struct ProjectionTestCase {
@@ -380,14 +396,14 @@ mod tests {
                 SstEntry::regular("third", "m"),
             ],
             sorted_runs: vec![
-                vec![
+                SimpleSortedRun::new(vec![
                     SstEntry::regular("sr0_first", "a"),
-                ],
-                vec![
+                ]),
+                SimpleSortedRun::new(vec![
                     SstEntry::regular("sr1_first", "a"),
                     SstEntry::regular("sr1_second", "f"),
                     SstEntry::regular("sr1_third", "m"),
-                ],
+                ]),
             ],
         },
         expected_manifest: SimpleManifest {
@@ -397,15 +413,15 @@ mod tests {
                 SstEntry::projected("third", "m", "m".."o"),
             ],
             sorted_runs: vec![
-                vec![
+                SimpleSortedRun::new(vec![
                     // We can't filter this one out, because we don't know the
                     // end key, so it might still fall within the range
                     SstEntry::projected("sr0_first", "a", "h".."o"),
-                ],
-                vec![
+                ]),
+                SimpleSortedRun::new(vec![
                     SstEntry::projected("sr1_second", "f", "h".."m"),
                     SstEntry::projected("sr1_third", "m", "m".."o"),
-                ],
+                ]),
             ],
         },
     })]
@@ -425,6 +441,35 @@ mod tests {
                 SstEntry::projected("bar", "k", "n".."p"),
             ],
             sorted_runs: vec![],
+        },
+    })]
+    #[case::empty_sorted_run_removed(ProjectionTestCase {
+        visible_range: "m".."z",
+        existing_manifest: SimpleManifest {
+            l0: vec![],
+            sorted_runs: vec![
+                // This sorted run has keys entirely before the projection range
+                SimpleSortedRun::new(vec![
+                    SstEntry::projected("sr0_first", "a", "a".."d"),
+                    SstEntry::projected("sr0_second", "d", "d".."g"),
+                    SstEntry::projected("sr0_third", "g", "g".."k"),
+                ]),
+                // This sorted run spans the projection range
+                SimpleSortedRun::new(vec![
+                    SstEntry::regular("sr1_first", "a"),
+                    SstEntry::regular("sr1_second", "m"),
+                ]),
+            ],
+        },
+        expected_manifest: SimpleManifest {
+            l0: vec![],
+            sorted_runs: vec![
+                // sr0 is removed entirely because all SSTs end before "m"
+                // sr1 retains sr1_second (preserves original ID 1)
+                SimpleSortedRun::with_id(1, vec![
+                    SstEntry::projected("sr1_second", "m", "m".."z"),
+                ]),
+            ],
         },
     })]
     fn test_projected(#[case] test_case: ProjectionTestCase) {
@@ -566,8 +611,9 @@ mod tests {
         }
         for (idx, sorted_run) in manifest.sorted_runs.iter().enumerate() {
             core.compacted.push(SortedRun {
-                id: idx as u32,
+                id: sorted_run.id.unwrap_or(idx as u32),
                 ssts: sorted_run
+                    .ssts
                     .iter()
                     .map(|entry| {
                         SsTableHandle::new_compacted(

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -1,5 +1,5 @@
 use std::cmp::{max, min};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::ops::Bound;
 use std::sync::Arc;
@@ -177,21 +177,35 @@ impl Manifest {
                 previous_range = Some(range);
             }
 
-            // Now we can zip the manifests together
+            // Merge the contents of all input manifests
             let mut external_dbs = vec![];
             let mut core = ManifestCore::new();
 
-            for (manifest, _) in ranges {
-                // First, we need to add all the external dbs
+            for (manifest, _) in &ranges {
                 external_dbs.extend_from_slice(&manifest.external_dbs);
-                // Then, we can add all the l0 ssts
                 for sst in &manifest.core.l0 {
                     core.l0.push_back(sst.clone());
                 }
-                // Finally, we can add all the sorted runs
+            }
+
+            // Merge sorted runs by tier: sorted runs with the same ID across
+            // input manifests are combined into a single sorted run. We use
+            // the SR ID (not position) to match tiers, since projection can
+            // remove sorted runs and shift positions.
+            let mut merged_by_id: BTreeMap<u32, Vec<SsTableHandle>> = BTreeMap::new();
+            for (manifest, _) in &ranges {
                 for sorted_run in &manifest.core.compacted {
-                    core.compacted.push(sorted_run.clone());
+                    merged_by_id
+                        .entry(sorted_run.id)
+                        .or_default()
+                        .extend(sorted_run.ssts.iter().cloned());
                 }
+            }
+
+            // Collect sorted runs ordered by ID descending (newest first),
+            // preserving the original IDs.
+            for (id, ssts) in merged_by_id.into_iter().rev() {
+                core.compacted.push(SortedRun { id, ssts });
             }
 
             Self {
@@ -596,6 +610,147 @@ mod tests {
                 SstEntry::projected("baz", "j", "o"..)
             ],
             sorted_runs: vec![]
+        },
+    })]
+    #[case::sorted_runs_merged_by_tier(UnionTestCase {
+        manifests: vec![
+            SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    // Newest tier has highest ID (compactor convention)
+                    SimpleSortedRun::with_id(2, vec![
+                        SstEntry::projected("sr0_a", "a", "a".."m"),
+                        SstEntry::projected("sr0_b", "d", "a".."m"),
+                    ]),
+                    SimpleSortedRun::with_id(1, vec![
+                        SstEntry::projected("sr1_a", "b", "a".."m"),
+                    ]),
+                ],
+            },
+            SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    SimpleSortedRun::with_id(2, vec![
+                        SstEntry::projected("sr0_c", "m", "m"..),
+                    ]),
+                    SimpleSortedRun::with_id(1, vec![
+                        SstEntry::projected("sr1_b", "n", "m"..),
+                        SstEntry::projected("sr1_c", "p", "m"..),
+                    ]),
+                ],
+            },
+        ],
+        expected: SimpleManifest {
+            l0: vec![],
+            sorted_runs: vec![
+                // Tier with original ID 2: merged
+                SimpleSortedRun::with_id(2, vec![
+                    SstEntry::projected("sr0_a", "a", "a".."m"),
+                    SstEntry::projected("sr0_b", "d", "a".."m"),
+                    SstEntry::projected("sr0_c", "m", "m"..),
+                ]),
+                // Tier with original ID 1: merged
+                SimpleSortedRun::with_id(1, vec![
+                    SstEntry::projected("sr1_a", "b", "a".."m"),
+                    SstEntry::projected("sr1_b", "n", "m"..),
+                    SstEntry::projected("sr1_c", "p", "m"..),
+                ]),
+            ],
+        },
+    })]
+    #[case::sorted_runs_uneven_tiers(UnionTestCase {
+        manifests: vec![
+            SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    SimpleSortedRun::with_id(3, vec![
+                        SstEntry::projected("sr0_a", "a", "a".."m"),
+                    ]),
+                    SimpleSortedRun::with_id(2, vec![
+                        SstEntry::projected("sr1_a", "c", "a".."m"),
+                    ]),
+                    SimpleSortedRun::with_id(1, vec![
+                        SstEntry::projected("sr2_a", "e", "a".."m"),
+                    ]),
+                ],
+            },
+            SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    // Only has the newest tier (ID 3)
+                    SimpleSortedRun::with_id(3, vec![
+                        SstEntry::projected("sr0_b", "m", "m"..),
+                    ]),
+                ],
+            },
+        ],
+        expected: SimpleManifest {
+            l0: vec![],
+            sorted_runs: vec![
+                SimpleSortedRun::with_id(3, vec![
+                    SstEntry::projected("sr0_a", "a", "a".."m"),
+                    SstEntry::projected("sr0_b", "m", "m"..),
+                ]),
+                SimpleSortedRun::with_id(2, vec![
+                    SstEntry::projected("sr1_a", "c", "a".."m"),
+                ]),
+                SimpleSortedRun::with_id(1, vec![
+                    SstEntry::projected("sr2_a", "e", "a".."m"),
+                ]),
+            ],
+        },
+    })]
+    #[case::sorted_runs_matched_by_id(UnionTestCase {
+        // Simulates union after projection where some sorted runs were
+        // removed from one manifest but not the other, shifting positions.
+        manifests: vec![
+            SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    // Has SR IDs 2, 1, 0 (3 tiers)
+                    SimpleSortedRun::with_id(2, vec![
+                        SstEntry::projected("sr2_a", "a", "a".."m"),
+                    ]),
+                    SimpleSortedRun::with_id(1, vec![
+                        SstEntry::projected("sr1_a", "c", "a".."m"),
+                    ]),
+                    SimpleSortedRun::with_id(0, vec![
+                        SstEntry::projected("sr0_a", "e", "a".."m"),
+                    ]),
+                ],
+            },
+            SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    // Has SR IDs 2, 0 only (SR 1 was removed by projection)
+                    // Position 0 here is SR ID 2, position 1 is SR ID 0
+                    SimpleSortedRun::with_id(2, vec![
+                        SstEntry::projected("sr2_b", "m", "m"..),
+                    ]),
+                    SimpleSortedRun::with_id(0, vec![
+                        SstEntry::projected("sr0_b", "o", "m"..),
+                    ]),
+                ],
+            },
+        ],
+        expected: SimpleManifest {
+            l0: vec![],
+            sorted_runs: vec![
+                // SR 2: merged from both, original ID preserved
+                SimpleSortedRun::with_id(2, vec![
+                    SstEntry::projected("sr2_a", "a", "a".."m"),
+                    SstEntry::projected("sr2_b", "m", "m"..),
+                ]),
+                // SR 1: only from first manifest, original ID preserved
+                SimpleSortedRun::with_id(1, vec![
+                    SstEntry::projected("sr1_a", "c", "a".."m"),
+                ]),
+                // SR 0: merged from both, original ID preserved
+                SimpleSortedRun::with_id(0, vec![
+                    SstEntry::projected("sr0_a", "e", "a".."m"),
+                    SstEntry::projected("sr0_b", "o", "m"..),
+                ]),
+            ],
         },
     })]
     fn test_union(#[case] test_case: UnionTestCase) {

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -182,6 +182,14 @@ impl Manifest {
         // initialized to true.
         core.initialized = false;
 
+        // Set last_l0_seq to the max across all sources so that new writes
+        // receive sequence numbers higher than any existing data.
+        core.last_l0_seq = ranges
+            .iter()
+            .map(|(m, _, _, _)| m.core.last_l0_seq)
+            .max()
+            .unwrap_or(0);
+
         // Deduplicate external_dbs by (path, source_checkpoint_id), merging
         // sst_ids. Without dedup, repeated projection/union cycles cause
         // exponential growth of duplicated entries.
@@ -1371,6 +1379,30 @@ mod tests {
         assert!(
             !result.core.initialized,
             "Union result should have initialized=false"
+        );
+    }
+
+    #[test]
+    fn test_union_computes_last_l0_seq() {
+        let sst1 = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let sst2 = SsTableId::Compacted(Ulid::from_parts(2000, 0));
+
+        let mut m1 = manifest_with_one_compacted_sst(sst1, b"a", BytesRange::from_ref("a".."m"));
+        m1.core.last_l0_seq = 42;
+
+        let mut m2 = manifest_with_one_compacted_sst(sst2, b"m", BytesRange::from_ref("m"..));
+        m2.core.last_l0_seq = 100;
+
+        let sources = vec![
+            (m1, "path1".to_string(), Uuid::new_v4()),
+            (m2, "path2".to_string(), Uuid::new_v4()),
+        ];
+
+        let result = Manifest::union(sources, Arc::new(DbRand::default()));
+
+        assert_eq!(
+            result.core.last_l0_seq, 100,
+            "last_l0_seq should be the max across all sources"
         );
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -292,7 +292,12 @@ impl Manifest {
                         };
                         l0_by_id.insert(
                             sst.id,
-                            SsTableHandle::new_compacted(sst.id, sst.info.clone(), merged_range),
+                            SsTableHandle::new_compacted(
+                                sst.id,
+                                crate::format::sst::SST_FORMAT_VERSION_LATEST,
+                                sst.info.clone(),
+                                merged_range,
+                            ),
                         );
                     }
                     None => {
@@ -879,7 +884,7 @@ mod tests {
         // ULIDs created with Ulid::new() within the same millisecond have random
         // ordering, which makes test assertions on L0 sort order non-deterministic.
         let mut next_ts: u64 = 1000;
-        let manifests: Vec<(Manifest, String, Uuid)> = test_case
+        let manifests: Vec<(Manifest, String, uuid::Uuid)> = test_case
             .manifests
             .iter()
             .enumerate()
@@ -894,7 +899,7 @@ mod tests {
                         sst_id
                     }
                 });
-                (manifest, format!("source_{}", i), Uuid::new_v4())
+                (manifest, format!("source_{}", i), uuid::Uuid::new_v4())
             })
             .collect();
 
@@ -920,7 +925,7 @@ mod tests {
                 sorted_runs: vec![],
             },
         ];
-        let manifests: Vec<(Manifest, String, Uuid)> = manifests
+        let manifests: Vec<(Manifest, String, uuid::Uuid)> = manifests
             .iter()
             .enumerate()
             .map(|(i, m)| {
@@ -933,7 +938,7 @@ mod tests {
                         sst_id
                     }
                 });
-                (manifest, format!("source_{}", i), Uuid::new_v4())
+                (manifest, format!("source_{}", i), uuid::Uuid::new_v4())
             })
             .collect();
 
@@ -1203,6 +1208,7 @@ mod tests {
             id: 0,
             ssts: vec![SsTableHandle::new_compacted(
                 sst_id,
+                SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::from_static(first_entry)),
                     ..SsTableInfo::default()
@@ -1219,8 +1225,8 @@ mod tests {
         use std::collections::HashSet;
 
         let shared_path = "shared_ancestor".to_string();
-        let shared_source_cp = Uuid::new_v4();
-        let original_final_cp = Uuid::new_v4();
+        let shared_source_cp = uuid::Uuid::new_v4();
+        let original_final_cp = uuid::Uuid::new_v4();
 
         let sst_a = SsTableId::Compacted(Ulid::from_parts(1000, 0));
         let sst_b = SsTableId::Compacted(Ulid::from_parts(1001, 0));
@@ -1248,8 +1254,8 @@ mod tests {
         });
 
         let sources = vec![
-            (m1, "path1".to_string(), Uuid::new_v4()),
-            (m2, "path2".to_string(), Uuid::new_v4()),
+            (m1, "path1".to_string(), uuid::Uuid::new_v4()),
+            (m2, "path2".to_string(), uuid::Uuid::new_v4()),
         ];
 
         let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
@@ -1287,9 +1293,9 @@ mod tests {
     fn test_union_regenerates_checkpoint_id_for_unique_external_db() {
         use super::ExternalDb;
 
-        let original_final_cp = Uuid::new_v4();
+        let original_final_cp = uuid::Uuid::new_v4();
         let ancestor_path = "ancestor".to_string();
-        let ancestor_source_cp = Uuid::new_v4();
+        let ancestor_source_cp = uuid::Uuid::new_v4();
 
         let sst_own1 = SsTableId::Compacted(Ulid::from_parts(1000, 0));
         let sst_own2 = SsTableId::Compacted(Ulid::from_parts(2000, 0));
@@ -1309,8 +1315,8 @@ mod tests {
         let m2 = manifest_with_one_compacted_sst(sst_own2, b"m", BytesRange::from_ref("m"..));
 
         let sources = vec![
-            (m1, "path1".to_string(), Uuid::new_v4()),
-            (m2, "path2".to_string(), Uuid::new_v4()),
+            (m1, "path1".to_string(), uuid::Uuid::new_v4()),
+            (m2, "path2".to_string(), uuid::Uuid::new_v4()),
         ];
 
         let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
@@ -1342,8 +1348,8 @@ mod tests {
 
         let path1 = "source_db_1".to_string();
         let path2 = "source_db_2".to_string();
-        let cp1 = Uuid::new_v4();
-        let cp2 = Uuid::new_v4();
+        let cp1 = uuid::Uuid::new_v4();
+        let cp2 = uuid::Uuid::new_v4();
 
         let sources = vec![(m1, path1.clone(), cp1), (m2, path2.clone(), cp2)];
 
@@ -1382,8 +1388,8 @@ mod tests {
         assert!(m2.core.initialized);
 
         let sources = vec![
-            (m1, "path1".to_string(), Uuid::new_v4()),
-            (m2, "path2".to_string(), Uuid::new_v4()),
+            (m1, "path1".to_string(), uuid::Uuid::new_v4()),
+            (m2, "path2".to_string(), uuid::Uuid::new_v4()),
         ];
 
         let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();
@@ -1406,8 +1412,8 @@ mod tests {
         m2.core.last_l0_seq = 100;
 
         let sources = vec![
-            (m1, "path1".to_string(), Uuid::new_v4()),
-            (m2, "path2".to_string(), Uuid::new_v4()),
+            (m1, "path1".to_string(), uuid::Uuid::new_v4()),
+            (m2, "path2".to_string(), uuid::Uuid::new_v4()),
         ];
 
         let result = Manifest::union(sources, Arc::new(DbRand::default())).unwrap();

--- a/specs/manifest/ManifestProjectUnion.fizz
+++ b/specs/manifest/ManifestProjectUnion.fizz
@@ -1,0 +1,292 @@
+---
+options:
+    max_actions: 5
+---
+
+NOT_FOUND = "notfound"
+
+# Small integer key space for tractable state exploration.
+VALUES = ["v0", "v1", NOT_FOUND]
+
+MIN_KEY = 0 # inclusive
+MAX_KEY = 3 # inclusive
+
+MIN_PARALLELISM = 1 # inclusive
+MAX_PARALLELISM = 3 # inclusive
+
+KEY_SPACE = range(MIN_KEY, MAX_KEY + 1) # [inclusive, exclusive)
+
+# --- Range helpers (def for global visibility) ---
+
+def key_in_ranges(k, visible_ranges):
+    if visible_ranges == None:
+        return True
+    elif visible_ranges == []:
+        return False
+    else:
+        for vr in visible_ranges:
+            if vr[0] <= k and k < vr[1]:
+                return True
+    return False
+
+def intersect_ranges(ranges, r):
+    if ranges == None or len(ranges) == 0:
+        return [r]
+    if r == None:
+        return ranges
+    intersection = []
+    for a in ranges:
+        lo = max(a[0], r[0])
+        hi = min(a[1], r[1])
+        if lo < hi:
+            intersection.append((lo, hi))
+    return intersection
+
+def union_ranges(a, b):
+    if a == None or b == None:
+        return None
+    union = a + b
+    # union.sort()
+    # todo: merge ranges
+    return union
+    # elif a[1] == b[0] or b[1] == a[0]:
+        # return (min(a[0], b[0]), max(a[1], b[1]))
+    # else:
+        # print("failure: gap in ranges")
+        # return None
+
+def do_project_l0(l0, proj_range):
+    new_l0 = []
+    for handle in l0:
+        vrs = intersect_ranges(handle.get("visible_ranges"), proj_range)
+        if vrs != None:
+            new_l0.append({"id": handle["id"], "visible_ranges": vrs})
+    return new_l0
+
+def do_project_compacted(compacted, proj_range):
+    new_compacted = []
+    for sr in compacted:
+        new_ssts = []
+        for handle in sr["ssts"]:
+            vrs = intersect_ranges(handle.get("visible_ranges"), proj_range)
+            if vrs != None:
+                new_ssts.append({"id": handle["id"], "visible_ranges": vrs})
+        if len(new_ssts) > 0:
+            new_compacted.append({"id": sr["id"], "ssts": new_ssts})
+    return new_compacted
+
+def do_union_l0(manifests):
+    l0_by_id = {}
+    for m in manifests:
+        for handle in m["l0"]:
+            sid = handle["id"]
+            if sid in l0_by_id:
+                merged_vrs = union_ranges(
+                    l0_by_id[sid].get("visible_ranges"), 
+                    handle.get("visible_ranges"),
+                )
+                l0_by_id[sid] = {"id": sid, "visible_ranges": merged_vrs}
+            else:
+                l0_by_id[sid] = dict(handle)
+    # todo: sort l0 correctly
+    return [l0_by_id[i] for i in sorted(l0_by_id.keys(), reverse=True)]
+
+def do_union_compacted(manifests):
+    sr_by_id = {}
+    for m in manifests:
+        for sr in m["compacted"]:
+            sr_id = sr["id"] 
+            ssts = sr["ssts"]
+            if sr_id in sr_by_id:
+                sr_by_id[sr_id]["ssts"].extend(ssts)
+            else:
+                sr_by_id[sr_id] = {"id": sr_id, "ssts": list(ssts)}
+    return [sr_by_id[i] for i in sorted(sr_by_id.keys(), reverse=True)]
+
+def do_union_last_l0_seq(manifests):
+    return max([m["last_l0_seq"] for m in manifests])
+
+def do_union_last_sr_id(manifests):
+    max_id = -1
+    for m in manifests:
+        for sr in m["compacted"]:
+            max_id = max(sr["id"], max_id)
+    return max_id
+
+def do_compact_l0s(l0_handles, store_objects):
+    merged = {}
+    for handle in reversed(l0_handles):
+        content = store_objects.get(handle["id"])
+        for k in content:
+            if key_in_ranges(k, handle.get("visible_ranges")):
+                merged[k] = content[k]
+    return merged
+
+# evenly distribute the given key space across the given number of partitions
+def do_compute_ranges(parallelism, start_key, end_key):
+    ranges = []
+    range_size = int(math.round((end_key - start_key) / parallelism))
+    prev_end = 0
+    for p in range(parallelism):
+        if p == parallelism - 1:
+            range_end = end_key
+        else:
+            range_end = prev_end + range_size
+        ranges.append([prev_end, range_end])
+        prev_end = range_end
+    return ranges
+    
+
+# --- Object Store ---
+
+role ObjectStore:
+    action Init:
+        self.objects = {}
+
+    atomic func Write(name, content):
+        self.objects[name] = content
+
+    atomic func Read(name):
+        return self.objects.get(name)
+
+
+# --- Database ---
+
+Status = enum('INIT', 'GC')
+
+role Db:
+    action Init:
+        # L0 SST handles (newest first).
+        # Each handle: {"id": int, "visible_ranges": tuple or None}
+        self.l0 = []
+        # Sorted runs (newest first).
+        # Each: {"id": int, "ssts": [handle]}
+        self.compacted = []
+        self.last_l0_seq = -1
+        self.last_sst_id = -1
+        self.last_sr_id = -1
+        self.visible_ranges = [[MIN_KEY, MAX_KEY + 1]]
+        self.status = Status.INIT
+
+    atomic action Put: # todo: customize number of entries per sst
+        require self.status == Status.INIT
+        k1 = any KEY_SPACE : key_in_ranges(k1, self.visible_ranges)
+        # k2 = any KEY_SPACE : k1 != k2 and k1 >= self.visible_ranges[0] and k1 < self.visible_ranges[1]
+        v1 = any VALUES
+        # v2 = any VALUES : v1 != v2
+        self.last_l0_seq += 1
+        # sst_id = self.with_db_id_prepended(self.last_l0_seq)
+        sst_id = str(self.ID) + ":" + str(self.last_l0_seq)
+        store.Write(sst_id, {k1: v1})
+        # store.Write(sst_id, {k1: v1, k2: v2})
+        self.l0.insert(0, {"id": sst_id, "visible_ranges": None})
+        _written[k1] = v1
+        # _written[k2] = v2
+
+    fair action Compact:
+        require self.status == Status.INIT
+        require len(self.l0) >= 1
+        atomic:
+            # Merge all L0 SSTs into one sorted run, respecting visible_ranges.
+            # Iterate oldest-first so newer values overwrite older ones.
+            merged = do_compact_l0s(self.l0, store.objects)
+            self.last_sst_id += 1
+            sst_id = self.with_db_id_prepended(self.last_sst_id)
+            store.Write(sst_id, merged)
+            self.last_sr_id += 1
+            sr_id = self.last_sr_id
+            self.compacted.insert(0, {
+                "id": sr_id,
+                "ssts": [{"id": sst_id, "visible_ranges": self.visible_ranges}],
+            })
+            self.l0 = []
+
+    atomic func get(k):
+        # require self.status == Status.INIT
+        # Search L0 (newest first)
+        for handle in self.l0:
+            if key_in_ranges(k, handle.get("visible_ranges")):
+                content = store.Read(handle["id"])
+                if content.get(k) != None:
+                    return content[k]
+        # Search sorted runs (newest first)
+        for sr in self.compacted:
+            for handle in sr["ssts"]:
+                if key_in_ranges(k, handle.get("visible_ranges")):
+                    content = store.Read(handle["id"])
+                    if content.get(k) != None:
+                        return content[k]
+        return NOT_FOUND
+
+    atomic func with_db_id_prepended(name):
+        return str(self.ID) + ":" + str(name)
+
+    atomic func destroy():
+        self.status = Status.GC
+
+# --- Top-level ---
+
+action Init:
+    store = ObjectStore()
+    _written = {} # for read assertions
+    _databases = []
+    _last_db_created = 0
+    _databases.append(Db(ID=_last_db_created))
+
+atomic action Rescale:
+    parallelism = any range(MIN_PARALLELISM, MAX_PARALLELISM + 1) : parallelism != len(_databases)
+    key_ranges = do_compute_ranges(parallelism, MIN_KEY, MAX_KEY + 1)
+    new_manifests = []
+    for key_range in key_ranges:
+        manifests = []
+        for db in _databases:
+            manifests.append({
+                "l0": do_project_l0(db.l0, key_range),
+                "compacted": do_project_compacted(db.compacted, key_range),
+                "last_l0_seq": db.last_l0_seq,
+            })
+        _last_db_created = _last_db_created + 1
+        # WARN: don't move this to def; otherwise actions aren't scheduled for the dynamic role
+        new_db = Db(ID = _last_db_created) 
+        new_db.l0 = do_union_l0(manifests)
+        new_db.compacted = do_union_compacted(manifests)
+        new_db.last_l0_seq = do_union_last_l0_seq(manifests)
+        new_db.last_sr_id = do_union_last_sr_id(manifests)
+        new_db.visible_ranges = [key_range]
+        new_manifests.append(new_db)
+
+    for db in _databases:
+        db.destroy()
+
+    _databases = new_manifests
+
+# --- Assertions ---
+
+always assertion ReadConsistency:
+    for k in KEY_SPACE:
+        expected = _written.get(k, NOT_FOUND)
+        actual = NOT_FOUND
+        for db in _databases:
+            candidate = db.get(k)
+            if candidate != NOT_FOUND:
+                if actual == NOT_FOUND:
+                    actual = candidate
+                else:
+                    return False
+        if actual != expected:
+            return False
+    return True
+
+always assertion L0Ordered:
+    for db in _databases:
+        for i in range(len(db.l0) - 1):
+            if db.l0[i]["id"] <= db.l0[i + 1]["id"]:
+                return False
+        return True
+
+always assertion CompactedOrdered:
+    for db in _databases:
+        for i in range(len(db.compacted) - 1):
+            if db.compacted[i]["id"] <= db.compacted[i + 1]["id"]:
+                return False
+        return True

--- a/specs/manifest/run.log
+++ b/specs/manifest/run.log
@@ -1,0 +1,72 @@
+fizz specs/manifest/ManifestProjectUnion.fizz
+
+Model checking specs/manifest/ManifestProjectUnion.json
+configFileName: specs/manifest/fizz.yaml
+fizz.yaml not found. Using default options
+StateSpaceOptions: options:{max_actions:5  max_concurrent_actions:2}
+Nodes: 20000, queued: 64847, elapsed: 15.923865375s
+Nodes: 40000, queued: 124759, elapsed: 32.570811959s
+Nodes: 80000, queued: 241785, elapsed: 1m5.481299167s
+Nodes: 120000, queued: 252720, elapsed: 1m38.048305084s
+Nodes: 140000, queued: 250574, elapsed: 1m54.876441s
+Nodes: 180000, queued: 245976, elapsed: 2m27.265887334s
+Nodes: 200000, queued: 242627, elapsed: 2m44.83595225s
+Nodes: 220000, queued: 239374, elapsed: 3m2.415618375s
+Nodes: 240000, queued: 235969, elapsed: 3m19.760548209s
+Nodes: 260000, queued: 234552, elapsed: 3m37.300952584s
+Nodes: 280000, queued: 233970, elapsed: 3m54.892749084s
+Nodes: 320000, queued: 232492, elapsed: 4m29.048749125s
+Nodes: 360000, queued: 233349, elapsed: 5m3.927329625s
+Nodes: 380000, queued: 231624, elapsed: 5m21.929696167s
+Nodes: 420000, queued: 229445, elapsed: 5m56.592918167s
+Nodes: 440000, queued: 230224, elapsed: 6m14.3062925s
+Nodes: 460000, queued: 230192, elapsed: 6m32.598392542s
+Nodes: 480000, queued: 228266, elapsed: 6m50.205122042s
+Nodes: 500000, queued: 227078, elapsed: 7m7.567698125s
+Nodes: 540000, queued: 227267, elapsed: 7m41.592293s
+Nodes: 560000, queued: 226966, elapsed: 8m0.7685005s
+Nodes: 580000, queued: 226306, elapsed: 8m18.701811584s
+Nodes: 600000, queued: 225474, elapsed: 8m37.157333667s
+Nodes: 620000, queued: 224649, elapsed: 8m57.457867084s
+Nodes: 640000, queued: 226082, elapsed: 9m24.318331834s
+Nodes: 660000, queued: 225705, elapsed: 9m50.089379084s
+Nodes: 680000, queued: 224337, elapsed: 10m12.564740042s
+Nodes: 700000, queued: 222630, elapsed: 10m35.745664792s
+Nodes: 720000, queued: 221420, elapsed: 10m59.63130825s
+Nodes: 760000, queued: 222356, elapsed: 11m51.891520292s
+Nodes: 780000, queued: 220568, elapsed: 12m16.102995459s
+Nodes: 860000, queued: 219293, elapsed: 14m11.316343959s
+Nodes: 880000, queued: 218468, elapsed: 14m39.613428625s
+Nodes: 900000, queued: 217813, elapsed: 15m11.819447625s
+Nodes: 920000, queued: 217424, elapsed: 15m42.705740792s
+Nodes: 940000, queued: 218677, elapsed: 16m21.104253959s
+Nodes: 960000, queued: 217911, elapsed: 16m57.781644292s
+Nodes: 980000, queued: 216699, elapsed: 17m34.677494417s
+Nodes: 1020000, queued: 215426, elapsed: 19m2.038933959s
+Nodes: 1040000, queued: 215487, elapsed: 19m55.598540542s
+Nodes: 1060000, queued: 214573, elapsed: 20m40.48205725s
+Nodes: 1080000, queued: 213195, elapsed: 21m28.095491709s
+Nodes: 1100000, queued: 211250, elapsed: 22m11.5463095s
+Nodes: 1140000, queued: 212287, elapsed: 23m37.567221625s
+Nodes: 1160000, queued: 211624, elapsed: 24m21.579874834s
+Nodes: 1180000, queued: 210806, elapsed: 25m7.476051917s
+Nodes: 1200000, queued: 209983, elapsed: 25m54.44016575s
+Nodes: 1220000, queued: 211411, elapsed: 26m44.908532125s
+Nodes: 1240000, queued: 211099, elapsed: 27m35.706263125s
+Nodes: 1260000, queued: 210056, elapsed: 28m11.451402959s
+Nodes: 1300000, queued: 207083, elapsed: 29m47.634289042s
+Nodes: 1320000, queued: 208200, elapsed: 30m43.995284875s
+Nodes: 1340000, queued: 207754, elapsed: 31m41.989002917s
+Nodes: 1380000, queued: 205567, elapsed: 33m10.402768084s
+Nodes: 1400000, queued: 204105, elapsed: 34m9.925815292s
+Nodes: 1408053, queued: 0, elapsed: 35m23.223970417s
+Time taken for model checking: 35m23.2240015s
+Skipping dotfile generation. Too many Nodes: 1408053
+Writen communication diagram dotfile: specs/manifest/out/run_2026-02-23_21-19-34/communication.dot
+To generate svg, run:
+dot -Tsvg specs/manifest/out/run_2026-02-23_21-19-34/communication.dot -o communication.svg && open communication.svg
+Valid Nodes: 1408053 Unique states: 1005069
+IsLive: true
+Time taken to check liveness: 7.596010291s
+PASSED: Model checker completed successfully
+Writen 2 node files and 1 link files to dir specs/manifest/out/run_2026-02-23_21-19-34


### PR DESCRIPTION
## Summary

As proposed in #1257, this PR documents `manifest::union()` and `manifest::projected()` operations from #618.

The first commit documents the current behavior as-is.
But I think there are some issues in it - subsequent commits address those issues and update RFC accordingly.

## Changes

```
Document manifest projection() and union() in RFC
[manifest][projection] Drop emptied Sorted Runs
[manifest][projection] Drop excluded SSTs from external_dbs and emptied external_dbs
[manifest][union] Include compacted SSTs in manifest::range()
[manifest][union] Merge Sorted Runs by tier and order by ID
[manifest][union] Deduplicate L0 SSTs by ID and sort by ULID
[manifest][union] Deduplicate external_dbs by (path, source_checkpoint_id)
[manifest][union] Regenerate final_checkpoint_id for external_dbs
[manifest][union] Track source databases as external_dbs entries
[manifest][union] Unset initialized in the resulting manifest
[manifest][union] Compute last_l0_seq as max last_l0_seq across sources
```

## Notes for Reviewers

1. For the general flow of projected/merge, it probably makes sense to review the final version of the RFC (after all fixes).
1. I plan to create separate PRs once we agree on the general approach.
1. This is essentially my 1st contribution in Rust and to SlateDB, so I might have easily missed something.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
