### PR TITLE
Add `ci-cross` profile to timeout tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,10 @@ command = "../scripts/backtrace-on-timeout.sh"
 filter = "all()"
 run-wrapper = "backtrace-on-timeout"
 
+# Cross-platform PR profile (no wrapper script so it works on Windows/macOS).
+[profile.ci-cross]
+slow-timeout = { period = "30s", terminate-after = 4 }
+
 # PR DST profile
 [profile.dst]
 slow-timeout = { period = "30m", terminate-after = 1 }

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -131,7 +131,7 @@ jobs:
         with:
           tool: nextest@0.9.98
       - name: Run Tests
-        run: cargo nextest run --workspace --all-features
+        run: cargo nextest run --workspace --all-features --profile ci-cross
       - name: Run Doc Tests
         run: cargo test --doc --all-features
 


### PR DESCRIPTION
## Summary

I noticed we're not running cross platform tests with a timeout (as we do for the main `tests` job). We can't use the `ci` profile because it uses Linux-specific `gdb` stuff. This PR adds a new profile that just times out.
