### PR TITLE
Expose `max_scan_parallelism` in ScanOptions with default of 64

### DIFF
--- a/slatedb-c/include/slatedb.h
+++ b/slatedb-c/include/slatedb.h
@@ -256,6 +256,8 @@ typedef struct slatedb_scan_options_t {
     bool cache_blocks;
     // Max concurrent fetch tasks.
     uint64_t max_fetch_tasks;
+    // Max concurrent SST iterator initializations during scan setup.
+    uint64_t max_scan_parallelism;
 } slatedb_scan_options_t;
 
 // Flush options passed to `slatedb_db_flush_with_options`.

--- a/slatedb-c/src/ffi.rs
+++ b/slatedb-c/src/ffi.rs
@@ -215,6 +215,8 @@ pub struct slatedb_scan_options_t {
     pub cache_blocks: bool,
     /// Max concurrent fetch tasks.
     pub max_fetch_tasks: u64,
+    /// Max concurrent SST iterator initializations during scan setup.
+    pub max_scan_parallelism: u64,
 }
 
 /// Reader options passed to `slatedb_db_reader_open`.
@@ -628,6 +630,12 @@ pub(crate) unsafe fn scan_options_from_ptr(
             "max_fetch_tasks does not fit in usize",
         )
     })?;
+    let max_scan_parallelism = usize::try_from(options.max_scan_parallelism).map_err(|_| {
+        error_result(
+            slatedb_error_kind_t::SLATEDB_ERROR_KIND_INVALID,
+            "max_scan_parallelism does not fit in usize",
+        )
+    })?;
 
     Ok(ScanOptions {
         durability_filter: durability_level_from_u8(options.durability_filter)?,
@@ -635,6 +643,7 @@ pub(crate) unsafe fn scan_options_from_ptr(
         read_ahead_bytes,
         cache_blocks: options.cache_blocks,
         max_fetch_tasks,
+        max_scan_parallelism,
     })
 }
 

--- a/slatedb-java/src/main/java/io/slatedb/NativeInterop.java
+++ b/slatedb-java/src/main/java/io/slatedb/NativeInterop.java
@@ -1181,6 +1181,7 @@ final class NativeInterop {
         slatedb_scan_options_t.read_ahead_bytes(nativeOptions, options.readAheadBytes());
         slatedb_scan_options_t.cache_blocks(nativeOptions, options.cacheBlocks());
         slatedb_scan_options_t.max_fetch_tasks(nativeOptions, options.maxFetchTasks());
+        slatedb_scan_options_t.max_scan_parallelism(nativeOptions, options.maxScanParallelism());
         return nativeOptions;
     }
 

--- a/slatedb-java/src/main/java/io/slatedb/SlateDbConfig.java
+++ b/slatedb-java/src/main/java/io/slatedb/SlateDbConfig.java
@@ -237,6 +237,7 @@ public final class SlateDbConfig {
         private final long readAheadBytes;
         private final boolean cacheBlocks;
         private final long maxFetchTasks;
+        private final long maxScanParallelism;
 
         private ScanOptions(Builder builder) {
             this.durabilityFilter = builder.durabilityFilter;
@@ -244,6 +245,7 @@ public final class SlateDbConfig {
             this.readAheadBytes = builder.readAheadBytes;
             this.cacheBlocks = builder.cacheBlocks;
             this.maxFetchTasks = builder.maxFetchTasks;
+            this.maxScanParallelism = builder.maxScanParallelism;
         }
 
         public Durability durabilityFilter() {
@@ -266,6 +268,10 @@ public final class SlateDbConfig {
             return maxFetchTasks;
         }
 
+        public long maxScanParallelism() {
+            return maxScanParallelism;
+        }
+
         public static Builder builder() {
             return new Builder();
         }
@@ -276,6 +282,7 @@ public final class SlateDbConfig {
             private long readAheadBytes = 1;
             private boolean cacheBlocks;
             private long maxFetchTasks = 1;
+            private long maxScanParallelism = 64;
 
             public Builder durabilityFilter(Durability durabilityFilter) {
                 this.durabilityFilter = Objects.requireNonNull(durabilityFilter, "durabilityFilter");
@@ -305,6 +312,14 @@ public final class SlateDbConfig {
                     throw new IllegalArgumentException("maxFetchTasks must be >= 0");
                 }
                 this.maxFetchTasks = maxFetchTasks;
+                return this;
+            }
+
+            public Builder maxScanParallelism(long maxScanParallelism) {
+                if (maxScanParallelism < 0) {
+                    throw new IllegalArgumentException("maxScanParallelism must be >= 0");
+                }
+                this.maxScanParallelism = maxScanParallelism;
                 return this;
             }
 

--- a/slatedb-py/src/lib.rs
+++ b/slatedb-py/src/lib.rs
@@ -296,6 +296,7 @@ fn build_scan_options(
     read_ahead_bytes: Option<usize>,
     cache_blocks: Option<bool>,
     max_fetch_tasks: Option<usize>,
+    max_scan_parallelism: Option<usize>,
 ) -> PyResult<ScanOptions> {
     let mut opts = ScanOptions::default();
     if let Some(df) = durability_filter {
@@ -320,6 +321,9 @@ fn build_scan_options(
     }
     if let Some(mft) = max_fetch_tasks {
         opts.max_fetch_tasks = mft;
+    }
+    if let Some(msp) = max_scan_parallelism {
+        opts.max_scan_parallelism = msp;
     }
     Ok(opts)
 }
@@ -675,7 +679,7 @@ impl PySlateDB {
         })
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options(
         &self,
         start: Vec<u8>,
@@ -685,6 +689,7 @@ impl PySlateDB {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -700,6 +705,7 @@ impl PySlateDB {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let db = self.inner.clone();
         let rt = get_runtime();
@@ -711,7 +717,7 @@ impl PySlateDB {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -722,6 +728,7 @@ impl PySlateDB {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -737,6 +744,7 @@ impl PySlateDB {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let db = self.inner.clone();
         future_into_py(py, async move {
@@ -748,7 +756,7 @@ impl PySlateDB {
         })
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options(
         &self,
         prefix: Vec<u8>,
@@ -757,6 +765,7 @@ impl PySlateDB {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         let opts = build_scan_options(
             durability_filter,
@@ -764,6 +773,7 @@ impl PySlateDB {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let db = self.inner.clone();
         let rt = get_runtime();
@@ -775,7 +785,7 @@ impl PySlateDB {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -785,6 +795,7 @@ impl PySlateDB {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = build_scan_options(
             durability_filter,
@@ -792,6 +803,7 @@ impl PySlateDB {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let db = self.inner.clone();
         future_into_py(py, async move {
@@ -1389,7 +1401,7 @@ impl PySlateDBSnapshot {
         })
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options(
         &self,
         start: Vec<u8>,
@@ -1399,6 +1411,7 @@ impl PySlateDBSnapshot {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -1414,6 +1427,7 @@ impl PySlateDBSnapshot {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let snapshot = self.inner_ref()?;
         let rt = get_runtime();
@@ -1426,7 +1440,7 @@ impl PySlateDBSnapshot {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -1437,6 +1451,7 @@ impl PySlateDBSnapshot {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -1452,6 +1467,7 @@ impl PySlateDBSnapshot {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let snapshot = self.inner_ref()?;
         future_into_py(py, async move {
@@ -1463,7 +1479,7 @@ impl PySlateDBSnapshot {
         })
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options(
         &self,
         prefix: Vec<u8>,
@@ -1472,6 +1488,7 @@ impl PySlateDBSnapshot {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         let opts = build_scan_options(
             durability_filter,
@@ -1479,6 +1496,7 @@ impl PySlateDBSnapshot {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let snapshot = self.inner_ref()?;
         let rt = get_runtime();
@@ -1491,7 +1509,7 @@ impl PySlateDBSnapshot {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -1501,6 +1519,7 @@ impl PySlateDBSnapshot {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = build_scan_options(
             durability_filter,
@@ -1508,6 +1527,7 @@ impl PySlateDBSnapshot {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let snapshot = self.inner_ref()?;
         future_into_py(py, async move {
@@ -1766,7 +1786,7 @@ impl PySlateDBTransaction {
         future_into_py(py, async move { Ok(PyDbIterator::from_iter(iter)) })
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options(
         &self,
         start: Vec<u8>,
@@ -1776,6 +1796,7 @@ impl PySlateDBTransaction {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -1791,6 +1812,7 @@ impl PySlateDBTransaction {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let txn = self.inner_ref()?;
         let rt = get_runtime();
@@ -1802,7 +1824,7 @@ impl PySlateDBTransaction {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -1813,6 +1835,7 @@ impl PySlateDBTransaction {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -1828,6 +1851,7 @@ impl PySlateDBTransaction {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let txn = self.inner_ref()?;
         let rt = get_runtime();
@@ -1841,7 +1865,7 @@ impl PySlateDBTransaction {
         future_into_py(py, async move { Ok(PyDbIterator::from_iter(iter)) })
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options(
         &self,
         prefix: Vec<u8>,
@@ -1850,6 +1874,7 @@ impl PySlateDBTransaction {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         let opts = build_scan_options(
             durability_filter,
@@ -1857,6 +1882,7 @@ impl PySlateDBTransaction {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let txn = self.inner_ref()?;
         let rt = get_runtime();
@@ -1868,7 +1894,7 @@ impl PySlateDBTransaction {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -1878,6 +1904,7 @@ impl PySlateDBTransaction {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = build_scan_options(
             durability_filter,
@@ -1885,6 +1912,7 @@ impl PySlateDBTransaction {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let txn = self.inner_ref()?;
         let rt = get_runtime();
@@ -2228,7 +2256,7 @@ impl PySlateDBReader {
         })
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options(
         &self,
         start: Vec<u8>,
@@ -2238,6 +2266,7 @@ impl PySlateDBReader {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -2253,6 +2282,7 @@ impl PySlateDBReader {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let reader = self.inner.clone();
         let rt = get_runtime();
@@ -2265,7 +2295,7 @@ impl PySlateDBReader {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (start, end = None, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -2276,6 +2306,7 @@ impl PySlateDBReader {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         if start.is_empty() {
             return Err(InvalidError::new_err("start cannot be empty"));
@@ -2291,6 +2322,7 @@ impl PySlateDBReader {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let reader = self.inner.clone();
         future_into_py(py, async move {
@@ -2302,7 +2334,7 @@ impl PySlateDBReader {
         })
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options(
         &self,
         prefix: Vec<u8>,
@@ -2311,6 +2343,7 @@ impl PySlateDBReader {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<PyDbIterator> {
         let opts = build_scan_options(
             durability_filter,
@@ -2318,6 +2351,7 @@ impl PySlateDBReader {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let reader = self.inner.clone();
         let rt = get_runtime();
@@ -2330,7 +2364,7 @@ impl PySlateDBReader {
         Ok(PyDbIterator::from_iter(iter))
     }
 
-    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None))]
+    #[pyo3(signature = (prefix, *, durability_filter = None, dirty = None, read_ahead_bytes = None, cache_blocks = None, max_fetch_tasks = None, max_scan_parallelism = None))]
     fn scan_prefix_with_options_async<'py>(
         &self,
         py: Python<'py>,
@@ -2340,6 +2374,7 @@ impl PySlateDBReader {
         read_ahead_bytes: Option<usize>,
         cache_blocks: Option<bool>,
         max_fetch_tasks: Option<usize>,
+        max_scan_parallelism: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let opts = build_scan_options(
             durability_filter,
@@ -2347,6 +2382,7 @@ impl PySlateDBReader {
             read_ahead_bytes,
             cache_blocks,
             max_fetch_tasks,
+            max_scan_parallelism,
         )?;
         let reader = self.inner.clone();
         future_into_py(py, async move {

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -331,6 +331,11 @@ pub struct ScanOptions {
     /// The maximum number of concurrent tasks for fetching blocks during scans.
     /// Higher values can improve throughput but use more resources. The default is 1.
     pub max_fetch_tasks: usize,
+    /// Controls how many SST iterators are initialized concurrently during scan setup.
+    /// Higher values can reduce scan initialization latency for large datasets,
+    /// especially with object stores that handle many concurrent requests.
+    /// The default is 64.
+    pub max_scan_parallelism: usize,
     #[cfg(dst)]
     /// Force the current timestamp for DST operations. See #719 for details.
     pub now: i64,
@@ -345,6 +350,7 @@ impl Default for ScanOptions {
             read_ahead_bytes: 1,
             cache_blocks: false,
             max_fetch_tasks: 1,
+            max_scan_parallelism: 64,
             #[cfg(dst)]
             now: 0,
         }
@@ -384,6 +390,13 @@ impl ScanOptions {
     pub fn with_max_fetch_tasks(self, max_fetch_tasks: usize) -> Self {
         Self {
             max_fetch_tasks,
+            ..self
+        }
+    }
+
+    pub fn with_max_scan_parallelism(self, max_scan_parallelism: usize) -> Self {
+        Self {
+            max_scan_parallelism,
             ..self
         }
     }
@@ -1522,6 +1535,7 @@ object_store_cache_options:
         assert_eq!(options.read_ahead_bytes, 1);
         assert!(!options.cache_blocks);
         assert_eq!(options.max_fetch_tasks, 1);
+        assert_eq!(options.max_scan_parallelism, 64);
     }
 
     #[test]

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -90,6 +90,7 @@ impl Reader {
         write_batch: Option<WriteBatch>,
         sst_iter_options: SstIteratorOptions,
         point_lookup_stats: Option<DbStats>,
+        max_scan_parallelism: usize,
     ) -> Result<IteratorSources, SlateDBError> {
         let write_batch_iter = write_batch
             .map(|batch| WriteBatchIterator::new(batch, range.clone(), IterationOrder::Ascending));
@@ -107,8 +108,11 @@ impl Reader {
             })
             .collect::<Vec<_>>();
 
-        let max_parallel =
-            compute_max_parallel(db_state.core().l0.len(), &db_state.core().compacted, 4);
+        let max_parallel = compute_max_parallel(
+            db_state.core().l0.len(),
+            &db_state.core().compacted,
+            max_scan_parallelism,
+        );
 
         let (l0_iters, sr_iters) = if let Some(point_key) = range.as_point().cloned() {
             let l0 = self.build_point_l0_iters(
@@ -308,6 +312,7 @@ impl Reader {
                 write_batch,
                 sst_iter_options,
                 Some(self.db_stats.clone()),
+                ScanOptions::default().max_scan_parallelism,
             )
             .await?;
 
@@ -382,7 +387,14 @@ impl Reader {
             l0_iters,
             sr_iters,
         } = self
-            .build_iterator_sources(&range, db_state, write_batch, sst_iter_options, None)
+            .build_iterator_sources(
+                &range,
+                db_state,
+                write_batch,
+                sst_iter_options,
+                None,
+                options.max_scan_parallelism,
+            )
             .await?;
 
         DbIterator::new(


### PR DESCRIPTION
## Summary

`max_scan_parallelism` was not exposed and set to a low default value of 4.

## Changes

- Expose `max_scan_parallelism`

## Notes for Reviewers

Related: https://github.com/slatedb/slatedb/issues/1302

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
