### PR TITLE
[slatedb-c] change type of `slatedb_bound_t.data` to be *void

### DIFF
--- a/slatedb-c/include/slatedb.h
+++ b/slatedb-c/include/slatedb.h
@@ -228,9 +228,9 @@ typedef struct slatedb_merge_options_t {
 typedef struct slatedb_bound_t {
     // Bound kind. Use `SLATEDB_BOUND_KIND_*` constants.
     uint8_t kind;
-    // Bound bytes for included/excluded bounds.
-    const uint8_t *data;
-    // Length of `data`.
+    // Bound value for included/excluded bounds.
+    const void *data;
+    // Length of `data` if data is an array.
     uintptr_t len;
 } slatedb_bound_t;
 

--- a/slatedb-c/src/db.rs
+++ b/slatedb-c/src/db.rs
@@ -4,14 +4,14 @@
 //! executing read/write operations.
 
 use crate::ffi::{
-    alloc_bytes, bytes_from_ptr, create_runtime, cstr_to_string, error_from_slate_error,
-    error_result, flush_options_from_ptr, merge_options_from_ptr, put_options_from_ptr,
-    range_from_c, read_options_from_ptr, require_handle, require_out_ptr, scan_options_from_ptr,
-    slatedb_db_t, slatedb_error_kind_t, slatedb_flush_options_t, slatedb_iterator_t,
-    slatedb_merge_options_t, slatedb_object_store_t, slatedb_put_options_t, slatedb_range_t,
-    slatedb_read_options_t, slatedb_result_t, slatedb_scan_options_t, slatedb_write_batch_t,
-    slatedb_write_handle_t, slatedb_write_options_t, success_result, take_write_batch,
-    validate_write_key, validate_write_key_value, write_options_from_ptr,
+    alloc_bytes, bytes_from_ptr, bytes_range_from_c, create_runtime, cstr_to_string,
+    error_from_slate_error, error_result, flush_options_from_ptr, merge_options_from_ptr,
+    put_options_from_ptr, read_options_from_ptr, require_handle, require_out_ptr,
+    scan_options_from_ptr, slatedb_db_t, slatedb_error_kind_t, slatedb_flush_options_t,
+    slatedb_iterator_t, slatedb_merge_options_t, slatedb_object_store_t, slatedb_put_options_t,
+    slatedb_range_t, slatedb_read_options_t, slatedb_result_t, slatedb_scan_options_t,
+    slatedb_write_batch_t, slatedb_write_handle_t, slatedb_write_options_t, success_result,
+    take_write_batch, validate_write_key, validate_write_key_value, write_options_from_ptr,
 };
 use serde_json::{Map, Value};
 use slatedb::Db;
@@ -806,7 +806,7 @@ pub unsafe extern "C" fn slatedb_db_scan_with_options(
         return err;
     }
 
-    let range = match range_from_c(range) {
+    let range = match bytes_range_from_c(range) {
         Ok(range) => range,
         Err(err) => return err,
     };

--- a/slatedb-c/src/db_reader.rs
+++ b/slatedb-c/src/db_reader.rs
@@ -3,11 +3,12 @@
 //! This module exposes C ABI functions backed by `slatedb::DbReader`.
 
 use crate::ffi::{
-    alloc_bytes, bytes_from_ptr, create_runtime, cstr_to_string, db_reader_options_from_ptr,
-    error_from_slate_error, error_result, range_from_c, read_options_from_ptr, require_handle,
-    require_out_ptr, scan_options_from_ptr, slatedb_db_reader_options_t, slatedb_db_reader_t,
-    slatedb_error_kind_t, slatedb_iterator_t, slatedb_object_store_t, slatedb_range_t,
-    slatedb_read_options_t, slatedb_result_t, slatedb_scan_options_t, success_result,
+    alloc_bytes, bytes_from_ptr, bytes_range_from_c, create_runtime, cstr_to_string,
+    db_reader_options_from_ptr, error_from_slate_error, error_result, read_options_from_ptr,
+    require_handle, require_out_ptr, scan_options_from_ptr, slatedb_db_reader_options_t,
+    slatedb_db_reader_t, slatedb_error_kind_t, slatedb_iterator_t, slatedb_object_store_t,
+    slatedb_range_t, slatedb_read_options_t, slatedb_result_t, slatedb_scan_options_t,
+    success_result,
 };
 use slatedb::DbReader;
 use uuid::Uuid;
@@ -276,7 +277,7 @@ pub unsafe extern "C" fn slatedb_db_reader_scan_with_options(
     }
     *out_iterator = std::ptr::null_mut();
 
-    let range = match range_from_c(range) {
+    let range = match bytes_range_from_c(range) {
         Ok(range) => range,
         Err(err) => return err,
     };
@@ -433,7 +434,7 @@ mod tests {
         slatedb_bound_t, slatedb_error_kind_t, SLATEDB_BOUND_KIND_EXCLUDED,
         SLATEDB_BOUND_KIND_INCLUDED,
     };
-    use std::ffi::{CStr, CString};
+    use std::ffi::{c_void, CStr, CString};
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
     use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
@@ -561,12 +562,12 @@ mod tests {
         let range = slatedb_range_t {
             start: slatedb_bound_t {
                 kind: SLATEDB_BOUND_KIND_INCLUDED,
-                data: start.as_ptr(),
+                data: start.as_ptr() as *const c_void,
                 len: start.len(),
             },
             end: slatedb_bound_t {
                 kind: SLATEDB_BOUND_KIND_EXCLUDED,
-                data: end.as_ptr(),
+                data: end.as_ptr() as *const c_void,
                 len: end.len(),
             },
         };

--- a/slatedb-go/go/db.go
+++ b/slatedb-go/go/db.go
@@ -105,13 +105,13 @@ func makeScanRange(start, end []byte) C.slatedb_range_t {
 
 	if len(start) > 0 {
 		rangeValue.start.kind = C.uint8_t(C.SLATEDB_BOUND_KIND_INCLUDED)
-		rangeValue.start.data = (*C.uint8_t)(unsafe.Pointer(&start[0]))
+		rangeValue.start.data = unsafe.Pointer(&start[0])
 		rangeValue.start.len = C.uintptr_t(len(start))
 	}
 
 	if len(end) > 0 {
 		rangeValue.end.kind = C.uint8_t(C.SLATEDB_BOUND_KIND_EXCLUDED)
-		rangeValue.end.data = (*C.uint8_t)(unsafe.Pointer(&end[0]))
+		rangeValue.end.data = unsafe.Pointer(&end[0])
 		rangeValue.end.len = C.uintptr_t(len(end))
 	}
 


### PR DESCRIPTION
## Summary

This commit generalizes the `slatedb_bound_t` struct by changing the data field from `*const uint8_t` to `*const void`, making the range bound type reusable for any scalar or array payload — not just byte slices. This was the prerequisite for using `slatedb_bound_t` in WAL reader ranges (which carry `uint64_t` WAL IDs rather than byte keys).

## Changes

  - `ffi.rs`: Changed `slatedb_bound_t.data` to `*const c_void`; added `bytes_from_c_void` helper that casts `*const c_void → *const u8`; renamed `bound_from_c/range_from_c` to `bytes_bound_from_c/bytes_range_from_c` to reflect that they handle byte-key ranges specifically.
  - `db.rs / db_reader.rs`: Updated callsites to use the renamed `bytes_range_from_c`; test code updated to cast `u8` slice pointers to `*const c_void`.
  - db.go: Updated makeScanRange to pass `unsafe.Pointer` directly (the field is now `unsafe.Pointer` / `*void` in CGo).

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
