### PR TITLE
Increase cache preload parallelism from 5 to 32

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -127,7 +127,7 @@ impl CachedObjectStore {
         }
 
         // Second pass: load the selected files in bouded parallelism and cache them.
-        let degree_of_parallelism = 5;
+        let degree_of_parallelism = 32;
         let _result = build_concurrent(files_to_load.into_iter(), degree_of_parallelism, |path| {
             let this = self.clone();
             async move {


### PR DESCRIPTION
Increases `degree_of_parallelism` in `CachedObjectStore::preload_cache` from 5 to 32.

With large numbers of SSTs, 5 concurrent fetches bottleneck on network latency rather than disk write speed. 32 keeps the disk saturated without issues in practice.

Closes #1311