### PR TITLE
Store `last_key` in SST metadata

### DIFF
--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -39,6 +39,10 @@ table SsTableInfo {
 
     // Type of SST. Defaults to Compacted for backwards compatibility.
     sst_type: SstType;
+
+    // Last entry in the SST file.
+    // The last entry is a key in an SST for compacted data.
+    last_entry: [ubyte];
 }
 
 table BlockMeta {

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -122,9 +122,13 @@ impl FlatBufferSsTableInfoCodec {
         let first_entry: Option<Bytes> = info
             .first_entry()
             .map(|entry| Bytes::copy_from_slice(entry.bytes()));
+        let last_entry: Option<Bytes> = info
+            .last_entry()
+            .map(|entry| Bytes::copy_from_slice(entry.bytes()));
 
         SsTableInfo {
             first_entry,
+            last_entry,
             index_offset: info.index_offset(),
             index_len: info.index_len(),
             filter_offset: info.filter_offset(),
@@ -413,11 +417,16 @@ impl<'b> DbFlatBufferBuilder<'b> {
             None => None,
             Some(first_entry_vector) => Some(self.builder.create_vector(first_entry_vector)),
         };
+        let last_entry = match info.last_entry.as_ref() {
+            None => None,
+            Some(last_entry_vector) => Some(self.builder.create_vector(last_entry_vector)),
+        };
 
         FbSsTableInfo::create(
             &mut self.builder,
             &SsTableInfoArgs {
                 first_entry,
+                last_entry,
                 index_offset: info.index_offset,
                 index_len: info.index_len,
                 filter_offset: info.filter_offset,

--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -261,6 +261,8 @@ pub(crate) struct EncodedSsTableFooterBuilder<'a, 'b> {
     blocks_size: u64,
     /// first entry in the SST, key for compacted data, sequence number for WAL
     first_entry: Option<Bytes>,
+    /// last entry (key) in the SST for compacted data, None for WAL SSTs
+    last_entry: Option<Bytes>,
     /// codec for compressing data blocks, index blocks, and filter blocks
     compression_codec: Option<CompressionCodec>,
     /// transformer for transforming data blocks, index blocks, and filter blocks
@@ -283,6 +285,7 @@ impl<'a, 'b> EncodedSsTableFooterBuilder<'a, 'b> {
     pub(crate) fn new(
         blocks_len: u64,
         sst_first_entry: Option<Bytes>,
+        sst_last_entry: Option<Bytes>,
         sst_codec: &'a dyn SsTableInfoCodec,
         index_builder: flatbuffers::FlatBufferBuilder<'b, DefaultAllocator>,
         block_meta: Vec<flatbuffers::WIPOffset<BlockMeta<'b>>>,
@@ -292,6 +295,7 @@ impl<'a, 'b> EncodedSsTableFooterBuilder<'a, 'b> {
         Self {
             blocks_size: blocks_len,
             first_entry: sst_first_entry,
+            last_entry: sst_last_entry,
             compression_codec: None,
             block_transformer: None,
             sst_info_codec: sst_codec,
@@ -363,6 +367,7 @@ impl<'a, 'b> EncodedSsTableFooterBuilder<'a, 'b> {
         let meta_offset = self.blocks_size + buf.len() as u64;
         let info = SsTableInfo {
             first_entry: self.first_entry,
+            last_entry: self.last_entry,
             index_offset,
             index_len,
             filter_offset,

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -845,6 +845,7 @@ mod tests {
     fn create_sst(size: u64) -> SsTableHandle {
         let info = SsTableInfo {
             first_entry: None,
+            last_entry: None,
             index_offset: size,
             index_len: 0,
             filter_offset: 0,

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -125,6 +125,7 @@ pub(crate) struct EncodedSsTableBuilder<'a> {
     index_builder: flatbuffers::FlatBufferBuilder<'a, DefaultAllocator>,
     first_key: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
     sst_first_key: Option<Bytes>,
+    sst_last_key: Option<Bytes>,
     current_block_max_key: Option<Bytes>,
     block_meta: Vec<flatbuffers::WIPOffset<BlockMeta<'a>>>,
     current_len: u64,
@@ -154,6 +155,7 @@ impl EncodedSsTableBuilder<'_> {
             block_meta: Vec::new(),
             first_key: None,
             sst_first_key: None,
+            sst_last_key: None,
             current_block_max_key: None,
             block_size,
             block_format: BlockFormat::Latest,
@@ -227,6 +229,7 @@ impl EncodedSsTableBuilder<'_> {
         if is_sst_first_key {
             self.sst_first_key = Some(entry.key.clone());
         }
+        self.sst_last_key = Some(entry.key.clone());
         self.current_block_max_key = Some(entry.key.clone());
 
         self.builder.add(entry)?;
@@ -331,6 +334,7 @@ impl EncodedSsTableBuilder<'_> {
         let mut footer_builder = EncodedSsTableFooterBuilder::new(
             self.current_len,
             self.sst_first_key,
+            self.sst_last_key,
             &*self.sst_codec,
             self.index_builder,
             self.block_meta,

--- a/slatedb/src/wal/wal_sst_builder.rs
+++ b/slatedb/src/wal/wal_sst_builder.rs
@@ -247,6 +247,7 @@ impl EncodedWalSsTableBuilder {
         let mut footer_builder = EncodedSsTableFooterBuilder::new(
             self.data_size,
             self.sst_first_seq,
+            None, // WAL SSTs don't have sorted keys, so no last_entry
             &*self.sst_codec,
             self.index_builder,
             self.block_meta,


### PR DESCRIPTION
## Summary

Each SST now records its last key alongside the existing first_entry, giving every SST a precise `[first_key, last_key]` range. This allows `calculate_view_range` to intersect query ranges with the SST's key bounds, so scans skip SSTs that don't overlap the query range.

This is especially impactful for L0 SSTs, which previously had no range-based filtering: every L0 was opened for every scan. Workloads with prefix-partitioned keys can now skip L0 SSTs in unrelated prefixes entirely.

WAL SSTs store `None` for `last_entry` since their keys are unsorted. Old SSTs without `last_entry` decode gracefully and fall back to the previous unbounded behavior.

## Changes

- Each SST now records its last key alongside the existing first_entry, giving every SST a precise `[first_key, last_key]` range.

## Notes for Reviewers

- Old SSTs without `last_entry` decode gracefully and fall back to the previous unbounded behavior.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
