### PR TITLE
use sync io from object store cache

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -9,9 +9,8 @@ use rand::{distr::Alphanumeric, Rng};
 use slatedb_common::clock::SystemClock;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::ops::Range;
-use std::os::unix::fs::FileExt;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -208,15 +207,18 @@ impl LocalCacheEntry for FsCacheEntry {
         let this_part_path = part_path.clone();
         #[allow(clippy::disallowed_methods)]
         let result = tokio::task::spawn_blocking(move || {
-            let file = match std::fs::File::open(&this_part_path) {
+            let mut file = match std::fs::File::open(&this_part_path) {
                 Ok(f) => f,
                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
                 Err(err) => return Err(wrap_io_err(err)),
             };
 
             let mut buffer = vec![0; range_in_part.len()];
-            file.read_exact_at(&mut buffer, range_in_part.start as u64)
+            let pos = file
+                .seek(SeekFrom::Start(range_in_part.start as u64))
                 .map_err(wrap_io_err)?;
+            assert_eq!(pos, range_in_part.start as u64);
+            file.read_exact(&mut buffer).map_err(wrap_io_err)?;
             Ok(Some(Bytes::from(buffer)))
         })
         .await


### PR DESCRIPTION
## Summary

Changes the object store cache to use synchronous i/o with `spawn_blocking` rather than the tokio async fs apis.

Tokio's fs APIs don't use the native async i/o apis (e.g. io_uring) on linux - rather, each async call spawns a new blocking task on the tokio runtime's blocking thread pool. Spawning a blocking task adds some overhead. Each logical cache operation (e.g. read head, read a part) is composed of multiple fs api calls. For example, reading a part first checks if the file exists, then opens the file, then seeks, and then reads. The overhead of spawning a blocking task adds up over so many calls to the fs api. To mitigate this, this patch changes the object store cache's lower level i/o operations (read part, read head, save part, save head) to do blocking i/o in a single blocking task per operation.

The following results from running `bencher db --db-options-path /home/ubuntu/slatedb.toml --duration 1800 --key-generator Random --key-len 32 --num-rows 10000000` with an object store cache shows the improvement to get performance. The dark blue line shows get throughput when using synchronous i/o. The dark grey line underneath it shows get throughput when using async i/o. The higher peaks of the blue bar show that we can achieve higher throughput with synchronous i/o. The valleys are caused by write backpressure that's relieved by compaction. I think the valleys are lower for the sync i/o run because it's able to run the benchmark faster which causes more pressure to build.

```mermaid
xychart-beta
      title "SlateDB Benchmark: Sync vs Async Cache I/O"
      x-axis "Time (s)" [10, 60, 110, 160, 210, 260, 310, 360, 410, 460, 510, 560, 610, 660, 710, 760, 810, 860, 910, 960, 1010, 1060, 1110, 1160, 1210, 1260, 1310, 1360, 1410, 1460, 1510, 1560, 1610, 1660, 1710, 1760]
      y-axis "Operations/second"
      line "Sync puts/s" [5479, 1671, 617, 311, 423, 564, 688, 496, 320, 419, 566, 680, 479, 310, 409, 539, 631, 458, 62, 66, 75, 82, 95, 111, 122, 142, 179, 240, 267, 375, 475, 323, 313, 389, 518, 611]
      line "Sync gets/s" [21727, 6664, 2454, 1234, 1684, 2263, 2751, 1984, 1278, 1675, 2256, 2700, 1930, 1250, 1631, 2147, 2536, 1821, 243, 271, 300, 335, 385, 446, 493, 570, 727, 953, 1067, 1498, 1902, 1305, 1248, 1572, 2079, 2449]
      line "Async puts/s" [4934, 1310, 544, 445, 208, 309, 319, 409, 436, 448, 379, 216, 300, 297, 392, 409, 419, 388, 205, 284, 288, 385, 367, 413, 434, 126, 54, 59, 67, 74, 83, 91, 108, 109, 126, 160]
      line "Async gets/s" [19761, 5249, 2168, 1766, 823, 1235, 1280, 1641, 1737, 1765, 1524, 868, 1207, 1197, 1550, 1633, 1677, 1557, 822, 1141, 1156, 1510, 1452, 1631, 1742, 511, 221, 241, 267, 295, 327, 370, 429, 438, 505, 633]
```

I also saw a large improvement in testing [opendata-vector](https://github.com/opendata-oss/opendata/tree/main/vector). Before this improvement, when testing recall for a dataset that fits in page cache, I was seeing ~70ms p90 latencies. After this change, the latency dropped to ~40ms.

The tokio authors also recommend this approach: https://docs.rs/tokio/latest/tokio/fs/index.html#tuning-your-file-io

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
