### PR TITLE
Add with_wal_object_store to `DbReaderBuilder`

### DIFF
--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -15,6 +15,7 @@ pub(crate) trait StoreProvider: Send + Sync {
 pub(crate) struct DefaultStoreProvider {
     pub(crate) path: Path,
     pub(crate) object_store: Arc<dyn ObjectStore>,
+    pub(crate) wal_object_store: Option<Arc<dyn ObjectStore>>,
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
     pub(crate) block_transformer: Option<Arc<dyn BlockTransformer>>,
 }
@@ -26,7 +27,10 @@ impl StoreProvider for DefaultStoreProvider {
             ..SsTableFormat::default()
         };
         Arc::new(TableStore::new(
-            ObjectStores::new(Arc::clone(&self.object_store), None),
+            ObjectStores::new(
+                Arc::clone(&self.object_store),
+                self.wal_object_store.clone(),
+            ),
             sst_format,
             self.path.clone(),
             self.block_cache.clone(),


### PR DESCRIPTION
## Summary

`DbReader` was missing the ability to configure a separate WAL object store, unlike `DbBuilder` which already supported this.

## Changes

- Add `with_wal_object_store()` method to `DbReaderBuilder`

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
