### PR TITLE
Make `InvalidClockTick` log `debug`

### DIFF
--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -18,7 +18,7 @@
 #![allow(clippy::disallowed_methods)]
 
 use crate::error::SlateDBError;
-use log::info;
+use log::debug;
 use slatedb_common::clock::SystemClock;
 use std::{
     cmp,
@@ -67,7 +67,7 @@ impl MonotonicClock {
                 next_tick: _,
             }) => {
                 let sync_millis = cmp::min(10_000, 2 * (last_tick - tick).unsigned_abs());
-                info!(
+                debug!(
                     "Clock tick {} is lagging behind the last known tick {}. \
                     Sleeping {}ms to potentially resolve skew before returning InvalidClockTick.",
                     tick, last_tick, sync_millis


### PR DESCRIPTION


## Summary

When slatedb is becoming cpu bound due to a large amount of queries being performed, the clock can lag very often, which spams the logs.

## Changes

- `info` -> `debug` on a `log` statement

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
