### PR TITLE
Allow `create_detached_checkpoint` with separate WAL stores

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -389,11 +389,14 @@ impl Admin {
             &self.path,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
         ));
-        manifest_store
-            .validate_no_wal_object_store_configured()
-            .await?;
         let mut stored_manifest =
             StoredManifest::load(manifest_store, self.system_clock.clone()).await?;
+
+        let manifest_has_wal = stored_manifest.db_state().wal_object_store_uri.is_some();
+        if self.object_stores.has_wal_object_store() != manifest_has_wal {
+            return Err(SlateDBError::WalStoreReconfigurationError.into());
+        }
+
         let checkpoint_id = self.rand.rng().gen_uuid();
         let checkpoint = stored_manifest
             .write_checkpoint(checkpoint_id, options)

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -40,6 +40,10 @@ impl ObjectStores {
         }
     }
 
+    pub(crate) fn has_wal_object_store(&self) -> bool {
+        self.wal_object_store.is_some()
+    }
+
     pub(crate) fn store_for(&self, id: &SsTableId) -> Arc<dyn ObjectStore> {
         match id {
             SsTableId::Wal(..) => self.store_of(ObjectStoreType::Wal).clone(),


### PR DESCRIPTION
## Summary

The previous check (`validate_no_wal_object_store_configured`) rejected all databases with a separate WAL store. Replace it with a reconfiguration check that only errors when the Admin's WAL config doesn't match the manifest.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
