### PR TITLE
Build Java releases against main not tags

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -137,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Set up Java 24
         uses: actions/setup-java@v4


### PR DESCRIPTION
Building against main allows us to fix minor release issues that pop up without having to cut a new release every time. Not best practices, but until releases get more stable, it's more ergonomic.