### PR TITLE
Flush all writes to single SST in test_compactor_compacts_l0

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1049,7 +1049,8 @@ mod tests {
     use crate::compactor_state::CompactionStatus;
     use crate::compactor_state::SourceId;
     use crate::config::{
-        MergeOptions, PutOptions, Settings, SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
+        FlushOptions, FlushType, MergeOptions, PutOptions, Settings,
+        SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
     };
     use crate::db::Db;
     use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
@@ -1093,7 +1094,9 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let mut options = db_options(Some(compactor_options()));
-        options.l0_sst_size_bytes = 128;
+        // Bigger than all writes so we keep all writes in a single SST.
+        // This makes it easier to verify all KV pairs are in that SST.
+        options.l0_sst_size_bytes = 512;
         let scheduler_options = SizeTieredCompactionSchedulerOptions {
             min_compaction_sources: 1,
             max_compaction_sources: 999,
@@ -1119,14 +1122,37 @@ mod tests {
             let k = vec![b'a' + i as u8; 16];
             let v = vec![b'b' + i as u8; 48];
             expected.insert(k.clone(), v.clone());
-            db.put(&k, &v).await.unwrap();
+            db.put_with_options(
+                &k,
+                &v,
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                },
+            )
+            .await
+            .unwrap();
             let k = vec![b'j' + i as u8; 16];
             let v = vec![b'k' + i as u8; 48];
-            db.put(&k, &v).await.unwrap();
+            db.put_with_options(
+                &k,
+                &v,
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                },
+            )
+            .await
+            .unwrap();
             expected.insert(k.clone(), v.clone());
         }
 
-        db.flush().await.unwrap();
+        // Force all writes to a single L0 SST.
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
 
         // when:
         let db_state = await_compaction(&db, Some(system_clock.clone())).await;


### PR DESCRIPTION
## Summary

test_compactor_compacts_l0 has been failing sporadically on the `nightly.yaml` `detect-flaky-tests` job lately:

https://github.com/slatedb/slatedb/actions/runs/22389054310/job/64806169026

It appears that the test is failing because the writes can occasionally get split across multiple SSTs depending on when the writes are flushed to L0 and when the compactor runs. `l0_sst_size_bytes` was set to 128, but each put is 24 bytes and we issue 8 of them. 24 * 8 = 192 + the row overhead. Depending on which rows are flushed and when compaction runs (poll_interval=100ms on the tests), it's possible for some rows to get compacted out of L0 before others.

I've prevented this by bumping the `l0_sst_size_bytes` is larger than all writes combined, and that we force an L0 flush before awaiting for compaction. This guarantees that all kv pairs go into a single L0 SST and then await_compaction guarantees that all those writes are compacted into a single SR SST. Afterwards, we verify that we see all KV pairs in the compaction.

## Changes

- Bump `l0_sst_size_bytes` to 512 to keep all writes in one memtable and L0 SST
- Force all writes to a single L0 flush

## Notes for Reviewers

To replicate the failure, I ran `test_compactor_compacts_l0` in a loop on my macbook with the CPU saturated. It failed consistently about every 200-300 runs. With this patch, it did not fail after 900 runs.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
