### PR TITLE
Introduce SsTableView indirection to allow multiple visible ranges per SST

### DIFF
--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -93,10 +93,24 @@ table ExternalDb {
     final_checkpoint_id: Uuid (required);
 
     // Compacted SST IDs belonging to external DB that are currently being referenced.
-    sst_ids: [CompactedSstId] (required);
+    sst_ids: [Ulid] (required);
 }
 
-table ManifestV1 {
+// A view referencing a CompactedSsTable by its id. This indirection allows the same
+// physical SST to appear multiple times in the manifest with different visible ranges
+// (e.g. after projection and union), without duplicating SST metadata.
+table CompactedSsTableView {
+    // Reference to a CompactedSsTable by its id (stored at the top level of ManifestV2).
+    id: Ulid (required);
+    visible_range: BytesRange;
+}
+
+table SortedRunV2 {
+    id: uint32;
+    ssts: [CompactedSsTableView] (required);
+}
+
+table ManifestV2 {
    // List of external databases referenced by this manifest.
    external_dbs: [ExternalDb];
 
@@ -110,6 +124,16 @@ table ManifestV1 {
    destroyed_at_s: u64;
 
    ...
+
+   // All compacted SSTs referenced by l0 and compacted (sorted runs) views.
+   // This is the single source of truth for SST metadata (id, info, format_version).
+   ssts: [CompactedSsTable] (required);
+
+   // L0 and sorted run entries reference SSTs via CompactedSsTableView, which holds
+   // only the SST id and a visible_range. This allows the same SST to be referenced
+   // multiple times with different visible ranges.
+   l0: [CompactedSsTableView] (required);
+   compacted: [SortedRunV2] (required);
 
    // A list of current checkpoints that may be active (note: this replaces the existing
    // snapshots field)
@@ -155,6 +179,24 @@ table Checkpoint {
    name: string;
 }
 ```
+
+### Manifest V1 to V2 Migration
+
+The introduction of ManifestV2 requires a phased rollout to ensure forward compatibility across
+mixed-version deployments:
+
+1. **Phase 1 (current):** Write V1, read V1+V2. All nodes can read the new V2 format, but manifests
+   are still written in V1 format. This allows older nodes that only understand V1 to continue
+   operating during a rolling upgrade. To support this, a `last_compacted_l0_sst_id` field is
+   maintained alongside `last_compacted_l0_sst_view_id`, since V1 encodes `l0_last_compacted` as an
+   SST ID rather than a view ID.
+
+2. **Phase 2:** Write V2, read V1+V2. Once all nodes are upgraded and can read V2, the writer
+   switches to emitting V2 manifests. V1 reading is retained for backward compatibility with
+   existing manifests on disk.
+
+3. **Phase 3:** Deprecate V1. Once no V1 manifests remain on disk (i.e., all have been superseded),
+   V1 reading support can be removed.
 
 ### Public API
 

--- a/schemas/compactor.fbs
+++ b/schemas/compactor.fbs
@@ -17,11 +17,14 @@ enum CompactionStatus : byte {
 }
 
 table TieredCompactionSpec {
-    // input L0 SSTable IDs
+    // deprecated: use l0_view_ids
     ssts: [Ulid];
 
     // input Sorted Run IDs
     sorted_runs: [uint32];
+
+    // input L0 SSTable View IDs
+    l0_view_ids: [Ulid];
 }
 
 table Compaction {

--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -78,6 +78,69 @@ table ManifestV1 {
     sequence_tracker: [ubyte];
 }
 
+// Manifest to persist state of DB, version 2 (CompactedSsTableV2 changed to CompactedSsTableView).
+table ManifestV2 {
+    // Id of manifest. Manifest file name will be derived from this id.
+    manifest_id: ulong;
+
+    // List of external databases referenced by this manifest.
+    external_dbs: [ExternalDb];
+
+    // Flag to indicate whether initialization has finished. When creating the initial manifest for
+    // a root db (one that is not a clone), this flag will be set to true. When creating the initial
+    // manifest for a clone db, this flag will be set to false and then updated to true once clone
+    // initialization has completed.
+    initialized: bool;
+
+    // The current writer's epoch.
+    writer_epoch: ulong;
+
+    // The current compactor's epoch.
+    compactor_epoch: ulong;
+
+    // Tracks the most recent SST in the WAL that has been flushed on the last L0 is compacted. When an Immutable 
+    // Memtable (IMM) is flushed to L0, we record the recent flushed WAL ID as `replay_after_wal_id`. During recovery,
+    // we use `replay_after_wal_id + 1` as the starting point for WAL replay, and skip the WAL entries with
+    // smaller `seq` than `last_l0_seq`.
+    replay_after_wal_id: ulong;
+
+    // The most recent SST in the WAL at the time manifest was updated.
+    wal_id_last_seen: ulong;
+
+    // The last compacted l0
+    last_compacted_l0_sst_view_id: Ulid;
+
+    // All compacted SSTs referenced by l0 and compacted (sorted runs) views.
+    ssts: [CompactedSsTableV2] (required);
+
+    // A list of the L0 SSTs that are valid to read in the `compacted` folder.
+    l0: [CompactedSsTableView] (required);
+
+    // A list of the sorted runs that are valid to read in the `compacted` folder.
+    compacted: [SortedRunV2] (required);
+
+    // The last L0 clock tick (the database should restore the latest
+    // tick when recovering from WAL if there are any WAL entries)
+    last_l0_clock_tick: long;
+
+    // A list of checkpoints that are currently open.
+    checkpoints: [Checkpoint] (required);
+
+    // The last seq number
+    last_l0_seq: ulong;
+
+    // The URI of the object store dedicated specifically for WAL, if any.
+    wal_object_store_uri: string;
+
+    // Minimum sequence number across all recent in-memory (write) snapshots. The compactor
+    // needs this to determine whether it's safe to drop duplicate key writes. If a recent snapshot
+    // still references an older version of a key, it should not be dropped.
+    recent_snapshot_min_seq: ulong;
+
+    // Serialized sequence tracker data as defined in RFC-0012.
+    sequence_tracker: [ubyte];
+}
+
 table WriterCheckpoint {
     epoch: uint64;
 }

--- a/schemas/sst.fbs
+++ b/schemas/sst.fbs
@@ -89,6 +89,7 @@ table SsTableIndex {
     block_meta: [BlockMeta] (required);
 }
 
+// deprecated: use CompactedSsTableV2
 table CompactedSsTable {
     id: Ulid (required);
     info: SsTableInfo (required);
@@ -96,7 +97,29 @@ table CompactedSsTable {
     format_version: uint16 = null;
 }
 
+table CompactedSsTableV2 {
+    id: Ulid (required);
+    info: SsTableInfo (required);
+    format_version: uint16 = null;
+}
+
+// A view over an SST specifying the key range that is visible for reads and compactions
+table CompactedSsTableView {
+    // Unique identifier for this view. Used to track individual views in compaction specs.
+    id: Ulid (required);
+    // Reference to a CompactedSsTable by its id (stored at the top level of ManifestV2).
+    sst_id: Ulid (required);
+    // The key range that this view is restricted to over
+    visible_range: BytesRange;
+}
+
+// deprecated: use SortedRunV2
 table SortedRun {
     id: uint32;
     ssts: [CompactedSsTable] (required);
+}
+
+table SortedRunV2 {
+    id: uint32;
+    ssts: [CompactedSsTableView] (required);
 }

--- a/slatedb-py/src/lib.rs
+++ b/slatedb-py/src/lib.rs
@@ -2508,7 +2508,7 @@ impl PyCompactionSpec {
             .into_iter()
             .map(|source| match source {
                 CompactionSourceInput::SortedRun(id) => SourceId::SortedRun(id),
-                CompactionSourceInput::Sst(ulid) => SourceId::Sst(ulid),
+                CompactionSourceInput::Sst(ulid) => SourceId::SstView(ulid),
             })
             .collect();
         Self {

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -63,7 +63,7 @@ mod tests {
     use crate::checkpoint::CheckpointCreateResult;
     use crate::config::{CheckpointOptions, CheckpointScope, Settings};
     use crate::db::Db;
-    use crate::db_state::SsTableId;
+    use crate::db_state::{SsTableId, SsTableView};
     use crate::format::sst::SsTableFormat;
     use crate::iter::RowEntryIterator;
     use crate::manifest::store::ManifestStore;
@@ -324,8 +324,10 @@ mod tests {
             flush_interval: Some(Duration::from_millis(5000)),
             ..Settings::default()
         };
-        test_checkpoint_scope_all(db_options, |manifest| manifest.core.l0.front().unwrap().id)
-            .await;
+        test_checkpoint_scope_all(db_options, |manifest| {
+            manifest.core.l0.front().unwrap().clone()
+        })
+        .await;
     }
 
     #[tokio::test]
@@ -336,11 +338,13 @@ mod tests {
             wal_enabled: false,
             ..Settings::default()
         };
-        test_checkpoint_scope_all(db_options, |manifest| manifest.core.l0.front().unwrap().id)
-            .await;
+        test_checkpoint_scope_all(db_options, |manifest| {
+            manifest.core.l0.front().unwrap().clone()
+        })
+        .await;
     }
 
-    async fn test_checkpoint_scope_all<F: FnOnce(Manifest) -> SsTableId>(
+    async fn test_checkpoint_scope_all<F: FnOnce(Manifest) -> SsTableView>(
         db_options: Settings,
         last_flushed_table: F,
     ) {
@@ -372,7 +376,7 @@ mod tests {
         assert_flushed_entry(
             Arc::clone(&object_store),
             path,
-            &last_flushed_table_id,
+            &last_flushed_table_id.sst.id,
             last_written_kv,
         )
         .await;
@@ -390,7 +394,7 @@ mod tests {
             path.clone(),
             None,
         ));
-        let sst_handle = table_store.open_sst(table_id).await.unwrap();
+        let sst_handle = SsTableView::identity(table_store.open_sst(table_id).await.unwrap());
 
         let mut sst_iter = SstIterator::for_key_with_stats_initialized(
             &sst_handle,

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -23,7 +23,7 @@ use crate::compactor_executor::{
 };
 use crate::compactor_state::{Compaction, CompactionSpec, SourceId};
 use crate::config::{CompactorOptions, CompressionCodec};
-use crate::db_state::{SsTableHandle, SsTableId};
+use crate::db_state::{SsTableHandle, SsTableId, SsTableView};
 use crate::error::SlateDBError;
 use crate::format::sst::SsTableFormat;
 use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -245,15 +245,20 @@ impl CompactionExecuteBench {
             ssts_by_id.insert(id, handle);
         }
         info!("finished loading");
-        let ssts: Vec<SsTableHandle> = sst_ids
+        let sst_views: Vec<SsTableView> = sst_ids
             .into_iter()
-            .map(|id| ssts_by_id.get(&id).expect("expected sst").clone())
+            .map(|id| {
+                SsTableView::new(
+                    rand.rng().gen_ulid(system_clock.as_ref()),
+                    ssts_by_id.get(&id).expect("expected sst").clone(),
+                )
+            })
             .collect();
         Ok(StartCompactionJobArgs {
             id: rand.rng().gen_ulid(system_clock.as_ref()),
             compaction_id: rand.rng().gen_ulid(system_clock.as_ref()),
             destination: 0,
-            ssts,
+            sst_views,
             sorted_runs: vec![],
             output_ssts: vec![],
             compaction_clock_tick: manifest.db_state().last_l0_clock_tick,
@@ -292,7 +297,7 @@ impl CompactionExecuteBench {
             id: rand.rng().gen_ulid(system_clock.as_ref()),
             compaction_id: job.id(),
             destination: 0,
-            ssts: vec![],
+            sst_views: vec![],
             sorted_runs: srs,
             output_ssts: vec![],
             compaction_clock_tick: state.last_l0_clock_tick,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -175,7 +175,7 @@ pub trait CompactionScheduler: Send + Sync {
                 let sources = manifest
                     .l0
                     .iter()
-                    .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+                    .map(|view| SourceId::SstView(view.id))
                     .chain(
                         manifest
                             .compacted
@@ -600,17 +600,11 @@ impl CompactorEventHandler {
         compaction: &Compaction,
         db_state: &crate::db_state::ManifestCore,
     ) -> u64 {
-        use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
+        use crate::db_state::{SortedRun, SsTableView};
         use std::collections::HashMap;
 
-        let ssts_by_id: HashMap<Ulid, &SsTableHandle> = db_state
-            .l0
-            .iter()
-            .map(|sst| match sst.id {
-                SsTableId::Compacted(id) => (id, sst),
-                SsTableId::Wal(_) => unreachable!("L0 SSTs should never have SsTableId::Wal"),
-            })
-            .collect();
+        let views_by_id: HashMap<Ulid, &SsTableView> =
+            db_state.l0.iter().map(|view| (view.id, view)).collect();
         let srs_by_id: HashMap<u32, &SortedRun> =
             db_state.compacted.iter().map(|sr| (sr.id, sr)).collect();
 
@@ -619,9 +613,9 @@ impl CompactorEventHandler {
             .sources()
             .iter()
             .map(|source| match source {
-                SourceId::Sst(id) => ssts_by_id
+                SourceId::SstView(id) => views_by_id
                     .get(id)
-                    .expect("compaction source SST not found in L0")
+                    .expect("compaction source view not found in L0")
                     .estimate_size(),
                 SourceId::SortedRun(id) => srs_by_id
                     .get(id)
@@ -688,13 +682,10 @@ impl CompactorEventHandler {
 
         // Validate compaction sources exist in DB state
         let db_state = self.state().db_state();
-        let l0_ids = db_state
+        let l0_view_ids = db_state
             .l0
             .iter()
-            .filter_map(|sst| match sst.id {
-                crate::db_state::SsTableId::Compacted(id) => Some(id),
-                crate::db_state::SsTableId::Wal(_) => None,
-            })
+            .map(|view| view.id)
             .collect::<std::collections::HashSet<_>>();
         let sr_ids = db_state
             .compacted
@@ -703,7 +694,7 @@ impl CompactorEventHandler {
             .collect::<std::collections::HashSet<_>>();
 
         if let Some(missing) = compaction.sources().iter().find(|source| match source {
-            SourceId::Sst(id) => !l0_ids.contains(id),
+            SourceId::SstView(id) => !l0_view_ids.contains(id),
             SourceId::SortedRun(id) => !sr_ids.contains(id),
         }) {
             warn!("compaction source missing from db state: {:?}", missing);
@@ -714,7 +705,7 @@ impl CompactorEventHandler {
         let has_only_l0 = compaction
             .sources()
             .iter()
-            .all(|s| matches!(s, SourceId::Sst(_)));
+            .all(|s| matches!(s, SourceId::SstView(_)));
 
         if has_only_l0 {
             // L0-only: must create new SR with id > highest_existing
@@ -869,7 +860,7 @@ impl CompactorEventHandler {
         self.log_compaction_state();
         let db_state = self.state().db_state();
 
-        let ssts = compaction.get_ssts(db_state);
+        let sst_views = compaction.get_l0_sst_views(db_state);
         let sorted_runs = compaction.get_sorted_runs(db_state);
         let spec = compaction.spec();
         // if there are no SRs when we compact L0 then the resulting SR is the last sorted run.
@@ -883,7 +874,7 @@ impl CompactorEventHandler {
             id: job_id,
             compaction_id: compaction.id(),
             destination: spec.destination(),
-            ssts,
+            sst_views,
             sorted_runs,
             output_ssts: compaction.output_ssts().clone(),
             compaction_clock_tick: db_state.last_l0_clock_tick,
@@ -1053,7 +1044,9 @@ mod tests {
         SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
     };
     use crate::db::Db;
-    use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::db_state::{
+        ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView,
+    };
     use crate::error::SlateDBError;
     use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
     use crate::iter::RowEntryIterator;
@@ -1160,7 +1153,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         for run in db_state.compacted {
-            for sst in run.ssts {
+            for sst in run.sst_views {
                 let mut iter = SstIterator::new_borrowed_initialized(
                     ..,
                     &sst,
@@ -1270,7 +1263,7 @@ mod tests {
         .unwrap();
         assert_eq!(db_state.compacted.len(), 1);
 
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1368,7 +1361,7 @@ mod tests {
         .unwrap();
         assert_eq!(db_state.compacted.len(), 1);
 
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1503,7 +1496,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1641,7 +1634,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1758,7 +1751,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1887,7 +1880,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1985,7 +1978,7 @@ mod tests {
         assert_eq!(db_state.last_l0_clock_tick, 20);
 
         // then: the compacted SST should only contain the non-expired merge
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2202,7 +2195,7 @@ mod tests {
         );
 
         // The compacted sorted run should contain both merge operations separately
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2337,10 +2330,10 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        assert!(db_state.l0_last_compacted.is_some());
+        assert!(db_state.last_compacted_l0_sst_view_id.is_some());
         assert_eq!(db_state.compacted.len(), 1);
         assert_eq!(db_state.last_l0_clock_tick, 70);
-        let compacted = &db_state.compacted.first().unwrap().ssts;
+        let compacted = &db_state.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -2538,8 +2531,6 @@ mod tests {
                 .await
                 .unwrap();
 
-        let l0_newest = Ulid::new();
-        let l0_oldest = Ulid::new();
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
         let l0_info = SsTableInfo {
             first_entry: Some(Bytes::from_static(b"a")),
@@ -2549,34 +2540,35 @@ mod tests {
             first_entry: Some(Bytes::from_static(b"m")),
             ..SsTableInfo::default()
         };
-        dirty.value.core.l0 = VecDeque::from(vec![
-            SsTableHandle::new(
-                SsTableId::Compacted(l0_newest),
-                SST_FORMAT_VERSION_LATEST,
-                l0_info.clone(),
-            ),
-            SsTableHandle::new(
-                SsTableId::Compacted(l0_oldest),
-                SST_FORMAT_VERSION_LATEST,
-                l0_info.clone(),
-            ),
-        ]);
+        let l0_view_newest: SsTableView = SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            l0_info.clone(),
+        ));
+        let l0_view_oldest: SsTableView = SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            l0_info.clone(),
+        ));
+        let l0_newest = l0_view_newest.id;
+        let l0_oldest = l0_view_oldest.id;
+        dirty.value.core.l0 = VecDeque::from(vec![l0_view_newest, l0_view_oldest]);
         dirty.value.core.compacted = vec![
             SortedRun {
                 id: 2,
-                ssts: vec![SsTableHandle::new(
+                sst_views: vec![SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::new()),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                )],
+                ))],
             },
             SortedRun {
                 id: 1,
-                ssts: vec![SsTableHandle::new(
+                sst_views: vec![SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::new()),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                )],
+                ))],
             },
         ];
         stored_manifest.update(dirty).await.unwrap();
@@ -2613,8 +2605,8 @@ mod tests {
             .get(&compaction_id)
             .expect("missing submitted compaction");
         let expected_sources = vec![
-            SourceId::Sst(l0_newest),
-            SourceId::Sst(l0_oldest),
+            SourceId::SstView(l0_newest),
+            SourceId::SstView(l0_oldest),
             SourceId::SortedRun(2),
             SourceId::SortedRun(1),
         ];
@@ -2643,8 +2635,6 @@ mod tests {
     #[test]
     fn test_plan_full_uses_all_sources_and_min_destination() {
         let scheduler = MockScheduler::new();
-        let l0_first = Ulid::from_parts(1, 0);
-        let l0_second = Ulid::from_parts(2, 0);
         let mut core = ManifestCore::new();
         let l0_info = SsTableInfo {
             first_entry: Some(Bytes::from_static(b"a")),
@@ -2654,34 +2644,35 @@ mod tests {
             first_entry: Some(Bytes::from_static(b"m")),
             ..SsTableInfo::default()
         };
-        core.l0 = VecDeque::from(vec![
-            SsTableHandle::new(
-                SsTableId::Compacted(l0_first),
-                SST_FORMAT_VERSION_LATEST,
-                l0_info.clone(),
-            ),
-            SsTableHandle::new(
-                SsTableId::Compacted(l0_second),
-                SST_FORMAT_VERSION_LATEST,
-                l0_info,
-            ),
-        ]);
+        let l0_view_first: SsTableView = SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(Ulid::from_parts(1, 0)),
+            SST_FORMAT_VERSION_LATEST,
+            l0_info.clone(),
+        ));
+        let l0_view_second: SsTableView = SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(Ulid::from_parts(2, 0)),
+            SST_FORMAT_VERSION_LATEST,
+            l0_info,
+        ));
+        let l0_first = l0_view_first.id;
+        let l0_second = l0_view_second.id;
+        core.l0 = VecDeque::from(vec![l0_view_first, l0_view_second]);
         core.compacted = vec![
             SortedRun {
                 id: 5,
-                ssts: vec![SsTableHandle::new(
+                sst_views: vec![SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(10, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                )],
+                ))],
             },
             SortedRun {
                 id: 2,
-                ssts: vec![SsTableHandle::new(
+                sst_views: vec![SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(11, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info,
-                )],
+                ))],
             },
         ];
         let state = CompactorStateView {
@@ -2694,8 +2685,8 @@ mod tests {
             .unwrap();
 
         let expected_sources = vec![
-            SourceId::Sst(l0_first),
-            SourceId::Sst(l0_second),
+            SourceId::SstView(l0_first),
+            SourceId::SstView(l0_second),
             SourceId::SortedRun(5),
             SourceId::SortedRun(2),
         ];
@@ -2809,7 +2800,7 @@ mod tests {
             let l0_ids_to_compact: Vec<SourceId> = db_state
                 .l0
                 .iter()
-                .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+                .map(|h| SourceId::SstView(h.id))
                 .collect();
             CompactionSpec::new(l0_ids_to_compact, 0)
         }
@@ -2909,22 +2900,22 @@ mod tests {
         let db_state = fixture.latest_db_state().await;
         assert_eq!(db_state.l0.len(), 1);
         assert_eq!(db_state.compacted.len(), 1);
-        let l0_id = db_state.l0.front().unwrap().id.unwrap_compacted_id();
+        let l0_id = db_state.l0.front().unwrap().sst.id.unwrap_compacted_id();
         let compacted_l0s: Vec<Ulid> = db_state
             .compacted
             .first()
             .unwrap()
-            .ssts
+            .sst_views
             .iter()
-            .map(|sst| sst.id.unwrap_compacted_id())
+            .map(|view| view.sst.id.unwrap_compacted_id())
             .collect();
         assert!(!compacted_l0s.contains(&l0_id));
         assert_eq!(
-            db_state.l0_last_compacted.unwrap(),
+            db_state.last_compacted_l0_sst_view_id.unwrap(),
             compaction
                 .sources()
                 .first()
-                .and_then(|id| id.maybe_unwrap_sst())
+                .and_then(|id| id.maybe_unwrap_sst_view())
                 .unwrap()
         );
     }
@@ -3269,7 +3260,7 @@ mod tests {
         let sources = db_state
             .l0
             .iter()
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
+            .map(|h| SourceId::SstView(h.id))
             .collect::<Vec<_>>();
         let spec = CompactionSpec::new(sources, 0);
         let compaction_id = Ulid::new();
@@ -3315,7 +3306,7 @@ mod tests {
         let db_state = handler.state().db_state().clone();
         let output_sr = SortedRun {
             id: jobs[0].destination,
-            ssts: db_state.l0.iter().cloned().collect(),
+            sst_views: db_state.l0.iter().cloned().collect(),
         };
         let msg = CompactorMessage::CompactionJobFinished {
             id: compaction_id,
@@ -3428,7 +3419,7 @@ mod tests {
         let db_state = fixture.latest_db_state().await;
         let output_sr = SortedRun {
             id: compaction.destination(),
-            ssts: db_state.l0.iter().cloned().collect(),
+            sst_views: db_state.l0.iter().cloned().collect(),
         };
         let msg = CompactorMessage::CompactionJobFinished {
             id: job.id,
@@ -3502,7 +3493,7 @@ mod tests {
             .core
             .l0
             .iter()
-            .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+            .map(|view| SourceId::SstView(view.id))
             .collect();
         assert_eq!(&l0_ids, compaction.sources());
     }
@@ -3574,7 +3565,7 @@ mod tests {
     async fn test_validate_compaction_rejects_missing_l0_source() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
         fixture.handler.handle_ticker().await.unwrap();
-        let c = CompactionSpec::new(vec![SourceId::Sst(Ulid::new())], 0);
+        let c = CompactionSpec::new(vec![SourceId::SstView(Ulid::new())], 0);
         let err = fixture.handler.validate_compaction(&c).unwrap_err();
         assert!(matches!(err, SlateDBError::InvalidCompaction));
     }
@@ -3659,9 +3650,9 @@ mod tests {
         fixture.handler.handle_ticker().await.unwrap();
         let state = fixture.latest_db_state().await;
         let sr_id = state.compacted.first().unwrap().id;
-        let l0_ulid = state.l0.front().unwrap().id.unwrap_compacted_id();
+        let l0_view_id = state.l0.front().unwrap().id;
         let mixed = CompactionSpec::new(
-            vec![SourceId::SortedRun(sr_id), SourceId::Sst(l0_ulid)],
+            vec![SourceId::SortedRun(sr_id), SourceId::SstView(l0_view_id)],
             sr_id,
         );
         // Compactor-level validation should not reject (scheduler default validate returns Ok(()))

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -16,7 +16,7 @@ use crate::compaction_filter_iterator::CompactionFilterIterator;
 use crate::compactor::CompactorMessage;
 use crate::compactor::CompactorMessage::CompactionJobFinished;
 use crate::config::CompactorOptions;
-use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
+use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableView};
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator, TrackedRowEntryIterator};
 use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -59,7 +59,7 @@ pub(crate) struct StartCompactionJobArgs {
     /// Destination sorted run id to be produced by this job.
     pub(crate) destination: u32,
     /// Input L0 SSTs for this job.
-    pub(crate) ssts: Vec<SsTableHandle>,
+    pub(crate) sst_views: Vec<SsTableView>,
     /// Input existing sorted runs for this job.
     pub(crate) sorted_runs: Vec<SortedRun>,
     /// Output SSTs already written for this compaction when resuming.
@@ -79,7 +79,7 @@ impl std::fmt::Debug for StartCompactionJobArgs {
             .field("id", &self.id)
             .field("job_id", &self.compaction_id)
             .field("destination", &self.destination)
-            .field("ssts", &self.ssts)
+            .field("ssts", &self.sst_views)
             .field("sorted_runs", &self.sorted_runs)
             .field("output_ssts", &self.output_ssts)
             .field("compaction_clock_tick", &self.compaction_clock_tick)
@@ -280,9 +280,9 @@ impl TokioCompactionExecutorInner {
             order: IterationOrder::Ascending,
         };
 
-        let max_parallel = compute_max_parallel(job_args.ssts.len(), &job_args.sorted_runs, 4);
+        let max_parallel = compute_max_parallel(job_args.sst_views.len(), &job_args.sorted_runs, 4);
         // L0 (borrowed)
-        let l0_iters_futures = build_concurrent(job_args.ssts.iter(), max_parallel, |h| {
+        let l0_iters_futures = build_concurrent(job_args.sst_views.iter(), max_parallel, |h| {
             SstIterator::new_borrowed_initialized(.., h, self.table_store.clone(), sst_iter_options)
         });
 
@@ -454,7 +454,13 @@ impl TokioCompactionExecutorInner {
 
         Ok(SortedRun {
             id: args.destination,
-            ssts: output_ssts,
+            sst_views: output_ssts
+                .into_iter()
+                .map(|sst| {
+                    let id = self.rand.rng().gen_ulid(self.clock.as_ref());
+                    SsTableView::new(id, sst)
+                })
+                .collect(),
         })
     }
 
@@ -1012,13 +1018,13 @@ mod tests {
 
         // Materialize L0 SSTs from the provided entry sets. Use a huge max size so
         // each entry set stays in a single SST, keeping the inputs predictable.
-        let mut l0_ssts = Vec::new();
+        let mut l0_sst_views = Vec::new();
         let mut sorted_runs = Vec::new();
         let mut all_entries = Vec::new();
 
         for entries in &l0_entry_sets {
             let ssts = write_sst(&table_store, entries, usize::MAX).await;
-            l0_ssts.extend(ssts);
+            l0_sst_views.extend(ssts.into_iter().map(SsTableView::identity));
             all_entries.extend(entries.iter().cloned());
         }
 
@@ -1034,7 +1040,7 @@ mod tests {
                 }
                 sorted_runs.push(SortedRun {
                     id: sr_id as u32,
-                    ssts: sr_ssts,
+                    sst_views: sr_ssts.into_iter().map(SsTableView::identity).collect(),
                 });
             }
         }
@@ -1064,7 +1070,7 @@ mod tests {
             id: Ulid::new(),
             compaction_id: Ulid::new(),
             destination: 0,
-            ssts: l0_ssts,
+            sst_views: l0_sst_views,
             sorted_runs,
             output_ssts,
             compaction_clock_tick: 0,
@@ -1217,7 +1223,7 @@ mod tests {
                 let mut l0_ssts = Vec::new();
                 for entries in &l0_entry_sets {
                     let ssts = write_ssts(&table_store, entries, usize::MAX).await;
-                    l0_ssts.extend(ssts);
+                    l0_ssts.extend(ssts.into_iter().map(SsTableView::identity));
                 }
 
                 let sorted_runs = build_sorted_runs(&table_store, &sr_entry_sets, usize::MAX).await;
@@ -1228,7 +1234,7 @@ mod tests {
                         id: Ulid::new(),
                         compaction_id: Ulid::new(),
                         destination: 0,
-                        ssts: l0_ssts.clone(),
+                        sst_views: l0_ssts.clone(),
                         sorted_runs: sorted_runs.clone(),
                         output_ssts: Vec::new(),
                         compaction_clock_tick: 0,
@@ -1239,7 +1245,7 @@ mod tests {
                     .unwrap();
 
                 let mut expected_entries = Vec::new();
-                for sst in &full_run.ssts {
+                for sst in &full_run.sst_views {
                     let mut iter = SstIterator::new(
                         SstView::Borrowed(sst, BytesRange::from(..)),
                         table_store.clone(),
@@ -1273,7 +1279,7 @@ mod tests {
                             id: Ulid::new(),
                             compaction_id: Ulid::new(),
                             destination: 0,
-                            ssts: l0_ssts.clone(),
+                            sst_views: l0_ssts.clone(),
                             sorted_runs: sorted_runs.clone(),
                             output_ssts,
                             compaction_clock_tick: 0,
@@ -1284,7 +1290,7 @@ mod tests {
                         .unwrap();
 
                     let mut resumed_entries = Vec::new();
-                    for sst in &resumed_run.ssts {
+                    for sst in &resumed_run.sst_views {
                         let mut iter = SstIterator::new(
                             SstView::Borrowed(sst, BytesRange::from(..)),
                             table_store.clone(),
@@ -1394,7 +1400,7 @@ mod tests {
                 id: Ulid::new(),
                 compaction_id: Ulid::new(),
                 destination: 0,
-                ssts,
+                sst_views: ssts.into_iter().map(SsTableView::identity).collect(),
                 sorted_runs: vec![],
                 output_ssts: vec![],
                 compaction_clock_tick: 0,
@@ -1455,8 +1461,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, result.ssts.len());
-        let sst = result.ssts[0].clone();
+        assert_eq!(1, result.sst_views.len());
+        let sst = result.sst_views[0].clone();
         let mut iter = SstIterator::new(
             SstView::Borrowed(&sst, BytesRange::from(..)),
             table_store.clone(),
@@ -1597,8 +1603,8 @@ mod tests {
         let result = ctx.run_compaction(vec![l0], true, None).await.unwrap();
 
         // Verify the output SST
-        assert_eq!(1, result.ssts.len());
-        let sst = result.ssts[0].clone();
+        assert_eq!(1, result.sst_views.len());
+        let sst = result.sst_views[0].clone();
         let mut iter = SstIterator::new(
             SstView::Borrowed(&sst, BytesRange::from(..)),
             table_store.clone(),

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -6,7 +6,7 @@ use log::{error, info};
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
-use crate::db_state::{ManifestCore, SortedRun, SsTableHandle};
+use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableView};
 use crate::error::SlateDBError;
 use crate::manifest::Manifest;
 use slatedb_txn_obj::DirtyObject;
@@ -15,11 +15,11 @@ use slatedb_txn_obj::DirtyObject;
 ///
 /// A `SourceId` distinguishes between two kinds of inputs a compaction can read:
 /// an existing compacted sorted run (identified by its run id), or an L0 SSTable
-/// (identified by its ULID).
+/// view (identified by its view ID).
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum SourceId {
     SortedRun(u32),
-    Sst(Ulid),
+    SstView(Ulid),
 }
 
 impl Display for SourceId {
@@ -31,7 +31,7 @@ impl Display for SourceId {
                 SourceId::SortedRun(id) => {
                     format!("{}", *id)
                 }
-                SourceId::Sst(_) => String::from("l0"),
+                SourceId::SstView(_) => String::from("l0"),
             }
         )
     }
@@ -44,25 +44,25 @@ impl SourceId {
     /// - The sorted run id.
     ///
     /// ## Panics
-    /// - If called on `SourceId::Sst`.
+    /// - If called on `SourceId::SstView`.
     pub(crate) fn unwrap_sorted_run(&self) -> u32 {
         self.maybe_unwrap_sorted_run()
-            .expect("tried to unwrap Sst as Sorted Run")
+            .expect("tried to unwrap SstView as Sorted Run")
     }
 
     /// Returns the sorted run id if this source is a `SortedRun`, otherwise `None`.
     pub(crate) fn maybe_unwrap_sorted_run(&self) -> Option<u32> {
         match self {
             SourceId::SortedRun(id) => Some(*id),
-            SourceId::Sst(_) => None,
+            SourceId::SstView(_) => None,
         }
     }
 
-    /// Returns the SST ULID if this source is an `Sst`, otherwise `None`.
-    pub(crate) fn maybe_unwrap_sst(&self) -> Option<Ulid> {
+    /// Returns the view ID if this source is an `SstView`, otherwise `None`.
+    pub(crate) fn maybe_unwrap_sst_view(&self) -> Option<Ulid> {
         match self {
             SourceId::SortedRun(_) => None,
-            SourceId::Sst(ulid) => Some(*ulid),
+            SourceId::SstView(id) => Some(*id),
         }
     }
 }
@@ -206,18 +206,15 @@ impl Compaction {
     ///
     /// ## Arguments
     /// - `db_state`: The current core DB state from the manifest.
-    pub(crate) fn get_ssts(&self, db_state: &ManifestCore) -> Vec<SsTableHandle> {
-        let ssts_by_id: HashMap<Ulid, &SsTableHandle> = db_state
-            .l0
-            .iter()
-            .map(|sst| (sst.id.unwrap_compacted_id(), sst))
-            .collect();
+    pub(crate) fn get_l0_sst_views(&self, db_state: &ManifestCore) -> Vec<SsTableView> {
+        let sst_views_by_id: HashMap<Ulid, &SsTableView> =
+            db_state.l0.iter().map(|view| (view.id, view)).collect();
 
         self.spec
             .sources()
             .iter()
-            .filter_map(|s| s.maybe_unwrap_sst())
-            .filter_map(|ulid| ssts_by_id.get(&ulid).map(|t| (*t).clone()))
+            .filter_map(|s| s.maybe_unwrap_sst_view())
+            .filter_map(|ulid| sst_views_by_id.get(&ulid).map(|t| (*t).clone()))
             .collect()
     }
 
@@ -527,17 +524,16 @@ impl CompactorState {
     pub(crate) fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyObject<Manifest>) {
         // the writer may have added more l0 SSTs. Add these to our l0 list.
         let my_db_state = self.db_state();
-        let last_compacted_l0 = my_db_state.l0_last_compacted;
+        let last_compacted_l0 = my_db_state.last_compacted_l0_sst_view_id;
         let mut merged_l0s = VecDeque::new();
         let writer_l0 = &remote_manifest.value.core.l0;
         for writer_l0_sst in writer_l0 {
-            let writer_l0_id = writer_l0_sst.id.unwrap_compacted_id();
             // todo: this is brittle. we are relying on the l0 list always being updated in
             //       an expected order. We should instead encode the ordering in the l0 SST IDs
             //       and assert that it follows the order
             if match &last_compacted_l0 {
                 None => true,
-                Some(last_compacted_l0_id) => writer_l0_id != *last_compacted_l0_id,
+                Some(last_compacted_l0_id) => writer_l0_sst.id != *last_compacted_l0_id,
             } {
                 merged_l0s.push_back(writer_l0_sst.clone());
             } else {
@@ -548,7 +544,8 @@ impl CompactorState {
         // write out the merged core db state and manifest
         let merged = ManifestCore {
             initialized: remote_manifest.value.core.initialized,
-            l0_last_compacted: my_db_state.l0_last_compacted,
+            last_compacted_l0_sst_view_id: my_db_state.last_compacted_l0_sst_view_id,
+            last_compacted_l0_sst_id: my_db_state.last_compacted_l0_sst_id,
             l0: merged_l0s,
             compacted: my_db_state.compacted.clone(),
             next_wal_sst_id: remote_manifest.value.core.next_wal_sst_id,
@@ -588,7 +585,7 @@ impl CompactorState {
             .any(|sr| sr.id == spec.destination())
             && !spec.sources().iter().any(|src| match src {
                 SourceId::SortedRun(sr) => *sr == spec.destination(),
-                SourceId::Sst(_) => false,
+                SourceId::SstView(_) => false,
             })
         {
             // the compaction overwrites an existing sr but doesn't include the sr
@@ -635,7 +632,7 @@ impl CompactorState {
             let compaction_l0s: HashSet<Ulid> = spec
                 .sources()
                 .iter()
-                .filter_map(|id| id.maybe_unwrap_sst())
+                .filter_map(|id| id.maybe_unwrap_sst_view())
                 .collect();
             let compaction_srs: HashSet<u32> = spec
                 .sources()
@@ -643,16 +640,11 @@ impl CompactorState {
                 .chain(std::iter::once(&SourceId::SortedRun(spec.destination())))
                 .filter_map(|id| id.maybe_unwrap_sorted_run())
                 .collect();
-            let new_l0: VecDeque<SsTableHandle> = db_state
+            let new_l0: VecDeque<SsTableView> = db_state
                 .l0
                 .iter()
-                .filter_map(|l0| {
-                    let l0_id = l0.id.unwrap_compacted_id();
-                    if compaction_l0s.contains(&l0_id) {
-                        return None;
-                    }
-                    Some(l0.clone())
-                })
+                .filter(|l0| !compaction_l0s.contains(&l0.id))
+                .cloned()
                 .collect();
             let mut new_compacted = Vec::new();
             let mut inserted = false;
@@ -673,10 +665,16 @@ impl CompactorState {
                 .sources()
                 .first()
                 .expect("illegal: empty compaction spec");
-            if let Some(compacted_l0) = first_source.maybe_unwrap_sst() {
-                // if there are l0s, the newest must be the first entry in sources
+            if let Some(view_id) = first_source.maybe_unwrap_sst_view() {
+                // if there are l0s, the newest must be the first entry in sources.
                 // TODO: validate that this is the case
-                db_state.l0_last_compacted = Some(compacted_l0)
+                db_state.last_compacted_l0_sst_view_id = Some(view_id);
+                // Resolve the SST ID from the view before it's removed from l0.
+                db_state.last_compacted_l0_sst_id = db_state
+                    .l0
+                    .iter()
+                    .find(|v| v.id == view_id)
+                    .map(|v| v.sst.id.unwrap_compacted_id());
             }
             db_state.l0 = new_l0;
             db_state.compacted = new_compacted;
@@ -707,7 +705,7 @@ mod tests {
 
     use super::*;
     use crate::checkpoint::Checkpoint;
-    use crate::compactor_state::SourceId::Sst;
+    use crate::compactor_state::SourceId::SstView;
     use crate::config::Settings;
     use crate::db::Db;
     use crate::db_state::SsTableId;
@@ -912,34 +910,27 @@ mod tests {
         let compacted_ssts = before_compaction.l0.iter().cloned().collect();
         let sr = SortedRun {
             id: 0,
-            ssts: compacted_ssts,
+            sst_views: compacted_ssts,
         };
         state.finish_compaction(compaction_id, sr.clone());
 
         // then:
         assert_eq!(
-            state.db_state().l0_last_compacted,
-            Some(
-                before_compaction
-                    .l0
-                    .front()
-                    .unwrap()
-                    .id
-                    .unwrap_compacted_id()
-            )
+            state.db_state().last_compacted_l0_sst_view_id,
+            Some(before_compaction.l0.front().unwrap().id)
         );
         assert_eq!(state.db_state().l0.len(), 0);
         assert_eq!(state.db_state().compacted.len(), 1);
         assert_eq!(state.db_state().compacted.first().unwrap().id, sr.id);
-        let expected_ids: Vec<SsTableId> = sr.ssts.iter().map(|h| h.id).collect();
+        let expected_ids: Vec<SsTableId> = sr.sst_views.iter().map(|h| h.sst.id).collect();
         let found_ids: Vec<SsTableId> = state
             .db_state()
             .compacted
             .first()
             .unwrap()
-            .ssts
+            .sst_views
             .iter()
-            .map(|h| h.id)
+            .map(|h| h.sst.id)
             .collect();
         assert_eq!(expected_ids, found_ids);
     }
@@ -961,7 +952,7 @@ mod tests {
         let compacted_ssts = before_compaction.l0.iter().cloned().collect();
         let sr = SortedRun {
             id: 0,
-            ssts: compacted_ssts,
+            sst_views: compacted_ssts,
         };
         state.finish_compaction(compaction_id, sr);
 
@@ -984,19 +975,19 @@ mod tests {
         state.merge_remote_manifest(sm.prepare_dirty().unwrap());
 
         // then:
-        assert!(state.db_state().l0_last_compacted.is_none());
+        assert!(state.db_state().last_compacted_l0_sst_view_id.is_none());
         let expected_merged_l0s: Vec<Ulid> = sm
             .manifest()
             .core
             .l0
             .iter()
-            .map(|t| t.id.unwrap_compacted_id())
+            .map(|t| t.sst.id.unwrap_compacted_id())
             .collect();
         let merged_l0s: Vec<Ulid> = state
             .db_state()
             .l0
             .iter()
-            .map(|h| h.id.unwrap_compacted_id())
+            .map(|h| h.sst.id.unwrap_compacted_id())
             .collect();
         assert_eq!(expected_merged_l0s, merged_l0s);
     }
@@ -1009,10 +1000,7 @@ mod tests {
         // compact the last sst
         let original_l0s = &state.db_state().clone().l0;
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
-        let spec = CompactionSpec::new(
-            vec![Sst(original_l0s.back().unwrap().id.unwrap_compacted_id())],
-            0,
-        );
+        let spec = CompactionSpec::new(vec![SstView(original_l0s.back().unwrap().id)], 0);
         let compaction = Compaction::new(compaction_id, spec);
         state
             .add_compaction(compaction)
@@ -1021,7 +1009,7 @@ mod tests {
             compaction_id,
             SortedRun {
                 id: 0,
-                ssts: vec![original_l0s.back().unwrap().clone()],
+                sst_views: vec![original_l0s.back().unwrap().clone()],
             },
         );
         // open a new db and write another l0
@@ -1038,7 +1026,7 @@ mod tests {
         let db_state = state.db_state();
         let mut expected_merged_l0s: VecDeque<Ulid> = original_l0s
             .iter()
-            .map(|h| h.id.unwrap_compacted_id())
+            .map(|h| h.sst.id.unwrap_compacted_id())
             .collect();
         expected_merged_l0s.pop_back();
         let new_l0 = sm
@@ -1047,13 +1035,14 @@ mod tests {
             .l0
             .front()
             .unwrap()
+            .sst
             .id
             .unwrap_compacted_id();
         expected_merged_l0s.push_front(new_l0);
         let merged_l0: VecDeque<Ulid> = db_state
             .l0
             .iter()
-            .map(|h| h.id.unwrap_compacted_id())
+            .map(|h| h.sst.id.unwrap_compacted_id())
             .collect();
         assert_eq!(merged_l0, expected_merged_l0s);
         assert_eq!(
@@ -1076,13 +1065,7 @@ mod tests {
         let original_l0s = &state.db_state().clone().l0;
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
 
-        let spec = CompactionSpec::new(
-            original_l0s
-                .iter()
-                .map(|h| Sst(h.id.unwrap_compacted_id()))
-                .collect(),
-            0,
-        );
+        let spec = CompactionSpec::new(original_l0s.iter().map(|h| SstView(h.id)).collect(), 0);
         let compaction = Compaction::new(compaction_id, spec);
         state
             .add_compaction(compaction)
@@ -1091,7 +1074,7 @@ mod tests {
             compaction_id,
             SortedRun {
                 id: 0,
-                ssts: original_l0s.clone().into(),
+                sst_views: original_l0s.clone().into(),
             },
         );
         assert_eq!(state.db_state().l0.len(), 0);
@@ -1113,13 +1096,14 @@ mod tests {
             .l0
             .front()
             .unwrap()
+            .sst
             .id
             .unwrap_compacted_id();
         expected_merged_l0s.push_front(new_l0);
         let merged_l0: VecDeque<Ulid> = db_state
             .l0
             .iter()
-            .map(|h| h.id.unwrap_compacted_id())
+            .map(|h| h.sst.id.unwrap_compacted_id())
             .collect();
         assert_eq!(merged_l0, expected_merged_l0s);
     }
@@ -1161,7 +1145,7 @@ mod tests {
                 .iter()
                 .enumerate()
                 .filter(|(i, _e)| i > &2usize)
-                .map(|(_i, x)| Sst(x.id.unwrap_compacted_id()))
+                .map(|(_i, x)| SstView(x.id))
                 .collect::<Vec<SourceId>>(),
             0,
         );
@@ -1180,10 +1164,7 @@ mod tests {
         let original_l0s = &state.db_state().clone().l0;
         let original_srs = &state.db_state().clone().compacted;
         // L0: from 4th onward (index > 2)
-        let l0_sources = original_l0s
-            .iter()
-            .skip(3)
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()));
+        let l0_sources = original_l0s.iter().skip(3).map(|h| SourceId::SstView(h.id));
 
         // SRs: first 3 (index < 3)
         let sr_sources = original_srs
@@ -1255,7 +1236,7 @@ mod tests {
     fn sorted_run_to_description(sr: &SortedRun) -> SortedRunDescription {
         SortedRunDescription {
             id: sr.id,
-            ssts: sr.ssts.iter().map(|h| h.id).collect(),
+            ssts: sr.sst_views.iter().map(|h| h.sst.id).collect(),
         }
     }
 
@@ -1274,11 +1255,8 @@ mod tests {
         .expect("no manifest found with l0 len");
     }
 
-    fn build_l0_compaction(ssts: &VecDeque<SsTableHandle>, dst: u32) -> CompactionSpec {
-        let sources = ssts
-            .iter()
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
-            .collect();
+    fn build_l0_compaction(ssts: &VecDeque<SsTableView>, dst: u32) -> CompactionSpec {
+        let sources = ssts.iter().map(|h| SourceId::SstView(h.id)).collect();
         CompactionSpec::new(sources, dst)
     }
 

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -396,7 +396,7 @@ mod tests {
     fn test_compactor_state_to_view() {
         let mut manifest = Manifest::initial(ManifestCore::new());
         manifest.compactor_epoch = 11;
-        manifest.core.l0_last_compacted = Some(Ulid::from_parts(5, 0));
+        manifest.core.last_compacted_l0_sst_view_id = Some(Ulid::from_parts(5, 0));
 
         let mut compactions = Compactions::new(manifest.compactor_epoch);
         let compaction_id = Ulid::from_parts(10, 0);
@@ -588,23 +588,21 @@ mod tests {
         .unwrap();
 
         let output_ssts = vec![
-            SsTableHandle::new_compacted(
+            SsTableHandle::new(
                 SsTableId::Compacted(Ulid::from_parts(10, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::copy_from_slice(b"a")),
                     ..Default::default()
                 },
-                None,
             ),
-            SsTableHandle::new_compacted(
+            SsTableHandle::new(
                 SsTableId::Compacted(Ulid::from_parts(11, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::copy_from_slice(b"m")),
                     ..Default::default()
                 },
-                None,
             ),
         ];
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2422,8 +2422,13 @@ mod tests {
 
         let state = db.inner.state.read().view();
         assert_eq!(1, state.state.manifest.value.core.l0.len());
-        let sst = state.state.manifest.value.core.l0.front().unwrap();
-        let index = db.inner.table_store.read_index(sst, true).await.unwrap();
+        let view = state.state.manifest.value.core.l0.front().unwrap();
+        let index = db
+            .inner
+            .table_store
+            .read_index(&view.sst, true)
+            .await
+            .unwrap();
         assert!(!index.borrow().block_meta().is_empty());
         assert_eq!(
             Some(Bytes::copy_from_slice(last_val.as_bytes())),
@@ -5321,7 +5326,7 @@ mod tests {
                 // flushed (await_durable in the put()'s above only wait for the writes to hit
                 // the WAL before returning).
                 should_compact_l0.store(true, Ordering::SeqCst);
-                s.l0_last_compacted.is_some() && s.l0.is_empty()
+                s.last_compacted_l0_sst_view_id.is_some() && s.l0.is_empty()
             },
             Duration::from_secs(10),
         )
@@ -5343,7 +5348,7 @@ mod tests {
                 // flushed (await_durable in the put()'s above only wait for the writes to hit
                 // the WAL before returning).
                 should_compact_l0.store(true, Ordering::SeqCst);
-                s.l0_last_compacted.is_some() && s.l0.is_empty()
+                s.last_compacted_l0_sst_view_id.is_some() && s.l0.is_empty()
             },
             Duration::from_secs(10),
         )
@@ -6468,7 +6473,7 @@ mod tests {
             1,
             "expected exactly one L0 SST in manifest"
         );
-        let l0_id = manifest.core.l0[0].id;
+        let l0_id = manifest.core.l0[0].sst.id;
         assert_eq!(
             l0_id, ssts[0].id,
             "expected SST {:?} but found SST {:?}",

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -224,7 +224,7 @@ impl DbReaderInner {
         let read_guard = self.state.read();
         let current_state = read_guard.core();
         latest.replay_after_wal_id > current_state.replay_after_wal_id
-            || latest.l0_last_compacted != current_state.l0_last_compacted
+            || latest.last_compacted_l0_sst_view_id != current_state.last_compacted_l0_sst_view_id
             || latest.compacted != current_state.compacted
     }
 

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -22,7 +22,7 @@ use ulid::Ulid;
 use uuid::Uuid;
 use SsTableId::{Compacted, Wal};
 
-/// A handle to an SSTable, including its ID, metadata, and visible key ranges.
+/// A handle to an SSTable — the physical SST on storage.
 #[derive(Clone, PartialEq, Serialize)]
 pub struct SsTableHandle {
     /// The unique identifier for this SSTable. The table can be either a WAL SST or a compacted SST.
@@ -33,31 +33,83 @@ pub struct SsTableHandle {
 
     /// Metadata information about this SSTable.
     pub info: SsTableInfo,
-
-    /// The range of keys that are visible to the user. If non-empty, this handle represents a projection
-    /// over the SST file.
-    pub(crate) visible_range: Option<BytesRange>,
-
-    /// The effective range of keys that are visible to the user, which is the intersection of the
-    /// physical range (first_key..unbounded) and any projection range. If a projection is specified,
-    /// this handle represents a subset of the SST file.
-    effective_range: BytesRange,
 }
 
 impl Debug for SsTableHandle {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_fmt(format_args!(
-            "SsTableHandle({:?}, {:?})",
-            self.id, self.visible_range
-        ))
+        f.write_fmt(format_args!("SsTableHandle({:?})", self.id))
     }
 }
 
 impl SsTableHandle {
     pub(crate) fn new(id: SsTableId, format_version: u16, info: SsTableInfo) -> Self {
-        let effective_range = match info.first_entry.clone() {
+        SsTableHandle {
+            id,
+            format_version,
+            info,
+        }
+    }
+
+    pub(crate) fn estimate_size(&self) -> u64 {
+        // this is a hacky estimate of the sst size since we don't have it stored anywhere
+        // right now. Just use the index's offset and add the index length. Since the index
+        // is the last thing we put in the SST before the info footer, this should be a good
+        // estimate for now.
+        self.info.index_offset + self.info.index_len
+    }
+}
+
+impl AsRef<SsTableHandle> for SsTableHandle {
+    fn as_ref(&self) -> &SsTableHandle {
+        self
+    }
+}
+
+/// A projected view of an SSTable, combining the physical SST handle with an
+/// optional visible_range projection.
+#[derive(Clone, PartialEq, Serialize)]
+pub struct SsTableView {
+    /// Unique identifier for this view.
+    pub(crate) id: Ulid,
+
+    /// The underlying physical SSTable handle.
+    pub sst: SsTableHandle,
+
+    /// The range of keys that are visible to the user. If non-empty, this view represents a projection
+    /// over the SST file.
+    pub(crate) visible_range: Option<BytesRange>,
+
+    /// The effective range of keys that are visible to the user, which is the intersection of the
+    /// physical range (first_key..unbounded) and any projection range.
+    effective_range: BytesRange,
+}
+
+impl Debug for SsTableView {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!(
+            "SsTableView({:?}, {:?})",
+            self.sst.id, self.visible_range
+        ))
+    }
+}
+
+impl SsTableView {
+    /// Create a view using a deterministic id derived from the SST's own identity.
+    /// Use this only for ephemeral views (e.g. WAL iteration) or legacy migration
+    /// where no `DbRand` is available and the id is not stored in the manifest.
+    pub(crate) fn identity(sst: SsTableHandle) -> Self {
+        let id = match &sst.id {
+            SsTableId::Compacted(ulid) => *ulid,
+            SsTableId::Wal(wal_id) => Ulid::from_parts(*wal_id, 0),
+        };
+        Self::new(id, sst)
+    }
+
+    /// Create a new view with no visible_range projection.
+    pub(crate) fn new(id: Ulid, sst: SsTableHandle) -> Self {
+        let effective_range = match sst.info.first_entry.clone() {
             Some(physical_first_entry) => {
-                let end_bound = match info.last_entry.clone() {
+                let end_bound = match sst.info.last_entry.clone() {
                     Some(physical_last_entry) => Included(physical_last_entry),
                     None => Unbounded,
                 };
@@ -66,24 +118,23 @@ impl SsTableHandle {
             None => BytesRange::new_empty(),
         };
 
-        SsTableHandle {
+        SsTableView {
             id,
-            format_version,
-            info,
+            sst,
             visible_range: None,
             effective_range,
         }
     }
 
-    pub(crate) fn new_compacted(
-        id: SsTableId,
-        format_version: u16,
-        info: SsTableInfo,
+    /// Create a new projected view with an optional visible_range.
+    pub(crate) fn new_projected(
+        id: Ulid,
+        sst: SsTableHandle,
         visible_range: Option<BytesRange>,
     ) -> Self {
-        let mut effective_range = match info.first_entry.clone() {
+        let mut effective_range = match sst.info.first_entry.clone() {
             Some(physical_first_entry) => {
-                let end_bound = match info.last_entry.clone() {
+                let end_bound = match sst.info.last_entry.clone() {
                     Some(physical_last_entry) => Included(physical_last_entry),
                     None => Unbounded,
                 };
@@ -102,22 +153,16 @@ impl SsTableHandle {
                 .intersect(visible_range)
                 .expect("An intersection of visible and physical range must be non-empty.")
         }
-        SsTableHandle {
+        SsTableView {
             id,
-            format_version,
-            info,
+            sst,
             visible_range,
             effective_range,
         }
     }
 
     pub(crate) fn with_visible_range(&self, visible_range: BytesRange) -> Self {
-        Self::new_compacted(
-            self.id,
-            self.format_version,
-            self.info.clone(),
-            Some(visible_range),
-        )
+        Self::new_projected(self.id, self.sst.clone(), Some(visible_range))
     }
 
     /// The range of keys that are visible to the user.
@@ -133,7 +178,7 @@ impl SsTableHandle {
     // memtable flushes, which should never produce empty SSTs. This method returns
     // the start bound after applying projections.
     pub(crate) fn compacted_effective_start_bound(&self) -> Bound<Bytes> {
-        assert!(matches!(self.id, Compacted(_)));
+        assert!(matches!(self.sst.id, Compacted(_)));
         self.effective_range.start_bound().cloned()
     }
 
@@ -141,7 +186,7 @@ impl SsTableHandle {
     // memtable flushes, which should never produce empty SSTs. This method returns
     // the start key after applying projections.
     pub(crate) fn compacted_effective_start_key(&self) -> &Bytes {
-        assert!(matches!(self.id, Compacted(_)));
+        assert!(matches!(self.sst.id, Compacted(_)));
         match self.effective_range.start_bound() {
             Included(k) => k,
             _ => unreachable!("Invalid start bound"),
@@ -154,14 +199,14 @@ impl SsTableHandle {
 
     pub(crate) fn compacted_intersection(
         &self,
-        next_handle: Option<&SsTableHandle>,
+        next_view: Option<&SsTableView>,
         range: &BytesRange,
     ) -> Option<BytesRange> {
-        assert!(matches!(self.id, Compacted(_)));
-        if let Some(next_handle) = next_handle {
+        assert!(matches!(self.sst.id, Compacted(_)));
+        if let Some(next_view) = next_view {
             BytesRange::new(
                 self.compacted_effective_start_bound(),
-                Excluded(next_handle.compacted_effective_start_key().clone()),
+                Excluded(next_view.compacted_effective_start_key().clone()),
             )
             .intersect(range)
         } else {
@@ -189,24 +234,14 @@ impl SsTableHandle {
         if let Some(visible_range) = &self.visible_range {
             return range.intersect(visible_range);
         }
-        if self.info.last_entry.is_some() {
+        if self.sst.info.last_entry.is_some() {
             return range.intersect(&self.effective_range);
         }
         Some(range)
     }
 
     pub(crate) fn estimate_size(&self) -> u64 {
-        // this is a hacky estimate of the sst size since we don't have it stored anywhere
-        // right now. Just use the index's offset and add the index length. Since the index
-        // is the last thing we put in the SST before the info footer, this should be a good
-        // estimate for now.
-        self.info.index_offset + self.info.index_len
-    }
-}
-
-impl AsRef<SsTableHandle> for SsTableHandle {
-    fn as_ref(&self) -> &SsTableHandle {
-        self
+        self.sst.estimate_size()
     }
 }
 
@@ -309,20 +344,20 @@ impl Clone for Box<dyn SsTableInfoCodec> {
 pub struct SortedRun {
     /// The unique identifier for this sorted run.
     pub id: u32,
-    /// The list of SSTables in this sorted run.
-    pub ssts: Vec<SsTableHandle>,
+    /// The list of SSTable views in this sorted run.
+    pub sst_views: Vec<SsTableView>,
 }
 
 impl SortedRun {
     /// Estimate the total size of all SSTables in this sorted run.
     pub fn estimate_size(&self) -> u64 {
-        self.ssts.iter().map(|sst| sst.estimate_size()).sum()
+        self.sst_views.iter().map(|sst| sst.estimate_size()).sum()
     }
 
     pub(crate) fn find_sst_with_range_covering_key_idx(&self, key: &[u8]) -> Option<usize> {
         // returns the sst after the one whose range includes the key
         let first_sst = self
-            .ssts
+            .sst_views
             .partition_point(|sst| sst.compacted_effective_start_key() <= key);
         if first_sst > 0 {
             return Some(first_sst - 1);
@@ -331,20 +366,20 @@ impl SortedRun {
         None
     }
 
-    pub(crate) fn find_sst_with_range_covering_key(&self, key: &[u8]) -> Option<&SsTableHandle> {
+    pub(crate) fn find_sst_with_range_covering_key(&self, key: &[u8]) -> Option<&SsTableView> {
         self.find_sst_with_range_covering_key_idx(key)
-            .map(|idx| &self.ssts[idx])
+            .map(|idx| &self.sst_views[idx])
     }
 
     fn table_idx_covering_range(&self, range: &BytesRange) -> Range<usize> {
         let mut min_idx = None;
         let mut max_idx = 0;
 
-        for idx in 0..self.ssts.len() {
-            let current_sst = &self.ssts[idx];
+        for idx in 0..self.sst_views.len() {
+            let current_sst = &self.sst_views[idx];
 
-            let upper_bound = if idx + 1 < self.ssts.len() {
-                let next_sst = &self.ssts[idx + 1];
+            let upper_bound = if idx + 1 < self.sst_views.len() {
+                let next_sst = &self.sst_views[idx + 1];
                 Excluded(next_sst.compacted_effective_start_key().clone())
             } else {
                 Unbounded
@@ -365,17 +400,17 @@ impl SortedRun {
         }
     }
 
-    pub(crate) fn tables_covering_range(&self, range: &BytesRange) -> VecDeque<&SsTableHandle> {
+    pub(crate) fn tables_covering_range(&self, range: &BytesRange) -> VecDeque<&SsTableView> {
         let matching_range = self.table_idx_covering_range(range);
-        self.ssts[matching_range].iter().collect()
+        self.sst_views[matching_range].iter().collect()
     }
 
     pub(crate) fn into_tables_covering_range(
         mut self,
         range: &BytesRange,
-    ) -> VecDeque<SsTableHandle> {
+    ) -> VecDeque<SsTableView> {
         let matching_range = self.table_idx_covering_range(range);
-        self.ssts.drain(matching_range).collect()
+        self.sst_views.drain(matching_range).collect()
     }
 }
 
@@ -414,11 +449,16 @@ pub struct ManifestCore {
     /// initialization has completed.
     pub initialized: bool,
 
-    /// The last compacted l0.
-    pub l0_last_compacted: Option<Ulid>,
+    /// The last compacted l0 SstView ID.
+    pub last_compacted_l0_sst_view_id: Option<Ulid>,
 
-    /// A list of the L0 SSTs that are valid to read in the `compacted` folder.
-    pub l0: VecDeque<SsTableHandle>,
+    /// The SST ID of the last compacted L0. In V2, view IDs differ from SST IDs,
+    /// but V1 only stores SST IDs. This field preserves the SST ID so that a
+    /// V1-encoded manifest can correctly reference the compacted L0.
+    pub last_compacted_l0_sst_id: Option<Ulid>,
+
+    /// A list of the L0 SST views that are valid to read in the `compacted` folder.
+    pub l0: VecDeque<SsTableView>,
 
     /// A list of the sorted runs that are valid to read in the `compacted` folder.
     pub compacted: Vec<SortedRun>,
@@ -463,7 +503,8 @@ impl ManifestCore {
     pub(crate) fn new() -> Self {
         Self {
             initialized: true,
-            l0_last_compacted: None,
+            last_compacted_l0_sst_view_id: None,
+            last_compacted_l0_sst_id: None,
             l0: VecDeque::new(),
             compacted: vec![],
             next_wal_sst_id: 1,
@@ -636,8 +677,9 @@ impl<'a> StateModifier<'a> {
     pub(crate) fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyObject<Manifest>) {
         // The compactor removes tables from l0_last_compacted, so we
         // only want to keep the tables up to there.
-        let l0_last_compacted = &remote_manifest.value.core.l0_last_compacted;
-        let new_l0 = if let Some(l0_last_compacted) = l0_last_compacted {
+        let l0_last_compacted_view_id = &remote_manifest.value.core.last_compacted_l0_sst_view_id;
+        let l0_last_compacted_sst_id = &remote_manifest.value.core.last_compacted_l0_sst_id;
+        let new_l0 = if l0_last_compacted_view_id.is_some() || l0_last_compacted_sst_id.is_some() {
             self.state
                 .manifest
                 .value
@@ -645,7 +687,20 @@ impl<'a> StateModifier<'a> {
                 .l0
                 .iter()
                 .cloned()
-                .take_while(|sst| sst.id.unwrap_compacted_id() != *l0_last_compacted)
+                .take_while(|view| {
+                    // Match by view ID first (V2 manifests), then fall back to SST ID (V1).
+                    if let Some(view_id) = l0_last_compacted_view_id {
+                        if view.id == *view_id {
+                            return false;
+                        }
+                    }
+                    if let Some(sst_id) = l0_last_compacted_sst_id {
+                        if view.sst.id.unwrap_compacted_id() == *sst_id {
+                            return false;
+                        }
+                    }
+                    true
+                })
                 .collect()
         } else {
             self.state.manifest.value.core.l0.iter().cloned().collect()
@@ -654,7 +709,8 @@ impl<'a> StateModifier<'a> {
         let my_db_state = self.state.core();
         remote_manifest.value.core = ManifestCore {
             initialized: my_db_state.initialized,
-            l0_last_compacted: remote_manifest.value.core.l0_last_compacted,
+            last_compacted_l0_sst_view_id: remote_manifest.value.core.last_compacted_l0_sst_view_id,
+            last_compacted_l0_sst_id: remote_manifest.value.core.last_compacted_l0_sst_id,
             l0: new_l0,
             compacted: remote_manifest.value.core.compacted,
             next_wal_sst_id: my_db_state.next_wal_sst_id,
@@ -693,7 +749,9 @@ impl WalIdStore for parking_lot::RwLock<DbState> {
 #[cfg(test)]
 mod tests {
     use crate::checkpoint::Checkpoint;
-    use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SstType};
+    use crate::db_state::{
+        DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType,
+    };
     use crate::db_status::DbStatusReporter;
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::store::test_utils::new_dirty_manifest;
@@ -743,8 +801,7 @@ mod tests {
         let mut compactor_state = new_dirty_manifest();
         compactor_state.value.core = db_state.state.core().clone();
         let last_compacted = compactor_state.value.core.l0.pop_back().unwrap();
-        compactor_state.value.core.l0_last_compacted =
-            Some(last_compacted.id.unwrap_compacted_id());
+        compactor_state.value.core.last_compacted_l0_sst_view_id = Some(last_compacted.id);
 
         // when:
         db_state.merge_remote_manifest(compactor_state.clone());
@@ -755,9 +812,15 @@ mod tests {
             .core
             .l0
             .iter()
-            .map(|l0| l0.id)
+            .map(|l0| l0.sst.id)
             .collect();
-        let merged: Vec<SsTableId> = db_state.state.core().l0.iter().map(|l0| l0.id).collect();
+        let merged: Vec<SsTableId> = db_state
+            .state
+            .core()
+            .l0
+            .iter()
+            .map(|l0| l0.sst.id)
+            .collect();
         assert_eq!(expected, merged);
     }
 
@@ -772,8 +835,14 @@ mod tests {
         db_state.merge_remote_manifest(new_dirty_manifest());
 
         // then:
-        let expected: Vec<SsTableId> = l0s.iter().map(|l0| l0.id).collect();
-        let merged: Vec<SsTableId> = db_state.state.core().l0.iter().map(|l0| l0.id).collect();
+        let expected: Vec<SsTableId> = l0s.iter().map(|l0| l0.sst.id).collect();
+        let merged: Vec<SsTableId> = db_state
+            .state
+            .core()
+            .l0
+            .iter()
+            .map(|l0| l0.sst.id)
+            .collect();
         assert_eq!(expected, merged);
     }
 
@@ -785,12 +854,13 @@ mod tests {
                 .expect("db in error state");
             let imm = db_state.state.imm_memtable.back().unwrap().clone();
             let handle = SsTableHandle::new(
-                SsTableId::Compacted(ulid::Ulid::new()),
+                SsTableId::Compacted(ulid::Ulid::from_parts(i as u64, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 dummy_info.clone(),
             );
+            let view: SsTableView = SsTableView::identity(handle);
             db_state.modify(|modifier| {
-                modifier.state.manifest.value.core.l0.push_front(handle);
+                modifier.state.manifest.value.core.l0.push_front(view);
                 modifier.state.manifest.value.core.replay_after_wal_id =
                     imm.recent_flushed_wal_id();
             });
@@ -842,15 +912,19 @@ mod tests {
     fn create_sorted_run(id: u32, first_keys: &BTreeSet<Bytes>) -> SortedRun {
         let mut ssts = Vec::new();
         for first_key in first_keys {
-            ssts.push(create_compacted_sst_handle(Some(first_key.clone())));
+            ssts.push(create_compacted_sst_view(Some(first_key.clone())));
         }
-        SortedRun { id, ssts }
+        SortedRun {
+            id,
+            sst_views: ssts,
+        }
     }
 
-    fn create_compacted_sst_handle(first_entry: Option<Bytes>) -> SsTableHandle {
+    fn create_compacted_sst_view(first_entry: Option<Bytes>) -> SsTableView {
         let sst_info = create_sst_info(first_entry);
-        let sst_id = SsTableId::Compacted(ulid::Ulid::new());
-        SsTableHandle::new(sst_id, SST_FORMAT_VERSION_LATEST, sst_info)
+        let sst_id = SsTableId::Compacted(ulid::Ulid::from_parts(0, 0));
+        let handle = SsTableHandle::new(sst_id, SST_FORMAT_VERSION_LATEST, sst_info);
+        SsTableView::identity(handle)
     }
 
     fn create_sst_info(first_entry: Option<Bytes>) -> SsTableInfo {

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -15,7 +15,7 @@ use crate::compactor_state::{
     Compactions as CompactorCompactions, SourceId,
 };
 use crate::db_state::{self, SsTableInfo, SsTableInfoCodec, SstType};
-use crate::db_state::{ManifestCore, SsTableHandle};
+use crate::db_state::{ManifestCore, SsTableHandle, SsTableView};
 
 #[path = "./generated/root_generated.rs"]
 #[allow(warnings, clippy::disallowed_macros, clippy::disallowed_types, clippy::disallowed_methods, unreachable_pub)]
@@ -23,8 +23,9 @@ use crate::db_state::{ManifestCore, SsTableHandle};
 mod root_generated;
 pub(crate) use root_generated::{
     BlockMeta, BlockMetaArgs, BlockStats as FbBlockStats, BlockStatsArgs as FbBlockStatsArgs,
-    ManifestV1, ManifestV1Args, SsTableIndex, SsTableIndexArgs, SsTableInfo as FbSsTableInfo,
-    SsTableInfoArgs, SstStats as FbSstStats, SstStatsArgs as FbSstStatsArgs,
+    ManifestV1, ManifestV2, ManifestV2Args, SsTableIndex, SsTableIndexArgs,
+    SsTableInfo as FbSsTableInfo, SsTableInfoArgs, SstStats as FbSstStats,
+    SstStatsArgs as FbSstStatsArgs,
 };
 
 use crate::config::CompressionCodec;
@@ -33,9 +34,11 @@ use crate::db_state::SsTableId::Compacted;
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::root_generated::{
     BoundType, Checkpoint, CheckpointArgs, CheckpointMetadata, CompactedSsTable,
-    CompactedSsTableArgs, Compaction as FbCompaction, CompactionArgs as FbCompactionArgs,
+    CompactedSsTableArgs, CompactedSsTableV2, CompactedSsTableV2Args, CompactedSsTableView,
+    CompactedSsTableViewArgs, Compaction as FbCompaction, CompactionArgs as FbCompactionArgs,
     CompactionSpec as FbCompactionSpec, CompactionStatus as FbCompactionStatus, CompactionsV1,
-    CompactionsV1Args, CompressionFormat, SortedRun, SortedRunArgs, SstType as FbSstType,
+    CompactionsV1Args, CompressionFormat, ManifestV1Args, SortedRun as FbSortedRunV1,
+    SortedRunArgs as FbSortedRunV1Args, SortedRunV2, SortedRunV2Args, SstType as FbSstType,
     TieredCompactionSpec, TieredCompactionSpecArgs, Ulid as FbUlid, UlidArgs as FbUlidArgs, Uuid,
     UuidArgs,
 };
@@ -46,7 +49,7 @@ use crate::seq_tracker::SequenceTracker;
 use crate::utils::clamp_allocated_size_bytes;
 use slatedb_txn_obj::ObjectCodec;
 
-pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 1;
+pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 2;
 pub(crate) const COMPACTIONS_FORMAT_VERSION: u16 = 1;
 pub(crate) const ORIGINAL_SST_FORMAT_VERSION: u16 = SST_FORMAT_VERSION;
 
@@ -154,7 +157,7 @@ pub(crate) struct FlatBufferManifestCodec {}
 
 impl ObjectCodec<Manifest> for FlatBufferManifestCodec {
     fn encode(&self, manifest: &Manifest) -> Bytes {
-        Self::create_from_manifest(manifest)
+        Self::create_from_manifest_v1(manifest)
     }
 
     fn decode(&self, bytes: &Bytes) -> Result<Manifest, Box<dyn std::error::Error + Send + Sync>> {
@@ -162,19 +165,28 @@ impl ObjectCodec<Manifest> for FlatBufferManifestCodec {
             return Err(Box::new(SlateDBError::EmptyManifest));
         }
         let version = u16::from_be_bytes([bytes[0], bytes[1]]);
-        if version != MANIFEST_FORMAT_VERSION {
-            return Err(Box::new(SlateDBError::InvalidVersion {
-                format_name: "manifest",
-                supported_versions: vec![MANIFEST_FORMAT_VERSION],
-                actual_version: version,
-            }));
-        }
         let unversioned_bytes = bytes.slice(2..);
-        let manifest = flatbuffers::root_with_opts::<ManifestV1>(
-            &verifier_options(),
-            unversioned_bytes.as_ref(),
-        )?;
-        Ok(Self::manifest(&manifest))
+        match version {
+            1 => {
+                let manifest = flatbuffers::root_with_opts::<ManifestV1>(
+                    &verifier_options(),
+                    unversioned_bytes.as_ref(),
+                )?;
+                Self::manifest_v1(&manifest)
+            }
+            2 => {
+                let manifest = flatbuffers::root_with_opts::<ManifestV2>(
+                    &verifier_options(),
+                    unversioned_bytes.as_ref(),
+                )?;
+                Self::manifest_v2(&manifest)
+            }
+            _ => Err(Box::new(SlateDBError::InvalidVersion {
+                format_name: "manifest",
+                supported_versions: vec![1, 2],
+                actual_version: version,
+            })),
+        }
     }
 }
 
@@ -204,20 +216,25 @@ impl FlatBufferManifestCodec {
         }
     }
 
-    pub(crate) fn manifest(manifest: &ManifestV1) -> Manifest {
+    // ManifestV1 has no view IDs, so we use SST IDs during migration.
+    // This also allows to use l0_last_compacted from V1 which is an SST ID rather than SST view ID.
+    #[allow(clippy::disallowed_methods)]
+    pub(crate) fn manifest_v1(
+        manifest: &ManifestV1,
+    ) -> Result<Manifest, Box<dyn std::error::Error + Send + Sync>> {
         let l0_last_compacted = manifest.l0_last_compacted().map(|id| id.ulid());
         let mut l0 = VecDeque::new();
 
         for man_sst in manifest.l0().iter() {
-            let sst_id = Compacted(man_sst.id().ulid());
+            let sst_ulid = man_sst.id().ulid();
             let format_version = man_sst
                 .format_version()
                 .unwrap_or(ORIGINAL_SST_FORMAT_VERSION);
             let sst_info = FlatBufferSsTableInfoCodec::sst_info(&man_sst.info());
-            let l0_sst = SsTableHandle::new_compacted(
-                sst_id,
-                format_version,
-                sst_info,
+            let handle = SsTableHandle::new(Compacted(sst_ulid), format_version, sst_info);
+            let l0_sst = SsTableView::new_projected(
+                sst_ulid,
+                handle,
                 man_sst.visible_range().map(Self::decode_bytes_range),
             );
             l0.push_back(l0_sst);
@@ -226,21 +243,21 @@ impl FlatBufferManifestCodec {
         for manifest_sr in manifest.compacted().iter() {
             let mut ssts = Vec::new();
             for manifest_sst in manifest_sr.ssts().iter() {
-                let id = Compacted(manifest_sst.id().ulid());
+                let sst_ulid = manifest_sst.id().ulid();
                 let format_version = manifest_sst
                     .format_version()
                     .unwrap_or(ORIGINAL_SST_FORMAT_VERSION);
                 let info = FlatBufferSsTableInfoCodec::sst_info(&manifest_sst.info());
-                ssts.push(SsTableHandle::new_compacted(
-                    id,
-                    format_version,
-                    info,
+                let handle = SsTableHandle::new(Compacted(sst_ulid), format_version, info);
+                ssts.push(SsTableView::new_projected(
+                    sst_ulid,
+                    handle,
                     manifest_sst.visible_range().map(Self::decode_bytes_range),
                 ));
             }
             compacted.push(db_state::SortedRun {
                 id: manifest_sr.id(),
-                ssts,
+                sst_views: ssts,
             })
         }
         let checkpoints: Vec<checkpoint::Checkpoint> = manifest
@@ -271,7 +288,9 @@ impl FlatBufferManifestCodec {
         };
         let core = ManifestCore {
             initialized: manifest.initialized(),
-            l0_last_compacted,
+            // In V1, view IDs are SST IDs, so both fields are the same.
+            last_compacted_l0_sst_view_id: l0_last_compacted,
+            last_compacted_l0_sst_id: l0_last_compacted,
             l0,
             compacted,
             next_wal_sst_id: manifest.wal_id_last_seen() + 1,
@@ -295,14 +314,135 @@ impl FlatBufferManifestCodec {
                 .collect()
         });
 
-        Manifest {
+        Ok(Manifest {
             external_dbs: external_dbs.unwrap_or_default(),
             core,
             writer_epoch: manifest.writer_epoch(),
             compactor_epoch: manifest.compactor_epoch(),
-        }
+        })
     }
 
+    fn decode_compacted_sst_view(
+        view: &CompactedSsTableView,
+        sst_lookup: &std::collections::HashMap<Ulid, SsTableHandle>,
+    ) -> Result<SsTableView, Box<dyn std::error::Error + Send + Sync>> {
+        let id = view.id().ulid();
+        let ulid = view.sst_id().ulid();
+        let handle = sst_lookup
+            .get(&ulid)
+            .ok_or_else(|| format!("CompactedSsTableView references unknown SST id: {ulid}"))?
+            .clone();
+        Ok(SsTableView::new_projected(
+            id,
+            handle,
+            view.visible_range().map(Self::decode_bytes_range),
+        ))
+    }
+
+    pub(crate) fn manifest_v2(
+        manifest: &ManifestV2,
+    ) -> Result<Manifest, Box<dyn std::error::Error + Send + Sync>> {
+        let sst_lookup: std::collections::HashMap<Ulid, SsTableHandle> = manifest
+            .ssts()
+            .iter()
+            .map(|fb_sst| {
+                let ulid = fb_sst.id().ulid();
+                let handle = FlatBufferCompactionsCodec::compacted_sst_v2(fb_sst);
+                (ulid, handle)
+            })
+            .collect();
+        let l0_last_compacted = manifest.last_compacted_l0_sst_view_id().map(|id| id.ulid());
+        let l0: VecDeque<SsTableView> = manifest
+            .l0()
+            .iter()
+            .map(|view| Self::decode_compacted_sst_view(&view, &sst_lookup))
+            .collect::<Result<_, _>>()?;
+        let compacted: Vec<db_state::SortedRun> = manifest
+            .compacted()
+            .iter()
+            .map(
+                |sr| -> Result<_, Box<dyn std::error::Error + Send + Sync>> {
+                    let ssts = sr
+                        .ssts()
+                        .iter()
+                        .map(|view| Self::decode_compacted_sst_view(&view, &sst_lookup))
+                        .collect::<Result<_, _>>()?;
+                    Ok(db_state::SortedRun {
+                        id: sr.id(),
+                        sst_views: ssts,
+                    })
+                },
+            )
+            .collect::<Result<_, _>>()?;
+        let checkpoints: Vec<checkpoint::Checkpoint> = manifest
+            .checkpoints()
+            .iter()
+            .map(|cp| checkpoint::Checkpoint {
+                id: Self::decode_uuid(cp.id()),
+                manifest_id: cp.manifest_id(),
+                expire_time: match cp.checkpoint_expire_time_s() {
+                    0 => None,
+                    _ => Some(
+                        DateTime::<Utc>::from_timestamp(cp.checkpoint_expire_time_s() as i64, 0)
+                            .expect("invalid timestamp"),
+                    ),
+                },
+                create_time: DateTime::<Utc>::from_timestamp(
+                    cp.checkpoint_create_time_s() as i64,
+                    0,
+                )
+                .expect("invalid timestamp"),
+                name: cp.name().map(|s| s.to_string()),
+            })
+            .collect();
+        let sequence_tracker = match manifest.sequence_tracker() {
+            Some(bytes) => SequenceTracker::from_bytes(bytes.bytes())
+                .expect("Invalid encoding of sequence tracker in manifest."),
+            None => SequenceTracker::new(),
+        };
+        let core = ManifestCore {
+            initialized: manifest.initialized(),
+            last_compacted_l0_sst_view_id: l0_last_compacted,
+            // Not persisted in V2; populated at runtime by finish_compaction.
+            last_compacted_l0_sst_id: None,
+            l0,
+            compacted,
+            next_wal_sst_id: manifest.wal_id_last_seen() + 1,
+            replay_after_wal_id: manifest.replay_after_wal_id(),
+            last_l0_seq: manifest.last_l0_seq(),
+            last_l0_clock_tick: manifest.last_l0_clock_tick(),
+            checkpoints,
+            wal_object_store_uri: manifest.wal_object_store_uri().map(|uri| uri.to_string()),
+            recent_snapshot_min_seq: manifest.recent_snapshot_min_seq(),
+            sequence_tracker,
+        };
+        let external_dbs = manifest.external_dbs().map(|external_dbs| {
+            external_dbs
+                .iter()
+                .map(|db| ExternalDb {
+                    path: db.path().to_string(),
+                    source_checkpoint_id: Self::decode_uuid(db.source_checkpoint_id()),
+                    final_checkpoint_id: db.final_checkpoint_id().map(|id| Self::decode_uuid(id)),
+                    sst_ids: db.sst_ids().iter().map(|id| Compacted(id.ulid())).collect(),
+                })
+                .collect()
+        });
+
+        Ok(Manifest {
+            external_dbs: external_dbs.unwrap_or_default(),
+            core,
+            writer_epoch: manifest.writer_epoch(),
+            compactor_epoch: manifest.compactor_epoch(),
+        })
+    }
+
+    pub(crate) fn create_from_manifest_v1(manifest: &Manifest) -> Bytes {
+        let builder = FlatBufferBuilder::new();
+        let mut db_fb_builder = DbFlatBufferBuilder::new(builder);
+        db_fb_builder.create_manifest_v1(manifest)
+    }
+
+    #[allow(unused)]
     pub(crate) fn create_from_manifest(manifest: &Manifest) -> Bytes {
         let builder = FlatBufferBuilder::new();
         let mut db_fb_builder = DbFlatBufferBuilder::new(builder);
@@ -377,8 +517,13 @@ impl FlatBufferCompactionsCodec {
                     return Err(SlateDBError::InvalidCompaction);
                 };
                 let mut sources = Vec::new();
-                if let Some(ssts) = spec.ssts() {
-                    sources.extend(ssts.iter().map(|s| SourceId::Sst(s.ulid())));
+                if let Some(view_ids) = spec.l0_view_ids() {
+                    sources.extend(view_ids.iter().map(|id| SourceId::SstView(id.ulid())));
+                } else if let Some(ssts) = spec.ssts() {
+                    // Backward compat: old specs stored SST ULIDs, not view IDs.
+                    // These won't match any view precisely, but this path only
+                    // applies to in-flight compactions from before the upgrade.
+                    sources.extend(ssts.iter().map(|s| SourceId::SstView(s.ulid())));
                 }
                 let sorted_runs: Vec<u32> = spec
                     .sorted_runs()
@@ -399,10 +544,16 @@ impl FlatBufferCompactionsCodec {
             .format_version()
             .unwrap_or(ORIGINAL_SST_FORMAT_VERSION);
         let info = FlatBufferSsTableInfoCodec::sst_info(&compacted_sst.info());
-        let visible_range = compacted_sst
-            .visible_range()
-            .map(FlatBufferManifestCodec::decode_bytes_range);
-        SsTableHandle::new_compacted(id, format_version, info, visible_range)
+        SsTableHandle::new(id, format_version, info)
+    }
+
+    fn compacted_sst_v2(compacted_sst: CompactedSsTableV2) -> SsTableHandle {
+        let id = Compacted(compacted_sst.id().ulid());
+        let format_version = compacted_sst
+            .format_version()
+            .unwrap_or(ORIGINAL_SST_FORMAT_VERSION);
+        let info = FlatBufferSsTableInfoCodec::sst_info(&compacted_sst.info());
+        SsTableHandle::new(id, format_version, info)
     }
 
     pub(crate) fn create_from_compactions(compactions: &CompactorCompactions) -> Bytes {
@@ -496,16 +647,12 @@ impl<'b> DbFlatBufferBuilder<'b> {
         };
         let compacted_sst_id = self.add_compacted_sst_id(&ulid);
         let compacted_sst_info = self.add_sst_info(&handle.info);
-        let visible_range = handle
-            .visible_range
-            .as_ref()
-            .map(|r| self.add_bytes_range(r));
         CompactedSsTable::create(
             &mut self.builder,
             &CompactedSsTableArgs {
                 id: Some(compacted_sst_id),
                 info: Some(compacted_sst_info),
-                visible_range,
+                visible_range: None,
                 format_version: Some(handle.format_version),
             },
         )
@@ -523,24 +670,138 @@ impl<'b> DbFlatBufferBuilder<'b> {
         self.builder.create_vector(compacted_ssts.as_ref())
     }
 
-    fn add_sorted_run(&mut self, sorted_run: &db_state::SortedRun) -> WIPOffset<SortedRun<'b>> {
-        let ssts = self.add_compacted_ssts(sorted_run.ssts.iter());
-        SortedRun::create(
+    fn add_compacted_sst_from_view(
+        &mut self,
+        view: &SsTableView,
+    ) -> WIPOffset<CompactedSsTable<'b>> {
+        let ulid = match view.sst.id {
+            SsTableId::Wal(_) => {
+                unreachable!("cannot pass WAL SST handle to create compacted sst from view")
+            }
+            SsTableId::Compacted(ulid) => ulid,
+        };
+        let compacted_sst_id = self.add_compacted_sst_id(&ulid);
+        let compacted_sst_info = self.add_sst_info(&view.sst.info);
+        let visible_range = view.visible_range.as_ref().map(|r| self.add_bytes_range(r));
+        CompactedSsTable::create(
             &mut self.builder,
-            &SortedRunArgs {
+            &CompactedSsTableArgs {
+                id: Some(compacted_sst_id),
+                info: Some(compacted_sst_info),
+                visible_range,
+                format_version: Some(view.sst.format_version),
+            },
+        )
+    }
+
+    fn add_compacted_sst_v2(
+        &mut self,
+        handle: &SsTableHandle,
+    ) -> WIPOffset<CompactedSsTableV2<'b>> {
+        let ulid = match handle.id {
+            SsTableId::Wal(_) => {
+                unreachable!("cannot pass WAL SST handle to create compacted sst v2")
+            }
+            SsTableId::Compacted(ulid) => ulid,
+        };
+        let compacted_sst_id = self.add_compacted_sst_id(&ulid);
+        let compacted_sst_info = self.add_sst_info(&handle.info);
+        CompactedSsTableV2::create(
+            &mut self.builder,
+            &CompactedSsTableV2Args {
+                id: Some(compacted_sst_id),
+                info: Some(compacted_sst_info),
+                format_version: Some(handle.format_version),
+            },
+        )
+    }
+
+    fn add_compacted_sst_view(
+        &mut self,
+        view: &SsTableView,
+    ) -> WIPOffset<CompactedSsTableView<'b>> {
+        let ulid = match view.sst.id {
+            SsTableId::Wal(_) => {
+                unreachable!("cannot pass WAL SST handle to create compacted sst view")
+            }
+            SsTableId::Compacted(ulid) => ulid,
+        };
+        let sst_id = self.add_compacted_sst_id(&ulid);
+        let visible_range = view.visible_range.as_ref().map(|r| self.add_bytes_range(r));
+        let id = Some(self.add_ulid(&view.id));
+        CompactedSsTableView::create(
+            &mut self.builder,
+            &CompactedSsTableViewArgs {
+                sst_id: Some(sst_id),
+                visible_range,
+                id,
+            },
+        )
+    }
+
+    fn add_compacted_sst_views<'a, I>(
+        &mut self,
+        ssts: I,
+    ) -> WIPOffset<Vector<'b, ForwardsUOffset<CompactedSsTableView<'b>>>>
+    where
+        I: Iterator<Item = &'a SsTableView>,
+    {
+        let views: Vec<WIPOffset<CompactedSsTableView>> =
+            ssts.map(|sst| self.add_compacted_sst_view(sst)).collect();
+        self.builder.create_vector(views.as_ref())
+    }
+
+    fn add_sorted_run_v2(
+        &mut self,
+        sorted_run: &db_state::SortedRun,
+    ) -> WIPOffset<SortedRunV2<'b>> {
+        let ssts = self.add_compacted_sst_views(sorted_run.sst_views.iter());
+        SortedRunV2::create(
+            &mut self.builder,
+            &SortedRunV2Args {
                 id: sorted_run.id,
                 ssts: Some(ssts),
             },
         )
     }
 
-    fn add_sorted_runs(
+    fn add_sorted_runs_v2(
         &mut self,
         sorted_runs: &[db_state::SortedRun],
-    ) -> WIPOffset<Vector<'b, ForwardsUOffset<SortedRun<'b>>>> {
-        let sorted_runs_fbs: Vec<WIPOffset<SortedRun>> = sorted_runs
+    ) -> WIPOffset<Vector<'b, ForwardsUOffset<SortedRunV2<'b>>>> {
+        let sorted_runs_fbs: Vec<WIPOffset<SortedRunV2>> = sorted_runs
             .iter()
-            .map(|sr| self.add_sorted_run(sr))
+            .map(|sr| self.add_sorted_run_v2(sr))
+            .collect();
+        self.builder.create_vector(sorted_runs_fbs.as_ref())
+    }
+
+    fn add_sorted_run_v1(
+        &mut self,
+        sorted_run: &db_state::SortedRun,
+    ) -> WIPOffset<FbSortedRunV1<'b>> {
+        let ssts: Vec<WIPOffset<CompactedSsTable>> = sorted_run
+            .sst_views
+            .iter()
+            .map(|view| self.add_compacted_sst_from_view(view))
+            .collect();
+        let ssts = self.builder.create_vector(ssts.as_ref());
+        FbSortedRunV1::create(
+            &mut self.builder,
+            &FbSortedRunV1Args {
+                id: sorted_run.id,
+                ssts: Some(ssts),
+            },
+        )
+    }
+
+    fn add_sorted_runs_v1(
+        &mut self,
+        sorted_runs: &[db_state::SortedRun],
+    ) -> WIPOffset<Vector<'b, ForwardsUOffset<FbSortedRunV1<'b>>>> {
+        let sorted_runs_fbs: Vec<WIPOffset<FbSortedRunV1>> = sorted_runs
+            .iter()
+            .map(|sr| self.add_sorted_run_v1(sr))
             .collect();
         self.builder.create_vector(sorted_runs_fbs.as_ref())
     }
@@ -549,20 +810,24 @@ impl<'b> DbFlatBufferBuilder<'b> {
         &mut self,
         spec: &CompactorCompactionSpec,
     ) -> (FbCompactionSpec, WIPOffset<flatbuffers::UnionWIPOffset>) {
-        let mut ssts = Vec::new();
+        let mut view_ids = Vec::new();
         let mut sorted_runs = Vec::new();
         for source in spec.sources().iter() {
             match source {
-                SourceId::Sst(id) => ssts.push(*id),
+                SourceId::SstView(id) => view_ids.push(*id),
                 SourceId::SortedRun(id) => sorted_runs.push(*id),
             }
         }
-        let ssts = (!ssts.is_empty()).then(|| self.add_ulids(ssts.iter()));
+        let l0_view_ids = (!view_ids.is_empty()).then(|| self.add_ulids(view_ids.iter()));
         let sorted_runs =
             (!sorted_runs.is_empty()).then(|| self.builder.create_vector(sorted_runs.as_slice()));
         let tiered_spec = TieredCompactionSpec::create(
             &mut self.builder,
-            &TieredCompactionSpecArgs { ssts, sorted_runs },
+            &TieredCompactionSpecArgs {
+                ssts: None,
+                sorted_runs,
+                l0_view_ids,
+            },
         );
         (
             FbCompactionSpec::TieredCompactionSpec,
@@ -682,12 +947,110 @@ impl<'b> DbFlatBufferBuilder<'b> {
 
     fn create_manifest(&mut self, manifest: &Manifest) -> Bytes {
         let core = &manifest.core;
-        let l0 = self.add_compacted_ssts(core.l0.iter());
+
+        // Collect all unique SSTs from l0 and compacted runs.
+        let mut unique_ssts: std::collections::HashMap<Ulid, &SsTableHandle> =
+            std::collections::HashMap::new();
+        for view in core.l0.iter() {
+            if let SsTableId::Compacted(ulid) = view.sst.id {
+                unique_ssts.entry(ulid).or_insert(&view.sst);
+            }
+        }
+        for sr in core.compacted.iter() {
+            for view in sr.sst_views.iter() {
+                if let SsTableId::Compacted(ulid) = view.sst.id {
+                    unique_ssts.entry(ulid).or_insert(&view.sst);
+                }
+            }
+        }
+        let ssts = {
+            let sst_offsets: Vec<WIPOffset<CompactedSsTableV2>> = unique_ssts
+                .values()
+                .map(|handle| self.add_compacted_sst_v2(handle))
+                .collect();
+            self.builder.create_vector(sst_offsets.as_ref())
+        };
+
+        let l0 = self.add_compacted_sst_views(core.l0.iter());
         let mut l0_last_compacted = None;
-        if let Some(ulid) = core.l0_last_compacted.as_ref() {
+        if let Some(ulid) = core.last_compacted_l0_sst_view_id.as_ref() {
             l0_last_compacted = Some(self.add_compacted_sst_id(ulid))
         }
-        let compacted = self.add_sorted_runs(&core.compacted);
+        let compacted = self.add_sorted_runs_v2(&core.compacted);
+        let checkpoints = self.add_checkpoints(&core.checkpoints);
+        let external_dbs = if manifest.external_dbs.is_empty() {
+            None
+        } else {
+            let external_dbs: Vec<WIPOffset<root_generated::ExternalDb>> = manifest
+                .external_dbs
+                .iter()
+                .map(|external_db| {
+                    let db_external_db_args = root_generated::ExternalDbArgs {
+                        path: Some(self.builder.create_string(&external_db.path)),
+                        source_checkpoint_id: Some(self.add_uuid(external_db.source_checkpoint_id)),
+                        final_checkpoint_id: external_db
+                            .final_checkpoint_id
+                            .map(|id| self.add_uuid(id)),
+                        sst_ids: Some(self.add_compacted_sst_ids(external_db.sst_ids.iter())),
+                    };
+                    root_generated::ExternalDb::create(&mut self.builder, &db_external_db_args)
+                })
+                .collect();
+            Some(self.builder.create_vector(external_dbs.as_ref()))
+        };
+
+        let wal_object_store_uri = core
+            .wal_object_store_uri
+            .as_ref()
+            .map(|uri| self.builder.create_string(uri));
+        let sequence_tracker_data = core.sequence_tracker.to_bytes();
+        let sequence_tracker = self.builder.create_vector(sequence_tracker_data.as_slice());
+
+        let manifest = ManifestV2::create(
+            &mut self.builder,
+            &ManifestV2Args {
+                manifest_id: 0, // todo: get rid of me
+                external_dbs,
+                initialized: core.initialized,
+                writer_epoch: manifest.writer_epoch,
+                compactor_epoch: manifest.compactor_epoch,
+                replay_after_wal_id: core.replay_after_wal_id,
+                wal_id_last_seen: core.next_wal_sst_id - 1,
+                last_compacted_l0_sst_view_id: l0_last_compacted,
+                ssts: Some(ssts),
+                l0: Some(l0),
+                compacted: Some(compacted),
+                last_l0_clock_tick: core.last_l0_clock_tick,
+                checkpoints: Some(checkpoints),
+                last_l0_seq: core.last_l0_seq,
+                wal_object_store_uri,
+                recent_snapshot_min_seq: core.recent_snapshot_min_seq,
+                sequence_tracker: Some(sequence_tracker),
+            },
+        );
+        self.builder.finish(manifest, None);
+        let mut bytes = BytesMut::new();
+        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_slice(self.builder.finished_data());
+        bytes.into()
+    }
+
+    fn create_manifest_v1(&mut self, manifest: &Manifest) -> Bytes {
+        let core = &manifest.core;
+
+        let l0: Vec<WIPOffset<CompactedSsTable>> = core
+            .l0
+            .iter()
+            .map(|view| self.add_compacted_sst_from_view(view))
+            .collect();
+        let l0 = self.builder.create_vector(l0.as_ref());
+
+        // V1's l0_last_compacted is an SST ID, not a view ID.
+        let mut l0_last_compacted = None;
+        if let Some(sst_id) = core.last_compacted_l0_sst_id.as_ref() {
+            l0_last_compacted = Some(self.add_compacted_sst_id(sst_id))
+        }
+        let compacted = self.add_sorted_runs_v1(&core.compacted);
         let checkpoints = self.add_checkpoints(&core.checkpoints);
         let external_dbs = if manifest.external_dbs.is_empty() {
             None
@@ -720,7 +1083,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         let manifest = ManifestV1::create(
             &mut self.builder,
             &ManifestV1Args {
-                manifest_id: 0, // todo: get rid of me
+                manifest_id: 0,
                 external_dbs,
                 initialized: core.initialized,
                 writer_epoch: manifest.writer_epoch,
@@ -740,7 +1103,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         );
         self.builder.finish(manifest, None);
         let mut bytes = BytesMut::new();
-        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_u16(1);
         bytes.put_slice(self.builder.finished_data());
         bytes.into()
     }
@@ -845,7 +1208,7 @@ mod tests {
         Compaction, CompactionSpec, CompactionStatus, Compactions, SourceId,
     };
     use crate::db_state::{
-        ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SstType,
+        ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType,
     };
     use crate::flatbuffer_types::{
         FlatBufferCompactionsCodec, FlatBufferManifestCodec, SsTableIndexOwned,
@@ -929,14 +1292,20 @@ mod tests {
 
     #[test]
     fn test_should_encode_decode_ssts_with_visible_ranges() {
-        fn new_sst_handle(first_entry: &[u8], visible_range: Option<BytesRange>) -> SsTableHandle {
-            SsTableHandle::new_compacted(
-                SsTableId::Compacted(ulid::Ulid::new()),
-                SST_FORMAT_VERSION_LATEST,
-                SsTableInfo {
-                    first_entry: Some(Bytes::copy_from_slice(first_entry)),
-                    ..Default::default()
-                },
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        fn new_sst_handle(first_entry: &[u8], visible_range: Option<BytesRange>) -> SsTableView {
+            let ulid = ulid::Ulid::from_parts(COUNTER.fetch_add(1, Ordering::Relaxed), 0);
+            SsTableView::new_projected(
+                ulid,
+                SsTableHandle::new(
+                    SsTableId::Compacted(ulid),
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::copy_from_slice(first_entry)),
+                        ..Default::default()
+                    },
+                ),
                 visible_range,
             )
         }
@@ -950,14 +1319,14 @@ mod tests {
         manifest.core.compacted = vec![
             SortedRun {
                 id: 0,
-                ssts: vec![
+                sst_views: vec![
                     new_sst_handle(b"a", None),
                     new_sst_handle(b"d", Some(BytesRange::from_ref("e".."f"))),
                 ],
             },
             SortedRun {
                 id: 0,
-                ssts: vec![
+                sst_views: vec![
                     new_sst_handle(b"a", None),
                     new_sst_handle(b"c", Some(BytesRange::from_ref("c"..))),
                     new_sst_handle(b"d", Some(BytesRange::from_ref("e".."f"))),
@@ -1004,10 +1373,8 @@ mod tests {
     fn test_should_validate_manifest_version() {
         let codec = FlatBufferManifestCodec {};
 
-        // Create a valid manifest with current version
+        // Create a valid V1 manifest
         let mut fbb = flatbuffers::FlatBufferBuilder::new();
-
-        // Create minimal required fields for ManifestV1
         let l0 = fbb.create_vector::<flatbuffers::WIPOffset<_>>(&[]);
         let compacted = fbb.create_vector::<flatbuffers::WIPOffset<_>>(&[]);
         let checkpoints = fbb.create_vector::<flatbuffers::WIPOffset<_>>(&[]);
@@ -1036,18 +1403,22 @@ mod tests {
         fbb.finish(manifest, None);
         let fb_data = fbb.finished_data();
 
+        // Test V1 decodes successfully with version byte 1
         let mut bytes = BytesMut::with_capacity(2 + fb_data.len());
-        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_u16(1);
         bytes.put_slice(fb_data);
-        let valid_bytes = bytes.freeze();
+        let v1_bytes = bytes.freeze();
+        codec.decode(&v1_bytes).expect("Should decode V1 manifest");
 
-        // Test valid version
-        match codec.decode(&valid_bytes) {
-            Ok(_) => { /* Expected success with valid flatbuffer data */ }
-            Err(e) => panic!("Should succeed with valid flatbuffer data: {:?}", e),
-        }
+        // Test encode/decode round-trip (currently writes V1 for forward compatibility)
+        let manifest = Manifest::initial(ManifestCore::new());
+        let encoded = codec.encode(&manifest);
+        assert_eq!(u16::from_be_bytes([encoded[0], encoded[1]]), 1);
+        codec
+            .decode(&encoded)
+            .expect("Should decode manifest round-trip");
 
-        // Test invalid version
+        // Test unsupported version
         let mut bytes = BytesMut::with_capacity(2 + fb_data.len());
         bytes.put_u16(MANIFEST_FORMAT_VERSION + 1);
         bytes.put_slice(fb_data);
@@ -1064,7 +1435,7 @@ mod tests {
                     panic!("Expected SlateDBError::InvalidVersion but got {:?}", err);
                 };
                 assert_eq!(*format_name, "manifest");
-                assert_eq!(*supported_versions, vec![MANIFEST_FORMAT_VERSION]);
+                assert_eq!(*supported_versions, vec![1u16, 2]);
                 assert_eq!(*actual_version, MANIFEST_FORMAT_VERSION + 1);
             }
             _ => panic!("Should fail with version mismatch"),
@@ -1107,25 +1478,21 @@ mod tests {
 
     #[test]
     fn test_should_encode_decode_compactions() {
-        fn new_output_sst(first_key: &[u8], visible_range: Option<BytesRange>) -> SsTableHandle {
-            SsTableHandle::new_compacted(
+        fn new_output_sst(first_key: &[u8]) -> SsTableHandle {
+            SsTableHandle::new(
                 SsTableId::Compacted(ulid::Ulid::new()),
                 SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::copy_from_slice(first_key)),
                     ..Default::default()
                 },
-                visible_range,
             )
         }
 
-        let output_ssts = vec![
-            new_output_sst(b"a", None),
-            new_output_sst(b"m", Some(BytesRange::from_ref("n"..="z"))),
-        ];
+        let output_ssts = vec![new_output_sst(b"a"), new_output_sst(b"m")];
         let compaction_l0 = Compaction::new(
             ulid::Ulid::new(),
-            CompactionSpec::new(vec![SourceId::Sst(ulid::Ulid::new())], 0),
+            CompactionSpec::new(vec![SourceId::SstView(ulid::Ulid::new())], 0),
         )
         .with_status(CompactionStatus::Running)
         .with_output_ssts(output_ssts);
@@ -1272,26 +1639,24 @@ mod tests {
     fn test_should_encode_decode_manifest_sst_with_version_set() {
         // given: a manifest with one L0 SST and one sorted run SST
         let mut manifest = Manifest::initial(ManifestCore::new());
-        manifest.core.l0 = VecDeque::from(vec![SsTableHandle::new_compacted(
+        manifest.core.l0 = VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
             SsTableId::Compacted(ulid::Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo {
                 first_entry: Some(Bytes::from_static(b"l0key")),
                 ..Default::default()
             },
-            None,
-        )]);
+        ))]);
         manifest.core.compacted = vec![SortedRun {
             id: 1,
-            ssts: vec![SsTableHandle::new_compacted(
+            sst_views: vec![SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(ulid::Ulid::new()),
                 SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::from_static(b"srkey")),
                     ..Default::default()
                 },
-                None,
-            )],
+            ))],
         }];
         let codec = FlatBufferManifestCodec {};
 
@@ -1300,9 +1665,12 @@ mod tests {
         let decoded = codec.decode(&bytes).expect("failed to decode manifest");
 
         // then:
-        assert_eq!(decoded.core.l0[0].format_version, SST_FORMAT_VERSION_LATEST);
         assert_eq!(
-            decoded.core.compacted[0].ssts[0].format_version,
+            decoded.core.l0[0].sst.format_version,
+            SST_FORMAT_VERSION_LATEST
+        );
+        assert_eq!(
+            decoded.core.compacted[0].sst_views[0].sst.format_version,
             SST_FORMAT_VERSION_LATEST
         );
         assert_eq!(manifest, decoded);
@@ -1392,7 +1760,7 @@ mod tests {
         );
         fbb.finish(manifest, None);
         let mut bytes = BytesMut::new();
-        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_u16(1); // V1 format
         bytes.put_slice(fbb.finished_data());
         let bytes = bytes.freeze();
 
@@ -1402,11 +1770,11 @@ mod tests {
 
         // then: format_version should default to ORIGINAL_SST_FORMAT_VERSION
         assert_eq!(
-            decoded.core.l0[0].format_version,
+            decoded.core.l0[0].sst.format_version,
             super::ORIGINAL_SST_FORMAT_VERSION
         );
         assert_eq!(
-            decoded.core.compacted[0].ssts[0].format_version,
+            decoded.core.compacted[0].sst_views[0].sst.format_version,
             super::ORIGINAL_SST_FORMAT_VERSION
         );
     }
@@ -1414,18 +1782,17 @@ mod tests {
     #[test]
     fn test_should_encode_decode_compaction_output_sst_with_version_set() {
         // given: a compaction with one output SST
-        let output_sst = SsTableHandle::new_compacted(
+        let output_sst = SsTableHandle::new(
             SsTableId::Compacted(ulid::Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo {
                 first_entry: Some(Bytes::from_static(b"key1")),
                 ..Default::default()
             },
-            None,
         );
         let compaction = Compaction::new(
             ulid::Ulid::new(),
-            CompactionSpec::new(vec![SourceId::Sst(ulid::Ulid::new())], 0),
+            CompactionSpec::new(vec![SourceId::SstView(ulid::Ulid::new())], 0),
         )
         .with_status(CompactionStatus::Running)
         .with_output_ssts(vec![output_sst]);
@@ -1500,6 +1867,7 @@ mod tests {
             &TieredCompactionSpecArgs {
                 ssts: Some(source_ssts),
                 sorted_runs: None,
+                l0_view_ids: None,
             },
         );
         let compaction_ulid = ulid::Ulid::new();
@@ -1544,5 +1912,126 @@ mod tests {
             decoded_compaction.output_ssts()[0].format_version,
             super::ORIGINAL_SST_FORMAT_VERSION
         );
+    }
+
+    #[test]
+    fn test_should_roundtrip_v1_write_with_visible_ranges() {
+        // Build SsTableViews using SST ULIDs as view IDs (matching V1 decode behavior).
+        fn new_view(first_entry: &[u8], visible_range: Option<BytesRange>) -> SsTableView {
+            let ulid = ulid::Ulid::new();
+            SsTableView::new_projected(
+                ulid,
+                SsTableHandle::new(
+                    SsTableId::Compacted(ulid),
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::copy_from_slice(first_entry)),
+                        ..Default::default()
+                    },
+                ),
+                visible_range,
+            )
+        }
+
+        let mut manifest = Manifest::initial(ManifestCore::new());
+        manifest.core.l0 = VecDeque::from(vec![
+            new_view(b"a", None),
+            new_view(b"b", Some(BytesRange::from_ref("c"..="d"))),
+        ]);
+        manifest.core.compacted = vec![
+            SortedRun {
+                id: 1,
+                sst_views: vec![
+                    new_view(b"e", None),
+                    new_view(b"f", Some(BytesRange::from_ref("g".."h"))),
+                ],
+            },
+            SortedRun {
+                id: 2,
+                sst_views: vec![
+                    new_view(b"i", None),
+                    new_view(b"j", Some(BytesRange::from_ref("k"..))),
+                ],
+            },
+        ];
+        manifest.core.last_compacted_l0_sst_view_id = Some(manifest.core.l0[0].id);
+        manifest.core.last_compacted_l0_sst_id =
+            Some(manifest.core.l0[0].sst.id.unwrap_compacted_id());
+        manifest.writer_epoch = 42;
+        manifest.compactor_epoch = 7;
+        manifest.core.next_wal_sst_id = 10;
+        manifest.core.replay_after_wal_id = 5;
+        manifest.core.last_l0_seq = 100;
+        manifest.core.last_l0_clock_tick = 999;
+
+        let codec = FlatBufferManifestCodec {};
+
+        // Encode as V1 and decode back.
+        let v1_bytes = FlatBufferManifestCodec::create_from_manifest_v1(&manifest);
+        assert_eq!(u16::from_be_bytes([v1_bytes[0], v1_bytes[1]]), 1);
+        let decoded = codec
+            .decode(&v1_bytes)
+            .expect("failed to decode V1 manifest");
+
+        assert_eq!(manifest, decoded);
+    }
+
+    #[test]
+    fn test_should_roundtrip_v1_write_with_external_dbs() {
+        let mut manifest = Manifest::initial(ManifestCore::new());
+        manifest.external_dbs = vec![ExternalDb {
+            path: "/path/to/external".to_string(),
+            source_checkpoint_id: uuid::Uuid::new_v4(),
+            final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+            sst_ids: vec![
+                SsTableId::Compacted(ulid::Ulid::new()),
+                SsTableId::Compacted(ulid::Ulid::new()),
+            ],
+        }];
+
+        let codec = FlatBufferManifestCodec {};
+        let v1_bytes = FlatBufferManifestCodec::create_from_manifest_v1(&manifest);
+        let decoded = codec
+            .decode(&v1_bytes)
+            .expect("failed to decode V1 manifest");
+
+        assert_eq!(manifest, decoded);
+    }
+
+    #[test]
+    fn test_v1_and_v2_roundtrip_produce_same_manifest() {
+        // When view IDs equal SST IDs (identity views), V1 and V2 should decode
+        // to the same in-memory Manifest.
+        let mut manifest = Manifest::initial(ManifestCore::new());
+        manifest.core.l0 = VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(ulid::Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                first_entry: Some(Bytes::from_static(b"l0key")),
+                ..Default::default()
+            },
+        ))]);
+        manifest.core.compacted = vec![SortedRun {
+            id: 1,
+            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(ulid::Ulid::new()),
+                SST_FORMAT_VERSION_LATEST,
+                SsTableInfo {
+                    first_entry: Some(Bytes::from_static(b"srkey")),
+                    ..Default::default()
+                },
+            ))],
+        }];
+        manifest.writer_epoch = 5;
+        manifest.compactor_epoch = 3;
+
+        let codec = FlatBufferManifestCodec {};
+        let v1_bytes = FlatBufferManifestCodec::create_from_manifest_v1(&manifest);
+        let v2_bytes = codec.encode(&manifest);
+
+        let decoded_v1 = codec.decode(&v1_bytes).expect("failed to decode V1");
+        let decoded_v2 = codec.decode(&v2_bytes).expect("failed to decode V2");
+
+        assert_eq!(decoded_v1, decoded_v2);
     }
 }

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -341,7 +341,7 @@ mod tests {
     use crate::format::sst::SsTableFormat;
     use crate::utils::WatchableOnceCell;
     use crate::{
-        db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId},
+        db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableView},
         manifest::store::{ManifestStore, StoredManifest},
         tablestore::TableStore,
     };
@@ -1014,13 +1014,20 @@ mod tests {
 
         // Create a manifest
         let mut state = ManifestCore::new();
-        state.l0.push_back(l0_sst_handle.clone());
-        state.l0.push_back(active_expired_l0_sst_handle.clone());
+        state
+            .l0
+            .push_back(SsTableView::identity(l0_sst_handle.clone()));
+        state
+            .l0
+            .push_back(SsTableView::identity(active_expired_l0_sst_handle.clone()));
         // Dont' push inactive_expired_l0_sst_handle
         state.compacted.push(SortedRun {
             id: 1,
             // Don't add inactive_expired_sst_handle
-            ssts: vec![active_sst_handle.clone(), active_expired_sst_handle.clone()],
+            sst_views: vec![
+                SsTableView::identity(active_sst_handle.clone()),
+                SsTableView::identity(active_expired_sst_handle.clone()),
+            ],
         });
         StoredManifest::create_new_db(
             manifest_store.clone(),
@@ -1051,7 +1058,7 @@ mod tests {
         let current_manifest = manifest_store.read_latest_manifest().await.unwrap().1;
         assert_eq!(current_manifest.core.l0.len(), 2);
         assert_eq!(current_manifest.core.compacted.len(), 1);
-        assert_eq!(current_manifest.core.compacted[0].ssts.len(), 2);
+        assert_eq!(current_manifest.core.compacted[0].sst_views.len(), 2);
 
         // Start the garbage collector
         run_gc_once(
@@ -1083,7 +1090,7 @@ mod tests {
         let current_manifest = manifest_store.read_latest_manifest().await.unwrap().1;
         assert_eq!(current_manifest.core.l0.len(), 2);
         assert_eq!(current_manifest.core.compacted.len(), 1);
-        assert_eq!(current_manifest.core.compacted[0].ssts.len(), 2);
+        assert_eq!(current_manifest.core.compacted[0].sst_views.len(), 2);
     }
 
     /// This test creates six compacted SSTs:
@@ -1116,15 +1123,19 @@ mod tests {
 
         // Create an initial manifest with active and active checkpoint tables
         let mut state = ManifestCore::new();
-        state.l0.push_back(active_l0_sst_handle.clone());
-        state.l0.push_back(active_checkpoint_l0_sst_handle.clone());
+        state
+            .l0
+            .push_back(SsTableView::identity(active_l0_sst_handle.clone()));
+        state.l0.push_back(SsTableView::identity(
+            active_checkpoint_l0_sst_handle.clone(),
+        ));
         state.compacted.push(SortedRun {
             id: 1,
-            ssts: vec![active_sst_handle.clone()],
+            sst_views: vec![SsTableView::identity(active_sst_handle.clone())],
         });
         state.compacted.push(SortedRun {
             id: 2,
-            ssts: vec![active_checkpoint_sst_handle.clone()],
+            sst_views: vec![SsTableView::identity(active_checkpoint_sst_handle.clone())],
         });
         let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
@@ -1296,13 +1307,13 @@ mod tests {
                 assert!(wal_ssts.contains(&SsTableId::Wal(wal_sst_id)));
             }
 
-            for sst in &manifest.core.l0 {
-                assert!(compacted_ssts.contains(&sst.id));
+            for view in &manifest.core.l0 {
+                assert!(compacted_ssts.contains(&view.sst.id));
             }
 
             for sr in &manifest.core.compacted {
-                for sst in &sr.ssts {
-                    assert!(compacted_ssts.contains(&sst.id));
+                for view in &sr.sst_views {
+                    assert!(compacted_ssts.contains(&view.sst.id));
                 }
             }
         }

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -68,12 +68,12 @@ impl CompactedGcTask {
         let mut active_ssts = HashSet::new();
         for manifest in active_manifests.values() {
             for sr in manifest.core.compacted.iter() {
-                for sst in sr.ssts.iter() {
-                    active_ssts.insert(sst.id);
+                for view in sr.sst_views.iter() {
+                    active_ssts.insert(view.sst.id);
                 }
             }
-            for sst in manifest.core.l0.iter() {
-                active_ssts.insert(sst.id);
+            for view in manifest.core.l0.iter() {
+                active_ssts.insert(view.sst.id);
             }
         }
         Ok(active_ssts)
@@ -103,9 +103,9 @@ impl CompactedGcTask {
                 .core
                 .l0
                 .iter()
-                .map(|sst| DateTime::<Utc>::from(sst.id.unwrap_compacted_id().datetime()))
+                .map(|view| DateTime::<Utc>::from(view.sst.id.unwrap_compacted_id().datetime()))
                 .collect::<Vec<_>>()
-        } else if let Some(l0_last_compacted) = manifest.core.l0_last_compacted {
+        } else if let Some(l0_last_compacted) = manifest.core.last_compacted_l0_sst_view_id {
             // Else fall back to the last compacted L0, which can serve as a conservative barrier
             vec![DateTime::<Utc>::from(l0_last_compacted.datetime())]
         } else {
@@ -230,7 +230,7 @@ mod tests {
     use super::*;
     use crate::compactions_store::{CompactionsStore, StoredCompactions};
     use crate::compactor_state::{Compaction, CompactionSpec, SourceId};
-    use crate::db_state::{ManifestCore, SsTableId};
+    use crate::db_state::{ManifestCore, SsTableId, SsTableView};
     use crate::format::sst::SsTableFormat;
     use crate::manifest::store::StoredManifest;
     use crate::object_stores::ObjectStores;
@@ -305,7 +305,11 @@ mod tests {
         // Mark one SST as active in the manifest so that most_recent_sst_dt
         // is newer than the configured minimum-age cutoff.
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
-        dirty.value.core.l0.push_back(active_handle);
+        dirty
+            .value
+            .core
+            .l0
+            .push_back(SsTableView::identity(active_handle));
         stored_manifest.update(dirty).await.unwrap();
 
         let stat_registry = Arc::new(StatRegistry::new());
@@ -406,7 +410,11 @@ mod tests {
         // Mark id_manifest as the only active SST in the manifest so that
         // most_recent_sst_dt is 3_000ms, which becomes the cutoff.
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
-        dirty.value.core.l0.push_back(manifest_handle);
+        dirty
+            .value
+            .core
+            .l0
+            .push_back(SsTableView::identity(manifest_handle));
         stored_manifest.update(dirty).await.unwrap();
 
         let stat_registry = Arc::new(StatRegistry::new());
@@ -495,7 +503,11 @@ mod tests {
         // most_recent_sst_dt boundary is 3_000ms and the compaction
         // low watermark (2_000ms) becomes the effective cutoff (see below).
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
-        dirty.value.core.l0.push_back(active_handle);
+        dirty
+            .value
+            .core
+            .l0
+            .push_back(SsTableView::identity(active_handle));
         stored_manifest.update(dirty).await.unwrap();
 
         // Persist a running compaction with a start time at 2_000ms to act as the GC barrier.
@@ -584,7 +596,11 @@ mod tests {
             .await
             .unwrap();
         let mut dirty_manifest = stored_manifest.prepare_dirty().unwrap();
-        dirty_manifest.value.core.l0.push_back(l0_handle);
+        dirty_manifest
+            .value
+            .core
+            .l0
+            .push_back(SsTableView::identity(l0_handle));
         stored_manifest.update(dirty_manifest).await.unwrap();
 
         // Simulate a compaction that starts after GC reads compaction state, writes an

--- a/slatedb/src/generated/root_generated.rs
+++ b/slatedb/src/generated/root_generated.rs
@@ -1939,6 +1939,272 @@ impl core::fmt::Debug for CompactedSsTable<'_> {
       ds.finish()
   }
 }
+pub enum CompactedSsTableV2Offset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct CompactedSsTableV2<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for CompactedSsTableV2<'a> {
+  type Inner = CompactedSsTableV2<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> CompactedSsTableV2<'a> {
+  pub const VT_ID: flatbuffers::VOffsetT = 4;
+  pub const VT_INFO: flatbuffers::VOffsetT = 6;
+  pub const VT_FORMAT_VERSION: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    CompactedSsTableV2 { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args CompactedSsTableV2Args<'args>
+  ) -> flatbuffers::WIPOffset<CompactedSsTableV2<'bldr>> {
+    let mut builder = CompactedSsTableV2Builder::new(_fbb);
+    if let Some(x) = args.info { builder.add_info(x); }
+    if let Some(x) = args.id { builder.add_id(x); }
+    if let Some(x) = args.format_version { builder.add_format_version(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn id(&self) -> Ulid<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Ulid>>(CompactedSsTableV2::VT_ID, None).unwrap()}
+  }
+  #[inline]
+  pub fn info(&self) -> SsTableInfo<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<SsTableInfo>>(CompactedSsTableV2::VT_INFO, None).unwrap()}
+  }
+  #[inline]
+  pub fn format_version(&self) -> Option<u16> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u16>(CompactedSsTableV2::VT_FORMAT_VERSION, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for CompactedSsTableV2<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Ulid>>("id", Self::VT_ID, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<SsTableInfo>>("info", Self::VT_INFO, true)?
+     .visit_field::<u16>("format_version", Self::VT_FORMAT_VERSION, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct CompactedSsTableV2Args<'a> {
+    pub id: Option<flatbuffers::WIPOffset<Ulid<'a>>>,
+    pub info: Option<flatbuffers::WIPOffset<SsTableInfo<'a>>>,
+    pub format_version: Option<u16>,
+}
+impl<'a> Default for CompactedSsTableV2Args<'a> {
+  #[inline]
+  fn default() -> Self {
+    CompactedSsTableV2Args {
+      id: None, // required field
+      info: None, // required field
+      format_version: None,
+    }
+  }
+}
+
+pub struct CompactedSsTableV2Builder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> CompactedSsTableV2Builder<'a, 'b, A> {
+  #[inline]
+  pub fn add_id(&mut self, id: flatbuffers::WIPOffset<Ulid<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Ulid>>(CompactedSsTableV2::VT_ID, id);
+  }
+  #[inline]
+  pub fn add_info(&mut self, info: flatbuffers::WIPOffset<SsTableInfo<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<SsTableInfo>>(CompactedSsTableV2::VT_INFO, info);
+  }
+  #[inline]
+  pub fn add_format_version(&mut self, format_version: u16) {
+    self.fbb_.push_slot_always::<u16>(CompactedSsTableV2::VT_FORMAT_VERSION, format_version);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> CompactedSsTableV2Builder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    CompactedSsTableV2Builder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<CompactedSsTableV2<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, CompactedSsTableV2::VT_ID,"id");
+    self.fbb_.required(o, CompactedSsTableV2::VT_INFO,"info");
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for CompactedSsTableV2<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("CompactedSsTableV2");
+      ds.field("id", &self.id());
+      ds.field("info", &self.info());
+      ds.field("format_version", &self.format_version());
+      ds.finish()
+  }
+}
+pub enum CompactedSsTableViewOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct CompactedSsTableView<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for CompactedSsTableView<'a> {
+  type Inner = CompactedSsTableView<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> CompactedSsTableView<'a> {
+  pub const VT_ID: flatbuffers::VOffsetT = 4;
+  pub const VT_SST_ID: flatbuffers::VOffsetT = 6;
+  pub const VT_VISIBLE_RANGE: flatbuffers::VOffsetT = 8;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    CompactedSsTableView { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args CompactedSsTableViewArgs<'args>
+  ) -> flatbuffers::WIPOffset<CompactedSsTableView<'bldr>> {
+    let mut builder = CompactedSsTableViewBuilder::new(_fbb);
+    if let Some(x) = args.visible_range { builder.add_visible_range(x); }
+    if let Some(x) = args.sst_id { builder.add_sst_id(x); }
+    if let Some(x) = args.id { builder.add_id(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn id(&self) -> Ulid<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Ulid>>(CompactedSsTableView::VT_ID, None).unwrap()}
+  }
+  #[inline]
+  pub fn sst_id(&self) -> Ulid<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Ulid>>(CompactedSsTableView::VT_SST_ID, None).unwrap()}
+  }
+  #[inline]
+  pub fn visible_range(&self) -> Option<BytesRange<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<BytesRange>>(CompactedSsTableView::VT_VISIBLE_RANGE, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for CompactedSsTableView<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Ulid>>("id", Self::VT_ID, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Ulid>>("sst_id", Self::VT_SST_ID, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<BytesRange>>("visible_range", Self::VT_VISIBLE_RANGE, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct CompactedSsTableViewArgs<'a> {
+    pub id: Option<flatbuffers::WIPOffset<Ulid<'a>>>,
+    pub sst_id: Option<flatbuffers::WIPOffset<Ulid<'a>>>,
+    pub visible_range: Option<flatbuffers::WIPOffset<BytesRange<'a>>>,
+}
+impl<'a> Default for CompactedSsTableViewArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    CompactedSsTableViewArgs {
+      id: None, // required field
+      sst_id: None, // required field
+      visible_range: None,
+    }
+  }
+}
+
+pub struct CompactedSsTableViewBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> CompactedSsTableViewBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_id(&mut self, id: flatbuffers::WIPOffset<Ulid<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Ulid>>(CompactedSsTableView::VT_ID, id);
+  }
+  #[inline]
+  pub fn add_sst_id(&mut self, sst_id: flatbuffers::WIPOffset<Ulid<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Ulid>>(CompactedSsTableView::VT_SST_ID, sst_id);
+  }
+  #[inline]
+  pub fn add_visible_range(&mut self, visible_range: flatbuffers::WIPOffset<BytesRange<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<BytesRange>>(CompactedSsTableView::VT_VISIBLE_RANGE, visible_range);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> CompactedSsTableViewBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    CompactedSsTableViewBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<CompactedSsTableView<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, CompactedSsTableView::VT_ID,"id");
+    self.fbb_.required(o, CompactedSsTableView::VT_SST_ID,"sst_id");
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for CompactedSsTableView<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("CompactedSsTableView");
+      ds.field("id", &self.id());
+      ds.field("sst_id", &self.sst_id());
+      ds.field("visible_range", &self.visible_range());
+      ds.finish()
+  }
+}
 pub enum SortedRunOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -2054,6 +2320,121 @@ impl core::fmt::Debug for SortedRun<'_> {
       ds.finish()
   }
 }
+pub enum SortedRunV2Offset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct SortedRunV2<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for SortedRunV2<'a> {
+  type Inner = SortedRunV2<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> SortedRunV2<'a> {
+  pub const VT_ID: flatbuffers::VOffsetT = 4;
+  pub const VT_SSTS: flatbuffers::VOffsetT = 6;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    SortedRunV2 { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args SortedRunV2Args<'args>
+  ) -> flatbuffers::WIPOffset<SortedRunV2<'bldr>> {
+    let mut builder = SortedRunV2Builder::new(_fbb);
+    if let Some(x) = args.ssts { builder.add_ssts(x); }
+    builder.add_id(args.id);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn id(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(SortedRunV2::VT_ID, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn ssts(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView<'a>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView>>>>(SortedRunV2::VT_SSTS, None).unwrap()}
+  }
+}
+
+impl flatbuffers::Verifiable for SortedRunV2<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u32>("id", Self::VT_ID, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTableView>>>>("ssts", Self::VT_SSTS, true)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct SortedRunV2Args<'a> {
+    pub id: u32,
+    pub ssts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView<'a>>>>>,
+}
+impl<'a> Default for SortedRunV2Args<'a> {
+  #[inline]
+  fn default() -> Self {
+    SortedRunV2Args {
+      id: 0,
+      ssts: None, // required field
+    }
+  }
+}
+
+pub struct SortedRunV2Builder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SortedRunV2Builder<'a, 'b, A> {
+  #[inline]
+  pub fn add_id(&mut self, id: u32) {
+    self.fbb_.push_slot::<u32>(SortedRunV2::VT_ID, id, 0);
+  }
+  #[inline]
+  pub fn add_ssts(&mut self, ssts: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CompactedSsTableView<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(SortedRunV2::VT_SSTS, ssts);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SortedRunV2Builder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    SortedRunV2Builder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<SortedRunV2<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, SortedRunV2::VT_SSTS,"ssts");
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for SortedRunV2<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("SortedRunV2");
+      ds.field("id", &self.id());
+      ds.field("ssts", &self.ssts());
+      ds.finish()
+  }
+}
 pub enum TieredCompactionSpecOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -2072,6 +2453,7 @@ impl<'a> flatbuffers::Follow<'a> for TieredCompactionSpec<'a> {
 impl<'a> TieredCompactionSpec<'a> {
   pub const VT_SSTS: flatbuffers::VOffsetT = 4;
   pub const VT_SORTED_RUNS: flatbuffers::VOffsetT = 6;
+  pub const VT_L0_VIEW_IDS: flatbuffers::VOffsetT = 8;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2083,6 +2465,7 @@ impl<'a> TieredCompactionSpec<'a> {
     args: &'args TieredCompactionSpecArgs<'args>
   ) -> flatbuffers::WIPOffset<TieredCompactionSpec<'bldr>> {
     let mut builder = TieredCompactionSpecBuilder::new(_fbb);
+    if let Some(x) = args.l0_view_ids { builder.add_l0_view_ids(x); }
     if let Some(x) = args.sorted_runs { builder.add_sorted_runs(x); }
     if let Some(x) = args.ssts { builder.add_ssts(x); }
     builder.finish()
@@ -2103,6 +2486,13 @@ impl<'a> TieredCompactionSpec<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(TieredCompactionSpec::VT_SORTED_RUNS, None)}
   }
+  #[inline]
+  pub fn l0_view_ids(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid>>>>(TieredCompactionSpec::VT_L0_VIEW_IDS, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for TieredCompactionSpec<'_> {
@@ -2114,6 +2504,7 @@ impl flatbuffers::Verifiable for TieredCompactionSpec<'_> {
     v.visit_table(pos)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("ssts", Self::VT_SSTS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("sorted_runs", Self::VT_SORTED_RUNS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("l0_view_ids", Self::VT_L0_VIEW_IDS, false)?
      .finish();
     Ok(())
   }
@@ -2121,6 +2512,7 @@ impl flatbuffers::Verifiable for TieredCompactionSpec<'_> {
 pub struct TieredCompactionSpecArgs<'a> {
     pub ssts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
     pub sorted_runs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+    pub l0_view_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
 }
 impl<'a> Default for TieredCompactionSpecArgs<'a> {
   #[inline]
@@ -2128,6 +2520,7 @@ impl<'a> Default for TieredCompactionSpecArgs<'a> {
     TieredCompactionSpecArgs {
       ssts: None,
       sorted_runs: None,
+      l0_view_ids: None,
     }
   }
 }
@@ -2144,6 +2537,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TieredCompactionSpecBuilder<'a,
   #[inline]
   pub fn add_sorted_runs(&mut self, sorted_runs: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TieredCompactionSpec::VT_SORTED_RUNS, sorted_runs);
+  }
+  #[inline]
+  pub fn add_l0_view_ids(&mut self, l0_view_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Ulid<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TieredCompactionSpec::VT_L0_VIEW_IDS, l0_view_ids);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TieredCompactionSpecBuilder<'a, 'b, A> {
@@ -2165,6 +2562,7 @@ impl core::fmt::Debug for TieredCompactionSpec<'_> {
     let mut ds = f.debug_struct("TieredCompactionSpec");
       ds.field("ssts", &self.ssts());
       ds.field("sorted_runs", &self.sorted_runs());
+      ds.field("l0_view_ids", &self.l0_view_ids());
       ds.finish()
   }
 }
@@ -2975,6 +3373,379 @@ impl core::fmt::Debug for ManifestV1<'_> {
       ds.field("replay_after_wal_id", &self.replay_after_wal_id());
       ds.field("wal_id_last_seen", &self.wal_id_last_seen());
       ds.field("l0_last_compacted", &self.l0_last_compacted());
+      ds.field("l0", &self.l0());
+      ds.field("compacted", &self.compacted());
+      ds.field("last_l0_clock_tick", &self.last_l0_clock_tick());
+      ds.field("checkpoints", &self.checkpoints());
+      ds.field("last_l0_seq", &self.last_l0_seq());
+      ds.field("wal_object_store_uri", &self.wal_object_store_uri());
+      ds.field("recent_snapshot_min_seq", &self.recent_snapshot_min_seq());
+      ds.field("sequence_tracker", &self.sequence_tracker());
+      ds.finish()
+  }
+}
+pub enum ManifestV2Offset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct ManifestV2<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for ManifestV2<'a> {
+  type Inner = ManifestV2<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> ManifestV2<'a> {
+  pub const VT_MANIFEST_ID: flatbuffers::VOffsetT = 4;
+  pub const VT_EXTERNAL_DBS: flatbuffers::VOffsetT = 6;
+  pub const VT_INITIALIZED: flatbuffers::VOffsetT = 8;
+  pub const VT_WRITER_EPOCH: flatbuffers::VOffsetT = 10;
+  pub const VT_COMPACTOR_EPOCH: flatbuffers::VOffsetT = 12;
+  pub const VT_REPLAY_AFTER_WAL_ID: flatbuffers::VOffsetT = 14;
+  pub const VT_WAL_ID_LAST_SEEN: flatbuffers::VOffsetT = 16;
+  pub const VT_LAST_COMPACTED_L0_SST_VIEW_ID: flatbuffers::VOffsetT = 18;
+  pub const VT_SSTS: flatbuffers::VOffsetT = 20;
+  pub const VT_L0: flatbuffers::VOffsetT = 22;
+  pub const VT_COMPACTED: flatbuffers::VOffsetT = 24;
+  pub const VT_LAST_L0_CLOCK_TICK: flatbuffers::VOffsetT = 26;
+  pub const VT_CHECKPOINTS: flatbuffers::VOffsetT = 28;
+  pub const VT_LAST_L0_SEQ: flatbuffers::VOffsetT = 30;
+  pub const VT_WAL_OBJECT_STORE_URI: flatbuffers::VOffsetT = 32;
+  pub const VT_RECENT_SNAPSHOT_MIN_SEQ: flatbuffers::VOffsetT = 34;
+  pub const VT_SEQUENCE_TRACKER: flatbuffers::VOffsetT = 36;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    ManifestV2 { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args ManifestV2Args<'args>
+  ) -> flatbuffers::WIPOffset<ManifestV2<'bldr>> {
+    let mut builder = ManifestV2Builder::new(_fbb);
+    builder.add_recent_snapshot_min_seq(args.recent_snapshot_min_seq);
+    builder.add_last_l0_seq(args.last_l0_seq);
+    builder.add_last_l0_clock_tick(args.last_l0_clock_tick);
+    builder.add_wal_id_last_seen(args.wal_id_last_seen);
+    builder.add_replay_after_wal_id(args.replay_after_wal_id);
+    builder.add_compactor_epoch(args.compactor_epoch);
+    builder.add_writer_epoch(args.writer_epoch);
+    builder.add_manifest_id(args.manifest_id);
+    if let Some(x) = args.sequence_tracker { builder.add_sequence_tracker(x); }
+    if let Some(x) = args.wal_object_store_uri { builder.add_wal_object_store_uri(x); }
+    if let Some(x) = args.checkpoints { builder.add_checkpoints(x); }
+    if let Some(x) = args.compacted { builder.add_compacted(x); }
+    if let Some(x) = args.l0 { builder.add_l0(x); }
+    if let Some(x) = args.ssts { builder.add_ssts(x); }
+    if let Some(x) = args.last_compacted_l0_sst_view_id { builder.add_last_compacted_l0_sst_view_id(x); }
+    if let Some(x) = args.external_dbs { builder.add_external_dbs(x); }
+    builder.add_initialized(args.initialized);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn manifest_id(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_MANIFEST_ID, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn external_dbs(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExternalDb<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExternalDb>>>>(ManifestV2::VT_EXTERNAL_DBS, None)}
+  }
+  #[inline]
+  pub fn initialized(&self) -> bool {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<bool>(ManifestV2::VT_INITIALIZED, Some(false)).unwrap()}
+  }
+  #[inline]
+  pub fn writer_epoch(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_WRITER_EPOCH, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn compactor_epoch(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_COMPACTOR_EPOCH, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn replay_after_wal_id(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_REPLAY_AFTER_WAL_ID, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn wal_id_last_seen(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_WAL_ID_LAST_SEEN, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn last_compacted_l0_sst_view_id(&self) -> Option<Ulid<'a>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<Ulid>>(ManifestV2::VT_LAST_COMPACTED_L0_SST_VIEW_ID, None)}
+  }
+  #[inline]
+  pub fn ssts(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableV2<'a>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableV2>>>>(ManifestV2::VT_SSTS, None).unwrap()}
+  }
+  #[inline]
+  pub fn l0(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView<'a>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView>>>>(ManifestV2::VT_L0, None).unwrap()}
+  }
+  #[inline]
+  pub fn compacted(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunV2<'a>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunV2>>>>(ManifestV2::VT_COMPACTED, None).unwrap()}
+  }
+  #[inline]
+  pub fn last_l0_clock_tick(&self) -> i64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<i64>(ManifestV2::VT_LAST_L0_CLOCK_TICK, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn checkpoints(&self) -> flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint>>>>(ManifestV2::VT_CHECKPOINTS, None).unwrap()}
+  }
+  #[inline]
+  pub fn last_l0_seq(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_LAST_L0_SEQ, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn wal_object_store_uri(&self) -> Option<&'a str> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ManifestV2::VT_WAL_OBJECT_STORE_URI, None)}
+  }
+  #[inline]
+  pub fn recent_snapshot_min_seq(&self) -> u64 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u64>(ManifestV2::VT_RECENT_SNAPSHOT_MIN_SEQ, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn sequence_tracker(&self) -> Option<flatbuffers::Vector<'a, u8>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(ManifestV2::VT_SEQUENCE_TRACKER, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for ManifestV2<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u64>("manifest_id", Self::VT_MANIFEST_ID, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<ExternalDb>>>>("external_dbs", Self::VT_EXTERNAL_DBS, false)?
+     .visit_field::<bool>("initialized", Self::VT_INITIALIZED, false)?
+     .visit_field::<u64>("writer_epoch", Self::VT_WRITER_EPOCH, false)?
+     .visit_field::<u64>("compactor_epoch", Self::VT_COMPACTOR_EPOCH, false)?
+     .visit_field::<u64>("replay_after_wal_id", Self::VT_REPLAY_AFTER_WAL_ID, false)?
+     .visit_field::<u64>("wal_id_last_seen", Self::VT_WAL_ID_LAST_SEEN, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<Ulid>>("last_compacted_l0_sst_view_id", Self::VT_LAST_COMPACTED_L0_SST_VIEW_ID, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTableV2>>>>("ssts", Self::VT_SSTS, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTableView>>>>("l0", Self::VT_L0, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SortedRunV2>>>>("compacted", Self::VT_COMPACTED, true)?
+     .visit_field::<i64>("last_l0_clock_tick", Self::VT_LAST_L0_CLOCK_TICK, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Checkpoint>>>>("checkpoints", Self::VT_CHECKPOINTS, true)?
+     .visit_field::<u64>("last_l0_seq", Self::VT_LAST_L0_SEQ, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<&str>>("wal_object_store_uri", Self::VT_WAL_OBJECT_STORE_URI, false)?
+     .visit_field::<u64>("recent_snapshot_min_seq", Self::VT_RECENT_SNAPSHOT_MIN_SEQ, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("sequence_tracker", Self::VT_SEQUENCE_TRACKER, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct ManifestV2Args<'a> {
+    pub manifest_id: u64,
+    pub external_dbs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<ExternalDb<'a>>>>>,
+    pub initialized: bool,
+    pub writer_epoch: u64,
+    pub compactor_epoch: u64,
+    pub replay_after_wal_id: u64,
+    pub wal_id_last_seen: u64,
+    pub last_compacted_l0_sst_view_id: Option<flatbuffers::WIPOffset<Ulid<'a>>>,
+    pub ssts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableV2<'a>>>>>,
+    pub l0: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView<'a>>>>>,
+    pub compacted: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunV2<'a>>>>>,
+    pub last_l0_clock_tick: i64,
+    pub checkpoints: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Checkpoint<'a>>>>>,
+    pub last_l0_seq: u64,
+    pub wal_object_store_uri: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub recent_snapshot_min_seq: u64,
+    pub sequence_tracker: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+}
+impl<'a> Default for ManifestV2Args<'a> {
+  #[inline]
+  fn default() -> Self {
+    ManifestV2Args {
+      manifest_id: 0,
+      external_dbs: None,
+      initialized: false,
+      writer_epoch: 0,
+      compactor_epoch: 0,
+      replay_after_wal_id: 0,
+      wal_id_last_seen: 0,
+      last_compacted_l0_sst_view_id: None,
+      ssts: None, // required field
+      l0: None, // required field
+      compacted: None, // required field
+      last_l0_clock_tick: 0,
+      checkpoints: None, // required field
+      last_l0_seq: 0,
+      wal_object_store_uri: None,
+      recent_snapshot_min_seq: 0,
+      sequence_tracker: None,
+    }
+  }
+}
+
+pub struct ManifestV2Builder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV2Builder<'a, 'b, A> {
+  #[inline]
+  pub fn add_manifest_id(&mut self, manifest_id: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_MANIFEST_ID, manifest_id, 0);
+  }
+  #[inline]
+  pub fn add_external_dbs(&mut self, external_dbs: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<ExternalDb<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_EXTERNAL_DBS, external_dbs);
+  }
+  #[inline]
+  pub fn add_initialized(&mut self, initialized: bool) {
+    self.fbb_.push_slot::<bool>(ManifestV2::VT_INITIALIZED, initialized, false);
+  }
+  #[inline]
+  pub fn add_writer_epoch(&mut self, writer_epoch: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_WRITER_EPOCH, writer_epoch, 0);
+  }
+  #[inline]
+  pub fn add_compactor_epoch(&mut self, compactor_epoch: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_COMPACTOR_EPOCH, compactor_epoch, 0);
+  }
+  #[inline]
+  pub fn add_replay_after_wal_id(&mut self, replay_after_wal_id: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_REPLAY_AFTER_WAL_ID, replay_after_wal_id, 0);
+  }
+  #[inline]
+  pub fn add_wal_id_last_seen(&mut self, wal_id_last_seen: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_WAL_ID_LAST_SEEN, wal_id_last_seen, 0);
+  }
+  #[inline]
+  pub fn add_last_compacted_l0_sst_view_id(&mut self, last_compacted_l0_sst_view_id: flatbuffers::WIPOffset<Ulid<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<Ulid>>(ManifestV2::VT_LAST_COMPACTED_L0_SST_VIEW_ID, last_compacted_l0_sst_view_id);
+  }
+  #[inline]
+  pub fn add_ssts(&mut self, ssts: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CompactedSsTableV2<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_SSTS, ssts);
+  }
+  #[inline]
+  pub fn add_l0(&mut self, l0: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CompactedSsTableView<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_L0, l0);
+  }
+  #[inline]
+  pub fn add_compacted(&mut self, compacted: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<SortedRunV2<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_COMPACTED, compacted);
+  }
+  #[inline]
+  pub fn add_last_l0_clock_tick(&mut self, last_l0_clock_tick: i64) {
+    self.fbb_.push_slot::<i64>(ManifestV2::VT_LAST_L0_CLOCK_TICK, last_l0_clock_tick, 0);
+  }
+  #[inline]
+  pub fn add_checkpoints(&mut self, checkpoints: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Checkpoint<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_CHECKPOINTS, checkpoints);
+  }
+  #[inline]
+  pub fn add_last_l0_seq(&mut self, last_l0_seq: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_LAST_L0_SEQ, last_l0_seq, 0);
+  }
+  #[inline]
+  pub fn add_wal_object_store_uri(&mut self, wal_object_store_uri: flatbuffers::WIPOffset<&'b  str>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_WAL_OBJECT_STORE_URI, wal_object_store_uri);
+  }
+  #[inline]
+  pub fn add_recent_snapshot_min_seq(&mut self, recent_snapshot_min_seq: u64) {
+    self.fbb_.push_slot::<u64>(ManifestV2::VT_RECENT_SNAPSHOT_MIN_SEQ, recent_snapshot_min_seq, 0);
+  }
+  #[inline]
+  pub fn add_sequence_tracker(&mut self, sequence_tracker: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u8>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_SEQUENCE_TRACKER, sequence_tracker);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ManifestV2Builder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    ManifestV2Builder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<ManifestV2<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, ManifestV2::VT_SSTS,"ssts");
+    self.fbb_.required(o, ManifestV2::VT_L0,"l0");
+    self.fbb_.required(o, ManifestV2::VT_COMPACTED,"compacted");
+    self.fbb_.required(o, ManifestV2::VT_CHECKPOINTS,"checkpoints");
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for ManifestV2<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("ManifestV2");
+      ds.field("manifest_id", &self.manifest_id());
+      ds.field("external_dbs", &self.external_dbs());
+      ds.field("initialized", &self.initialized());
+      ds.field("writer_epoch", &self.writer_epoch());
+      ds.field("compactor_epoch", &self.compactor_epoch());
+      ds.field("replay_after_wal_id", &self.replay_after_wal_id());
+      ds.field("wal_id_last_seen", &self.wal_id_last_seen());
+      ds.field("last_compacted_l0_sst_view_id", &self.last_compacted_l0_sst_view_id());
+      ds.field("ssts", &self.ssts());
       ds.field("l0", &self.l0());
       ds.field("compacted", &self.compacted());
       ds.field("last_l0_clock_tick", &self.last_l0_clock_tick());

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -15,7 +15,9 @@ use uuid::Uuid;
 pub(crate) mod store;
 
 // TODO: should probably move these into manifest/mod.rs (this file)
-pub use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+pub use crate::db_state::{
+    ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView,
+};
 
 #[derive(Clone, Serialize, PartialEq, Debug)]
 pub(crate) struct Manifest {
@@ -63,8 +65,8 @@ impl Manifest {
             .core
             .compacted
             .iter()
-            .flat_map(|sr| sr.ssts.iter().map(|s| s.id))
-            .chain(parent_manifest.core.l0.iter().map(|s| s.id))
+            .flat_map(|sr| sr.sst_views.iter().map(|s| s.sst.id))
+            .chain(parent_manifest.core.l0.iter().map(|s| s.sst.id))
             .filter(|id| !parent_external_sst_ids.contains(id))
             .collect();
 
@@ -90,26 +92,26 @@ impl Manifest {
         for sorter_run in &projected.core.compacted {
             sorter_runs_filtered.push(SortedRun {
                 id: sorter_run.id,
-                ssts: Self::filter_sst_handles(&sorter_run.ssts, false, &range),
+                sst_views: Self::filter_view_handles(&sorter_run.sst_views, false, &range),
             });
         }
-        projected.core.l0 = Self::filter_sst_handles(&projected.core.l0, true, &range).into();
+        projected.core.l0 = Self::filter_view_handles(&projected.core.l0, true, &range).into();
         projected.core.compacted = sorter_runs_filtered;
         projected
     }
 
-    fn filter_sst_handles<'a, T>(
-        handles: T,
-        handles_overlap: bool,
+    fn filter_view_handles<'a, T>(
+        views: T,
+        views_overlap: bool,
         projection_range: &BytesRange,
-    ) -> Vec<SsTableHandle>
+    ) -> Vec<SsTableView>
     where
-        T: IntoIterator<Item = &'a SsTableHandle>,
+        T: IntoIterator<Item = &'a SsTableView>,
     {
-        let mut iter = handles.into_iter().peekable();
+        let mut iter = views.into_iter().peekable();
         let mut filtered_handles = vec![];
         while let Some(current_handle) = iter.next() {
-            let next_handle = if handles_overlap {
+            let next_handle = if views_overlap {
                 None
             } else {
                 iter.peek().copied()
@@ -232,7 +234,9 @@ mod tests {
 
     use super::Manifest;
     use crate::config::CheckpointOptions;
-    use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::db_state::{
+        ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView,
+    };
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::rand::DbRand;
     use bytes::Bytes;
@@ -554,29 +558,39 @@ mod tests {
     {
         let mut core = ManifestCore::new();
         for entry in &manifest.l0 {
-            core.l0.push_back(SsTableHandle::new_compacted(
-                sst_id_fn(entry.sst_alias),
-                SST_FORMAT_VERSION_LATEST,
-                SsTableInfo {
-                    first_entry: Some(entry.first_entry.clone()),
-                    ..SsTableInfo::default()
-                },
+            let sst_id = sst_id_fn(entry.sst_alias);
+            let view_id = sst_id.unwrap_compacted_id();
+            core.l0.push_back(SsTableView::new_projected(
+                view_id,
+                SsTableHandle::new(
+                    sst_id,
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(entry.first_entry.clone()),
+                        ..SsTableInfo::default()
+                    },
+                ),
                 entry.visible_range.clone(),
             ));
         }
         for (idx, sorted_run) in manifest.sorted_runs.iter().enumerate() {
             core.compacted.push(SortedRun {
                 id: idx as u32,
-                ssts: sorted_run
+                sst_views: sorted_run
                     .iter()
                     .map(|entry| {
-                        SsTableHandle::new_compacted(
-                            sst_id_fn(entry.sst_alias),
-                            SST_FORMAT_VERSION_LATEST,
-                            SsTableInfo {
-                                first_entry: Some(entry.first_entry.clone()),
-                                ..SsTableInfo::default()
-                            },
+                        let sst_id = sst_id_fn(entry.sst_alias);
+                        let view_id = sst_id.unwrap_compacted_id();
+                        SsTableView::new_projected(
+                            view_id,
+                            SsTableHandle::new(
+                                sst_id,
+                                SST_FORMAT_VERSION_LATEST,
+                                SsTableInfo {
+                                    first_entry: Some(entry.first_entry.clone()),
+                                    ..SsTableInfo::default()
+                                },
+                            ),
                             entry.visible_range.clone(),
                         )
                     })
@@ -600,11 +614,12 @@ mod tests {
             // Format actual L0 entries
             for (idx, handle) in actual.core.l0.iter().enumerate() {
                 let id_str = sst_aliases
-                    .get(&handle.id)
+                    .get(&handle.sst.id)
                     .map(|a| a.as_str())
                     .unwrap_or("UNKNOWN");
 
                 let first_entry = handle
+                    .sst
                     .info
                     .first_entry
                     .as_ref()
@@ -637,9 +652,10 @@ mod tests {
 
             // Format expected L0 entries
             for (idx, handle) in expected.core.l0.iter().enumerate() {
-                let id_str = sst_aliases.get(&handle.id).unwrap();
+                let id_str = sst_aliases.get(&handle.sst.id).unwrap();
 
                 let first_entry = handle
+                    .sst
                     .info
                     .first_entry
                     .as_ref()

--- a/slatedb/src/mem_table_flush.rs
+++ b/slatedb/src/mem_table_flush.rs
@@ -1,7 +1,7 @@
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::SsTableId;
+use crate::db_state::{SsTableId, SsTableView};
 use crate::dispatcher::{MessageFactory, MessageHandler};
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
@@ -159,7 +159,19 @@ impl MemtableFlusher {
                         .pop_back()
                         .expect("expected imm memtable");
                     assert!(Arc::ptr_eq(&popped, &imm_memtable));
-                    modifier.state.manifest.value.core.l0.push_front(sst_handle);
+                    modifier
+                        .state
+                        .manifest
+                        .value
+                        .core
+                        .l0
+                        .push_front(SsTableView::new(
+                            self.db_inner
+                                .rand
+                                .rng()
+                                .gen_ulid(self.db_inner.system_clock.as_ref()),
+                            sst_handle,
+                        ));
                     modifier.state.manifest.value.core.replay_after_wal_id =
                         imm_memtable.recent_flushed_wal_id();
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -417,6 +417,7 @@ mod tests {
     use crate::clock::MonotonicClock;
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
     use crate::format::sst::SsTableFormat;
+    use crate::manifest::SsTableView;
     use crate::object_stores::ObjectStores;
     use crate::oracle::DbReaderOracle;
     use crate::stats::StatRegistry;
@@ -495,7 +496,7 @@ mod tests {
                 return Ok(());
             }
             let sst_handle = self.build_sst(entries).await?;
-            self.core.l0.push_front(sst_handle);
+            self.core.l0.push_front(SsTableView::identity(sst_handle));
             Ok(())
         }
 
@@ -512,11 +513,11 @@ mod tests {
 
             // Find or create the sorted run
             if let Some(sr) = self.core.compacted.iter_mut().find(|sr| sr.id == sr_id) {
-                sr.ssts.push(sst_handle);
+                sr.sst_views.push(SsTableView::identity(sst_handle));
             } else {
                 let new_sr = SortedRun {
                     id: sr_id,
-                    ssts: vec![sst_handle],
+                    sst_views: vec![SsTableView::identity(sst_handle)],
                 };
                 self.core.compacted.push(new_sr);
             }

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -215,7 +215,7 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
             .manifest()
             .l0
             .iter()
-            .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+            .map(|view| SourceId::SstView(view.id))
             .chain(
                 state
                     .manifest()
@@ -374,24 +374,25 @@ impl SizeTieredCompactionScheduler {
         &self,
         db_state: &ManifestCore,
     ) -> (Vec<CompactionSource>, Vec<CompactionSource>) {
-        (
-            db_state
-                .l0
-                .iter()
-                .map(|l0| CompactionSource {
-                    source: SourceId::Sst(l0.id.unwrap_compacted_id()),
-                    size: l0.estimate_size(),
-                })
-                .collect(),
-            db_state
-                .compacted
-                .iter()
-                .map(|sr| CompactionSource {
-                    source: SourceId::SortedRun(sr.id),
-                    size: sr.estimate_size(),
-                })
-                .collect(),
-        )
+        let collected_l0: Vec<CompactionSource> = db_state
+            .l0
+            .iter()
+            .map(|l0| CompactionSource {
+                source: SourceId::SstView(l0.id),
+                size: l0.estimate_size(),
+            })
+            .collect();
+
+        let collected_sr = db_state
+            .compacted
+            .iter()
+            .map(|sr| CompactionSource {
+                source: SourceId::SortedRun(sr.id),
+                size: sr.estimate_size(),
+            })
+            .collect();
+
+        (collected_l0, collected_sr)
     }
 }
 
@@ -428,7 +429,9 @@ mod tests {
         Compaction, CompactionSpec, Compactions, CompactorState, SourceId,
     };
     use crate::config::{CompactorOptions, SizeTieredCompactionSchedulerOptions};
-    use crate::db_state::{ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::db_state::{
+        ManifestCore, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView,
+    };
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::seq_tracker::SequenceTracker;
@@ -445,7 +448,12 @@ mod tests {
     fn test_should_compact_l0s_to_first_sr() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = [create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let l0 = [
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+        ];
         let state =
             &create_compactor_state(create_db_state(l0.iter().cloned().collect(), Vec::new()));
 
@@ -455,10 +463,7 @@ mod tests {
         // then:
         assert_eq!(requests.len(), 1);
         let request = requests.first().unwrap();
-        let expected_sources: Vec<SourceId> = l0
-            .iter()
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
-            .collect();
+        let expected_sources: Vec<SourceId> = l0.iter().map(|h| SourceId::SstView(h.id)).collect();
         assert_eq!(request.sources(), &expected_sources);
         assert_eq!(request.destination(), 0);
     }
@@ -478,7 +483,7 @@ mod tests {
             ..CompactorOptions::default()
         };
         let scheduler = supplier.compaction_scheduler(&compactor_options);
-        let l0 = [create_sst(1), create_sst(1)];
+        let l0 = [create_sst_view(1), create_sst_view(1)];
         let state =
             &create_compactor_state(create_db_state(l0.iter().cloned().collect(), Vec::new()));
 
@@ -488,10 +493,7 @@ mod tests {
         // then:
         assert_eq!(requests.len(), 1);
         let request = requests.first().unwrap();
-        let expected_sources: Vec<SourceId> = l0
-            .iter()
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
-            .collect();
+        let expected_sources: Vec<SourceId> = l0.iter().map(|h| SourceId::SstView(h.id)).collect();
         assert_eq!(request.sources(), &expected_sources);
     }
 
@@ -499,7 +501,12 @@ mod tests {
     fn test_should_compact_l0s_to_new_sr() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = [create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let l0 = [
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+        ];
         let state = &create_compactor_state(create_db_state(
             l0.iter().cloned().collect(),
             vec![create_sr2(10, 2), create_sr2(0, 2)],
@@ -518,7 +525,7 @@ mod tests {
     fn test_should_not_compact_l0s_if_fewer_than_min_threshold() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = [create_sst(1), create_sst(1), create_sst(1)];
+        let l0 = [create_sst_view(1), create_sst_view(1), create_sst_view(1)];
         let state = &create_compactor_state(create_db_state(l0.iter().cloned().collect(), vec![]));
 
         // when:
@@ -701,7 +708,12 @@ mod tests {
     fn test_should_apply_backpressure_for_l0s() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = [create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let l0 = [
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+        ];
         let mut state = create_compactor_state(create_db_state(
             l0.iter().cloned().collect(),
             vec![
@@ -738,7 +750,12 @@ mod tests {
     fn test_should_return_multiple_compactions() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = vec![create_sst(1), create_sst(1), create_sst(1), create_sst(1)];
+        let l0 = vec![
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+        ];
         let state = &create_compactor_state(create_db_state(
             l0.iter().cloned().collect(),
             vec![
@@ -773,7 +790,11 @@ mod tests {
     fn test_should_submit_invalid_compaction_wrong_order() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = VecDeque::from(vec![create_sst(1), create_sst(1), create_sst(1)]);
+        let l0 = VecDeque::from(vec![
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+        ]);
         let state = &create_compactor_state(create_db_state(l0.clone(), Vec::new()));
 
         let mut l0_sst = l0;
@@ -791,7 +812,11 @@ mod tests {
     fn test_should_submit_invalid_compaction_skipped_sst() {
         // given:
         let scheduler = SizeTieredCompactionScheduler::default();
-        let l0 = VecDeque::from(vec![create_sst(1), create_sst(1), create_sst(1)]);
+        let l0 = VecDeque::from(vec![
+            create_sst_view(1),
+            create_sst_view(1),
+            create_sst_view(1),
+        ]);
         let state = &create_compactor_state(create_db_state(l0.clone(), Vec::new()));
 
         let mut l0_sst = l0;
@@ -843,7 +868,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    fn create_sst(size: u64) -> SsTableHandle {
+    fn create_sst_view(size: u64) -> SsTableView {
         let info = SsTableInfo {
             first_entry: None,
             last_entry: None,
@@ -854,11 +879,11 @@ mod tests {
             compression_codec: None,
             ..Default::default()
         };
-        SsTableHandle::new(
+        SsTableView::identity(SsTableHandle::new(
             SsTableId::Compacted(ulid::Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             info,
-        )
+        ))
     }
 
     fn create_sr2(id: u32, size: u64) -> SortedRun {
@@ -870,14 +895,18 @@ mod tests {
     }
 
     fn create_sr(id: u32, sst_size: u64, num_ssts: usize) -> SortedRun {
-        let ssts: Vec<SsTableHandle> = (0..num_ssts).map(|_| create_sst(sst_size)).collect();
-        SortedRun { id, ssts }
+        let ssts: Vec<SsTableView> = (0..num_ssts).map(|_| create_sst_view(sst_size)).collect();
+        SortedRun {
+            id,
+            sst_views: ssts,
+        }
     }
 
-    fn create_db_state(l0: VecDeque<SsTableHandle>, srs: Vec<SortedRun>) -> ManifestCore {
+    fn create_db_state(l0: VecDeque<SsTableView>, srs: Vec<SortedRun>) -> ManifestCore {
         ManifestCore {
             initialized: true,
-            l0_last_compacted: None,
+            last_compacted_l0_sst_view_id: None,
+            last_compacted_l0_sst_id: None,
             l0,
             compacted: srs,
             next_wal_sst_id: 0,
@@ -898,11 +927,8 @@ mod tests {
         CompactorState::new(dirty, compactions)
     }
 
-    fn create_l0_compaction(l0: &[SsTableHandle], dst: u32) -> CompactionSpec {
-        let sources: Vec<SourceId> = l0
-            .iter()
-            .map(|h| SourceId::Sst(h.id.unwrap_compacted_id()))
-            .collect();
+    fn create_l0_compaction(l0: &[SsTableView], dst: u32) -> CompactionSpec {
+        let sources: Vec<SourceId> = l0.iter().map(|h| SourceId::SstView(h.id)).collect();
 
         CompactionSpec::new(sources, dst)
     }

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -1,5 +1,5 @@
 use crate::bytes_range::BytesRange;
-use crate::db_state::{SortedRun, SsTableHandle};
+use crate::db_state::{SortedRun, SsTableView};
 use crate::error::SlateDBError;
 use crate::iter::RowEntryIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions, SstView};
@@ -13,9 +13,9 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 enum SortedRunView<'a> {
-    Owned(VecDeque<SsTableHandle>, BytesRange),
+    Owned(VecDeque<SsTableView>, BytesRange),
     Borrowed(
-        VecDeque<&'a SsTableHandle>,
+        VecDeque<&'a SsTableView>,
         (Bound<&'a [u8]>, Bound<&'a [u8]>),
     ),
 }
@@ -45,7 +45,7 @@ impl<'a> SortedRunView<'a> {
         Ok(next_iter)
     }
 
-    fn peek_next_table(&self) -> Option<&SsTableHandle> {
+    fn peek_next_table(&self) -> Option<&SsTableView> {
         match self {
             SortedRunView::Owned(tables, _) => tables.front(),
             SortedRunView::Borrowed(tables, _) => tables.front().copied(),
@@ -191,7 +191,7 @@ impl RowEntryIterator for SortedRunIterator<'_> {
 mod tests {
     use super::*;
     use crate::bytes_generator::OrderedBytesGenerator;
-    use crate::db_state::SsTableId;
+    use crate::db_state::{SsTableHandle, SsTableId};
     use crate::format::sst::SsTableFormat;
     use crate::proptest_util;
     use crate::proptest_util::sample;
@@ -240,7 +240,7 @@ mod tests {
         let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
-            ssts: vec![handle],
+            sst_views: vec![SsTableView::identity(handle)],
         };
 
         let mut iter = SortedRunIterator::new_owned_initialized(
@@ -301,7 +301,10 @@ mod tests {
         let handle2 = table_store.write_sst(&id2, encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
-            ssts: vec![handle1, handle2],
+            sst_views: vec![
+                SsTableView::identity(handle1),
+                SsTableView::identity(handle2),
+            ],
         };
 
         let mut iter = SortedRunIterator::new_owned_initialized(
@@ -513,10 +516,13 @@ mod tests {
             let encoded = builder.build().await.unwrap();
             let id = SsTableId::Compacted(ulid::Ulid::new());
             let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
-            ssts.push(handle);
+            ssts.push(SsTableView::identity(handle));
         }
 
-        SortedRun { id: 0, ssts }
+        SortedRun {
+            id: 0,
+            sst_views: ssts,
+        }
     }
 
     async fn build_sr_with_ssts(
@@ -526,7 +532,7 @@ mod tests {
         mut key_gen: OrderedBytesGenerator,
         mut val_gen: OrderedBytesGenerator,
     ) -> SortedRun {
-        let mut ssts = Vec::<SsTableHandle>::new();
+        let mut ssts = Vec::<SsTableView>::new();
         for _ in 0..n {
             let mut writer = table_store.table_writer(SsTableId::Compacted(ulid::Ulid::new()));
             for _ in 0..keys_per_sst {
@@ -535,9 +541,12 @@ mod tests {
                 writer.add(entry).await.unwrap();
             }
             let sst = writer.close().await.unwrap();
-            ssts.push(sst);
+            ssts.push(SsTableView::identity(sst));
         }
-        SortedRun { id: 0, ssts }
+        SortedRun {
+            id: 0,
+            sst_views: ssts,
+        }
     }
 
     mod mixed_version_tests {
@@ -613,7 +622,12 @@ mod tests {
 
             let sorted_run = SortedRun {
                 id: 0,
-                ssts: vec![sst1_v1, sst2_v2, sst3_v1, sst4_v2],
+                sst_views: vec![
+                    SsTableView::identity(sst1_v1),
+                    SsTableView::identity(sst2_v2),
+                    SsTableView::identity(sst3_v1),
+                    SsTableView::identity(sst4_v2),
+                ],
             };
 
             // when: iterating over the sorted run
@@ -679,7 +693,12 @@ mod tests {
 
             let sorted_run = SortedRun {
                 id: 0,
-                ssts: vec![sst1_v1, sst2_v2, sst3_v1, sst4_v2],
+                sst_views: vec![
+                    SsTableView::identity(sst1_v1),
+                    SsTableView::identity(sst2_v2),
+                    SsTableView::identity(sst3_v1),
+                    SsTableView::identity(sst4_v2),
+                ],
             };
 
             let mut iter = SortedRunIterator::new_owned_initialized(

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -408,7 +408,7 @@ mod tests {
     use crate::blob::ReadOnlyBlob;
     use crate::block_iterator::{BlockIteratorLatest, BlockLike};
     use crate::bytes_range::BytesRange;
-    use crate::db_state::SsTableId;
+    use crate::db_state::{SsTableId, SsTableView};
     use crate::filter::filter_hash;
     use crate::format::block::Block;
     use crate::object_stores::ObjectStores;
@@ -1041,10 +1041,9 @@ mod tests {
         let encoded = builder.build().await?;
 
         let sst_id = SsTableId::Wal(0);
-        let sst_handle = table_store
-            .write_sst(&sst_id, encoded, false)
-            .await?
-            .with_visible_range(BytesRange::from_ref("c"..="f"));
+        let sst_handle =
+            SsTableView::identity(table_store.write_sst(&sst_id, encoded, false).await?)
+                .with_visible_range(BytesRange::from_ref("c"..="f"));
 
         let expected_entries = vec![
             RowEntry::new_value(b"c", b"value", 0),
@@ -1338,7 +1337,7 @@ mod tests {
         // when: reading the SST back
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             Arc::new(table_store),
             SstIteratorOptions::default(),
         )
@@ -1402,7 +1401,7 @@ mod tests {
         // when: reading the SST back
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             Arc::new(table_store),
             SstIteratorOptions::default(),
         )

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -10,7 +10,7 @@ use tokio::task::JoinHandle;
 use crate::block_iterator::BlockLike;
 use crate::block_iterator_v2::BlockIteratorV2;
 use crate::bytes_range::BytesRange;
-use crate::db_state::{SsTableHandle, SsTableId};
+use crate::db_state::{SsTableId, SsTableView};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::filter::{self, BloomFilter};
@@ -92,12 +92,12 @@ impl Default for SstIteratorOptions {
 }
 
 /// This enum encapsulates access to an SST and corresponding ownership requirements.
-/// For example, [`SstView::Owned`] allows the table handle to be owned, which is
+/// For example, [`SstView::Owned`] allows the table view to be owned, which is
 /// needed for [`crate::db::Db::scan`] since it returns the iterator, while [`SstView::Borrowed`]
 /// accommodates access by reference which is useful for [`crate::db::Db::get`].
 pub(crate) enum SstView<'a> {
-    Owned(Box<SsTableHandle>, BytesRange),
-    Borrowed(&'a SsTableHandle, BytesRange),
+    Owned(Box<SsTableView>, BytesRange),
+    Borrowed(&'a SsTableView, BytesRange),
 }
 
 impl SstView<'_> {
@@ -120,7 +120,7 @@ impl SstView<'_> {
         }
     }
 
-    fn table_as_ref(&self) -> &SsTableHandle {
+    fn table_as_ref(&self) -> &SsTableView {
         match self {
             SstView::Owned(t, _) => t,
             SstView::Borrowed(t, _) => t,
@@ -311,7 +311,7 @@ impl<'a> InternalSstIterator<'a> {
     }
 
     fn table_id(&self) -> SsTableId {
-        self.view.table_as_ref().id
+        self.view.table_as_ref().sst.id
     }
 
     fn view(&self) -> &SstView<'a> {
@@ -324,7 +324,7 @@ impl<'a> InternalSstIterator<'a> {
 
     fn new_owned<T: RangeBounds<Bytes>>(
         range: T,
-        table: SsTableHandle,
+        table: SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -337,7 +337,7 @@ impl<'a> InternalSstIterator<'a> {
 
     async fn new_owned_initialized<T: RangeBounds<Bytes>>(
         range: T,
-        table: SsTableHandle,
+        table: SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -347,7 +347,7 @@ impl<'a> InternalSstIterator<'a> {
 
     fn new_borrowed<T: RangeBounds<Bytes>>(
         range: T,
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -360,7 +360,7 @@ impl<'a> InternalSstIterator<'a> {
 
     async fn new_borrowed_initialized<T: RangeBounds<Bytes>>(
         range: T,
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -369,7 +369,7 @@ impl<'a> InternalSstIterator<'a> {
     }
 
     fn for_key(
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         key: &'a [u8],
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
@@ -383,7 +383,7 @@ impl<'a> InternalSstIterator<'a> {
     }
 
     async fn for_key_initialized(
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         key: &'a [u8],
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
@@ -455,7 +455,7 @@ impl<'a> InternalSstIterator<'a> {
                         self.options.blocks_to_fetch,
                         self.block_idx_range.end - self.next_block_idx_to_fetch,
                     );
-                    let table = self.view.table_as_ref().clone();
+                    let table = self.view.table_as_ref().sst.clone();
                     let table_store = self.table_store.clone();
                     let blocks_start = self.next_block_idx_to_fetch;
                     let blocks_end = self.next_block_idx_to_fetch + blocks_to_fetch;
@@ -484,7 +484,7 @@ impl<'a> InternalSstIterator<'a> {
                         self.options.blocks_to_fetch,
                         self.next_block_idx_to_fetch - self.block_idx_range.start,
                     );
-                    let table = self.view.table_as_ref().clone();
+                    let table = self.view.table_as_ref().sst.clone();
                     let table_store = self.table_store.clone();
                     let blocks_end = self.next_block_idx_to_fetch;
                     let blocks_start = blocks_end - blocks_to_fetch;
@@ -514,7 +514,7 @@ impl<'a> InternalSstIterator<'a> {
         if self.index.is_none() {
             return Ok(None);
         }
-        let sst_version = self.view.table_as_ref().format_version;
+        let sst_version = self.view.table_as_ref().sst.format_version;
         loop {
             if spawn_fetches {
                 self.spawn_fetches();
@@ -608,7 +608,7 @@ impl<'a> InternalSstIterator<'a> {
         if self.index.is_none() {
             let index = self
                 .table_store
-                .read_index(self.view.table_as_ref(), self.options.cache_blocks)
+                .read_index(&self.view.table_as_ref().sst, self.options.cache_blocks)
                 .await?;
             let block_idx_range =
                 InternalSstIterator::blocks_covering_view(&index.borrow(), &self.view);
@@ -853,7 +853,7 @@ impl RowEntryIterator for BloomFilterIterator<'_> {
                 .inner
                 .table_store()
                 .read_filter(
-                    self.inner.view().table_as_ref(),
+                    &self.inner.view().table_as_ref().sst,
                     self.inner.options.cache_blocks,
                 )
                 .await?;
@@ -931,7 +931,7 @@ impl<'a> SstIterator<'a> {
     #[allow(dead_code)]
     pub(crate) fn new_owned_with_stats<T: RangeBounds<Bytes>>(
         range: T,
-        table: SsTableHandle,
+        table: SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
         db_stats: Option<DbStats>,
@@ -943,7 +943,7 @@ impl<'a> SstIterator<'a> {
     #[allow(dead_code)]
     pub(crate) fn new_owned<T: RangeBounds<Bytes>>(
         range: T,
-        table: SsTableHandle,
+        table: SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -952,7 +952,7 @@ impl<'a> SstIterator<'a> {
 
     pub(crate) async fn new_owned_initialized<T: RangeBounds<Bytes>>(
         range: T,
-        table: SsTableHandle,
+        table: SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -976,7 +976,7 @@ impl<'a> SstIterator<'a> {
     #[allow(dead_code)]
     fn new_borrowed_with_stats<T: RangeBounds<Bytes>>(
         range: T,
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
         db_stats: Option<DbStats>,
@@ -988,7 +988,7 @@ impl<'a> SstIterator<'a> {
     #[allow(dead_code)]
     pub(crate) fn new_borrowed<T: RangeBounds<Bytes>>(
         range: T,
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -997,7 +997,7 @@ impl<'a> SstIterator<'a> {
 
     pub(crate) async fn new_borrowed_initialized<T: RangeBounds<Bytes>>(
         range: T,
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
@@ -1021,7 +1021,7 @@ impl<'a> SstIterator<'a> {
 
     #[allow(dead_code)]
     pub(crate) fn for_key_with_stats(
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         key: &'a [u8],
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
@@ -1033,7 +1033,7 @@ impl<'a> SstIterator<'a> {
 
     #[allow(dead_code)]
     pub(crate) async fn for_key_with_stats_initialized(
-        table: &'a SsTableHandle,
+        table: &'a SsTableView,
         key: &'a [u8],
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
@@ -1103,7 +1103,7 @@ mod tests {
     use crate::db_cache::test_utils::TestCache;
     use crate::db_cache::DbCache;
     use crate::db_cache::SplitCache;
-    use crate::db_state::SsTableId;
+    use crate::db_state::{SsTableId, SsTableView};
     use crate::db_stats::DbStats;
     use crate::filter;
     use crate::format::sst::SsTableFormat;
@@ -1168,7 +1168,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             table_store.clone(),
             sst_iter_options,
         )
@@ -1268,7 +1268,7 @@ mod tests {
         let sst_handle = build_single_block_sst(&table_store, &existing_keys).await;
 
         let filter = table_store
-            .read_filter(&sst_handle, true)
+            .read_filter(&sst_handle.sst, true)
             .await
             .expect("filter read should succeed")
             .expect("filter should exist");
@@ -1324,7 +1324,7 @@ mod tests {
             .add_value(b"key2", b"value2", Some(2), None)
             .await
             .unwrap();
-        let handle = writer
+        let sst = writer
             .write_sst(
                 &SsTableId::Compacted(ulid::Ulid::new()),
                 builder.build().await.unwrap(),
@@ -1332,6 +1332,7 @@ mod tests {
             )
             .await
             .unwrap();
+        let handle = SsTableView::identity(sst);
 
         let meta_cache = Arc::new(TestCache::new());
         let cache = Arc::new(
@@ -1363,7 +1364,7 @@ mod tests {
         let _ = iter.next().await.unwrap();
 
         assert!(meta_cache
-            .get_filter(&(handle.id, handle.info.filter_offset).into())
+            .get_filter(&(handle.sst.id, handle.sst.info.filter_offset).into())
             .await
             .unwrap()
             .is_none());
@@ -1385,7 +1386,7 @@ mod tests {
         let _ = iter.next().await.unwrap();
 
         assert!(meta_cache
-            .get_filter(&(handle.id, handle.info.filter_offset).into())
+            .get_filter(&(handle.sst.id, handle.sst.info.filter_offset).into())
             .await
             .unwrap()
             .is_some());
@@ -1407,10 +1408,7 @@ mod tests {
         ))
     }
 
-    async fn build_single_block_sst(
-        table_store: &Arc<TableStore>,
-        keys: &[&[u8]],
-    ) -> SsTableHandle {
+    async fn build_single_block_sst(table_store: &Arc<TableStore>, keys: &[&[u8]]) -> SsTableView {
         let mut builder = table_store.table_builder();
         for key in keys {
             let value = format!("v_{}", String::from_utf8_lossy(key));
@@ -1421,7 +1419,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        table_store.write_sst(&id, encoded, false).await.unwrap()
+        SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap())
     }
 
     #[tokio::test]
@@ -1475,7 +1473,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             table_store.clone(),
             sst_iter_options,
         )
@@ -1677,7 +1675,8 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        let sst_handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+        let sst_handle =
+            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
 
         // Initialize iterator in descending order with full range
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -1794,7 +1793,7 @@ mod tests {
         ts: Arc<TableStore>,
         mut key_gen: OrderedBytesGenerator,
         mut val_gen: OrderedBytesGenerator,
-    ) -> (SsTableHandle, usize) {
+    ) -> (SsTableView, usize) {
         let mut writer = ts.table_writer(SsTableId::Wal(0));
         let mut nkeys = 0usize;
         while writer.blocks_written() < n {
@@ -1803,7 +1802,7 @@ mod tests {
             nkeys += 1;
         }
         let sst = writer.close().await.unwrap();
-        (sst, nkeys)
+        (SsTableView::identity(sst), nkeys)
     }
 
     #[tokio::test]
@@ -1862,7 +1861,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             table_store.clone(),
             sst_iter_options,
         )
@@ -1895,7 +1894,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             table_store.clone(),
             sst_iter_options,
         )
@@ -1923,7 +1922,7 @@ mod tests {
     async fn build_v2_sst(
         table_store: &Arc<TableStore>,
         keys_and_values: &[(&[u8], &[u8])],
-    ) -> SsTableHandle {
+    ) -> SsTableView {
         let mut builder = table_store
             .table_builder()
             .with_block_format(BlockFormat::V2);
@@ -1932,7 +1931,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        table_store.write_sst(&id, encoded, false).await.unwrap()
+        SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap())
     }
 
     #[tokio::test]
@@ -2066,7 +2065,8 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        let sst_handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+        let sst_handle =
+            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
 
         // when: iterating over all keys
         let sst_iter_options = SstIteratorOptions {
@@ -2139,10 +2139,11 @@ mod tests {
         );
 
         // when: seeking to a key in a later block (key_0030)
+        let sst_view = SsTableView::identity(sst_handle);
         let seek_key = b"key_0030";
         let mut iter = SstIterator::new_borrowed_initialized(
             BytesRange::from_slice(seek_key.as_ref()..),
-            &sst_handle,
+            &sst_view,
             table_store.clone(),
             SstIteratorOptions::default(),
         )
@@ -2194,7 +2195,8 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        let sst_handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+        let sst_handle =
+            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
 
         // when: searching for a non-existent key (odd number)
         let mut iter = SstIterator::for_key_with_stats_initialized(
@@ -2245,7 +2247,8 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        let sst_handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+        let sst_handle =
+            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
 
         // when: seeking past the last key
         let iter = SstIterator::new_borrowed_initialized(
@@ -2332,7 +2335,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             BytesRange::from_slice(start_key.as_ref()..=end_key.as_ref()),
-            sst_handle,
+            SsTableView::identity(sst_handle),
             table_store.clone(),
             sst_iter_options,
         )
@@ -2457,7 +2460,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            sst_handle,
+            SsTableView::identity(sst_handle),
             table_store.clone(),
             sst_iter_options,
         )
@@ -2521,7 +2524,7 @@ mod tests {
 
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            handle,
+            SsTableView::identity(handle),
             table_store.clone(),
             SstIteratorOptions {
                 order,

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -717,6 +717,7 @@ mod tests {
     use crate::error;
     use crate::format::block::Block;
     use crate::format::sst::SsTableFormat;
+    use crate::manifest::SsTableView;
     use crate::object_stores::ObjectStores;
     use crate::rand::DbRand;
     use crate::retrying_object_store::RetryingObjectStore;
@@ -800,10 +801,15 @@ mod tests {
             ..SstIteratorOptions::default()
         };
         // then:
-        let mut iter = SstIterator::new_owned_initialized(.., sst, ts.clone(), sst_iter_options)
-            .await
-            .unwrap()
-            .expect("Expected Some(iter) but got None");
+        let mut iter = SstIterator::new_owned_initialized(
+            ..,
+            SsTableView::identity(sst),
+            ts.clone(),
+            sst_iter_options,
+        )
+        .await
+        .unwrap()
+        .expect("Expected Some(iter) but got None");
         assert_iterator(
             &mut iter,
             vec![
@@ -868,10 +874,15 @@ mod tests {
             ..SstIteratorOptions::default()
         };
         // then:
-        let mut iter = SstIterator::new_owned_initialized(.., sst, ts.clone(), sst_iter_options)
-            .await
-            .unwrap()
-            .expect("Expected Some(iter) but got None");
+        let mut iter = SstIterator::new_owned_initialized(
+            ..,
+            SsTableView::identity(sst),
+            ts.clone(),
+            sst_iter_options,
+        )
+        .await
+        .unwrap()
+        .expect("Expected Some(iter) but got None");
         assert_iterator(
             &mut iter,
             vec![

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -2,7 +2,7 @@ use crate::compactor::{CompactionScheduler, CompactionSchedulerSupplier};
 use crate::compactor_state::{CompactionSpec, SourceId};
 use crate::compactor_state_protocols::CompactorStateView;
 use crate::config::{CompactorOptions, PutOptions, WriteOptions};
-use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
+use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableView};
 use crate::error::SlateDBError;
 use crate::format::row::SstRowCodecV0;
 use crate::iter::{IterationOrder, RowEntryIterator};
@@ -324,11 +324,11 @@ pub(crate) async fn build_sorted_runs(
         let mut sr_ssts = Vec::new();
         for entries in sr_sst_sets {
             let ssts = write_ssts(table_store, entries, max_sst_size).await;
-            sr_ssts.extend(ssts);
+            sr_ssts.extend(ssts.into_iter().map(SsTableView::identity));
         }
         sorted_runs.push(SortedRun {
             id: sr_id as u32,
-            ssts: sr_ssts,
+            sst_views: sr_ssts,
         });
     }
 
@@ -363,7 +363,7 @@ impl CompactionScheduler for OnDemandCompactionScheduler {
         let mut sources: Vec<SourceId> = db_state
             .l0
             .iter()
-            .map(|sst| SourceId::Sst(sst.id.unwrap_compacted_id()))
+            .map(|view| SourceId::SstView(view.id))
             .collect();
 
         // Add SSTs from all sorted runs

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -466,7 +466,7 @@ pub(crate) fn sign_extend(val: u32, bits: u8) -> i32 {
 /// Returns:
 /// - The effective max parallelism.
 pub(crate) fn compute_max_parallel(l0_count: usize, srs: &[SortedRun], cap: usize) -> usize {
-    let total_ssts = l0_count + srs.iter().map(|sr| sr.ssts.len()).sum::<usize>();
+    let total_ssts = l0_count + srs.iter().map(|sr| sr.sst_views.len()).sum::<usize>();
     total_ssts.min(cap).max(1)
 }
 
@@ -492,7 +492,7 @@ pub(crate) fn estimate_bytes_before_key(sorted_runs: &[SortedRun], key: &Bytes) 
                 return 0;
             };
             sorted_run
-                .ssts
+                .sst_views
                 .iter()
                 .take(idx)
                 .map(|sst| sst.estimate_size())
@@ -738,14 +738,23 @@ pub(crate) async fn preload_cache_from_manifest(
     match preload_level {
         Some(PreloadLevel::AllSst) => {
             let mut all_sst_paths: Vec<object_store::path::Path> = Vec::with_capacity(
-                core.l0.len() + core.compacted.iter().map(|sr| sr.ssts.len()).sum::<usize>(),
+                core.l0.len()
+                    + core
+                        .compacted
+                        .iter()
+                        .map(|sr| sr.sst_views.len())
+                        .sum::<usize>(),
             );
-            all_sst_paths.extend(core.l0.iter().map(|sst| path_resolver.table_path(&sst.id)));
+            all_sst_paths.extend(
+                core.l0
+                    .iter()
+                    .map(|view| path_resolver.table_path(&view.sst.id)),
+            );
             all_sst_paths.extend(
                 core.compacted
                     .iter()
-                    .flat_map(|sr| &sr.ssts)
-                    .map(|sst| path_resolver.table_path(&sst.id)),
+                    .flat_map(|sr| &sr.sst_views)
+                    .map(|view| path_resolver.table_path(&view.sst.id)),
             );
             if !all_sst_paths.is_empty() {
                 if let Err(e) = cached_obj_store
@@ -760,7 +769,7 @@ pub(crate) async fn preload_cache_from_manifest(
             let l0_sst_paths: Vec<object_store::path::Path> = core
                 .l0
                 .iter()
-                .map(|sst| path_resolver.table_path(&sst.id))
+                .map(|view| path_resolver.table_path(&view.sst.id))
                 .collect();
             if !l0_sst_paths.is_empty() {
                 if let Err(e) = cached_obj_store
@@ -784,7 +793,7 @@ mod tests {
     use slatedb_common::MockSystemClock;
 
     use crate::clock::MonotonicClock;
-    use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo};
+    use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
     use crate::error::SlateDBError;
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::sst_builder::BlockFormat;
@@ -827,19 +836,18 @@ mod tests {
         }
     }
 
-    fn make_compacted_sst(start_key: &str, size: u64) -> SsTableHandle {
+    fn make_sst_view(start_key: &str, size: u64) -> SsTableView {
         let info = SsTableInfo {
             first_entry: Some(Bytes::from(start_key.as_bytes().to_vec())),
             index_offset: size.saturating_sub(1),
             index_len: 1,
             ..Default::default()
         };
-        SsTableHandle::new_compacted(
+        SsTableView::identity(SsTableHandle::new(
             SsTableId::Compacted(Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             info,
-            None,
-        )
+        ))
     }
 
     #[test]
@@ -1323,16 +1331,16 @@ mod tests {
     fn test_estimate_bytes_before_key() {
         let run1 = SortedRun {
             id: 1,
-            ssts: vec![
-                make_compacted_sst("a", 10),
-                make_compacted_sst("k", 20), // k < m < z, so only "a" counts
-                make_compacted_sst("z", 30),
+            sst_views: vec![
+                make_sst_view("a", 10),
+                make_sst_view("k", 20), // k < m < z, so only "a" counts
+                make_sst_view("z", 30),
             ],
         };
         let run2 = SortedRun {
             id: 2,
             // f < m < ..., so only "b" counts
-            ssts: vec![make_compacted_sst("b", 40), make_compacted_sst("f", 50)],
+            sst_views: vec![make_sst_view("b", 40), make_sst_view("f", 50)],
         };
 
         let key = Bytes::from("m");

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -604,6 +604,7 @@ mod tests {
     use crate::format::sst::SsTableFormat;
     use crate::iter::RowEntryIterator;
     use crate::manifest::store::test_utils::new_dirty_manifest;
+    use crate::manifest::SsTableView;
     use crate::object_stores::ObjectStores;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
     use crate::stats::StatRegistry;
@@ -870,7 +871,7 @@ mod tests {
         };
         let mut iter = SstIterator::new_owned_initialized(
             ..,
-            table_store.open_sst(&SsTableId::Wal(1)).await.unwrap(),
+            SsTableView::identity(table_store.open_sst(&SsTableId::Wal(1)).await.unwrap()),
             table_store.clone(),
             sst_iter_options,
         )

--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -75,6 +75,7 @@ use object_store::ObjectStore;
 use crate::db_state::SsTableId;
 use crate::format::sst::SsTableFormat;
 use crate::iter::{EmptyIterator, RowEntryIterator};
+use crate::manifest::SsTableView;
 use crate::object_stores::ObjectStores;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
@@ -153,7 +154,7 @@ impl WalFile {
         let sst = self.table_store.open_sst(&SsTableId::Wal(self.id)).await?;
         let iter = match SstIterator::new_owned_initialized(
             ..,
-            sst,
+            SsTableView::identity(sst),
             Arc::clone(&self.table_store),
             SstIteratorOptions::default(),
         )

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -1,6 +1,7 @@
 use crate::db_state::{ManifestCore, SsTableId};
 use crate::error::SlateDBError;
 use crate::iter::RowEntryIterator;
+use crate::manifest::SsTableView;
 use crate::mem_table::WritableKVTable;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
@@ -157,8 +158,13 @@ impl WalReplayIterator<'_> {
             table_store: Arc<TableStore>,
         ) -> Result<Option<SstIterator<'a>>, SlateDBError> {
             let sst = table_store.open_sst(&SsTableId::Wal(wal_id)).await?;
-            SstIterator::new_owned_initialized(.., sst, Arc::clone(&table_store), sst_iter_options)
-                .await
+            SstIterator::new_owned_initialized(
+                ..,
+                SsTableView::identity(sst),
+                Arc::clone(&table_store),
+                sst_iter_options,
+            )
+            .await
         }
 
         let handle = task::spawn(load_iter(


### PR DESCRIPTION
## Summary

This is an implementation of approach No. 3 from https://docs.google.com/document/d/1E42RLty2o8wyiakAi--Cwcn2bXleJol4Mdm1zFokJZA/edit?usp=sharing to address the issues discussed in #1285 .

Namely, `union` operation might result in SSTs with duplicated IDs. Besides of violating the assumption of Ulid uniqeuness, this can cause unnecessary compactions, back-pressure due to `l0_max_ssts`, large metadata, etc.

This PR introduces a layer of indirection `CompactedSsTableView` between Manifest and SST; so that the same SST can be referenced multiple times (with different visible ranges).
Iterators use the new `CompactedSsTableView`, while compactions, caching, etc. operate on SST level.

## Changes

Schema and compaction changes (fbs) were done manually (1st, 3rd, and 4th commits);
Commit `Introduce SsTableView indirection to allow multiple visible ranges per SST` was implemented by Claude:
```
  Summary

  Split SsTableHandle into two types in db_state.rs:

  SsTableHandle — the physical SST on disk:
  pub struct SsTableHandle {
      pub id: SsTableId,
      pub(crate) format_version: u16,
      pub info: SsTableInfo,
  }

  SsTableView — a projected view of an SST:
  pub struct SsTableView {
      pub sst: SsTableHandle,
      pub(crate) visible_range: Option<BytesRange>,
      effective_range: BytesRange,
  }

  Key changes across the codebase:

  - SortedRun.ssts: Vec<SsTableHandle> → Vec<SsTableView>
  - ManifestCore.l0: VecDeque<SsTableHandle> → VecDeque<SsTableView>
  - SstView enum (sst_iter.rs): wraps SsTableView instead of SsTableHandle
  - SortedRunView enum (sorted_run_iterator.rs): uses SsTableView
  - Flatbuffer codec: decoder constructs SsTableHandle then wraps in SsTableView::new_projected(); encoder accesses view.sst.* fields
  - TableStore functions (read_filter, read_index, read_blocks): still take &SsTableHandle; callers pass &view.sst
  - Flush path: creates SsTableHandle, wraps in SsTableView::new(handle) before pushing to L0
  - Compactor/GC/utils: access SST identity via sst.sst.id instead of sst.id

  Verification:

  - cargo build -p slatedb — clean, no warnings
  - cargo test -p slatedb --lib — 1164 passed, 0 failed
  - cargo test -p slatedb (doc tests) — 57 passed, 0 failed

```

## Notes for Reviewers

After this PR, I plan to get back to #1285

One issue not discussed in #1285 and not covered in this PR is that after compaction, SSTs are never removed from External DBs and the final_checkpoint is not removed from the parent database.
I plan to fix it it in a follow-up PR.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
    - Most of the changes are mechanical changes to replace SST with SST view
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
    - The PR changes the structure but not the behavior, so it should be covered by the existing tests
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
