### PR TITLE
Fix flaky `test_should_read_from_compacted_db` test

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -5225,11 +5225,7 @@ mod tests {
         )
         .await;
         let manifest = db.manifest();
-        info!(
-            "1 l0: {} {}",
-            manifest.l0.len(),
-            manifest.compacted.len()
-        );
+        info!("1 l0: {} {}", manifest.l0.len(), manifest.compacted.len());
 
         // write more l0s and wait for compaction
         for i in 0..4 {
@@ -5251,11 +5247,7 @@ mod tests {
         )
         .await;
         let manifest = db.manifest();
-        info!(
-            "2 l0: {} {}",
-            manifest.l0.len(),
-            manifest.compacted.len()
-        );
+        info!("2 l0: {} {}", manifest.l0.len(), manifest.compacted.len());
         // write another l0
         db.put(&[b'a'; 32], &[128u8; 32]).await.unwrap();
         db.put(&[b'm'; 32], &[129u8; 32]).await.unwrap();
@@ -5266,11 +5258,7 @@ mod tests {
         assert_eq!(val, Some(Bytes::copy_from_slice(&[129u8; 32])));
         for i in 1..4 {
             let manifest = db.manifest();
-            info!(
-                "3 l0: {} {}",
-                manifest.l0.len(),
-                manifest.compacted.len()
-            );
+            info!("3 l0: {} {}", manifest.l0.len(), manifest.compacted.len());
             let val = db.get([b'a' + i; 32]).await.unwrap();
             assert_eq!(val, Some(Bytes::copy_from_slice(&[1u8 + i; 32])));
             let val = db.get([b'm' + i; 32]).await.unwrap();


### PR DESCRIPTION
## Summary

We had a sporadic failure with `test_should_read_from_compacted_db` last week:

https://github.com/slatedb/slatedb/actions/runs/22253572717/job/64381091693

After some investigation, it appears that double read locking in a single statement can cause a deadlock if a write lock occurs in between:

```
info!(
    "1 l0: {} {}",
    db.inner.state.read().state().core().l0.len(),
    // write lock occurs here
    db.inner.state.read().state().core().compacted.len()
    manifest.l0.len(),
    manifest.compacted.len()
);
```

According to Codex, it's a lock starvation thing:

  - In the info! calls, state.read() was called twice in one statement.
  - Rust keeps those temporary read guards alive for the full statement.
  - If a writer is queued (compactor/background task), parking_lot may block the second read to avoid writer starvation.
  - Then the same thread is stuck: second read waits, writer waits for first read to drop, but first read won’t drop until statement end.

_EDIT: I don't think it's writer starvation. I think if the reader is holding the lock, then the writer tries to grab the lock, the second reader lock is blocked. It appears the read lock is not reentrant. See the [Discord thread](https://discord.com/channels/1232385660460204122/1478535690437525658) for more._

## Changes

- Replace double lockingn in `info!` statement with a single `db.manifest()` call

## Notes for Reviewers

I was able to reproduce this several times when running the test in a loop. It failed in the 200-600 execution range on my macbook with the CPU fully saturated. After the patch, I ran the test 1200+ times with full CPU saturation and was unable to trigger the deadlock.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
