### PR TITLE
Eliminate memory spike during disk cache preload

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -127,8 +127,6 @@ impl CachedObjectStore {
         }
 
         // Second pass: load the selected files in bounded parallelism and cache them.
-        // We only need to call maybe_prefetch_range to download and save SSTs to disk.
-        // There's no need to read the data back into memory via result.bytes().
         let degree_of_parallelism = 32;
         let _result = build_concurrent(files_to_load.into_iter(), degree_of_parallelism, |path| {
             let this = self.clone();


### PR DESCRIPTION
## Summary

- During disk cache preload (`load_files_to_cache`), `cached_get_opts` + `result.bytes().await` was used to trigger caching. However, `maybe_prefetch_range` (called inside `cached_get_opts`) already downloads the SST from the object store and saves all parts to disk. The subsequent `result.bytes().await` then reads the **entire SST back from disk into a single in-memory `Bytes` allocation**, only to immediately drop it.
- With 32 concurrent loads of large compacted SSTs (hundreds of MB each), this creates a multi-GB memory spike that can cause OOM on memory-constrained deployments.
- Fix: call `maybe_prefetch_range` directly instead of `cached_get_opts` + `result.bytes()`, eliminating the wasteful read-back.

## Test plan

- [x] Verified fix eliminates memory spike in production (Ethereum mainnet, 28GiB pod, ~80GiB of SSTs)
- [ ] Existing `test_preload_cache_*` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)