### PR TITLE
Make is_empty pub in write_batch

### DIFF
--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -281,12 +281,12 @@ impl WriteBatch {
         self.write_idx += 1;
     }
 
-    pub(crate) fn keys(&self) -> HashSet<Bytes> {
-        self.ops.keys().map(|key| key.user_key.clone()).collect()
+    pub fn is_empty(&self) -> bool {
+        self.ops.is_empty()
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
-        self.ops.is_empty()
+    pub(crate) fn keys(&self) -> HashSet<Bytes> {
+        self.ops.keys().map(|key| key.user_key.clone()).collect()
     }
 
     /// Converts a WriteBatch into a vector of RowEntry objects with seq and timestamp set,


### PR DESCRIPTION
## Summary

What is being changed and why?

## Changes

Now that `SlateDB` rejects empty batches. Users would have to track the batch on their side and know if it's empty. It seems simpler to just expose `is_empty` here. 

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
