### PR TITLE
Clean recent commits when no active transactions

### DIFF
--- a/slatedb/src/transaction_manager.rs
+++ b/slatedb/src/transaction_manager.rs
@@ -250,9 +250,6 @@ impl TransactionManager {
 
     /// Record a recent committed transaction for conflict detection.
     /// This method should be called after confirming no conflicts exist.
-    ///
-    /// The transaction will be moved from active_txns to recent_committed_txns
-    /// if it is still needed for future conflict checking with other transactions.
     pub(crate) fn track_recent_committed_txn(&self, txn_id: &Uuid, committed_seq: u64) {
         // remove the transaction from active_txns, and add it to recent_committed_txns
         let mut inner = self.inner.write();


### PR DESCRIPTION
## Summary

Was working on some other stuff when Codex found this bug in a `/review`:

> - [P1] Avoid retaining every non-transactional write forever — /private/tmp/slatedb/slatedb/src/transaction_manager.rs:285-292 When callers use ordinary db.put/db.write without any active write transaction, this unconditional push_back adds a TransactionState to recent_committed_txns, but that deque is only reclaimed from drop_txn(). Because non-transactional writes never call drop_txn(), long-running write-heavy workloads will leak one committed record per write and make conflict checks walk an ever-growing deque.

I think this was an unintended bug I introduced here:

https://github.com/slatedb/slatedb/pull/1301/changes#diff-43b4c48a1c3a2e230ab0a058cae083ba7b6d3ae4444cc6d7775c6a21f56b0170L231-L236

Rather than re-introduce that check, I decided to more aggressively drop commit tracking when there are no active transactions (read-write). This felt safer. It does add a bit of extra logic to the write path, but I suspect it'll be fine. We have some put perf tracking in the microbenchmark anyway.

I also think this change is safe because the tracking changes are all done while the inner write lock is held. This should keep us from bumping up against the kind of issues we faced in #1301.

## Changes

- Clear `recent_committed_txns` on write if there are no active read-write transactions.
- Updated a few tests that were assuming the writes would still be there with empty active transactions.

## Notes for Reviewers

I think sniffing around the test changes is worth doing.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
