### PR TITLE
Partitioned SST Index RFC

### DIFF
--- a/rfcs/0021-partitioned-sst-index.md
+++ b/rfcs/0021-partitioned-sst-index.md
@@ -13,6 +13,9 @@ Table of Contents:
    * [Format version](#format-version)
    * [Write path (`EncodedSsTableFooterBuilder::build`)](#write-path-encodedsstablefooterbuilderbuild)
    * [Read path (`SsTableFormat::read_index`)](#read-path-sstableformatread_index)
+   * [Metadata cache changes (`slatedb/src/db_cache/mod.rs`)](#metadata-cache-changes-slatedbsrcdb_cachemodrs)
+      + [Cache key structure](#cache-key-structure)
+      + [Cache stats](#cache-stats)
 - [Impact Analysis](#impact-analysis)
    * [Core API & Query Semantics](#core-api-query-semantics)
    * [Consistency, Isolation, and Multi-Versioning](#consistency-isolation-and-multi-versioning)
@@ -33,7 +36,6 @@ Table of Contents:
 - [Open Questions](#open-questions)
 - [References](#references)
 - [Updates](#updates)
-
 <!-- TOC end -->
 
 Status: Draft
@@ -176,6 +178,47 @@ On a read against an SST with partitioned index:
 4. Binary search the `PartitionIndex.blocks` to find the data block offset, then proceed as today.
 
 On a read against an SST with `index_type = Flat` in the `SsTableInfo` footer, the existing flat-index path is used unchanged.
+
+### Metadata cache changes (`slatedb/src/db_cache/mod.rs`)
+
+Two new variants are added to the internal `CachedItem` enum, SsTableIndexV2 for the cached top-level index directory and PartitionIndex for the cached partitions of the index:
+
+```rust
+enum CachedItem {
+    Block(Arc<Block>),
+    SsTableIndex(Arc<SsTableIndexOwned>),      // existing flat v1 index
+    SsTableIndexV2(Arc<SsTableIndexV2Owned>),  // new top-level partition directory
+    PartitionIndex(Arc<PartitionIndexOwned>),   // individual partition blocks
+    BloomFilter(Arc<BloomFilter>),
+    SstStats(Arc<SstStats>),
+}
+```
+
+Both new types route to the **meta cache** in `SplitCache::insert`, consistent with the existing index and filter entries.
+
+#### Cache key structure
+
+`CachedKey` is `(scope_id, sst_id, block_id)` where `block_id` is a byte offset
+within the SST file. Within a single SST file, partition index blocks and data blocks occupy
+non-overlapping byte ranges, so their byte offsets are guaranteed to be distinct.
+No `CachedKey` collision is possible, and no changes to `CachedKey` are required. The `CachedItem` variant already encodes the
+type, providing an additional layer of differentiation.
+
+#### Cache stats
+
+`SsTableIndexV2` lookups reuse the existing `dbcache.index_hit` / `dbcache.index_miss`
+counters, since it fills the same conceptual role as the flat index (the top-level
+entry point for an SST's index structure).
+
+`PartitionIndex` gets two new counters registered in `DbCacheStats`:
+
+- `dbcache.partition_index_hit`
+- `dbcache.partition_index_miss`
+
+These are kept separate because partition block cache effectiveness is the primary
+observable outcome of this RFC; lumping them into the existing index counters would
+make it impossible to distinguish top-level directory hits from individual partition
+block hits.
 
 
 ## Impact Analysis


### PR DESCRIPTION
## Summary

Proposes replacing SlateDB's flat monolithic SST index with a two-level partitioned index. Currently, every point-get or scan must load the full index (up to ~2.5MB for a 256MB SST) before reading a single 4KB data block. This RFC introduces a small top-level directory pointing to per-partition index blocks, so reads only fetch and cache the partition(s) covering the requested key range.

## Changes

RFC only, no code changes. See rfcs/0021-partitioned-index-filter.md.

## Notes for Reviewers

  - Schema: Does the proposed FlatBuffers schema (IndexType enum, PartitionMeta, PartitionIndex) look right? Any concerns with the backward-compatibility approach (defaulting index_type to Flat)?
  - Scope: Should partitioned bloom filters be included in this RFC or deferred? See Open Questions.
  - Partition granularity: The default of ~4KB of index data per partition is borrowed from RocksDB. Does that feel right for SlateDB's typical workloads?

## Related to: #1068 

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [X] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏