### PR TITLE
Replay WAL into DbReader in correct order

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -424,8 +424,8 @@ impl DbReaderInner {
             sst_iter_options,
         };
 
-        let wal_id_start = if let Some(last_replayed_table) = into_tables.back() {
-            last_replayed_table.recent_flushed_wal_id() + 1
+        let wal_id_start = if let Some(latest_replayed_table) = into_tables.front() {
+            latest_replayed_table.recent_flushed_wal_id() + 1
         } else {
             core.replay_after_wal_id + 1
         };
@@ -450,7 +450,7 @@ impl DbReaderInner {
             last_committed_seq = replayed_table.last_seq;
             let imm_memtable =
                 ImmutableMemtable::new(replayed_table.table, replayed_table.last_wal_id);
-            into_tables.push_back(Arc::new(imm_memtable));
+            into_tables.push_front(Arc::new(imm_memtable));
         }
 
         Ok((last_wal_id, last_committed_seq))


### PR DESCRIPTION
## Summary

The DbReader incorrectly replays WALs into memtables from by putting newer WAL data at the back of the immutable memtable vecdeque rather than the front. This causes stale data to be visible incorrectly.

The into_tables should be structured like this [t3, t2, t1], with newer data getting pushed to the front and older data at the back. This is how `Reader` expects it.

Fixes #1385

## Changes

- Derive WAL ID replay start from the most recent write rather than the oldest.
- Push new memtables to the front of the vecdeque rather than the back

## Notes for Reviewers

I verified that the provided tests in #1385 pass. I didn't include them in this PR because they are non-deterministic (time dependency). I opted to include a deterministic test that verifies just the behavior change.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
