### PR TITLE
Filter DbReader rows by `last_l0_seq` on refresh

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -329,7 +329,7 @@ impl DbReaderInner {
                 // have sequence numbers < manifest.core.last_l0_seq, while others have sequence
                 // numbers > manifest.core.last_l0_seq. Retain only those that are more recent
                 // than the manifest's last L0 sequence number.
-                let filtered_table = table.filter_by_seq(manifest.core.last_l0_seq);
+                let filtered_table = table.filter_after_seq(manifest.core.last_l0_seq);
                 // Push to the back because we are iterating prior from newest to oldest, and we
                 // want the imm memtables in checkpoint state to be ordered the same way.
                 imm_memtable.push_back(Arc::new(filtered_table));

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -250,7 +250,7 @@ impl ImmutableMemtable {
     /// Returns a new [`ImmutableMemtable`] that only contains entries with sequence
     /// number greater than the given `seq`. [`ImmutableMemtable::recent_flushed_wal_id`]
     /// remains the same.
-    pub(crate) fn filter_by_seq(&self, seq: u64) -> Self {
+    pub(crate) fn filter_after_seq(&self, seq: u64) -> Self {
         let new_table = WritableKVTable::new();
         let mut table_iter = self.table.iter();
         while let Some(entry) = table_iter.next_sync() {


### PR DESCRIPTION
## Summary

The `DbReader` keeps recently replayed WAL data in its immutable memtables (in-memory). Those tables sit in front of the data in the manifest (L0+). When a new manifest is refreshed, it's possible that the in-memory memtables now have data that's older than the L0+ data in the new manifest. This is a problem: `Reader` always reads data from the in-memory tables before the in-object store tables. `DbReader` addresses this problem by filtering the old data out of the in-memory tables after a manifest refresh.

The current logic to filter old data out is broken. It filters all memtables that have a WAL Id < `replay_after_wal_id`. This is incorrect. `replay_after_wal_id` represents the most recent WAL ID at the time a writer's memtable is frozen. It's possible the L0 contains more recent data (we have decoupled the L0 and WAL flush paths). This can cause some tables in the `DbReader` to have an ID > `replay_after_wal_id`, but with seqnums < `last_l0_seq`.

To fix this issue, I changed the filtering logic to use seqnums instead of WAL IDs. We now use the following rules:

- Drop an in-memory table if its max seq is <= last_l0_seq
- Retain an in-memory table if its min seq is > last_l0_seq
- Rebuild an in-memory table if it has min seq <= last_l0_seq < max seq

I think this approach is loosely similar to the WalReplayIterator, which uses `last_l0_seq` to filter rows when it replays WAL entries back into the ReplayedMemtable during WAL recovery in db.rs.

Fixes #1369

## Changes

- Add min seq tracking to `KVTable`
- Add `filter_by_seq` to `ImmutableMemtable`
- Update filtering logic in `db_reader.rs`
- Add tests

## Notes for Reviewers

I opted to be explicit in the if branching rather than use range bound checks. It felt easier to read and reason about.

@rodesai I added a test that was loosely similar to yours. I didn't use yours because it was a bit messy and failed when things worked properly (it tested that things failed rather than things behaved properly).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
