### PR TITLE
Don't fail DbReader WAL replay on 404

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -223,7 +223,7 @@ impl DbReaderInner {
     fn should_reestablish_checkpoint(&self, latest: &ManifestCore) -> bool {
         let read_guard = self.state.read();
         let current_state = read_guard.core();
-            latest.last_compacted_l0_sst_view_id != current_state.last_compacted_l0_sst_view_id
+        latest.last_compacted_l0_sst_view_id != current_state.last_compacted_l0_sst_view_id
             || latest.compacted != current_state.compacted
             || latest.last_l0_seq > read_guard.last_remote_persisted_seq
     }


### PR DESCRIPTION
## Summary

The DbReader was replay WALs from its last_wal_id all the way until the most recently WAL in the table store. This can cause an issue the DbReader was in the middle of a WAL replay. The reader can see WAL entries that are eligible for deletion by the GC. If the GC deletes them, we fail with a 404.

This PR fixes the issue by having the DbReader gracefully stop replaying the WAL if it hits a 404 on WAL replay. On the next manifest poll, it will see the new manifest and reestablish its checkpoint accordingly.

Fixes #1368

## Changes

- Detect 404 errors on WAL replay and stop replaying when they occur
- Reestablish checkpoints by or `last_remote_persisted_seq`
- Add tests

## Notes for Reviewers

@rodesai I opted to go the 404 route because it felt much cleaner to implement. We don't need to modify the manifest and deal with merge logic, and it seems to fit in nicely with the existing logic. LMK if you prefer the "reestablish checkpoint on every new WAL detected" approach.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
