### PR TITLE
Rescaling: regenerate IDs of SortedRuns on union()

### DIFF
--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -184,7 +184,13 @@ impl Manifest {
     fn range(&self) -> Option<BytesRange> {
         let mut start_bound = None;
         let mut end_bound = None;
-        for sst in &self.core.l0 {
+        let all_views = self.core.l0.iter().chain(
+            self.core
+                .compacted
+                .iter()
+                .flat_map(|sr| sr.sst_views.iter()),
+        );
+        for sst in all_views {
             let range = sst.compacted_effective_range();
             start_bound = start_bound
                 .map(|b| min(b, range.comparable_start_bound()))
@@ -586,6 +592,28 @@ mod tests {
         let union = Manifest::union(manifests);
 
         assert_manifest_equal(&union, &expected_manifest, &sst_ids);
+    }
+
+    #[test]
+    fn test_range_includes_compacted_ssts() {
+        let manifest = build_manifest(
+            &SimpleManifest::new(
+                vec![],
+                vec![(
+                    0,
+                    vec![
+                        SstEntry::projected("sr_a", "a", "a".."m"),
+                        SstEntry::projected("sr_n", "n", "m"..),
+                    ],
+                )],
+            ),
+            |_| SsTableId::Compacted(Ulid::new()),
+        );
+        let range = manifest
+            .range()
+            .expect("range should be Some for manifest with sorted runs");
+        assert_eq!(range.start_bound(), Bound::Included(&Bytes::from("a")));
+        assert_eq!(range.end_bound(), Bound::Unbounded);
     }
 
     fn build_manifest<F>(manifest: &SimpleManifest, mut sst_id_fn: F) -> Manifest

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -172,6 +172,11 @@ impl Manifest {
                 }
             }
 
+            // Renumber sorted runs to ensure sequential IDs without duplicates
+            for (idx, sorted_run) in core.compacted.iter_mut().enumerate() {
+                sorted_run.id = idx as u32;
+            }
+
             Self {
                 external_dbs,
                 core,
@@ -375,6 +380,15 @@ mod tests {
     struct SimpleManifest {
         l0: Vec<SstEntry>,
         sorted_runs: Vec<Vec<SstEntry>>,
+    }
+
+    impl SimpleManifest {
+        fn new(l0: Vec<SstEntry>, sorted_runs: Vec<(u32, Vec<SstEntry>)>) -> Self {
+            Self {
+                l0,
+                sorted_runs: sorted_runs.into_iter().map(|(_, ssts)| ssts).collect(),
+            }
+        }
     }
 
     struct ProjectionTestCase {
@@ -592,6 +606,48 @@ mod tests {
         let union = Manifest::union(manifests);
 
         assert_manifest_equal(&union, &expected_manifest, &sst_ids);
+    }
+
+    #[test]
+    fn test_union_renumbers_sr_ids() {
+        // Create manifest 1 with 2 sorted runs covering "a".."m"
+        let manifest1 = build_manifest(
+            &SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    vec![SstEntry::projected("sr1_0_sst0", "a", "a".."g")],
+                    vec![SstEntry::projected("sr1_1_sst0", "g", "g".."m")],
+                ],
+            },
+            |_| SsTableId::Compacted(Ulid::new()),
+        );
+
+        // Create manifest 2 with 3 sorted runs covering "m"..∞
+        let manifest2 = build_manifest(
+            &SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![
+                    vec![SstEntry::projected("sr2_0_sst0", "m", "m".."s")],
+                    vec![SstEntry::projected("sr2_1_sst0", "s", "s".."t")],
+                    vec![SstEntry::projected("sr2_2_sst0", "t", "t"..)],
+                ],
+            },
+            |_| SsTableId::Compacted(Ulid::new()),
+        );
+
+        let union = Manifest::union(vec![manifest1, manifest2]);
+
+        // After union, we should have 5 SRs with IDs 0, 1, 2, 3, 4
+        assert_eq!(union.core.compacted.len(), 5);
+
+        let sr_ids: Vec<u32> = union.core.compacted.iter().map(|sr| sr.id).collect();
+        assert_eq!(sr_ids, vec![0, 1, 2, 3, 4], "SR IDs should be sequential");
+
+        // Verify no duplicates
+        let mut seen = std::collections::HashSet::new();
+        for id in &sr_ids {
+            assert!(seen.insert(id), "Duplicate SR ID: {}", id);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

regenerate IDs of Sorted Runs when merging manifests as per #1395 

This prevents breaking the invariant about SR ID order and uniqueness.

## Changes

1. Rescaling: regenerate IDs of SortedRuns on union()
1. Rescaling: take SR SST Views ranges into account when merging manifests

## Notes for Reviewers

This PR was extracted from #1285 and follows #1395.
I plan to follow up with more PRs.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
