### PR TITLE
Fix sequence tracker merge on manifest refresh

### DIFF
--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -707,12 +707,6 @@ impl<'a> StateModifier<'a> {
         };
 
         let my_db_state = self.state.core();
-        let remote_last_l0_seq = remote_manifest.value.core.last_l0_seq;
-        let mut merged_sequence_tracker = remote_manifest.value.core.sequence_tracker.clone();
-        let local_sequence_suffix = my_db_state
-            .sequence_tracker
-            .filter_after_seq(remote_last_l0_seq);
-        merged_sequence_tracker.extend_from(&local_sequence_suffix);
         remote_manifest.value.core = ManifestCore {
             initialized: my_db_state.initialized,
             last_compacted_l0_sst_view_id: remote_manifest.value.core.last_compacted_l0_sst_view_id,
@@ -724,7 +718,7 @@ impl<'a> StateModifier<'a> {
             last_l0_clock_tick: my_db_state.last_l0_clock_tick,
             last_l0_seq: my_db_state.last_l0_seq,
             recent_snapshot_min_seq: my_db_state.recent_snapshot_min_seq,
-            sequence_tracker: merged_sequence_tracker,
+            sequence_tracker: my_db_state.sequence_tracker.clone(),
             checkpoints: remote_manifest.value.core.checkpoints,
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
         };
@@ -762,7 +756,7 @@ mod tests {
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::proptest_util::arbitrary;
-    use crate::seq_tracker::{FindOption, TrackedSeq};
+    use crate::seq_tracker::{FindOption, SequenceTracker, TrackedSeq};
     use crate::test_utils;
     use bytes::Bytes;
     use chrono::{TimeZone, Utc};
@@ -855,7 +849,7 @@ mod tests {
     }
 
     #[test]
-    fn test_should_merge_sequence_tracker_from_remote_prefix_and_local_suffix() {
+    fn test_should_keep_local_sequence_tracker_on_merge() {
         let mut db_state = DbState::new(new_dirty_manifest(), DbStatusReporter::new(0));
         db_state.modify(|modifier| {
             let core = &mut modifier.state.manifest.value.core;
@@ -874,33 +868,26 @@ mod tests {
             });
         });
 
+        // Remote has a stale sequence tracker (e.g. missing recent entries).
         let mut remote_state = new_dirty_manifest();
         remote_state.value.core = db_state.state.core().clone();
-        remote_state.value.core.last_l0_seq = 1;
-        remote_state.value.core.sequence_tracker =
-            db_state.state.core().sequence_tracker.filter_after_seq(0);
+        remote_state.value.core.sequence_tracker = SequenceTracker::new();
 
         db_state.merge_remote_manifest(remote_state);
 
-        let merged_tracker = &db_state.state.core().sequence_tracker;
+        // The local tracker should be preserved as-is.
+        let tracker = &db_state.state.core().sequence_tracker;
         assert_eq!(
-            merged_tracker.find_ts(1, FindOption::RoundDown),
+            tracker.find_ts(1, FindOption::RoundDown),
             Utc.timestamp_opt(60, 0).single()
         );
         assert_eq!(
-            merged_tracker.find_ts(2, FindOption::RoundDown),
+            tracker.find_ts(2, FindOption::RoundDown),
             Utc.timestamp_opt(120, 0).single()
         );
         assert_eq!(
-            merged_tracker.find_ts(3, FindOption::RoundDown),
+            tracker.find_ts(3, FindOption::RoundDown),
             Utc.timestamp_opt(180, 0).single()
-        );
-        assert_eq!(
-            merged_tracker.find_seq(
-                Utc.timestamp_opt(180, 0).single().unwrap(),
-                FindOption::RoundDown
-            ),
-            Some(3)
         );
     }
 

--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -130,17 +130,6 @@ impl SequenceTracker {
         }
     }
 
-    pub(crate) fn filter_after_seq(&self, min_exclusive_seq: u64) -> Self {
-        let start = self
-            .sequence_numbers
-            .partition_point(|seq| *seq <= min_exclusive_seq);
-        let mut filtered = Self::with_config(self.capacity, self.interval_secs);
-        filtered.sequence_numbers = self.sequence_numbers[start..].to_vec();
-        filtered.timestamps = self.timestamps[start..].to_vec();
-        filtered.last_recorded_ts = filtered.timestamps.last().copied();
-        filtered
-    }
-
     /// Downsample by removing every other entry
     fn downsample(&mut self) {
         let mut new_seqs = Vec::with_capacity(self.capacity as usize);


### PR DESCRIPTION
The logic for updating the sequence_tracker when merging manifest looks wrong. Although we overwrite `last_l0_seq` from the local state and we merge L0, we take the remote `sequence_tracker` without including local changes. This patch adds the missing merge logic.