### PR TITLE
Remove RFC HTML escaping

### DIFF
--- a/website/scripts/generate-rfcs.js
+++ b/website/scripts/generate-rfcs.js
@@ -1,4 +1,4 @@
-// Generate MDX wrappers for top-level RFCs so Starlight has frontmatter.
+// Generate Markdown wrappers for top-level RFCs so Starlight has frontmatter.
 // - Reads Markdown files via the `src/content/docs/rfcs` symlink.
 // - Writes wrappers to `src/content/docs/rfcs/` with frontmatter and rendered content.
 
@@ -96,9 +96,8 @@ export async function generateRfcWrappers() {
     // Remove wrappers that no longer have a source.
     const existing = await fs.readdir(wrappersDir).catch(() => []);
     for (const f of existing) {
-      if (!f.endsWith('.mdx')) continue;
-      const base = f.replace(/\.mdx$/, '.md');
-      if (!rfcFiles.includes(base)) {
+      if (!f.endsWith('.md')) continue;
+      if (!rfcFiles.includes(f)) {
         await fs.unlink(path.join(wrappersDir, f)).catch(() => {});
       }
     }
@@ -124,13 +123,13 @@ export async function generateRfcWrappers() {
         .filter(Boolean)
         .join('\n');
 
-      // Trim the first H1, strip any generated TOC, escape HTML entities, then write content as MDX.
+      // Trim the first H1, strip any generated TOC, then write content as Markdown.
       const contentWithoutH1 = raw.replace(/^\s*#\s+.+?(\r?\n)+/, '');
       const withoutToc = stripToc(contentWithoutH1);
       const withRfcLinks = rewriteRfcLinks(withoutToc, rfcFiles);
       const body = `${frontmatter}\n${withRfcLinks}\n`;
 
-      const outPath = path.join(wrappersDir, name.replace(/\.md$/, '.mdx'));
+      const outPath = path.join(wrappersDir, name);
       const prev = await fs.readFile(outPath, 'utf8').catch(() => null);
       if (prev !== body) {
         await fs.writeFile(outPath, body, 'utf8');


### PR DESCRIPTION
## Summary

currently the website doesnt render the code snippet in rfcs correctly.

<img width="668" height="28" alt="image" src="https://github.com/user-attachments/assets/39bca8dc-8cbe-4c5a-b724-10315a5f4de0" />

which is hard to read.

## Changes

Don't remove html tag escaping when generating rfc content.

<img width="498" height="36" alt="image" src="https://github.com/user-attachments/assets/2c9bb8d9-3947-4cee-9b26-33fca82a2e7c" />

the symbol can be rendered correctly.

## Notes for Reviewers

start the website locally to see the effect.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
