### PR TITLE
Rescaling: Allow to project cloned and source manifests

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1,3 +1,6 @@
+pub use crate::db::builder::CloneBuilder;
+pub use crate::db::builder::CloneSourceSpec;
+
 use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
 use crate::compactions_store::CompactionsStore;
 use crate::compactor::{Compaction, CompactionSpec, Compactor, CompactorStateView};
@@ -12,22 +15,21 @@ use crate::garbage_collector::GC_TASK_NAME;
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use slatedb_common::clock::SystemClock;
 
-use crate::clone;
 use crate::db_status::ClosedResultWriter;
 use crate::object_stores::{ObjectStoreType, ObjectStores};
 use crate::rand::DbRand;
 use crate::seq_tracker::FindOption;
 use crate::utils::IdGenerator;
 use crate::utils::WatchableOnceCell;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use fail_parallel::FailPointRegistry;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use rand::RngCore;
 use std::env;
 use std::env::VarError;
 use std::error::Error;
-use std::ops::RangeBounds;
+use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -550,18 +552,13 @@ impl Admin {
         )
     }
 
-    /// Clone a database. If no db already exists at the specified path, then this will create
-    /// a new db under the path that is a clone of the db at parent_path.
+    /// Clone a database using a builder pattern. If no db already exists at the specified path,
+    /// then this will create a new db under the path that is a clone of the db at parent_path.
     ///
     /// A clone is a shallow copy of the parent database - it starts with a manifest that
     /// references the same SSTs, but doesn't actually copy those SSTs, except for the WAL.
     /// New writes will be written to the newly created db and will not be reflected in the
     /// parent database.
-    ///
-    /// The clone can optionally be created from an existing checkpoint. If
-    /// `parent_checkpoint` is present, then the referenced manifest is used
-    /// as the base for the clone db's manifest. Otherwise, this method creates a new checkpoint
-    /// for the current version of the parent db.
     ///
     /// # Examples
     ///
@@ -580,31 +577,28 @@ impl Admin {
     ///    db.close().await?;
     ///
     ///    let admin = AdminBuilder::new("clone_path", object_store).build();
-    ///    admin.create_clone(
-    ///      "parent_path",
-    ///      None,
-    ///    ).await?;
+    ///    admin.create_clone_builder("parent_path", None).build().await?;
     ///
     ///    Ok(())
     /// }
     /// ```
-    pub async fn create_clone<P: Into<Path>>(
+    pub fn create_clone_builder<P: Into<Path>>(
         &self,
         parent_path: P,
         parent_checkpoint: Option<Uuid>,
-    ) -> Result<(), Box<dyn Error>> {
-        clone::create_clone(
+    ) -> CloneBuilder<(Bound<Bytes>, Bound<Bytes>)> {
+        let source = match parent_checkpoint {
+            Some(cp) => CloneSourceSpec::with_checkpoint(parent_path, cp),
+            None => CloneSourceSpec::new(parent_path),
+        };
+        CloneBuilder::new(
             self.path.clone(),
-            parent_path.into(),
+            source,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
             self.object_stores.store_of(ObjectStoreType::Wal).clone(),
-            parent_checkpoint,
-            Arc::new(FailPointRegistry::new()),
             self.system_clock.clone(),
             self.rand.clone(),
         )
-        .await?;
-        Ok(())
     }
 
     /// Creates a new builder for an admin client at the given path.
@@ -1138,5 +1132,34 @@ mod tests {
             .build();
 
         assert!(admin.compaction_filter_supplier.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_clone_builder() {
+        use crate::manifest::store::ManifestStore;
+        use crate::Db;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_parent");
+        let clone_path = Path::from("/tmp/test_clone");
+
+        let parent_db = Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap();
+        parent_db.close().await.unwrap();
+
+        let admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+
+        // Test basic builder without checkpoint
+        admin
+            .create_clone_builder(parent_path.clone(), None)
+            .build()
+            .await
+            .expect("clone should succeed");
+
+        // Verify clone was created
+        let clone_manifest_store = ManifestStore::new(&clone_path, object_store.clone());
+        let manifest = clone_manifest_store.read_latest_manifest().await;
+        assert!(manifest.is_ok(), "cloned manifest should exist");
     }
 }

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -595,10 +595,8 @@ impl Admin {
             self.path.clone(),
             source,
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            self.object_stores.store_of(ObjectStoreType::Wal).clone(),
-            self.system_clock.clone(),
-            self.rand.clone(),
         )
+        .with_wal_object_store(self.object_stores.store_of(ObjectStoreType::Wal).clone())
     }
 
     /// Creates a new builder for an admin client at the given path.

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -7,6 +7,8 @@ use crate::error::SlateDBError;
 use crate::error::SlateDBError::CheckpointMissing;
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::Manifest;
+use crate::object_stores::ObjectStoreType::{Main, Wal};
+use crate::object_stores::ObjectStores;
 use crate::paths::PathResolver;
 use crate::rand::DbRand;
 use crate::utils::IdGenerator;
@@ -20,11 +22,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
-pub(crate) async fn create_clone<P: Into<Path>>(
-    clone_source: CloneSourceSpec,
+pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
+    clone_source: CloneSourceSpec<R>,
     clone_path: P,
-    object_store: Arc<dyn ObjectStore>,
-    wal_object_store: Arc<dyn ObjectStore>,
+    object_stores: ObjectStores,
     fp_registry: Arc<FailPointRegistry>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -40,7 +41,7 @@ pub(crate) async fn create_clone<P: Into<Path>>(
     let mut clone_manifest = create_clone_manifest(
         clone_path.clone(),
         clone_source.clone(),
-        object_store.clone(),
+        object_stores.store_of(Main).clone(),
         system_clock.clone(),
         rand,
         fp_registry.clone(),
@@ -50,7 +51,7 @@ pub(crate) async fn create_clone<P: Into<Path>>(
 
     if !clone_manifest.db_state().initialized {
         copy_wal_ssts(
-            wal_object_store,
+            object_stores.store_of(Wal).clone(),
             clone_manifest.db_state(),
             &parent_path,
             &clone_path,
@@ -342,6 +343,7 @@ mod tests {
     use crate::error::SlateDBError;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::Manifest;
+    use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::proptest_util::{rng, sample};
     use crate::rand::DbRand;
@@ -377,8 +379,7 @@ mod tests {
         crate::clone::create_clone(
             source,
             clone_path,
-            object_store,
-            wal_object_store,
+            ObjectStores::new(object_store, Some(wal_object_store)),
             fp_registry,
             system_clock,
             rand,

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -1,49 +1,50 @@
+use crate::bytes_range::BytesRange;
 use crate::checkpoint::Checkpoint;
 use crate::config::CheckpointOptions;
+use crate::db::builder::CloneSourceSpec;
 use crate::db_state::{ManifestCore, SsTableId};
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::CheckpointMissing;
 use crate::manifest::store::{ManifestStore, StoredManifest};
+use crate::manifest::Manifest;
 use crate::paths::PathResolver;
 use crate::rand::DbRand;
 use crate::utils::IdGenerator;
+use bytes::Bytes;
 use fail_parallel::{fail_point, FailPointRegistry};
 use object_store::path::Path;
 use object_store::ObjectStore;
 use slatedb_common::clock::SystemClock;
+use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
 
 pub(crate) async fn create_clone<P: Into<Path>>(
+    clone_source: CloneSourceSpec,
     clone_path: P,
-    parent_path: P,
     object_store: Arc<dyn ObjectStore>,
     wal_object_store: Arc<dyn ObjectStore>,
-    parent_checkpoint: Option<Uuid>,
     fp_registry: Arc<FailPointRegistry>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
+    projection_range: Option<R>,
 ) -> Result<(), SlateDBError> {
     let clone_path = clone_path.into();
-    let parent_path = parent_path.into();
+    let parent_path = clone_source.path.clone();
 
     if clone_path == parent_path {
         return Err(SlateDBError::IdenticalClonePaths(parent_path));
     }
 
-    let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-    let parent_manifest_store = Arc::new(ManifestStore::new(&parent_path, object_store.clone()));
-
     let mut clone_manifest = create_clone_manifest(
-        clone_manifest_store,
-        parent_manifest_store,
-        parent_path.to_string(),
-        parent_checkpoint,
+        clone_path.clone(),
+        clone_source.clone(),
         object_store.clone(),
         system_clock.clone(),
         rand,
         fp_registry.clone(),
+        projection_range,
     )
     .await?;
 
@@ -65,29 +66,34 @@ pub(crate) async fn create_clone<P: Into<Path>>(
     Ok(())
 }
 
-async fn create_clone_manifest(
-    clone_manifest_store: Arc<ManifestStore>,
-    parent_manifest_store: Arc<ManifestStore>,
-    parent_path: String,
-    parent_checkpoint_id: Option<Uuid>,
+async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
+    clone_path: Path,
+    source_spec: CloneSourceSpec<R>,
     object_store: Arc<dyn ObjectStore>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
     #[allow(unused)] fp_registry: Arc<FailPointRegistry>,
+    projection_range: Option<R>,
 ) -> Result<StoredManifest, SlateDBError> {
+    let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+    let parent_manifest_store =
+        Arc::new(ManifestStore::new(&source_spec.path, object_store.clone()));
+
+    let parent_checkpoint_id = source_spec.checkpoint;
+
     let clone_manifest =
         match StoredManifest::try_load(clone_manifest_store.clone(), system_clock.clone()).await? {
             Some(initialized_clone_manifest)
                 if initialized_clone_manifest.db_state().initialized =>
             {
                 validate_attached_to_external_db(
-                    parent_path.clone(),
+                    source_spec.path.to_string(),
                     parent_checkpoint_id,
                     &initialized_clone_manifest,
                 )?;
                 validate_external_dbs_contain_final_checkpoint(
                     parent_manifest_store,
-                    parent_path.clone(),
+                    source_spec.path.to_string(),
                     &initialized_clone_manifest,
                     object_store.clone(),
                 )
@@ -96,7 +102,7 @@ async fn create_clone_manifest(
             }
             Some(uninitialized_clone_manifest) => {
                 validate_attached_to_external_db(
-                    parent_path.clone(),
+                    source_spec.path.to_string(),
                     parent_checkpoint_id,
                     &uninitialized_clone_manifest,
                 )?;
@@ -112,14 +118,26 @@ async fn create_clone_manifest(
                     rand.clone(),
                 )
                 .await?;
-                let parent_manifest_at_checkpoint = parent_manifest_store
+                let mut parent_manifest_at_checkpoint = parent_manifest_store
                     .read_manifest(parent_checkpoint.manifest_id)
                     .await?;
+
+                let r = match (source_spec.projection_range.clone(), projection_range) {
+                    (Some(l), Some(r)) => to_byte_range(&l).intersect(&to_byte_range(&r)),
+                    (Some(l), None) => Some(to_byte_range(&l)),
+                    (None, Some(r)) => Some(to_byte_range(&r)),
+                    (None, None) => None,
+                };
+
+                parent_manifest_at_checkpoint = match r {
+                    Some(range) => Manifest::projected(&parent_manifest_at_checkpoint, range),
+                    None => parent_manifest_at_checkpoint,
+                };
 
                 StoredManifest::create_uninitialized_clone(
                     clone_manifest_store,
                     &parent_manifest_at_checkpoint,
-                    parent_path.clone(),
+                    source_spec.path.to_string(),
                     parent_checkpoint.id,
                     rand,
                     system_clock.clone(),
@@ -138,7 +156,7 @@ async fn create_clone_manifest(
             // If the final checkpoint id is not set, we can skip this check
             continue;
         };
-        let external_db_manifest_store = if external_db.path == parent_path {
+        let external_db_manifest_store = if external_db.path == source_spec.path.to_string() {
             parent_manifest_store.clone()
         } else {
             Arc::new(ManifestStore::new(
@@ -168,6 +186,10 @@ async fn create_clone_manifest(
     }
 
     Ok(clone_manifest)
+}
+
+fn to_byte_range<T: RangeBounds<Bytes> + Clone>(bounds: &T) -> BytesRange {
+    BytesRange::from(bounds.clone())
 }
 
 // Get a checkpoint and the corresponding manifest that will be used as the source
@@ -310,11 +332,11 @@ async fn copy_wal_ssts(
 
 #[cfg(test)]
 mod tests {
-    use crate::clone::create_clone;
     use crate::config::{
         CheckpointOptions, CheckpointScope, FlushOptions, FlushType, PutOptions, Settings,
         WriteOptions,
     };
+    use crate::db::builder::CloneSourceSpec;
     use crate::db::Db;
     use crate::db_state::{ManifestCore, SsTableId};
     use crate::error::SlateDBError;
@@ -330,9 +352,40 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::Error as ObjectStoreError;
+    use object_store::ObjectStore;
     use slatedb_common::clock::DefaultSystemClock;
+    use slatedb_common::SystemClock;
     use std::ops::RangeFull;
     use std::sync::Arc;
+    use uuid::Uuid;
+
+    // helper method for tests that creates CloneSourceSpec
+    async fn create_clone<P: Into<Path>>(
+        clone_path: P,
+        parent_path: P,
+        object_store: Arc<dyn ObjectStore>,
+        wal_object_store: Arc<dyn ObjectStore>,
+        parent_checkpoint: Option<Uuid>,
+        fp_registry: Arc<FailPointRegistry>,
+        system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
+    ) -> Result<(), SlateDBError> {
+        let source: CloneSourceSpec = match parent_checkpoint {
+            Some(cp) => CloneSourceSpec::with_checkpoint(parent_path, cp),
+            None => CloneSourceSpec::new(parent_path),
+        };
+        crate::clone::create_clone(
+            source,
+            clone_path,
+            object_store,
+            wal_object_store,
+            fp_registry,
+            system_clock,
+            rand,
+            None,
+        )
+        .await
+    }
 
     #[tokio::test]
     async fn should_clone_latest_state_if_no_checkpoint_provided() {

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -102,8 +102,10 @@
 //! ```
 //!
 use std::collections::HashMap;
+use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
+use bytes::Bytes;
 use fail_parallel::FailPointRegistry;
 use log::info;
 use log::warn;
@@ -162,6 +164,7 @@ use slatedb_common::metrics::MetricLevel;
 use slatedb_common::metrics::MetricsRecorder;
 use slatedb_common::metrics::MetricsRecorderHelper;
 use slatedb_common::metrics::NoopMetricsRecorder;
+use uuid::Uuid;
 
 /// A builder for creating a new Db instance.
 ///
@@ -1383,6 +1386,137 @@ fn default_db_cache() -> Option<Arc<dyn DbCache>> {
             .with_meta_cache(meta_cache)
             .build(),
     ) as Arc<dyn DbCache>)
+}
+
+/// Specifies the source database and checkpoint for a clone operation.
+pub struct CloneSourceSpec<R: RangeBounds<Bytes> + Clone = (Bound<Bytes>, Bound<Bytes>)> {
+    /// Path to the parent/source database.
+    pub path: Path,
+    /// Optional checkpoint ID to clone from. If None, the latest state is used.
+    pub checkpoint: Option<Uuid>,
+    /// Optional range to limit the visible keys in the source database.
+    pub projection_range: Option<R>,
+}
+
+impl<R: RangeBounds<Bytes> + Clone> Clone for CloneSourceSpec<R> {
+    fn clone(&self) -> Self {
+        CloneSourceSpec {
+            path: self.path.clone(),
+            checkpoint: self.checkpoint,
+            projection_range: self.projection_range.clone(),
+        }
+    }
+}
+
+impl<R: RangeBounds<Bytes> + Clone> CloneSourceSpec<R> {
+    /// Set the visible range to limit the keys visible in the source database.
+    pub fn with_projection_range(mut self, range: R) -> Self {
+        self.projection_range = Some(range);
+        self
+    }
+}
+
+impl CloneSourceSpec<(Bound<Bytes>, Bound<Bytes>)> {
+    /// Create a new clone source pointing to the latest state of a database.
+    pub fn new<P: Into<Path>>(path: P) -> Self {
+        CloneSourceSpec {
+            path: path.into(),
+            checkpoint: None,
+            projection_range: None,
+        }
+    }
+
+    /// Create a new clone source pointing to a specific checkpoint.
+    pub fn with_checkpoint<P: Into<Path>>(path: P, checkpoint: Uuid) -> Self {
+        CloneSourceSpec {
+            path: path.into(),
+            checkpoint: Some(checkpoint),
+            projection_range: None,
+        }
+    }
+}
+
+/// A builder for configuring database clone operations.
+pub struct CloneBuilder<R: RangeBounds<Bytes> + Clone = (Bound<Bytes>, Bound<Bytes>)> {
+    clone_path: Path,
+    source: CloneSourceSpec<R>,
+    object_store: Arc<dyn ObjectStore>,
+    wal_object_store: Arc<dyn ObjectStore>,
+    system_clock: Arc<dyn SystemClock>,
+    rand: Arc<DbRand>,
+    projection_range: Option<R>,
+}
+
+impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
+    pub(crate) fn new(
+        clone_path: Path,
+        source: CloneSourceSpec<R>,
+        object_store: Arc<dyn ObjectStore>,
+        wal_object_store: Arc<dyn ObjectStore>,
+        system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
+    ) -> Self {
+        CloneBuilder {
+            clone_path,
+            source,
+            object_store,
+            wal_object_store,
+            system_clock,
+            rand,
+            projection_range: None,
+        }
+    }
+
+    pub fn with_clone_path(mut self, clone_path: Path) -> Self {
+        self.clone_path = clone_path;
+        self
+    }
+
+    pub fn with_source(mut self, source: CloneSourceSpec<R>) -> Self {
+        self.source = source;
+        self
+    }
+
+    pub fn with_object_store(mut self, object_store: Arc<dyn ObjectStore>) -> Self {
+        self.object_store = object_store;
+        self
+    }
+
+    pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
+        self.wal_object_store = wal_object_store;
+        self
+    }
+
+    pub fn with_projection_range(mut self, projection_range: Option<R>) -> Self {
+        self.projection_range = projection_range;
+        self
+    }
+
+    pub fn with_system_clock(mut self, system_clock: Arc<dyn SystemClock>) -> Self {
+        self.system_clock = system_clock;
+        self
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.rand = Arc::new(DbRand::new(seed));
+        self
+    }
+
+    /// Build and execute the clone operation.
+    pub async fn build(self) -> Result<(), Box<dyn std::error::Error>> {
+        crate::clone::create_clone(
+            self.source,
+            self.clone_path,
+            self.object_store,
+            self.wal_object_store,
+            Arc::new(FailPointRegistry::new()),
+            self.system_clock,
+            self.rand,
+            self.projection_range,
+        )
+        .await?;
+        Ok(())
+    }
 }
 
 fn instrumented_retrying_object_store(

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1441,9 +1441,9 @@ pub struct CloneBuilder<R: RangeBounds<Bytes> + Clone = (Bound<Bytes>, Bound<Byt
     clone_path: Path,
     source: CloneSourceSpec<R>,
     object_store: Arc<dyn ObjectStore>,
-    wal_object_store: Arc<dyn ObjectStore>,
-    system_clock: Arc<dyn SystemClock>,
-    rand: Arc<DbRand>,
+    wal_object_store: Option<Arc<dyn ObjectStore>>,
+    system_clock: Option<Arc<dyn SystemClock>>,
+    rand: Option<Arc<DbRand>>,
     projection_range: Option<R>,
 }
 
@@ -1452,17 +1452,14 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
         clone_path: Path,
         source: CloneSourceSpec<R>,
         object_store: Arc<dyn ObjectStore>,
-        wal_object_store: Arc<dyn ObjectStore>,
-        system_clock: Arc<dyn SystemClock>,
-        rand: Arc<DbRand>,
     ) -> Self {
         CloneBuilder {
             clone_path,
             source,
             object_store,
-            wal_object_store,
-            system_clock,
-            rand,
+            wal_object_store: None,
+            system_clock: None,
+            rand: None,
             projection_range: None,
         }
     }
@@ -1483,7 +1480,7 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     }
 
     pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
-        self.wal_object_store = wal_object_store;
+        self.wal_object_store = Some(wal_object_store);
         self
     }
 
@@ -1493,12 +1490,12 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     }
 
     pub fn with_system_clock(mut self, system_clock: Arc<dyn SystemClock>) -> Self {
-        self.system_clock = system_clock;
+        self.system_clock = Some(system_clock);
         self
     }
 
     pub fn with_seed(mut self, seed: u64) -> Self {
-        self.rand = Arc::new(DbRand::new(seed));
+        self.rand = Some(Arc::new(DbRand::new(seed)));
         self
     }
 
@@ -1507,11 +1504,11 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
         crate::clone::create_clone(
             self.source,
             self.clone_path,
-            self.object_store,
-            self.wal_object_store,
+            ObjectStores::new(self.object_store, self.wal_object_store),
             Arc::new(FailPointRegistry::new()),
-            self.system_clock,
-            self.rand,
+            self.system_clock
+                .unwrap_or_else(|| Arc::new(DefaultSystemClock::new())),
+            self.rand.unwrap_or_else(|| Arc::new(Default::default())),
             self.projection_range,
         )
         .await?;

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -85,7 +85,6 @@ impl Manifest {
         }
     }
 
-    #[allow(unused)]
     pub(crate) fn projected(source_manifest: &Manifest, range: BytesRange) -> Manifest {
         let mut projected = source_manifest.clone();
         let mut sorter_runs_filtered = vec![];


### PR DESCRIPTION
## Summary

Expose `Manifest::projected()` added in #618 to the end users.
To make the API more flexible, this PR first introduces SourceSpec and CloneBuilder.
The existing `create_clone` (public) API is deprecated.

Later, I'm planning to expose `Manifest::union` building on top of these changes.

## Changes

```
Rescaling: Introduce CreateCloneBuilder and CloneSourceSpec
Rescaling: Allow to project cloned manifest
Rescaling: Allow to project source manifest
```

## Notes for Reviewers

UniFFI bindings currently doesn't expose clone/checkpoint functionality so they are untouched by this PR; only Rust API is covered.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
