### PR TITLE
refactor TableStore.open_sst method

### DIFF
--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -627,22 +627,6 @@ impl SsTableFormat {
         Ok(())
     }
 
-    pub(crate) async fn read_version(&self, obj: &impl ReadOnlyBlob) -> Result<u16, SlateDBError> {
-        let (_, _, version) = self
-            .read_length_and_metadata_offset_and_version(obj)
-            .await?;
-        self.validate_version(version)?;
-        Ok(version)
-    }
-
-    pub(crate) async fn read_info(
-        &self,
-        obj: &impl ReadOnlyBlob,
-    ) -> Result<SsTableInfo, SlateDBError> {
-        let (info, _) = self.read_info_and_version(obj).await?;
-        Ok(info)
-    }
-
     pub(crate) async fn read_info_and_version(
         &self,
         obj: &impl ReadOnlyBlob,

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -994,7 +994,7 @@ mod tests {
         let valid_blob = BytesBlob {
             bytes: bytes.clone(),
         };
-        let result = format.read_info(&valid_blob).await;
+        let result = format.read_info_and_version(&valid_blob).await;
         match result {
             Ok(_) => {}
             Err(e) => {
@@ -1009,7 +1009,7 @@ mod tests {
             bytes: invalid_bytes.freeze(),
         };
         assert!(matches!(
-            format.read_info(&invalid_blob).await,
+            format.read_info_and_version(&invalid_blob).await,
             Err(SlateDBError::InvalidVersion { .. })
         ));
     }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -334,11 +334,13 @@ impl TableStore {
         Ok(SsTableHandle::new(*id, version, info))
     }
 
+    #[cfg(test)]
     pub(crate) async fn read_sst_version(&self, id: &SsTableId) -> Result<u16, SlateDBError> {
         let object_store = self.object_stores.store_for(id);
         let path = self.path(id);
         let obj = ReadOnlyObject { object_store, path };
-        self.sst_format.read_version(&obj).await
+        let (_, version) = self.sst_format.read_info_and_version(&obj).await?;
+        Ok(version)
     }
 
     /// Reads the Bloom filter of an SSTable.


### PR DESCRIPTION
## Summary

With current implementation `open_sst` makes 3 HEAD + 3 GET requests with proposed change we will make 1 HEAD and 2 GET requests.

These extra requests are visible in these log lines from object storage service

```
"HEAD /HeadObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"GET /GetObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"HEAD /HeadObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"GET /GetObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"HEAD /HeadObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"GET /GetObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"GET /GetObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
"GET /GetObject/tmp/test_kv_store/wal/00000000000000000002.sst HTTP/1.1"
```

If we were certain that object store supports negative ranges then only 2 GET requests are necessary.

This change is related to this issue https://github.com/slatedb/slatedb/issues/1416

## Changes

Added new method (`read_length_and_metadata_offset_and_version`) to `SsTableFormat`

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
