### PR TITLE
Skip stale WAL tables in DbReader instead of asserting

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -469,9 +469,23 @@ impl DbReaderInner {
             Err(err) => return Err(err),
         } {
             assert!(replayed_table.last_wal_id > replay_after_wal_id);
-            // Allow equality here since it's possible that a WAL file is an empty fence entry.
-            assert!(replayed_table.last_seq >= last_committed_seq);
+            // Always advance the WAL ID so we don't re-replay this WAL.
             replay_after_wal_id = replayed_table.last_wal_id;
+            // When the manifest advances (L0 flush) but old WAL files still
+            // exist, WalReplayIterator filters out all their entries
+            // (seq <= last_l0_seq), producing an empty table whose last_seq
+            // equals core.last_l0_seq.  If in-memory tables already have a
+            // higher last_seq from a prior replay, last_seq < last_committed_seq.
+            // This is safe to skip: the table is empty and all data is in L0.
+            if replayed_table.last_seq < last_committed_seq {
+                debug_assert!(
+                    replayed_table.table.is_empty(),
+                    "non-empty replayed table with last_seq ({}) < last_committed_seq ({})",
+                    replayed_table.last_seq,
+                    last_committed_seq,
+                );
+                continue;
+            }
             last_committed_seq = replayed_table.last_seq;
             let imm_memtable =
                 ImmutableMemtable::new(replayed_table.table, replayed_table.last_wal_id);
@@ -1589,6 +1603,89 @@ mod tests {
 
         let mut replayed_iter = replayed.table().iter();
         test_utils::assert_iterator(&mut replayed_iter, vec![wal_row]).await;
+    }
+
+    /// Reproduces a panic where `replay_wal_into` asserts
+    /// `replayed_table.last_seq >= last_committed_seq` during a manifest
+    /// refresh. The scenario:
+    ///
+    /// 1. Reader has in-memory tables from a prior WAL replay (last_seq = 10,
+    ///    WAL ID = 5).
+    /// 2. The manifest advances with last_l0_seq = 8 (writer flushed to L0).
+    /// 3. WAL 6 exists on disk but all its entries have seq <= 8, so
+    ///    WalReplayIterator filters them out, producing an empty table with
+    ///    last_seq = 8.
+    /// 4. last_committed_seq = 10 (from the existing in-memory table).
+    /// 5. 8 < 10 → the old assertion panicked.
+    ///
+    /// The fix: skip the empty table instead of asserting, since all its data
+    /// is already covered by L0.
+    #[tokio::test]
+    async fn replay_wal_into_should_skip_stale_wal_tables() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_db_reader_skip_stale_wal");
+        let test_provider = TestProvider::new(path, Arc::clone(&object_store));
+        let table_store = test_provider.table_store();
+
+        // WAL 6 has entries with seq 7 and 8 — both <= last_l0_seq (set below).
+        // WalReplayIterator will filter them all out.
+        write_wal_sst(
+            Arc::clone(&table_store),
+            6,
+            vec![
+                RowEntry::new_value(b"old1", b"v1", 7),
+                RowEntry::new_value(b"old2", b"v2", 8),
+            ],
+        )
+        .await
+        .unwrap();
+
+        // WAL 7 has a fresh entry with seq 11 (> last_committed_seq of 10).
+        write_wal_sst(
+            Arc::clone(&table_store),
+            7,
+            vec![RowEntry::new_value(b"new_key", b"new_value", 11)],
+        )
+        .await
+        .unwrap();
+
+        // Existing in-memory table from prior replay: WAL ID 5, last_seq 10.
+        let mut into_tables = VecDeque::new();
+        into_tables.push_front(immutable_memtable(
+            5,
+            vec![RowEntry::new_value(b"prior_key", b"prior_value", 10)],
+        ));
+
+        // Manifest has last_l0_seq = 8 (data up to seq 8 is in L0).
+        let mut core = ManifestCore::new();
+        core.last_l0_seq = 8;
+        core.next_wal_sst_id = 8;
+
+        let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
+            Arc::clone(&table_store),
+            &DbReaderOptions::default(),
+            &core,
+            &mut into_tables,
+            false,
+        )
+        .await
+        .unwrap();
+
+        // WAL 7 was replayed successfully.
+        assert_eq!(last_wal_id, 7);
+        assert_eq!(last_committed_seq, 11);
+
+        // into_tables should have: [wal7(new), prior(old)]
+        assert_eq!(into_tables.len(), 2);
+
+        let newest = into_tables.front().unwrap();
+        assert_eq!(newest.recent_flushed_wal_id(), 7);
+        let mut newest_iter = newest.table().iter();
+        test_utils::assert_iterator(
+            &mut newest_iter,
+            vec![RowEntry::new_value(b"new_key", b"new_value", 11)],
+        )
+        .await;
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Summary

Fixes a `DbReader` panic during manifest refresh where WAL replay asserts `replayed_table.last_seq >= last_committed_seq`.

When the reader refreshes after a manifest update (L0 flush), it replays new WAL files on top of existing in-memory tables. If a WAL file's entries have all been flushed to L0, `WalReplayIterator` filters them out, producing an empty table with `last_seq = core.last_l0_seq`. When existing in-memory tables already have a higher `last_seq` from a prior replay, this triggers the assertion.

Fixes #1420

## Changes

- Replace `assert!(replayed_table.last_seq >= last_committed_seq)` with a `continue` when `last_seq < last_committed_seq`
- Move `replay_after_wal_id` update before the check so WAL progress is always tracked
- Add `debug_assert!` confirming the skipped table is empty (safety invariant)
- Add test `replay_wal_into_should_skip_stale_wal_tables` that reproduces the panic

## Notes for Reviewers

This is a follow-up to #1390 and #1392. The skip is safe because:

- The skipped table is provably empty — `WalReplayIterator` already filters entries with `seq <= last_l0_seq`, and since WAL IDs / sequence numbers increase monotonically, any surviving entry would have `seq > last_committed_seq` (which would not trigger the skip). A `debug_assert!` confirms this invariant.
- WAL iteration progress (`replay_after_wal_id`) is still tracked correctly.
- `last_committed_seq` retains its correct value from existing in-memory tables.

> **AI disclosure:** This PR was largely generated using Claude Code (claude-opus-4-6). The changes have been reviewed by the submitter.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏