### PR TITLE
Bump block fetch size in `WalReader`

### DIFF
--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -156,7 +156,11 @@ impl WalFile {
             ..,
             SsTableView::identity(sst),
             Arc::clone(&self.table_store),
-            SstIteratorOptions::default(),
+            SstIteratorOptions {
+                // Optimize for throughput. Go for 256MiB per-fetch (4096 bytes/block default).
+                blocks_to_fetch: 65_536,
+                ..Default::default()
+            },
         )
         .await
         {


### PR DESCRIPTION
## Summary

`WalReader` uses `SstIteratorOptions::default`. This uses:

```rs
        SstIteratorOptions {
            max_fetch_tasks: 1,
            blocks_to_fetch: 1,
            cache_blocks: true,
            eager_spawn: false,
            order: IterationOrder::Ascending,
        }
```

For WAL reads we're mostly optimizing for throughput. We should use a much higher `blocks_to_fetch`. I opted for `65_536`, which fetches up to 256MiB per read. This will almost always read thew hole SST in a single fetch. API costs should drop a lot, and throughput should go up.

Addresses #1416

## Changes

- Use `65_536` for `SstIteratorOptions` in `WalReader`.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
