### PR TITLE
Expose `started_seq` in `DbSnapshot`

### DIFF
--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -39,6 +39,12 @@ impl DbSnapshot {
         })
     }
 
+    /// Get the sequence number this snapshot was started at. This determines data visibility
+    /// for reads in this snapshot.
+    pub fn seq(&self) -> u64 {
+        self.started_seq
+    }
+
     /// Get a value from the snapshot with default read options.
     ///
     /// ## Arguments
@@ -749,7 +755,7 @@ mod tests {
 
         // At this point the data is in the memtable but not committed; create the snapshot
         let snapshot = db.snapshot().await?;
-        assert_eq!(snapshot.started_seq, recent_committed_seq);
+        assert_eq!(snapshot.seq(), recent_committed_seq);
 
         // Turn off the failpoint to let the put complete
         fail_parallel::cfg(fp_registry.clone(), "write-batch-pre-commit", "off").unwrap();


### PR DESCRIPTION
## Summary

Users might want to know a `DbSnapshot`'s sequence number so they can coordinate any number of things (WAL reads, reads on other machines, and so on). This PR adds a function so users can see it.

## Changes

- add `DbSnapshot::seq()`

## Notes for Reviewers

Cane up in [this Discord thread](https://discord.com/channels/1232385660460204122/1485045776269971646).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
