### PR TITLE
Fix SstStats::size so it takes child BlockStats also into account.

### DIFF
--- a/slatedb/src/sst_stats.rs
+++ b/slatedb/src/sst_stats.rs
@@ -29,12 +29,12 @@ impl SstStats {
         self.num_puts + self.num_deletes + self.num_merges
     }
 
-    /// Returns the in-memory size in bytes (5 u64 fields).
+    /// Returns the in-memory size in bytes (struct + heap-allocated block_stats).
     pub(crate) fn size(&self) -> usize {
-        std::mem::size_of::<Self>()
+        std::mem::size_of::<Self>() + self.block_stats.len() * std::mem::size_of::<BlockStats>()
     }
 
-    /// Returns a clone (no heap allocations to clamp).
+    /// Returns a clone.
     pub(crate) fn clamp_allocated_size(&self) -> Self {
         self.clone()
     }


### PR DESCRIPTION
## Summary

Small fix to SstStats::size to take BlockStats into account.

## Changes

Implemenation of `SstStats::size`.

## Notes for Reviewers

Likely forgotton in https://github.com/slatedb/slatedb/pull/1384

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
