### PR TITLE
Fix sporadic seqnum test failure

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3522,7 +3522,7 @@ mod tests {
     async fn test_sequence_tracker_not_ahead_of_last_l0_seq_when_flush_races_with_writes() {
         let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let mut settings = test_db_options(0, 512, None);
+        let mut settings = test_db_options(0, 2048, None);
         settings.flush_interval = None;
 
         let system_clock = Arc::new(MockSystemClock::new());


### PR DESCRIPTION
## Summary

`test_sequence_tracker_not_ahead_of_last_l0_seq_when_flush_races_with_writes` failed in `nightly.yaml`'s `detect-flaky-tests` job a few nights back:

https://github.com/slatedb/slatedb/actions/runs/23375752889/job/68007385548

It seems that it's possible for writes 0 and 1 to go above 512 bytes. This can cause a race where the memtables might get flushed before the memtable failpoint is set to pause. That causes the test to fail because we never see an `imm_memtable` that's non-empty.

I bumped the bytes to 2048 to be conservative and everything works now. Before this bump, the test would fail after ~200 iterations with CPU saturated. Now, I can run it > 1000 times without any error.