### PR TITLE
Clarify some details around checkpoint behavior

### DIFF
--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -204,14 +204,13 @@ We’ll make the following changes to the public API to support creating and usi
 
 ```rust
 /// Defines the scope targeted by a given checkpoint. If set to All, then the checkpoint will include
-/// all writes that were issued at the time that create_checkpoint is called. If force_flush is true,
-/// then SlateDB will force the current wal, or memtable if wal_enabled is false, to flush its data.
-/// Otherwise, the database will wait for the current wal or memtable to be flushed due to
-/// flush_interval or reaching l0_sst_size_bytes, respectively. If set to Durable, then the
-/// checkpoint includes only writes that were durable at the time of the call. This will be faster,
-/// but may not include data from recent writes.
+/// all writes that were issued at the time that create_checkpoint is called. SlateDB will flush WALs
+/// (if enabled) and do a best-effort flush of memtables to L0 SSTs in order to optimize for
+/// readers. The memtable flush will not await if blocked by backpressure. If set to Durable, then
+/// the checkpoint includes only writes that were durable at the time of the call. This will be
+/// faster, but may not include data from recent writes.
 enum CheckpointScope {
-    All { force_flush: bool },
+    All,
     Durable
 }
 

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -510,12 +510,11 @@ pub enum Ttl {
 }
 
 /// Defines the scope targeted by a given checkpoint. If set to All, then the checkpoint will
-/// include all writes that were issued at the time that create_checkpoint is called. If force_flush
-/// is true, then SlateDB will force the current wal, or memtable if wal_enabled is false, to flush
-/// its data. Otherwise, the database will wait for the current wal or memtable to be flushed due to
-/// flush_interval or reaching l0_sst_size_bytes, respectively. If set to Durable, then the
-/// checkpoint includes only writes that were durable at the time of the call. This will be faster,
-/// but may not include data from recent writes.
+/// include all writes that were issued at the time that create_checkpoint is called. SlateDB will
+/// flush WALs (if enabled) and do a best-effort flush of memtables to L0 SSTs in order to
+/// optimize for readers. The memtable flush will not await if blocked by backpressure. If set
+/// to Durable, then the checkpoint includes only writes that were durable at the time of the
+/// call. This will be faster, but may not include data from recent writes.
 #[non_exhaustive]
 #[derive(Debug, Copy, Clone)]
 pub enum CheckpointScope {
@@ -920,6 +919,8 @@ pub struct DbReaderOptions {
     /// compacted into L0 or lower levels. This is useful for read-heavy workloads that
     /// don't need to see the most recent uncommitted writes and want to minimize the
     /// cost of opening many readers.
+    ///
+    /// WAL replay is also skipped when the reader is opened from a checkpoint.
     ///
     /// When combined with manifest polling (no explicit checkpoint), the reader will
     /// still see newly compacted data as manifests are updated.


### PR DESCRIPTION
This patch updates documentation to clarify some points about checkpoints that surprised me a little. When we create a checkpoint scope for `All`, we currently flush memtables, which I think is not strictly necessary. Due to issue #1391, it is only a best-effort flush in any case. We could consider this a reader-optimized checkpoint I guess. Perhaps we might also support a write-optimized checkpoint which just flushed wals? This might be similar to the `FlushType` option that is exposed in flush_with_options.

Finally, I was surprised that skip_wal_replay gets applied when reading from a checkpoint. I wasn't really sure if that made sense. Feels like it's more intended for readers actively following the current state.