### PR TITLE
Fix localstack

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -319,7 +319,7 @@ jobs:
 
       - name: Start chaos services (docker compose)
         run: |
-          docker compose -f scripts/run_chaos_scenarios.compose.yaml up -d
+          docker compose -f scripts/run_chaos_scenarios.compose.yaml up -d --wait
 
       - name: Configure S3 toxiproxy proxy
         run: |
@@ -359,6 +359,7 @@ jobs:
       - name: Dump logs on failure
         if: failure()
         run: |
+          echo "--- Docker Compose PS ---"; docker compose -f scripts/run_chaos_scenarios.compose.yaml ps || true
           echo "--- LocalStack logs ---"; docker logs --tail 500 localstack || true
           echo "--- lowdown logs ---"; docker logs --tail 500 lowdown || true
           echo "--- Toxiproxy logs ---"; docker logs --tail 500 toxiproxy || true

--- a/scripts/run_chaos_scenarios.compose.yaml
+++ b/scripts/run_chaos_scenarios.compose.yaml
@@ -1,6 +1,7 @@
 services:
   localstack:
-    image: localstack/localstack:latest
+    # Pin LocalStack so CI is not broken by `latest` drifting to auth-gated builds.
+    image: localstack/localstack:4.14.0
     container_name: localstack
     environment:
       - SERVICES=s3


### PR DESCRIPTION
## Summary

LocalStack is doing shenanigans to their Docker images. It broke our chaos tests. I'm pinning to a working version.

https://docs.localstack.cloud/aws/capabilities/config/docker-images/

## Changes

- Pin to 4.14.0