### PR TITLE
Remove race condition in chaos test

### DIFF
--- a/scripts/run_chaos_scenarios.compose.yaml
+++ b/scripts/run_chaos_scenarios.compose.yaml
@@ -42,7 +42,7 @@ services:
     depends_on:
       - localstack
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:9001/health >/dev/null 2>&1 || exit 1"]
+      test: ["CMD", "/toxiproxy-cli", "list"]
       interval: 2s
       timeout: 2s
       retries: 15


### PR DESCRIPTION
## Summary

The nightly chaos job can fail before any chaos scenarios run because the `toxiproxy` container is marked unhealthy during `docker compose up -d`.

The existing health check probes `localhost:9001`, but that port is only usable after the workflow creates the `s3` proxy. In the failing nightly run, Toxiproxy itself was already up and serving the admin
API on `:8474`, but Compose waited on the health check, marked the container unhealthy, and aborted startup before the proxy-configuration step ran.

This change switches the health check to `["CMD", "/toxiproxy-cli", "list"]`, which verifies that Toxiproxy itself is ready without depending on a proxy that has not been created yet.

## Changes

- replace the `toxiproxy` health check in `scripts/run_chaos_scenarios.compose.yaml`
- stop probing the unconfigured proxy port (`9001`)
- probe Toxiproxy readiness via the bundled CLI instead