### PR TITLE
Expose SstTableView::id

### DIFF
--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -70,7 +70,7 @@ impl AsRef<SsTableHandle> for SsTableHandle {
 #[derive(Clone, PartialEq, Serialize)]
 pub struct SsTableView {
     /// Unique identifier for this view.
-    pub(crate) id: Ulid,
+    pub id: Ulid,
 
     /// The underlying physical SSTable handle.
     pub sst: SsTableHandle,


### PR DESCRIPTION
Compaction schedulers need to be able to create `Vec<SourceId>` in `CompactionSpec`. For tables in L0 exposed through `SsTableView`, we need access to the `id` field so that we can build `SourceId::SstView`. Not sure if there was another plan for this?