### PR TITLE
Expose max_fetch_tasks in Compactor config

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -273,7 +273,7 @@ impl TokioCompactionExecutorInner {
             None => None,
         };
         let sst_iter_options = SstIteratorOptions {
-            max_fetch_tasks: 4,
+            max_fetch_tasks: self.options.max_fetch_tasks,
             blocks_to_fetch: 256,
             cache_blocks: false, // don't clobber the cache
             eager_spawn: true,

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1002,6 +1002,11 @@ pub struct CompactorOptions {
     /// The maximum number of concurrent compactions to execute at once
     pub max_concurrent_compactions: usize,
 
+    /// The maximum number of concurrent tasks for fetching blocks during
+    /// compaction. Higher values can improve compaction throughput but use
+    /// more resources. The default is 4.
+    pub max_fetch_tasks: usize,
+
     /// Scheduler-specific options expressed as string key/value pairs.
     #[serde(default)]
     pub scheduler_options: HashMap<String, String>,
@@ -1018,6 +1023,7 @@ impl Default for CompactorOptions {
             manifest_update_timeout: Duration::from_secs(300),
             max_sst_size: 256 * 1024 * 1024,
             max_concurrent_compactions: 4,
+            max_fetch_tasks: 4,
             scheduler_options: HashMap::new(),
         }
     }
@@ -1034,6 +1040,7 @@ impl std::fmt::Debug for CompactorOptions {
                 "max_concurrent_compactions",
                 &self.max_concurrent_compactions,
             )
+            .field("max_fetch_tasks", &self.max_fetch_tasks)
             .field("scheduler_options", &self.scheduler_options)
             .finish()
     }


### PR DESCRIPTION
While testing with #1452, I found that compaction throughput quickly became a bottleneck once parallel flushes of L0 were present. Increasing the number of fetch tasks in my benchmark from 4 to 8 made a dramatic difference. We already expose a similar config in `ScanOptions`, so I think it makes sense to expose in the compactor as well.