### PR TITLE
Fix for seek after scan running into assert

### DIFF
--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -545,12 +545,12 @@ impl<'a> InternalSstIterator<'a> {
                 }
             } else {
                 assert!(self.fetch_tasks.is_empty());
-                // When spawn_fetches is true (normal iteration), all blocks
-                // must have been scheduled by this point. When false (called
-                // from seek's already_fetched path), the fetch cursor may
-                // not have reached the end because the seek drained buffered
-                // tasks without scheduling new ones and the caller handles
-                // resetting the cursor afterward.
+                // With spawn_fetches=true, running out of tasks means we've
+                // exhausted the entire range.
+                // With spawn_fetches=false, it only means the prefetch buffer
+                // is drained, but there may still be blocks in the range, and
+                // the caller is responsible for scheduling more fetches if
+                // needed.
                 if spawn_fetches {
                     match self.options.order {
                         IterationOrder::Ascending => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/slatedb/slatedb/issues/1465

The change removes an assert in case of seek that if fetch tasks are exhausted, then the end of the block idx range is reached because this invariant is not correct in the case of seek. 

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
