### PR TITLE
remove Debug requirement from metrics traits [minor]

### DIFF
--- a/slatedb-common/src/metrics.rs
+++ b/slatedb-common/src/metrics.rs
@@ -111,25 +111,25 @@ pub trait MetricsRecorder: Send + Sync {
 }
 
 /// Handle for incrementing a monotonic counter.
-pub trait CounterFn: Send + Sync + std::fmt::Debug {
+pub trait CounterFn: Send + Sync {
     /// Add `value` to the counter.
     fn increment(&self, value: u64);
 }
 
 /// Handle for setting a gauge to an arbitrary value.
-pub trait GaugeFn: Send + Sync + std::fmt::Debug {
+pub trait GaugeFn: Send + Sync {
     /// Set the gauge to `value`.
     fn set(&self, value: i64);
 }
 
 /// Handle for incrementing or decrementing a bidirectional counter.
-pub trait UpDownCounterFn: Send + Sync + std::fmt::Debug {
+pub trait UpDownCounterFn: Send + Sync {
     /// Add `value` to the counter (may be negative).
     fn increment(&self, value: i64);
 }
 
 /// Handle for recording observations into a histogram.
-pub trait HistogramFn: Send + Sync + std::fmt::Debug {
+pub trait HistogramFn: Send + Sync {
     /// Record a single observation.
     fn record(&self, value: f64);
 }

--- a/slatedb/src/cached_object_store/stats.rs
+++ b/slatedb/src/cached_object_store/stats.rs
@@ -1,4 +1,5 @@
 use slatedb_common::metrics::{CounterFn, GaugeFn, MetricsRecorderHelper};
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 macro_rules! oscache_stat_name {
@@ -14,7 +15,7 @@ pub const OBJECT_STORE_CACHE_BYTES: &str = oscache_stat_name!("cache_bytes");
 pub const OBJECT_STORE_CACHE_EVICTED_KEYS: &str = oscache_stat_name!("evicted_keys");
 pub const OBJECT_STORE_CACHE_EVICTED_BYTES: &str = oscache_stat_name!("evicted_bytes");
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CachedObjectStoreStats {
     pub(super) object_store_cache_part_hits: Arc<dyn CounterFn>,
     pub(super) object_store_cache_part_access: Arc<dyn CounterFn>,
@@ -22,6 +23,19 @@ pub struct CachedObjectStoreStats {
     pub(super) object_store_cache_bytes: Arc<dyn GaugeFn>,
     pub(super) object_store_cache_evicted_keys: Arc<dyn CounterFn>,
     pub(super) object_store_cache_evicted_bytes: Arc<dyn CounterFn>,
+}
+
+impl Debug for CachedObjectStoreStats {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachedObjectStoreStats")
+            .field("object_store_cache_part_hits", &"<counter>")
+            .field("object_store_cache_part_access", &"<counter>")
+            .field("object_store_cache_keys", &"<gauge>")
+            .field("object_store_cache_bytes", &"<gauge>")
+            .field("object_store_cache_evicted_keys", &"<counter>")
+            .field("object_store_cache_evicted_bytes", &"<counter>")
+            .finish()
+    }
 }
 
 impl CachedObjectStoreStats {


### PR DESCRIPTION
fixes #1456  - turns out this was more trivial after implementing the removal of the metrics registry code.

Quick note: `CachedObjectStoreStats` is never logged in debug anywhere, but the object store crate required us to implement `Debug` so there's a dummy implementation in this PR.