### PR TITLE
Wire GarbageCollector through GarbageCollectorBuilder in DbBuilder

### DIFF
--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -605,10 +605,10 @@ impl<P: Into<Path>> DbBuilder<P> {
                 .with_system_clock(system_clock.clone())
                 .with_recorder(recorder.clone())
                 .with_seed(rand.rng().next_u64())
-                .build_from_stores(
+                .build_collector(
+                    uncached_table_store.clone(),
                     manifest_store.clone(),
                     compactions_store.clone(),
-                    uncached_table_store.clone(),
                 );
             // Garbage collector only uses tickers, so pass in a dummy rx channel
             let (_, rx) = mpsc::unbounded_channel();
@@ -789,11 +789,11 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
     }
 
     /// Builds a GarbageCollector using pre-existing stores (used by DbBuilder).
-    pub(crate) fn build_from_stores(
+    pub(crate) fn build_collector(
         self,
+        table_store: Arc<TableStore>,
         manifest_store: Arc<ManifestStore>,
         compactions_store: Arc<CompactionsStore>,
-        table_store: Arc<TableStore>,
     ) -> GarbageCollector {
         GarbageCollector::new(
             manifest_store,


### PR DESCRIPTION
## Summary

Fixes #1454

Mirror the CompactorBuilder pattern for GC: add into_path_builder(), gc_builder field on DbBuilder, with_gc_builder() method, and route DbBuilder::open() through the builder instead of constructing GC directly. This enables DbBuilder to wire shared state (metrics, clock, seed) into the GC the same way it does for the compactor.

## Notes for Reviewers

Has the same quirks as the compactor builder pattern that are net new (reuses the same `retrying_object_store` and overwrites seeds/paths from the config using the one in the main db builder/config.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
