### PR TITLE
pin the version of uniffi-bindgen-node-js

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Install uniffi-bindgen-node-js
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-node-js
+        run: cargo install uniffi-bindgen-node-js@0.0.6
 
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -256,7 +256,7 @@ jobs:
       - name: Install uniffi-bindgen-node-js
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-node-js
+        run: cargo install uniffi-bindgen-node-js@0.0.6
 
       - name: Build Node package (bindings/node)
         run: npm --prefix bindings/node run build


### PR DESCRIPTION
See this failure: https://github.com/slatedb/slatedb/actions/runs/23931693923/job/69800343353?pr=1478

```
failed to load UniFFI component configs from '/home/runner/work/slatedb/slatedb/target/debug/libslatedb_uniffi.so': unsupported legacy [bindings.node] settings:
- bindings.node.cdylib_name is no longer supported; the generator now derives the expected packaged native library name from the input cdylib, so delete this setting
file:///home/runner/work/slatedb/slatedb/bindings/node/build.mjs:46
    throw new Error(`command failed: ${command} ${args.join(" ")}`);
          ^

Error: command failed: uniffi-bindgen-node-js generate /home/runner/work/slatedb/slatedb/target/debug/libslatedb_uniffi.so --crate-name slatedb-uniffi --out-dir /tmp/slatedb-node-build-GxSHGJ
    at run (file:///home/runner/work/slatedb/slatedb/bindings/node/build.mjs:46:11)
    at generateBindings (file:///home/runner/work/slatedb/slatedb/bindings/node/build.mjs:155:3)
    at main (file:///home/runner/work/slatedb/slatedb/bindings/node/build.mjs:237:5)
    at file:///home/runner/work/slatedb/slatedb/bindings/node/build.mjs:249:1
    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:665:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

I treid to just remove that configuration but other things broke, so I'm pinning the bindgen version
