### PR TITLE
Upgrade UniFFI bindings to 0.31

### DIFF
--- a/.github/workflows/java.yaml
+++ b/.github/workflows/java.yaml
@@ -151,7 +151,7 @@ jobs:
       - name: Install uniffi-bindgen-java
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-java --git https://github.com/IronCoreLabs/uniffi-bindgen-java.git --rev 265d9b93645ce50307449bea2489b2b748fb67ee
+        run: cargo install uniffi-bindgen-java --version 0.3.1
 
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Install uniffi-bindgen-node-js
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-node-js
+        run: cargo install uniffi-bindgen-node-js --version 0.0.7
 
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install maturin "uniffi-bindgen==0.29.5" ruff
+          pip install maturin "uniffi-bindgen==0.31.0" ruff
 
       - name: Build editable package with test deps
         working-directory: ./bindings/python
@@ -192,7 +192,7 @@ jobs:
           sudo apt-get install -y build-essential pkg-config
 
       - name: Install uniffi-bindgen-go
-        run: cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.5.0+v0.29.5
+        run: cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.0+v0.31.0
 
       - name: Generate Go bindings
         run: ./scripts/generate-go-uniffi.sh
@@ -228,7 +228,7 @@ jobs:
           # uniffi-bindgen-java has some warnings that we don't want to fail the build, so we
           # override RUSTFLAGS here to avoid the -Dwarnings from the global env.
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-java --git https://github.com/IronCoreLabs/uniffi-bindgen-java.git --rev 265d9b93645ce50307449bea2489b2b748fb67ee
+        run: cargo install uniffi-bindgen-java --version 0.3.1
 
       - name: Run Java tests (bindings/java)
         run: ./bindings/java/gradlew -p bindings/java :slatedb-uniffi:check
@@ -256,7 +256,7 @@ jobs:
       - name: Install uniffi-bindgen-node-js
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-node-js
+        run: cargo install uniffi-bindgen-node-js --version 0.0.7
 
       - name: Build Node package (bindings/node)
         run: npm --prefix bindings/node run build

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install uniffi-bindgen
-        run: pip install "uniffi-bindgen==0.29.5"
+        run: pip install "uniffi-bindgen==0.31.0"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:
@@ -79,7 +79,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install uniffi-bindgen
-        run: pip install "uniffi-bindgen==0.29.5"
+        run: pip install "uniffi-bindgen==0.31.0"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -112,7 +112,7 @@ jobs:
           python-version: 3.x
           architecture: ${{ matrix.platform.target }}
       - name: Install uniffi-bindgen
-        run: pip install "uniffi-bindgen==0.29.5"
+        run: pip install "uniffi-bindgen==0.31.0"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -141,7 +141,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install uniffi-bindgen
-        run: pip install "uniffi-bindgen==0.29.5"
+        run: pip install "uniffi-bindgen==0.31.0"
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -165,7 +165,7 @@ jobs:
         with:
           python-version: 3.x
       - name: Install uniffi-bindgen
-        run: pip install "uniffi-bindgen==0.29.5"
+        run: pip install "uniffi-bindgen==0.31.0"
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "askama"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
 dependencies = [
  "askama_derive",
  "itoa",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "askama_parser"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
 dependencies = [
  "memchr",
  "serde",
@@ -980,7 +980,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
- "toml 0.8.20",
+ "toml",
  "uncased",
  "version_check",
 ]
@@ -1726,6 +1726,8 @@ checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1959,7 +1961,7 @@ dependencies = [
  "spin",
  "tokio",
  "tokio-util",
- "toml 0.8.20",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3256,12 +3258,6 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
-name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
@@ -3320,7 +3316,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "siphasher 1.0.1",
+ "siphasher",
  "slatedb-common",
  "slatedb-txn-obj",
  "snap",
@@ -3821,15 +3817,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
@@ -4006,9 +3993,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "uniffi"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
+checksum = "b8c6dec3fc6645f71a16a3fa9ff57991028153bd194ca97f4b55e610c73ce66a"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -4020,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
+checksum = "4ed0150801958d4825da56a41c71f000a457ac3a4613fa9647df78ac4b6b6881"
 dependencies = [
  "anyhow",
  "askama",
@@ -4037,7 +4024,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml 0.5.11",
+ "toml",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -4046,9 +4033,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
+checksum = "b0ef62e69762fbb9386dcb6c87cd3dd05d525fa8a3a579a290892e60ddbda47e"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -4059,9 +4046,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
+checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -4072,9 +4059,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
+checksum = "db9d12529f1223d014fd501e5f29ca0884d15d6ed5ddddd9f506e55350327dc3"
 dependencies = [
  "camino",
  "fs-err",
@@ -4083,27 +4070,27 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.100",
- "toml 0.5.11",
+ "toml",
  "uniffi_meta",
 ]
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
+checksum = "9df6d413db2827c68588f8149d30d49b71d540d46539e435b23a7f7dbd4d4f86"
 dependencies = [
  "anyhow",
- "siphasher 0.3.11",
+ "siphasher",
  "uniffi_internal_macros",
  "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
+checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -4114,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
+checksum = "0d1a7339539bf6f6fa3e9b534dece13f778bda2d54b1a6d4e40b4d6090ac26e7"
 dependencies = [
  "anyhow",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ tracing = "0.1.40"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3" }
 thread_local = "1.1.9"
-uniffi = "0.29.2"
+uniffi = "0.31.0"
 ulid = "1.2.1"
 uuid = "1.18.0"
 walkdir = "2.3.3"

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -24,12 +24,12 @@ There is no handwritten Go wrapper layer yet.
 - Go 1.25.0 or newer
 - CGO enabled
 - A working C toolchain
-- `uniffi-bindgen-go` `0.5.0+v0.29.5`
+- `uniffi-bindgen-go` `0.7.0+v0.31.0`
 
 Install the generator with:
 
 ```bash
-cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.5.0+v0.29.5
+cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.0+v0.31.0
 ```
 
 ## Regenerate

--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 	"runtime"
 	"runtime/cgo"
 	"sync"
@@ -154,17 +155,18 @@ func LiftFromRustBuffer[GoType any](bufReader BufReader[GoType], rbuf RustBuffer
 	return item
 }
 
-func rustCallWithError[E any, U any](converter BufReader[*E], callback func(*C.RustCallStatus) U) (U, *E) {
+func rustCallWithError[E any, U any](converter BufReader[E], callback func(*C.RustCallStatus) U) (U, E) {
 	var status C.RustCallStatus
 	returnValue := callback(&status)
 	err := checkCallStatus(converter, status)
 	return returnValue, err
 }
 
-func checkCallStatus[E any](converter BufReader[*E], status C.RustCallStatus) *E {
+func checkCallStatus[E any](converter BufReader[E], status C.RustCallStatus) E {
 	switch status.code {
 	case 0:
-		return nil
+		var zero E
+		return zero
 	case 1:
 		return LiftFromRustBuffer(converter, GoRustBuffer{inner: status.errorBuf})
 	case 2:
@@ -364,7 +366,7 @@ func init() {
 
 func uniffiCheckChecksums() {
 	// Get the bindings contract version from our ComponentInterface
-	bindingsContractVersion := 29
+	bindingsContractVersion := 30
 	// Get the scaffolding contract version by calling the into the dylib
 	scaffoldingContractVersion := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint32_t {
 		return C.ffi_slatedb_uniffi_uniffi_contract_version()
@@ -377,214 +379,16 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_func_init_logging()
 		})
-		if checksum != 20973 {
+		if checksum != 43029 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_func_init_logging: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_begin()
-		})
-		if checksum != 51275 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_begin: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_delete()
-		})
-		if checksum != 34129 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_delete: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_delete_with_options()
-		})
-		if checksum != 42509 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_delete_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_flush()
-		})
-		if checksum != 18130 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_flush: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_flush_with_options()
-		})
-		if checksum != 63293 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_flush_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_get()
-		})
-		if checksum != 50068 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_get_key_value()
-		})
-		if checksum != 57684 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get_key_value: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_get_key_value_with_options()
-		})
-		if checksum != 20648 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get_key_value_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_get_with_options()
-		})
-		if checksum != 20501 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_merge()
-		})
-		if checksum != 17999 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_merge: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_merge_with_options()
-		})
-		if checksum != 61231 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_merge_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_put()
-		})
-		if checksum != 59996 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_put: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_put_with_options()
-		})
-		if checksum != 58268 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_put_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_scan()
-		})
-		if checksum != 38146 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_scan_prefix()
-		})
-		if checksum != 16589 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan_prefix: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_scan_prefix_with_options()
-		})
-		if checksum != 37166 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan_prefix_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_scan_with_options()
-		})
-		if checksum != 57778 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_shutdown()
-		})
-		if checksum != 43377 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_shutdown: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_snapshot()
-		})
-		if checksum != 13313 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_snapshot: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_status()
-		})
-		if checksum != 55824 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_status: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_write()
-		})
-		if checksum != 13969 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_write: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_db_write_with_options()
-		})
-		if checksum != 34167 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_write_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_build()
 		})
-		if checksum != 57780 {
+		if checksum != 18005 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_build: UniFFI API checksum mismatch")
 		}
@@ -593,7 +397,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_db_cache_disabled()
 		})
-		if checksum != 47291 {
+		if checksum != 17477 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_db_cache_disabled: UniFFI API checksum mismatch")
 		}
@@ -602,7 +406,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_merge_operator()
 		})
-		if checksum != 26367 {
+		if checksum != 5839 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_merge_operator: UniFFI API checksum mismatch")
 		}
@@ -611,7 +415,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_seed()
 		})
-		if checksum != 4525 {
+		if checksum != 58796 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_seed: UniFFI API checksum mismatch")
 		}
@@ -620,7 +424,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_settings()
 		})
-		if checksum != 60845 {
+		if checksum != 64263 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_settings: UniFFI API checksum mismatch")
 		}
@@ -629,7 +433,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_sst_block_size()
 		})
-		if checksum != 9450 {
+		if checksum != 40009 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_sst_block_size: UniFFI API checksum mismatch")
 		}
@@ -638,97 +442,16 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_wal_object_store()
 		})
-		if checksum != 59224 {
+		if checksum != 4790 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_wal_object_store: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbiterator_next()
-		})
-		if checksum != 49160 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbiterator_next: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbiterator_seek()
-		})
-		if checksum != 43547 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbiterator_seek: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_get()
-		})
-		if checksum != 22886 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_get: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_get_with_options()
-		})
-		if checksum != 9133 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_get_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan()
-		})
-		if checksum != 19575 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix()
-		})
-		if checksum != 51732 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix_with_options()
-		})
-		if checksum != 24990 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan_with_options()
-		})
-		if checksum != 33406 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan_with_options: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
-			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown()
-		})
-		if checksum != 33391 {
-			// If this happens try cleaning and rebuilding your project
-			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown: UniFFI API checksum mismatch")
-		}
-	}
-	{
-		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_build()
 		})
-		if checksum != 3383 {
+		if checksum != 11741 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_build: UniFFI API checksum mismatch")
 		}
@@ -737,7 +460,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_checkpoint_id()
 		})
-		if checksum != 20357 {
+		if checksum != 41016 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_checkpoint_id: UniFFI API checksum mismatch")
 		}
@@ -746,7 +469,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_merge_operator()
 		})
-		if checksum != 54971 {
+		if checksum != 63455 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_merge_operator: UniFFI API checksum mismatch")
 		}
@@ -755,7 +478,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_options()
 		})
-		if checksum != 5765 {
+		if checksum != 46155 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_options: UniFFI API checksum mismatch")
 		}
@@ -764,16 +487,277 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_wal_object_store()
 		})
-		if checksum != 15471 {
+		if checksum != 2290 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_wal_object_store: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_begin()
+		})
+		if checksum != 38869 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_begin: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_delete()
+		})
+		if checksum != 4063 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_delete: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_delete_with_options()
+		})
+		if checksum != 44744 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_delete_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_flush()
+		})
+		if checksum != 42157 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_flush: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_flush_with_options()
+		})
+		if checksum != 27835 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_flush_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_get()
+		})
+		if checksum != 39474 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_get_key_value()
+		})
+		if checksum != 35423 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get_key_value: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_get_key_value_with_options()
+		})
+		if checksum != 6898 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get_key_value_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_get_with_options()
+		})
+		if checksum != 20708 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_get_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_merge()
+		})
+		if checksum != 28366 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_merge: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_merge_with_options()
+		})
+		if checksum != 15865 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_merge_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_put()
+		})
+		if checksum != 53275 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_put: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_put_with_options()
+		})
+		if checksum != 37591 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_put_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_scan()
+		})
+		if checksum != 60557 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_scan_prefix()
+		})
+		if checksum != 44288 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan_prefix: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_scan_prefix_with_options()
+		})
+		if checksum != 34774 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan_prefix_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_scan_with_options()
+		})
+		if checksum != 63326 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_scan_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_shutdown()
+		})
+		if checksum != 3032 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_shutdown: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_snapshot()
+		})
+		if checksum != 53137 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_snapshot: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_status()
+		})
+		if checksum != 26 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_status: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_write()
+		})
+		if checksum != 29016 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_write: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_write_with_options()
+		})
+		if checksum != 13580 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_write_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_get()
+		})
+		if checksum != 53337 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_get: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_get_with_options()
+		})
+		if checksum != 22247 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_get_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan()
+		})
+		if checksum != 19340 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix()
+		})
+		if checksum != 2510 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix_with_options()
+		})
+		if checksum != 46251 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan_prefix_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_scan_with_options()
+		})
+		if checksum != 27137 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_scan_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown()
+		})
+		if checksum != 34395 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get()
 		})
-		if checksum != 37663 {
+		if checksum != 52436 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get: UniFFI API checksum mismatch")
 		}
@@ -782,7 +766,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get_key_value()
 		})
-		if checksum != 1007 {
+		if checksum != 58808 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get_key_value: UniFFI API checksum mismatch")
 		}
@@ -791,7 +775,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get_key_value_with_options()
 		})
-		if checksum != 20762 {
+		if checksum != 21706 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get_key_value_with_options: UniFFI API checksum mismatch")
 		}
@@ -800,7 +784,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get_with_options()
 		})
-		if checksum != 29177 {
+		if checksum != 58422 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_get_with_options: UniFFI API checksum mismatch")
 		}
@@ -809,7 +793,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan()
 		})
-		if checksum != 18781 {
+		if checksum != 5467 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan: UniFFI API checksum mismatch")
 		}
@@ -818,7 +802,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan_prefix()
 		})
-		if checksum != 43063 {
+		if checksum != 57746 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan_prefix: UniFFI API checksum mismatch")
 		}
@@ -827,7 +811,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan_prefix_with_options()
 		})
-		if checksum != 39827 {
+		if checksum != 4221 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan_prefix_with_options: UniFFI API checksum mismatch")
 		}
@@ -836,7 +820,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan_with_options()
 		})
-		if checksum != 1457 {
+		if checksum != 63293 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbsnapshot_scan_with_options: UniFFI API checksum mismatch")
 		}
@@ -845,7 +829,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_commit()
 		})
-		if checksum != 17358 {
+		if checksum != 56467 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_commit: UniFFI API checksum mismatch")
 		}
@@ -854,7 +838,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_commit_with_options()
 		})
-		if checksum != 53495 {
+		if checksum != 62589 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_commit_with_options: UniFFI API checksum mismatch")
 		}
@@ -863,7 +847,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_delete()
 		})
-		if checksum != 9717 {
+		if checksum != 7933 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_delete: UniFFI API checksum mismatch")
 		}
@@ -872,7 +856,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_get()
 		})
-		if checksum != 27661 {
+		if checksum != 4279 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_get: UniFFI API checksum mismatch")
 		}
@@ -881,7 +865,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_get_key_value()
 		})
-		if checksum != 62855 {
+		if checksum != 51665 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_get_key_value: UniFFI API checksum mismatch")
 		}
@@ -890,7 +874,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_get_key_value_with_options()
 		})
-		if checksum != 37939 {
+		if checksum != 61936 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_get_key_value_with_options: UniFFI API checksum mismatch")
 		}
@@ -899,7 +883,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_get_with_options()
 		})
-		if checksum != 53534 {
+		if checksum != 30800 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_get_with_options: UniFFI API checksum mismatch")
 		}
@@ -908,7 +892,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_id()
 		})
-		if checksum != 16876 {
+		if checksum != 33247 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_id: UniFFI API checksum mismatch")
 		}
@@ -917,7 +901,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_mark_read()
 		})
-		if checksum != 26788 {
+		if checksum != 33456 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_mark_read: UniFFI API checksum mismatch")
 		}
@@ -926,7 +910,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_merge()
 		})
-		if checksum != 28294 {
+		if checksum != 16664 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_merge: UniFFI API checksum mismatch")
 		}
@@ -935,7 +919,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_merge_with_options()
 		})
-		if checksum != 63505 {
+		if checksum != 17753 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_merge_with_options: UniFFI API checksum mismatch")
 		}
@@ -944,7 +928,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_put()
 		})
-		if checksum != 30341 {
+		if checksum != 56350 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_put: UniFFI API checksum mismatch")
 		}
@@ -953,7 +937,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_put_with_options()
 		})
-		if checksum != 24593 {
+		if checksum != 37260 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_put_with_options: UniFFI API checksum mismatch")
 		}
@@ -962,7 +946,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_rollback()
 		})
-		if checksum != 23348 {
+		if checksum != 25213 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_rollback: UniFFI API checksum mismatch")
 		}
@@ -971,7 +955,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan()
 		})
-		if checksum != 12571 {
+		if checksum != 2520 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan: UniFFI API checksum mismatch")
 		}
@@ -980,7 +964,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan_prefix()
 		})
-		if checksum != 49961 {
+		if checksum != 28799 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan_prefix: UniFFI API checksum mismatch")
 		}
@@ -989,7 +973,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan_prefix_with_options()
 		})
-		if checksum != 33081 {
+		if checksum != 31002 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan_prefix_with_options: UniFFI API checksum mismatch")
 		}
@@ -998,7 +982,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan_with_options()
 		})
-		if checksum != 55349 {
+		if checksum != 5569 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_scan_with_options: UniFFI API checksum mismatch")
 		}
@@ -1007,7 +991,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_seqnum()
 		})
-		if checksum != 60506 {
+		if checksum != 63575 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_seqnum: UniFFI API checksum mismatch")
 		}
@@ -1016,16 +1000,34 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbtransaction_unmark_write()
 		})
-		if checksum != 15301 {
+		if checksum != 16990 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbtransaction_unmark_write: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbiterator_next()
+		})
+		if checksum != 1225 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbiterator_next: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbiterator_seek()
+		})
+		if checksum != 61052 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbiterator_seek: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_logcallback_log()
 		})
-		if checksum != 11398 {
+		if checksum != 36316 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_logcallback_log: UniFFI API checksum mismatch")
 		}
@@ -1034,7 +1036,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_mergeoperator_merge()
 		})
-		if checksum != 9511 {
+		if checksum != 48409 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_mergeoperator_merge: UniFFI API checksum mismatch")
 		}
@@ -1043,7 +1045,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_settings_set()
 		})
-		if checksum != 31996 {
+		if checksum != 34344 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_settings_set: UniFFI API checksum mismatch")
 		}
@@ -1052,7 +1054,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_settings_to_json_string()
 		})
-		if checksum != 62526 {
+		if checksum != 8458 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_settings_to_json_string: UniFFI API checksum mismatch")
 		}
@@ -1061,7 +1063,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walfile_id()
 		})
-		if checksum != 51355 {
+		if checksum != 62512 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walfile_id: UniFFI API checksum mismatch")
 		}
@@ -1070,7 +1072,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walfile_iterator()
 		})
-		if checksum != 50239 {
+		if checksum != 46880 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walfile_iterator: UniFFI API checksum mismatch")
 		}
@@ -1079,7 +1081,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walfile_metadata()
 		})
-		if checksum != 30832 {
+		if checksum != 32912 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walfile_metadata: UniFFI API checksum mismatch")
 		}
@@ -1088,7 +1090,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walfile_next_file()
 		})
-		if checksum != 52353 {
+		if checksum != 56800 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walfile_next_file: UniFFI API checksum mismatch")
 		}
@@ -1097,7 +1099,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walfile_next_id()
 		})
-		if checksum != 60587 {
+		if checksum != 48353 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walfile_next_id: UniFFI API checksum mismatch")
 		}
@@ -1106,7 +1108,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walfileiterator_next()
 		})
-		if checksum != 18233 {
+		if checksum != 51490 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walfileiterator_next: UniFFI API checksum mismatch")
 		}
@@ -1115,7 +1117,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walreader_get()
 		})
-		if checksum != 40699 {
+		if checksum != 11510 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walreader_get: UniFFI API checksum mismatch")
 		}
@@ -1124,7 +1126,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_walreader_list()
 		})
-		if checksum != 62366 {
+		if checksum != 43661 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_walreader_list: UniFFI API checksum mismatch")
 		}
@@ -1133,7 +1135,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_writebatch_delete()
 		})
-		if checksum != 37032 {
+		if checksum != 58549 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_writebatch_delete: UniFFI API checksum mismatch")
 		}
@@ -1142,7 +1144,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_writebatch_merge()
 		})
-		if checksum != 51939 {
+		if checksum != 62067 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_writebatch_merge: UniFFI API checksum mismatch")
 		}
@@ -1151,7 +1153,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_writebatch_merge_with_options()
 		})
-		if checksum != 30105 {
+		if checksum != 24696 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_writebatch_merge_with_options: UniFFI API checksum mismatch")
 		}
@@ -1160,7 +1162,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_writebatch_put()
 		})
-		if checksum != 35694 {
+		if checksum != 48246 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_writebatch_put: UniFFI API checksum mismatch")
 		}
@@ -1169,7 +1171,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_writebatch_put_with_options()
 		})
-		if checksum != 23639 {
+		if checksum != 31177 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_writebatch_put_with_options: UniFFI API checksum mismatch")
 		}
@@ -1178,7 +1180,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_dbbuilder_new()
 		})
-		if checksum != 20774 {
+		if checksum != 60260 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_dbbuilder_new: UniFFI API checksum mismatch")
 		}
@@ -1187,7 +1189,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_dbreaderbuilder_new()
 		})
-		if checksum != 63705 {
+		if checksum != 20397 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_dbreaderbuilder_new: UniFFI API checksum mismatch")
 		}
@@ -1196,7 +1198,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_objectstore_from_env()
 		})
-		if checksum != 31525 {
+		if checksum != 61956 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_objectstore_from_env: UniFFI API checksum mismatch")
 		}
@@ -1205,7 +1207,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_objectstore_resolve()
 		})
-		if checksum != 27737 {
+		if checksum != 17196 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_objectstore_resolve: UniFFI API checksum mismatch")
 		}
@@ -1214,7 +1216,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_settings_default()
 		})
-		if checksum != 56170 {
+		if checksum != 64704 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_settings_default: UniFFI API checksum mismatch")
 		}
@@ -1223,7 +1225,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_settings_from_env()
 		})
-		if checksum != 49511 {
+		if checksum != 28170 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_settings_from_env: UniFFI API checksum mismatch")
 		}
@@ -1232,7 +1234,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_settings_from_env_with_default()
 		})
-		if checksum != 6106 {
+		if checksum != 3189 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_settings_from_env_with_default: UniFFI API checksum mismatch")
 		}
@@ -1241,7 +1243,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_settings_from_file()
 		})
-		if checksum != 40167 {
+		if checksum != 38462 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_settings_from_file: UniFFI API checksum mismatch")
 		}
@@ -1250,7 +1252,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_settings_from_json_string()
 		})
-		if checksum != 43399 {
+		if checksum != 38360 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_settings_from_json_string: UniFFI API checksum mismatch")
 		}
@@ -1259,7 +1261,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_settings_load()
 		})
-		if checksum != 3704 {
+		if checksum != 7949 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_settings_load: UniFFI API checksum mismatch")
 		}
@@ -1268,7 +1270,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_walreader_new()
 		})
-		if checksum != 791 {
+		if checksum != 30537 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_walreader_new: UniFFI API checksum mismatch")
 		}
@@ -1277,7 +1279,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_constructor_writebatch_new()
 		})
-		if checksum != 25201 {
+		if checksum != 2056 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_constructor_writebatch_new: UniFFI API checksum mismatch")
 		}
@@ -1493,26 +1495,26 @@ func (FfiDestroyerBytes) Destroy(_ []byte) {}
 // https://github.com/mozilla/uniffi-rs/blob/0dc031132d9493ca812c3af6e7dd60ad2ea95bf0/uniffi_bindgen/src/bindings/kotlin/templates/ObjectRuntime.kt#L31
 
 type FfiObject struct {
-	pointer       unsafe.Pointer
+	handle        C.uint64_t
 	callCounter   atomic.Int64
-	cloneFunction func(unsafe.Pointer, *C.RustCallStatus) unsafe.Pointer
-	freeFunction  func(unsafe.Pointer, *C.RustCallStatus)
+	cloneFunction func(C.uint64_t, *C.RustCallStatus) C.uint64_t
+	freeFunction  func(C.uint64_t, *C.RustCallStatus)
 	destroyed     atomic.Bool
 }
 
 func newFfiObject(
-	pointer unsafe.Pointer,
-	cloneFunction func(unsafe.Pointer, *C.RustCallStatus) unsafe.Pointer,
-	freeFunction func(unsafe.Pointer, *C.RustCallStatus),
+	handle C.uint64_t,
+	cloneFunction func(C.uint64_t, *C.RustCallStatus) C.uint64_t,
+	freeFunction func(C.uint64_t, *C.RustCallStatus),
 ) FfiObject {
 	return FfiObject{
-		pointer:       pointer,
+		handle:        handle,
 		cloneFunction: cloneFunction,
 		freeFunction:  freeFunction,
 	}
 }
 
-func (ffiObject *FfiObject) incrementPointer(debugName string) unsafe.Pointer {
+func (ffiObject *FfiObject) incrementPointer(debugName string) C.uint64_t {
 	for {
 		counter := ffiObject.callCounter.Load()
 		if counter <= -1 {
@@ -1526,8 +1528,8 @@ func (ffiObject *FfiObject) incrementPointer(debugName string) unsafe.Pointer {
 		}
 	}
 
-	return rustCall(func(status *C.RustCallStatus) unsafe.Pointer {
-		return ffiObject.cloneFunction(ffiObject.pointer, status)
+	return rustCall(func(status *C.RustCallStatus) C.uint64_t {
+		return ffiObject.cloneFunction(ffiObject.handle, status)
 	})
 }
 
@@ -1546,8 +1548,11 @@ func (ffiObject *FfiObject) destroy() {
 }
 
 func (ffiObject *FfiObject) freeRustArcPtr() {
+	if ffiObject.handle == 0 {
+		return
+	}
 	rustCall(func(status *C.RustCallStatus) int32 {
-		ffiObject.freeFunction(ffiObject.pointer, status)
+		ffiObject.freeFunction(ffiObject.handle, status)
 		return 0
 	})
 }
@@ -1616,26 +1621,26 @@ type Db struct {
 func (_self *Db) Begin(isolationLevel IsolationLevel) (*DbTransaction, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbTransaction {
+		func(ffi C.uint64_t) *DbTransaction {
 			return FfiConverterDbTransactionINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_db_begin(
 			_pointer, FfiConverterIsolationLevelINSTANCE.Lower(isolationLevel)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -1650,7 +1655,7 @@ func (_self *Db) Begin(isolationLevel IsolationLevel) (*DbTransaction, error) {
 func (_self *Db) Delete(key []byte) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1686,7 +1691,7 @@ func (_self *Db) Delete(key []byte) (WriteHandle, error) {
 func (_self *Db) DeleteWithOptions(key []byte, options WriteOptions) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1722,7 +1727,7 @@ func (_self *Db) DeleteWithOptions(key []byte, options WriteOptions) (WriteHandl
 func (_self *Db) Flush() error {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -1754,7 +1759,7 @@ func (_self *Db) Flush() error {
 func (_self *Db) FlushWithOptions(options FlushOptions) error {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -1786,7 +1791,7 @@ func (_self *Db) FlushWithOptions(options FlushOptions) error {
 func (_self *Db) Get(key []byte) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1822,7 +1827,7 @@ func (_self *Db) Get(key []byte) (*[]byte, error) {
 func (_self *Db) GetKeyValue(key []byte) (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1858,7 +1863,7 @@ func (_self *Db) GetKeyValue(key []byte) (*KeyValue, error) {
 func (_self *Db) GetKeyValueWithOptions(key []byte, options ReadOptions) (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1894,7 +1899,7 @@ func (_self *Db) GetKeyValueWithOptions(key []byte, options ReadOptions) (*KeyVa
 func (_self *Db) GetWithOptions(key []byte, options ReadOptions) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1930,7 +1935,7 @@ func (_self *Db) GetWithOptions(key []byte, options ReadOptions) (*[]byte, error
 func (_self *Db) Merge(key []byte, operand []byte) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -1966,7 +1971,7 @@ func (_self *Db) Merge(key []byte, operand []byte) (WriteHandle, error) {
 func (_self *Db) MergeWithOptions(key []byte, operand []byte, mergeOptions MergeOptions, writeOptions WriteOptions) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2005,7 +2010,7 @@ func (_self *Db) MergeWithOptions(key []byte, operand []byte, mergeOptions Merge
 func (_self *Db) Put(key []byte, value []byte) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2041,7 +2046,7 @@ func (_self *Db) Put(key []byte, value []byte) (WriteHandle, error) {
 func (_self *Db) PutWithOptions(key []byte, value []byte, putOptions PutOptions, writeOptions WriteOptions) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2077,26 +2082,26 @@ func (_self *Db) PutWithOptions(key []byte, value []byte, putOptions PutOptions,
 func (_self *Db) Scan(varRange KeyRange) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_db_scan(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2111,26 +2116,26 @@ func (_self *Db) Scan(varRange KeyRange) (*DbIterator, error) {
 func (_self *Db) ScanPrefix(prefix []byte) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_db_scan_prefix(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2145,26 +2150,26 @@ func (_self *Db) ScanPrefix(prefix []byte) (*DbIterator, error) {
 func (_self *Db) ScanPrefixWithOptions(prefix []byte, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_db_scan_prefix_with_options(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2179,26 +2184,26 @@ func (_self *Db) ScanPrefixWithOptions(prefix []byte, options ScanOptions) (*DbI
 func (_self *Db) ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_db_scan_with_options(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2213,7 +2218,7 @@ func (_self *Db) ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIte
 func (_self *Db) Shutdown() error {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -2245,26 +2250,26 @@ func (_self *Db) Shutdown() error {
 func (_self *Db) Snapshot() (*DbSnapshot, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbSnapshot {
+		func(ffi C.uint64_t) *DbSnapshot {
 			return FfiConverterDbSnapshotINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_db_snapshot(
 			_pointer),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2279,7 +2284,7 @@ func (_self *Db) Snapshot() (*DbSnapshot, error) {
 func (_self *Db) Status() error {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_db_status(
 			_pointer, _uniffiStatus)
 		return false
@@ -2293,7 +2298,7 @@ func (_self *Db) Status() error {
 func (_self *Db) Write(batch *WriteBatch) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2331,7 +2336,7 @@ func (_self *Db) Write(batch *WriteBatch) (WriteHandle, error) {
 func (_self *Db) WriteWithOptions(batch *WriteBatch, options WriteOptions) (WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2371,15 +2376,15 @@ type FfiConverterDb struct{}
 
 var FfiConverterDbINSTANCE = FfiConverterDb{}
 
-func (c FfiConverterDb) Lift(pointer unsafe.Pointer) *Db {
+func (c FfiConverterDb) Lift(handle C.uint64_t) *Db {
 	result := &Db{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_db(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_db(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_db(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_db(handle, status)
 			},
 		),
 	}
@@ -2388,21 +2393,28 @@ func (c FfiConverterDb) Lift(pointer unsafe.Pointer) *Db {
 }
 
 func (c FfiConverterDb) Read(reader io.Reader) *Db {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDb) Lower(value *Db) unsafe.Pointer {
+func (c FfiConverterDb) Lower(value *Db) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*Db")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*Db")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDb) Write(writer io.Writer, value *Db) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDb(handle uint64) *Db {
+	return FfiConverterDbINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDb(value *Db) uint64 {
+	return uint64(FfiConverterDbINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDb struct{}
@@ -2440,7 +2452,7 @@ type DbBuilder struct {
 
 // Creates a new database builder for `path` in `object_store`.
 func NewDbBuilder(path string, objectStore *ObjectStore) *DbBuilder {
-	return FfiConverterDbBuilderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterDbBuilderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_dbbuilder_new(FfiConverterStringINSTANCE.Lower(path), FfiConverterObjectStoreINSTANCE.Lower(objectStore), _uniffiStatus)
 	}))
 }
@@ -2449,26 +2461,26 @@ func NewDbBuilder(path string, objectStore *ObjectStore) *DbBuilder {
 func (_self *DbBuilder) Build() (*Db, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *Db {
+		func(ffi C.uint64_t) *Db {
 			return FfiConverterDbINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_build(
 			_pointer),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2483,7 +2495,7 @@ func (_self *DbBuilder) Build() (*Db, error) {
 func (_self *DbBuilder) WithDbCacheDisabled() error {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_with_db_cache_disabled(
 			_pointer, _uniffiStatus)
 		return false
@@ -2495,7 +2507,7 @@ func (_self *DbBuilder) WithDbCacheDisabled() error {
 func (_self *DbBuilder) WithMergeOperator(mergeOperator MergeOperator) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_with_merge_operator(
 			_pointer, FfiConverterMergeOperatorINSTANCE.Lower(mergeOperator), _uniffiStatus)
 		return false
@@ -2507,7 +2519,7 @@ func (_self *DbBuilder) WithMergeOperator(mergeOperator MergeOperator) error {
 func (_self *DbBuilder) WithSeed(seed uint64) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_with_seed(
 			_pointer, FfiConverterUint64INSTANCE.Lower(seed), _uniffiStatus)
 		return false
@@ -2519,7 +2531,7 @@ func (_self *DbBuilder) WithSeed(seed uint64) error {
 func (_self *DbBuilder) WithSettings(settings *Settings) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_with_settings(
 			_pointer, FfiConverterSettingsINSTANCE.Lower(settings), _uniffiStatus)
 		return false
@@ -2531,7 +2543,7 @@ func (_self *DbBuilder) WithSettings(settings *Settings) error {
 func (_self *DbBuilder) WithSstBlockSize(sstBlockSize SstBlockSize) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_with_sst_block_size(
 			_pointer, FfiConverterSstBlockSizeINSTANCE.Lower(sstBlockSize), _uniffiStatus)
 		return false
@@ -2543,7 +2555,7 @@ func (_self *DbBuilder) WithSstBlockSize(sstBlockSize SstBlockSize) error {
 func (_self *DbBuilder) WithWalObjectStore(walObjectStore *ObjectStore) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbbuilder_with_wal_object_store(
 			_pointer, FfiConverterObjectStoreINSTANCE.Lower(walObjectStore), _uniffiStatus)
 		return false
@@ -2559,15 +2571,15 @@ type FfiConverterDbBuilder struct{}
 
 var FfiConverterDbBuilderINSTANCE = FfiConverterDbBuilder{}
 
-func (c FfiConverterDbBuilder) Lift(pointer unsafe.Pointer) *DbBuilder {
+func (c FfiConverterDbBuilder) Lift(handle C.uint64_t) *DbBuilder {
 	result := &DbBuilder{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_dbbuilder(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_dbbuilder(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_dbbuilder(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_dbbuilder(handle, status)
 			},
 		),
 	}
@@ -2576,21 +2588,28 @@ func (c FfiConverterDbBuilder) Lift(pointer unsafe.Pointer) *DbBuilder {
 }
 
 func (c FfiConverterDbBuilder) Read(reader io.Reader) *DbBuilder {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDbBuilder) Lower(value *DbBuilder) unsafe.Pointer {
+func (c FfiConverterDbBuilder) Lower(value *DbBuilder) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*DbBuilder")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*DbBuilder")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDbBuilder) Write(writer io.Writer, value *DbBuilder) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDbBuilder(handle uint64) *DbBuilder {
+	return FfiConverterDbBuilderINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDbBuilder(value *DbBuilder) uint64 {
+	return uint64(FfiConverterDbBuilderINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDbBuilder struct{}
@@ -2616,7 +2635,7 @@ type DbIterator struct {
 func (_self *DbIterator) Next() (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbIterator")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2652,7 +2671,7 @@ func (_self *DbIterator) Next() (*KeyValue, error) {
 func (_self *DbIterator) Seek(key []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbIterator")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -2688,15 +2707,15 @@ type FfiConverterDbIterator struct{}
 
 var FfiConverterDbIteratorINSTANCE = FfiConverterDbIterator{}
 
-func (c FfiConverterDbIterator) Lift(pointer unsafe.Pointer) *DbIterator {
+func (c FfiConverterDbIterator) Lift(handle C.uint64_t) *DbIterator {
 	result := &DbIterator{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_dbiterator(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_dbiterator(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_dbiterator(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_dbiterator(handle, status)
 			},
 		),
 	}
@@ -2705,21 +2724,28 @@ func (c FfiConverterDbIterator) Lift(pointer unsafe.Pointer) *DbIterator {
 }
 
 func (c FfiConverterDbIterator) Read(reader io.Reader) *DbIterator {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDbIterator) Lower(value *DbIterator) unsafe.Pointer {
+func (c FfiConverterDbIterator) Lower(value *DbIterator) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*DbIterator")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*DbIterator")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDbIterator) Write(writer io.Writer, value *DbIterator) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDbIterator(handle uint64) *DbIterator {
+	return FfiConverterDbIteratorINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDbIterator(value *DbIterator) uint64 {
+	return uint64(FfiConverterDbIteratorINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDbIterator struct{}
@@ -2755,7 +2781,7 @@ type DbReader struct {
 func (_self *DbReader) Get(key []byte) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2791,7 +2817,7 @@ func (_self *DbReader) Get(key []byte) (*[]byte, error) {
 func (_self *DbReader) GetWithOptions(key []byte, options ReadOptions) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -2827,26 +2853,26 @@ func (_self *DbReader) GetWithOptions(key []byte, options ReadOptions) (*[]byte,
 func (_self *DbReader) Scan(varRange KeyRange) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbreader_scan(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2861,26 +2887,26 @@ func (_self *DbReader) Scan(varRange KeyRange) (*DbIterator, error) {
 func (_self *DbReader) ScanPrefix(prefix []byte) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbreader_scan_prefix(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2895,26 +2921,26 @@ func (_self *DbReader) ScanPrefix(prefix []byte) (*DbIterator, error) {
 func (_self *DbReader) ScanPrefixWithOptions(prefix []byte, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbreader_scan_prefix_with_options(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2929,26 +2955,26 @@ func (_self *DbReader) ScanPrefixWithOptions(prefix []byte, options ScanOptions)
 func (_self *DbReader) ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbreader_scan_with_options(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -2963,7 +2989,7 @@ func (_self *DbReader) ScanWithOptions(varRange KeyRange, options ScanOptions) (
 func (_self *DbReader) Shutdown() error {
 	_pointer := _self.ffiObject.incrementPointer("*DbReader")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -2999,15 +3025,15 @@ type FfiConverterDbReader struct{}
 
 var FfiConverterDbReaderINSTANCE = FfiConverterDbReader{}
 
-func (c FfiConverterDbReader) Lift(pointer unsafe.Pointer) *DbReader {
+func (c FfiConverterDbReader) Lift(handle C.uint64_t) *DbReader {
 	result := &DbReader{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_dbreader(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_dbreader(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_dbreader(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_dbreader(handle, status)
 			},
 		),
 	}
@@ -3016,21 +3042,28 @@ func (c FfiConverterDbReader) Lift(pointer unsafe.Pointer) *DbReader {
 }
 
 func (c FfiConverterDbReader) Read(reader io.Reader) *DbReader {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDbReader) Lower(value *DbReader) unsafe.Pointer {
+func (c FfiConverterDbReader) Lower(value *DbReader) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*DbReader")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*DbReader")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDbReader) Write(writer io.Writer, value *DbReader) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDbReader(handle uint64) *DbReader {
+	return FfiConverterDbReaderINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDbReader(value *DbReader) uint64 {
+	return uint64(FfiConverterDbReaderINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDbReader struct{}
@@ -3064,7 +3097,7 @@ type DbReaderBuilder struct {
 
 // Creates a new reader builder for `path` in `object_store`.
 func NewDbReaderBuilder(path string, objectStore *ObjectStore) *DbReaderBuilder {
-	return FfiConverterDbReaderBuilderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterDbReaderBuilderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_dbreaderbuilder_new(FfiConverterStringINSTANCE.Lower(path), FfiConverterObjectStoreINSTANCE.Lower(objectStore), _uniffiStatus)
 	}))
 }
@@ -3073,26 +3106,26 @@ func NewDbReaderBuilder(path string, objectStore *ObjectStore) *DbReaderBuilder 
 func (_self *DbReaderBuilder) Build() (*DbReader, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbReaderBuilder")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbReader {
+		func(ffi C.uint64_t) *DbReader {
 			return FfiConverterDbReaderINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_build(
 			_pointer),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -3107,7 +3140,7 @@ func (_self *DbReaderBuilder) Build() (*DbReader, error) {
 func (_self *DbReaderBuilder) WithCheckpointId(checkpointId string) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbReaderBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_checkpoint_id(
 			_pointer, FfiConverterStringINSTANCE.Lower(checkpointId), _uniffiStatus)
 		return false
@@ -3119,7 +3152,7 @@ func (_self *DbReaderBuilder) WithCheckpointId(checkpointId string) error {
 func (_self *DbReaderBuilder) WithMergeOperator(mergeOperator MergeOperator) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbReaderBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_merge_operator(
 			_pointer, FfiConverterMergeOperatorINSTANCE.Lower(mergeOperator), _uniffiStatus)
 		return false
@@ -3131,7 +3164,7 @@ func (_self *DbReaderBuilder) WithMergeOperator(mergeOperator MergeOperator) err
 func (_self *DbReaderBuilder) WithOptions(options ReaderOptions) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbReaderBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_options(
 			_pointer, FfiConverterReaderOptionsINSTANCE.Lower(options), _uniffiStatus)
 		return false
@@ -3143,7 +3176,7 @@ func (_self *DbReaderBuilder) WithOptions(options ReaderOptions) error {
 func (_self *DbReaderBuilder) WithWalObjectStore(walObjectStore *ObjectStore) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbReaderBuilder")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_wal_object_store(
 			_pointer, FfiConverterObjectStoreINSTANCE.Lower(walObjectStore), _uniffiStatus)
 		return false
@@ -3159,15 +3192,15 @@ type FfiConverterDbReaderBuilder struct{}
 
 var FfiConverterDbReaderBuilderINSTANCE = FfiConverterDbReaderBuilder{}
 
-func (c FfiConverterDbReaderBuilder) Lift(pointer unsafe.Pointer) *DbReaderBuilder {
+func (c FfiConverterDbReaderBuilder) Lift(handle C.uint64_t) *DbReaderBuilder {
 	result := &DbReaderBuilder{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_dbreaderbuilder(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_dbreaderbuilder(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_dbreaderbuilder(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_dbreaderbuilder(handle, status)
 			},
 		),
 	}
@@ -3176,21 +3209,28 @@ func (c FfiConverterDbReaderBuilder) Lift(pointer unsafe.Pointer) *DbReaderBuild
 }
 
 func (c FfiConverterDbReaderBuilder) Read(reader io.Reader) *DbReaderBuilder {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDbReaderBuilder) Lower(value *DbReaderBuilder) unsafe.Pointer {
+func (c FfiConverterDbReaderBuilder) Lower(value *DbReaderBuilder) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*DbReaderBuilder")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*DbReaderBuilder")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDbReaderBuilder) Write(writer io.Writer, value *DbReaderBuilder) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDbReaderBuilder(handle uint64) *DbReaderBuilder {
+	return FfiConverterDbReaderBuilderINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDbReaderBuilder(value *DbReaderBuilder) uint64 {
+	return uint64(FfiConverterDbReaderBuilderINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDbReaderBuilder struct{}
@@ -3228,7 +3268,7 @@ type DbSnapshot struct {
 func (_self *DbSnapshot) Get(key []byte) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3264,7 +3304,7 @@ func (_self *DbSnapshot) Get(key []byte) (*[]byte, error) {
 func (_self *DbSnapshot) GetKeyValue(key []byte) (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3300,7 +3340,7 @@ func (_self *DbSnapshot) GetKeyValue(key []byte) (*KeyValue, error) {
 func (_self *DbSnapshot) GetKeyValueWithOptions(key []byte, options ReadOptions) (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3336,7 +3376,7 @@ func (_self *DbSnapshot) GetKeyValueWithOptions(key []byte, options ReadOptions)
 func (_self *DbSnapshot) GetWithOptions(key []byte, options ReadOptions) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3372,26 +3412,26 @@ func (_self *DbSnapshot) GetWithOptions(key []byte, options ReadOptions) (*[]byt
 func (_self *DbSnapshot) Scan(varRange KeyRange) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -3406,26 +3446,26 @@ func (_self *DbSnapshot) Scan(varRange KeyRange) (*DbIterator, error) {
 func (_self *DbSnapshot) ScanPrefix(prefix []byte) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_prefix(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -3440,26 +3480,26 @@ func (_self *DbSnapshot) ScanPrefix(prefix []byte) (*DbIterator, error) {
 func (_self *DbSnapshot) ScanPrefixWithOptions(prefix []byte, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_prefix_with_options(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -3474,26 +3514,26 @@ func (_self *DbSnapshot) ScanPrefixWithOptions(prefix []byte, options ScanOption
 func (_self *DbSnapshot) ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbSnapshot")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_with_options(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -3512,15 +3552,15 @@ type FfiConverterDbSnapshot struct{}
 
 var FfiConverterDbSnapshotINSTANCE = FfiConverterDbSnapshot{}
 
-func (c FfiConverterDbSnapshot) Lift(pointer unsafe.Pointer) *DbSnapshot {
+func (c FfiConverterDbSnapshot) Lift(handle C.uint64_t) *DbSnapshot {
 	result := &DbSnapshot{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_dbsnapshot(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_dbsnapshot(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_dbsnapshot(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_dbsnapshot(handle, status)
 			},
 		),
 	}
@@ -3529,21 +3569,28 @@ func (c FfiConverterDbSnapshot) Lift(pointer unsafe.Pointer) *DbSnapshot {
 }
 
 func (c FfiConverterDbSnapshot) Read(reader io.Reader) *DbSnapshot {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDbSnapshot) Lower(value *DbSnapshot) unsafe.Pointer {
+func (c FfiConverterDbSnapshot) Lower(value *DbSnapshot) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*DbSnapshot")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*DbSnapshot")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDbSnapshot) Write(writer io.Writer, value *DbSnapshot) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDbSnapshot(handle uint64) *DbSnapshot {
+	return FfiConverterDbSnapshotINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDbSnapshot(value *DbSnapshot) uint64 {
+	return uint64(FfiConverterDbSnapshotINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDbSnapshot struct{}
@@ -3617,7 +3664,7 @@ type DbTransaction struct {
 func (_self *DbTransaction) Commit() (*WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3655,7 +3702,7 @@ func (_self *DbTransaction) Commit() (*WriteHandle, error) {
 func (_self *DbTransaction) CommitWithOptions(options WriteOptions) (*WriteHandle, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3691,7 +3738,7 @@ func (_self *DbTransaction) CommitWithOptions(options WriteOptions) (*WriteHandl
 func (_self *DbTransaction) Delete(key []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -3723,7 +3770,7 @@ func (_self *DbTransaction) Delete(key []byte) error {
 func (_self *DbTransaction) Get(key []byte) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3759,7 +3806,7 @@ func (_self *DbTransaction) Get(key []byte) (*[]byte, error) {
 func (_self *DbTransaction) GetKeyValue(key []byte) (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3795,7 +3842,7 @@ func (_self *DbTransaction) GetKeyValue(key []byte) (*KeyValue, error) {
 func (_self *DbTransaction) GetKeyValueWithOptions(key []byte, options ReadOptions) (*KeyValue, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3831,7 +3878,7 @@ func (_self *DbTransaction) GetKeyValueWithOptions(key []byte, options ReadOptio
 func (_self *DbTransaction) GetWithOptions(key []byte, options ReadOptions) (*[]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -3879,7 +3926,7 @@ func (_self *DbTransaction) Id() string {
 func (_self *DbTransaction) MarkRead(keys [][]byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -3911,7 +3958,7 @@ func (_self *DbTransaction) MarkRead(keys [][]byte) error {
 func (_self *DbTransaction) Merge(key []byte, operand []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -3943,7 +3990,7 @@ func (_self *DbTransaction) Merge(key []byte, operand []byte) error {
 func (_self *DbTransaction) MergeWithOptions(key []byte, operand []byte, options MergeOptions) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -3975,7 +4022,7 @@ func (_self *DbTransaction) MergeWithOptions(key []byte, operand []byte, options
 func (_self *DbTransaction) Put(key []byte, value []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -4007,7 +4054,7 @@ func (_self *DbTransaction) Put(key []byte, value []byte) error {
 func (_self *DbTransaction) PutWithOptions(key []byte, value []byte, options PutOptions) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -4039,7 +4086,7 @@ func (_self *DbTransaction) PutWithOptions(key []byte, value []byte, options Put
 func (_self *DbTransaction) Rollback() error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -4071,26 +4118,26 @@ func (_self *DbTransaction) Rollback() error {
 func (_self *DbTransaction) Scan(varRange KeyRange) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbtransaction_scan(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -4105,26 +4152,26 @@ func (_self *DbTransaction) Scan(varRange KeyRange) (*DbIterator, error) {
 func (_self *DbTransaction) ScanPrefix(prefix []byte) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_prefix(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -4139,26 +4186,26 @@ func (_self *DbTransaction) ScanPrefix(prefix []byte) (*DbIterator, error) {
 func (_self *DbTransaction) ScanPrefixWithOptions(prefix []byte, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_prefix_with_options(
 			_pointer, FfiConverterBytesINSTANCE.Lower(prefix), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -4173,26 +4220,26 @@ func (_self *DbTransaction) ScanPrefixWithOptions(prefix []byte, options ScanOpt
 func (_self *DbTransaction) ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *DbIterator {
+		func(ffi C.uint64_t) *DbIterator {
 			return FfiConverterDbIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_with_options(
 			_pointer, FfiConverterKeyRangeINSTANCE.Lower(varRange), FfiConverterScanOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -4217,7 +4264,7 @@ func (_self *DbTransaction) Seqnum() uint64 {
 func (_self *DbTransaction) UnmarkWrite(keys [][]byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*DbTransaction")
 	defer _self.ffiObject.decrementPointer()
-	_, err := uniffiRustCallAsync[Error](
+	_, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
@@ -4253,15 +4300,15 @@ type FfiConverterDbTransaction struct{}
 
 var FfiConverterDbTransactionINSTANCE = FfiConverterDbTransaction{}
 
-func (c FfiConverterDbTransaction) Lift(pointer unsafe.Pointer) *DbTransaction {
+func (c FfiConverterDbTransaction) Lift(handle C.uint64_t) *DbTransaction {
 	result := &DbTransaction{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_dbtransaction(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_dbtransaction(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_dbtransaction(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_dbtransaction(handle, status)
 			},
 		),
 	}
@@ -4270,21 +4317,28 @@ func (c FfiConverterDbTransaction) Lift(pointer unsafe.Pointer) *DbTransaction {
 }
 
 func (c FfiConverterDbTransaction) Read(reader io.Reader) *DbTransaction {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterDbTransaction) Lower(value *DbTransaction) unsafe.Pointer {
+func (c FfiConverterDbTransaction) Lower(value *DbTransaction) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*DbTransaction")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*DbTransaction")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterDbTransaction) Write(writer io.Writer, value *DbTransaction) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalDbTransaction(handle uint64) *DbTransaction {
+	return FfiConverterDbTransactionINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalDbTransaction(value *DbTransaction) uint64 {
+	return uint64(FfiConverterDbTransactionINSTANCE.Lower(value))
 }
 
 type FfiDestroyerDbTransaction struct{}
@@ -4327,37 +4381,62 @@ var FfiConverterLogCallbackINSTANCE = FfiConverterLogCallback{
 	handleMap: newConcurrentHandleMap[LogCallback](),
 }
 
-func (c FfiConverterLogCallback) Lift(pointer unsafe.Pointer) LogCallback {
-	result := &LogCallbackImpl{
-		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_logcallback(pointer, status)
-			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_logcallback(pointer, status)
-			},
-		),
+func (c FfiConverterLogCallback) Lift(handle C.uint64_t) LogCallback {
+	if uint64(handle)&1 == 0 {
+		// Rust-generated handle (even), construct a new object wrapping the handle
+		result := &LogCallbackImpl{
+			newFfiObject(
+				handle,
+				func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+					return C.uniffi_slatedb_uniffi_fn_clone_logcallback(handle, status)
+				},
+				func(handle C.uint64_t, status *C.RustCallStatus) {
+					C.uniffi_slatedb_uniffi_fn_free_logcallback(handle, status)
+				},
+			),
+		}
+		runtime.SetFinalizer(result, (*LogCallbackImpl).Destroy)
+		return result
+	} else {
+		// Go-generated handle (odd), retrieve from the handle map
+		val, ok := c.handleMap.tryGet(uint64(handle))
+		if !ok {
+			panic(fmt.Errorf("no callback in handle map: %d", handle))
+		}
+		c.handleMap.remove(uint64(handle))
+		return val
 	}
-	runtime.SetFinalizer(result, (*LogCallbackImpl).Destroy)
-	return result
 }
 
 func (c FfiConverterLogCallback) Read(reader io.Reader) LogCallback {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterLogCallback) Lower(value LogCallback) unsafe.Pointer {
+func (c FfiConverterLogCallback) Lower(value LogCallback) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := unsafe.Pointer(uintptr(c.handleMap.insert(value)))
-	return pointer
-
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	if val, ok := value.(*LogCallbackImpl); ok {
+		// Rust-backed object, clone the handle
+		handle := val.ffiObject.incrementPointer("LogCallback")
+		defer val.ffiObject.decrementPointer()
+		return handle
+	} else {
+		// Go-backed object, insert into handle map
+		return C.uint64_t(c.handleMap.insert(value))
+	}
 }
 
 func (c FfiConverterLogCallback) Write(writer io.Writer, value LogCallback) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalLogCallback(handle uint64) LogCallback {
+	return FfiConverterLogCallbackINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalLogCallback(value LogCallback) uint64 {
+	return uint64(FfiConverterLogCallbackINSTANCE.Lower(value))
 }
 
 type FfiDestroyerLogCallback struct{}
@@ -4365,8 +4444,6 @@ type FfiDestroyerLogCallback struct{}
 func (_ FfiDestroyerLogCallback) Destroy(value LogCallback) {
 	if val, ok := value.(*LogCallbackImpl); ok {
 		val.Destroy()
-	} else {
-		panic("Expected *LogCallbackImpl")
 	}
 }
 
@@ -4388,7 +4465,8 @@ type concurrentHandleMap[T any] struct {
 
 func newConcurrentHandleMap[T any]() *concurrentHandleMap[T] {
 	return &concurrentHandleMap[T]{
-		handles: map[uint64]T{},
+		handles:       map[uint64]T{},
+		currentHandle: 1,
 	}
 }
 
@@ -4396,9 +4474,10 @@ func (cm *concurrentHandleMap[T]) insert(obj T) uint64 {
 	cm.lock.Lock()
 	defer cm.lock.Unlock()
 
-	cm.currentHandle = cm.currentHandle + 1
-	cm.handles[cm.currentHandle] = obj
-	return cm.currentHandle
+	handle := cm.currentHandle
+	cm.currentHandle = cm.currentHandle + 2
+	cm.handles[handle] = obj
+	return handle
 }
 
 func (cm *concurrentHandleMap[T]) remove(handle uint64) {
@@ -4416,8 +4495,8 @@ func (cm *concurrentHandleMap[T]) tryGet(handle uint64) (T, bool) {
 	return val, ok
 }
 
-//export slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackMethod0
-func slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackMethod0(uniffiHandle C.uint64_t, record C.RustBuffer, uniffiOutReturn *C.void, callStatus *C.RustCallStatus) {
+//export slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackMethod0
+func slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackMethod0(uniffiHandle C.uint64_t, record C.RustBuffer, uniffiOutReturn *C.void, callStatus *C.RustCallStatus) {
 	handle := uint64(uniffiHandle)
 	uniffiObj, ok := FfiConverterLogCallbackINSTANCE.handleMap.tryGet(handle)
 	if !ok {
@@ -4433,14 +4512,23 @@ func slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackMethod0(uniffiHandle
 }
 
 var UniffiVTableCallbackInterfaceLogCallbackINSTANCE = C.UniffiVTableCallbackInterfaceLogCallback{
-	log: (C.UniffiCallbackInterfaceLogCallbackMethod0)(C.slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackMethod0),
-
-	uniffiFree: (C.UniffiCallbackInterfaceFree)(C.slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackFree),
+	uniffiFree:  (C.UniffiCallbackInterfaceFree)(C.slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackFree),
+	uniffiClone: (C.UniffiCallbackInterfaceClone)(C.slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackClone),
+	log:         (C.UniffiCallbackInterfaceLogCallbackMethod0)(C.slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackMethod0),
 }
 
-//export slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackFree
-func slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackFree(handle C.uint64_t) {
+//export slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackFree
+func slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackFree(handle C.uint64_t) {
 	FfiConverterLogCallbackINSTANCE.handleMap.remove(uint64(handle))
+}
+
+//export slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackClone
+func slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackClone(handle C.uint64_t) C.uint64_t {
+	val, ok := FfiConverterLogCallbackINSTANCE.handleMap.tryGet(uint64(handle))
+	if !ok {
+		panic(fmt.Errorf("no callback in handle map: %d", handle))
+	}
+	return C.uint64_t(FfiConverterLogCallbackINSTANCE.handleMap.insert(val))
 }
 
 func (c FfiConverterLogCallback) register() {
@@ -4466,7 +4554,7 @@ type MergeOperatorImpl struct {
 func (_self *MergeOperatorImpl) Merge(key []byte, existingValue *[]byte, operand []byte) ([]byte, error) {
 	_pointer := _self.ffiObject.incrementPointer("MergeOperator")
 	defer _self.ffiObject.decrementPointer()
-	_uniffiRV, _uniffiErr := rustCallWithError[MergeOperatorCallbackError](FfiConverterMergeOperatorCallbackError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+	_uniffiRV, _uniffiErr := rustCallWithError[*MergeOperatorCallbackError](FfiConverterMergeOperatorCallbackError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer{
 			inner: C.uniffi_slatedb_uniffi_fn_method_mergeoperator_merge(
 				_pointer, FfiConverterBytesINSTANCE.Lower(key), FfiConverterOptionalBytesINSTANCE.Lower(existingValue), FfiConverterBytesINSTANCE.Lower(operand), _uniffiStatus),
@@ -4492,37 +4580,62 @@ var FfiConverterMergeOperatorINSTANCE = FfiConverterMergeOperator{
 	handleMap: newConcurrentHandleMap[MergeOperator](),
 }
 
-func (c FfiConverterMergeOperator) Lift(pointer unsafe.Pointer) MergeOperator {
-	result := &MergeOperatorImpl{
-		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_mergeoperator(pointer, status)
-			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_mergeoperator(pointer, status)
-			},
-		),
+func (c FfiConverterMergeOperator) Lift(handle C.uint64_t) MergeOperator {
+	if uint64(handle)&1 == 0 {
+		// Rust-generated handle (even), construct a new object wrapping the handle
+		result := &MergeOperatorImpl{
+			newFfiObject(
+				handle,
+				func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+					return C.uniffi_slatedb_uniffi_fn_clone_mergeoperator(handle, status)
+				},
+				func(handle C.uint64_t, status *C.RustCallStatus) {
+					C.uniffi_slatedb_uniffi_fn_free_mergeoperator(handle, status)
+				},
+			),
+		}
+		runtime.SetFinalizer(result, (*MergeOperatorImpl).Destroy)
+		return result
+	} else {
+		// Go-generated handle (odd), retrieve from the handle map
+		val, ok := c.handleMap.tryGet(uint64(handle))
+		if !ok {
+			panic(fmt.Errorf("no callback in handle map: %d", handle))
+		}
+		c.handleMap.remove(uint64(handle))
+		return val
 	}
-	runtime.SetFinalizer(result, (*MergeOperatorImpl).Destroy)
-	return result
 }
 
 func (c FfiConverterMergeOperator) Read(reader io.Reader) MergeOperator {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterMergeOperator) Lower(value MergeOperator) unsafe.Pointer {
+func (c FfiConverterMergeOperator) Lower(value MergeOperator) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := unsafe.Pointer(uintptr(c.handleMap.insert(value)))
-	return pointer
-
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	if val, ok := value.(*MergeOperatorImpl); ok {
+		// Rust-backed object, clone the handle
+		handle := val.ffiObject.incrementPointer("MergeOperator")
+		defer val.ffiObject.decrementPointer()
+		return handle
+	} else {
+		// Go-backed object, insert into handle map
+		return C.uint64_t(c.handleMap.insert(value))
+	}
 }
 
 func (c FfiConverterMergeOperator) Write(writer io.Writer, value MergeOperator) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalMergeOperator(handle uint64) MergeOperator {
+	return FfiConverterMergeOperatorINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalMergeOperator(value MergeOperator) uint64 {
+	return uint64(FfiConverterMergeOperatorINSTANCE.Lower(value))
 }
 
 type FfiDestroyerMergeOperator struct{}
@@ -4530,13 +4643,11 @@ type FfiDestroyerMergeOperator struct{}
 func (_ FfiDestroyerMergeOperator) Destroy(value MergeOperator) {
 	if val, ok := value.(*MergeOperatorImpl); ok {
 		val.Destroy()
-	} else {
-		panic("Expected *MergeOperatorImpl")
 	}
 }
 
-//export slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorMethod0
-func slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorMethod0(uniffiHandle C.uint64_t, key C.RustBuffer, existingValue C.RustBuffer, operand C.RustBuffer, uniffiOutReturn *C.RustBuffer, callStatus *C.RustCallStatus) {
+//export slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorMethod0
+func slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorMethod0(uniffiHandle C.uint64_t, key C.RustBuffer, existingValue C.RustBuffer, operand C.RustBuffer, uniffiOutReturn *C.RustBuffer, callStatus *C.RustCallStatus) {
 	handle := uint64(uniffiHandle)
 	uniffiObj, ok := FfiConverterMergeOperatorINSTANCE.handleMap.tryGet(handle)
 	if !ok {
@@ -4575,14 +4686,23 @@ func slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorMethod0(uniffiHand
 }
 
 var UniffiVTableCallbackInterfaceMergeOperatorINSTANCE = C.UniffiVTableCallbackInterfaceMergeOperator{
-	merge: (C.UniffiCallbackInterfaceMergeOperatorMethod0)(C.slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorMethod0),
-
-	uniffiFree: (C.UniffiCallbackInterfaceFree)(C.slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorFree),
+	uniffiFree:  (C.UniffiCallbackInterfaceFree)(C.slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorFree),
+	uniffiClone: (C.UniffiCallbackInterfaceClone)(C.slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorClone),
+	merge:       (C.UniffiCallbackInterfaceMergeOperatorMethod0)(C.slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorMethod0),
 }
 
-//export slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorFree
-func slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorFree(handle C.uint64_t) {
+//export slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorFree
+func slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorFree(handle C.uint64_t) {
 	FfiConverterMergeOperatorINSTANCE.handleMap.remove(uint64(handle))
+}
+
+//export slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorClone
+func slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorClone(handle C.uint64_t) C.uint64_t {
+	val, ok := FfiConverterMergeOperatorINSTANCE.handleMap.tryGet(uint64(handle))
+	if !ok {
+		panic(fmt.Errorf("no callback in handle map: %d", handle))
+	}
+	return C.uint64_t(FfiConverterMergeOperatorINSTANCE.handleMap.insert(val))
 }
 
 func (c FfiConverterMergeOperator) register() {
@@ -4603,7 +4723,7 @@ type ObjectStore struct {
 // When `env_file` is provided, environment variables are loaded from that
 // file before constructing the store.
 func ObjectStoreFromEnv(envFile *string) (*ObjectStore, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_objectstore_from_env(FfiConverterOptionalStringINSTANCE.Lower(envFile), _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4616,7 +4736,7 @@ func ObjectStoreFromEnv(envFile *string) (*ObjectStore, error) {
 
 // Resolves an object store from a URL understood by SlateDB.
 func ObjectStoreResolve(url string) (*ObjectStore, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_objectstore_resolve(FfiConverterStringINSTANCE.Lower(url), _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4636,15 +4756,15 @@ type FfiConverterObjectStore struct{}
 
 var FfiConverterObjectStoreINSTANCE = FfiConverterObjectStore{}
 
-func (c FfiConverterObjectStore) Lift(pointer unsafe.Pointer) *ObjectStore {
+func (c FfiConverterObjectStore) Lift(handle C.uint64_t) *ObjectStore {
 	result := &ObjectStore{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_objectstore(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_objectstore(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_objectstore(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_objectstore(handle, status)
 			},
 		),
 	}
@@ -4653,21 +4773,28 @@ func (c FfiConverterObjectStore) Lift(pointer unsafe.Pointer) *ObjectStore {
 }
 
 func (c FfiConverterObjectStore) Read(reader io.Reader) *ObjectStore {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterObjectStore) Lower(value *ObjectStore) unsafe.Pointer {
+func (c FfiConverterObjectStore) Lower(value *ObjectStore) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*ObjectStore")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*ObjectStore")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterObjectStore) Write(writer io.Writer, value *ObjectStore) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalObjectStore(handle uint64) *ObjectStore {
+	return FfiConverterObjectStoreINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalObjectStore(value *ObjectStore) uint64 {
+	return uint64(FfiConverterObjectStoreINSTANCE.Lower(value))
 }
 
 type FfiDestroyerObjectStore struct{}
@@ -4713,14 +4840,14 @@ type Settings struct {
 
 // Creates a settings object populated with SlateDB defaults.
 func SettingsDefault() *Settings {
-	return FfiConverterSettingsINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterSettingsINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_settings_default(_uniffiStatus)
 	}))
 }
 
 // Loads settings from environment variables using `prefix`.
 func SettingsFromEnv(prefix string) (*Settings, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_settings_from_env(FfiConverterStringINSTANCE.Lower(prefix), _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4733,7 +4860,7 @@ func SettingsFromEnv(prefix string) (*Settings, error) {
 
 // Loads settings from environment variables, falling back to `default_settings`.
 func SettingsFromEnvWithDefault(prefix string, defaultSettings *Settings) (*Settings, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_settings_from_env_with_default(FfiConverterStringINSTANCE.Lower(prefix), FfiConverterSettingsINSTANCE.Lower(defaultSettings), _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4746,7 +4873,7 @@ func SettingsFromEnvWithDefault(prefix string, defaultSettings *Settings) (*Sett
 
 // Loads settings from a JSON, TOML, or YAML file based on its extension.
 func SettingsFromFile(path string) (*Settings, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_settings_from_file(FfiConverterStringINSTANCE.Lower(path), _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4759,7 +4886,7 @@ func SettingsFromFile(path string) (*Settings, error) {
 
 // Parses settings from a JSON string.
 func SettingsFromJsonString(json string) (*Settings, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_settings_from_json_string(FfiConverterStringINSTANCE.Lower(json), _uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4772,7 +4899,7 @@ func SettingsFromJsonString(json string) (*Settings, error) {
 
 // Loads settings from SlateDB's default file and environment lookup order.
 func SettingsLoad() (*Settings, error) {
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_settings_load(_uniffiStatus)
 	})
 	if _uniffiErr != nil {
@@ -4809,7 +4936,7 @@ func SettingsLoad() (*Settings, error) {
 func (_self *Settings) Set(key string, valueJson string) error {
 	_pointer := _self.ffiObject.incrementPointer("*Settings")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_settings_set(
 			_pointer, FfiConverterStringINSTANCE.Lower(key), FfiConverterStringINSTANCE.Lower(valueJson), _uniffiStatus)
 		return false
@@ -4821,7 +4948,7 @@ func (_self *Settings) Set(key string, valueJson string) error {
 func (_self *Settings) ToJsonString() (string, error) {
 	_pointer := _self.ffiObject.incrementPointer("*Settings")
 	defer _self.ffiObject.decrementPointer()
-	_uniffiRV, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+	_uniffiRV, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer{
 			inner: C.uniffi_slatedb_uniffi_fn_method_settings_to_json_string(
 				_pointer, _uniffiStatus),
@@ -4843,15 +4970,15 @@ type FfiConverterSettings struct{}
 
 var FfiConverterSettingsINSTANCE = FfiConverterSettings{}
 
-func (c FfiConverterSettings) Lift(pointer unsafe.Pointer) *Settings {
+func (c FfiConverterSettings) Lift(handle C.uint64_t) *Settings {
 	result := &Settings{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_settings(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_settings(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_settings(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_settings(handle, status)
 			},
 		),
 	}
@@ -4860,21 +4987,28 @@ func (c FfiConverterSettings) Lift(pointer unsafe.Pointer) *Settings {
 }
 
 func (c FfiConverterSettings) Read(reader io.Reader) *Settings {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterSettings) Lower(value *Settings) unsafe.Pointer {
+func (c FfiConverterSettings) Lower(value *Settings) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*Settings")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*Settings")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterSettings) Write(writer io.Writer, value *Settings) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalSettings(handle uint64) *Settings {
+	return FfiConverterSettingsINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalSettings(value *Settings) uint64 {
+	return uint64(FfiConverterSettingsINSTANCE.Lower(value))
 }
 
 type FfiDestroyerSettings struct{}
@@ -4916,26 +5050,26 @@ func (_self *WalFile) Id() uint64 {
 func (_self *WalFile) Iterator() (*WalFileIterator, error) {
 	_pointer := _self.ffiObject.incrementPointer("*WalFile")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
-		func(handle C.uint64_t, status *C.RustCallStatus) unsafe.Pointer {
-			res := C.ffi_slatedb_uniffi_rust_future_complete_pointer(handle, status)
+		func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_u64(handle, status)
 			return res
 		},
 		// liftFn
-		func(ffi unsafe.Pointer) *WalFileIterator {
+		func(ffi C.uint64_t) *WalFileIterator {
 			return FfiConverterWalFileIteratorINSTANCE.Lift(ffi)
 		},
 		C.uniffi_slatedb_uniffi_fn_method_walfile_iterator(
 			_pointer),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_poll_pointer(handle, continuation, data)
+			C.ffi_slatedb_uniffi_rust_future_poll_u64(handle, continuation, data)
 		},
 		// freeFn
 		func(handle C.uint64_t) {
-			C.ffi_slatedb_uniffi_rust_future_free_pointer(handle)
+			C.ffi_slatedb_uniffi_rust_future_free_u64(handle)
 		},
 	)
 
@@ -4950,7 +5084,7 @@ func (_self *WalFile) Iterator() (*WalFileIterator, error) {
 func (_self *WalFile) Metadata() (WalFileMetadata, error) {
 	_pointer := _self.ffiObject.incrementPointer("*WalFile")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -4986,7 +5120,7 @@ func (_self *WalFile) Metadata() (WalFileMetadata, error) {
 func (_self *WalFile) NextFile() *WalFile {
 	_pointer := _self.ffiObject.incrementPointer("*WalFile")
 	defer _self.ffiObject.decrementPointer()
-	return FfiConverterWalFileINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterWalFileINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_walfile_next_file(
 			_pointer, _uniffiStatus)
 	}))
@@ -5010,15 +5144,15 @@ type FfiConverterWalFile struct{}
 
 var FfiConverterWalFileINSTANCE = FfiConverterWalFile{}
 
-func (c FfiConverterWalFile) Lift(pointer unsafe.Pointer) *WalFile {
+func (c FfiConverterWalFile) Lift(handle C.uint64_t) *WalFile {
 	result := &WalFile{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_walfile(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_walfile(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_walfile(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_walfile(handle, status)
 			},
 		),
 	}
@@ -5027,21 +5161,28 @@ func (c FfiConverterWalFile) Lift(pointer unsafe.Pointer) *WalFile {
 }
 
 func (c FfiConverterWalFile) Read(reader io.Reader) *WalFile {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterWalFile) Lower(value *WalFile) unsafe.Pointer {
+func (c FfiConverterWalFile) Lower(value *WalFile) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*WalFile")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*WalFile")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterWalFile) Write(writer io.Writer, value *WalFile) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalWalFile(handle uint64) *WalFile {
+	return FfiConverterWalFileINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalWalFile(value *WalFile) uint64 {
+	return uint64(FfiConverterWalFileINSTANCE.Lower(value))
 }
 
 type FfiDestroyerWalFile struct{}
@@ -5065,7 +5206,7 @@ type WalFileIterator struct {
 func (_self *WalFileIterator) Next() (*RowEntry, error) {
 	_pointer := _self.ffiObject.incrementPointer("*WalFileIterator")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -5105,15 +5246,15 @@ type FfiConverterWalFileIterator struct{}
 
 var FfiConverterWalFileIteratorINSTANCE = FfiConverterWalFileIterator{}
 
-func (c FfiConverterWalFileIterator) Lift(pointer unsafe.Pointer) *WalFileIterator {
+func (c FfiConverterWalFileIterator) Lift(handle C.uint64_t) *WalFileIterator {
 	result := &WalFileIterator{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_walfileiterator(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_walfileiterator(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_walfileiterator(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_walfileiterator(handle, status)
 			},
 		),
 	}
@@ -5122,21 +5263,28 @@ func (c FfiConverterWalFileIterator) Lift(pointer unsafe.Pointer) *WalFileIterat
 }
 
 func (c FfiConverterWalFileIterator) Read(reader io.Reader) *WalFileIterator {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterWalFileIterator) Lower(value *WalFileIterator) unsafe.Pointer {
+func (c FfiConverterWalFileIterator) Lower(value *WalFileIterator) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*WalFileIterator")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*WalFileIterator")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterWalFileIterator) Write(writer io.Writer, value *WalFileIterator) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalWalFileIterator(handle uint64) *WalFileIterator {
+	return FfiConverterWalFileIteratorINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalWalFileIterator(value *WalFileIterator) uint64 {
+	return uint64(FfiConverterWalFileIteratorINSTANCE.Lower(value))
 }
 
 type FfiDestroyerWalFileIterator struct{}
@@ -5162,7 +5310,7 @@ type WalReader struct {
 
 // Creates a WAL reader for `path` in `object_store`.
 func NewWalReader(path string, objectStore *ObjectStore) *WalReader {
-	return FfiConverterWalReaderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterWalReaderINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_walreader_new(FfiConverterStringINSTANCE.Lower(path), FfiConverterObjectStoreINSTANCE.Lower(objectStore), _uniffiStatus)
 	}))
 }
@@ -5171,7 +5319,7 @@ func NewWalReader(path string, objectStore *ObjectStore) *WalReader {
 func (_self *WalReader) Get(id uint64) *WalFile {
 	_pointer := _self.ffiObject.incrementPointer("*WalReader")
 	defer _self.ffiObject.decrementPointer()
-	return FfiConverterWalFileINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterWalFileINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_walreader_get(
 			_pointer, FfiConverterUint64INSTANCE.Lower(id), _uniffiStatus)
 	}))
@@ -5183,7 +5331,7 @@ func (_self *WalReader) Get(id uint64) *WalFile {
 func (_self *WalReader) List(startId *uint64, endId *uint64) ([]*WalFile, error) {
 	_pointer := _self.ffiObject.incrementPointer("*WalReader")
 	defer _self.ffiObject.decrementPointer()
-	res, err := uniffiRustCallAsync[Error](
+	res, err := uniffiRustCallAsync[*Error](
 		FfiConverterErrorINSTANCE,
 		// completeFn
 		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
@@ -5223,15 +5371,15 @@ type FfiConverterWalReader struct{}
 
 var FfiConverterWalReaderINSTANCE = FfiConverterWalReader{}
 
-func (c FfiConverterWalReader) Lift(pointer unsafe.Pointer) *WalReader {
+func (c FfiConverterWalReader) Lift(handle C.uint64_t) *WalReader {
 	result := &WalReader{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_walreader(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_walreader(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_walreader(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_walreader(handle, status)
 			},
 		),
 	}
@@ -5240,21 +5388,28 @@ func (c FfiConverterWalReader) Lift(pointer unsafe.Pointer) *WalReader {
 }
 
 func (c FfiConverterWalReader) Read(reader io.Reader) *WalReader {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterWalReader) Lower(value *WalReader) unsafe.Pointer {
+func (c FfiConverterWalReader) Lower(value *WalReader) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*WalReader")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*WalReader")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterWalReader) Write(writer io.Writer, value *WalReader) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalWalReader(handle uint64) *WalReader {
+	return FfiConverterWalReaderINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalWalReader(value *WalReader) uint64 {
+	return uint64(FfiConverterWalReaderINSTANCE.Lower(value))
 }
 
 type FfiDestroyerWalReader struct{}
@@ -5288,7 +5443,7 @@ type WriteBatch struct {
 
 // Creates an empty write batch.
 func NewWriteBatch() *WriteBatch {
-	return FfiConverterWriteBatchINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) unsafe.Pointer {
+	return FfiConverterWriteBatchINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_constructor_writebatch_new(_uniffiStatus)
 	}))
 }
@@ -5297,7 +5452,7 @@ func NewWriteBatch() *WriteBatch {
 func (_self *WriteBatch) Delete(key []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*WriteBatch")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_writebatch_delete(
 			_pointer, FfiConverterBytesINSTANCE.Lower(key), _uniffiStatus)
 		return false
@@ -5309,7 +5464,7 @@ func (_self *WriteBatch) Delete(key []byte) error {
 func (_self *WriteBatch) Merge(key []byte, operand []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*WriteBatch")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_writebatch_merge(
 			_pointer, FfiConverterBytesINSTANCE.Lower(key), FfiConverterBytesINSTANCE.Lower(operand), _uniffiStatus)
 		return false
@@ -5321,7 +5476,7 @@ func (_self *WriteBatch) Merge(key []byte, operand []byte) error {
 func (_self *WriteBatch) MergeWithOptions(key []byte, operand []byte, options MergeOptions) error {
 	_pointer := _self.ffiObject.incrementPointer("*WriteBatch")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_writebatch_merge_with_options(
 			_pointer, FfiConverterBytesINSTANCE.Lower(key), FfiConverterBytesINSTANCE.Lower(operand), FfiConverterMergeOptionsINSTANCE.Lower(options), _uniffiStatus)
 		return false
@@ -5333,7 +5488,7 @@ func (_self *WriteBatch) MergeWithOptions(key []byte, operand []byte, options Me
 func (_self *WriteBatch) Put(key []byte, value []byte) error {
 	_pointer := _self.ffiObject.incrementPointer("*WriteBatch")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_writebatch_put(
 			_pointer, FfiConverterBytesINSTANCE.Lower(key), FfiConverterBytesINSTANCE.Lower(value), _uniffiStatus)
 		return false
@@ -5345,7 +5500,7 @@ func (_self *WriteBatch) Put(key []byte, value []byte) error {
 func (_self *WriteBatch) PutWithOptions(key []byte, value []byte, options PutOptions) error {
 	_pointer := _self.ffiObject.incrementPointer("*WriteBatch")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_method_writebatch_put_with_options(
 			_pointer, FfiConverterBytesINSTANCE.Lower(key), FfiConverterBytesINSTANCE.Lower(value), FfiConverterPutOptionsINSTANCE.Lower(options), _uniffiStatus)
 		return false
@@ -5361,15 +5516,15 @@ type FfiConverterWriteBatch struct{}
 
 var FfiConverterWriteBatchINSTANCE = FfiConverterWriteBatch{}
 
-func (c FfiConverterWriteBatch) Lift(pointer unsafe.Pointer) *WriteBatch {
+func (c FfiConverterWriteBatch) Lift(handle C.uint64_t) *WriteBatch {
 	result := &WriteBatch{
 		newFfiObject(
-			pointer,
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) unsafe.Pointer {
-				return C.uniffi_slatedb_uniffi_fn_clone_writebatch(pointer, status)
+			handle,
+			func(handle C.uint64_t, status *C.RustCallStatus) C.uint64_t {
+				return C.uniffi_slatedb_uniffi_fn_clone_writebatch(handle, status)
 			},
-			func(pointer unsafe.Pointer, status *C.RustCallStatus) {
-				C.uniffi_slatedb_uniffi_fn_free_writebatch(pointer, status)
+			func(handle C.uint64_t, status *C.RustCallStatus) {
+				C.uniffi_slatedb_uniffi_fn_free_writebatch(handle, status)
 			},
 		),
 	}
@@ -5378,21 +5533,28 @@ func (c FfiConverterWriteBatch) Lift(pointer unsafe.Pointer) *WriteBatch {
 }
 
 func (c FfiConverterWriteBatch) Read(reader io.Reader) *WriteBatch {
-	return c.Lift(unsafe.Pointer(uintptr(readUint64(reader))))
+	return c.Lift(C.uint64_t(readUint64(reader)))
 }
 
-func (c FfiConverterWriteBatch) Lower(value *WriteBatch) unsafe.Pointer {
+func (c FfiConverterWriteBatch) Lower(value *WriteBatch) C.uint64_t {
 	// TODO: this is bad - all synchronization from ObjectRuntime.go is discarded here,
-	// because the pointer will be decremented immediately after this function returns,
-	// and someone will be left holding onto a non-locked pointer.
-	pointer := value.ffiObject.incrementPointer("*WriteBatch")
+	// because the handle will be decremented immediately after this function returns,
+	// and someone will be left holding onto a non-locked handle.
+	handle := value.ffiObject.incrementPointer("*WriteBatch")
 	defer value.ffiObject.decrementPointer()
-	return pointer
-
+	return handle
 }
 
 func (c FfiConverterWriteBatch) Write(writer io.Writer, value *WriteBatch) {
-	writeUint64(writer, uint64(uintptr(c.Lower(value))))
+	writeUint64(writer, uint64(c.Lower(value)))
+}
+
+func LiftFromExternalWriteBatch(handle uint64) *WriteBatch {
+	return FfiConverterWriteBatchINSTANCE.Lift(C.uint64_t(handle))
+}
+
+func LowerToExternalWriteBatch(value *WriteBatch) uint64 {
+	return uint64(FfiConverterWriteBatchINSTANCE.Lower(value))
 }
 
 type FfiDestroyerWriteBatch struct{}
@@ -7397,13 +7559,13 @@ func slatedb_uniffiFutureContinuationCallback(data C.uint64_t, pollResult C.int8
 }
 
 func uniffiRustCallAsync[E any, T any, F any](
-	errConverter BufReader[*E],
+	errConverter BufReader[E],
 	completeFunc rustFutureCompleteFunc[F],
 	liftFunc func(F) T,
 	rustFuture C.uint64_t,
 	pollFunc rustFuturePollFunc,
 	freeFunc rustFutureFreeFunc,
-) (T, *E) {
+) (T, E) {
 	defer freeFunc(rustFuture)
 
 	pollResult := int8(-1)
@@ -7422,16 +7584,13 @@ func uniffiRustCallAsync[E any, T any, F any](
 	}
 
 	var goValue T
-	var ffiValue F
-	var err *E
-
-	ffiValue, err = rustCallWithError(errConverter, func(status *C.RustCallStatus) F {
+	ffiValue, err := rustCallWithError(errConverter, func(status *C.RustCallStatus) F {
 		return completeFunc(rustFuture, status)
 	})
-	if err != nil {
+	if value := reflect.ValueOf(err); value.IsValid() && !value.IsZero() {
 		return goValue, err
 	}
-	return liftFunc(ffiValue), nil
+	return liftFunc(ffiValue), err
 }
 
 //export slatedb_uniffiFreeGorutine
@@ -7448,7 +7607,7 @@ func slatedb_uniffiFreeGorutine(data C.uint64_t) {
 // If `callback` is provided, log records are forwarded to it. Otherwise logs
 // are written to standard error using the default tracing formatter.
 func InitLogging(level LogLevel, callback *LogCallback) error {
-	_, _uniffiErr := rustCallWithError[Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
+	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
 		C.uniffi_slatedb_uniffi_fn_func_init_logging(FfiConverterLogLevelINSTANCE.Lower(level), FfiConverterOptionalLogCallbackINSTANCE.Lower(callback), _uniffiStatus)
 		return false
 	})

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -57,14 +57,14 @@ static void call_UniffiRustFutureContinuationCallback(
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_FREE
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_FREE
-typedef void (*UniffiForeignFutureFree)(uint64_t handle);
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK
+typedef void (*UniffiForeignFutureDroppedCallback)(uint64_t handle);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
-static void call_UniffiForeignFutureFree(
-				UniffiForeignFutureFree cb, uint64_t handle)
+static void call_UniffiForeignFutureDroppedCallback(
+				UniffiForeignFutureDroppedCallback cb, uint64_t handle)
 {
 	return cb(handle);
 }
@@ -85,293 +85,285 @@ static void call_UniffiCallbackInterfaceFree(
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE
-typedef struct UniffiForeignFuture {
-    uint64_t handle;
-    UniffiForeignFutureFree free;
-} UniffiForeignFuture;
+#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_CLONE
+#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_CLONE
+typedef uint64_t (*UniffiCallbackInterfaceClone)(uint64_t handle);
+
+// Making function static works arround:
+// https://github.com/golang/go/issues/11263
+static uint64_t call_UniffiCallbackInterfaceClone(
+				UniffiCallbackInterfaceClone cb, uint64_t handle)
+{
+	return cb(handle);
+}
+
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U8
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U8
-typedef struct UniffiForeignFutureStructU8 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK_STRUCT
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_DROPPED_CALLBACK_STRUCT
+typedef struct UniffiForeignFutureDroppedCallbackStruct {
+    uint64_t handle;
+    UniffiForeignFutureDroppedCallback free;
+} UniffiForeignFutureDroppedCallbackStruct;
+
+#endif
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U8
+typedef struct UniffiForeignFutureResultU8 {
     uint8_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU8;
+} UniffiForeignFutureResultU8;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U8
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U8
-typedef void (*UniffiForeignFutureCompleteU8)(uint64_t callback_data, UniffiForeignFutureStructU8 result);
+typedef void (*UniffiForeignFutureCompleteU8)(uint64_t callback_data, UniffiForeignFutureResultU8 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteU8(
-				UniffiForeignFutureCompleteU8 cb, uint64_t callback_data, UniffiForeignFutureStructU8 result)
+				UniffiForeignFutureCompleteU8 cb, uint64_t callback_data, UniffiForeignFutureResultU8 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I8
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I8
-typedef struct UniffiForeignFutureStructI8 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I8
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I8
+typedef struct UniffiForeignFutureResultI8 {
     int8_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI8;
+} UniffiForeignFutureResultI8;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I8
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I8
-typedef void (*UniffiForeignFutureCompleteI8)(uint64_t callback_data, UniffiForeignFutureStructI8 result);
+typedef void (*UniffiForeignFutureCompleteI8)(uint64_t callback_data, UniffiForeignFutureResultI8 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteI8(
-				UniffiForeignFutureCompleteI8 cb, uint64_t callback_data, UniffiForeignFutureStructI8 result)
+				UniffiForeignFutureCompleteI8 cb, uint64_t callback_data, UniffiForeignFutureResultI8 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U16
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U16
-typedef struct UniffiForeignFutureStructU16 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U16
+typedef struct UniffiForeignFutureResultU16 {
     uint16_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU16;
+} UniffiForeignFutureResultU16;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U16
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U16
-typedef void (*UniffiForeignFutureCompleteU16)(uint64_t callback_data, UniffiForeignFutureStructU16 result);
+typedef void (*UniffiForeignFutureCompleteU16)(uint64_t callback_data, UniffiForeignFutureResultU16 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteU16(
-				UniffiForeignFutureCompleteU16 cb, uint64_t callback_data, UniffiForeignFutureStructU16 result)
+				UniffiForeignFutureCompleteU16 cb, uint64_t callback_data, UniffiForeignFutureResultU16 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I16
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I16
-typedef struct UniffiForeignFutureStructI16 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I16
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I16
+typedef struct UniffiForeignFutureResultI16 {
     int16_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI16;
+} UniffiForeignFutureResultI16;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I16
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I16
-typedef void (*UniffiForeignFutureCompleteI16)(uint64_t callback_data, UniffiForeignFutureStructI16 result);
+typedef void (*UniffiForeignFutureCompleteI16)(uint64_t callback_data, UniffiForeignFutureResultI16 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteI16(
-				UniffiForeignFutureCompleteI16 cb, uint64_t callback_data, UniffiForeignFutureStructI16 result)
+				UniffiForeignFutureCompleteI16 cb, uint64_t callback_data, UniffiForeignFutureResultI16 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U32
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U32
-typedef struct UniffiForeignFutureStructU32 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U32
+typedef struct UniffiForeignFutureResultU32 {
     uint32_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU32;
+} UniffiForeignFutureResultU32;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U32
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U32
-typedef void (*UniffiForeignFutureCompleteU32)(uint64_t callback_data, UniffiForeignFutureStructU32 result);
+typedef void (*UniffiForeignFutureCompleteU32)(uint64_t callback_data, UniffiForeignFutureResultU32 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteU32(
-				UniffiForeignFutureCompleteU32 cb, uint64_t callback_data, UniffiForeignFutureStructU32 result)
+				UniffiForeignFutureCompleteU32 cb, uint64_t callback_data, UniffiForeignFutureResultU32 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I32
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I32
-typedef struct UniffiForeignFutureStructI32 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I32
+typedef struct UniffiForeignFutureResultI32 {
     int32_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI32;
+} UniffiForeignFutureResultI32;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I32
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I32
-typedef void (*UniffiForeignFutureCompleteI32)(uint64_t callback_data, UniffiForeignFutureStructI32 result);
+typedef void (*UniffiForeignFutureCompleteI32)(uint64_t callback_data, UniffiForeignFutureResultI32 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteI32(
-				UniffiForeignFutureCompleteI32 cb, uint64_t callback_data, UniffiForeignFutureStructI32 result)
+				UniffiForeignFutureCompleteI32 cb, uint64_t callback_data, UniffiForeignFutureResultI32 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U64
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_U64
-typedef struct UniffiForeignFutureStructU64 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_U64
+typedef struct UniffiForeignFutureResultU64 {
     uint64_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructU64;
+} UniffiForeignFutureResultU64;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U64
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_U64
-typedef void (*UniffiForeignFutureCompleteU64)(uint64_t callback_data, UniffiForeignFutureStructU64 result);
+typedef void (*UniffiForeignFutureCompleteU64)(uint64_t callback_data, UniffiForeignFutureResultU64 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteU64(
-				UniffiForeignFutureCompleteU64 cb, uint64_t callback_data, UniffiForeignFutureStructU64 result)
+				UniffiForeignFutureCompleteU64 cb, uint64_t callback_data, UniffiForeignFutureResultU64 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I64
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_I64
-typedef struct UniffiForeignFutureStructI64 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_I64
+typedef struct UniffiForeignFutureResultI64 {
     int64_t returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructI64;
+} UniffiForeignFutureResultI64;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I64
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_I64
-typedef void (*UniffiForeignFutureCompleteI64)(uint64_t callback_data, UniffiForeignFutureStructI64 result);
+typedef void (*UniffiForeignFutureCompleteI64)(uint64_t callback_data, UniffiForeignFutureResultI64 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteI64(
-				UniffiForeignFutureCompleteI64 cb, uint64_t callback_data, UniffiForeignFutureStructI64 result)
+				UniffiForeignFutureCompleteI64 cb, uint64_t callback_data, UniffiForeignFutureResultI64 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F32
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F32
-typedef struct UniffiForeignFutureStructF32 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F32
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F32
+typedef struct UniffiForeignFutureResultF32 {
     float returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructF32;
+} UniffiForeignFutureResultF32;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F32
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F32
-typedef void (*UniffiForeignFutureCompleteF32)(uint64_t callback_data, UniffiForeignFutureStructF32 result);
+typedef void (*UniffiForeignFutureCompleteF32)(uint64_t callback_data, UniffiForeignFutureResultF32 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteF32(
-				UniffiForeignFutureCompleteF32 cb, uint64_t callback_data, UniffiForeignFutureStructF32 result)
+				UniffiForeignFutureCompleteF32 cb, uint64_t callback_data, UniffiForeignFutureResultF32 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F64
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_F64
-typedef struct UniffiForeignFutureStructF64 {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F64
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_F64
+typedef struct UniffiForeignFutureResultF64 {
     double returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructF64;
+} UniffiForeignFutureResultF64;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F64
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_F64
-typedef void (*UniffiForeignFutureCompleteF64)(uint64_t callback_data, UniffiForeignFutureStructF64 result);
+typedef void (*UniffiForeignFutureCompleteF64)(uint64_t callback_data, UniffiForeignFutureResultF64 result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteF64(
-				UniffiForeignFutureCompleteF64 cb, uint64_t callback_data, UniffiForeignFutureStructF64 result)
+				UniffiForeignFutureCompleteF64 cb, uint64_t callback_data, UniffiForeignFutureResultF64 result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_POINTER
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_POINTER
-typedef struct UniffiForeignFutureStructPointer {
-    void* returnValue;
-    RustCallStatus callStatus;
-} UniffiForeignFutureStructPointer;
-
-#endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_POINTER
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_POINTER
-typedef void (*UniffiForeignFutureCompletePointer)(uint64_t callback_data, UniffiForeignFutureStructPointer result);
-
-// Making function static works arround:
-// https://github.com/golang/go/issues/11263
-static void call_UniffiForeignFutureCompletePointer(
-				UniffiForeignFutureCompletePointer cb, uint64_t callback_data, UniffiForeignFutureStructPointer result)
-{
-	return cb(callback_data, result);
-}
-
-
-#endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_RUST_BUFFER
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_RUST_BUFFER
-typedef struct UniffiForeignFutureStructRustBuffer {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_RUST_BUFFER
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_RUST_BUFFER
+typedef struct UniffiForeignFutureResultRustBuffer {
     RustBuffer returnValue;
     RustCallStatus callStatus;
-} UniffiForeignFutureStructRustBuffer;
+} UniffiForeignFutureResultRustBuffer;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_RUST_BUFFER
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_RUST_BUFFER
-typedef void (*UniffiForeignFutureCompleteRustBuffer)(uint64_t callback_data, UniffiForeignFutureStructRustBuffer result);
+typedef void (*UniffiForeignFutureCompleteRustBuffer)(uint64_t callback_data, UniffiForeignFutureResultRustBuffer result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteRustBuffer(
-				UniffiForeignFutureCompleteRustBuffer cb, uint64_t callback_data, UniffiForeignFutureStructRustBuffer result)
+				UniffiForeignFutureCompleteRustBuffer cb, uint64_t callback_data, UniffiForeignFutureResultRustBuffer result)
 {
 	return cb(callback_data, result);
 }
 
 
 #endif
-#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_VOID
-#define UNIFFI_FFIDEF_FOREIGN_FUTURE_STRUCT_VOID
-typedef struct UniffiForeignFutureStructVoid {
+#ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_VOID
+#define UNIFFI_FFIDEF_FOREIGN_FUTURE_RESULT_VOID
+typedef struct UniffiForeignFutureResultVoid {
     RustCallStatus callStatus;
-} UniffiForeignFutureStructVoid;
+} UniffiForeignFutureResultVoid;
 
 #endif
 #ifndef UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_VOID
 #define UNIFFI_FFIDEF_FOREIGN_FUTURE_COMPLETE_VOID
-typedef void (*UniffiForeignFutureCompleteVoid)(uint64_t callback_data, UniffiForeignFutureStructVoid result);
+typedef void (*UniffiForeignFutureCompleteVoid)(uint64_t callback_data, UniffiForeignFutureResultVoid result);
 
 // Making function static works arround:
 // https://github.com/golang/go/issues/11263
 static void call_UniffiForeignFutureCompleteVoid(
-				UniffiForeignFutureCompleteVoid cb, uint64_t callback_data, UniffiForeignFutureStructVoid result)
+				UniffiForeignFutureCompleteVoid cb, uint64_t callback_data, UniffiForeignFutureResultVoid result)
 {
 	return cb(callback_data, result);
 }
@@ -409,462 +401,464 @@ static void call_UniffiCallbackInterfaceMergeOperatorMethod0(
 #ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_LOG_CALLBACK
 #define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_LOG_CALLBACK
 typedef struct UniffiVTableCallbackInterfaceLogCallback {
-    UniffiCallbackInterfaceLogCallbackMethod0 log;
     UniffiCallbackInterfaceFree uniffiFree;
+    UniffiCallbackInterfaceClone uniffiClone;
+    UniffiCallbackInterfaceLogCallbackMethod0 log;
 } UniffiVTableCallbackInterfaceLogCallback;
 
 #endif
 #ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_MERGE_OPERATOR
 #define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_MERGE_OPERATOR
 typedef struct UniffiVTableCallbackInterfaceMergeOperator {
-    UniffiCallbackInterfaceMergeOperatorMethod0 merge;
     UniffiCallbackInterfaceFree uniffiFree;
+    UniffiCallbackInterfaceClone uniffiClone;
+    UniffiCallbackInterfaceMergeOperatorMethod0 merge;
 } UniffiVTableCallbackInterfaceMergeOperator;
 
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DB
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DB
-void* uniffi_slatedb_uniffi_fn_clone_db(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DB
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DB
-void uniffi_slatedb_uniffi_fn_free_db(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_BEGIN
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_BEGIN
-uint64_t uniffi_slatedb_uniffi_fn_method_db_begin(void* ptr, RustBuffer isolation_level
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE
-uint64_t uniffi_slatedb_uniffi_fn_method_db_delete(void* ptr, RustBuffer key
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_delete_with_options(void* ptr, RustBuffer key, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH
-uint64_t uniffi_slatedb_uniffi_fn_method_db_flush(void* ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_flush_with_options(void* ptr, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET
-uint64_t uniffi_slatedb_uniffi_fn_method_db_get(void* ptr, RustBuffer key
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE
-uint64_t uniffi_slatedb_uniffi_fn_method_db_get_key_value(void* ptr, RustBuffer key
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_get_key_value_with_options(void* ptr, RustBuffer key, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_get_with_options(void* ptr, RustBuffer key, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE
-uint64_t uniffi_slatedb_uniffi_fn_method_db_merge(void* ptr, RustBuffer key, RustBuffer operand
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_merge_with_options(void* ptr, RustBuffer key, RustBuffer operand, RustBuffer merge_options, RustBuffer write_options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT
-uint64_t uniffi_slatedb_uniffi_fn_method_db_put(void* ptr, RustBuffer key, RustBuffer value
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_put_with_options(void* ptr, RustBuffer key, RustBuffer value, RustBuffer put_options, RustBuffer write_options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN
-uint64_t uniffi_slatedb_uniffi_fn_method_db_scan(void* ptr, RustBuffer range
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX
-uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_prefix(void* ptr, RustBuffer prefix
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_prefix_with_options(void* ptr, RustBuffer prefix, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_with_options(void* ptr, RustBuffer range, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SHUTDOWN
-uint64_t uniffi_slatedb_uniffi_fn_method_db_shutdown(void* ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SNAPSHOT
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SNAPSHOT
-uint64_t uniffi_slatedb_uniffi_fn_method_db_snapshot(void* ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_STATUS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_STATUS
-void uniffi_slatedb_uniffi_fn_method_db_status(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
-uint64_t uniffi_slatedb_uniffi_fn_method_db_write(void* ptr, void* batch
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_db_write_with_options(void* ptr, void* batch, RustBuffer options
-);
-#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBBUILDER
-void* uniffi_slatedb_uniffi_fn_clone_dbbuilder(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_dbbuilder(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBBUILDER
-void uniffi_slatedb_uniffi_fn_free_dbbuilder(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_dbbuilder(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_DBBUILDER_NEW
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_DBBUILDER_NEW
-void* uniffi_slatedb_uniffi_fn_constructor_dbbuilder_new(RustBuffer path, void* object_store, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_dbbuilder_new(RustBuffer path, uint64_t object_store, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_BUILD
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_BUILD
-uint64_t uniffi_slatedb_uniffi_fn_method_dbbuilder_build(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_dbbuilder_build(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_DB_CACHE_DISABLED
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_DB_CACHE_DISABLED
-void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_db_cache_disabled(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_db_cache_disabled(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_MERGE_OPERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_MERGE_OPERATOR
-void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_merge_operator(void* ptr, void* merge_operator, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_merge_operator(uint64_t ptr, uint64_t merge_operator, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_SEED
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_SEED
-void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_seed(void* ptr, uint64_t seed, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_seed(uint64_t ptr, uint64_t seed, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_SETTINGS
-void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_settings(void* ptr, void* settings, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_settings(uint64_t ptr, uint64_t settings, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_SST_BLOCK_SIZE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_SST_BLOCK_SIZE
-void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_sst_block_size(void* ptr, RustBuffer sst_block_size, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_sst_block_size(uint64_t ptr, RustBuffer sst_block_size, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_WAL_OBJECT_STORE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBBUILDER_WITH_WAL_OBJECT_STORE
-void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_wal_object_store(void* ptr, void* wal_object_store, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBITERATOR
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBITERATOR
-void* uniffi_slatedb_uniffi_fn_clone_dbiterator(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBITERATOR
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBITERATOR
-void uniffi_slatedb_uniffi_fn_free_dbiterator(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_NEXT
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_NEXT
-uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_next(void* ptr
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_SEEK
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_SEEK
-uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_seek(void* ptr, RustBuffer key
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBREADER
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBREADER
-void* uniffi_slatedb_uniffi_fn_clone_dbreader(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADER
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADER
-void uniffi_slatedb_uniffi_fn_free_dbreader(void* ptr, RustCallStatus *out_status
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_get(void* ptr, RustBuffer key
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_get_with_options(void* ptr, RustBuffer key, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan(void* ptr, RustBuffer range
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_prefix(void* ptr, RustBuffer prefix
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_prefix_with_options(void* ptr, RustBuffer prefix, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_with_options(void* ptr, RustBuffer range, RustBuffer options
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SHUTDOWN
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SHUTDOWN
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_shutdown(void* ptr
+void uniffi_slatedb_uniffi_fn_method_dbbuilder_with_wal_object_store(uint64_t ptr, uint64_t wal_object_store, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBREADERBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBREADERBUILDER
-void* uniffi_slatedb_uniffi_fn_clone_dbreaderbuilder(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_dbreaderbuilder(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADERBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADERBUILDER
-void uniffi_slatedb_uniffi_fn_free_dbreaderbuilder(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_dbreaderbuilder(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_DBREADERBUILDER_NEW
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_DBREADERBUILDER_NEW
-void* uniffi_slatedb_uniffi_fn_constructor_dbreaderbuilder_new(RustBuffer path, void* object_store, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_dbreaderbuilder_new(RustBuffer path, uint64_t object_store, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_BUILD
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_BUILD
-uint64_t uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_build(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_build(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_CHECKPOINT_ID
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_CHECKPOINT_ID
-void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_checkpoint_id(void* ptr, RustBuffer checkpoint_id, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_checkpoint_id(uint64_t ptr, RustBuffer checkpoint_id, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_MERGE_OPERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_MERGE_OPERATOR
-void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_merge_operator(void* ptr, void* merge_operator, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_merge_operator(uint64_t ptr, uint64_t merge_operator, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_OPTIONS
-void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_options(void* ptr, RustBuffer options, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_options(uint64_t ptr, RustBuffer options, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_WAL_OBJECT_STORE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADERBUILDER_WITH_WAL_OBJECT_STORE
-void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_wal_object_store(void* ptr, void* wal_object_store, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_dbreaderbuilder_with_wal_object_store(uint64_t ptr, uint64_t wal_object_store, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DB
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DB
+uint64_t uniffi_slatedb_uniffi_fn_clone_db(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DB
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DB
+void uniffi_slatedb_uniffi_fn_free_db(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_BEGIN
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_BEGIN
+uint64_t uniffi_slatedb_uniffi_fn_method_db_begin(uint64_t ptr, RustBuffer isolation_level
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE
+uint64_t uniffi_slatedb_uniffi_fn_method_db_delete(uint64_t ptr, RustBuffer key
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_DELETE_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_delete_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH
+uint64_t uniffi_slatedb_uniffi_fn_method_db_flush(uint64_t ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_flush_with_options(uint64_t ptr, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET
+uint64_t uniffi_slatedb_uniffi_fn_method_db_get(uint64_t ptr, RustBuffer key
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE
+uint64_t uniffi_slatedb_uniffi_fn_method_db_get_key_value(uint64_t ptr, RustBuffer key
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_KEY_VALUE_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_get_key_value_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_GET_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_get_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE
+uint64_t uniffi_slatedb_uniffi_fn_method_db_merge(uint64_t ptr, RustBuffer key, RustBuffer operand
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_MERGE_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_merge_with_options(uint64_t ptr, RustBuffer key, RustBuffer operand, RustBuffer merge_options, RustBuffer write_options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT
+uint64_t uniffi_slatedb_uniffi_fn_method_db_put(uint64_t ptr, RustBuffer key, RustBuffer value
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_PUT_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_put_with_options(uint64_t ptr, RustBuffer key, RustBuffer value, RustBuffer put_options, RustBuffer write_options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN
+uint64_t uniffi_slatedb_uniffi_fn_method_db_scan(uint64_t ptr, RustBuffer range
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX
+uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_prefix(uint64_t ptr, RustBuffer prefix
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_PREFIX_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_prefix_with_options(uint64_t ptr, RustBuffer prefix, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SCAN_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_with_options(uint64_t ptr, RustBuffer range, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SHUTDOWN
+uint64_t uniffi_slatedb_uniffi_fn_method_db_shutdown(uint64_t ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SNAPSHOT
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SNAPSHOT
+uint64_t uniffi_slatedb_uniffi_fn_method_db_snapshot(uint64_t ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_STATUS
+void uniffi_slatedb_uniffi_fn_method_db_status(uint64_t ptr, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
+uint64_t uniffi_slatedb_uniffi_fn_method_db_write(uint64_t ptr, uint64_t batch
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_write_with_options(uint64_t ptr, uint64_t batch, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBREADER
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBREADER
+uint64_t uniffi_slatedb_uniffi_fn_clone_dbreader(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADER
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADER
+void uniffi_slatedb_uniffi_fn_free_dbreader(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_get(uint64_t ptr, RustBuffer key
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_get_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan(uint64_t ptr, RustBuffer range
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_prefix(uint64_t ptr, RustBuffer prefix
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_PREFIX_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_prefix_with_options(uint64_t ptr, RustBuffer prefix, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SCAN_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_with_options(uint64_t ptr, RustBuffer range, RustBuffer options
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SHUTDOWN
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SHUTDOWN
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_shutdown(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBSNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBSNAPSHOT
-void* uniffi_slatedb_uniffi_fn_clone_dbsnapshot(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_dbsnapshot(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBSNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBSNAPSHOT
-void uniffi_slatedb_uniffi_fn_free_dbsnapshot(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_dbsnapshot(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get(void* ptr, RustBuffer key
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get(uint64_t ptr, RustBuffer key
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET_KEY_VALUE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET_KEY_VALUE
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get_key_value(void* ptr, RustBuffer key
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get_key_value(uint64_t ptr, RustBuffer key
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET_KEY_VALUE_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET_KEY_VALUE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get_key_value_with_options(void* ptr, RustBuffer key, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get_key_value_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_GET_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get_with_options(void* ptr, RustBuffer key, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_get_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan(void* ptr, RustBuffer range
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan(uint64_t ptr, RustBuffer range
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN_PREFIX
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN_PREFIX
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_prefix(void* ptr, RustBuffer prefix
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_prefix(uint64_t ptr, RustBuffer prefix
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN_PREFIX_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN_PREFIX_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_prefix_with_options(void* ptr, RustBuffer prefix, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_prefix_with_options(uint64_t ptr, RustBuffer prefix, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBSNAPSHOT_SCAN_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_with_options(void* ptr, RustBuffer range, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbsnapshot_scan_with_options(uint64_t ptr, RustBuffer range, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBTRANSACTION
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBTRANSACTION
-void* uniffi_slatedb_uniffi_fn_clone_dbtransaction(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_dbtransaction(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBTRANSACTION
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBTRANSACTION
-void uniffi_slatedb_uniffi_fn_free_dbtransaction(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_dbtransaction(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_COMMIT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_COMMIT
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_commit(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_commit(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_COMMIT_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_COMMIT_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_commit_with_options(void* ptr, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_commit_with_options(uint64_t ptr, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_DELETE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_DELETE
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_delete(void* ptr, RustBuffer key
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_delete(uint64_t ptr, RustBuffer key
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get(void* ptr, RustBuffer key
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get(uint64_t ptr, RustBuffer key
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET_KEY_VALUE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET_KEY_VALUE
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get_key_value(void* ptr, RustBuffer key
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get_key_value(uint64_t ptr, RustBuffer key
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET_KEY_VALUE_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET_KEY_VALUE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get_key_value_with_options(void* ptr, RustBuffer key, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get_key_value_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_GET_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get_with_options(void* ptr, RustBuffer key, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_get_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_ID
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_ID
-RustBuffer uniffi_slatedb_uniffi_fn_method_dbtransaction_id(void* ptr, RustCallStatus *out_status
+RustBuffer uniffi_slatedb_uniffi_fn_method_dbtransaction_id(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_MARK_READ
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_MARK_READ
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_mark_read(void* ptr, RustBuffer keys
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_mark_read(uint64_t ptr, RustBuffer keys
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_MERGE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_MERGE
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_merge(void* ptr, RustBuffer key, RustBuffer operand
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_merge(uint64_t ptr, RustBuffer key, RustBuffer operand
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_MERGE_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_MERGE_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_merge_with_options(void* ptr, RustBuffer key, RustBuffer operand, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_merge_with_options(uint64_t ptr, RustBuffer key, RustBuffer operand, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_PUT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_PUT
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_put(void* ptr, RustBuffer key, RustBuffer value
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_put(uint64_t ptr, RustBuffer key, RustBuffer value
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_PUT_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_PUT_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_put_with_options(void* ptr, RustBuffer key, RustBuffer value, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_put_with_options(uint64_t ptr, RustBuffer key, RustBuffer value, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_ROLLBACK
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_ROLLBACK
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_rollback(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_rollback(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan(void* ptr, RustBuffer range
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan(uint64_t ptr, RustBuffer range
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN_PREFIX
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN_PREFIX
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_prefix(void* ptr, RustBuffer prefix
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_prefix(uint64_t ptr, RustBuffer prefix
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN_PREFIX_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN_PREFIX_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_prefix_with_options(void* ptr, RustBuffer prefix, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_prefix_with_options(uint64_t ptr, RustBuffer prefix, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SCAN_WITH_OPTIONS
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_with_options(void* ptr, RustBuffer range, RustBuffer options
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_scan_with_options(uint64_t ptr, RustBuffer range, RustBuffer options
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SEQNUM
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_SEQNUM
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_seqnum(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_seqnum(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_UNMARK_WRITE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBTRANSACTION_UNMARK_WRITE
-uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_unmark_write(void* ptr, RustBuffer keys
+uint64_t uniffi_slatedb_uniffi_fn_method_dbtransaction_unmark_write(uint64_t ptr, RustBuffer keys
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBITERATOR
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBITERATOR
+uint64_t uniffi_slatedb_uniffi_fn_clone_dbiterator(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBITERATOR
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBITERATOR
+void uniffi_slatedb_uniffi_fn_free_dbiterator(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_NEXT
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_NEXT
+uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_next(uint64_t ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_SEEK
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_SEEK
+uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_seek(uint64_t ptr, RustBuffer key
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_LOGCALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_LOGCALLBACK
-void* uniffi_slatedb_uniffi_fn_clone_logcallback(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_logcallback(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_LOGCALLBACK
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_LOGCALLBACK
-void uniffi_slatedb_uniffi_fn_free_logcallback(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_logcallback(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_INIT_CALLBACK_VTABLE_LOGCALLBACK
@@ -874,17 +868,17 @@ void uniffi_slatedb_uniffi_fn_init_callback_vtable_logcallback(UniffiVTableCallb
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_LOGCALLBACK_LOG
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_LOGCALLBACK_LOG
-void uniffi_slatedb_uniffi_fn_method_logcallback_log(void* ptr, RustBuffer record, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_logcallback_log(uint64_t ptr, RustBuffer record, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_MERGEOPERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_MERGEOPERATOR
-void* uniffi_slatedb_uniffi_fn_clone_mergeoperator(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_mergeoperator(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_MERGEOPERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_MERGEOPERATOR
-void uniffi_slatedb_uniffi_fn_free_mergeoperator(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_mergeoperator(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_INIT_CALLBACK_VTABLE_MERGEOPERATOR
@@ -894,195 +888,195 @@ void uniffi_slatedb_uniffi_fn_init_callback_vtable_mergeoperator(UniffiVTableCal
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_MERGEOPERATOR_MERGE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_MERGEOPERATOR_MERGE
-RustBuffer uniffi_slatedb_uniffi_fn_method_mergeoperator_merge(void* ptr, RustBuffer key, RustBuffer existing_value, RustBuffer operand, RustCallStatus *out_status
+RustBuffer uniffi_slatedb_uniffi_fn_method_mergeoperator_merge(uint64_t ptr, RustBuffer key, RustBuffer existing_value, RustBuffer operand, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_OBJECTSTORE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_OBJECTSTORE
-void* uniffi_slatedb_uniffi_fn_clone_objectstore(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_objectstore(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_OBJECTSTORE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_OBJECTSTORE
-void uniffi_slatedb_uniffi_fn_free_objectstore(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_objectstore(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_OBJECTSTORE_FROM_ENV
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_OBJECTSTORE_FROM_ENV
-void* uniffi_slatedb_uniffi_fn_constructor_objectstore_from_env(RustBuffer env_file, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_objectstore_from_env(RustBuffer env_file, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_OBJECTSTORE_RESOLVE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_OBJECTSTORE_RESOLVE
-void* uniffi_slatedb_uniffi_fn_constructor_objectstore_resolve(RustBuffer url, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_objectstore_resolve(RustBuffer url, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_SETTINGS
-void* uniffi_slatedb_uniffi_fn_clone_settings(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_settings(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_SETTINGS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_SETTINGS
-void uniffi_slatedb_uniffi_fn_free_settings(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_settings(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_DEFAULT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_DEFAULT
-void* uniffi_slatedb_uniffi_fn_constructor_settings_default(RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_settings_default(RustCallStatus *out_status
     
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_ENV
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_ENV
-void* uniffi_slatedb_uniffi_fn_constructor_settings_from_env(RustBuffer prefix, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_settings_from_env(RustBuffer prefix, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_ENV_WITH_DEFAULT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_ENV_WITH_DEFAULT
-void* uniffi_slatedb_uniffi_fn_constructor_settings_from_env_with_default(RustBuffer prefix, void* default_settings, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_settings_from_env_with_default(RustBuffer prefix, uint64_t default_settings, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_FILE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_FILE
-void* uniffi_slatedb_uniffi_fn_constructor_settings_from_file(RustBuffer path, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_settings_from_file(RustBuffer path, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_JSON_STRING
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_FROM_JSON_STRING
-void* uniffi_slatedb_uniffi_fn_constructor_settings_from_json_string(RustBuffer json, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_settings_from_json_string(RustBuffer json, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_LOAD
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_SETTINGS_LOAD
-void* uniffi_slatedb_uniffi_fn_constructor_settings_load(RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_settings_load(RustCallStatus *out_status
     
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_SETTINGS_SET
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_SETTINGS_SET
-void uniffi_slatedb_uniffi_fn_method_settings_set(void* ptr, RustBuffer key, RustBuffer value_json, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_settings_set(uint64_t ptr, RustBuffer key, RustBuffer value_json, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_SETTINGS_TO_JSON_STRING
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_SETTINGS_TO_JSON_STRING
-RustBuffer uniffi_slatedb_uniffi_fn_method_settings_to_json_string(void* ptr, RustCallStatus *out_status
+RustBuffer uniffi_slatedb_uniffi_fn_method_settings_to_json_string(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WALFILE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WALFILE
-void* uniffi_slatedb_uniffi_fn_clone_walfile(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_walfile(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WALFILE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WALFILE
-void uniffi_slatedb_uniffi_fn_free_walfile(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_walfile(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_ID
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_ID
-uint64_t uniffi_slatedb_uniffi_fn_method_walfile_id(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_method_walfile_id(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_ITERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_ITERATOR
-uint64_t uniffi_slatedb_uniffi_fn_method_walfile_iterator(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_walfile_iterator(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_METADATA
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_METADATA
-uint64_t uniffi_slatedb_uniffi_fn_method_walfile_metadata(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_walfile_metadata(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_NEXT_FILE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_NEXT_FILE
-void* uniffi_slatedb_uniffi_fn_method_walfile_next_file(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_method_walfile_next_file(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_NEXT_ID
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILE_NEXT_ID
-uint64_t uniffi_slatedb_uniffi_fn_method_walfile_next_id(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_method_walfile_next_id(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WALFILEITERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WALFILEITERATOR
-void* uniffi_slatedb_uniffi_fn_clone_walfileiterator(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_walfileiterator(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WALFILEITERATOR
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WALFILEITERATOR
-void uniffi_slatedb_uniffi_fn_free_walfileiterator(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_walfileiterator(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILEITERATOR_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALFILEITERATOR_NEXT
-uint64_t uniffi_slatedb_uniffi_fn_method_walfileiterator_next(void* ptr
+uint64_t uniffi_slatedb_uniffi_fn_method_walfileiterator_next(uint64_t ptr
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WALREADER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WALREADER
-void* uniffi_slatedb_uniffi_fn_clone_walreader(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_walreader(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WALREADER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WALREADER
-void uniffi_slatedb_uniffi_fn_free_walreader(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_walreader(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_WALREADER_NEW
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_WALREADER_NEW
-void* uniffi_slatedb_uniffi_fn_constructor_walreader_new(RustBuffer path, void* object_store, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_walreader_new(RustBuffer path, uint64_t object_store, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALREADER_GET
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALREADER_GET
-void* uniffi_slatedb_uniffi_fn_method_walreader_get(void* ptr, uint64_t id, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_method_walreader_get(uint64_t ptr, uint64_t id, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALREADER_LIST
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WALREADER_LIST
-uint64_t uniffi_slatedb_uniffi_fn_method_walreader_list(void* ptr, RustBuffer start_id, RustBuffer end_id
+uint64_t uniffi_slatedb_uniffi_fn_method_walreader_list(uint64_t ptr, RustBuffer start_id, RustBuffer end_id
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WRITEBATCH
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_WRITEBATCH
-void* uniffi_slatedb_uniffi_fn_clone_writebatch(void* ptr, RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_clone_writebatch(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WRITEBATCH
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_WRITEBATCH
-void uniffi_slatedb_uniffi_fn_free_writebatch(void* ptr, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_free_writebatch(uint64_t handle, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_WRITEBATCH_NEW
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CONSTRUCTOR_WRITEBATCH_NEW
-void* uniffi_slatedb_uniffi_fn_constructor_writebatch_new(RustCallStatus *out_status
+uint64_t uniffi_slatedb_uniffi_fn_constructor_writebatch_new(RustCallStatus *out_status
     
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_DELETE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_DELETE
-void uniffi_slatedb_uniffi_fn_method_writebatch_delete(void* ptr, RustBuffer key, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_writebatch_delete(uint64_t ptr, RustBuffer key, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_MERGE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_MERGE
-void uniffi_slatedb_uniffi_fn_method_writebatch_merge(void* ptr, RustBuffer key, RustBuffer operand, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_writebatch_merge(uint64_t ptr, RustBuffer key, RustBuffer operand, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_MERGE_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_MERGE_WITH_OPTIONS
-void uniffi_slatedb_uniffi_fn_method_writebatch_merge_with_options(void* ptr, RustBuffer key, RustBuffer operand, RustBuffer options, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_writebatch_merge_with_options(uint64_t ptr, RustBuffer key, RustBuffer operand, RustBuffer options, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_PUT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_PUT
-void uniffi_slatedb_uniffi_fn_method_writebatch_put(void* ptr, RustBuffer key, RustBuffer value, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_writebatch_put(uint64_t ptr, RustBuffer key, RustBuffer value, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_PUT_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_WRITEBATCH_PUT_WITH_OPTIONS
-void uniffi_slatedb_uniffi_fn_method_writebatch_put_with_options(void* ptr, RustBuffer key, RustBuffer value, RustBuffer options, RustCallStatus *out_status
+void uniffi_slatedb_uniffi_fn_method_writebatch_put_with_options(uint64_t ptr, RustBuffer key, RustBuffer value, RustBuffer options, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FUNC_INIT_LOGGING
@@ -1310,26 +1304,6 @@ void ffi_slatedb_uniffi_rust_future_free_f64(uint64_t handle
 double ffi_slatedb_uniffi_rust_future_complete_f64(uint64_t handle, RustCallStatus *out_status
 );
 #endif
-#ifndef UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_POLL_POINTER
-#define UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_POLL_POINTER
-void ffi_slatedb_uniffi_rust_future_poll_pointer(uint64_t handle, UniffiRustFutureContinuationCallback callback, uint64_t callback_data
-);
-#endif
-#ifndef UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_CANCEL_POINTER
-#define UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_CANCEL_POINTER
-void ffi_slatedb_uniffi_rust_future_cancel_pointer(uint64_t handle
-);
-#endif
-#ifndef UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_FREE_POINTER
-#define UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_FREE_POINTER
-void ffi_slatedb_uniffi_rust_future_free_pointer(uint64_t handle
-);
-#endif
-#ifndef UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_COMPLETE_POINTER
-#define UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_COMPLETE_POINTER
-void* ffi_slatedb_uniffi_rust_future_complete_pointer(uint64_t handle, RustCallStatus *out_status
-);
-#endif
 #ifndef UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_POLL_RUST_BUFFER
 #define UNIFFI_FFIDEF_FFI_SLATEDB_UNIFFI_RUST_FUTURE_POLL_RUST_BUFFER
 void ffi_slatedb_uniffi_rust_future_poll_rust_buffer(uint64_t handle, UniffiRustFutureContinuationCallback callback, uint64_t callback_data
@@ -1373,6 +1347,78 @@ void ffi_slatedb_uniffi_rust_future_complete_void(uint64_t handle, RustCallStatu
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_FUNC_INIT_LOGGING
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_FUNC_INIT_LOGGING
 uint16_t uniffi_slatedb_uniffi_checksum_func_init_logging(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_BUILD
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_BUILD
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_build(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_DB_CACHE_DISABLED
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_DB_CACHE_DISABLED
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_db_cache_disabled(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_MERGE_OPERATOR
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_MERGE_OPERATOR
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_merge_operator(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SEED
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SEED
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_seed(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SETTINGS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SETTINGS
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_settings(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SST_BLOCK_SIZE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SST_BLOCK_SIZE
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_sst_block_size(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_WAL_OBJECT_STORE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_WAL_OBJECT_STORE
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_wal_object_store(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_BUILD
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_BUILD
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_build(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_CHECKPOINT_ID
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_CHECKPOINT_ID
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_checkpoint_id(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_MERGE_OPERATOR
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_MERGE_OPERATOR
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_merge_operator(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_OPTIONS
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_options(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_WAL_OBJECT_STORE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_WAL_OBJECT_STORE
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_wal_object_store(void
     
 );
 #endif
@@ -1508,60 +1554,6 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_db_write_with_options(void
     
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_BUILD
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_BUILD
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_build(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_DB_CACHE_DISABLED
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_DB_CACHE_DISABLED
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_db_cache_disabled(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_MERGE_OPERATOR
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_MERGE_OPERATOR
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_merge_operator(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SEED
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SEED
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_seed(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SETTINGS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SETTINGS
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_settings(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SST_BLOCK_SIZE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_SST_BLOCK_SIZE
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_sst_block_size(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_WAL_OBJECT_STORE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBBUILDER_WITH_WAL_OBJECT_STORE
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbbuilder_with_wal_object_store(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbiterator_next(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_SEEK
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_SEEK
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbiterator_seek(void
-    
-);
-#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_GET
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_GET
 uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_get(void
@@ -1601,36 +1593,6 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_scan_with_options(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_SHUTDOWN
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_SHUTDOWN
 uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_BUILD
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_BUILD
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_build(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_CHECKPOINT_ID
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_CHECKPOINT_ID
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_checkpoint_id(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_MERGE_OPERATOR
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_MERGE_OPERATOR
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_merge_operator(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_OPTIONS
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_OPTIONS
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_options(void
-    
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_WAL_OBJECT_STORE
-#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADERBUILDER_WITH_WAL_OBJECT_STORE
-uint16_t uniffi_slatedb_uniffi_checksum_method_dbreaderbuilder_with_wal_object_store(void
     
 );
 #endif
@@ -1799,6 +1761,18 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_dbtransaction_seqnum(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBTRANSACTION_UNMARK_WRITE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBTRANSACTION_UNMARK_WRITE
 uint16_t uniffi_slatedb_uniffi_checksum_method_dbtransaction_unmark_write(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbiterator_next(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_SEEK
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_SEEK
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbiterator_seek(void
     
 );
 #endif
@@ -1983,10 +1957,12 @@ uint32_t ffi_slatedb_uniffi_uniffi_contract_version(void
 );
 #endif
 
- void slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackMethod0(uint64_t uniffi_handle, RustBuffer record, void* uniffi_out_return, RustCallStatus* callStatus );
- void slatedb_uniffi_cgo_dispatchCallbackInterfaceLogCallbackFree(uint64_t handle);
- void slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorMethod0(uint64_t uniffi_handle, RustBuffer key, RustBuffer existing_value, RustBuffer operand, RustBuffer* uniffi_out_return, RustCallStatus* callStatus );
- void slatedb_uniffi_cgo_dispatchCallbackInterfaceMergeOperatorFree(uint64_t handle);
+ void slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackMethod0(uint64_t uniffi_handle, RustBuffer record, void* uniffi_out_return, RustCallStatus* callStatus );
+ void slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackFree(uint64_t handle);
+uint64_t slatedb_uniffi_logging_cgo_dispatchCallbackInterfaceLogCallbackClone(uint64_t handle);
+ void slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorMethod0(uint64_t uniffi_handle, RustBuffer key, RustBuffer existing_value, RustBuffer operand, RustBuffer* uniffi_out_return, RustCallStatus* callStatus );
+ void slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorFree(uint64_t handle);
+uint64_t slatedb_uniffi_merge_operator_cgo_dispatchCallbackInterfaceMergeOperatorClone(uint64_t handle);
 
 void slatedb_uniffiFutureContinuationCallback(uint64_t, int8_t);
 void slatedb_uniffiFreeGorutine(uint64_t);

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -102,7 +102,7 @@ You only need these if you are regenerating bindings or building from source in 
 Install the generator with:
 
 ```bash
-cargo install uniffi-bindgen-java --git https://github.com/IronCoreLabs/uniffi-bindgen-java.git
+cargo install uniffi-bindgen-java --version 0.3.1
 ```
 
 ## Regenerate

--- a/bindings/java/slatedb-uniffi/build.gradle
+++ b/bindings/java/slatedb-uniffi/build.gradle
@@ -159,7 +159,7 @@ def generateJavaBindings = tasks.register("generateJavaBindings") { task ->
         } catch (Exception ex) {
             throw new GradleException(
                 "uniffi-bindgen-java is required on PATH. Install it with: " +
-                    "cargo install uniffi-bindgen-java --git https://github.com/IronCoreLabs/uniffi-bindgen-java.git. " +
+                    "cargo install uniffi-bindgen-java --version 0.3.1. " +
                     "If Gradle cannot find it, set UNIFFI_BINDGEN_JAVA or -Pslatedb.uniffi.bindgen to the executable path.",
                 ex
             )
@@ -173,7 +173,6 @@ def generateJavaBindings = tasks.register("generateJavaBindings") { task ->
 
         execOperations.exec {
             commandLine uniffiBindgenBinary, "generate",
-                "--library",
                 "--config", uniffiConfigFile.absolutePath,
                 "--out-dir", tempOutputDir.absolutePath,
                 hostNativeLibraryForGeneration.absolutePath

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -86,7 +86,7 @@ You only need these tools when regenerating bindings, running tests from this re
 Install the generator with:
 
 ```bash
-cargo install uniffi-bindgen-node-js
+cargo install uniffi-bindgen-node-js --version 0.0.7
 ```
 
 Install the package dependency used by the generated bindings with:

--- a/bindings/node/build.mjs
+++ b/bindings/node/build.mjs
@@ -13,6 +13,7 @@ import { spawnSync } from "node:child_process";
 
 const PACKAGE_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(PACKAGE_DIR, "..", "..");
+const UNIFFI_MANIFEST_PATH = join(REPO_ROOT, "bindings", "uniffi", "Cargo.toml");
 const NAMESPACE = "slatedb";
 const CRATE_NAME = "slatedb-uniffi";
 const CDYLIB_NAME = "slatedb_uniffi";
@@ -155,6 +156,8 @@ function generateBindings(libraryPath, tempOutputDir) {
   run("uniffi-bindgen-node-js", [
     "generate",
     libraryPath,
+    "--manifest-path",
+    UNIFFI_MANIFEST_PATH,
     "--crate-name",
     CRATE_NAME,
     "--out-dir",

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -75,7 +75,7 @@ cd bindings/python
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install maturin "uniffi-bindgen==0.29.5" ruff
+pip install maturin "uniffi-bindgen==0.31.0" ruff
 maturin develop
 ruff check .
 python -c "import slatedb; import slatedb.uniffi; from slatedb.uniffi import *"

--- a/bindings/python/docs/requirements.txt
+++ b/bindings/python/docs/requirements.txt
@@ -2,4 +2,4 @@ sphinx>=7.4
 sphinx-rtd-theme>=3.0
 sphinx-autoapi>=3.0
 maturin>=1.10,<2.0
-uniffi-bindgen==0.29.5
+uniffi-bindgen==0.31.0

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.10,<2.0", "uniffi-bindgen==0.29.5"]
+requires = ["maturin>=1.10,<2.0", "uniffi-bindgen==0.31.0"]
 build-backend = "maturin"
 
 [project]

--- a/bindings/uniffi/uniffi.toml
+++ b/bindings/uniffi/uniffi.toml
@@ -9,7 +9,6 @@ cdylib_name = "slatedb_uniffi"
 
 [bindings.node]
 package_name = "@slatedb/uniffi"
-cdylib_name = "slatedb_uniffi"
 node_engine = ">=20"
 bundled_prebuilds = true
 manual_load = false

--- a/scripts/generate-go-uniffi.sh
+++ b/scripts/generate-go-uniffi.sh
@@ -12,10 +12,25 @@ cleanup() {
 }
 trap cleanup EXIT
 
+apply_async_error_workaround() {
+  local generated_file="$1"
+
+  # uniffi-bindgen-go v0.7.0+v0.31.0 does not include PR #91 yet.
+  # Patch the generated async helper so RustBuffer-backed error returns
+  # propagate the original UniFFI error instead of panicking on an empty buffer.
+  perl -0pi -e 's/"math"\n\t"runtime"/"math"\n\t"reflect"\n\t"runtime"/' "${generated_file}"
+  perl -0pi -e 's/\tffiValue, err := rustCallWithError\(errConverter, func\(status \*C\.RustCallStatus\) F \{\n\t\treturn completeFunc\(rustFuture, status\)\n\t\}\)\n\treturn liftFunc\(ffiValue\), err/\tvar goValue T\n\tffiValue, err := rustCallWithError(errConverter, func(status *C.RustCallStatus) F {\n\t\treturn completeFunc(rustFuture, status)\n\t})\n\tif value := reflect.ValueOf(err); value.IsValid() && !value.IsZero() {\n\t\treturn goValue, err\n\t}\n\treturn liftFunc(ffiValue), err/' "${generated_file}"
+
+  if ! grep -q '"reflect"' "${generated_file}" || ! grep -q 'return goValue, err' "${generated_file}"; then
+    echo "failed to apply async error workaround to ${generated_file}" >&2
+    exit 1
+  fi
+}
+
 if ! command -v uniffi-bindgen-go >/dev/null 2>&1; then
   echo "uniffi-bindgen-go is required on PATH" >&2
   echo "Install it with:" >&2
-  echo "  cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.5.0+v0.29.5" >&2
+  echo "  cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.7.0+v0.31.0" >&2
   exit 1
 fi
 
@@ -59,4 +74,5 @@ rm -f \
   "${GO_PKG_DIR}/slatedb.h"
 cp "${GENERATED_GO_FILE}" "${GO_PKG_DIR}/$(basename "${GENERATED_GO_FILE}")"
 cp "${GENERATED_H_FILE}" "${GO_PKG_DIR}/$(basename "${GENERATED_H_FILE}")"
+apply_async_error_workaround "${GO_PKG_DIR}/$(basename "${GENERATED_GO_FILE}")"
 go -C "${GO_PKG_DIR}" fmt ./...


### PR DESCRIPTION
I'm upgrading all UniFFI bindings to 0.31 in lock-step.

## Changes

- Update the workspace and foreign generators to the UniFFI 0.31 toolchain.
- Backport the uniffi-bindgen-go PR https://github.com/NordSecurity/uniffi-bindgen-go/pull/91 async error-propagation fix in the generation script until it is released upstream.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
