### PR TITLE
Fix descending memtable iterator seq ordering within same key

### DIFF
--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -247,9 +247,8 @@ impl MemTableIterator {
             None => {
                 // item is None — either iterator is exhausted, or this is the
                 // priming call. Advance inner to populate item for the next call.
-                let next = self.with_inner_mut(|inner| {
-                    inner.next_back().map(|entry| entry.value().clone())
-                });
+                let next = self
+                    .with_inner_mut(|inner| inner.next_back().map(|entry| entry.value().clone()));
                 self.with_item_mut(|item| *item = next);
                 None
             }


### PR DESCRIPTION
The test that is failing is at the bottom of the changes. MemTableIterator doesn't properly take care of reverse iteration. Ran into this while wanting to expose reverse iteration API side (https://github.com/slatedb/slatedb/issues/438).

## Summary
I don't know where this exactly was introduced, it might already have been on main quite a while.

The SkipMap orders entries as `(user_key ASC, seq DESC)`. When iterating in descending mode via `next_back()`, the entire ordering reverses, yielding `(user_key DESC, seq ASC)`. This breaks the merge iterator's dedup logic which expects highest seq first for each key.

## Changes

Claude suggested an approach similar to https://github.com/slatedb/slatedb/pull/1265. In reverse order iteration a stack is filled and then drained once we have seen all entries for the key group (reversing the ASC order in reverse SkipMap iteration). 

The functions seem overly complex to me for such simple reversal. I have the impression that the `next_sync` function is badly overloaded. It is used for initialization (returning `None` in that case) , but also for advancing (returning also `None` when exhausted). I think the initialization should be moved into some `init` function.


## Notes for Reviewers

Mainly generated with Claude Opus 4.6. I left a comment inline where I felt the inner API behaviour is off and maybe should be fixed. 


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
