### PR TITLE
[feedback requested] support scoping reads to specific SSTs/SRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,6 +3437,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "ulid",
  "uniffi",
  "uuid",
 ]

--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -7239,12 +7239,15 @@ type ReadOptions struct {
 	Dirty bool
 	// Whether fetched blocks should be inserted into the block cache.
 	CacheBlocks bool
+	// Sources consulted by this read. An empty list means "all sources".
+	ReadSources ReadSources
 }
 
 func (r *ReadOptions) Destroy() {
 	FfiDestroyerDurabilityLevel{}.Destroy(r.DurabilityFilter)
 	FfiDestroyerBool{}.Destroy(r.Dirty)
 	FfiDestroyerBool{}.Destroy(r.CacheBlocks)
+	FfiDestroyerReadSources{}.Destroy(r.ReadSources)
 }
 
 type FfiConverterReadOptions struct{}
@@ -7260,6 +7263,7 @@ func (c FfiConverterReadOptions) Read(reader io.Reader) ReadOptions {
 		FfiConverterDurabilityLevelINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterReadSourcesINSTANCE.Read(reader),
 	}
 }
 
@@ -7275,11 +7279,54 @@ func (c FfiConverterReadOptions) Write(writer io.Writer, value ReadOptions) {
 	FfiConverterDurabilityLevelINSTANCE.Write(writer, value.DurabilityFilter)
 	FfiConverterBoolINSTANCE.Write(writer, value.Dirty)
 	FfiConverterBoolINSTANCE.Write(writer, value.CacheBlocks)
+	FfiConverterReadSourcesINSTANCE.Write(writer, value.ReadSources)
 }
 
 type FfiDestroyerReadOptions struct{}
 
 func (_ FfiDestroyerReadOptions) Destroy(value ReadOptions) {
+	value.Destroy()
+}
+
+// Source set consulted by point reads and scans.
+type ReadSources struct {
+	// Sources that should be included. An empty list means "all sources".
+	Sources []ReadSource
+}
+
+func (r *ReadSources) Destroy() {
+	FfiDestroyerSequenceReadSource{}.Destroy(r.Sources)
+}
+
+type FfiConverterReadSources struct{}
+
+var FfiConverterReadSourcesINSTANCE = FfiConverterReadSources{}
+
+func (c FfiConverterReadSources) Lift(rb RustBufferI) ReadSources {
+	return LiftFromRustBuffer[ReadSources](c, rb)
+}
+
+func (c FfiConverterReadSources) Read(reader io.Reader) ReadSources {
+	return ReadSources{
+		FfiConverterSequenceReadSourceINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterReadSources) Lower(value ReadSources) C.RustBuffer {
+	return LowerIntoRustBuffer[ReadSources](c, value)
+}
+
+func (c FfiConverterReadSources) LowerExternal(value ReadSources) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[ReadSources](c, value))
+}
+
+func (c FfiConverterReadSources) Write(writer io.Writer, value ReadSources) {
+	FfiConverterSequenceReadSourceINSTANCE.Write(writer, value.Sources)
+}
+
+type FfiDestroyerReadSources struct{}
+
+func (_ FfiDestroyerReadSources) Destroy(value ReadSources) {
 	value.Destroy()
 }
 
@@ -7419,6 +7466,8 @@ type ScanOptions struct {
 	CacheBlocks bool
 	// Maximum number of concurrent fetch tasks used by the scan.
 	MaxFetchTasks uint64
+	// Sources consulted by this scan. An empty list means "all sources".
+	ReadSources ReadSources
 }
 
 func (r *ScanOptions) Destroy() {
@@ -7427,6 +7476,7 @@ func (r *ScanOptions) Destroy() {
 	FfiDestroyerUint64{}.Destroy(r.ReadAheadBytes)
 	FfiDestroyerBool{}.Destroy(r.CacheBlocks)
 	FfiDestroyerUint64{}.Destroy(r.MaxFetchTasks)
+	FfiDestroyerReadSources{}.Destroy(r.ReadSources)
 }
 
 type FfiConverterScanOptions struct{}
@@ -7444,6 +7494,7 @@ func (c FfiConverterScanOptions) Read(reader io.Reader) ScanOptions {
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterReadSourcesINSTANCE.Read(reader),
 	}
 }
 
@@ -7461,6 +7512,7 @@ func (c FfiConverterScanOptions) Write(writer io.Writer, value ScanOptions) {
 	FfiConverterUint64INSTANCE.Write(writer, value.ReadAheadBytes)
 	FfiConverterBoolINSTANCE.Write(writer, value.CacheBlocks)
 	FfiConverterUint64INSTANCE.Write(writer, value.MaxFetchTasks)
+	FfiConverterReadSourcesINSTANCE.Write(writer, value.ReadSources)
 }
 
 type FfiDestroyerScanOptions struct{}
@@ -8355,6 +8407,91 @@ func (_ FfiDestroyerMetricValue) Destroy(value MetricValue) {
 	value.Destroy()
 }
 
+// Options that control a point read.
+type ReadSource interface {
+	Destroy()
+}
+
+// Read from in-memory memtables.
+type ReadSourceMemtable struct {
+}
+
+func (e ReadSourceMemtable) Destroy() {
+}
+
+// Read from the L0 SST with this ULID.
+type ReadSourceL0 struct {
+	Field0 string
+}
+
+func (e ReadSourceL0) Destroy() {
+	FfiDestroyerString{}.Destroy(e.Field0)
+}
+
+// Read from the sorted run with this manifest id.
+type ReadSourceSortedRun struct {
+	Field0 uint32
+}
+
+func (e ReadSourceSortedRun) Destroy() {
+	FfiDestroyerUint32{}.Destroy(e.Field0)
+}
+
+type FfiConverterReadSource struct{}
+
+var FfiConverterReadSourceINSTANCE = FfiConverterReadSource{}
+
+func (c FfiConverterReadSource) Lift(rb RustBufferI) ReadSource {
+	return LiftFromRustBuffer[ReadSource](c, rb)
+}
+
+func (c FfiConverterReadSource) Lower(value ReadSource) C.RustBuffer {
+	return LowerIntoRustBuffer[ReadSource](c, value)
+}
+
+func (c FfiConverterReadSource) LowerExternal(value ReadSource) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[ReadSource](c, value))
+}
+func (FfiConverterReadSource) Read(reader io.Reader) ReadSource {
+	id := readInt32(reader)
+	switch id {
+	case 1:
+		return ReadSourceMemtable{}
+	case 2:
+		return ReadSourceL0{
+			FfiConverterStringINSTANCE.Read(reader),
+		}
+	case 3:
+		return ReadSourceSortedRun{
+			FfiConverterUint32INSTANCE.Read(reader),
+		}
+	default:
+		panic(fmt.Sprintf("invalid enum value %v in FfiConverterReadSource.Read()", id))
+	}
+}
+
+func (FfiConverterReadSource) Write(writer io.Writer, value ReadSource) {
+	switch variant_value := value.(type) {
+	case ReadSourceMemtable:
+		writeInt32(writer, 1)
+	case ReadSourceL0:
+		writeInt32(writer, 2)
+		FfiConverterStringINSTANCE.Write(writer, variant_value.Field0)
+	case ReadSourceSortedRun:
+		writeInt32(writer, 3)
+		FfiConverterUint32INSTANCE.Write(writer, variant_value.Field0)
+	default:
+		_ = variant_value
+		panic(fmt.Sprintf("invalid enum value `%v` in FfiConverterReadSource.Write", value))
+	}
+}
+
+type FfiDestroyerReadSource struct{}
+
+func (_ FfiDestroyerReadSource) Destroy(value ReadSource) {
+	value.Destroy()
+}
+
 // Kind of row entry stored in WAL iteration results.
 type RowEntryKind uint
 
@@ -9230,6 +9367,53 @@ type FfiDestroyerSequenceMetricLabel struct{}
 func (FfiDestroyerSequenceMetricLabel) Destroy(sequence []MetricLabel) {
 	for _, value := range sequence {
 		FfiDestroyerMetricLabel{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceReadSource struct{}
+
+var FfiConverterSequenceReadSourceINSTANCE = FfiConverterSequenceReadSource{}
+
+func (c FfiConverterSequenceReadSource) Lift(rb RustBufferI) []ReadSource {
+	return LiftFromRustBuffer[[]ReadSource](c, rb)
+}
+
+func (c FfiConverterSequenceReadSource) Read(reader io.Reader) []ReadSource {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]ReadSource, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterReadSourceINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceReadSource) Lower(value []ReadSource) C.RustBuffer {
+	return LowerIntoRustBuffer[[]ReadSource](c, value)
+}
+
+func (c FfiConverterSequenceReadSource) LowerExternal(value []ReadSource) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[[]ReadSource](c, value))
+}
+
+func (c FfiConverterSequenceReadSource) Write(writer io.Writer, value []ReadSource) {
+	if len(value) > math.MaxInt32 {
+		panic("[]ReadSource is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterReadSourceINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceReadSource struct{}
+
+func (FfiDestroyerSequenceReadSource) Destroy(sequence []ReadSource) {
+	for _, value := range sequence {
+		FfiDestroyerReadSource{}.Destroy(value)
 	}
 }
 

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/TestSupport.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/TestSupport.java
@@ -9,6 +9,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -318,12 +319,18 @@ final class TestSupport {
     }
 
     static ReadOptions readOptions() {
-        return new ReadOptions(DurabilityLevel.MEMORY, false, true);
+        return new ReadOptions(
+                DurabilityLevel.MEMORY, false, true, new ReadSources(Collections.emptyList()));
     }
 
     static ScanOptions scanOptions(long readAheadBytes, boolean cacheBlocks, long maxFetchTasks) {
         return new ScanOptions(
-                DurabilityLevel.MEMORY, false, readAheadBytes, cacheBlocks, maxFetchTasks);
+                DurabilityLevel.MEMORY,
+                false,
+                readAheadBytes,
+                cacheBlocks,
+                maxFetchTasks,
+                new ReadSources(Collections.emptyList()));
     }
 
     static ReaderOptions readerOptions(boolean skipWalReplay) {

--- a/bindings/node/tests/support.mjs
+++ b/bindings/node/tests/support.mjs
@@ -47,6 +47,7 @@ export function readOptions() {
     durability_filter: "Memory",
     dirty: false,
     cache_blocks: true,
+    read_sources: { sources: [] },
   };
 }
 
@@ -57,6 +58,7 @@ export function scanOptions(readAheadBytes, cacheBlocks, maxFetchTasks) {
     read_ahead_bytes: readAheadBytes,
     cache_blocks: cacheBlocks,
     max_fetch_tasks: maxFetchTasks,
+    read_sources: { sources: [] },
   };
 }
 

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -22,6 +22,7 @@ from slatedb.uniffi import (
     ObjectStore,
     PutOptions,
     ReadOptions,
+    ReadSources,
     ReaderOptions,
     RowEntry,
     RowEntryKind,
@@ -49,6 +50,7 @@ def read_options() -> ReadOptions:
         durability_filter=DurabilityLevel.MEMORY,
         dirty=False,
         cache_blocks=True,
+        read_sources=ReadSources(sources=[]),
     )
 
 
@@ -59,6 +61,7 @@ def scan_options(read_ahead_bytes: int, cache_blocks: bool, max_fetch_tasks: int
         read_ahead_bytes=read_ahead_bytes,
         cache_blocks=cache_blocks,
         max_fetch_tasks=max_fetch_tasks,
+        read_sources=ReadSources(sources=[]),
     )
 
 

--- a/bindings/uniffi/Cargo.toml
+++ b/bindings/uniffi/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 tracing-log = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 uniffi = { workspace = true, features = ["tokio"] }
+ulid = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use crate::error::{Error, SlateDbError};
+use ulid::Ulid;
 
 /// Minimum durability level required for data returned by reads and scans.
 #[derive(Clone, Copy, Debug, Default, uniffi::Enum)]
@@ -119,6 +120,52 @@ impl From<Ttl> for slatedb::config::Ttl {
 }
 
 /// Options that control a point read.
+#[derive(Clone, Debug, uniffi::Enum)]
+pub enum ReadSource {
+    /// Read from in-memory memtables.
+    Memtable,
+    /// Read from the L0 SST with this ULID.
+    L0(String),
+    /// Read from the sorted run with this manifest id.
+    SortedRun(u32),
+}
+
+impl TryFrom<ReadSource> for slatedb::config::ReadSource {
+    type Error = Error;
+
+    fn try_from(value: ReadSource) -> Result<Self, Self::Error> {
+        match value {
+            ReadSource::Memtable => Ok(Self::Memtable),
+            ReadSource::L0(id) => {
+                let id = Ulid::from_string(&id)
+                    .map_err(|source| Error::from(SlateDbError::InvalidL0SstId { source }))?;
+                Ok(Self::L0(id))
+            }
+            ReadSource::SortedRun(id) => Ok(Self::SortedRun(id)),
+        }
+    }
+}
+
+/// Source set consulted by point reads and scans.
+#[derive(Clone, Debug, Default, uniffi::Record)]
+pub struct ReadSources {
+    /// Sources that should be included. An empty list means "all sources".
+    pub sources: Vec<ReadSource>,
+}
+
+impl TryFrom<ReadSources> for slatedb::config::ReadSources {
+    type Error = Error;
+
+    fn try_from(value: ReadSources) -> Result<Self, Self::Error> {
+        let mut read_sources = slatedb::config::ReadSources::new(Vec::new());
+        for source in value.sources {
+            read_sources = read_sources.with_source(source.try_into()?);
+        }
+        Ok(read_sources)
+    }
+}
+
+/// Options that control a point read.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct ReadOptions {
     /// Minimum durability level a returned row must satisfy.
@@ -127,6 +174,8 @@ pub struct ReadOptions {
     pub dirty: bool,
     /// Whether fetched blocks should be inserted into the block cache.
     pub cache_blocks: bool,
+    /// Sources consulted by this read. An empty list means "all sources".
+    pub read_sources: ReadSources,
 }
 
 impl Default for ReadOptions {
@@ -135,17 +184,21 @@ impl Default for ReadOptions {
             durability_filter: DurabilityLevel::default(),
             dirty: false,
             cache_blocks: true,
+            read_sources: ReadSources::default(),
         }
     }
 }
 
-impl From<ReadOptions> for slatedb::config::ReadOptions {
-    fn from(value: ReadOptions) -> Self {
-        slatedb::config::ReadOptions {
+impl TryFrom<ReadOptions> for slatedb::config::ReadOptions {
+    type Error = Error;
+
+    fn try_from(value: ReadOptions) -> Result<Self, Self::Error> {
+        Ok(slatedb::config::ReadOptions {
             durability_filter: value.durability_filter.into(),
             dirty: value.dirty,
             cache_blocks: value.cache_blocks,
-        }
+            read_sources: value.read_sources.try_into()?,
+        })
     }
 }
 
@@ -198,6 +251,8 @@ pub struct ScanOptions {
     pub cache_blocks: bool,
     /// Maximum number of concurrent fetch tasks used by the scan.
     pub max_fetch_tasks: u64,
+    /// Sources consulted by this scan. An empty list means "all sources".
+    pub read_sources: ReadSources,
 }
 
 impl Default for ScanOptions {
@@ -208,6 +263,7 @@ impl Default for ScanOptions {
             read_ahead_bytes: 1,
             cache_blocks: false,
             max_fetch_tasks: 1,
+            read_sources: ReadSources::default(),
         }
     }
 }
@@ -230,6 +286,7 @@ impl TryFrom<ScanOptions> for slatedb::config::ScanOptions {
                     field: "max_fetch_tasks",
                 })
             })?,
+            read_sources: value.read_sources.try_into()?,
         })
     }
 }

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -53,7 +53,7 @@ impl Db {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         Ok(self
             .inner
             .get_with_options(key, &options)
@@ -74,7 +74,7 @@ impl Db {
         options: ReadOptions,
     ) -> Result<Option<KeyValue>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         Ok(self
             .inner
             .get_key_value_with_options(key, &options)

--- a/bindings/uniffi/src/db_reader.rs
+++ b/bindings/uniffi/src/db_reader.rs
@@ -33,7 +33,7 @@ impl DbReader {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         Ok(self
             .inner
             .get_with_options(key, &options)

--- a/bindings/uniffi/src/db_snapshot.rs
+++ b/bindings/uniffi/src/db_snapshot.rs
@@ -33,7 +33,7 @@ impl DbSnapshot {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         Ok(self
             .inner
             .get_with_options(key, &options)
@@ -54,7 +54,7 @@ impl DbSnapshot {
         options: ReadOptions,
     ) -> Result<Option<KeyValue>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         Ok(self
             .inner
             .get_key_value_with_options(key, &options)

--- a/bindings/uniffi/src/db_transaction.rs
+++ b/bindings/uniffi/src/db_transaction.rs
@@ -135,7 +135,7 @@ impl DbTransaction {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         let guard = self.inner.lock().await;
         let tx = guard.as_ref().ok_or(SlateDbError::TransactionCompleted)?;
         Ok(tx
@@ -159,7 +159,7 @@ impl DbTransaction {
         options: ReadOptions,
     ) -> Result<Option<KeyValue>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let options = options.try_into()?;
         let guard = self.inner.lock().await;
         let tx = guard.as_ref().ok_or(SlateDbError::TransactionCompleted)?;
         Ok(tx

--- a/bindings/uniffi/src/error.rs
+++ b/bindings/uniffi/src/error.rs
@@ -28,6 +28,9 @@ pub(crate) enum SlateDbError {
     #[error("invalid checkpoint_id UUID: {source}")]
     InvalidCheckpointId { source: uuid::Error },
 
+    #[error("invalid L0 SST ULID: {source}")]
+    InvalidL0SstId { source: ulid::DecodeError },
+
     #[error("range start cannot be empty")]
     EmptyRangeStart,
 

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -19,7 +19,8 @@ mod write_batch;
 pub use builder::{DbBuilder, DbReaderBuilder};
 pub use config::{
     DurabilityLevel, FlushOptions, FlushType, IsolationLevel, MergeOptions, PutOptions,
-    ReadOptions, ReaderOptions, ScanOptions, SstBlockSize, Ttl, WriteOptions,
+    ReadOptions, ReadSource, ReadSources, ReaderOptions, ScanOptions, SstBlockSize, Ttl,
+    WriteOptions,
 };
 pub use db::Db;
 pub use db_reader::DbReader;

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -186,6 +186,7 @@ use serde::{Deserialize, Serialize, Serializer};
 use std::collections::HashMap;
 use std::path::Path;
 use std::{str::FromStr, time::Duration};
+use ulid::Ulid;
 use uuid::Uuid;
 
 use crate::error::SlateDBError;
@@ -256,6 +257,72 @@ pub enum DurabilityLevel {
     Memory,
 }
 
+/// A source that may be included in an explicit read view.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReadSource {
+    /// Read from in-memory memtables.
+    ///
+    /// This includes the active memtable and immutable memtables.
+    Memtable,
+    /// Read from the L0 SST with this physical id.
+    L0(Ulid),
+    /// Read only from the sorted run with this manifest id.
+    SortedRun(u32),
+}
+
+/// A normalized read view used by point reads and scans.
+///
+/// An empty source list means "include everything", which is the default
+/// behavior and is equivalent to the normal merged read path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReadSources {
+    sources: Vec<ReadSource>,
+}
+
+impl Default for ReadSources {
+    fn default() -> Self {
+        Self::all()
+    }
+}
+
+impl ReadSources {
+    /// Returns a read view that includes every source.
+    ///
+    /// This is represented as an empty source list.
+    pub fn all() -> Self {
+        Self { sources: Vec::new() }
+    }
+
+    /// Creates a read view from the provided sources.
+    ///
+    /// An empty vector means "include everything".
+    pub fn new(sources: Vec<ReadSource>) -> Self {
+        Self { sources }
+    }
+
+    /// Adds one source to the read view.
+    pub fn with_source(mut self, source: ReadSource) -> Self {
+        if !self.sources.contains(&source) {
+            self.sources.push(source);
+        }
+        self
+    }
+
+    /// Returns whether `target` is included in this read view.
+    ///
+    /// If `self` was created with an empty source list, this returns `true` for
+    /// every target.
+    pub fn is_included(&self, target: ReadSource) -> bool {
+        self.sources.is_empty()
+            || self.sources.iter().any(|source| match (*source, target) {
+                (ReadSource::Memtable, ReadSource::Memtable) => true,
+                (ReadSource::SortedRun(id), ReadSource::SortedRun(target_id)) => id == target_id,
+                (ReadSource::L0(id), ReadSource::L0(target_id)) => id == target_id,
+                _ => false,
+            })
+    }
+}
+
 /// Configuration for client read operations. `ReadOptions` is supplied for each
 /// read call and controls the behavior of the read.
 #[derive(Clone, Debug)]
@@ -269,6 +336,9 @@ pub struct ReadOptions {
     pub dirty: bool,
     /// Whether or not fetched blocks should be cached
     pub cache_blocks: bool,
+    /// Restrict the read to an explicit source set instead of consulting the
+    /// full merged read stack.
+    pub read_sources: ReadSources,
 }
 
 impl Default for ReadOptions {
@@ -277,6 +347,7 @@ impl Default for ReadOptions {
             durability_filter: DurabilityLevel::default(),
             dirty: false,
             cache_blocks: true,
+            read_sources: ReadSources::default(),
         }
     }
 }
@@ -303,6 +374,20 @@ impl ReadOptions {
             ..self
         }
     }
+
+    pub fn with_read_source(self, read_source: ReadSource) -> Self {
+        Self {
+            read_sources: self.read_sources.with_source(read_source),
+            ..self
+        }
+    }
+
+    pub fn with_read_sources(self, read_sources: ReadSources) -> Self {
+        Self {
+            read_sources,
+            ..self
+        }
+    }
 }
 #[derive(Clone, Debug)]
 pub struct ScanOptions {
@@ -322,6 +407,9 @@ pub struct ScanOptions {
     /// The maximum number of concurrent tasks for fetching blocks during scans.
     /// Higher values can improve throughput but use more resources. The default is 1.
     pub max_fetch_tasks: usize,
+    /// Restrict the scan to an explicit source set instead of consulting the
+    /// full merged read stack.
+    pub read_sources: ReadSources,
 }
 
 impl Default for ScanOptions {
@@ -333,6 +421,7 @@ impl Default for ScanOptions {
             read_ahead_bytes: 1,
             cache_blocks: false,
             max_fetch_tasks: 1,
+            read_sources: ReadSources::default(),
         }
     }
 }
@@ -363,6 +452,20 @@ impl ScanOptions {
     pub fn with_cache_blocks(self, cache_blocks: bool) -> Self {
         Self {
             cache_blocks,
+            ..self
+        }
+    }
+
+    pub fn with_read_source(self, read_source: ReadSource) -> Self {
+        Self {
+            read_sources: self.read_sources.with_source(read_source),
+            ..self
+        }
+    }
+
+    pub fn with_read_sources(self, read_sources: ReadSources) -> Self {
+        Self {
+            read_sources,
             ..self
         }
     }
@@ -1461,6 +1564,8 @@ object_store_cache_options:
         assert_eq!(options.durability_filter, DurabilityLevel::Memory);
         assert!(!options.dirty);
         assert!(options.cache_blocks);
+        assert!(options.read_sources.is_included(ReadSource::Memtable));
+        assert!(options.read_sources.is_included(ReadSource::SortedRun(7)));
 
         let options = ScanOptions::default();
         assert_eq!(options.durability_filter, DurabilityLevel::Memory);
@@ -1468,6 +1573,8 @@ object_store_cache_options:
         assert_eq!(options.read_ahead_bytes, 1);
         assert!(!options.cache_blocks);
         assert_eq!(options.max_fetch_tasks, 1);
+        assert!(options.read_sources.is_included(ReadSource::Memtable));
+        assert!(options.read_sources.is_included(ReadSource::SortedRun(7)));
     }
 
     #[test]

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -290,7 +290,9 @@ impl ReadSources {
     ///
     /// This is represented as an empty source list.
     pub fn all() -> Self {
-        Self { sources: Vec::new() }
+        Self {
+            sources: Vec::new(),
+        }
     }
 
     /// Creates a read view from the provided sources.

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6754,19 +6754,11 @@ mod tests {
             .unwrap();
         }
 
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
-        let mut stored_manifest =
-            StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
-                .await
-                .unwrap();
-        wait_for_manifest_condition(
-            &mut stored_manifest,
-            |m| m.l0.len() > 2,
-            Duration::from_secs(30),
-        )
-        .await;
-
-        info!("GOT MANIFEST WITH 3 L0s");
+        // Flush all pending writes to L0 before triggering compaction.
+        // Without this, the compactor can race the flusher and compact only a
+        // partial set of L0s, producing too few SSTs to satisfy the multi-SST
+        // sorted-run condition below.
+        db.flush().await.unwrap();
 
         // Compact until we observe a sorted run where a single logical key spans SST boundaries.
         should_compact.store(true, Ordering::SeqCst);
@@ -6908,19 +6900,11 @@ mod tests {
             .unwrap();
         }
 
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
-        let mut stored_manifest =
-            StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
-                .await
-                .unwrap();
-        wait_for_manifest_condition(
-            &mut stored_manifest,
-            |m| m.l0.len() > 2,
-            Duration::from_secs(30),
-        )
-        .await;
-
-        info!("GOT MANIFEST WITH 3 L0s");
+        // Flush all pending writes to L0 before triggering compaction.
+        // Without this, the compactor can race the flusher and compact only a
+        // partial set of L0s, producing too few SSTs to satisfy the multi-SST
+        // sorted-run condition below.
+        db.flush().await.unwrap();
 
         // Compact until we observe a sorted run where a single logical key spans SST boundaries.
         should_compact.store(true, Ordering::SeqCst);

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2063,6 +2063,7 @@ mod tests {
                                         durability_filter: Memory,
                                         dirty: false,
                                         cache_blocks: true,
+                                        read_sources: crate::config::ReadSources::default(),
                                     }
                                 )
                                 .await

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -1,7 +1,7 @@
 use crate::batch::{WriteBatch, WriteBatchIterator};
 use crate::bytes_range::BytesRange;
 use crate::clock::MonotonicClock;
-use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
+use crate::config::{DurabilityLevel, ReadOptions, ReadSource, ReadSources, ScanOptions};
 use crate::db_state::ManifestCore;
 use crate::db_stats::DbStats;
 use crate::iter::{IterationOrder, RowEntryIterator};
@@ -86,24 +86,34 @@ impl Reader {
         range: &BytesRange,
         db_state: &(dyn DbStateReader + Sync),
         write_batch: Option<WriteBatch>,
+        read_sources: ReadSources,
         sst_iter_options: SstIteratorOptions,
         point_lookup_stats: Option<DbStats>,
     ) -> Result<IteratorSources, SlateDBError> {
-        let write_batch_iter = write_batch
-            .map(|batch| WriteBatchIterator::new(batch, range.clone(), IterationOrder::Ascending));
-
-        let mut memtables = VecDeque::new();
-        memtables.push_back(db_state.memtable());
-        for memtable in db_state.imm_memtable() {
-            memtables.push_back(memtable.table());
-        }
-        let mem_iters = memtables
-            .iter()
-            .map(|table| {
-                Box::new(table.range_ascending(range.clone()))
-                    as Box<dyn RowEntryIterator + 'static>
+        let write_batch_iter = if read_sources.is_included(ReadSource::Memtable) {
+            write_batch.map(|batch| {
+                WriteBatchIterator::new(batch, range.clone(), IterationOrder::Ascending)
             })
-            .collect::<Vec<_>>();
+        } else {
+            None
+        };
+
+        let mem_iters = if read_sources.is_included(ReadSource::Memtable) {
+            let mut memtables = VecDeque::new();
+            memtables.push_back(db_state.memtable());
+            for memtable in db_state.imm_memtable() {
+                memtables.push_back(memtable.table());
+            }
+            memtables
+                .iter()
+                .map(|table| {
+                    Box::new(table.range_ascending(range.clone()))
+                        as Box<dyn RowEntryIterator + 'static>
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
 
         let max_parallel =
             compute_max_parallel(db_state.core().l0.len(), &db_state.core().compacted, 4);
@@ -112,6 +122,7 @@ impl Reader {
             let l0 = self.build_point_l0_iters(
                 range,
                 db_state,
+                read_sources.clone(),
                 sst_iter_options,
                 point_lookup_stats.clone(),
             )?;
@@ -119,15 +130,26 @@ impl Reader {
                 range,
                 point_key.as_ref(),
                 db_state,
+                read_sources.clone(),
                 sst_iter_options,
                 point_lookup_stats,
             )?;
             (l0, sr)
         } else {
-            let l0_future =
-                self.build_range_l0_iters(range, db_state, sst_iter_options, max_parallel);
-            let sr_future =
-                self.build_range_sr_iters(range, db_state, sst_iter_options, max_parallel);
+            let l0_future = self.build_range_l0_iters(
+                range,
+                db_state,
+                read_sources.clone(),
+                sst_iter_options,
+                max_parallel,
+            );
+            let sr_future = self.build_range_sr_iters(
+                range,
+                db_state,
+                read_sources,
+                sst_iter_options,
+                max_parallel,
+            );
             let (l0_res, sr_res) = join(l0_future, sr_future).await;
             (l0_res?, sr_res?)
         };
@@ -144,11 +166,15 @@ impl Reader {
         &self,
         range: &BytesRange,
         db_state: &(dyn DbStateReader + Sync),
+        read_sources: ReadSources,
         sst_iter_options: SstIteratorOptions,
         db_stats: Option<DbStats>,
     ) -> Result<VecDeque<Box<dyn RowEntryIterator + 'a>>, SlateDBError> {
         let mut iters = VecDeque::new();
         for sst in &db_state.core().l0 {
+            if !read_sources.is_included(ReadSource::L0(sst.sst.id.unwrap_compacted_id())) {
+                continue;
+            }
             let iterator = SstIterator::new_owned_with_stats(
                 range.clone(),
                 sst.clone(),
@@ -168,12 +194,17 @@ impl Reader {
         range: &BytesRange,
         key: &[u8],
         db_state: &(dyn DbStateReader + Sync),
+        read_sources: ReadSources,
         sst_iter_options: SstIteratorOptions,
         db_stats: Option<DbStats>,
     ) -> Result<VecDeque<Box<dyn RowEntryIterator + 'a>>, SlateDBError> {
         let mut iters = VecDeque::new();
         for sr in &db_state.core().compacted {
+            let include_sorted_run = read_sources.is_included(ReadSource::SortedRun(sr.id));
             for handle in sr.tables_covering_point_key(key) {
+                if !include_sorted_run {
+                    continue;
+                }
                 let iterator = SstIterator::new_owned_with_stats(
                     range.clone(),
                     handle.clone(),
@@ -193,13 +224,23 @@ impl Reader {
         &self,
         range: &BytesRange,
         db_state: &(dyn DbStateReader + Sync),
+        read_sources: ReadSources,
         sst_iter_options: SstIteratorOptions,
         max_parallel: usize,
     ) -> Result<VecDeque<Box<dyn RowEntryIterator + 'a>>, SlateDBError> {
         let range_clone = range.clone();
         let table_store = self.table_store.clone();
+        let selected_l0: Vec<_> = db_state
+            .core()
+            .l0
+            .iter()
+            .filter(|sst| {
+                read_sources.is_included(ReadSource::L0(sst.sst.id.unwrap_compacted_id()))
+            })
+            .cloned()
+            .collect();
         build_concurrent(
-            db_state.core().l0.iter().cloned(),
+            selected_l0.into_iter(),
             max_parallel,
             move |sst| {
                 let table_store = table_store.clone();
@@ -225,31 +266,43 @@ impl Reader {
         &self,
         range: &BytesRange,
         db_state: &(dyn DbStateReader + Sync),
+        read_sources: ReadSources,
         sst_iter_options: SstIteratorOptions,
         max_parallel: usize,
     ) -> Result<VecDeque<Box<dyn RowEntryIterator + 'a>>, SlateDBError> {
-        let range_clone = range.clone();
-        let table_store = self.table_store.clone();
-        build_concurrent(
-            db_state.core().compacted.iter().cloned(),
-            max_parallel,
-            move |sr| {
-                let table_store = table_store.clone();
-                let range = range_clone.clone();
-                async move {
-                    SortedRunIterator::new_owned_initialized_with_stats(
-                        range.clone(),
-                        sr,
-                        table_store,
-                        sst_iter_options,
-                        Some(self.db_stats.clone()),
-                    )
-                    .await
-                    .map(|iter| Some(Box::new(iter) as Box<dyn RowEntryIterator + 'a>))
-                }
-            },
-        )
-        .await
+        let selected_sorted_runs: Vec<_> = db_state
+            .core()
+            .compacted
+            .iter()
+            .filter(|sr| read_sources.is_included(ReadSource::SortedRun(sr.id)))
+            .cloned()
+            .collect();
+        if selected_sorted_runs.is_empty() {
+            Ok(VecDeque::new())
+        } else {
+            let range_clone = range.clone();
+            let table_store = self.table_store.clone();
+            build_concurrent(
+                selected_sorted_runs.into_iter(),
+                max_parallel,
+                move |sr| {
+                    let table_store = table_store.clone();
+                    let range = range_clone.clone();
+                    async move {
+                        SortedRunIterator::new_owned_initialized_with_stats(
+                            range.clone(),
+                            sr,
+                            table_store,
+                            sst_iter_options,
+                            Some(self.db_stats.clone()),
+                        )
+                        .await
+                        .map(|iter| Some(Box::new(iter) as Box<dyn RowEntryIterator + 'a>))
+                    }
+                },
+            )
+            .await
+        }
     }
 
     /// Get the full row entry for the given key.
@@ -300,6 +353,7 @@ impl Reader {
                 &range,
                 db_state,
                 write_batch,
+                options.read_sources.clone(),
                 sst_iter_options,
                 Some(self.db_stats.clone()),
             )
@@ -376,7 +430,14 @@ impl Reader {
             l0_iters,
             sr_iters,
         } = self
-            .build_iterator_sources(&range, db_state, write_batch, sst_iter_options, None)
+            .build_iterator_sources(
+                &range,
+                db_state,
+                write_batch,
+                options.read_sources.clone(),
+                sst_iter_options,
+                None,
+            )
             .await?;
 
         DbIterator::new(
@@ -1709,6 +1770,93 @@ mod tests {
                 .collect::<Vec<_>>()
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_support_memtable_only_read_view() -> Result<(), SlateDBError> {
+        let entries = vec![
+            TestEntry::value(b"key1", b"mem", 50),
+            TestEntry::value(b"key1", b"l0", 40).with_location(LayerLocation::L0Sst(0)),
+            TestEntry::value(b"key1", b"sr", 30).with_location(LayerLocation::SortedRun(0)),
+        ];
+
+        let mut test_db_state = TestDbState::new().await;
+        let write_batch = populate_db_state(&mut test_db_state, entries).await?;
+
+        let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+        let db_stats = DbStats::new(&recorder);
+        let reader = build_reader(&test_db_state, db_stats, false).await;
+
+        let result = reader
+            .get_key_value_with_options(
+                b"key1",
+                &ReadOptions::default()
+                    .with_dirty(true)
+                    .with_read_source(ReadSource::Memtable),
+                &test_db_state,
+                write_batch,
+                None,
+            )
+            .await?;
+
+        let kv = result.expect("should return memtable value");
+        assert_eq!(kv.value.as_ref(), b"mem");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_support_multi_source_scan_view() -> Result<(), SlateDBError> {
+        let entries = vec![
+            TestEntry::value(b"key1", b"mem", 50).with_location(LayerLocation::Memtable),
+            TestEntry::value(b"key2", b"l0_keep", 40).with_location(LayerLocation::L0Sst(0)),
+            TestEntry::value(b"key3", b"l0_skip", 40).with_location(LayerLocation::L0Sst(1)),
+            TestEntry::value(b"key4", b"sr_skip", 30).with_location(LayerLocation::SortedRun(0)),
+            TestEntry::value(b"key5", b"sr_keep", 30).with_location(LayerLocation::SortedRun(1)),
+        ];
+
+        let mut test_db_state = TestDbState::new().await;
+        let write_batch = populate_db_state(&mut test_db_state, entries).await?;
+
+        let selected_l0_id = test_db_state
+            .core
+            .l0
+            .iter()
+            .find(|sst| sst.sst.info.first_entry.as_deref() == Some(&b"key2"[..]))
+            .expect("missing selected l0 sst")
+            .sst
+            .id
+            .unwrap_compacted_id();
+
+        let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+        let db_stats = DbStats::new(&recorder);
+        let reader = build_reader(&test_db_state, db_stats, false).await;
+
+        let range = BytesRange::from_slice(b"key1".as_ref()..b"key6".as_ref());
+        let scan_options = ScanOptions::default()
+            .with_dirty(true)
+            .with_read_source(ReadSource::L0(selected_l0_id))
+            .with_read_source(ReadSource::SortedRun(1));
+        let mut iter = reader
+            .scan_with_options(range, &scan_options, &test_db_state, write_batch, None, None)
+            .await?;
+
+        let mut actual = Vec::new();
+        while let Some(kv) = iter
+            .next()
+            .await
+            .map_err(|e| SlateDBError::IoError(Arc::new(std::io::Error::other(e))))?
+        {
+            actual.push((kv.key.to_vec(), kv.value.to_vec()));
+        }
+
+        assert_eq!(
+            actual,
+            vec![
+                (b"key2".to_vec(), b"l0_keep".to_vec()),
+                (b"key5".to_vec(), b"sr_keep".to_vec()),
+            ]
+        );
         Ok(())
     }
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -239,26 +239,22 @@ impl Reader {
             })
             .cloned()
             .collect();
-        build_concurrent(
-            selected_l0.into_iter(),
-            max_parallel,
-            move |sst| {
-                let table_store = table_store.clone();
-                let range = range_clone.clone();
-                async move {
-                    SstIterator::new_owned_initialized(
-                        range.clone(),
-                        sst,
-                        table_store,
-                        sst_iter_options,
-                    )
-                    .await
-                    .map(|maybe_iter| {
-                        maybe_iter.map(|iter| Box::new(iter) as Box<dyn RowEntryIterator + 'a>)
-                    })
-                }
-            },
-        )
+        build_concurrent(selected_l0.into_iter(), max_parallel, move |sst| {
+            let table_store = table_store.clone();
+            let range = range_clone.clone();
+            async move {
+                SstIterator::new_owned_initialized(
+                    range.clone(),
+                    sst,
+                    table_store,
+                    sst_iter_options,
+                )
+                .await
+                .map(|maybe_iter| {
+                    maybe_iter.map(|iter| Box::new(iter) as Box<dyn RowEntryIterator + 'a>)
+                })
+            }
+        })
         .await
     }
 
@@ -282,25 +278,21 @@ impl Reader {
         } else {
             let range_clone = range.clone();
             let table_store = self.table_store.clone();
-            build_concurrent(
-                selected_sorted_runs.into_iter(),
-                max_parallel,
-                move |sr| {
-                    let table_store = table_store.clone();
-                    let range = range_clone.clone();
-                    async move {
-                        SortedRunIterator::new_owned_initialized_with_stats(
-                            range.clone(),
-                            sr,
-                            table_store,
-                            sst_iter_options,
-                            Some(self.db_stats.clone()),
-                        )
-                        .await
-                        .map(|iter| Some(Box::new(iter) as Box<dyn RowEntryIterator + 'a>))
-                    }
-                },
-            )
+            build_concurrent(selected_sorted_runs.into_iter(), max_parallel, move |sr| {
+                let table_store = table_store.clone();
+                let range = range_clone.clone();
+                async move {
+                    SortedRunIterator::new_owned_initialized_with_stats(
+                        range.clone(),
+                        sr,
+                        table_store,
+                        sst_iter_options,
+                        Some(self.db_stats.clone()),
+                    )
+                    .await
+                    .map(|iter| Some(Box::new(iter) as Box<dyn RowEntryIterator + 'a>))
+                }
+            })
             .await
         }
     }
@@ -1838,7 +1830,14 @@ mod tests {
             .with_read_source(ReadSource::L0(selected_l0_id))
             .with_read_source(ReadSource::SortedRun(1));
         let mut iter = reader
-            .scan_with_options(range, &scan_options, &test_db_state, write_batch, None, None)
+            .scan_with_options(
+                range,
+                &scan_options,
+                &test_db_state,
+                write_batch,
+                None,
+                None,
+            )
             .await?;
 
         let mut actual = Vec::new();


### PR DESCRIPTION
## Summary

I want a way to scope reads and scans to a specific set of sources instead of always using the full LSM.

The main use case (for me) is cache warming after compactions. A reader can diff the old and new manifests, detect new SSTs created by flush or compaction, and issue scans that touch only those new SSTs. That would let us warm block cache and object-store cache without scanning unnecessary files. I imagine it's also interesting for debugging purposes.

This is a bit of a footgun, because it might allow you to read entries that are tombstones higher up the tree. I think that's an acceptable tradeoff.

Related to https://github.com/slatedb/slatedb/issues/1405

## Changes

- Adds `ReadSource`/`ReadSources` to `ReadOptions` and `ScanOptions`
- When building the Reader iterators, filter out SSTs/Sorted Runs that aren't scoped
- UniFFI Bindings

## Notes for Reviewers

I had originally wanted to allow reading from any SST, even one _within_ a sorted run, but that complicates the code a bit and I wasn't sure the use case for that was quite as strong so I force users to specify either an L0 SST or a full SR.

Changes are split into three commits:

1. Rust Code
2. UniFFI Bindings
3. Generated Go Bindings

I'd love to get your thoughts on the approach to solving this problem. I figured that because the implementation is so straightforward it really doesn't complicate the code much at all so this strikes a good middle ground.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
