### PR TITLE
Fix flaky SR split key tests by flushing before compaction

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6753,24 +6753,19 @@ mod tests {
             .unwrap();
         }
 
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
-        let mut stored_manifest =
-            StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
-                .await
-                .unwrap();
-        wait_for_manifest_condition(
-            &mut stored_manifest,
-            |m| m.l0.len() > 2,
-            Duration::from_secs(30),
-        )
-        .await;
+        // Flush all pending writes to L0 before triggering compaction.
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
 
-        info!("GOT MANIFEST WITH 3 L0s");
-
-        // Compact until we observe a sorted run where a single logical key spans SST boundaries.
-        should_compact.store(true, Ordering::SeqCst);
+        // Compact until we observe a sorted run where a single logical key spans
+        // multiple SSTs. Re-arm should_compact each iteration so partial compactions
+        // can be followed by additional rounds.
         tokio::time::timeout(Duration::from_secs(60), async {
             loop {
+                should_compact.store(true, Ordering::SeqCst);
                 {
                     let state = db.inner.state.read();
                     info!(
@@ -6907,24 +6902,19 @@ mod tests {
             .unwrap();
         }
 
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
-        let mut stored_manifest =
-            StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
-                .await
-                .unwrap();
-        wait_for_manifest_condition(
-            &mut stored_manifest,
-            |m| m.l0.len() > 2,
-            Duration::from_secs(30),
-        )
-        .await;
+        // Flush all pending writes to L0 before triggering compaction.
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
 
-        info!("GOT MANIFEST WITH 3 L0s");
-
-        // Compact until we observe a sorted run where a single logical key spans SST boundaries.
-        should_compact.store(true, Ordering::SeqCst);
+        // Compact until we observe a sorted run where a single logical key spans
+        // multiple SSTs. Re-arm should_compact each iteration so partial compactions
+        // can be followed by additional rounds.
         tokio::time::timeout(Duration::from_secs(60), async {
             loop {
+                should_compact.store(true, Ordering::SeqCst);
                 {
                     let state = db.inner.state.read();
                     info!(


### PR DESCRIPTION
## Summary

The issue was detected / reproduced with the help of Claude Opus 4.6 high [high effort].

🔗 [Original Failure](https://github.com/slatedb/slatedb/actions/runs/24118294943/job/70366818883?pr=1503)

Fix flaky `reads_succeed_when_compacted_sr_splits_same_key_across_ssts` and `reads_succeed_when_compacted_sr_splits_same_merge_key_across_ssts` tests that time out in CI.

## Changes

Two fixes:

1. **Flush before compaction**: Replace `wait_for_manifest_condition(|m| m.l0.len() > 2)` with `db.flush_with_options(FlushType::MemTable)`. The old condition raced with the flusher — in CI the compactor would fire with only 3 L0s flushed, producing a single-SST sorted run.

2. **Re-arm compaction flag each loop iteration**: The `should_compact` flag used `compare_exchange(true, false)`, so only one compaction could ever fire. If that compaction produced a sorted run with one SST, the test could never recover. Moving `should_compact.store(true)` into the wait loop allows partial compactions to be followed by additional rounds.

## Notes for Reviewers

Reproduced locally by wrapping `InMemory` with `object_store::throttle::ThrottledStore` (`wait_put_per_call = 500ms`). With the slow store, the test required multiple compaction rounds (3 L0s → SR(225), then remaining L0s + SR → SR(537) with multiple SSTs) and passed in ~24s. Without the fix, it timed out at 60s.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests)
- [x] Self-reviewed the diff
- [x] Tests passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`