### PR TITLE
Add Db::manifest_poll for forcing a manifest poll

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1526,6 +1526,22 @@ impl Db {
         self.inner.manifest()
     }
 
+    /// Enqueue a manifest poll immediately and wait for it to complete.
+    ///
+    /// A `PollManifest` command is enqueued immediately, bypassing the regular
+    /// [`Settings::manifest_poll_interval`] timer.
+    ///
+    /// ## Errors
+    /// - Returns [`Error`] if the database is closed before the next poll completes.
+    pub async fn manifest_poll(&self) -> Result<(), crate::Error> {
+        self.inner.check_closed()?;
+        self.inner
+            .memtable_flusher
+            .poll_manifest()
+            .await
+            .map_err(Into::into)
+    }
+
     /// Subscribe to database state changes.
     ///
     /// Returns a [`tokio::sync::watch::Receiver<DbStatus>`] that always

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -59,7 +59,9 @@ enum ManifestWriterCommand {
         sender: oneshot::Sender<Result<CheckpointCreateResult, SlateDBError>>,
     },
     /// Periodic manifest poll to pick up remote changes (e.g. compaction).
-    PollManifest,
+    PollManifest {
+        done: Option<oneshot::Sender<Result<(), SlateDBError>>>,
+    },
 }
 
 impl std::fmt::Debug for ManifestWriterCommand {
@@ -78,7 +80,7 @@ impl std::fmt::Debug for ManifestWriterCommand {
             Self::CreateCheckpoint { through_seq, .. } => {
                 write!(f, "CreateCheckpoint({through_seq:?})")
             }
-            Self::PollManifest => write!(f, "PollManifest"),
+            Self::PollManifest { .. } => write!(f, "PollManifest"),
         }
     }
 }
@@ -153,6 +155,15 @@ impl ManifestWriter {
             })
     }
 
+    /// Enqueues a manifest poll; the result is delivered to `sender` on completion.
+    pub(crate) fn send_poll(
+        &self,
+        sender: oneshot::Sender<Result<(), SlateDBError>>,
+    ) -> Result<(), SlateDBError> {
+        self.commands_tx
+            .send(ManifestWriterCommand::PollManifest { done: Some(sender) })
+    }
+
     pub(crate) async fn shutdown(executor: &crate::dispatcher::MessageHandlerExecutor) {
         if let Err(e) = executor.shutdown_task(MANIFEST_WRITER_TASK_NAME).await {
             log::warn!("failed to shutdown l0 manifest writer [error={:?}]", e);
@@ -185,7 +196,7 @@ impl MessageHandler<ManifestWriterCommand> for ManifestWriterHandler {
     )> {
         vec![(
             self.manifest_poll_interval,
-            Box::new(|| ManifestWriterCommand::PollManifest),
+            Box::new(|| ManifestWriterCommand::PollManifest { done: None }),
         )]
     }
 
@@ -209,7 +220,9 @@ impl MessageHandler<ManifestWriterCommand> for ManifestWriterHandler {
                 self.handle_create_checkpoint(through_seq, options, sender)
                     .await
             }
-            ManifestWriterCommand::PollManifest => self.refresh_manifest_progress().await,
+            ManifestWriterCommand::PollManifest { done } => {
+                self.refresh_manifest_progress(done).await
+            }
         }
     }
 
@@ -546,10 +559,16 @@ impl ManifestWriterHandler {
         Ok(())
     }
 
-    async fn refresh_manifest_progress(&mut self) -> Result<(), SlateDBError> {
+    async fn refresh_manifest_progress(
+        &mut self,
+        done: Option<oneshot::Sender<Result<(), SlateDBError>>>,
+    ) -> Result<(), SlateDBError> {
         self.manifest.refresh().await?;
         let remote_dirty = self.manifest.prepare_dirty()?;
         self.merge_remote_manifest(remote_dirty);
+        if let Some(tx) = done {
+            let _ = tx.send(Ok(()));
+        }
         let _ = self.tracker_tx.send(TrackerMessage::ManifestRefreshed);
         Ok(())
     }

--- a/slatedb/src/memtable_flusher/mod.rs
+++ b/slatedb/src/memtable_flusher/mod.rs
@@ -20,7 +20,7 @@ use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
 use crate::memtable_flusher::manifest_writer::ManifestWriter;
-use crate::memtable_flusher::tracker::FlushTracker;
+use crate::memtable_flusher::tracker::{FlushTracker, TrackerMessage};
 use crate::memtable_flusher::uploader::Uploader;
 use crate::utils::SafeSender;
 use log::warn;
@@ -96,6 +96,14 @@ impl MemtableFlusher {
         )?;
 
         Ok(())
+    }
+
+    /// Enqueues a manifest poll and waits until it completes.
+    pub(crate) async fn poll_manifest(&self) -> Result<(), SlateDBError> {
+        let (tx, rx) = oneshot::channel();
+        self.messages_tx
+            .send(TrackerMessage::PollManifest { sender: tx })?;
+        rx.await.map_err(SlateDBError::ReadChannelError)?
     }
 
     /// Processes one flush request using the requested target.

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -52,6 +52,10 @@ pub(crate) enum TrackerMessage {
     FlushComplete { through_seq: u64 },
     /// Remote manifest changes were merged into local state.
     ManifestRefreshed,
+    /// Poll the remote manifest and signal the caller when complete.
+    PollManifest {
+        sender: oneshot::Sender<Result<(), SlateDBError>>,
+    },
 }
 
 impl std::fmt::Debug for TrackerMessage {
@@ -71,6 +75,7 @@ impl std::fmt::Debug for TrackerMessage {
                 write!(f, "FlushComplete(through_seq={through_seq})")
             }
             Self::ManifestRefreshed => write!(f, "ManifestRefreshed"),
+            Self::PollManifest { .. } => write!(f, "PollManifest"),
         }
     }
 }
@@ -119,6 +124,7 @@ impl MessageHandler<TrackerMessage> for FlushTracker {
                 self.reconcile_and_dispatch().await
             }
             TrackerMessage::ManifestRefreshed => self.reconcile_and_dispatch().await,
+            TrackerMessage::PollManifest { sender } => self.manifest_writer.send_poll(sender),
         }
     }
 
@@ -237,6 +243,9 @@ impl FlushTracker {
                     let _ = sender.send(Err(err.clone()));
                 }
                 TrackerMessage::CheckpointRequest { sender, .. } => {
+                    let _ = sender.send(Err(err.clone()));
+                }
+                TrackerMessage::PollManifest { sender } => {
                     let _ = sender.send(Err(err.clone()));
                 }
                 other => {

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -350,3 +350,32 @@ async fn test_concurrent_writers_and_readers() {
         .await
         .expect("Failed to close DB after retries");
 }
+
+/// Verify that manifest_poll enqueues a poll and returns once it completes,
+/// and returns an error once the DB is closed.
+#[tokio::test]
+async fn test_manifest_poll() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = Db::builder("test_manifest_poll", object_store.clone())
+        .with_settings(Settings {
+            manifest_poll_interval: Duration::from_secs(60 * 60),
+            ..Default::default()
+        })
+        .build()
+        .await
+        .expect("failed to open db");
+
+    // Should return once the enqueued poll completes.
+    db.manifest_poll()
+        .await
+        .expect("manifest_poll returned error");
+
+    // After close, manifest_poll should return an error.
+    db.close().await.expect("failed to close db");
+    let result = db.manifest_poll().await;
+    assert!(
+        result.is_err(),
+        "expected error after close, got {:?}",
+        result
+    );
+}


### PR DESCRIPTION
## Summary

Adds a method on `Db` that forces a manifest poll. Clients can use this to force an update to the manifest. 

## Changes

- adds a poll_manifest after the PollManifest command completes

## Notes for Reviewers

I chose a oneshot pattern because I think each caller should have their own command enqueued and responded to. I think this is different than the proposed db::Subscribe option.

This is intended as a test helper, but I think it could also be useful for writing benchmarks, or orchestration code.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
