### PR TITLE
pipe in the manifest ID into ManifestCore

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -570,6 +570,7 @@ impl CompactorState {
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
             recent_snapshot_min_seq: remote_manifest.value.core.recent_snapshot_min_seq,
             sequence_tracker: remote_manifest.value.core.sequence_tracker,
+            manifest_id: u64::from(remote_manifest.id) + 1,
         };
         remote_manifest.value.core = merged;
         self.manifest = remote_manifest;
@@ -1144,6 +1145,25 @@ mod tests {
 
         // then:
         assert_eq!(vec![checkpoint], state.db_state().checkpoints);
+    }
+
+    #[test]
+    fn test_should_set_manifest_id_on_compactor_merge() {
+        // given:
+        let manifest = new_dirty_manifest();
+        let compactions = new_dirty_compactions(manifest.value.compactor_epoch);
+        let mut state = CompactorState::new(manifest, compactions);
+        let remote_id = 7u64;
+        let remote = slatedb_txn_obj::test_utils::new_dirty_object(
+            remote_id,
+            Manifest::initial(state.db_state().clone()),
+        );
+
+        // when:
+        state.merge_remote_manifest(remote);
+
+        // then:
+        assert_eq!(state.db_state().manifest_id, remote_id + 1);
     }
 
     #[test]

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -530,6 +530,10 @@ pub struct ManifestCore {
 
     /// The URI of the object store dedicated specifically for WAL, if any.
     pub wal_object_store_uri: Option<String>,
+
+    /// The manifest ID that will be used when this manifest is next persisted.
+    /// Always equals `stored_manifest_id + 1` after loading or merging.
+    pub manifest_id: u64,
 }
 
 impl ManifestCore {
@@ -548,6 +552,7 @@ impl ManifestCore {
             wal_object_store_uri: None,
             recent_snapshot_min_seq: 0,
             sequence_tracker: SequenceTracker::new(),
+            manifest_id: 0,
         }
     }
 
@@ -722,6 +727,7 @@ impl<'a> StateModifier<'a> {
             sequence_tracker: my_db_state.sequence_tracker.clone(),
             checkpoints: remote_manifest.value.core.checkpoints,
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
+            manifest_id: u64::from(remote_manifest.id) + 1,
         };
         self.state.manifest = remote_manifest;
     }
@@ -1019,6 +1025,24 @@ mod tests {
         let sst_id = SsTableId::Compacted(ulid::Ulid::new());
         let handle = SsTableHandle::new(sst_id, SST_FORMAT_VERSION_LATEST, sst_info);
         SsTableView::identity(handle)
+    }
+
+    #[test]
+    fn test_should_set_manifest_id_on_writer_merge() {
+        // given:
+        let mut db_state = DbState::new(new_dirty_manifest());
+        let remote_id = 5u64;
+        let mut remote = slatedb_txn_obj::test_utils::new_dirty_object(
+            remote_id,
+            db_state.state.manifest.value.clone(),
+        );
+        remote.value.core = db_state.state.core().clone();
+
+        // when:
+        db_state.merge_remote_manifest(remote);
+
+        // then:
+        assert_eq!(db_state.state.core().manifest_id, remote_id + 1);
     }
 
     fn create_sst_info(first_entry: Option<Bytes>) -> SsTableInfo {

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -301,6 +301,7 @@ impl FlatBufferManifestCodec {
             wal_object_store_uri: manifest.wal_object_store_uri().map(|uri| uri.to_string()),
             recent_snapshot_min_seq: manifest.recent_snapshot_min_seq(),
             sequence_tracker,
+            manifest_id: manifest.manifest_id(),
         };
         let external_dbs = manifest.external_dbs().map(|external_dbs| {
             external_dbs
@@ -415,6 +416,7 @@ impl FlatBufferManifestCodec {
             wal_object_store_uri: None,
             recent_snapshot_min_seq: manifest.recent_snapshot_min_seq(),
             sequence_tracker,
+            manifest_id: manifest.manifest_id(),
         };
         let external_dbs = manifest.external_dbs().map(|external_dbs| {
             external_dbs
@@ -1005,7 +1007,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         let manifest = ManifestV2::create(
             &mut self.builder,
             &ManifestV2Args {
-                manifest_id: 0, // todo: get rid of me
+                manifest_id: 0,
                 external_dbs,
                 initialized: core.initialized,
                 writer_epoch: manifest.writer_epoch,

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -254,7 +254,9 @@ impl StoredManifest {
     }
 
     pub(crate) fn prepare_dirty(&self) -> Result<DirtyObject<Manifest>, SlateDBError> {
-        Ok(self.inner.prepare_dirty()?)
+        let mut dirty = self.inner.prepare_dirty()?;
+        dirty.value.core.manifest_id = u64::from(dirty.id) + 1;
+        Ok(dirty)
     }
 
     pub(crate) fn db_state(&self) -> &ManifestCore {
@@ -1433,5 +1435,33 @@ mod tests {
             Some(SlateDBError::Fenced)
         ));
         assert!(fm_a.refresh().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_should_set_manifest_id_on_prepare_dirty() {
+        // given:
+        let ms = new_memory_manifest_store();
+        let mut sm = StoredManifest::create_new_db(
+            ms.clone(),
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(sm.id(), 1);
+
+        // when:
+        let dirty = sm.prepare_dirty().unwrap();
+
+        // then: manifest_id should be stored_id + 1
+        assert_eq!(dirty.value.core.manifest_id, 2);
+
+        // when: write and prepare again
+        sm.update(dirty).await.unwrap();
+        assert_eq!(sm.id(), 2);
+        let dirty = sm.prepare_dirty().unwrap();
+
+        // then: manifest_id advances
+        assert_eq!(dirty.value.core.manifest_id, 3);
     }
 }

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -917,6 +917,7 @@ mod tests {
             wal_object_store_uri: None,
             recent_snapshot_min_seq: 0,
             sequence_tracker: SequenceTracker::new(),
+            manifest_id: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

This came up in discussion for #1514 - we want to make sure that subscription always returns new manifests and doesn't go back in time. Using the ID allows us to ensure that property.

## Changes

- Set the id whenever we call `prepare_dirty` to the next ID

## Notes for Reviewers

I intentionally did not update the flatbuffer types to be aligned because there's a TODO about removing the manifest id from it. I can add that if we want to keep it properly piped through.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
