### PR TITLE
Return `DbStatus` when `status()` is called

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -690,7 +690,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_db_status()
 		})
-		if checksum != 26 {
+		if checksum != 33776 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_status: UniFFI API checksum mismatch")
 		}
@@ -774,6 +774,15 @@ func uniffiCheckChecksums() {
 		if checksum != 34395 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_status()
+		})
+		if checksum != 4488 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_status: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -1977,8 +1986,8 @@ type DbInterface interface {
 	Shutdown() error
 	// Creates a read-only snapshot representing a consistent point in time.
 	Snapshot() (*DbSnapshot, error)
-	// Returns an error if the database is not currently healthy and open.
-	Status() error
+	// Returns the latest database status snapshot.
+	Status() DbStatus
 	// Applies all operations in `batch` atomically.
 	//
 	// The provided batch is consumed and cannot be reused afterwards.
@@ -2657,16 +2666,16 @@ func (_self *Db) Snapshot() (*DbSnapshot, error) {
 	return res, err
 }
 
-// Returns an error if the database is not currently healthy and open.
-func (_self *Db) Status() error {
+// Returns the latest database status snapshot.
+func (_self *Db) Status() DbStatus {
 	_pointer := _self.ffiObject.incrementPointer("*Db")
 	defer _self.ffiObject.decrementPointer()
-	_, _uniffiErr := rustCallWithError[*Error](FfiConverterError{}, func(_uniffiStatus *C.RustCallStatus) bool {
-		C.uniffi_slatedb_uniffi_fn_method_db_status(
-			_pointer, _uniffiStatus)
-		return false
-	})
-	return _uniffiErr.AsError()
+	return FfiConverterDbStatusINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer{
+			inner: C.uniffi_slatedb_uniffi_fn_method_db_status(
+				_pointer, _uniffiStatus),
+		}
+	}))
 }
 
 // Applies all operations in `batch` atomically.
@@ -3161,6 +3170,8 @@ type DbReaderInterface interface {
 	ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIterator, error)
 	// Closes the reader.
 	Shutdown() error
+	// Returns the latest reader status snapshot.
+	Status() DbStatus
 }
 
 // Read-only database handle opened by [`crate::DbReaderBuilder`].
@@ -3406,6 +3417,18 @@ func (_self *DbReader) Shutdown() error {
 	}
 
 	return err
+}
+
+// Returns the latest reader status snapshot.
+func (_self *DbReader) Status() DbStatus {
+	_pointer := _self.ffiObject.incrementPointer("*DbReader")
+	defer _self.ffiObject.decrementPointer()
+	return FfiConverterDbStatusINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer{
+			inner: C.uniffi_slatedb_uniffi_fn_method_dbreader_status(
+				_pointer, _uniffiStatus),
+		}
+	}))
 }
 func (object *DbReader) Destroy() {
 	runtime.SetFinalizer(object, nil)
@@ -6748,6 +6771,53 @@ func (_ FfiDestroyerWriteBatch) Destroy(value *WriteBatch) {
 	value.Destroy()
 }
 
+// Snapshot of the current database lifecycle and durability state.
+type DbStatus struct {
+	// Highest durable sequence number observed by this handle.
+	DurableSeq uint64
+	// Present once the handle has been closed.
+	CloseReason *CloseReason
+}
+
+func (r *DbStatus) Destroy() {
+	FfiDestroyerUint64{}.Destroy(r.DurableSeq)
+	FfiDestroyerOptionalCloseReason{}.Destroy(r.CloseReason)
+}
+
+type FfiConverterDbStatus struct{}
+
+var FfiConverterDbStatusINSTANCE = FfiConverterDbStatus{}
+
+func (c FfiConverterDbStatus) Lift(rb RustBufferI) DbStatus {
+	return LiftFromRustBuffer[DbStatus](c, rb)
+}
+
+func (c FfiConverterDbStatus) Read(reader io.Reader) DbStatus {
+	return DbStatus{
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterOptionalCloseReasonINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterDbStatus) Lower(value DbStatus) C.RustBuffer {
+	return LowerIntoRustBuffer[DbStatus](c, value)
+}
+
+func (c FfiConverterDbStatus) LowerExternal(value DbStatus) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[DbStatus](c, value))
+}
+
+func (c FfiConverterDbStatus) Write(writer io.Writer, value DbStatus) {
+	FfiConverterUint64INSTANCE.Write(writer, value.DurableSeq)
+	FfiConverterOptionalCloseReasonINSTANCE.Write(writer, value.CloseReason)
+}
+
+type FfiDestroyerDbStatus struct{}
+
+func (_ FfiDestroyerDbStatus) Destroy(value DbStatus) {
+	value.Destroy()
+}
+
 // Options for an explicit flush request.
 type FlushOptions struct {
 	// Which storage layer should be flushed.
@@ -8990,6 +9060,47 @@ type FfiDestroyerOptionalWriteHandle struct{}
 func (_ FfiDestroyerOptionalWriteHandle) Destroy(value *WriteHandle) {
 	if value != nil {
 		FfiDestroyerWriteHandle{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalCloseReason struct{}
+
+var FfiConverterOptionalCloseReasonINSTANCE = FfiConverterOptionalCloseReason{}
+
+func (c FfiConverterOptionalCloseReason) Lift(rb RustBufferI) *CloseReason {
+	return LiftFromRustBuffer[*CloseReason](c, rb)
+}
+
+func (_ FfiConverterOptionalCloseReason) Read(reader io.Reader) *CloseReason {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterCloseReasonINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalCloseReason) Lower(value *CloseReason) C.RustBuffer {
+	return LowerIntoRustBuffer[*CloseReason](c, value)
+}
+
+func (c FfiConverterOptionalCloseReason) LowerExternal(value *CloseReason) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*CloseReason](c, value))
+}
+
+func (_ FfiConverterOptionalCloseReason) Write(writer io.Writer, value *CloseReason) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterCloseReasonINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalCloseReason struct{}
+
+func (_ FfiDestroyerOptionalCloseReason) Destroy(value *CloseReason) {
+	if value != nil {
+		FfiDestroyerCloseReason{}.Destroy(*value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -783,7 +783,7 @@ uint64_t uniffi_slatedb_uniffi_fn_method_db_snapshot(uint64_t ptr
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_STATUS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_STATUS
-void uniffi_slatedb_uniffi_fn_method_db_status(uint64_t ptr, RustCallStatus *out_status
+RustBuffer uniffi_slatedb_uniffi_fn_method_db_status(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
@@ -839,6 +839,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_scan_with_options(uint64_t ptr
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SHUTDOWN
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_SHUTDOWN
 uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_shutdown(uint64_t ptr
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_STATUS
+RustBuffer uniffi_slatedb_uniffi_fn_method_dbreader_status(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBSNAPSHOT
@@ -1941,6 +1946,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_scan_with_options(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_SHUTDOWN
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_SHUTDOWN
 uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_STATUS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_STATUS
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_status(void
     
 );
 #endif

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -418,8 +418,9 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, nil)
 
-	if err := handle.db.Status(); err != nil {
-		t.Fatalf("Status(): %v", err)
+	status := handle.db.Status()
+	if status.CloseReason != nil {
+		t.Fatalf("Status() on open db: got close reason %v, want nil", *status.CloseReason)
 	}
 
 	if _, err := handle.db.Put([]byte("lifecycle"), []byte("value")); err != nil {
@@ -431,17 +432,12 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 	}
 	handle.open = false
 
-	err := handle.db.Status()
-	if !errors.Is(err, slatedb.ErrErrorClosed) {
-		t.Fatalf("Status() after Shutdown(): got %v, want closed error", err)
+	status = handle.db.Status()
+	if status.CloseReason == nil {
+		t.Fatalf("Status() after Shutdown(): got nil close reason, want %v", slatedb.CloseReasonClean)
 	}
-
-	var closedErr *slatedb.ErrorClosed
-	if !errors.As(err, &closedErr) {
-		t.Fatalf("Status() after Shutdown(): expected *ErrorClosed, got %T", err)
-	}
-	if closedErr.Reason != slatedb.CloseReasonClean {
-		t.Fatalf("Status() after Shutdown(): got close reason %v, want %v", closedErr.Reason, slatedb.CloseReasonClean)
+	if *status.CloseReason != slatedb.CloseReasonClean {
+		t.Fatalf("Status() after Shutdown(): got close reason %v, want %v", *status.CloseReason, slatedb.CloseReasonClean)
 	}
 
 	if _, err := handle.db.Put([]byte("after-shutdown"), []byte("value")); !errors.Is(err, slatedb.ErrErrorClosed) {

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbDbTest.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbDbTest.java
@@ -16,14 +16,13 @@ class SlateDbDbTest {
                 TestSupport.ManagedDb handle = TestSupport.openDb(store)) {
             Db db = handle.db();
 
-            db.status();
+            assertNull(db.status().closeReason());
             TestSupport.await(db.put(TestSupport.bytes("lifecycle"), TestSupport.bytes("value")));
 
             TestSupport.await(db.shutdown());
             handle.markClosed();
 
-            Error.Closed statusError = TestSupport.expectFailure(Error.Closed.class, db::status);
-            assertEquals(CloseReason.CLEAN, statusError.reason());
+            assertEquals(CloseReason.CLEAN, db.status().closeReason());
 
             TestSupport.awaitFailure(
                     Error.Closed.class,

--- a/bindings/node/tests/db.test.mjs
+++ b/bindings/node/tests/db.test.mjs
@@ -30,17 +30,11 @@ test("db lifecycle and status", async (t) => {
   const store = cleanup.track(newMemoryStore());
   const db = await openDb(store, { cleanup });
 
-  db.status();
+  assert.equal(db.status().close_reason, null);
   await db.put(bytes("lifecycle"), bytes("value"));
   await db.shutdown();
 
-  await expectClosed(
-    () => db.status(),
-    {
-      reason: CloseReason.Clean,
-      message: "Closed error: db is closed",
-    },
-  );
+  assert.equal(db.status().close_reason, CloseReason.Clean);
 
   await expectClosed(
     () => db.put(bytes("after-shutdown"), bytes("value")),

--- a/bindings/node/tests/db.test.mjs
+++ b/bindings/node/tests/db.test.mjs
@@ -30,7 +30,7 @@ test("db lifecycle and status", async (t) => {
   const store = cleanup.track(newMemoryStore());
   const db = await openDb(store, { cleanup });
 
-  assert.equal(db.status().close_reason, null);
+  assert.equal(db.status().close_reason, undefined);
   await db.put(bytes("lifecycle"), bytes("value"));
   await db.shutdown();
 

--- a/bindings/python/tests/test_db.py
+++ b/bindings/python/tests/test_db.py
@@ -32,14 +32,13 @@ async def test_db_lifecycle_and_status() -> None:
     store = new_memory_store()
     db = await DbBuilder(TEST_DB_PATH, store).build()
 
-    db.status()
+    status = db.status()
+    assert status.close_reason is None
     await db.put(b"lifecycle", b"value")
     await db.shutdown()
 
-    with pytest.raises(Error.Closed) as exc:
-        db.status()
-    assert exc.value.reason == CloseReason.CLEAN
-    assert exc.value.message == "Closed error: db is closed"
+    status = db.status()
+    assert status.close_reason == CloseReason.CLEAN
 
     with pytest.raises(Error.Closed) as exc:
         await db.put(b"after-shutdown", b"value")

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -7,7 +7,7 @@ use crate::db_snapshot::DbSnapshot;
 use crate::db_transaction::DbTransaction;
 use crate::error::Error;
 use crate::iterator::DbIterator;
-use crate::types::{KeyRange, KeyValue, WriteHandle};
+use crate::types::{DbStatus, KeyRange, KeyValue, WriteHandle};
 use crate::validation::{validate_key, validate_key_value};
 use crate::write_batch::WriteBatch;
 
@@ -25,9 +25,9 @@ impl Db {
 
 #[uniffi::export]
 impl Db {
-    /// Returns an error if the database is not currently healthy and open.
-    pub fn status(&self) -> Result<(), Error> {
-        self.inner.status().map_err(Into::into)
+    /// Returns the latest database status snapshot.
+    pub fn status(&self) -> DbStatus {
+        self.inner.status().into()
     }
 }
 

--- a/bindings/uniffi/src/db_reader.rs
+++ b/bindings/uniffi/src/db_reader.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::config::{ReadOptions, ScanOptions};
 use crate::error::Error;
 use crate::iterator::DbIterator;
-use crate::types::KeyRange;
+use crate::types::{DbStatus, KeyRange};
 use crate::validation::validate_key;
 
 /// Read-only database handle opened by [`crate::DbReaderBuilder`].
@@ -15,6 +15,14 @@ pub struct DbReader {
 impl DbReader {
     pub(crate) fn new(inner: slatedb::DbReader) -> Self {
         Self { inner }
+    }
+}
+
+#[uniffi::export]
+impl DbReader {
+    /// Returns the latest reader status snapshot.
+    pub fn status(&self) -> DbStatus {
+        self.inner.status().into()
     }
 }
 

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -35,7 +35,7 @@ pub use metrics::{
 };
 pub use object_store::ObjectStore;
 pub use settings::Settings;
-pub use types::{KeyRange, KeyValue, RowEntry, RowEntryKind, WriteHandle};
+pub use types::{DbStatus, KeyRange, KeyValue, RowEntry, RowEntryKind, WriteHandle};
 pub use wal_reader::{WalFile, WalFileIterator, WalFileMetadata, WalReader};
 pub use write_batch::WriteBatch;
 

--- a/bindings/uniffi/src/types.rs
+++ b/bindings/uniffi/src/types.rs
@@ -2,7 +2,7 @@ use std::ops::Bound;
 
 use slatedb::ValueDeletable;
 
-use crate::error::SlateDbError;
+use crate::error::{CloseReason, SlateDbError};
 
 type KeyBound = Bound<Vec<u8>>;
 type KeyBounds = (KeyBound, KeyBound);
@@ -70,6 +70,24 @@ impl From<slatedb::WriteHandle> for WriteHandle {
         Self {
             seqnum: value.seqnum(),
             create_ts: value.create_ts(),
+        }
+    }
+}
+
+/// Snapshot of the current database lifecycle and durability state.
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]
+pub struct DbStatus {
+    /// Highest durable sequence number observed by this handle.
+    pub durable_seq: u64,
+    /// Present once the handle has been closed.
+    pub close_reason: Option<CloseReason>,
+}
+
+impl From<slatedb::DbStatus> for DbStatus {
+    fn from(value: slatedb::DbStatus) -> Self {
+        Self {
+            durable_seq: value.durable_seq,
+            close_reason: value.close_reason.map(Into::into),
         }
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -222,7 +222,7 @@ impl DbInner {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, SlateDBError> {
-        self.status()?;
+        self.check_closed()?;
         let db_state = self.state.read().view();
         self.reader
             .get_key_value_with_options(key, options, &db_state, None, None)
@@ -234,7 +234,7 @@ impl DbInner {
         range: BytesRange,
         options: &ScanOptions,
     ) -> Result<DbIterator, SlateDBError> {
-        self.status()?;
+        self.check_closed()?;
         let db_state = self.state.read().view();
         self.reader
             .scan_with_options(range, options, &db_state, None, None, None)
@@ -297,7 +297,7 @@ impl DbInner {
     ) -> Result<WriteHandle, SlateDBError> {
         self.db_stats.write_batch_count.increment(1);
         self.db_stats.write_ops.increment(batch.ops.len() as u64);
-        self.status()?;
+        self.check_closed()?;
         if batch.ops.is_empty() {
             return Err(SlateDBError::EmptyBatch);
         }
@@ -495,7 +495,7 @@ impl DbInner {
     ) -> Result<(), SlateDBError> {
         self.db_stats.flush_requests.increment(1);
         if check_status {
-            self.status()?;
+            self.check_closed()?;
         }
         match options.flush_type {
             FlushType::Wal => {
@@ -571,6 +571,11 @@ impl DbInner {
         .await
     }
 
+    /// Returns the latest database status snapshot.
+    pub(crate) fn status(&self) -> DbStatus {
+        self.status_manager.status()
+    }
+
     /// Returns an error if the database has been closed.
     ///
     /// ## Returns
@@ -579,7 +584,7 @@ impl DbInner {
     ///   (state.result_reader() returns Ok(())).
     /// - `Err(e)` if the DB was closed with an error, where `e` is the error
     ///   (state.result_reader() returns Err(e)).
-    pub(crate) fn status(&self) -> Result<(), SlateDBError> {
+    pub(crate) fn check_closed(&self) -> Result<(), SlateDBError> {
         if let Some(result) = self.status_manager.result_reader().read() {
             return match result {
                 Ok(()) => Err(SlateDBError::Closed),
@@ -685,18 +690,16 @@ impl Db {
     /// }
     /// ```
     pub async fn close(&self) -> Result<(), crate::Error> {
-        let should_flush = match self.status() {
+        let should_flush = match self.status().close_reason {
             // If already closed, don't close again.
-            Err(e) if matches!(e.kind(), crate::ErrorKind::Closed(CloseReason::Clean)) => {
-                return Err(e);
-            }
+            Some(CloseReason::Clean) => return Err(SlateDBError::Closed.into()),
             // If in failed state, allow close, but don't flush since the database
             // might be in a bad state. Note that multiple close() calls will always
             // run when in a failed state (vs. a clean closure, which will return
             // Error::Closed(CloseReason::Clean) on subsequent calls).
-            Err(_) => false,
+            Some(_) => false,
             // Flush outstanding writes if the database is still open.
-            Ok(_) => true,
+            None => true,
         };
 
         // Mark the database as closed before flushing.
@@ -772,7 +775,7 @@ impl Db {
     /// }
     /// ```
     pub async fn snapshot(&self) -> Result<Arc<DbSnapshot>, crate::Error> {
-        self.inner.status()?;
+        self.inner.check_closed()?;
         let snapshot = DbSnapshot::new(self.inner.clone(), None);
         Ok(snapshot)
     }
@@ -1594,7 +1597,7 @@ impl Db {
         &self,
         isolation_level: IsolationLevel,
     ) -> Result<DbTransaction, crate::Error> {
-        self.inner.status()?;
+        self.inner.check_closed()?;
         let txn = DbTransaction::new(
             self.inner.clone(),
             self.inner.txn_manager.clone(),
@@ -1626,22 +1629,16 @@ impl Db {
         Ok(object_store)
     }
 
-    /// Check the database status.
+    /// Returns the latest in-memory database status snapshot.
     ///
-    /// This is a passive check that does not perform any I/O. The status is checked at
-    /// least every [`Settings::manifest_poll_interval`], but might also be updated based
-    /// on other internal events or user-facing operations.
+    /// This is a passive check that does not perform any I/O. The snapshot is updated at
+    /// least every [`Settings::manifest_poll_interval`], but might also be refreshed by
+    /// other internal events or user-facing operations.
     ///
     /// Once a database is closed, either normally or due to an error, it can't be reopened.
     /// A new `Db` instance must be created to access the database again.
-    ///
-    /// ## Returns
-    /// - `Ok(())` if the DB is still open.
-    /// - `Err(ErrorKind::Closed)` if the DB was closed normally.
-    /// - `Err(e)` if the DB was closed with an error, where `e` is the error that caused
-    ///   the closure.
-    pub fn status(&self) -> Result<(), crate::Error> {
-        self.inner.status().map_err(|e| e.into())
+    pub fn status(&self) -> DbStatus {
+        self.inner.status()
     }
 }
 
@@ -2352,11 +2349,8 @@ mod tests {
             lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
             0
         );
-        let status_err = db.status().unwrap_err();
-        assert_eq!(
-            status_err.kind(),
-            crate::ErrorKind::Closed(CloseReason::Fenced)
-        );
+        let status = db.status();
+        assert_eq!(status.close_reason, Some(CloseReason::Fenced));
     }
 
     #[tokio::test]
@@ -2399,11 +2393,8 @@ mod tests {
             lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
             1
         );
-        let status_err = db.status().unwrap_err();
-        assert_eq!(
-            status_err.kind(),
-            crate::ErrorKind::Closed(CloseReason::Clean)
-        );
+        let status = db.status();
+        assert_eq!(status.close_reason, Some(CloseReason::Clean));
     }
 
     #[tokio::test]
@@ -4017,7 +4008,7 @@ mod tests {
 
         // Verify that the memtable has not been flushed by checking the db for error state
         assert!(
-            kv_store.inner.status().is_ok(),
+            kv_store.inner.status().close_reason.is_none(),
             "DB should not have an error state"
         );
     }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1629,14 +1629,10 @@ impl Db {
         Ok(object_store)
     }
 
-    /// Returns the latest in-memory database status snapshot.
+    /// Returns the latest database status.
     ///
-    /// This is a passive check that does not perform any I/O. The snapshot is updated at
-    /// least every [`Settings::manifest_poll_interval`], but might also be refreshed by
-    /// other internal events or user-facing operations.
-    ///
-    /// Once a database is closed, either normally or due to an error, it can't be reopened.
-    /// A new `Db` instance must be created to access the database again.
+    /// This is a snapshot of the current state and will not update automatically.
+    /// Use [`subscribe`](Db::subscribe) to receive real-time updates.
     pub fn status(&self) -> DbStatus {
         self.inner.status()
     }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -509,6 +509,10 @@ impl DbReaderInner {
         Ok((replay_after_wal_id, last_committed_seq))
     }
 
+    pub(crate) fn status(&self) -> DbStatus {
+        self.status_manager.status()
+    }
+
     /// Returns an error if the reader has been closed.
     ///
     /// ## Returns
@@ -1059,11 +1063,11 @@ impl DbReader {
         self.inner.status_manager.subscribe()
     }
 
-    /// Check the reader status.
+    /// Returns the latest reader status snapshot.
     ///
     /// See [`Db::status`](crate::Db::status) for full semantics.
-    pub fn status(&self) -> Result<(), crate::Error> {
-        self.inner.check_closed().map_err(Into::into)
+    pub fn status(&self) -> DbStatus {
+        self.inner.status()
     }
 }
 
@@ -1143,7 +1147,7 @@ mod tests {
     use crate::store_provider::StoreProvider;
     use crate::tablestore::TableStore;
     use crate::types::RowEntry;
-    use crate::{error::SlateDBError, test_utils, Db};
+    use crate::{error::SlateDBError, test_utils, CloseReason, Db};
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -2553,7 +2557,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_return_ok_status_when_open() {
+    async fn should_report_open_status() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
         let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
@@ -2564,14 +2568,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(reader.status().is_ok());
+        assert_eq!(reader.status().close_reason, None);
 
         reader.close().await.unwrap();
         db.close().await.unwrap();
     }
 
     #[tokio::test]
-    async fn should_return_err_status_when_closed() {
+    async fn should_report_closed_status() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
         let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
@@ -2583,7 +2587,7 @@ mod tests {
             .unwrap();
 
         reader.close().await.unwrap();
-        assert!(reader.status().is_err());
+        assert_eq!(reader.status().close_reason, Some(CloseReason::Clean));
 
         db.close().await.unwrap();
     }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -509,6 +509,10 @@ impl DbReaderInner {
         Ok((replay_after_wal_id, last_committed_seq))
     }
 
+    /// Returns the latest database status.
+    ///
+    /// This is a snapshot of the current state and will not update automatically.
+    /// Use [`subscribe`](DbReader::subscribe) to receive real-time updates.
     pub(crate) fn status(&self) -> DbStatus {
         self.status_manager.status()
     }

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -78,7 +78,7 @@ impl DbSnapshot {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
-        self.db_inner.status()?;
+        self.db_inner.check_closed()?;
         let db_state = self.db_inner.state.read().view();
         let kv = self
             .db_inner
@@ -129,7 +129,7 @@ impl DbSnapshot {
             .end_bound()
             .map(|b| Bytes::copy_from_slice(b.as_ref()));
         let range = (start, end);
-        self.db_inner.status()?;
+        self.db_inner.check_closed()?;
         let db_state = self.db_inner.state.read().view();
         self.db_inner
             .reader

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -124,9 +124,7 @@ impl DbStatusManager {
     }
 
     pub(crate) fn status(&self) -> DbStatus {
-        let rx = self.subscribe();
-        let status = rx.borrow().clone();
-        status
+        self.tx.borrow().clone()
     }
 }
 

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -122,6 +122,12 @@ impl DbStatusManager {
     pub(crate) fn subscribe(&self) -> watch::Receiver<DbStatus> {
         self.tx.subscribe()
     }
+
+    pub(crate) fn status(&self) -> DbStatus {
+        let rx = self.subscribe();
+        let status = rx.borrow().clone();
+        status
+    }
 }
 
 impl ClosedResultWriter for WatchableOnceCell<Result<(), SlateDBError>> {

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -138,7 +138,7 @@ impl DbTransaction {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
-        self.db_inner.status()?;
+        self.db_inner.check_closed()?;
 
         // Track read key for SSI conflict detection if needed
         if self.isolation_level == IsolationLevel::SerializableSnapshot {
@@ -221,7 +221,7 @@ impl DbTransaction {
             None
         };
 
-        self.db_inner.status()?;
+        self.db_inner.check_closed()?;
         let db_state = self.db_inner.state.read().view();
 
         // Clone the WriteBatch for the scan to ensure that the scan within a transaction


### PR DESCRIPTION
## Summary

Db::status() and DbReader::status currently return a `Result<(), crate::Error>`. This is useful for checking of a DB is still healthy, but not much else. Now that we have a `DbStatus`, we should return it instead. This style seems:

- Far more intuitive
- Matches the Db::subscribe() behavior
- Allows users to check more than just whether a DB is open

## Changes

-

## Notes for Reviewers

- I opted to keep `db.manifest()` even though `ManifestCore` will also be in `DbStatus` as of #1514. This seemed more intuitive, especially when we add `db.manifest_poll` in #1513. Could be convinced to remove `manifest()`, though.
- I tried to update `DbStatus` to contain a `crate::Error` instead of just `ClosedReason`. That required converting the BoxError in `error.rs` into an `Arc`. I didn't want to bother with that in this PR. Maybe something for later if we feel like it. The advantage of having the error instead of the close reason is we could add a `DbStatus::ok` and users could do `db.status().ok?;` and get the `crate::Error` if things are bad. Anyway.. I digress.
- Because I couldn't find a good `ok()?` approach, I left `check_status()` fn's for both Db and DbReader (for internal use).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
