### PR TITLE
Add NPM trusted publisher support for Github

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -219,6 +219,11 @@ jobs:
           tar -tf "${TARBALL}" | grep -Fx 'package/prebuilds/win32-x64/slatedb_uniffi.dll'
           tar -tf "${TARBALL}" | grep -Fx 'package/prebuilds/win32-arm64/slatedb_uniffi.dll'
 
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@11
+          npm --version
+
       - name: Publish to npm
         working-directory: ./bindings/node
         run: npm publish --provenance --access public


### PR DESCRIPTION
Fix: https://github.com/slatedb/slatedb/actions/runs/24270477286