### PR TITLE
Add node auth token for NPM publication

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -226,4 +226,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: ./bindings/node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
         run: npm publish --provenance --access public


### PR DESCRIPTION
Fixes: https://github.com/slatedb/slatedb/actions/runs/24272624645/job/70880972714