### PR TITLE
fix(compactor): keep db open on takeover

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -507,7 +507,7 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
 
         match result {
             Err(SlateDBError::Fenced) if self.degrade_on_fence => {
-                self.handle_fence().await?;
+                self.degrade_fence().await?;
                 Ok(())
             }
             other => other,
@@ -567,7 +567,7 @@ impl CompactorEventHandler {
         &mut self.state_writer.state
     }
 
-    async fn handle_fence(&mut self) -> Result<(), SlateDBError> {
+    async fn degrade_fence(&mut self) -> Result<(), SlateDBError> {
         if self.fenced {
             return Ok(());
         }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -358,6 +358,7 @@ impl Compactor {
             self.rand.clone(),
             self.stats.clone(),
             self.system_clock.clone(),
+            false,
         )
         .await?;
         self.task_executor
@@ -434,6 +435,8 @@ pub(crate) struct CompactorEventHandler {
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     system_clock: Arc<dyn SystemClock>,
+    degrade_on_fence: bool,
+    fenced: bool,
 }
 
 #[async_trait]
@@ -452,19 +455,32 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
     }
 
     async fn handle(&mut self, message: CompactorMessage) -> Result<(), SlateDBError> {
-        match message {
-            CompactorMessage::LogStats => self.handle_log_ticker(),
-            CompactorMessage::PollManifest => self.handle_ticker().await?,
+        if self.fenced {
+            return Ok(());
+        }
+
+        let result = match message {
+            CompactorMessage::LogStats => {
+                self.handle_log_ticker();
+                Ok(())
+            }
+            CompactorMessage::PollManifest => self.handle_ticker().await,
             CompactorMessage::CompactionJobFinished { id, result } => {
-                match result {
-                    Ok(sr) => self.finish_compaction(id, sr).await?,
+                let finish_result = match result {
+                    Ok(sr) => self.finish_compaction(id, sr).await,
                     Err(err) => {
                         error!("error executing compaction [error={:#?}]", err);
-                        self.finish_failed_compaction(id).await?;
+                        self.finish_failed_compaction(id).await
                     }
+                };
+
+                match finish_result {
+                    Ok(()) => match self.maybe_schedule_compactions().await {
+                        Ok(()) => self.maybe_start_compactions().await,
+                        Err(err) => Err(err),
+                    },
+                    Err(err) => Err(err),
                 }
-                self.maybe_schedule_compactions().await?;
-                self.maybe_start_compactions().await?;
             }
             CompactorMessage::CompactionJobProgress {
                 id,
@@ -482,11 +498,20 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
                 });
                 // To prevent excessive writes, only persist if output SSTs changed.
                 if update_output_ssts {
-                    self.state_writer.write_compactions_safely().await?;
+                    self.state_writer.write_compactions_safely().await
+                } else {
+                    Ok(())
                 }
             }
+        };
+
+        match result {
+            Err(SlateDBError::Fenced) if self.degrade_on_fence => {
+                self.handle_fence().await?;
+                Ok(())
+            }
+            other => other,
         }
-        Ok(())
     }
 
     async fn cleanup(
@@ -511,6 +536,7 @@ impl CompactorEventHandler {
         rand: Arc<DbRand>,
         stats: Arc<CompactionStats>,
         system_clock: Arc<dyn SystemClock>,
+        degrade_on_fence: bool,
     ) -> Result<Self, SlateDBError> {
         let state_writer = CompactorStateWriter::new(
             manifest_store,
@@ -528,6 +554,8 @@ impl CompactorEventHandler {
             rand,
             stats,
             system_clock,
+            degrade_on_fence,
+            fenced: false,
         })
     }
 
@@ -537,6 +565,18 @@ impl CompactorEventHandler {
 
     fn state_mut(&mut self) -> &mut CompactorState {
         &mut self.state_writer.state
+    }
+
+    async fn handle_fence(&mut self) -> Result<(), SlateDBError> {
+        if self.fenced {
+            return Ok(());
+        }
+        self.fenced = true;
+        warn!("embedded compactor fenced; stopping compactor without closing db");
+        if !self.is_executor_stopped() {
+            self.stop_executor().await?;
+        }
+        Ok(())
     }
 
     /// Emits the current compaction state and per-job progress.
@@ -3046,6 +3086,14 @@ mod tests {
 
     impl CompactorEventHandlerTestFixture {
         async fn new() -> Self {
+            Self::new_with_fence_policy(false).await
+        }
+
+        async fn new_embedded() -> Self {
+            Self::new_with_fence_policy(true).await
+        }
+
+        async fn new_with_fence_policy(degrade_on_fence: bool) -> Self {
             let compactor_options = Arc::new(compactor_options());
             let options = db_options(None);
 
@@ -3091,6 +3139,7 @@ mod tests {
                 rand.clone(),
                 compactor_stats.clone(),
                 Arc::new(DefaultSystemClock::new()),
+                degrade_on_fence,
             )
             .await
             .unwrap();
@@ -3624,6 +3673,7 @@ mod tests {
             rand,
             compactor_stats,
             system_clock,
+            false,
         )
         .await
         .unwrap();
@@ -3685,6 +3735,83 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_standalone_compactor_should_return_fenced_when_replaced() {
+        // given: an existing DB and a standalone compactor
+        let os = Arc::new(InMemory::new());
+        let _db = Db::builder(PATH, os.clone())
+            .with_settings(db_options(None))
+            .build()
+            .await
+            .unwrap();
+        let compactor1 = CompactorBuilder::new(PATH, os.clone())
+            .with_options(CompactorOptions {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            })
+            .build();
+        let compactor2 = CompactorBuilder::new(PATH, os)
+            .with_options(CompactorOptions {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            })
+            .build();
+        let compactor1_task = tokio::spawn({
+            let compactor1 = compactor1.clone();
+            async move { compactor1.run().await }
+        });
+
+        // when: another standalone compactor takes ownership
+        let compactor2_task = tokio::spawn({
+            let compactor2 = compactor2.clone();
+            async move { compactor2.run().await }
+        });
+        let fenced_result = tokio::time::timeout(Duration::from_secs(2), async {
+            compactor1_task.await.unwrap()
+        })
+        .await
+        .expect("timed out waiting for standalone compactor to be fenced")
+        .expect_err("standalone compactor should return fenced when replaced");
+
+        // then:
+        assert_eq!(
+            fenced_result.kind(),
+            crate::ErrorKind::Closed(crate::CloseReason::Fenced)
+        );
+
+        compactor2.stop().await.unwrap();
+        compactor2_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_should_stop_embedded_compactor_when_polling_if_fenced() {
+        // given:
+        let mut fixture = CompactorEventHandlerTestFixture::new_embedded().await;
+
+        // fence the handler by bumping the compactions epoch elsewhere
+        let stored_compactions = StoredCompactions::load(fixture.compactions_store.clone())
+            .await
+            .unwrap();
+        FenceableCompactions::init(
+            stored_compactions,
+            fixture.handler.options.manifest_update_timeout,
+            fixture.handler.system_clock.clone(),
+        )
+        .await
+        .unwrap();
+
+        // when:
+        fixture
+            .handler
+            .handle(CompactorMessage::PollManifest)
+            .await
+            .unwrap();
+
+        // then:
+        assert!(fixture.handler.fenced);
+        assert!(fixture.executor.is_stopped());
+    }
+
+    #[tokio::test]
     async fn test_should_update_failed_compaction_status() {
         // given:
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
@@ -3727,9 +3854,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_should_error_when_finishing_if_compactions_fenced() {
+    async fn test_should_stop_embedded_compactor_when_finishing_if_compactions_fenced() {
         // given:
-        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        let mut fixture = CompactorEventHandlerTestFixture::new_embedded().await;
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
@@ -3760,10 +3887,11 @@ mod tests {
         };
 
         // when:
-        let result = fixture.handler.handle(msg).await;
+        fixture.handler.handle(msg).await.unwrap();
 
         // then:
-        assert!(matches!(result, Err(SlateDBError::Fenced)));
+        assert!(fixture.handler.fenced);
+        assert!(fixture.executor.is_stopped());
     }
 
     #[tokio::test]
@@ -4180,6 +4308,7 @@ mod tests {
 
     struct MockExecutorInner {
         jobs: Vec<StartCompactionJobArgs>,
+        stopped: bool,
     }
 
     #[derive(Clone)]
@@ -4190,7 +4319,10 @@ mod tests {
     impl MockExecutor {
         fn new() -> Self {
             Self {
-                inner: Arc::new(Mutex::new(MockExecutorInner { jobs: vec![] })),
+                inner: Arc::new(Mutex::new(MockExecutorInner {
+                    jobs: vec![],
+                    stopped: false,
+                })),
             }
         }
 
@@ -4206,10 +4338,13 @@ mod tests {
             guard.jobs.push(compaction);
         }
 
-        fn stop(&self) {}
+        fn stop(&self) {
+            let mut guard = self.inner.lock();
+            guard.stopped = true;
+        }
 
         fn is_stopped(&self) -> bool {
-            false
+            self.inner.lock().stopped
         }
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6815,6 +6815,113 @@ mod tests {
         assert_eq!(status.close_reason, Some(CloseReason::Fenced));
     }
 
+    #[tokio::test]
+    async fn should_keep_db_open_when_standalone_compactor_takes_over() {
+        // Given: a DB with an embedded compactor and a watcher
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_standalone_compactor_takeover");
+        let embedded_compactor_options = CompactorOptions {
+            poll_interval: Duration::from_millis(20),
+            ..Default::default()
+        };
+        let mut settings = test_db_options(0, 1024, Some(embedded_compactor_options));
+        settings.flush_interval = None;
+        let db = Db::builder(path.clone(), object_store.clone())
+            .with_settings(settings)
+            .build()
+            .await
+            .unwrap();
+        let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
+        let mut stored_manifest =
+            StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
+                .await
+                .unwrap();
+        let should_compact = Arc::new(AtomicBool::new(true));
+
+        // When: a standalone compactor starts for the same DB
+        let standalone_compactor = CompactorBuilder::new(path.clone(), object_store.clone())
+            .with_options(CompactorOptions {
+                poll_interval: Duration::from_millis(20),
+                ..Default::default()
+            })
+            .with_scheduler_supplier(Arc::new(OnDemandCompactionSchedulerSupplier::new(
+                Arc::new({
+                    let should_compact = should_compact.clone();
+                    move |state| {
+                        !state.manifest().l0.is_empty()
+                            && should_compact.swap(false, Ordering::SeqCst)
+                    }
+                }),
+            )))
+            .build();
+        let standalone_task = tokio::spawn({
+            let standalone_compactor = standalone_compactor.clone();
+            async move { standalone_compactor.run().await }
+        });
+
+        // Then: the embedded compactor should not close the DB after takeover.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(db.status().close_reason.is_none());
+
+        // And: the standalone compactor should compact new L0 output after takeover.
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            db.put_with_options(
+                b"key-after-takeover",
+                b"value-after-takeover",
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                },
+            ),
+        )
+        .await
+        .expect("timed out writing after standalone compactor takeover")
+        .unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            db.flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            }),
+        )
+        .await
+        .expect("timed out flushing memtable after standalone compactor takeover")
+        .unwrap();
+
+        let manifest = tokio::time::timeout(
+            Duration::from_secs(10),
+            wait_for_manifest_condition(
+                &mut stored_manifest,
+                |state| {
+                    state.last_compacted_l0_sst_view_id.is_some()
+                        && state.l0.is_empty()
+                        && !state.compacted.is_empty()
+                },
+                Duration::from_secs(10),
+            ),
+        )
+        .await
+        .expect("timed out waiting for standalone compactor to compact takeover writes");
+        assert!(
+            !manifest.compacted.is_empty(),
+            "standalone compactor should compact flushed L0 tables after takeover"
+        );
+
+        // Reads and writes should still work.
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), db.get(b"key-after-takeover"),)
+                .await
+                .expect("timed out reading after standalone compactor takeover")
+                .unwrap(),
+            Some(Bytes::from_static(b"value-after-takeover"))
+        );
+        assert!(db.status().close_reason.is_none());
+
+        standalone_task.abort();
+        let _ = standalone_task.await;
+        db.close().await.unwrap();
+    }
+
     #[cfg(feature = "wal_disable")]
     #[tokio::test]
     async fn should_notify_seq_watcher_on_l0_flush_when_wal_disabled() {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1699,6 +1699,7 @@ mod tests {
     use crate::cached_object_store::stats::{PART_ACCESS_COUNT, PART_HIT_COUNT};
     use crate::cached_object_store::{CachedObjectStore, FsCacheStorage};
     use crate::cached_object_store_stats::CachedObjectStoreStats;
+    use crate::compactions_store::{CompactionsStore, StoredCompactions};
     use crate::config::DurabilityLevel::{Memory, Remote};
     use crate::config::{
         CheckpointOptions, CompactorOptions, GarbageCollectorDirectoryOptions,
@@ -5588,6 +5589,42 @@ mod tests {
         panic!("manifest condition took longer than timeout")
     }
 
+    async fn wait_for_compactor_takeover(
+        watcher: &mut tokio::sync::watch::Receiver<DbStatus>,
+        manifest: &mut StoredManifest,
+        compactions: &mut StoredCompactions,
+        initial_manifest_id: u64,
+        initial_epoch: u64,
+        timeout: Duration,
+    ) -> u64 {
+        let status = tokio::time::timeout(
+            timeout,
+            watcher.wait_for(|status| status.current_manifest.id > initial_manifest_id),
+        )
+        .await
+        .expect("timed out waiting for DB manifest refresh after compactor takeover")
+        .expect("watch channel closed")
+        .clone();
+        let refreshed_manifest_id = status.current_manifest.id;
+
+        let start = tokio::time::Instant::now();
+        while start.elapsed() < timeout {
+            let refreshed_manifest = manifest.refresh().await.unwrap();
+            let manifest_epoch = refreshed_manifest.compactor_epoch;
+            let manifest_id = manifest.id();
+            let compactions_epoch = compactions.refresh().await.unwrap().compactor_epoch;
+            if manifest_id >= refreshed_manifest_id
+                && manifest_epoch > initial_epoch
+                && compactions_epoch == manifest_epoch
+            {
+                return manifest_epoch;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        panic!("compactor takeover condition took longer than timeout")
+    }
+
     fn test_db_options(
         min_filter_keys: u32,
         l0_sst_size_bytes: usize,
@@ -6831,11 +6868,20 @@ mod tests {
             .build()
             .await
             .unwrap();
+        let mut watcher = db.subscribe();
         let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
+        let compactions_store = Arc::new(CompactionsStore::new(&path, object_store.clone()));
         let mut stored_manifest =
             StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
                 .await
                 .unwrap();
+        let mut stored_compactions = StoredCompactions::load(compactions_store).await.unwrap();
+        let initial_manifest_id = stored_manifest.id();
+        let initial_compactor_epoch = stored_manifest.manifest().compactor_epoch;
+        assert_eq!(
+            initial_compactor_epoch,
+            stored_compactions.compactions().compactor_epoch
+        );
         let should_compact = Arc::new(AtomicBool::new(true));
 
         // When: a standalone compactor starts for the same DB
@@ -6859,8 +6905,17 @@ mod tests {
             async move { standalone_compactor.run().await }
         });
 
-        // Then: the embedded compactor should not close the DB after takeover.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Then: the takeover should bump compactor epochs and refresh the DB manifest.
+        let takeover_epoch = wait_for_compactor_takeover(
+            &mut watcher,
+            &mut stored_manifest,
+            &mut stored_compactions,
+            initial_manifest_id,
+            initial_compactor_epoch,
+            Duration::from_secs(10),
+        )
+        .await;
+        assert!(takeover_epoch > initial_compactor_epoch);
         assert!(db.status().close_reason.is_none());
 
         // And: the standalone compactor should compact new L0 output after takeover.

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1120,6 +1120,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             self.rand,
             stats,
             self.system_clock,
+            true,
         )
         .await?;
         Ok((handler, rx))


### PR DESCRIPTION
## Summary

What is being changed and why?

  Fixes #1119.

When a standalone compactor starts against a DB that already has anembedded compactor, the embedded compactor was getting fenced and bringing the whole DB down. This change keeps the DB open in that case, while keeping the old standalone compactor behavior when ownership is lost to another standalone compactor.

## Changes

  - add a separate fence policy for embedded and standalone compactors
  - make the embedded compactor stop and go idle on `Fenced` instead of
    closing the DB
  - keep standalone compactor fencing behavior unchanged so it still
    returns `Fenced` when replaced
  - add tests for embedded compactor fencing during polling and compaction
    completion
  - extend the takeover regression test to verify the DB stays open, L0
    data is still compacted by the standalone compactor, and reads still
    work after takeover

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

- LLM agent was used for this pr and reviewed and guided by me

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
