### PR TITLE
Go bindings add query timeout

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -208,6 +208,9 @@ jobs:
           LD_LIBRARY_PATH: "${{ github.workspace }}/target/debug:${LD_LIBRARY_PATH}"
         run: go test ./...
 
+      - name: Run S3-backed Go timeout tests
+        run: scripts/run_go_timeout_tests.sh
+
   bindings-java:
     runs-on: ubuntu-latest
     needs: tests

--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -7239,12 +7239,15 @@ type ReadOptions struct {
 	Dirty bool
 	// Whether fetched blocks should be inserted into the block cache.
 	CacheBlocks bool
+	// Timeout in milliseconds for the read. Defaults to no timeout.
+	TimeoutMs *uint64
 }
 
 func (r *ReadOptions) Destroy() {
 	FfiDestroyerDurabilityLevel{}.Destroy(r.DurabilityFilter)
 	FfiDestroyerBool{}.Destroy(r.Dirty)
 	FfiDestroyerBool{}.Destroy(r.CacheBlocks)
+	FfiDestroyerOptionalUint64{}.Destroy(r.TimeoutMs)
 }
 
 type FfiConverterReadOptions struct{}
@@ -7260,6 +7263,7 @@ func (c FfiConverterReadOptions) Read(reader io.Reader) ReadOptions {
 		FfiConverterDurabilityLevelINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
 	}
 }
 
@@ -7275,6 +7279,7 @@ func (c FfiConverterReadOptions) Write(writer io.Writer, value ReadOptions) {
 	FfiConverterDurabilityLevelINSTANCE.Write(writer, value.DurabilityFilter)
 	FfiConverterBoolINSTANCE.Write(writer, value.Dirty)
 	FfiConverterBoolINSTANCE.Write(writer, value.CacheBlocks)
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.TimeoutMs)
 }
 
 type FfiDestroyerReadOptions struct{}
@@ -7732,6 +7737,7 @@ var ErrErrorUnavailable = fmt.Errorf("ErrorUnavailable")
 var ErrErrorInvalid = fmt.Errorf("ErrorInvalid")
 var ErrErrorData = fmt.Errorf("ErrorData")
 var ErrErrorInternal = fmt.Errorf("ErrorInternal")
+var ErrErrorTimeout = fmt.Errorf("ErrorTimeout")
 
 // Variant structs
 // Transaction-specific failure.
@@ -7921,6 +7927,36 @@ func (self ErrorInternal) Is(target error) bool {
 	return target == ErrErrorInternal
 }
 
+// The operation exceeded the configured timeout.
+type ErrorTimeout struct {
+	Message string
+}
+
+// The operation exceeded the configured timeout.
+func NewErrorTimeout(
+	message string,
+) *Error {
+	return &Error{err: &ErrorTimeout{
+		Message: message}}
+}
+
+func (e ErrorTimeout) destroy() {
+	FfiDestroyerString{}.Destroy(e.Message)
+}
+
+func (err ErrorTimeout) Error() string {
+	return fmt.Sprint("Timeout",
+		": ",
+
+		"Message=",
+		err.Message,
+	)
+}
+
+func (self ErrorTimeout) Is(target error) bool {
+	return target == ErrErrorTimeout
+}
+
 type FfiConverterError struct{}
 
 var FfiConverterErrorINSTANCE = FfiConverterError{}
@@ -7966,6 +8002,10 @@ func (c FfiConverterError) Read(reader io.Reader) *Error {
 		return &Error{&ErrorInternal{
 			Message: FfiConverterStringINSTANCE.Read(reader),
 		}}
+	case 7:
+		return &Error{&ErrorTimeout{
+			Message: FfiConverterStringINSTANCE.Read(reader),
+		}}
 	default:
 		panic(fmt.Sprintf("Unknown error code %d in FfiConverterError.Read()", errorID))
 	}
@@ -7992,6 +8032,9 @@ func (c FfiConverterError) Write(writer io.Writer, value *Error) {
 	case *ErrorInternal:
 		writeInt32(writer, 6)
 		FfiConverterStringINSTANCE.Write(writer, variantValue.Message)
+	case *ErrorTimeout:
+		writeInt32(writer, 7)
+		FfiConverterStringINSTANCE.Write(writer, variantValue.Message)
 	default:
 		_ = variantValue
 		panic(fmt.Sprintf("invalid error value `%v` in FfiConverterError.Write", value))
@@ -8013,6 +8056,8 @@ func (_ FfiDestroyerError) Destroy(value *Error) {
 	case ErrorData:
 		variantValue.destroy()
 	case ErrorInternal:
+		variantValue.destroy()
+	case ErrorTimeout:
 		variantValue.destroy()
 	default:
 		_ = variantValue

--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -7587,10 +7587,13 @@ func (_ FfiDestroyerWriteHandle) Destroy(value WriteHandle) {
 type WriteOptions struct {
 	// Whether the call waits for the write to become durable before returning.
 	AwaitDurable bool
+	// Timeout in milliseconds for the write. Defaults to no timeout.
+	TimeoutMs *uint64
 }
 
 func (r *WriteOptions) Destroy() {
 	FfiDestroyerBool{}.Destroy(r.AwaitDurable)
+	FfiDestroyerOptionalUint64{}.Destroy(r.TimeoutMs)
 }
 
 type FfiConverterWriteOptions struct{}
@@ -7604,6 +7607,7 @@ func (c FfiConverterWriteOptions) Lift(rb RustBufferI) WriteOptions {
 func (c FfiConverterWriteOptions) Read(reader io.Reader) WriteOptions {
 	return WriteOptions{
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
 	}
 }
 
@@ -7617,6 +7621,7 @@ func (c FfiConverterWriteOptions) LowerExternal(value WriteOptions) ExternalCRus
 
 func (c FfiConverterWriteOptions) Write(writer io.Writer, value WriteOptions) {
 	FfiConverterBoolINSTANCE.Write(writer, value.AwaitDurable)
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.TimeoutMs)
 }
 
 type FfiDestroyerWriteOptions struct{}

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -820,6 +820,31 @@ func TestDbTransactionGetWithTimeout(t *testing.T) {
 	}
 }
 
+func TestDbPutWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	wh, err := handle.db.PutWithOptions(
+		[]byte("k1"), []byte("v1"),
+		slatedb.PutOptions{Ttl: slatedb.TtlDefault{}},
+		slatedb.WriteOptions{AwaitDurable: true, TimeoutMs: uint64Ptr(30000)},
+	)
+	if err != nil {
+		t.Fatalf("PutWithOptions(timeout=30s): %v", err)
+	}
+	if wh.Seqnum == 0 {
+		t.Fatal("PutWithOptions(timeout=30s): Seqnum = 0")
+	}
+
+	value, err := handle.db.Get([]byte("k1"))
+	if err != nil {
+		t.Fatalf("Get(k1): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("v1")) {
+		t.Fatalf("Get(k1): got %v, want %q", value, "v1")
+	}
+}
+
 func TestDbBatchWriteAndConsumption(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, nil)

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -873,6 +873,40 @@ func TestDbDeleteWithTimeout(t *testing.T) {
 	}
 }
 
+func TestDbMergeWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, func(t *testing.T, builder *slatedb.DbBuilder) {
+		t.Helper()
+		if err := builder.WithMergeOperator(concatMergeOperator{}); err != nil {
+			t.Fatalf("WithMergeOperator(): %v", err)
+		}
+	})
+
+	if _, err := handle.db.Put([]byte("k1"), []byte("base")); err != nil {
+		t.Fatalf("Put(k1): %v", err)
+	}
+
+	wh, err := handle.db.MergeWithOptions(
+		[]byte("k1"), []byte(":ext"),
+		slatedb.MergeOptions{Ttl: slatedb.TtlDefault{}},
+		slatedb.WriteOptions{AwaitDurable: true, TimeoutMs: uint64Ptr(30000)},
+	)
+	if err != nil {
+		t.Fatalf("MergeWithOptions(timeout=30s): %v", err)
+	}
+	if wh.Seqnum == 0 {
+		t.Fatal("MergeWithOptions(timeout=30s): Seqnum = 0")
+	}
+
+	value, err := handle.db.Get([]byte("k1"))
+	if err != nil {
+		t.Fatalf("Get(k1): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("base:ext")) {
+		t.Fatalf("Get(k1): got %v, want %q", value, "base:ext")
+	}
+}
+
 func TestDbBatchWriteAndConsumption(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, nil)

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -845,6 +845,34 @@ func TestDbPutWithTimeout(t *testing.T) {
 	}
 }
 
+func TestDbDeleteWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	if _, err := handle.db.Put([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("Put(k1): %v", err)
+	}
+
+	wh, err := handle.db.DeleteWithOptions(
+		[]byte("k1"),
+		slatedb.WriteOptions{AwaitDurable: true, TimeoutMs: uint64Ptr(30000)},
+	)
+	if err != nil {
+		t.Fatalf("DeleteWithOptions(timeout=30s): %v", err)
+	}
+	if wh.Seqnum == 0 {
+		t.Fatal("DeleteWithOptions(timeout=30s): Seqnum = 0")
+	}
+
+	value, err := handle.db.Get([]byte("k1"))
+	if err != nil {
+		t.Fatalf("Get(k1): %v", err)
+	}
+	if value != nil {
+		t.Fatalf("Get(k1) after delete: got %q, want nil", *value)
+	}
+}
+
 func TestDbBatchWriteAndConsumption(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, nil)

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -907,6 +907,70 @@ func TestDbMergeWithTimeout(t *testing.T) {
 	}
 }
 
+func TestDbWriteWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	batch := slatedb.NewWriteBatch()
+	t.Cleanup(batch.Destroy)
+
+	if err := batch.Put([]byte("wk1"), []byte("wv1")); err != nil {
+		t.Fatalf("WriteBatch.Put(): %v", err)
+	}
+
+	wh, err := handle.db.WriteWithOptions(
+		batch,
+		slatedb.WriteOptions{AwaitDurable: true, TimeoutMs: uint64Ptr(30000)},
+	)
+	if err != nil {
+		t.Fatalf("WriteWithOptions(timeout=30s): %v", err)
+	}
+	if wh.Seqnum == 0 {
+		t.Fatal("WriteWithOptions(timeout=30s): Seqnum = 0")
+	}
+
+	value, err := handle.db.Get([]byte("wk1"))
+	if err != nil {
+		t.Fatalf("Get(wk1): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("wv1")) {
+		t.Fatalf("Get(wk1): got %v, want %q", value, "wv1")
+	}
+}
+
+func TestDbTransactionCommitWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	tx, err := handle.db.Begin(slatedb.IsolationLevelSnapshot)
+	if err != nil {
+		t.Fatalf("Begin(): %v", err)
+	}
+	t.Cleanup(tx.Destroy)
+
+	if err := tx.Put([]byte("ck1"), []byte("cv1")); err != nil {
+		t.Fatalf("tx.Put(ck1): %v", err)
+	}
+
+	wh, err := tx.CommitWithOptions(
+		slatedb.WriteOptions{AwaitDurable: true, TimeoutMs: uint64Ptr(30000)},
+	)
+	if err != nil {
+		t.Fatalf("CommitWithOptions(timeout=30s): %v", err)
+	}
+	if wh == nil || wh.Seqnum == 0 {
+		t.Fatal("CommitWithOptions(timeout=30s): got nil or zero seqnum")
+	}
+
+	value, err := handle.db.Get([]byte("ck1"))
+	if err != nil {
+		t.Fatalf("Get(ck1): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("cv1")) {
+		t.Fatalf("Get(ck1): got %v, want %q", value, "cv1")
+	}
+}
+
 func TestDbBatchWriteAndConsumption(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, nil)

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -674,6 +674,152 @@ func TestDbScanVariants(t *testing.T) {
 	requireRows(t, drainIterator(t, iter), []string{"item:01", "item:02", "item:03"}, []string{"first", "second", "third"})
 }
 
+func uint64Ptr(v uint64) *uint64 { return &v }
+
+func TestDbGetWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	if _, err := handle.db.Put([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("Put(k1): %v", err)
+	}
+
+	value, err := handle.db.GetWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            false,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("GetWithOptions(timeout=30s): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("v1")) {
+		t.Fatalf("GetWithOptions(timeout=30s): got %v, want %q", value, "v1")
+	}
+
+	kv, err := handle.db.GetKeyValueWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            false,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("GetKeyValueWithOptions(timeout=30s): %v", err)
+	}
+	if kv == nil || !bytes.Equal(kv.Value, []byte("v1")) {
+		t.Fatalf("GetKeyValueWithOptions(timeout=30s): got %v, want value %q", kv, "v1")
+	}
+}
+
+func TestDbReaderGetWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("Put(k1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	readerHandle := openTestReader(t, store, nil)
+
+	value, err := readerHandle.reader.GetWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            false,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("DbReader.GetWithOptions(timeout=30s): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("v1")) {
+		t.Fatalf("DbReader.GetWithOptions(timeout=30s): got %v, want %q", value, "v1")
+	}
+}
+
+func TestDbSnapshotGetWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	if _, err := handle.db.Put([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("Put(k1): %v", err)
+	}
+
+	snapshot, err := handle.db.Snapshot()
+	if err != nil {
+		t.Fatalf("Snapshot(): %v", err)
+	}
+	t.Cleanup(snapshot.Destroy)
+
+	value, err := snapshot.GetWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            false,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("DbSnapshot.GetWithOptions(timeout=30s): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("v1")) {
+		t.Fatalf("DbSnapshot.GetWithOptions(timeout=30s): got %v, want %q", value, "v1")
+	}
+
+	kv, err := snapshot.GetKeyValueWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            false,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("DbSnapshot.GetKeyValueWithOptions(timeout=30s): %v", err)
+	}
+	if kv == nil || !bytes.Equal(kv.Value, []byte("v1")) {
+		t.Fatalf("DbSnapshot.GetKeyValueWithOptions(timeout=30s): got %v, want value %q", kv, "v1")
+	}
+}
+
+func TestDbTransactionGetWithTimeout(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+
+	tx, err := handle.db.Begin(slatedb.IsolationLevelSnapshot)
+	if err != nil {
+		t.Fatalf("Begin(): %v", err)
+	}
+	t.Cleanup(tx.Destroy)
+
+	if err := tx.Put([]byte("k1"), []byte("v1")); err != nil {
+		t.Fatalf("tx.Put(k1): %v", err)
+	}
+
+	value, err := tx.GetWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            true,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("DbTransaction.GetWithOptions(timeout=30s): %v", err)
+	}
+	if value == nil || !bytes.Equal(*value, []byte("v1")) {
+		t.Fatalf("DbTransaction.GetWithOptions(timeout=30s): got %v, want %q", value, "v1")
+	}
+
+	kv, err := tx.GetKeyValueWithOptions([]byte("k1"), slatedb.ReadOptions{
+		DurabilityFilter: slatedb.DurabilityLevelMemory,
+		Dirty:            true,
+		CacheBlocks:      true,
+		TimeoutMs:        uint64Ptr(30000),
+	})
+	if err != nil {
+		t.Fatalf("DbTransaction.GetKeyValueWithOptions(timeout=30s): %v", err)
+	}
+	if kv == nil || !bytes.Equal(kv.Value, []byte("v1")) {
+		t.Fatalf("DbTransaction.GetKeyValueWithOptions(timeout=30s): got %v, want value %q", kv, "v1")
+	}
+}
+
 func TestDbBatchWriteAndConsumption(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, nil)

--- a/bindings/go/uniffi/slatedb_toxic_test.go
+++ b/bindings/go/uniffi/slatedb_toxic_test.go
@@ -1,0 +1,67 @@
+//go:build toxic
+
+// Requires env vars: SLATEDB_S3_URL, TOXIPROXY_ADMIN_URL, plus AWS creds.
+// See scripts/run_go_timeout_tests.sh.
+
+package slatedb_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+
+	slatedb "slatedb.io/slatedb-go/uniffi"
+)
+
+func openS3Store(t *testing.T) *slatedb.ObjectStore {
+	t.Helper()
+
+	s3URL := os.Getenv("SLATEDB_S3_URL")
+	if s3URL == "" {
+		t.Skip("SLATEDB_S3_URL not set; skipping S3-backed test")
+	}
+
+	store, err := slatedb.ObjectStoreResolve(s3URL)
+	if err != nil {
+		t.Fatalf("ObjectStoreResolve(%q): %v", s3URL, err)
+	}
+	t.Cleanup(store.Destroy)
+	return store
+}
+
+func seedS3Data(handle *testDB) error {
+	for i := range 100 {
+		key := fmt.Sprintf("timeout-key:%04d", i)
+		val := fmt.Sprintf("timeout-val:%04d", i)
+		if _, err := handle.db.Put([]byte(key), []byte(val)); err != nil {
+			return err
+		}
+	}
+	if err := handle.db.Flush(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func TestPutWithTimeoutTripped(t *testing.T) {
+	store := openS3Store(t)
+	handle := openTestDB(t, store, nil)
+	seedS3Data(handle)
+
+	_, err := handle.db.PutWithOptions(
+		[]byte("foo"),
+		[]byte("bar"),
+		slatedb.PutOptions{
+			Ttl: slatedb.TtlDefault{},
+		},
+		slatedb.WriteOptions{
+			TimeoutMs:    uint64Ptr(1),
+			AwaitDurable: true,
+		},
+	)
+
+	if err == nil || !errors.Is(err, slatedb.ErrErrorTimeout) {
+		t.Fatalf("PutWithOptions(timeout=100ms): got %v, want ErrErrorTimeout", err)
+	}
+}

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -265,12 +265,16 @@ impl TryFrom<ScanOptions> for slatedb::config::ScanOptions {
 pub struct WriteOptions {
     /// Whether the call waits for the write to become durable before returning.
     pub await_durable: bool,
+    /// Timeout in milliseconds for the write. Defaults to no timeout.
+    #[uniffi(default = None)]
+    pub timeout_ms: Option<u64>,
 }
 
 impl Default for WriteOptions {
     fn default() -> Self {
         Self {
             await_durable: true,
+            timeout_ms: None,
         }
     }
 }

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -127,6 +127,9 @@ pub struct ReadOptions {
     pub dirty: bool,
     /// Whether fetched blocks should be inserted into the block cache.
     pub cache_blocks: bool,
+    /// Timeout in milliseconds for the read. Defaults to no timeout.
+    #[uniffi(default = None)]
+    pub timeout_ms: Option<u64>,
 }
 
 impl Default for ReadOptions {
@@ -135,6 +138,7 @@ impl Default for ReadOptions {
             durability_filter: DurabilityLevel::default(),
             dirty: false,
             cache_blocks: true,
+            timeout_ms: None,
         }
     }
 }

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -185,8 +185,18 @@ impl Db {
         options: WriteOptions,
     ) -> Result<WriteHandle, Error> {
         validate_key(&key)?;
-        let options = options.into();
-        Ok(self.inner.delete_with_options(key, &options).await?.into())
+        let timeout_ms = options.timeout_ms;
+        let write_options = options.into();
+        let fut = self.inner.delete_with_options(key, &write_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("delete timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.into())
     }
 
     /// Appends a merge operand for `key` and returns metadata for the write.

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -155,13 +155,21 @@ impl Db {
         write_options: WriteOptions,
     ) -> Result<WriteHandle, Error> {
         validate_key_value(&key, &value)?;
+        let timeout_ms = write_options.timeout_ms;
         let put_options = put_options.into();
         let write_options = write_options.into();
-        Ok(self
+        let fut = self
             .inner
-            .put_with_options(key, value, &put_options, &write_options)
-            .await?
-            .into())
+            .put_with_options(key, value, &put_options, &write_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("put timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.into())
     }
 
     /// Deletes `key` and returns metadata for the write.

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -214,13 +214,21 @@ impl Db {
         write_options: WriteOptions,
     ) -> Result<WriteHandle, Error> {
         validate_key_value(&key, &operand)?;
+        let timeout_ms = write_options.timeout_ms;
         let merge_options = merge_options.into();
         let write_options = write_options.into();
-        Ok(self
+        let fut = self
             .inner
-            .merge_with_options(key, operand, &merge_options, &write_options)
-            .await?
-            .into())
+            .merge_with_options(key, operand, &merge_options, &write_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("merge timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.into())
     }
 
     /// Applies all operations in `batch` atomically.

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::config::{
     FlushOptions, IsolationLevel, MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions,
@@ -53,12 +54,18 @@ impl Db {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
-        Ok(self
-            .inner
-            .get_with_options(key, &options)
-            .await?
-            .map(|value| value.to_vec()))
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
+        let fut = self.inner.get_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(|value| value.to_vec()))
     }
 
     /// Reads the current row version for `key`, including metadata.
@@ -74,12 +81,18 @@ impl Db {
         options: ReadOptions,
     ) -> Result<Option<KeyValue>, Error> {
         validate_key(&key)?;
-        let options = options.into();
-        Ok(self
-            .inner
-            .get_key_value_with_options(key, &options)
-            .await?
-            .map(KeyValue::from))
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
+        let fut = self.inner.get_key_value_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get_key_value timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(KeyValue::from))
     }
 
     /// Scans rows inside `range`.

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -248,8 +248,18 @@ impl Db {
         options: WriteOptions,
     ) -> Result<WriteHandle, Error> {
         let batch = batch.take_for_write()?;
-        let options = options.into();
-        Ok(self.inner.write_with_options(batch, &options).await?.into())
+        let timeout_ms = options.timeout_ms;
+        let write_options = options.into();
+        let fut = self.inner.write_with_options(batch, &write_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("write timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.into())
     }
 
     /// Flushes the default storage layer.

--- a/bindings/uniffi/src/db_reader.rs
+++ b/bindings/uniffi/src/db_reader.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::config::{ReadOptions, ScanOptions};
 use crate::error::Error;
@@ -33,12 +34,18 @@ impl DbReader {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
-        Ok(self
-            .inner
-            .get_with_options(key, &options)
-            .await?
-            .map(|value| value.to_vec()))
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
+        let fut = self.inner.get_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(|value| value.to_vec()))
     }
 
     /// Scans rows inside `range`.

--- a/bindings/uniffi/src/db_snapshot.rs
+++ b/bindings/uniffi/src/db_snapshot.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::config::{ReadOptions, ScanOptions};
 use crate::error::Error;
@@ -33,12 +34,18 @@ impl DbSnapshot {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
-        Ok(self
-            .inner
-            .get_with_options(key, &options)
-            .await?
-            .map(|value| value.to_vec()))
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
+        let fut = self.inner.get_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(|value| value.to_vec()))
     }
 
     /// Reads the row version visible in this snapshot for `key`.
@@ -54,12 +61,18 @@ impl DbSnapshot {
         options: ReadOptions,
     ) -> Result<Option<KeyValue>, Error> {
         validate_key(&key)?;
-        let options = options.into();
-        Ok(self
-            .inner
-            .get_key_value_with_options(key, &options)
-            .await?
-            .map(KeyValue::from))
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
+        let fut = self.inner.get_key_value_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get_key_value timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(KeyValue::from))
     }
 
     /// Scans rows inside `range` as of this snapshot.

--- a/bindings/uniffi/src/db_transaction.rs
+++ b/bindings/uniffi/src/db_transaction.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::Mutex;
 
@@ -135,13 +136,20 @@ impl DbTransaction {
         options: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
         let guard = self.inner.lock().await;
         let tx = guard.as_ref().ok_or(SlateDbError::TransactionCompleted)?;
-        Ok(tx
-            .get_with_options(key, &options)
-            .await?
-            .map(|value| value.to_vec()))
+        let fut = tx.get_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(|value| value.to_vec()))
     }
 
     /// Reads the row version visible to this transaction for `key`.
@@ -159,13 +167,20 @@ impl DbTransaction {
         options: ReadOptions,
     ) -> Result<Option<KeyValue>, Error> {
         validate_key(&key)?;
-        let options = options.into();
+        let timeout_ms = options.timeout_ms;
+        let read_options = options.into();
         let guard = self.inner.lock().await;
         let tx = guard.as_ref().ok_or(SlateDbError::TransactionCompleted)?;
-        Ok(tx
-            .get_key_value_with_options(key, &options)
-            .await?
-            .map(KeyValue::from))
+        let fut = tx.get_key_value_with_options(key, &read_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("get_key_value timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(KeyValue::from))
     }
 
     /// Scans rows inside `range` as visible to this transaction.

--- a/bindings/uniffi/src/db_transaction.rs
+++ b/bindings/uniffi/src/db_transaction.rs
@@ -245,14 +245,21 @@ impl DbTransaction {
         &self,
         options: WriteOptions,
     ) -> Result<Option<WriteHandle>, Error> {
-        let options = options.into();
+        let timeout_ms = options.timeout_ms;
+        let write_options = options.into();
         let tx = {
             let mut guard = self.inner.lock().await;
             guard.take().ok_or(SlateDbError::TransactionCompleted)?
         };
-        Ok(tx
-            .commit_with_options(&options)
-            .await?
-            .map(WriteHandle::from))
+        let fut = tx.commit_with_options(&write_options);
+        let result = match timeout_ms {
+            Some(ms) => tokio::time::timeout(Duration::from_millis(ms), fut)
+                .await
+                .map_err(|_| Error::Timeout {
+                    message: format!("commit timed out after {}ms", ms),
+                })?,
+            None => fut.await,
+        }?;
+        Ok(result.map(WriteHandle::from))
     }
 }

--- a/bindings/uniffi/src/error.rs
+++ b/bindings/uniffi/src/error.rs
@@ -128,6 +128,10 @@ pub enum Error {
     /// Internal failure inside SlateDB or the binding layer.
     #[error("{message}")]
     Internal { message: String },
+
+    /// The operation exceeded the configured timeout.
+    #[error("{message}")]
+    Timeout { message: String },
 }
 
 impl From<SlateDbError> for Error {

--- a/scripts/go-timeout-tests.compose.yaml
+++ b/scripts/go-timeout-tests.compose.yaml
@@ -1,0 +1,31 @@
+services:
+  localstack:
+    image: localstack/localstack:4.14.0
+    container_name: go-timeout-localstack
+    environment:
+      - SERVICES=s3
+    ports:
+      - "14566:4566"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - curl -sf http://localhost:4566/_localstack/health || exit 1
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:latest
+    container_name: go-timeout-toxiproxy
+    depends_on:
+      - localstack
+    healthcheck:
+      test: ["CMD", "/toxiproxy-cli", "list"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+      start_period: 5s
+    ports:
+      - "18474:8474"
+      - "19001:9001"

--- a/scripts/run_go_timeout_tests.sh
+++ b/scripts/run_go_timeout_tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Run the S3-backed Go timeout tests against LocalStack + Toxiproxy.
+#
+# Prerequisites:
+#   - Docker and docker compose
+#   - AWS CLI (aws) on PATH
+#   - Go toolchain
+#   - Rust toolchain (to build slatedb-uniffi)
+set -euo pipefail
+
+REPO_ROOT="$(realpath $(dirname $0)/..)"
+COMPOSE_FILE="$REPO_ROOT/scripts/go-timeout-tests.compose.yaml"
+LOCALSTACK_ENDPOINT="http://127.0.0.1:14566"
+TOXIPROXY_ADMIN="http://127.0.0.1:18474"
+TOXIPROXY_PROXY="http://127.0.0.1:19001"
+BUCKET="slatedb-go-test"
+DB_PATH="timeout-test"
+
+cleanup() {
+  docker compose -f "$COMPOSE_FILE" down --remove-orphans
+}
+
+trap cleanup EXIT
+
+docker compose -f "$COMPOSE_FILE" up -d --wait
+
+cargo build -p slatedb-uniffi
+
+AWS_ACCESS_KEY_ID=test \
+AWS_SECRET_ACCESS_KEY=test \
+AWS_DEFAULT_REGION=us-east-1 \
+aws --endpoint-url "$LOCALSTACK_ENDPOINT" s3 mb "s3://$BUCKET"
+
+curl -sf -X POST "$TOXIPROXY_ADMIN/proxies" \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"s3","listen":"0.0.0.0:9001","upstream":"go-timeout-localstack:4566"}'
+
+curl -fsS -w '\n' -X POST "$TOXIPROXY_ADMIN/proxies/s3/toxics" \
+    -H 'Content-Type: application/json' \
+    -d '{"name":"s3_latency","type":"latency","stream":"downstream","toxicity":1.0,"attributes":{"latency":100}}'
+
+curl -fsS -w '\n' -X POST "$TOXIPROXY_ADMIN/proxies/s3/toxics" \
+    -H 'Content-Type: application/json' \
+    -d '{"name":"s3_latency_up","type":"latency","stream":"upstream","toxicity":1.0,"attributes":{"latency":100}}'
+
+
+cd "$REPO_ROOT/bindings/go"
+
+CGO_ENABLED=1 \
+CGO_LDFLAGS=-L$REPO_ROOT/target/debug \
+LD_LIBRARY_PATH=$REPO_ROOT/target/debug:${LD_LIBRARY_PATH:-} \
+DYLD_LIBRARY_PATH=$REPO_ROOT/target/debug:${DYLD_LIBRARY_PATH:-} \
+SLATEDB_S3_URL=s3://$BUCKET/$DB_PATH \
+AWS_ACCESS_KEY_ID=test \
+AWS_SECRET_ACCESS_KEY=test \
+AWS_REGION=us-east-1 \
+AWS_ALLOW_HTTP=true \
+AWS_ENDPOINT_URL="$TOXIPROXY_PROXY" \
+TOXIPROXY_ADMIN_URL="$TOXIPROXY_ADMIN" \
+go test -v -run 'WithTimeoutTripped$' -tags toxic -timeout 120s ./uniffi/


### PR DESCRIPTION
## Summary

This is an attempt to add a client timeout option to the Go bindings as discussed in https://github.com/slatedb/slatedb/issues/1148. I started work on this in https://github.com/slatedb/slatedb/pull/1160 but the bindings were re-written recently and so it seemed better to start again.

## Changes

- Add timeout to GetWithOptions and GetKeyValueWithOptions
- Add timeout to PutWithOptions
- Add timeout to DeleteWithOptions
- Add timeout to MergeWithOptions
- Add timeout to WriteWithOptions and CommitWithOptions
- Add timeout error test for PutWithOptions

## Notes for Reviewers

I considered adding more tests that confirmed the timeout actually threw an error but it's my last day of leave and I'm likely to lose any motivation to continue working on this soon (like last time).

I tripped over the requirement to use the `AwaitDurable` option when supplying a timeout, otherwise it will always return even if the underlying storage is unavailable/slow. I wonder if we should just document it?

I couldn't find an easy way to implement this for Scan/ScanPrefix, since the timeout would only wrap the return of the iterator and that's not really useful.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
