### PR TITLE
Remove fsync from disk cache writes

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -130,7 +130,6 @@ impl FsCacheEntry {
                 .open(tmp_path)
                 .map_err(wrap_io_err)?;
             file.write_all(&buf).map_err(wrap_io_err)?;
-            file.sync_all().map_err(wrap_io_err)?;
             std::fs::rename(tmp_path, path).map_err(wrap_io_err)
         })
         .await?


### PR DESCRIPTION
## Summary

Remove `sync_all()` (fsync) from disk cache writes. The disk cache is ephemeral with the remote object store as source of truth, so durability is unnecessary. Atomicity is preserved by the write-to-temp-then-rename pattern, and integrity is already enforced by the CRC32 checksums embedded in the SST block format which are validated on every consumer read.

## Changes

 - Remove `file.sync_all()` call from `FsCacheEntry::atomic_write`

## Notes for Reviewers

This was previously attempted in #1041 and closed over concerns about serving corrupt data after a crash without checksums. Every structure flowing through the cache (SST blocks, bloom filters, index, table info) already carries a CRC32 checksum validated via `SsTableFormat::validate_checksum` on read. The cache layer doesn't need its own integrity checks.

Follow-up consideration: if a `ChecksumMismatch` is detected at the SST layer, we currently propagate a hard error rather than invalidating the cache entry and retrying from remote. Adding that retry path would make crash-corruption fully self-healing, but that's a separate concern.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
