### PR TITLE
Use trusted publishing for @slatedb/uniffi publication

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -224,8 +224,6 @@ jobs:
           node --version
           npm --version
 
-      - name: Publish to npm
+      - name: Publish to npm via trusted publishing
         working-directory: ./bindings/node
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
-        run: npm publish --provenance --access public
+        run: npm publish


### PR DESCRIPTION
This pull request updates the npm publishing step in the GitHub Actions workflow to use trusted publishing. The workflow no longer sets the `NODE_AUTH_TOKEN` environment variable or passes additional flags to the `npm publish` command.