### PR TITLE
Fix flaky `test_should_merge_db_state_correctly`

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -720,7 +720,7 @@ mod tests {
     use super::*;
     use crate::checkpoint::Checkpoint;
     use crate::compactor_state::SourceId::SstView;
-    use crate::config::Settings;
+    use crate::config::{FlushOptions, FlushType, Settings};
     use crate::db::Db;
     use crate::db_state::SsTableId;
     use crate::manifest::store::test_utils::new_dirty_manifest;
@@ -1308,7 +1308,16 @@ mod tests {
                 .block_on(db.put(&[b'j' + i as u8; 16], &[b'k' + i as u8; 48]))
                 .unwrap();
         }
-        tokio_handle.block_on(db.close()).unwrap();
+        tokio_handle.block_on(async {
+            // Persist the seeded L0s into the manifest before close so reopen
+            // doesn't reconstruct them from WAL replay on a slow shutdown.
+            db.flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+            db.close().await.unwrap();
+        });
         let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
         let rand: Arc<DbRand> = Arc::new(DbRand::default());
 


### PR DESCRIPTION
## Summary

`test_should_merge_db_state_correctly` was depending on db.close() to flush all writes. But since the WAL is enabled, the flush writes data out to the WAL rather than L0. This can lead to a case where the data gets replayed from the WAL on restart and never gets written to L0. this causes a timeout waiting for the L0 count to quiesce.

Fixes: https://github.com/slatedb/slatedb/actions/runs/24351721397/job/71108855172

## Changes

- Forcibly flush memtables before close to guarantee all L0s are as expected.

## Notes for Reviewers

Reproduced after 280 iterations with CPU saturation. Patched. Unable to reproduce post-patch after 600+ iterations.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
