### PR TITLE
rename manifest_poll -> refresh_manifest [minor]

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1551,18 +1551,26 @@ impl Db {
         self.inner.manifest()
     }
 
-    /// Enqueue a manifest poll immediately and wait for it to complete.
+    /// Refresh the manifest immediately and wait for it to complete.
     ///
-    /// A `PollManifest` command is enqueued immediately, bypassing the regular
-    /// [`Settings::manifest_poll_interval`] timer.
+    /// The database normally refreshes its manifest on a background timer
+    /// controlled by [`Settings::manifest_poll_interval`]. This method
+    /// bypasses that timer, triggering an immediate refresh and waiting
+    /// for it to finish.
+    ///
+    /// Use this when you know the manifest has changed externally and
+    /// want to ensure the database has observed the update before
+    /// proceeding — for example, after a compaction completes and you
+    /// need to confirm that a compaction filter has been applied.
     ///
     /// ## Errors
-    /// - Returns [`Error`] if the database is closed before the next poll completes.
-    pub async fn manifest_poll(&self) -> Result<(), crate::Error> {
+    /// - Returns [`Error`] if the database is closed before the refresh
+    ///   completes.
+    pub async fn refresh_manifest(&self) -> Result<(), crate::Error> {
         self.inner.check_closed()?;
         self.inner
             .memtable_flusher
-            .poll_manifest()
+            .refresh_manifest()
             .await
             .map_err(Into::into)
     }

--- a/slatedb/src/memtable_flusher/mod.rs
+++ b/slatedb/src/memtable_flusher/mod.rs
@@ -98,8 +98,8 @@ impl MemtableFlusher {
         Ok(())
     }
 
-    /// Enqueues a manifest poll and waits until it completes.
-    pub(crate) async fn poll_manifest(&self) -> Result<(), SlateDBError> {
+    /// Enqueues a manifest refresh and waits until it completes.
+    pub(crate) async fn refresh_manifest(&self) -> Result<(), SlateDBError> {
         let (tx, rx) = oneshot::channel();
         self.messages_tx
             .send(TrackerMessage::PollManifest { sender: tx })?;

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -351,12 +351,12 @@ async fn test_concurrent_writers_and_readers() {
         .expect("Failed to close DB after retries");
 }
 
-/// Verify that manifest_poll enqueues a poll and returns once it completes,
+/// Verify that refresh_manifest enqueues a poll and returns once it completes,
 /// and returns an error once the DB is closed.
 #[tokio::test]
-async fn test_manifest_poll() {
+async fn test_refresh_manifest() {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-    let db = Db::builder("test_manifest_poll", object_store.clone())
+    let db = Db::builder("test_refresh_manifest", object_store.clone())
         .with_settings(Settings {
             manifest_poll_interval: Duration::from_secs(60 * 60),
             ..Default::default()
@@ -366,13 +366,13 @@ async fn test_manifest_poll() {
         .expect("failed to open db");
 
     // Should return once the enqueued poll completes.
-    db.manifest_poll()
+    db.refresh_manifest()
         .await
-        .expect("manifest_poll returned error");
+        .expect("refresh_manifest returned error");
 
-    // After close, manifest_poll should return an error.
+    // After close, refresh_manifest should return an error.
     db.close().await.expect("failed to close db");
-    let result = db.manifest_poll().await;
+    let result = db.refresh_manifest().await;
     assert!(
         result.is_err(),
         "expected error after close, got {:?}",


### PR DESCRIPTION
## Summary

Minor rename of a method to make it a bit clearer. See #1513 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
