### PR TITLE
Await memtable flush on clean shutdown

### DIFF
--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -656,7 +656,9 @@ mod tests {
         let rand = Arc::new(DbRand::default());
         let system_clock = Arc::new(DefaultSystemClock::new());
 
-        let parent_db = Db::open(parent_path.clone(), object_store.clone())
+        let parent_db = Db::builder(parent_path.clone(), object_store.clone())
+            .with_fp_registry(fp_registry.clone())
+            .build()
             .await
             .unwrap();
         let mut rng = rng::new_test_rng(None);
@@ -669,7 +671,20 @@ mod tests {
             .await
             .unwrap();
         parent_db.flush().await.unwrap();
+        // Block L0 uploads so the data remains in the WAL after close.
+        fail_parallel::cfg(
+            Arc::clone(&fp_registry),
+            "write-compacted-sst-io-error",
+            "return",
+        )
+        .unwrap();
         parent_db.close().await.unwrap();
+        fail_parallel::cfg(
+            Arc::clone(&fp_registry),
+            "write-compacted-sst-io-error",
+            "off",
+        )
+        .unwrap();
 
         fail_parallel::cfg(
             Arc::clone(&fp_registry),
@@ -867,6 +882,7 @@ mod tests {
 
     #[tokio::test]
     async fn clone_should_fail_when_wal_store_is_not_provided() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store = Arc::new(InMemory::new());
         let wal_object_store = Arc::new(InMemory::new());
         let parent_path = "/tmp/test_parent";
@@ -874,6 +890,7 @@ mod tests {
 
         let parent_db = Db::builder(parent_path, object_store.clone())
             .with_wal_object_store(wal_object_store.clone())
+            .with_fp_registry(fp_registry.clone())
             .build()
             .await
             .unwrap();
@@ -921,7 +938,15 @@ mod tests {
         let expected_missing_wal_path = PathResolver::new(Path::from(parent_path))
             .table_path(&SsTableId::Wal(manifest.replay_after_wal_id + 1))
             .to_string();
+        // Block L0 uploads so the WAL-only data stays in the WAL.
+        fail_parallel::cfg(
+            fp_registry.clone(),
+            "write-compacted-sst-io-error",
+            "return",
+        )
+        .unwrap();
         parent_db.close().await.unwrap();
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
 
         // Pass main store as WAL store — WAL SSTs won't be found there
         let err = create_clone(

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -4919,9 +4919,7 @@ mod tests {
         assert_eq!(db.inner.wal_buffer.recent_flushed_wal_id(), 2);
 
         // Let background flush attempts fail while WAL durability preserves recovery.
-        eprintln!("begin close");
         db.close().await.unwrap();
-        eprintln!("end close");
 
         // pause write-compacted-sst-io-error to prevent immutable tables
         // from being flushed, so we can snapshot the state when there is

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -440,41 +440,7 @@ impl DbInner {
         &self.memtable_flusher
     }
 
-    /// Flush in-memory writes to disk. See [`Db::flush`] for details.
-    ///
-    /// `check_status` exists so we can call flush in [`Db::close`] after marking the
-    /// database as closed.
-    ///
-    /// ## Arguments
-    /// - `check_status`: if true, checks the database status before flushing.
-    ///
-    /// ## Returns
-    /// - `Ok(())` if the flush was successful.
-    /// - `Err(SlateDBError)` if there was an error flushing the database. If
-    ///   `check_status` is true, this may return `SlateDBError::Closed` if the database
-    ///   has already been closed.
-    pub(crate) async fn flush(&self, check_status: bool) -> Result<(), SlateDBError> {
-        if self.wal_enabled {
-            self.flush_with_options(
-                FlushOptions {
-                    flush_type: FlushType::Wal,
-                },
-                check_status,
-            )
-            .await
-        } else {
-            self.flush_with_options(
-                FlushOptions {
-                    flush_type: FlushType::MemTable,
-                },
-                check_status,
-            )
-            .await
-        }
-    }
-
-    /// Flush in-memory writes to disk with custom options. See [`Db::flush_with_options`]
-    /// for details.
+    /// Flush in-memory writes to disk. See [`Db::flush_with_options`] for details.
     ///
     /// `check_status` exists so we can call flush in [`Db::close`] after marking the
     /// database as closed.
@@ -488,7 +454,7 @@ impl DbInner {
     /// - `Err(SlateDBError)` if there was an error flushing the database. If
     ///   `check_status` is true, this may return `SlateDBError::Closed` if the database
     ///   has already been closed.
-    pub(crate) async fn flush_with_options(
+    pub(crate) async fn flush(
         &self,
         options: FlushOptions,
         check_status: bool,
@@ -706,7 +672,18 @@ impl Db {
         self.inner.status_manager.write_result(Ok(()));
 
         if should_flush {
-            if let Err(e) = self.inner.flush(false).await {
+            // Flush memtables to L0 so that the WAL does not need to be
+            // replayed on the next startup.
+            if let Err(e) = self
+                .inner
+                .flush(
+                    FlushOptions {
+                        flush_type: FlushType::MemTable,
+                    },
+                    false,
+                )
+                .await
+            {
                 warn!("failed to flush db during close [error={:?}]", e);
             }
         }
@@ -1499,7 +1476,15 @@ impl Db {
     /// }
     /// ```
     pub async fn flush(&self) -> Result<(), crate::Error> {
-        self.inner.flush(true).await.map_err(Into::into)
+        let flush_type = if self.inner.wal_enabled {
+            FlushType::Wal
+        } else {
+            FlushType::MemTable
+        };
+        self.inner
+            .flush(FlushOptions { flush_type }, true)
+            .await
+            .map_err(Into::into)
     }
 
     /// Flush in-memory writes to disk with custom options.
@@ -1538,10 +1523,7 @@ impl Db {
     /// }
     /// ```
     pub async fn flush_with_options(&self, options: FlushOptions) -> Result<(), crate::Error> {
-        self.inner
-            .flush_with_options(options, true)
-            .await
-            .map_err(Into::into)
+        self.inner.flush(options, true).await.map_err(Into::into)
     }
 
     /// Get the current manifest state.
@@ -2440,6 +2422,48 @@ mod tests {
         );
         let status = db.status();
         assert_eq!(status.close_reason, Some(CloseReason::Clean));
+    }
+
+    #[tokio::test]
+    async fn test_close_flushes_memtables_to_l0() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db_options = {
+            let mut db_options = test_db_options(0, 1024, None);
+            db_options.flush_interval = None;
+            db_options
+        };
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let db = Db::builder("/tmp/test_close_flushes_memtables_to_l0", object_store)
+            .with_settings(db_options)
+            .with_metrics_recorder(metrics_recorder.clone())
+            .build()
+            .await
+            .unwrap();
+
+        db.put_with_options(
+            b"test_key",
+            b"test_value",
+            &PutOptions::default(),
+            &WriteOptions {
+                await_durable: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        // No L0 flushes should have happened yet.
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap_or(0),
+            0
+        );
+
+        db.close().await.unwrap();
+
+        // close() should have flushed memtables to L0.
+        assert!(
+            lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap() > 0,
+            "expected L0 flush during close"
+        );
     }
 
     #[tokio::test]
@@ -4383,11 +4407,22 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)]
     async fn test_restore_seq_number() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        // Block L0 uploads so the data remains only in the WAL. The
+        // uploader gives up on shutdown when the WAL is enabled, so
+        // close() will complete without flushing memtables to L0.
+        fail_parallel::cfg(
+            fp_registry.clone(),
+            "write-compacted-sst-io-error",
+            "return",
+        )
+        .unwrap();
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_kv_store";
         let db = Db::builder(path, object_store.clone())
             .with_settings(test_db_options(0, 256, None))
             .with_system_clock(Arc::new(MockSystemClock::new()))
+            .with_fp_registry(fp_registry.clone())
             .build()
             .await
             .unwrap();
@@ -4425,9 +4460,13 @@ mod tests {
         db.flush().await.unwrap();
         db.close().await.unwrap();
 
+        // Disable the failpoint so the restored DB can flush normally.
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
+
         let db_restored = Db::builder(path, object_store.clone())
             .with_settings(test_db_options(0, 256, None))
             .with_system_clock(Arc::new(MockSystemClock::new()))
+            .with_fp_registry(fp_registry.clone())
             .build()
             .await
             .unwrap();
@@ -4880,7 +4919,9 @@ mod tests {
         assert_eq!(db.inner.wal_buffer.recent_flushed_wal_id(), 2);
 
         // Let background flush attempts fail while WAL durability preserves recovery.
+        eprintln!("begin close");
         db.close().await.unwrap();
+        eprintln!("end close");
 
         // pause write-compacted-sst-io-error to prevent immutable tables
         // from being flushed, so we can snapshot the state when there is
@@ -5323,6 +5364,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_recover_clock_tick_from_wal() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        // Block L0 uploads so the data remains only in the WAL. The
+        // uploader gives up on shutdown when the WAL is enabled, so
+        // close() will complete without flushing memtables to L0.
+        fail_parallel::cfg(
+            fp_registry.clone(),
+            "write-compacted-sst-io-error",
+            "return",
+        )
+        .unwrap();
         let clock = Arc::new(MockSystemClock::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_kv_store";
@@ -5330,6 +5381,7 @@ mod tests {
         let db = Db::builder(path, object_store.clone())
             .with_settings(test_db_options(0, 1024, None))
             .with_system_clock(clock.clone())
+            .with_fp_registry(fp_registry.clone())
             .build()
             .await
             .unwrap();
@@ -5372,10 +5424,14 @@ mod tests {
         let last_clock_tick = db_state.last_l0_clock_tick;
         assert_eq!(last_clock_tick, i64::MIN);
 
+        // Disable the failpoint so the restored DB can flush normally.
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
+
         let clock = Arc::new(MockSystemClock::new());
         let db = Db::builder(path, object_store.clone())
             .with_settings(test_db_options(0, 1024, None))
             .with_system_clock(clock.clone())
+            .with_fp_registry(fp_registry.clone())
             .build()
             .await
             .unwrap();

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -23,7 +23,7 @@ use crate::utils::SafeSender;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use futures::StreamExt;
-use log::warn;
+use log::{info, warn};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -168,7 +168,17 @@ impl UploadHandler {
             let encoded_sst = self.db.build_imm_sst(job.imm_memtable.table()).await?;
             match self.try_upload_once(job, encoded_sst).await {
                 Ok(success) => return Ok(success),
-                Err(_) => {
+                Err(e) => {
+                    // When the WAL is enabled and the database is shutting
+                    // down, give up immediately. The data is already durable
+                    // in the WAL and will be recovered on the next startup.
+                    if self.db.wal_enabled && self.db.check_closed().is_err() {
+                        info!(
+                            "skipping l0 upload retry during shutdown [sst_id={:?}, error={:?}]",
+                            job.sst_id, e
+                        );
+                        return Err(e);
+                    }
                     self.db.system_clock.sleep(self.retry_backoff).await;
                 }
             }
@@ -577,5 +587,35 @@ mod tests {
             !matches!(err, SlateDBError::Closed),
             "expected specific error, got Closed"
         );
+    }
+
+    #[tokio::test]
+    async fn should_stop_retrying_on_shutdown_when_wal_enabled() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        fail_parallel::cfg(
+            Arc::clone(&fp_registry),
+            "write-compacted-sst-io-error",
+            "return",
+        )
+        .unwrap();
+        let db = setup_db(
+            "/tmp/test_parallel_l0_flush_uploader_shutdown_retry",
+            fp_registry,
+        )
+        .await;
+        assert!(db.wal_enabled);
+        let job = next_upload_job(&db, b"key", b"value", 1);
+
+        let test = start_test_uploader(&db);
+        test.submit(job).unwrap();
+
+        // Mark the database as closed (simulates Db::close()).
+        db.status_manager.write_result(Ok(()));
+
+        // The uploader should give up retrying and report the error.
+        let result = timeout(Duration::from_secs(5), test.await_closed())
+            .await
+            .expect("uploader should stop retrying on shutdown");
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
This patch fixes part of #1540 . Prior to this patch, when the WAL is enabled, we did not await memtable flush on shutdown, which potentially leaves memtable uploads in progress during shutdown and can cause spurious logging. In this patch, we flush memtables as well which clears the pipeline, but is arguably better behavior in any case. Leaving the memtables unflushed means that they will need to be rebuilt from the WAL after restart. So we trade some latency on close for latency and cost (additional reads from the WAL) on startup. On the other hand, since flushing memtables is not strictly necessary, we probably do not want to delay shutdown if the flush needs to be retried. So in the current patch, we bail early on retry if a shutdown is in progress. Conveniently, this also gives us a way to fix tests which relied on the old behavior.

There are a few lingering issues related to #1540  that I've opted to address separately. First, we may need a different approach when the WAL is disabled. If we do not retry, then we should propagate the error to the user. However, the current logic in close() writes `Ok()` to the closed result before the flush is attempted, so errors cannot be propagated. Second, we probably still ought to fix the shutdown ordering logic in `MemtableFlusher`. 