### PR TITLE
Remove WriteBatch clone in DbTransaction 

### DIFF
--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -356,7 +356,7 @@ pub(crate) struct WriteBatchIterator {
 
 impl WriteBatchIterator {
     pub(crate) fn new(
-        batch: WriteBatch,
+        batch: &WriteBatch,
         range: impl RangeBounds<Bytes>,
         ordering: IterationOrder,
     ) -> Self {

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -547,7 +547,7 @@ mod tests {
         batch.put(b"key2", b"value2");
         batch.delete(b"key4");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         let expected = vec![
             RowEntry::new_value(b"key1", b"value1", u64::MAX),
@@ -574,7 +574,7 @@ mod tests {
 
         // Test range [key2, key4)
         let mut iter = WriteBatchIterator::new(
-            batch.clone(),
+            &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
         );
@@ -591,7 +591,7 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key2", b"value2");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Descending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Descending);
 
         let expected = vec![
             RowEntry::new_value(b"key3", b"value3", u64::MAX),
@@ -609,7 +609,7 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key5", b"value5");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Seek to key3
         iter.seek(b"key3").await.unwrap();
@@ -630,7 +630,7 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key5", b"value5");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Descending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Descending);
 
         // Seek to key3 (in descending, we want keys <= key3)
         iter.seek(b"key3").await.unwrap();
@@ -647,7 +647,7 @@ mod tests {
     #[tokio::test]
     async fn test_writebatch_iterator_empty_batch() {
         let batch = WriteBatch::new();
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         let result = iter.next().await.unwrap();
         assert!(result.is_none());
@@ -659,7 +659,7 @@ mod tests {
         batch.put(b"key1", b"value1");
         batch.put(b"key3", b"value3");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Seek to key2 (doesn't exist)
         iter.seek(b"key2").await.unwrap();
@@ -681,7 +681,7 @@ mod tests {
         batch.put(b"key1", b"value1");
         batch.put(b"key3", b"value3");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Seek beyond maximum key
         iter.seek(b"key9").await.unwrap();
@@ -699,7 +699,7 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.delete(b"key4");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         let expected = vec![
             RowEntry::new_value(b"key1", b"value1", u64::MAX),
@@ -729,7 +729,7 @@ mod tests {
         batch.put(b"key2", b"value2");
         batch.put(b"key3", b"value3");
 
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Seek before first key
         iter.seek(b"key1").await.unwrap();
@@ -752,7 +752,7 @@ mod tests {
 
         // Range [key2, key4) should include tombstones
         let mut iter = WriteBatchIterator::new(
-            batch.clone(),
+            &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
         );
@@ -1020,7 +1020,7 @@ mod tests {
         batch.delete(b"key3");
 
         // When: creating an iterator
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Then: the iterator should return all operations in order
         let expected = vec![
@@ -1060,7 +1060,7 @@ mod tests {
         batch.merge(b"key1", b"merge3");
 
         // When: creating an iterator
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Then: the iterator should return all merge operations
         let expected = vec![
@@ -1099,7 +1099,7 @@ mod tests {
         batch.merge(b"key1", b"merge3");
 
         // When: creating a descending iterator
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Descending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Descending);
 
         // Then: the iterator should return operations in descending order
         let expected = vec![
@@ -1139,7 +1139,7 @@ mod tests {
 
         // When: creating an iterator with a range filter
         let mut iter = WriteBatchIterator::new(
-            batch.clone(),
+            &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
         );
@@ -1165,7 +1165,7 @@ mod tests {
         batch.merge(b"key5", b"merge5");
 
         // When: creating an iterator and seeking to key3
-        let mut iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
         iter.seek(b"key3").await.unwrap();
 
         // Then: the iterator should return key3 and key5

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -532,7 +532,7 @@ mod tests {
         batch.put(b"key3", b"value3");
 
         // Create WriteBatchIterator
-        let wb_iter = WriteBatchIterator::new(batch.clone(), .., IterationOrder::Ascending);
+        let wb_iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
 
         // Create DbIterator with WriteBatch
         let mem_iters: VecDeque<Box<dyn RowEntryIterator + 'static>> = VecDeque::new();

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -5,13 +5,14 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::batch::WriteBatch;
+use crate::batch::{WriteBatch, WriteBatchIterator};
 use crate::bytes_range::BytesRange;
 use crate::config::{MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions};
 use crate::db::DbInner;
 use crate::db::WriteHandle;
 use crate::db_iter::{DbIterator, DbIteratorRangeTracker};
 use crate::error::SlateDBError;
+use crate::iter::IterationOrder;
 use crate::transaction_manager::{IsolationLevel, TransactionManager};
 use crate::types::KeyValue;
 use crate::DbRead;
@@ -150,10 +151,21 @@ impl DbTransaction {
 
         let db_state = self.db_inner.state.read().view();
 
-        // Clone the WriteBatch for snapshot isolation
-        let write_batch_cloned = self.write_batch.read().clone();
+        // Build the write batch iterator synchronously while holding the read
+        // guard, avoiding a clone of the full batch. The iterator materializes
+        // only the entries overlapping the read range (a single key for a
+        // point get), so this is O(log N) instead of O(N).
+        let key_slice = key.as_ref();
+        let range = BytesRange::from_slice(key_slice..=key_slice);
+        let write_batch_iter = {
+            let guard = self.write_batch.read();
+            Some(WriteBatchIterator::new(
+                &*guard,
+                range,
+                IterationOrder::Ascending,
+            ))
+        };
 
-        // For now, delegate to the underlying reader
         let kv = self
             .db_inner
             .reader
@@ -161,7 +173,7 @@ impl DbTransaction {
                 key,
                 options,
                 &db_state,
-                Some(write_batch_cloned),
+                write_batch_iter,
                 Some(self.started_seq),
             )
             .await
@@ -224,18 +236,26 @@ impl DbTransaction {
         self.db_inner.check_closed()?;
         let db_state = self.db_inner.state.read().view();
 
-        // Clone the WriteBatch for the scan to ensure that the scan within a transaction
-        // sees a consistent view of the current writes.
-        let write_batch_cloned = self.write_batch.read().clone();
+        // Build the write batch iterator synchronously while holding the read
+        // guard, avoiding a clone of the full batch. The iterator materializes
+        // only the entries in the scan range.
+        let range = BytesRange::from(range);
+        let write_batch_iter = {
+            let guard = self.write_batch.read();
+            Some(WriteBatchIterator::new(
+                &*guard,
+                range.clone(),
+                options.order,
+            ))
+        };
 
-        // For now, delegate to the underlying reader
         self.db_inner
             .reader
             .scan_with_options(
-                BytesRange::from(range),
+                range,
                 options,
                 &db_state,
-                Some(write_batch_cloned),
+                write_batch_iter,
                 Some(self.started_seq),
                 range_tracker,
             )

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -160,7 +160,7 @@ impl DbTransaction {
         let write_batch_iter = {
             let guard = self.write_batch.read();
             Some(WriteBatchIterator::new(
-                &*guard,
+                &guard,
                 range,
                 IterationOrder::Ascending,
             ))
@@ -243,7 +243,7 @@ impl DbTransaction {
         let write_batch_iter = {
             let guard = self.write_batch.read();
             Some(WriteBatchIterator::new(
-                &*guard,
+                &guard,
                 range.clone(),
                 options.order,
             ))

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -1,4 +1,4 @@
-use crate::batch::{WriteBatch, WriteBatchIterator};
+use crate::batch::WriteBatchIterator;
 use crate::bytes_range::BytesRange;
 use crate::clock::MonotonicClock;
 use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
@@ -109,13 +109,10 @@ impl Reader {
         &self,
         range: &BytesRange,
         db_state: &(dyn DbStateReader + Sync),
-        write_batch: Option<WriteBatch>,
+        write_batch_iter: Option<WriteBatchIterator>,
         sst_iter_options: SstIteratorOptions,
         point_lookup_stats: Option<DbStats>,
     ) -> Result<IteratorSources, SlateDBError> {
-        let write_batch_iter = write_batch
-            .map(|batch| WriteBatchIterator::new(batch, range.clone(), sst_iter_options.order));
-
         let mut memtables = VecDeque::new();
         memtables.push_back(db_state.memtable());
         for memtable in db_state.imm_memtable() {
@@ -300,7 +297,7 @@ impl Reader {
         key: K,
         options: &ReadOptions,
         db_state: &(dyn DbStateReader + Sync + Send),
-        write_batch: Option<WriteBatch>,
+        write_batch_iter: Option<WriteBatchIterator>,
         max_seq: Option<u64>,
     ) -> Result<Option<KeyValue>, SlateDBError> {
         self.db_stats.get_requests.increment(1);
@@ -323,7 +320,7 @@ impl Reader {
             .build_iterator_sources(
                 &range,
                 db_state,
-                write_batch,
+                write_batch_iter,
                 sst_iter_options,
                 Some(self.db_stats.clone()),
             )
@@ -379,7 +376,7 @@ impl Reader {
         range: BytesRange,
         options: &ScanOptions,
         db_state: &(dyn DbStateReader + Sync),
-        write_batch: Option<WriteBatch>,
+        write_batch_iter: Option<WriteBatchIterator>,
         max_seq: Option<u64>,
         range_tracker: Option<Arc<DbIteratorRangeTracker>>,
     ) -> Result<DbIterator, SlateDBError> {
@@ -401,7 +398,7 @@ impl Reader {
             l0_iters,
             sr_iters,
         } = self
-            .build_iterator_sources(&range, db_state, write_batch, sst_iter_options, None)
+            .build_iterator_sources(&range, db_state, write_batch_iter, sst_iter_options, None)
             .await?;
 
         DbIterator::new(

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -430,6 +430,27 @@ mod tests {
 
     use crate::batch::WriteBatch;
     use crate::clock::MonotonicClock;
+    use crate::iter::IterationOrder;
+
+    fn wb_point_iter(write_batch: &Option<WriteBatch>, key: &[u8]) -> Option<WriteBatchIterator> {
+        write_batch.as_ref().map(|wb| {
+            WriteBatchIterator::new(
+                wb,
+                BytesRange::from_slice(key..=key),
+                IterationOrder::Ascending,
+            )
+        })
+    }
+
+    fn wb_range_iter(
+        write_batch: &Option<WriteBatch>,
+        range: &BytesRange,
+        order: IterationOrder,
+    ) -> Option<WriteBatchIterator> {
+        write_batch
+            .as_ref()
+            .map(|wb| WriteBatchIterator::new(wb, range.clone(), order))
+    }
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
     use crate::db_status::DbStatusManager;
     use crate::format::sst::SsTableFormat;
@@ -1257,7 +1278,7 @@ mod tests {
                 test_case.query_key,
                 &read_options,
                 &test_db_state,
-                write_batch,
+                wb_point_iter(&write_batch, test_case.query_key),
                 test_case.max_seq,
             )
             .await?;
@@ -1685,12 +1706,13 @@ mod tests {
 
         // Call the actual scan_with_options method
         let scan_options = ScanOptions::default().with_dirty(test_case.dirty);
+        let wb_iter = wb_range_iter(&write_batch, &range, scan_options.order);
         let mut iter = reader
             .scan_with_options(
                 range,
                 &scan_options,
                 &test_db_state,
-                write_batch,
+                wb_iter,
                 test_case.max_seq,
                 None,
             )
@@ -1795,7 +1817,7 @@ mod tests {
                 b"key1",
                 &ReadOptions::default().with_dirty(true),
                 &test_db_state,
-                write_batch.clone(),
+                wb_point_iter(&write_batch, b"key1"),
                 None,
             )
             .await?;
@@ -1809,12 +1831,15 @@ mod tests {
             Some(0)
         );
 
+        let scan_range = BytesRange::from_slice(b"key1".as_ref()..b"key3".as_ref());
+        let scan_options = ScanOptions::default().with_dirty(true);
+        let wb_iter = wb_range_iter(&write_batch, &scan_range, scan_options.order);
         let mut iter = reader
             .scan_with_options(
-                BytesRange::from_slice(b"key1".as_ref()..b"key3".as_ref()),
-                &ScanOptions::default().with_dirty(true),
+                scan_range,
+                &scan_options,
                 &test_db_state,
-                write_batch,
+                wb_iter,
                 None,
                 None,
             )
@@ -1875,7 +1900,7 @@ mod tests {
                 b"key2",
                 &ReadOptions::default().with_dirty(true),
                 &test_db_state,
-                write_batch,
+                wb_point_iter(&write_batch, b"key2"),
                 None,
             )
             .await?;
@@ -1918,7 +1943,7 @@ mod tests {
                 b"key1",
                 &ReadOptions::default().with_dirty(true),
                 &test_db_state,
-                write_batch.clone(),
+                wb_point_iter(&write_batch, b"key1"),
                 None,
             )
             .await?;
@@ -1932,7 +1957,7 @@ mod tests {
                 b"key2",
                 &ReadOptions::default().with_dirty(true),
                 &test_db_state,
-                write_batch,
+                wb_point_iter(&write_batch, b"key2"),
                 None,
             )
             .await?;
@@ -1962,15 +1987,9 @@ mod tests {
         // when: scanning all keys
         let range = BytesRange::from_slice(b"key1".as_ref()..b"key4".as_ref());
         let scan_options = ScanOptions::default().with_dirty(true);
+        let wb_iter = wb_range_iter(&write_batch, &range, scan_options.order);
         let mut iter = reader
-            .scan_with_options(
-                range,
-                &scan_options,
-                &test_db_state,
-                write_batch,
-                None,
-                None,
-            )
+            .scan_with_options(range, &scan_options, &test_db_state, wb_iter, None, None)
             .await?;
 
         // then: each result should carry its expire_ts
@@ -2028,7 +2047,7 @@ mod tests {
                 b"key1",
                 &ReadOptions::default().with_dirty(true),
                 &test_db_state,
-                write_batch,
+                wb_point_iter(&write_batch, b"key1"),
                 None,
             )
             .await?;
@@ -2068,7 +2087,7 @@ mod tests {
                 b"key1",
                 &ReadOptions::default().with_dirty(true),
                 &test_db_state,
-                write_batch,
+                wb_point_iter(&write_batch, b"key1"),
                 None,
             )
             .await?;


### PR DESCRIPTION
## Summary

We clone the `WriteBatch` in `DbTransaction` for point gets, but it's not necessary. I think this is from the time we added interior mutability for the transaction. We can clone what we want only from the `WriteBatch` under the read lock. Found this while doing some cpu profiling for transactions. 

## Changes

- The change uses `WriteBatchIterator` with the requested range which clones only the requested keys instead of cloning the entire batch. 

The results with a simple test for point get in a transaction. 

Batch size | Before | After
-- | -- | --
1,000 | 24.18 µs | 2.31 µs
5,000 | 100.24 µs | 2.02 µs

<br class="Apple-interchange-newline">

## Notes for Reviewers

Let me know if I'm breaking any invariant here. It seemed fine. 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
