### PR TITLE
Add close() to DbCache trait + documentation

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -733,6 +733,10 @@ impl Db {
             warn!("failed to shutdown wal writer task [error={:?}]", e);
         }
 
+        if let Err(e) = self.inner.table_store.close_cache().await {
+            warn!("failed to close block cache [error={:?}]", e);
+        }
+
         info!("db closed");
         Ok(())
     }

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -64,6 +64,7 @@ use crate::{
     error::SlateDBError,
 };
 use async_trait::async_trait;
+use log::info;
 
 pub struct FoyerHybridCache {
     inner: foyer::HybridCache<CachedKey, CachedEntry>,
@@ -114,6 +115,25 @@ impl DbCache for FoyerHybridCache {
     fn entry_count(&self) -> u64 {
         // foyer cache doesn't support an entry count estimate
         0
+    }
+
+    async fn close(&self) -> Result<(), crate::Error> {
+        let memory_bytes = self.inner.memory().usage();
+        info!(
+            "foyer hybrid cache: closing \
+             (flushing {:.2} MB from memory to disk)",
+            memory_bytes as f64 / (1024.0 * 1024.0)
+        );
+        let result = self
+            .inner
+            .close()
+            .await
+            .map_err(|e| crate::Error::from(SlateDBError::from(e)));
+        match &result {
+            Ok(()) => info!("foyer hybrid cache: closed successfully"),
+            Err(e) => info!("foyer hybrid cache: close failed [error={e:?}]"),
+        }
+        result
     }
 }
 
@@ -174,17 +194,51 @@ mod tests {
 
     async fn setup() -> (FoyerHybridCache, TempDir) {
         let tempdir = tempdir().unwrap();
+        let cache = open_cache(tempdir.path()).await;
+        (cache, tempdir)
+    }
+
+    async fn open_cache(path: &std::path::Path) -> FoyerHybridCache {
         let cache = HybridCacheBuilder::new()
             .with_name("hybrid_cache_test")
-            .memory(1024)
+            .memory(1024 * 1024)
             .with_weighter(|_, v: &CachedEntry| v.size())
             .storage(Engine::large())
             .with_device_options(
-                DirectFsDeviceOptions::new(tempdir.path()).with_capacity(1024 * 1024),
+                DirectFsDeviceOptions::new(path)
+                    .with_capacity(4 * 1024 * 1024)
+                    .with_file_size(64 * 1024),
             )
             .build()
             .await
             .unwrap();
-        (FoyerHybridCache::new_with_cache(cache), tempdir)
+        FoyerHybridCache::new_with_cache(cache)
+    }
+
+    #[tokio::test]
+    async fn should_persist_blocks_to_disk_on_close() {
+        // given: a cache with entries
+        let dir = tempdir().unwrap();
+        let cache = open_cache(dir.path()).await;
+        let mut keys = Vec::new();
+        for b in 0u64..64 {
+            let k = CachedKey::from((SST_ID, b));
+            cache.insert(k.clone(), build_block()).await;
+            keys.push(k);
+        }
+
+        // when: close (flush to disk) and reopen
+        cache.close().await.unwrap();
+        drop(cache);
+        let cache = open_cache(dir.path()).await;
+
+        // then: all entries should be recoverable from disk
+        let mut found = 0;
+        for k in &keys {
+            if cache.get_block(k).await.unwrap().is_some() {
+                found += 1;
+            }
+        }
+        assert_eq!(found, keys.len(), "all entries should survive close+reopen");
     }
 }

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -146,6 +146,15 @@ pub trait DbCache: Send + Sync {
     async fn remove(&self, key: &CachedKey);
     #[allow(dead_code)]
     fn entry_count(&self) -> u64;
+
+    /// Gracefully close the cache, flushing any in-memory state to disk.
+    ///
+    /// Implementations backed by hybrid (memory + disk) caches should use
+    /// this to ensure cached entries survive process restarts. The default
+    /// implementation is a no-op.
+    async fn close(&self) -> Result<(), crate::Error> {
+        Ok(())
+    }
 }
 
 /// A key used to identify a cached entry.
@@ -396,6 +405,16 @@ impl DbCache for SplitCache {
         self.block_cache.as_ref().map_or(0, |c| c.entry_count())
             + self.meta_cache.as_ref().map_or(0, |c| c.entry_count())
     }
+
+    async fn close(&self) -> Result<(), crate::Error> {
+        if let Some(ref cache) = self.block_cache {
+            cache.close().await?;
+        }
+        if let Some(ref cache) = self.meta_cache {
+            cache.close().await?;
+        }
+        Ok(())
+    }
 }
 
 /// Wraps a [`DbCache`] to add statistics, error logging, and cache scoping.
@@ -555,6 +574,10 @@ impl DbCache for DbCacheWrapper {
 
     fn entry_count(&self) -> u64 {
         self.cache.entry_count()
+    }
+
+    async fn close(&self) -> Result<(), crate::Error> {
+        self.cache.close().await
     }
 }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -27,7 +27,7 @@ use crate::{Checkpoint, DbIterator};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use log::info;
+use log::{info, warn};
 use object_store::path::Path;
 use object_store::ObjectStore;
 use once_cell::sync::Lazy;
@@ -1054,7 +1054,13 @@ impl DbReader {
         self.task_executor
             .shutdown_task(DB_READER_TASK_NAME)
             .await
-            .map_err(Into::into)
+            .map_err(Into::<crate::Error>::into)?;
+
+        if let Err(e) = self.inner.table_store.close_cache().await {
+            warn!("failed to close block cache [error={:?}]", e);
+        }
+
+        Ok(())
     }
 
     /// Subscribe to database status changes.

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -117,6 +117,14 @@ impl TableStore {
         Ok(last_wal_id.unwrap_or(0))
     }
 
+    /// Gracefully close the block cache, flushing in-memory entries to disk.
+    pub(crate) async fn close_cache(&self) -> Result<(), crate::Error> {
+        if let Some(ref cache) = self.cache {
+            cache.close().await?;
+        }
+        Ok(())
+    }
+
     pub(crate) async fn list_wal_ssts<R: RangeBounds<u64>>(
         &self,
         id_range: R,

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -171,6 +171,10 @@ export default defineConfig({
 							link: '/docs/operations/configuration/',
 						},
 						{
+							label: 'Configuring Foyer Cache',
+							link: '/docs/operations/foyer-cache/',
+						},
+						{
 							label: 'Data Modeling',
 							link: '/docs/operations/data-modeling/',
 						},

--- a/website/src/content/docs/docs/design/caching.mdx
+++ b/website/src/content/docs/docs/design/caching.mdx
@@ -13,7 +13,7 @@ The block cache sits in the SST reader. It stores decoded data blocks, index blo
 
 You can replace the cache with [`DbBuilder::with_db_cache`](https://docs.rs/slatedb/latest/slatedb/db/struct.DbBuilder.html#method.with_db_cache), or disable it with [`DbBuilder::with_db_cache_disabled`](https://docs.rs/slatedb/latest/slatedb/db/struct.DbBuilder.html#method.with_db_cache_disabled). If you want to plug in your own implementation, use the [`DbCache`](https://docs.rs/slatedb/latest/slatedb/db_cache/trait.DbCache.html) trait.
 
-[`FoyerHybridCache`](https://docs.rs/slatedb/latest/slatedb/db_cache/foyer_hybrid/struct.FoyerHybridCache.html) also belongs in this layer. It is a `DbCache` implementation, so it caches decoded SST entries, not raw object-store bytes. Its memory tier works like any other database cache. Its disk tier can still avoid remote I/O and decode work, but it adds a local disk read on a miss in memory.
+[`FoyerHybridCache`](https://docs.rs/slatedb/latest/slatedb/db_cache/foyer_hybrid/struct.FoyerHybridCache.html) also belongs in this layer. It is a `DbCache` implementation, so it caches decoded SST entries, not raw object-store bytes. Its memory tier works like any other database cache. Its disk tier can still avoid remote I/O and decode work, but it adds a local disk read on a miss in memory. See [Configuring Foyer Cache](/docs/operations/foyer-cache) for tuning guidance.
 
 ## Object-Store Cache
 

--- a/website/src/content/docs/docs/operations/foyer-cache.mdx
+++ b/website/src/content/docs/docs/operations/foyer-cache.mdx
@@ -23,7 +23,7 @@ The admission picker decides *whether* the flusher accepts a submitted entry. `A
 
 These two checks run in series. Under the defaults, entries only reach the flusher when
 memory pressure forces an eviction. If the memory tier is large enough to hold the working
-set, nothing is ever evicted, and nothing reaches disk.
+set, nothing is ever evicted, and nothing reaches disk until the db is closed.
 
 ### Flusher pipeline tuning
 
@@ -38,7 +38,8 @@ If this happens, you will notice the `storage_queue_channel_overflow` /
 foyer's internal metrics and accessible via `with_metrics_registry()` when you
 construct your cache.
 
-If you need the disk tier to hold data across restarts, increase the flusher capacity:
+Ensure that your flusher and buffer pools are configured to large enough to avoid the
+backpressure mechanism (see section on Monitoring below for sizing guidance):
 
 ```rust
 use foyer::{

--- a/website/src/content/docs/docs/operations/foyer-cache.mdx
+++ b/website/src/content/docs/docs/operations/foyer-cache.mdx
@@ -1,0 +1,119 @@
+---
+title: Configuring Foyer Cache
+description: Configuration and tuning guide for SlateDB's FoyerHybridCache block cache
+---
+
+[`FoyerHybridCache`][foyer-hybrid] wraps Foyer's `HybridCache` to give SlateDB a two-tier
+block cache: a fast in-memory tier backed by a persistent disk tier. For background on how
+it fits into SlateDB's cache layers, see the [Caching](/docs/design/caching) design doc.
+
+## Disk write pipeline
+
+Two mechanisms control whether an in-memory entry reaches disk. Both need configuration for
+the disk tier to be useful.
+
+### Write policy and admission
+
+The write policy (`HybridCachePolicy`) decides *when* Foyer submits an entry to the disk
+flusher. `WriteOnEviction` (default) submits entries only when they are evicted from the
+memory tier. `WriteOnInsertion` submits them on insert.
+
+The admission picker decides *whether* the flusher accepts a submitted entry. `AdmitAll`
+(default) accepts everything.
+
+These two checks run in series. Under the defaults, entries only reach the flusher when
+memory pressure forces an eviction. If the memory tier is large enough to hold the working
+set, nothing is ever evicted, and nothing reaches disk.
+
+### Flusher pipeline tuning
+
+Even after an entry is submitted, Foyer's default `LargeEngineOptions` can silently drop
+it. The defaults allocate a single flusher thread and a 16 MiB buffer pool. When inserts
+outpace the flusher entries are dropped in two ways: the submit queue discards
+entries once it exceeds `submit_queue_size_threshold`, and the IO buffer drops
+entries that don't fit in the buffer pool.
+
+If this happens, you will notice the `storage_queue_channel_overflow` /
+`storage_queue_buffer_overflow` counters increment, which are available in
+foyer's internal metrics and accessible via `with_metrics_registry()` when you
+construct your cache.
+
+If you need the disk tier to hold data across restarts, increase the flusher capacity:
+
+```rust
+use foyer::{
+    DirectFsDeviceOptions, Engine, HybridCacheBuilder,
+    LargeEngineOptions,
+};
+use slatedb::db_cache::CachedEntry;
+use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
+
+let cache = HybridCacheBuilder::new()
+    .with_name("slatedb_block_cache")
+    .memory(8 * 1024 * 1024 * 1024)  // 8 GB memory tier
+    .with_weighter(|_, v: &CachedEntry| v.size())
+    .storage(Engine::Large(
+        LargeEngineOptions::default()
+            .with_flushers(4)
+            .with_buffer_pool_size(256 * 1024 * 1024)  // large buffer pool
+            .with_submit_queue_size_threshold(1024 * 1024 * 1024), // large queue size
+    ))
+    .with_device_options(
+        DirectFsDeviceOptions::new("/data/slatedb-cache")
+            .with_capacity(100 * 1024 * 1024 * 1024),  // 100 GB disk tier
+    )
+    .build()
+    .await
+    .unwrap();
+
+let cache = FoyerHybridCache::new_with_cache(cache);
+```
+
+### Write policy choice
+
+`WriteOnEviction` (default) only writes entries to disk under memory pressure or at
+`close()`. This is fine when the memory tier is smaller than the working set (so eviction
+happens naturally) or when you can guarantee a clean shutdown via `Db::close()` /
+`DbReader::close()`.
+
+`WriteOnInsertion` writes entries to disk on insert. At `close()` time, in-memory entries
+already have disk copies, so the shutdown flush only waits for the current queue to purge. 
+
+Set the policy via `HybridCacheBuilder::with_policy()`:
+
+```rust
+use foyer::HybridCachePolicy;
+
+let cache = HybridCacheBuilder::new()
+    // ...
+    .with_policy(HybridCachePolicy::WriteOnInsertion)
+    // ...
+    .build()
+    .await
+    .unwrap();
+```
+
+## Shutdown
+
+If the process exits without calling `close()` (`SIGKILL`, panic, or dropping the `Db`
+without closing), the in-memory tier is lost. Only entries that Foyer wrote to disk during
+normal operation survive.
+
+:::caution
+Always call `Db::close()` or `DbReader::close()` before shutdown. Dropping without
+closing races with tokio runtime teardown and will lose in-memory cached entries.
+:::
+
+## Monitoring
+
+Foyer exposes internal metrics through `with_metrics_registry()` on the builder. Two
+counters are especially important to know whether you are dropping entries without
+tiering to disk:
+
+| Counter | Meaning |
+|---------|---------|
+| `storage_queue_channel_overflow` | Entries dropped because the submit queue was full |
+| `storage_queue_buffer_overflow` | Entries dropped because the IO buffer was full |
+
+If either counter is climbing, increase `with_flushers()`, `with_buffer_pool_size()`, or
+`with_submit_queue_size_threshold()`.


### PR DESCRIPTION
## Summary

Fixes #1545

Some cache backends (e.g. Foyer HybridCache) benefit from an explicit close signal. Without it, the hybrid caches lose in-memory entries on shutdown because the async runtime is gone by the time Drop runs.

## Changes

- Add `close()` to `DbCache` with a default no-op
- Implement for `FoyerHybridCache`, `SplitCache`, `DbCacheWrapper`
- Add `TableStore::close_cache()` and call from `Db::close()` / `DbReader::close()`
- Add test verifying entries survive close + reopen for Foyer hybrid
- Doccccccccccccccs 🦖 

## Notes for Reviewers

Pretty simple :) This is not a breaking change because of the default impl.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
