### PR TITLE
Rescaling: add union sources themselves as external_dbs

### DIFF
--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -135,9 +135,7 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                     ),
                     [..] => {
                         validate_no_wal(&sources)?;
-                        Manifest::cloned_from_union(
-                            sources.iter().map(|s| s.manifest.clone()).collect(),
-                        )
+                        Manifest::cloned_from_union(sources, rand)
                     }
                 };
 
@@ -200,7 +198,7 @@ fn to_byte_range<T: RangeBounds<Bytes> + Clone>(bounds: &T) -> BytesRange {
 }
 
 #[derive(Clone)]
-struct CloneSource {
+pub(crate) struct CloneSource {
     pub path: Path,
     pub manifest: Manifest,
     pub checkpoint: Checkpoint,

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::bytes_range::BytesRange;
 use crate::checkpoint::Checkpoint;
+use crate::clone::CloneSource;
 use crate::rand::DbRand;
 use crate::seq_tracker::SequenceTracker;
 use crate::utils::IdGenerator;
@@ -360,14 +361,14 @@ impl Manifest {
         filtered_handles
     }
 
-    pub(crate) fn cloned_from_union(manifests: Vec<Manifest>) -> Manifest {
+    pub(crate) fn cloned_from_union(sources: Vec<CloneSource>, rand: Arc<DbRand>) -> Manifest {
         let mut ranges = vec![];
-        for manifest in &manifests {
-            let range = manifest.range();
+        for source in &sources {
+            let range = source.manifest.range();
             if let Some(range) = range {
-                ranges.push((manifest, range));
+                ranges.push((source, range));
             } else {
-                warn!("manifest has no SST files [manifest={:?}]", manifest);
+                warn!("manifest has no SST files [manifest={:?}]", source.manifest);
             }
         }
         ranges.sort_by_key(|(_, range)| range.comparable_start_bound().cloned());
@@ -387,7 +388,9 @@ impl Manifest {
         let mut external_dbs = vec![];
         let mut core = ManifestCore::new();
 
-        for (manifest, _) in ranges {
+        for (source, _) in ranges {
+            let manifest = &source.manifest;
+
             // First, we need to add all the external dbs
             external_dbs.extend_from_slice(&manifest.external_dbs);
             // Then, we can add all the l0 ssts
@@ -398,6 +401,16 @@ impl Manifest {
             for sorted_run in &manifest.core.compacted {
                 core.compacted.push(sorted_run.clone());
             }
+
+            let owned_ssts = manifest.owned_ssts();
+            if !owned_ssts.is_empty() {
+                external_dbs.push(ExternalDb {
+                    path: source.path.clone().into(),
+                    source_checkpoint_id: source.checkpoint.id,
+                    final_checkpoint_id: Some(rand.rng().gen_uuid()),
+                    sst_ids: owned_ssts,
+                });
+            }
         }
 
         // Renumber sorted runs to ensure sequential IDs without duplicates
@@ -405,8 +418,8 @@ impl Manifest {
             sorted_run.id = idx as u32;
         }
 
-        for manifest in &manifests {
-            core.last_l0_seq = max(core.last_l0_seq, manifest.core.last_l0_seq);
+        for source in &sources {
+            core.last_l0_seq = max(core.last_l0_seq, source.manifest.core.last_l0_seq);
         }
         Self {
             external_dbs,
@@ -465,6 +478,25 @@ impl Manifest {
         external_ssts
     }
 
+    pub(crate) fn owned_ssts(&self) -> Vec<SsTableId> {
+        // SST IDs already tracked by the source's own external_dbs
+        let source_external_sst_ids: HashSet<SsTableId> = self
+            .external_dbs
+            .iter()
+            .flat_map(|db| db.sst_ids.iter().copied())
+            .collect();
+        // Owned SSTs = SSTs in core not already delegated to an external_db
+        let owned_sst_ids: Vec<SsTableId> = self
+            .core
+            .compacted
+            .iter()
+            .flat_map(|sr| sr.sst_views.iter().map(|s| s.sst.id))
+            .chain(self.core.l0.iter().map(|s| s.sst.id))
+            .filter(|id| !source_external_sst_ids.contains(id))
+            .collect();
+        owned_sst_ids
+    }
+
     pub(crate) fn has_wal_sst_reference(&self, wal_sst_id: u64) -> bool {
         wal_sst_id > self.core.replay_after_wal_id && wal_sst_id < self.core.next_wal_sst_id
     }
@@ -477,11 +509,13 @@ mod tests {
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
 
     use super::{ExternalDb, Manifest};
+    use crate::clone::CloneSource;
     use crate::config::CheckpointOptions;
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::ManifestCore;
     use crate::rand::DbRand;
+    use crate::Checkpoint;
     use bytes::Bytes;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -816,11 +850,13 @@ mod tests {
     })]
     fn test_union(#[case] test_case: UnionTestCase) {
         let mut sst_ids: HashMap<String, SsTableId> = HashMap::new();
-        let manifests: Vec<Manifest> = test_case
+        let rand = Arc::new(DbRand::default());
+        let sources: Vec<crate::clone::CloneSource> = test_case
             .manifests
             .iter()
-            .map(|m| {
-                build_manifest(m, |alias| {
+            .enumerate()
+            .map(|(i, m)| {
+                let manifest = build_manifest(m, |alias| {
                     if let Some(sst_id) = sst_ids.get(alias) {
                         *sst_id
                     } else {
@@ -828,14 +864,19 @@ mod tests {
                         sst_ids.insert(alias.to_string(), sst_id);
                         sst_id
                     }
-                })
+                });
+                CloneSource {
+                    manifest,
+                    path: Path::from(format!("/tmp/db{}", i)),
+                    checkpoint: new_checkpoint(Uuid::new_v4()),
+                }
             })
             .collect();
 
         let expected_manifest =
             build_manifest(&test_case.expected, |alias| *sst_ids.get(alias).unwrap());
 
-        let union = Manifest::cloned_from_union(manifests);
+        let union = Manifest::cloned_from_union(sources, rand);
 
         assert_manifest_equal(&union, &expected_manifest, &sst_ids);
     }
@@ -867,7 +908,22 @@ mod tests {
             |_| SsTableId::Compacted(Ulid::new()),
         );
 
-        let union = Manifest::cloned_from_union(vec![manifest1, manifest2]);
+        let rand = Arc::new(DbRand::default());
+        let union = Manifest::cloned_from_union(
+            vec![
+                CloneSource {
+                    manifest: manifest1,
+                    path: Path::from("/tmp/db1"),
+                    checkpoint: new_checkpoint(Uuid::new_v4()),
+                },
+                CloneSource {
+                    manifest: manifest2,
+                    path: Path::from("/tmp/db2"),
+                    checkpoint: new_checkpoint(Uuid::new_v4()),
+                },
+            ],
+            rand,
+        );
 
         // After union, we should have 5 SRs with IDs 0, 1, 2, 3, 4
         assert_eq!(union.core.compacted.len(), 5);
@@ -902,9 +958,127 @@ mod tests {
         );
         manifest2.core.last_l0_seq = 200;
 
-        let union = Manifest::cloned_from_union(vec![manifest1, manifest2]);
+        let union = Manifest::cloned_from_union(
+            vec![
+                CloneSource {
+                    manifest: manifest1,
+                    path: Path::from("/tmp/db1"),
+                    checkpoint: new_checkpoint(Uuid::new_v4()),
+                },
+                CloneSource {
+                    manifest: manifest2,
+                    path: Path::from("/tmp/db2"),
+                    checkpoint: new_checkpoint(Uuid::new_v4()),
+                },
+            ],
+            Arc::new(DbRand::default()),
+        );
 
         assert_eq!(union.core.last_l0_seq, 200);
+    }
+
+    #[test]
+    fn test_union_external_dbs() {
+        // manifest1 is clone-like: owns own_sst in core and inherits grandparent_sst
+        // via an existing external_db entry. manifest2 is a plain source.
+        // The union must: add each source as an ExternalDb (owned SSTs only),
+        // carry over inherited chains, and resolve all SSTs to the correct paths.
+        let rand = Arc::new(DbRand::default());
+
+        let parent1_sst1 = SsTableId::Compacted(Ulid::new());
+        let parent2_sst1 = SsTableId::Compacted(Ulid::new());
+        let grandparent_sst = SsTableId::Compacted(Ulid::new());
+
+        let mut manifest1 = build_manifest(
+            &SimpleManifest {
+                l0: vec![SstEntry::projected("own", "a", "a".."m")],
+                sorted_runs: vec![],
+            },
+            |_| parent1_sst1,
+        );
+        manifest1.external_dbs.push(ExternalDb {
+            path: "/tmp/grandparent".to_string(),
+            source_checkpoint_id: Uuid::new_v4(),
+            final_checkpoint_id: Some(Uuid::new_v4()),
+            sst_ids: vec![grandparent_sst],
+        });
+
+        let manifest2 = build_manifest(
+            &SimpleManifest {
+                l0: vec![SstEntry::projected("sst2", "m", "m"..)],
+                sorted_runs: vec![],
+            },
+            |_| parent2_sst1,
+        );
+
+        let cp1 = Uuid::new_v4();
+        let cp2 = Uuid::new_v4();
+        let union = Manifest::cloned_from_union(
+            vec![
+                CloneSource {
+                    manifest: manifest1,
+                    path: Path::from("/tmp/db1"),
+                    checkpoint: new_checkpoint(cp1),
+                },
+                CloneSource {
+                    manifest: manifest2,
+                    path: Path::from("/tmp/db2"),
+                    checkpoint: new_checkpoint(cp2),
+                },
+            ],
+            rand,
+        );
+
+        // db1 (owned SSTs only), grandparent (carried over), db2
+        assert_eq!(union.external_dbs.len(), 3);
+
+        let db1 = union
+            .external_dbs
+            .iter()
+            .find(|e| e.path == "tmp/db1")
+            .unwrap();
+        assert_eq!(db1.source_checkpoint_id, cp1);
+        assert!(db1.final_checkpoint_id.is_some());
+        assert_eq!(db1.sst_ids, vec![parent1_sst1]); // grandparent_sst must not leak in
+
+        let db2 = union
+            .external_dbs
+            .iter()
+            .find(|e| e.path == "tmp/db2")
+            .unwrap();
+        assert_eq!(db2.source_checkpoint_id, cp2);
+        assert!(db2.final_checkpoint_id.is_some());
+        assert_eq!(db2.sst_ids, vec![parent2_sst1]);
+
+        assert!(union
+            .external_dbs
+            .iter()
+            .any(|e| e.path == "/tmp/grandparent"));
+
+        // All three SSTs must resolve to their correct source paths
+        let external_ssts = union.external_ssts();
+        assert_eq!(
+            external_ssts.get(&parent1_sst1),
+            Some(&Path::from("/tmp/db1"))
+        );
+        assert_eq!(
+            external_ssts.get(&parent2_sst1),
+            Some(&Path::from("/tmp/db2"))
+        );
+        assert_eq!(
+            external_ssts.get(&grandparent_sst),
+            Some(&Path::from("/tmp/grandparent"))
+        );
+    }
+
+    fn new_checkpoint(id: Uuid) -> Checkpoint {
+        Checkpoint {
+            id,
+            manifest_id: 1,
+            create_time: DefaultSystemClock::new().now(),
+            expire_time: None,
+            name: None,
+        }
     }
 
     #[test]

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -361,63 +361,58 @@ impl Manifest {
     }
 
     pub(crate) fn cloned_from_union(manifests: Vec<Manifest>) -> Manifest {
-        if manifests.len() == 1 {
-            manifests[0].clone()
-        } else {
-            let mut ranges = vec![];
-            for manifest in &manifests {
-                let range = manifest.range();
-                if let Some(range) = range {
-                    ranges.push((manifest, range));
-                } else {
-                    warn!("manifest has no SST files [manifest={:?}]", manifest);
+        let mut ranges = vec![];
+        for manifest in &manifests {
+            let range = manifest.range();
+            if let Some(range) = range {
+                ranges.push((manifest, range));
+            } else {
+                warn!("manifest has no SST files [manifest={:?}]", manifest);
+            }
+        }
+        ranges.sort_by_key(|(_, range)| range.comparable_start_bound().cloned());
+
+        // Ensure manifests are non-overlapping
+        let mut previous_range = None;
+        for (_, range) in ranges.iter() {
+            if let Some(previous_range) = previous_range {
+                if range.intersect(previous_range).is_some() {
+                    unreachable!("overlapping ranges found");
                 }
             }
-            ranges.sort_by_key(|(_, range)| range.comparable_start_bound().cloned());
+            previous_range = Some(range);
+        }
 
-            // Ensure manifests are non-overlapping
-            let mut previous_range = None;
-            for (_, range) in ranges.iter() {
-                if let Some(previous_range) = previous_range {
-                    if range.intersect(previous_range).is_some() {
-                        unreachable!("overlapping ranges found");
-                    }
-                }
-                previous_range = Some(range);
+        // Now we can zip the manifests together
+        let mut external_dbs = vec![];
+        let mut core = ManifestCore::new();
+
+        for (manifest, _) in ranges {
+            // First, we need to add all the external dbs
+            external_dbs.extend_from_slice(&manifest.external_dbs);
+            // Then, we can add all the l0 ssts
+            for sst in &manifest.core.l0 {
+                core.l0.push_back(sst.clone());
             }
-
-            // Now we can zip the manifests together
-            let mut external_dbs = vec![];
-            let mut core = ManifestCore::new();
-
-            for (manifest, _) in ranges {
-                // First, we need to add all the external dbs
-                external_dbs.extend_from_slice(&manifest.external_dbs);
-                // Then, we can add all the l0 ssts
-                for sst in &manifest.core.l0 {
-                    core.l0.push_back(sst.clone());
-                }
-                // Finally, we can add all the sorted runs
-                for sorted_run in &manifest.core.compacted {
-                    core.compacted.push(sorted_run.clone());
-                }
+            // Finally, we can add all the sorted runs
+            for sorted_run in &manifest.core.compacted {
+                core.compacted.push(sorted_run.clone());
             }
+        }
 
-            // Renumber sorted runs to ensure sequential IDs without duplicates
-            for (idx, sorted_run) in core.compacted.iter_mut().enumerate() {
-                sorted_run.id = idx as u32;
-            }
+        // Renumber sorted runs to ensure sequential IDs without duplicates
+        for (idx, sorted_run) in core.compacted.iter_mut().enumerate() {
+            sorted_run.id = idx as u32;
+        }
 
-            for manifest in &manifests {
-                core.last_l0_seq = max(core.last_l0_seq, manifest.core.last_l0_seq);
-            }
-
-            Self {
-                external_dbs,
-                core,
-                writer_epoch: 0,
-                compactor_epoch: 0,
-            }
+        for manifest in &manifests {
+            core.last_l0_seq = max(core.last_l0_seq, manifest.core.last_l0_seq);
+        }
+        Self {
+            external_dbs,
+            core,
+            writer_epoch: 0,
+            compactor_epoch: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes `union` added in #618:

Without this change, path resolution doesn't work; and SSTs might be GCed by the clone as it assumes ownership.

## Changes

```
Rescaling: uniform handling of any number of sources

Union has to perform some operations regardless of
the number of sources, such as adding source as
external database or adding a final checkpoint
(subsequent commits)
```

```
Rescaling: add union sources themselves as external_dbs

Without this change, path resolution doesn't work; and
SSTs might be GCed by the clone as it assumes ownership.

```

## Notes for Reviewers

I extracted the 1st commit mostly to ease reviewing.
Union is not yet exposed to the users.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
