### PR TITLE
Add GCP to 'all' feature

### DIFF
--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -99,6 +99,7 @@ aws = ["object_store/aws"]
 azure = ["object_store/azure"]
 bencher = ["aws", "azure", "wal_disable", "foyer"]
 compression = ["snappy"]
+gcp = ["object_store/gcp"]
 opendal = ["dep:opendal", "dep:object_store_opendal"]
 snappy = ["dep:snap"]
 zlib = ["dep:flate2"]
@@ -116,6 +117,7 @@ all = [
     "aws",
     "azure",
     "compression",
+    "gcp",
     "opendal",
     "snappy",
     "zlib",


### PR DESCRIPTION
## Summary

Looks like we missed GCS/GCP support in the "all" feature. Bindings are unable to support GCS right now. This fixes that.

## Changes

- Add `object_store/gcp` and `gcp` to "all".