### PR TITLE
Upgrade UniFFI bindgen Node.js to 0.0.13

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -154,7 +154,7 @@ jobs:
       - name: Install uniffi-bindgen-node-js
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-node-js --version 0.0.12
+        run: cargo install uniffi-bindgen-node-js --version 0.0.13
 
       - name: Download Linux artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -256,7 +256,7 @@ jobs:
       - name: Install uniffi-bindgen-node-js
         env:
           RUSTFLAGS: ""
-        run: cargo install uniffi-bindgen-node-js --version 0.0.12
+        run: cargo install uniffi-bindgen-node-js --version 0.0.13
 
       - name: Build Node package (bindings/node)
         run: npm --prefix bindings/node run build

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -127,7 +127,7 @@ You only need these tools when regenerating bindings, running tests from this re
 Install the generator with:
 
 ```bash
-cargo install uniffi-bindgen-node-js --version 0.0.12
+cargo install uniffi-bindgen-node-js --version 0.0.13
 ```
 
 Install the package dependency used by the generated bindings with:


### PR DESCRIPTION
## Summary

The 0.0.12 UniFFI Node.js bindgen always tried to load the .so file even on mac/windows machines. 0.0.13 attempts to address this.