### PR TITLE
Use branch names for Python/Node releases

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -102,7 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Setup Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -140,7 +140,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
 
       - name: Set up Node 24.14.1
         uses: actions/setup-node@v4

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
@@ -158,7 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: "v${{ github.event.inputs.version }}"
+          ref: ${{ github.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x


### PR DESCRIPTION
## Summary

I'm updating the Node/Python release Github workflows to check out branch names (e.g. v0.12.x) instead of specific release tags (e.g. v0.12.1). This is not good practice. We should be releasing off of release tag checksums.

Unfortunately, the release process for the bindings is not yet fully stable. I find myself having to modify things on each release to navigate around AUTH token junk in Node, Linux musl/gnu stuff in Python, and so on. Until things stabilize, I'd like to cut releases from their branch. For bindings, this works because we always override the release version for the binding when publishing it (we ignore the version in the package.json/build.gradle/pyproject.toml). So it doesn't really matter from where we release; we always set the version according to the input value in the GH action trigger.

I totally understand if folks object; I can back off. It just would make my life easier in the short/medium term.