### PR TITLE
Rescaling: set last_l0_seq to max across manifests on union

### DIFF
--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -409,6 +409,10 @@ impl Manifest {
                 sorted_run.id = idx as u32;
             }
 
+            for manifest in &manifests {
+                core.last_l0_seq = max(core.last_l0_seq, manifest.core.last_l0_seq);
+            }
+
             Self {
                 external_dbs,
                 core,
@@ -880,6 +884,31 @@ mod tests {
         for id in &sr_ids {
             assert!(seen.insert(id), "Duplicate SR ID: {}", id);
         }
+    }
+
+    #[test]
+    fn test_union_propagates_last_l0_seq() {
+        let mut manifest1 = build_manifest(
+            &SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![vec![SstEntry::projected("sr1", "a", "a".."m")]],
+            },
+            |_| SsTableId::Compacted(Ulid::new()),
+        );
+        manifest1.core.last_l0_seq = 100;
+
+        let mut manifest2 = build_manifest(
+            &SimpleManifest {
+                l0: vec![],
+                sorted_runs: vec![vec![SstEntry::projected("sr2", "m", "m"..)]],
+            },
+            |_| SsTableId::Compacted(Ulid::new()),
+        );
+        manifest2.core.last_l0_seq = 200;
+
+        let union = Manifest::union(vec![manifest1, manifest2]);
+
+        assert_eq!(union.core.last_l0_seq, 200);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implement [part](https://github.com/slatedb/slatedb/blob/main/rfcs/0004-checkpoints.md#union) of checkpointing RFC (updated in ##1395):

> last_l0_seq is set to the maximum of last_l0_seq across all input manifests. This ensures that the new database's writer assigns sequence numbers higher than any existing data. Without this, new writes could receive sequence numbers that collide with those in the carried-over SSTs, breaking snapshot isolation and MVCC ordering. Note that existing SSTs from independent sources may have overlapping sequence numbers, but this is safe because the non-overlapping key range validation (step 2) guarantees that no two entries for the same key can have conflicting sequence numbers.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
