### PR TITLE
Rescaling: Allow to union source manifests

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1143,15 +1143,95 @@ mod tests {
         let admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
 
         // Test basic builder without checkpoint
-        admin
-            .create_clone_builder(parent_path.clone(), None)
-            .build()
-            .await
-            .expect("clone should succeed");
+        let r = admin.create_clone_builder(parent_path.clone(), None);
+        r.build().await.expect("clone should succeed");
 
         // Verify clone was created
         let clone_manifest_store = ManifestStore::new(&clone_path, object_store.clone());
         let manifest = clone_manifest_store.read_latest_manifest().await;
         assert!(manifest.is_ok(), "cloned manifest should exist");
+    }
+
+    #[cfg(feature = "wal_disable")]
+    #[tokio::test]
+    async fn test_create_clone_with_multiple_sources() {
+        use crate::config::{PutOptions, Settings, WriteOptions};
+        use crate::manifest::store::ManifestStore;
+        use crate::{admin::CloneSourceSpec, Db};
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let grandparent_path1 = Path::from("/tmp/test_grandparent1");
+        let grandparent_path2 = Path::from("/tmp/test_grandparent2");
+        let parent_path1 = Path::from("/tmp/test_parent1");
+        let parent_path2 = Path::from("/tmp/test_parent2");
+        let clone_path = Path::from("/tmp/test_clone_multi");
+
+        let settings = Settings {
+            wal_enabled: false,
+            ..Settings::default()
+        };
+        let write_opts = WriteOptions {
+            await_durable: false,
+        };
+
+        // Two grandparents, each with a single-key SST. Disjoint ranges are required
+        // because the union path rejects overlapping source manifests.
+        let grandparent_db1 = Db::builder(grandparent_path1.clone(), object_store.clone())
+            .with_settings(settings.clone())
+            .build()
+            .await
+            .unwrap();
+        grandparent_db1
+            .put_with_options(b"a", b"1", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        grandparent_db1.close().await.unwrap();
+
+        let grandparent_db2 = Db::builder(grandparent_path2.clone(), object_store.clone())
+            .with_settings(settings)
+            .build()
+            .await
+            .unwrap();
+        grandparent_db2
+            .put_with_options(b"z", b"2", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        grandparent_db2.close().await.unwrap();
+
+        // Make each source a clone, so its manifest carries an external_db entry that
+        // propagates through `cloned_from_union`.
+        AdminBuilder::new(parent_path1.clone(), object_store.clone())
+            .build()
+            .create_clone_builder(grandparent_path1.clone(), None)
+            .build()
+            .await
+            .expect("parent clone 1 should succeed");
+
+        AdminBuilder::new(parent_path2.clone(), object_store.clone())
+            .build()
+            .create_clone_builder(grandparent_path2.clone(), None)
+            .build()
+            .await
+            .expect("parent clone 2 should succeed");
+
+        let admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+
+        admin
+            .create_clone_builder(parent_path1.clone(), None)
+            .with_source(CloneSourceSpec::new(parent_path2.clone()))
+            .build()
+            .await
+            .expect("clone with multiple sources should succeed");
+
+        let clone_manifest_store = ManifestStore::new(&clone_path, object_store.clone());
+        let manifest = clone_manifest_store.read_latest_manifest().await;
+        assert!(manifest.is_ok(), "cloned manifest should exist");
+
+        let manifest_data = manifest.unwrap();
+        assert_eq!(
+            manifest_data.manifest.external_dbs.len(),
+            2,
+            "clone should have an external database for each parent"
+        );
     }
 }

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
-    clone_source: CloneSourceSpec<R>,
+    clone_sources: Vec<CloneSourceSpec<R>>,
     clone_path: P,
     object_stores: ObjectStores,
     fp_registry: Arc<FailPointRegistry>,
@@ -33,15 +33,12 @@ pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
     projection_range: Option<R>,
 ) -> Result<(), SlateDBError> {
     let clone_path = clone_path.into();
-    let parent_path = clone_source.path.clone();
 
-    if clone_path == parent_path {
-        return Err(SlateDBError::IdenticalClonePaths(parent_path));
-    }
+    validate_clone_source_specs(clone_sources.clone(), clone_path.clone())?;
 
     let mut clone_manifest = create_clone_manifest(
         clone_path.clone(),
-        clone_source.clone(),
+        clone_sources.clone(),
         object_stores.store_of(Main).clone(),
         system_clock.clone(),
         rand,
@@ -51,14 +48,21 @@ pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
     .await?;
 
     if !clone_manifest.db_state().initialized {
-        copy_wal_ssts(
-            object_stores.store_of(Wal).clone(),
-            clone_manifest.db_state(),
-            &parent_path,
-            &clone_path,
-            fp_registry,
-        )
-        .await?;
+        // Copy WAL SSTs from all sources - WAL is only supported for single source
+        // this invariant is enforced in create_clone_manifest()
+        if clone_sources.len() == 1 {
+            for source in &clone_sources {
+                let parent_path = source.path.clone();
+                copy_wal_ssts(
+                    object_stores.store_of(Wal).clone(),
+                    clone_manifest.db_state(),
+                    &parent_path,
+                    &clone_path,
+                    fp_registry.clone(),
+                )
+                .await?;
+            }
+        }
 
         let mut dirty = clone_manifest.prepare_dirty()?;
         dirty.value.core.initialized = true;
@@ -70,7 +74,7 @@ pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
 
 async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
     clone_path: Path,
-    source_spec: CloneSourceSpec<R>,
+    source_specs: Vec<CloneSourceSpec<R>>,
     object_store: Arc<dyn ObjectStore>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -78,70 +82,71 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
     projection_range: Option<R>,
 ) -> Result<StoredManifest, SlateDBError> {
     let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-    let parent_manifest_store =
-        Arc::new(ManifestStore::new(&source_spec.path, object_store.clone()));
-
-    let parent_checkpoint_id = source_spec.checkpoint;
 
     let clone_manifest =
         match StoredManifest::try_load(clone_manifest_store.clone(), system_clock.clone()).await? {
             Some(initialized_clone_manifest)
                 if initialized_clone_manifest.db_state().initialized =>
             {
-                validate_attached_to_external_db(
-                    source_spec.path.to_string(),
-                    parent_checkpoint_id,
-                    &initialized_clone_manifest,
-                )?;
-                validate_external_dbs_contain_final_checkpoint(
-                    parent_manifest_store,
-                    source_spec.path.to_string(),
-                    &initialized_clone_manifest,
-                    object_store.clone(),
-                )
-                .await?;
+                for source_spec in &source_specs {
+                    validate_attached_to_external_db(
+                        source_spec.path.to_string(),
+                        source_spec.checkpoint,
+                        &initialized_clone_manifest,
+                    )?;
+                }
+
+                for source_spec in &source_specs {
+                    let parent_manifest_store =
+                        Arc::new(ManifestStore::new(&source_spec.path, object_store.clone()));
+                    validate_external_dbs_contain_final_checkpoint(
+                        parent_manifest_store,
+                        source_spec.path.to_string(),
+                        &initialized_clone_manifest,
+                        object_store.clone(),
+                    )
+                    .await?;
+                }
                 return Ok(initialized_clone_manifest);
             }
             Some(uninitialized_clone_manifest) => {
-                validate_attached_to_external_db(
-                    source_spec.path.to_string(),
-                    parent_checkpoint_id,
-                    &uninitialized_clone_manifest,
-                )?;
+                for source_spec in &source_specs {
+                    validate_attached_to_external_db(
+                        source_spec.path.to_string(),
+                        source_spec.checkpoint,
+                        &uninitialized_clone_manifest,
+                    )?;
+                }
                 uninitialized_clone_manifest
             }
             None => {
-                let mut parent_manifest =
-                    load_initialized_manifest(parent_manifest_store.clone(), system_clock.clone())
-                        .await?;
-                let parent_checkpoint = get_or_create_parent_checkpoint(
-                    &mut parent_manifest,
-                    parent_checkpoint_id,
-                    rand.clone(),
+                let sources = build_sources(
+                    &source_specs,
+                    &object_store,
+                    &system_clock,
+                    &rand,
+                    &projection_range,
                 )
                 .await?;
-                let mut parent_manifest_at_checkpoint = parent_manifest_store
-                    .read_manifest(parent_checkpoint.manifest_id)
-                    .await?;
 
-                let r = match (source_spec.projection_range.clone(), projection_range) {
-                    (Some(l), Some(r)) => to_byte_range(&l).intersect(&to_byte_range(&r)),
-                    (Some(l), None) => Some(to_byte_range(&l)),
-                    (None, Some(r)) => Some(to_byte_range(&r)),
-                    (None, None) => None,
+                let manifest: Manifest = match &sources[..] {
+                    [single_source] => Manifest::cloned(
+                        &single_source.manifest,
+                        single_source.path.to_string(),
+                        single_source.checkpoint.id,
+                        rand,
+                    ),
+                    [..] => {
+                        validate_no_wal(&sources)?;
+                        Manifest::cloned_from_union(
+                            sources.iter().map(|s| s.manifest.clone()).collect(),
+                        )
+                    }
                 };
 
-                parent_manifest_at_checkpoint = match r {
-                    Some(range) => Manifest::projected(&parent_manifest_at_checkpoint, range),
-                    None => parent_manifest_at_checkpoint,
-                };
-
-                StoredManifest::create_uninitialized_clone(
+                StoredManifest::store_uninitialized_clone(
                     clone_manifest_store,
-                    &parent_manifest_at_checkpoint,
-                    source_spec.path.to_string(),
-                    parent_checkpoint.id,
-                    rand,
+                    manifest,
                     system_clock.clone(),
                 )
                 .await?
@@ -158,14 +163,17 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
             // If the final checkpoint id is not set, we can skip this check
             continue;
         };
-        let external_db_manifest_store = if external_db.path == source_spec.path.to_string() {
-            parent_manifest_store.clone()
-        } else {
-            Arc::new(ManifestStore::new(
-                &external_db.path.clone().into(),
-                object_store.clone(),
-            ))
-        };
+        let external_db_manifest_store = source_specs
+            .iter()
+            .find(|p| p.path.to_string() == external_db.path)
+            .map(|p| Arc::new(ManifestStore::new(&p.path, object_store.clone())))
+            .unwrap_or_else(|| {
+                Arc::new(ManifestStore::new(
+                    &external_db.path.clone().into(),
+                    object_store.clone(),
+                ))
+            });
+
         let mut external_db_manifest =
             load_initialized_manifest(external_db_manifest_store, system_clock.clone()).await?;
 
@@ -192,6 +200,52 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
 
 fn to_byte_range<T: RangeBounds<Bytes> + Clone>(bounds: &T) -> BytesRange {
     BytesRange::from(bounds.clone())
+}
+
+#[derive(Clone)]
+struct CloneSource {
+    pub path: Path,
+    pub manifest: Manifest,
+    pub checkpoint: Checkpoint,
+}
+
+async fn build_sources<R: RangeBounds<Bytes> + Clone>(
+    source_specs: &Vec<CloneSourceSpec<R>>,
+    object_store: &Arc<dyn ObjectStore>,
+    system_clock: &Arc<dyn SystemClock>,
+    rand: &Arc<DbRand>,
+    projection_range: &Option<R>,
+) -> Result<Vec<CloneSource>, SlateDBError> {
+    let mut result: Vec<CloneSource> = vec![];
+    for source in source_specs {
+        let manifest_store = Arc::new(ManifestStore::new(&source.path, object_store.clone()));
+        let mut latest_manifest =
+            load_initialized_manifest(manifest_store.clone(), system_clock.clone()).await?;
+        let checkpoint =
+            get_or_create_parent_checkpoint(&mut latest_manifest, source.checkpoint, rand.clone())
+                .await?;
+        let mut manifest_at_checkpoint =
+            manifest_store.read_manifest(checkpoint.manifest_id).await?;
+
+        let range: Option<BytesRange> = match (source.projection_range.clone(), projection_range) {
+            (Some(l), Some(r)) => to_byte_range(&l).intersect(&to_byte_range(r)),
+            (Some(l), None) => Some(to_byte_range(&l)),
+            (None, Some(r)) => Some(to_byte_range(r)),
+            (None, None) => None,
+        };
+
+        manifest_at_checkpoint = match range {
+            Some(range) => Manifest::projected(&manifest_at_checkpoint, range),
+            None => manifest_at_checkpoint,
+        };
+
+        result.push(CloneSource {
+            path: source.path.clone(),
+            manifest: manifest_at_checkpoint,
+            checkpoint,
+        });
+    }
+    Ok(result)
 }
 
 // Get a checkpoint and the corresponding manifest that will be used as the source
@@ -225,6 +279,43 @@ async fn get_or_create_parent_checkpoint(
         }
     };
     Ok(checkpoint)
+}
+
+fn validate_clone_source_specs<R: RangeBounds<Bytes> + Clone>(
+    specs: Vec<CloneSourceSpec<R>>,
+    clone_path: Path,
+) -> Result<(), SlateDBError> {
+    if specs.is_empty() {
+        return Err(SlateDBError::InvalidUnionSetEmpty());
+    }
+
+    let mut seen_paths = std::collections::HashSet::new();
+    for source in &specs {
+        if clone_path == source.path {
+            return Err(SlateDBError::IdenticalClonePaths(clone_path.clone()));
+        }
+        if !seen_paths.insert(source.path.to_string()) {
+            return Err(SlateDBError::DuplicatedCloneSourcePath(source.path.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_no_wal(sources: &[CloneSource]) -> Result<(), SlateDBError> {
+    let mut parents_with_wal = vec![];
+    for source in sources {
+        let m = source.manifest.clone();
+        let has_wal = m.core.next_wal_sst_id - 1 > m.core.replay_after_wal_id;
+        if has_wal {
+            parents_with_wal.push(source.path.clone());
+        }
+    }
+    if !parents_with_wal.is_empty() {
+        return Err(SlateDBError::InvalidUnionSourceWithWal {
+            paths: parents_with_wal,
+        });
+    }
+    Ok(())
 }
 
 // Validate that the manifest is attached to an external database at specific checkpoint.
@@ -382,7 +473,7 @@ mod tests {
             None => CloneSourceSpec::new(parent_path),
         };
         crate::clone::create_clone(
-            source,
+            vec![source],
             clone_path,
             ObjectStores::new(object_store, Some(wal_object_store)),
             fp_registry,
@@ -517,12 +608,14 @@ mod tests {
         // Create an uninitialized manifest with an invalid checkpoint id
         let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
         let non_existent_source_checkpoint_id = uuid::Uuid::new_v4();
-        StoredManifest::create_uninitialized_clone(
+        StoredManifest::store_uninitialized_clone(
             clone_manifest_store,
-            &Manifest::initial(ManifestCore::new()),
-            parent_path.to_string(),
-            non_existent_source_checkpoint_id,
-            rand.clone(),
+            Manifest::cloned(
+                &Manifest::initial(ManifestCore::new()),
+                parent_path.to_string(),
+                non_existent_source_checkpoint_id,
+                rand.clone(),
+            ),
             system_clock.clone(),
         )
         .await
@@ -578,12 +671,14 @@ mod tests {
 
         // Create an uninitialized manifest referring to the first checkpoint
         let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-        StoredManifest::create_uninitialized_clone(
+        StoredManifest::store_uninitialized_clone(
             clone_manifest_store,
-            &Manifest::initial(ManifestCore::new()),
-            parent_path.to_string(),
-            checkpoint_1.id,
-            rand.clone(),
+            Manifest::cloned(
+                &Manifest::initial(ManifestCore::new()),
+                parent_path.to_string(),
+                checkpoint_1.id,
+                rand.clone(),
+            ),
             system_clock.clone(),
         )
         .await
@@ -621,12 +716,14 @@ mod tests {
         // Setup an uninitialized manifest pointing to a different parent
         let parent_manifest = Manifest::initial(ManifestCore::new());
         let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-        StoredManifest::create_uninitialized_clone(
-            Arc::clone(&clone_manifest_store),
-            &parent_manifest,
-            original_parent_path.to_string(),
-            uuid::Uuid::new_v4(),
-            rand.clone(),
+        StoredManifest::store_uninitialized_clone(
+            clone_manifest_store,
+            Manifest::cloned(
+                &parent_manifest,
+                original_parent_path.to_string(),
+                uuid::Uuid::new_v4(),
+                rand.clone(),
+            ),
             system_clock.clone(),
         )
         .await

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -125,6 +125,8 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                 .await?;
 
                 let manifest: Manifest = match &sources[..] {
+                    // no need to call validate_no_wal() because for single source, WAL is copied
+                    // by the caller (create_clone)
                     [single_source] => Manifest::cloned(
                         &single_source.manifest,
                         single_source.path.to_string(),
@@ -204,6 +206,10 @@ struct CloneSource {
     pub checkpoint: Checkpoint,
 }
 
+/// Builds a list of clone sources from the provided specifications. For each source spec, a
+/// manifest at the specified checkpoint is loaded (if the checkpoint is not specified then it is
+/// created). Additionally, if projection_range is specified then it is applied to the returned
+/// manifests using `Manifest::projected`.
 async fn build_sources<R: RangeBounds<Bytes> + Clone>(
     source_specs: &Vec<CloneSourceSpec<R>>,
     object_store: &Arc<dyn ObjectStore>,

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -94,13 +94,8 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                         source_spec.checkpoint,
                         &initialized_clone_manifest,
                     )?;
-                }
-
-                for source_spec in &source_specs {
-                    let parent_manifest_store =
-                        Arc::new(ManifestStore::new(&source_spec.path, object_store.clone()));
                     validate_external_dbs_contain_final_checkpoint(
-                        parent_manifest_store,
+                        Arc::new(ManifestStore::new(&source_spec.path, object_store.clone())),
                         source_spec.path.to_string(),
                         &initialized_clone_manifest,
                         object_store.clone(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1439,7 +1439,7 @@ impl CloneSourceSpec<(Bound<Bytes>, Bound<Bytes>)> {
 /// A builder for configuring database clone operations.
 pub struct CloneBuilder<R: RangeBounds<Bytes> + Clone = (Bound<Bytes>, Bound<Bytes>)> {
     clone_path: Path,
-    source: CloneSourceSpec<R>,
+    sources: Vec<CloneSourceSpec<R>>,
     object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     system_clock: Option<Arc<dyn SystemClock>>,
@@ -1455,7 +1455,7 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     ) -> Self {
         CloneBuilder {
             clone_path,
-            source,
+            sources: vec![source],
             object_store,
             wal_object_store: None,
             system_clock: None,
@@ -1470,7 +1470,7 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     }
 
     pub fn with_source(mut self, source: CloneSourceSpec<R>) -> Self {
-        self.source = source;
+        self.sources.push(source);
         self
     }
 
@@ -1502,7 +1502,7 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     /// Build and execute the clone operation.
     pub async fn build(self) -> Result<(), Box<dyn std::error::Error>> {
         crate::clone::create_clone(
-            self.source,
+            self.sources,
             self.clone_path,
             ObjectStores::new(self.object_store, self.wal_object_store),
             Arc::new(FailPointRegistry::new()),

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1303,12 +1303,14 @@ mod tests {
         let parent_path = "/tmp/parent_store".to_string();
         let source_checkpoint_id = uuid::Uuid::new_v4();
 
-        let _ = StoredManifest::create_uninitialized_clone(
+        let _ = StoredManifest::store_uninitialized_clone(
             Arc::clone(&manifest_store),
-            &parent_manifest,
-            parent_path,
-            source_checkpoint_id,
-            Arc::new(DbRand::default()),
+            Manifest::cloned(
+                &parent_manifest,
+                parent_path,
+                source_checkpoint_id,
+                Arc::new(DbRand::default()),
+            ),
             Arc::new(DefaultSystemClock::new()),
         )
         .await

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -169,6 +169,15 @@ pub(crate) enum SlateDBError {
     )]
     IdenticalClonePaths(Path),
 
+    #[error("clone source paths must be unique, found duplicate: `{0}`")]
+    DuplicatedCloneSourcePath(Path),
+
+    #[error("Manifest union of sources with WAL is not supported, source with WAL: `{paths:?}`")]
+    InvalidUnionSourceWithWal { paths: Vec<Path> },
+
+    #[error("Source manifest set must not be empty")]
+    InvalidUnionSetEmpty(),
+
     #[error("invalid checkpoint lifetime. lifetime=`{0:?}`")]
     InvalidCheckpointLifetime(Duration),
 
@@ -570,6 +579,9 @@ impl From<SlateDBError> for Error {
             SlateDBError::TransactionalObjectError(err) => {
                 Error::internal(msg).with_source(Box::new(err))
             }
+            SlateDBError::DuplicatedCloneSourcePath(_) => Error::internal(msg),
+            SlateDBError::InvalidUnionSourceWithWal { .. } => Error::internal(msg),
+            SlateDBError::InvalidUnionSetEmpty() => Error::internal(msg),
         }
     }
 }

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -579,9 +579,9 @@ impl From<SlateDBError> for Error {
             SlateDBError::TransactionalObjectError(err) => {
                 Error::internal(msg).with_source(Box::new(err))
             }
-            SlateDBError::DuplicatedCloneSourcePath(_) => Error::internal(msg),
-            SlateDBError::InvalidUnionSourceWithWal { .. } => Error::internal(msg),
-            SlateDBError::InvalidUnionSetEmpty() => Error::internal(msg),
+            SlateDBError::DuplicatedCloneSourcePath(_) => Error::invalid(msg),
+            SlateDBError::InvalidUnionSourceWithWal { .. } => Error::invalid(msg),
+            SlateDBError::InvalidUnionSetEmpty() => Error::invalid(msg),
         }
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -360,8 +360,7 @@ impl Manifest {
         filtered_handles
     }
 
-    #[allow(unused)]
-    pub(crate) fn union(manifests: Vec<Manifest>) -> Manifest {
+    pub(crate) fn cloned_from_union(manifests: Vec<Manifest>) -> Manifest {
         if manifests.len() == 1 {
             manifests[0].clone()
         } else {
@@ -521,12 +520,14 @@ mod tests {
 
         let clone_path = Path::from("/tmp/test_clone");
         let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
-        let clone_stored_manifest = StoredManifest::create_uninitialized_clone(
-            Arc::clone(&clone_manifest_store),
-            parent_manifest.manifest(),
-            parent_path.to_string(),
-            checkpoint.id,
-            Arc::new(DbRand::default()),
+        let clone_stored_manifest = StoredManifest::store_uninitialized_clone(
+            clone_manifest_store,
+            Manifest::cloned(
+                parent_manifest.manifest(),
+                parent_path.to_string(),
+                checkpoint.id,
+                Arc::new(DbRand::default()),
+            ),
             Arc::new(DefaultSystemClock::new()),
         )
         .await
@@ -839,7 +840,7 @@ mod tests {
         let expected_manifest =
             build_manifest(&test_case.expected, |alias| *sst_ids.get(alias).unwrap());
 
-        let union = Manifest::union(manifests);
+        let union = Manifest::cloned_from_union(manifests);
 
         assert_manifest_equal(&union, &expected_manifest, &sst_ids);
     }
@@ -871,7 +872,7 @@ mod tests {
             |_| SsTableId::Compacted(Ulid::new()),
         );
 
-        let union = Manifest::union(vec![manifest1, manifest2]);
+        let union = Manifest::cloned_from_union(vec![manifest1, manifest2]);
 
         // After union, we should have 5 SRs with IDs 0, 1, 2, 3, 4
         assert_eq!(union.core.compacted.len(), 5);
@@ -906,7 +907,7 @@ mod tests {
         );
         manifest2.core.last_l0_seq = 200;
 
-        let union = Manifest::union(vec![manifest1, manifest2]);
+        let union = Manifest::cloned_from_union(vec![manifest1, manifest2]);
 
         assert_eq!(union.core.last_l0_seq, 200);
     }

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -6,7 +6,6 @@ use crate::error::SlateDBError::{
 };
 use crate::flatbuffer_types::FlatBufferManifestCodec;
 use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
-use crate::rand::DbRand;
 use chrono::Utc;
 use log::debug;
 use object_store::path::Path;
@@ -198,18 +197,12 @@ impl StoredManifest {
         Self::init(store, manifest, clock).await
     }
 
-    /// Create a new manifest for a new cloned database. The initial manifest
-    /// will be written with the `initialized` field set to false in order to allow
-    /// for the rest of the clone state to be initialized
-    pub(crate) async fn create_uninitialized_clone(
+    /// Store a new manifest (for a new cloned database).
+    pub(crate) async fn store_uninitialized_clone(
         clone_manifest_store: Arc<ManifestStore>,
-        parent_manifest: &Manifest,
-        parent_path: String,
-        source_checkpoint_id: Uuid,
-        rand: Arc<DbRand>,
+        manifest: Manifest,
         clock: Arc<dyn SystemClock>,
     ) -> Result<Self, SlateDBError> {
-        let manifest = Manifest::cloned(parent_manifest, parent_path, source_checkpoint_id, rand);
         Self::init(clone_manifest_store, manifest, clock).await
     }
 


### PR DESCRIPTION
## Summary

Expose `Manifest::union()` added in #618 to the end users (renamed to `cloned_from_union`).
The PR modifies the existing API added in #1409 by changes single source to multiple sources.
Thereby, most of the cloning logic is reused (such as validation, retries, creating final checkpoints, etc).

## Notes for Reviewers

Union contains a bug: parent DB is not added into `external_dbs`; it is fixed separately in #1551.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
