### PR TITLE
Add LeveledCompactionSpec to FlatBuffers schema

### DIFF
--- a/schemas/compactor.fbs
+++ b/schemas/compactor.fbs
@@ -3,6 +3,13 @@ include "sst.fbs";
 
 union CompactionSpec {
     TieredCompactionSpec,
+    LeveledCompactionSpec,
+}
+
+// A selection of specific SST views from a sorted run for file-level compaction.
+table SortedRunSstSelection {
+    sr_id: uint32;
+    view_ids: [Ulid];
 }
 
 enum CompactionStatus : byte {
@@ -25,6 +32,26 @@ table TieredCompactionSpec {
 
     // input L0 SSTable View IDs
     l0_view_ids: [Ulid];
+}
+
+// Compaction spec with explicit destination and optional file-level SST
+// selections. Used when destination cannot be derived from sorted run inputs
+// (e.g. leveled compaction) or when individual SSTs are selected from sorted
+// runs instead of consuming entire runs.
+table LeveledCompactionSpec {
+    // input L0 SSTable View IDs
+    l0_view_ids: [Ulid];
+
+    // input Sorted Run IDs (whole SRs)
+    sorted_runs: [uint32];
+
+    // explicit destination sorted run ID
+    destination: uint32;
+
+    // optional: specific SST views to select from each sorted run.
+    // If present for a given SR, only the listed views are included
+    // (the SR is partially consumed, not destroyed).
+    sr_sst_selections: [SortedRunSstSelection];
 }
 
 table Compaction {

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -37,10 +37,10 @@ use crate::flatbuffer_types::root_generated::{
     CompactedSsTableArgs, CompactedSsTableV2, CompactedSsTableV2Args, CompactedSsTableView,
     CompactedSsTableViewArgs, Compaction as FbCompaction, CompactionArgs as FbCompactionArgs,
     CompactionSpec as FbCompactionSpec, CompactionStatus as FbCompactionStatus, CompactionsV1,
-    CompactionsV1Args, CompressionFormat, ManifestV1Args, SortedRun as FbSortedRunV1,
-    SortedRunArgs as FbSortedRunV1Args, SortedRunV2, SortedRunV2Args, SstType as FbSstType,
-    TieredCompactionSpec, TieredCompactionSpecArgs, Ulid as FbUlid, UlidArgs as FbUlidArgs, Uuid,
-    UuidArgs,
+    CompactionsV1Args, CompressionFormat, LeveledCompactionSpec, LeveledCompactionSpecArgs,
+    ManifestV1Args, SortedRun as FbSortedRunV1, SortedRunArgs as FbSortedRunV1Args, SortedRunV2,
+    SortedRunV2Args, SstType as FbSstType, TieredCompactionSpec, TieredCompactionSpecArgs,
+    Ulid as FbUlid, UlidArgs as FbUlidArgs, Uuid, UuidArgs,
 };
 use crate::format::sst::SST_FORMAT_VERSION;
 use crate::manifest::{ExternalDb, Manifest, ManifestCore};
@@ -543,6 +543,37 @@ impl FlatBufferCompactionsCodec {
                 let destination = sorted_runs.iter().copied().min().unwrap_or(0);
                 Ok(CompactorCompactionSpec::new(sources, destination))
             }
+            FbCompactionSpec::LeveledCompactionSpec => {
+                let Some(spec) = compaction.spec_as_leveled_compaction_spec() else {
+                    return Err(SlateDBError::InvalidCompaction);
+                };
+                let mut sources = Vec::new();
+                if let Some(view_ids) = spec.l0_view_ids() {
+                    sources.extend(view_ids.iter().map(|id| SourceId::SstView(id.ulid())));
+                }
+
+                // Collect per-SR SST selections for file-level compaction.
+                // Maps SR ID -> set of selected view ULIDs.
+                let mut sst_selections: std::collections::HashMap<u32, Vec<Ulid>> =
+                    std::collections::HashMap::new();
+                if let Some(selections) = spec.sr_sst_selections() {
+                    for sel in selections.iter() {
+                        if let Some(view_ids) = sel.view_ids() {
+                            let views: Vec<Ulid> = view_ids.iter().map(|id| id.ulid()).collect();
+                            sst_selections.insert(sel.sr_id(), views);
+                        }
+                    }
+                }
+
+                let sorted_runs: Vec<u32> = spec
+                    .sorted_runs()
+                    .map(|runs| runs.iter().collect())
+                    .unwrap_or_default();
+                sources.extend(sorted_runs.iter().copied().map(SourceId::SortedRun));
+
+                let destination = spec.destination();
+                Ok(CompactorCompactionSpec::new(sources, destination))
+            }
             _ => Err(SlateDBError::InvalidCompaction),
         }
     }
@@ -827,21 +858,47 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 SourceId::SortedRun(id) => sorted_runs.push(*id),
             }
         }
-        let l0_view_ids = (!view_ids.is_empty()).then(|| self.add_ulids(view_ids.iter()));
-        let sorted_runs =
-            (!sorted_runs.is_empty()).then(|| self.builder.create_vector(sorted_runs.as_slice()));
-        let tiered_spec = TieredCompactionSpec::create(
-            &mut self.builder,
-            &TieredCompactionSpecArgs {
-                ssts: None,
-                sorted_runs,
-                l0_view_ids,
-            },
-        );
-        (
-            FbCompactionSpec::TieredCompactionSpec,
-            tiered_spec.as_union_value(),
-        )
+
+        // Use LeveledCompactionSpec when the destination cannot be derived
+        // from min(sorted_runs). This happens with leveled compaction where
+        // the destination level may not be among the sources (e.g. compacting
+        // L1 into a not-yet-existing L2). TieredCompactionSpec is used
+        // otherwise for backward compatibility.
+        let derived_dest = sorted_runs.iter().copied().min().unwrap_or(0);
+        if spec.destination() != derived_dest {
+            let l0_view_ids = (!view_ids.is_empty()).then(|| self.add_ulids(view_ids.iter()));
+            let sr_vec = (!sorted_runs.is_empty())
+                .then(|| self.builder.create_vector(sorted_runs.as_slice()));
+            let leveled_spec = LeveledCompactionSpec::create(
+                &mut self.builder,
+                &LeveledCompactionSpecArgs {
+                    l0_view_ids,
+                    sorted_runs: sr_vec,
+                    destination: spec.destination(),
+                    sr_sst_selections: None,
+                },
+            );
+            (
+                FbCompactionSpec::LeveledCompactionSpec,
+                leveled_spec.as_union_value(),
+            )
+        } else {
+            let l0_view_ids = (!view_ids.is_empty()).then(|| self.add_ulids(view_ids.iter()));
+            let sorted_runs = (!sorted_runs.is_empty())
+                .then(|| self.builder.create_vector(sorted_runs.as_slice()));
+            let tiered_spec = TieredCompactionSpec::create(
+                &mut self.builder,
+                &TieredCompactionSpecArgs {
+                    ssts: None,
+                    sorted_runs,
+                    l0_view_ids,
+                },
+            );
+            (
+                FbCompactionSpec::TieredCompactionSpec,
+                tiered_spec.as_union_value(),
+            )
+        }
     }
 
     fn add_compaction(&mut self, compaction: &CompactorCompaction) -> WIPOffset<FbCompaction<'b>> {
@@ -1562,6 +1619,67 @@ mod tests {
                 .expect("missing sr compaction"),
             &compaction_sr
         );
+    }
+
+    #[test]
+    fn test_should_encode_decode_leveled_compaction_spec() {
+        // Tests LeveledCompactionSpec round-trip:
+        // 1. Explicit destination that differs from min(sorted_runs)
+        // 2. Backward compat: specs where dest == min(sorted_runs) still use TieredCompactionSpec
+
+        // Case 1: destination (4) != min(sorted_runs) (5) — uses LeveledCompactionSpec
+        let compaction_leveled = Compaction::new(
+            ulid::Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SortedRun(5)], 4),
+        )
+        .with_status(CompactionStatus::Submitted);
+
+        // Case 2: destination == min(sorted_runs) — uses TieredCompactionSpec (backward compat)
+        let compaction_tiered = Compaction::new(
+            ulid::Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SortedRun(5), SourceId::SortedRun(3)], 3),
+        )
+        .with_status(CompactionStatus::Running);
+
+        // Case 3: L0-only with destination 5, no sorted runs — min defaults to 0,
+        // so destination (5) != 0 — uses LeveledCompactionSpec
+        let compaction_l0_leveled = Compaction::new(
+            ulid::Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SstView(ulid::Ulid::new())], 5),
+        )
+        .with_status(CompactionStatus::Completed);
+
+        let mut compactions = Compactions::new(42);
+        compactions.insert(compaction_leveled.clone());
+        compactions.insert(compaction_tiered.clone());
+        compactions.insert(compaction_l0_leveled.clone());
+
+        let codec = FlatBufferCompactionsCodec {};
+        let bytes = codec.encode(&compactions);
+        let decoded = codec.decode(&bytes).expect("failed to decode");
+
+        // Verify all three round-trip correctly
+        let decoded_leveled = decoded
+            .get(&compaction_leveled.id())
+            .expect("missing leveled compaction");
+        assert_eq!(decoded_leveled.spec(), compaction_leveled.spec());
+        assert_eq!(decoded_leveled.spec().destination(), 4);
+        assert_eq!(
+            decoded_leveled.spec().sources(),
+            &vec![SourceId::SortedRun(5)]
+        );
+
+        let decoded_tiered = decoded
+            .get(&compaction_tiered.id())
+            .expect("missing tiered compaction");
+        assert_eq!(decoded_tiered.spec(), compaction_tiered.spec());
+        assert_eq!(decoded_tiered.spec().destination(), 3);
+
+        let decoded_l0 = decoded
+            .get(&compaction_l0_leveled.id())
+            .expect("missing l0 leveled compaction");
+        assert_eq!(decoded_l0.spec(), compaction_l0_leveled.spec());
+        assert_eq!(decoded_l0.spec().destination(), 5);
     }
 
     #[test]

--- a/slatedb/src/generated/root_generated.rs
+++ b/slatedb/src/generated/root_generated.rs
@@ -372,12 +372,13 @@ impl flatbuffers::SimpleToVerifyInSlice for FilterFormat {}
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 pub const ENUM_MIN_COMPACTION_SPEC: u8 = 0;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
-pub const ENUM_MAX_COMPACTION_SPEC: u8 = 1;
+pub const ENUM_MAX_COMPACTION_SPEC: u8 = 2;
 #[deprecated(since = "2.0.0", note = "Use associated constants instead. This will no longer be generated in 2021.")]
 #[allow(non_camel_case_types)]
-pub const ENUM_VALUES_COMPACTION_SPEC: [CompactionSpec; 2] = [
+pub const ENUM_VALUES_COMPACTION_SPEC: [CompactionSpec; 3] = [
   CompactionSpec::NONE,
   CompactionSpec::TieredCompactionSpec,
+  CompactionSpec::LeveledCompactionSpec,
 ];
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -387,18 +388,21 @@ pub struct CompactionSpec(pub u8);
 impl CompactionSpec {
   pub const NONE: Self = Self(0);
   pub const TieredCompactionSpec: Self = Self(1);
+  pub const LeveledCompactionSpec: Self = Self(2);
 
   pub const ENUM_MIN: u8 = 0;
-  pub const ENUM_MAX: u8 = 1;
+  pub const ENUM_MAX: u8 = 2;
   pub const ENUM_VALUES: &'static [Self] = &[
     Self::NONE,
     Self::TieredCompactionSpec,
+    Self::LeveledCompactionSpec,
   ];
   /// Returns the variant's name or "" if unknown.
   pub fn variant_name(self) -> Option<&'static str> {
     match self {
       Self::NONE => Some("NONE"),
       Self::TieredCompactionSpec => Some("TieredCompactionSpec"),
+      Self::LeveledCompactionSpec => Some("LeveledCompactionSpec"),
       _ => None,
     }
   }
@@ -2537,6 +2541,120 @@ impl core::fmt::Debug for SortedRunV2<'_> {
       ds.finish()
   }
 }
+pub enum SortedRunSstSelectionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct SortedRunSstSelection<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for SortedRunSstSelection<'a> {
+  type Inner = SortedRunSstSelection<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> SortedRunSstSelection<'a> {
+  pub const VT_SR_ID: flatbuffers::VOffsetT = 4;
+  pub const VT_VIEW_IDS: flatbuffers::VOffsetT = 6;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    SortedRunSstSelection { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args SortedRunSstSelectionArgs<'args>
+  ) -> flatbuffers::WIPOffset<SortedRunSstSelection<'bldr>> {
+    let mut builder = SortedRunSstSelectionBuilder::new(_fbb);
+    if let Some(x) = args.view_ids { builder.add_view_ids(x); }
+    builder.add_sr_id(args.sr_id);
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn sr_id(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(SortedRunSstSelection::VT_SR_ID, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn view_ids(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid>>>>(SortedRunSstSelection::VT_VIEW_IDS, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for SortedRunSstSelection<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<u32>("sr_id", Self::VT_SR_ID, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("view_ids", Self::VT_VIEW_IDS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct SortedRunSstSelectionArgs<'a> {
+    pub sr_id: u32,
+    pub view_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
+}
+impl<'a> Default for SortedRunSstSelectionArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    SortedRunSstSelectionArgs {
+      sr_id: 0,
+      view_ids: None,
+    }
+  }
+}
+
+pub struct SortedRunSstSelectionBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SortedRunSstSelectionBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_sr_id(&mut self, sr_id: u32) {
+    self.fbb_.push_slot::<u32>(SortedRunSstSelection::VT_SR_ID, sr_id, 0);
+  }
+  #[inline]
+  pub fn add_view_ids(&mut self, view_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Ulid<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(SortedRunSstSelection::VT_VIEW_IDS, view_ids);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SortedRunSstSelectionBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    SortedRunSstSelectionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<SortedRunSstSelection<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for SortedRunSstSelection<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("SortedRunSstSelection");
+      ds.field("sr_id", &self.sr_id());
+      ds.field("view_ids", &self.view_ids());
+      ds.finish()
+  }
+}
 pub enum TieredCompactionSpecOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -2668,6 +2786,154 @@ impl core::fmt::Debug for TieredCompactionSpec<'_> {
       ds.finish()
   }
 }
+pub enum LeveledCompactionSpecOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct LeveledCompactionSpec<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for LeveledCompactionSpec<'a> {
+  type Inner = LeveledCompactionSpec<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> LeveledCompactionSpec<'a> {
+  pub const VT_L0_VIEW_IDS: flatbuffers::VOffsetT = 4;
+  pub const VT_SORTED_RUNS: flatbuffers::VOffsetT = 6;
+  pub const VT_DESTINATION: flatbuffers::VOffsetT = 8;
+  pub const VT_SR_SST_SELECTIONS: flatbuffers::VOffsetT = 10;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    LeveledCompactionSpec { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args LeveledCompactionSpecArgs<'args>
+  ) -> flatbuffers::WIPOffset<LeveledCompactionSpec<'bldr>> {
+    let mut builder = LeveledCompactionSpecBuilder::new(_fbb);
+    if let Some(x) = args.sr_sst_selections { builder.add_sr_sst_selections(x); }
+    builder.add_destination(args.destination);
+    if let Some(x) = args.sorted_runs { builder.add_sorted_runs(x); }
+    if let Some(x) = args.l0_view_ids { builder.add_l0_view_ids(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn l0_view_ids(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid>>>>(LeveledCompactionSpec::VT_L0_VIEW_IDS, None)}
+  }
+  #[inline]
+  pub fn sorted_runs(&self) -> Option<flatbuffers::Vector<'a, u32>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u32>>>(LeveledCompactionSpec::VT_SORTED_RUNS, None)}
+  }
+  #[inline]
+  pub fn destination(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(LeveledCompactionSpec::VT_DESTINATION, Some(0)).unwrap()}
+  }
+  #[inline]
+  pub fn sr_sst_selections(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunSstSelection<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunSstSelection>>>>(LeveledCompactionSpec::VT_SR_SST_SELECTIONS, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for LeveledCompactionSpec<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("l0_view_ids", Self::VT_L0_VIEW_IDS, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("sorted_runs", Self::VT_SORTED_RUNS, false)?
+     .visit_field::<u32>("destination", Self::VT_DESTINATION, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SortedRunSstSelection>>>>("sr_sst_selections", Self::VT_SR_SST_SELECTIONS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct LeveledCompactionSpecArgs<'a> {
+    pub l0_view_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
+    pub sorted_runs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
+    pub destination: u32,
+    pub sr_sst_selections: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunSstSelection<'a>>>>>,
+}
+impl<'a> Default for LeveledCompactionSpecArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    LeveledCompactionSpecArgs {
+      l0_view_ids: None,
+      sorted_runs: None,
+      destination: 0,
+      sr_sst_selections: None,
+    }
+  }
+}
+
+pub struct LeveledCompactionSpecBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> LeveledCompactionSpecBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_l0_view_ids(&mut self, l0_view_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Ulid<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(LeveledCompactionSpec::VT_L0_VIEW_IDS, l0_view_ids);
+  }
+  #[inline]
+  pub fn add_sorted_runs(&mut self, sorted_runs: flatbuffers::WIPOffset<flatbuffers::Vector<'b , u32>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(LeveledCompactionSpec::VT_SORTED_RUNS, sorted_runs);
+  }
+  #[inline]
+  pub fn add_destination(&mut self, destination: u32) {
+    self.fbb_.push_slot::<u32>(LeveledCompactionSpec::VT_DESTINATION, destination, 0);
+  }
+  #[inline]
+  pub fn add_sr_sst_selections(&mut self, sr_sst_selections: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<SortedRunSstSelection<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(LeveledCompactionSpec::VT_SR_SST_SELECTIONS, sr_sst_selections);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> LeveledCompactionSpecBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    LeveledCompactionSpecBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<LeveledCompactionSpec<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for LeveledCompactionSpec<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("LeveledCompactionSpec");
+      ds.field("l0_view_ids", &self.l0_view_ids());
+      ds.field("sorted_runs", &self.sorted_runs());
+      ds.field("destination", &self.destination());
+      ds.field("sr_sst_selections", &self.sr_sst_selections());
+      ds.finish()
+  }
+}
 pub enum CompactionOffset {}
 #[derive(Copy, Clone, PartialEq)]
 
@@ -2758,6 +3024,20 @@ impl<'a> Compaction<'a> {
     }
   }
 
+  #[inline]
+  #[allow(non_snake_case)]
+  pub fn spec_as_leveled_compaction_spec(&self) -> Option<LeveledCompactionSpec<'a>> {
+    if self.spec_type() == CompactionSpec::LeveledCompactionSpec {
+      let u = self.spec();
+      // Safety:
+      // Created from a valid Table for this object
+      // Which contains a valid union in this slot
+      Some(unsafe { LeveledCompactionSpec::init_from_table(u) })
+    } else {
+      None
+    }
+  }
+
 }
 
 impl flatbuffers::Verifiable for Compaction<'_> {
@@ -2771,6 +3051,7 @@ impl flatbuffers::Verifiable for Compaction<'_> {
      .visit_union::<CompactionSpec, _>("spec_type", Self::VT_SPEC_TYPE, "spec", Self::VT_SPEC, true, |key, v, pos| {
         match key {
           CompactionSpec::TieredCompactionSpec => v.verify_union_variant::<flatbuffers::ForwardsUOffset<TieredCompactionSpec>>("CompactionSpec::TieredCompactionSpec", pos),
+          CompactionSpec::LeveledCompactionSpec => v.verify_union_variant::<flatbuffers::ForwardsUOffset<LeveledCompactionSpec>>("CompactionSpec::LeveledCompactionSpec", pos),
           _ => Ok(()),
         }
      })?
@@ -2850,6 +3131,13 @@ impl core::fmt::Debug for Compaction<'_> {
       match self.spec_type() {
         CompactionSpec::TieredCompactionSpec => {
           if let Some(x) = self.spec_as_tiered_compaction_spec() {
+            ds.field("spec", &x)
+          } else {
+            ds.field("spec", &"InvalidFlatbuffer: Union discriminant does not match value.")
+          }
+        },
+        CompactionSpec::LeveledCompactionSpec => {
+          if let Some(x) = self.spec_as_leveled_compaction_spec() {
             ds.field("spec", &x)
           } else {
             ds.field("spec", &"InvalidFlatbuffer: Union discriminant does not match value.")


### PR DESCRIPTION
## Summary

First step in implementing leveled compaction. Unlike size tiered compaction, leveled compaction does not operate only on full sorted runs, it needs to work on individual sst files. This adds a new `LeveledCompactionSpec` variant to the `CompactionSpec` union for compaction specs that need an explicit destination or file-level SST selections.

The existing `TieredCompactionSpec` derives destination as `min(sorted_runs)` on deserialization, which works for size-tiered compaction but breaks for leveled compaction where the destination level may not be among the sources (e.g. compacting L1 into a not-yet-existing L2). I [read in the rocksdb wiki](https://github.com/facebook/rocksdb/wiki/Leveled-Compaction) that leveled compaction falls back to size tiered compaction in this case.


Serialization changes:
- Encoder uses `LeveledCompactionSpec` when destination differs from `min(sorted_runs)`, `TieredCompactionSpec` otherwise for backward compatibility
- Decoder handles both variants

## Changes

- `LeveledCompactionSpec` table with explicit `destination` field, plus `l0_view_ids`, `sorted_runs`, and optional `sr_sst_selections` for future file-level compaction
- `SortedRunSstSelection` table mapping an SR ID to specific SST view ULIDs (consumed by the decoder, encoding deferred to a follow-up PR that adds the `SortedRunSst` source type)

This looks like another forwards only change if people do start to use leveled compaction, the compactor state might break if they go backwards.

## Notes for Reviewers

I started a thread in discord about why this is useful for us.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
