### PR TITLE
Drop fsync from disk cache writes; add CRC + invalidate-and-retry

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -157,6 +157,22 @@ impl CachedObjectStore {
 
     /// Returns the canonical cache key for a requested location.
     ///
+    /// Delete any cached parts and head for `location`. Called from higher
+    /// layers (SST reader, manifest reader) when a checksum mismatch is
+    /// detected on content served via this store - the entry is dropped so
+    /// the next request bypasses the cache and refetches from the remote
+    /// object store. A no-op if the cache root has not been resolved yet or
+    /// the entry does not exist.
+    pub(crate) async fn invalidate(&self, location: &Path) -> object_store::Result<()> {
+        let Some(cache_location) = self.cache_location_for(location) else {
+            return Ok(());
+        };
+        let entry = self
+            .cache_storage
+            .entry(&cache_location, self.part_size_bytes);
+        entry.invalidate().await
+    }
+
     /// The key is `resolved_root + location` once root resolution succeeds.
     /// Returns `None` while the root is still unresolved. The root is resolved
     /// lazily from observed metadata locations, so this method may return `None`

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -95,6 +95,12 @@ pub trait LocalCacheEntry: Send + Sync + std::fmt::Debug + 'static {
     async fn save_head(&self, meta: (&ObjectMeta, &Attributes)) -> object_store::Result<()>;
 
     async fn read_head(&self) -> object_store::Result<Option<(ObjectMeta, Attributes)>>;
+
+    /// Remove the head file and all part files for this entry. Used when a
+    /// higher layer (e.g. the SST or manifest reader) observes a checksum
+    /// mismatch and wants to refetch from the remote object store. Missing
+    /// files are treated as already-invalidated.
+    async fn invalidate(&self) -> object_store::Result<()>;
 }
 
 pub type PartID = usize;

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -130,7 +130,13 @@ impl FsCacheEntry {
                 .open(tmp_path)
                 .map_err(wrap_io_err)?;
             file.write_all(&buf).map_err(wrap_io_err)?;
-            file.sync_all().map_err(wrap_io_err)?;
+            // No fsync: the disk cache is ephemeral (the remote object store
+            // is the source of truth) so durability is unnecessary. After an
+            // unclean shutdown a cached entry may come back truncated or
+            // with lost pages; every cached payload carries a CRC (SST block
+            // footers, or the manifest v3 envelope) which the fetching layer
+            // validates, and `ChecksumMismatch` self-heals by invalidating
+            // the cache entry and refetching from the remote store.
             std::fs::rename(tmp_path, path).map_err(wrap_io_err)
         })
         .await?
@@ -312,6 +318,23 @@ impl LocalCacheEntry for FsCacheEntry {
         let meta_path = Self::make_head_path(self.root_folder.clone(), &self.location);
 
         self.atomic_write(meta_path, buf).await
+    }
+
+    async fn invalidate(&self) -> object_store::Result<()> {
+        // Every cache file for a given location lives under
+        // `root_folder / <location>`: `_head` plus `_part{size}-{N}` files.
+        // Remove that whole directory. A missing directory means the entry
+        // was already evicted (or never existed) and is treated as success.
+        let mut dir = self.root_folder.clone();
+        dir.push(self.location.to_string());
+        #[allow(clippy::disallowed_methods)]
+        tokio::task::spawn_blocking(move || match std::fs::remove_dir_all(&dir) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(wrap_io_err(err)),
+        })
+        .await
+        .map_err(wrap_io_err)?
     }
 
     async fn read_head(&self) -> object_store::Result<Option<(ObjectMeta, Attributes)>> {

--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -1,9 +1,11 @@
+use crate::cached_object_store::CachedObjectStore;
 use crate::compactor_state::{Compactions, VersionedCompactions};
 use crate::error::SlateDBError;
 #[allow(dead_code)]
 use crate::error::SlateDBError::LatestTransactionalObjectVersionMissing;
 use crate::flatbuffer_types::FlatBufferCompactionsCodec;
 use chrono::Utc;
+use log::warn;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::Serialize;
@@ -11,11 +13,24 @@ use slatedb_common::clock::SystemClock;
 use slatedb_txn_obj::object_store::ObjectStoreSequencedStorageProtocol;
 use slatedb_txn_obj::{
     DirtyObject, FenceableTransactionalObject, MonotonicId, SequencedStorageProtocol,
-    SimpleTransactionalObject, TransactionalObject, TransactionalStorageProtocol,
+    SimpleTransactionalObject, TransactionalObject, TransactionalObjectError,
+    TransactionalStorageProtocol,
 };
 use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
+
+const COMPACTIONS_SUBDIR: &str = "compactions";
+const COMPACTIONS_FILE_SUFFIX: &str = "compactions";
+
+fn is_checksum_mismatch(err: &TransactionalObjectError) -> bool {
+    if let TransactionalObjectError::CallbackError(inner) = err {
+        if let Some(e) = inner.downcast_ref::<SlateDBError>() {
+            return matches!(e, SlateDBError::ChecksumMismatch);
+        }
+    }
+    false
+}
 
 /// Represents the compactions stored in the object store. This type tracks the current
 /// contents and id of the stored compactions state, and allows callers to read and update
@@ -197,6 +212,8 @@ where
 
 pub(crate) struct CompactionsStore {
     inner: Arc<dyn SequencedStorageProtocol<Compactions>>,
+    compactions_dir: Path,
+    cached_object_store: Option<Arc<CachedObjectStore>>,
 }
 
 impl CompactionsStore {
@@ -204,11 +221,69 @@ impl CompactionsStore {
         let inner = Arc::new(ObjectStoreSequencedStorageProtocol::<Compactions>::new(
             root_path,
             object_store,
-            "compactions",
-            "compactions",
+            COMPACTIONS_SUBDIR,
+            COMPACTIONS_FILE_SUFFIX,
             Box::new(FlatBufferCompactionsCodec {}),
         ));
-        Self { inner }
+        Self {
+            inner,
+            compactions_dir: root_path.child(COMPACTIONS_SUBDIR),
+            cached_object_store: None,
+        }
+    }
+
+    /// Attach a `CachedObjectStore` so reads can self-heal from a corrupt
+    /// cache entry (e.g. after an unclean shutdown) by invalidating it and
+    /// refetching from the remote object store.
+    pub(crate) fn with_cache_invalidator(
+        mut self,
+        cached_object_store: Arc<CachedObjectStore>,
+    ) -> Self {
+        self.cached_object_store = Some(cached_object_store);
+        self
+    }
+
+    fn compactions_path(&self, id: MonotonicId) -> Path {
+        self.compactions_dir
+            .child(format!("{:020}.{}", id.id(), COMPACTIONS_FILE_SUFFIX))
+    }
+
+    async fn invalidate_on_checksum_mismatch(
+        &self,
+        id: MonotonicId,
+        err: &TransactionalObjectError,
+    ) -> bool {
+        let Some(cache) = self.cached_object_store.as_ref() else {
+            return false;
+        };
+        if !is_checksum_mismatch(err) {
+            return false;
+        }
+        let path = self.compactions_path(id);
+        warn!(
+            "compactions failed checksum on read, invalidating cache and retrying once [id={}, path={}]",
+            id.id(),
+            path
+        );
+        if let Err(invalidate_err) = cache.invalidate(&path).await {
+            warn!(
+                "failed to invalidate cached compactions [path={}, error={}]",
+                path, invalidate_err
+            );
+        }
+        true
+    }
+
+    async fn try_read_with_retry(
+        &self,
+        id: MonotonicId,
+    ) -> Result<Option<Compactions>, TransactionalObjectError> {
+        match self.inner.try_read(id).await {
+            Err(err) if self.invalidate_on_checksum_mismatch(id, &err).await => {
+                self.inner.try_read(id).await
+            }
+            other => other,
+        }
     }
 
     /// Delete a compactions file from the object store.
@@ -245,11 +320,32 @@ impl CompactionsStore {
     pub(crate) async fn try_read_latest_compactions(
         &self,
     ) -> Result<Option<VersionedCompactions>, SlateDBError> {
-        Ok(self.inner.try_read_latest().await.map(|opt| {
-            opt.map(|(id, compactions)| {
-                VersionedCompactions::from_compactions(id.into(), compactions)
-            })
-        })?)
+        // Mirror `ObjectStoreSequencedStorageProtocol::try_read_latest`:
+        // list, take the newest id, read via the retry path. Re-list on
+        // `Ok(None)` to handle the existing race with GC.
+        loop {
+            let files = self
+                .inner
+                .list(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+                .await?;
+            let Some(file) = files.last() else {
+                return Ok(None);
+            };
+            match self.try_read_with_retry(file.id).await? {
+                Some(compactions) => {
+                    return Ok(Some(VersionedCompactions::from_compactions(
+                        file.id.into(),
+                        compactions,
+                    )));
+                }
+                None => {
+                    warn!(
+                        "listed compactions file missing on read, retrying [location={}]",
+                        file.location
+                    );
+                }
+            }
+        }
     }
 
     #[cfg(test)]
@@ -266,7 +362,7 @@ impl CompactionsStore {
         &self,
         id: u64,
     ) -> Result<Option<Compactions>, SlateDBError> {
-        Ok(self.inner.try_read(MonotonicId::new(id)).await?)
+        Ok(self.try_read_with_retry(MonotonicId::new(id)).await?)
     }
 
     #[allow(dead_code)]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -448,15 +448,24 @@ impl<P: Into<Path>> DbBuilder<P> {
             None => retrying_main_object_store.clone(),
         };
 
-        // Setup the manifest store and load latest manifest
-        let manifest_store = Arc::new(ManifestStore::new(
-            &path,
-            maybe_cached_main_object_store.clone(),
-        ));
-        let compactions_store = Arc::new(CompactionsStore::new(
-            &path,
-            maybe_cached_main_object_store.clone(),
-        ));
+        // Setup the manifest store and load latest manifest. If we're reading
+        // through a local disk cache, pass the cache in so a corrupt cached
+        // manifest (from an unclean shutdown, for example) self-heals by
+        // invalidating the entry and refetching from the remote store.
+        let manifest_store = {
+            let store = ManifestStore::new(&path, maybe_cached_main_object_store.clone());
+            match &cached_object_store {
+                Some(cache) => Arc::new(store.with_cache_invalidator(cache.clone())),
+                None => Arc::new(store),
+            }
+        };
+        let compactions_store = {
+            let store = CompactionsStore::new(&path, maybe_cached_main_object_store.clone());
+            match &cached_object_store {
+                Some(cache) => Arc::new(store.with_cache_invalidator(cache.clone())),
+                None => Arc::new(store),
+            }
+        };
         let latest_manifest =
             StoredManifest::try_load(manifest_store.clone(), system_clock.clone()).await?;
 
@@ -473,13 +482,20 @@ impl<P: Into<Path>> DbBuilder<P> {
             None => HashMap::new(),
         };
 
-        // Create path resolver and table store
+        // Create path resolver and table store. When the main object store is
+        // served through a local disk cache, hand the cache to `ObjectStores`
+        // so SST readers can invalidate a corrupt entry and refetch from the
+        // remote object store on `ChecksumMismatch`.
         let path_resolver = PathResolver::new_with_external_ssts(path.clone(), external_ssts);
+        let mut object_stores = ObjectStores::new(
+            maybe_cached_main_object_store.clone(),
+            retrying_wal_object_store.clone(),
+        );
+        if let Some(cache) = &cached_object_store {
+            object_stores = object_stores.with_main_cache(cache.clone());
+        }
         let table_store = Arc::new(TableStore::new_with_fp_registry(
-            ObjectStores::new(
-                maybe_cached_main_object_store.clone(),
-                retrying_wal_object_store.clone(),
-            ),
+            object_stores,
             sst_format.clone(),
             path_resolver.clone(),
             self.fp_registry.clone(),
@@ -1340,7 +1356,13 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
         };
 
         // Validate WAL object store configuration.
-        let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
+        let manifest_store = {
+            let store = ManifestStore::new(&path, object_store.clone());
+            match &maybe_cached {
+                Some(cache) => Arc::new(store.with_cache_invalidator(cache.clone())),
+                None => Arc::new(store),
+            }
+        };
         let latest_manifest =
             StoredManifest::try_load(manifest_store, self.system_clock.clone()).await?;
         if let Some(latest_manifest) = &latest_manifest {
@@ -1355,6 +1377,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             wal_object_store: retrying_wal_object_store,
             block_cache: self.db_cache.clone(),
             block_transformer: self.block_transformer.clone(),
+            cached_object_store: maybe_cached.clone(),
         };
 
         let reader = DbReader::open_internal(

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -49,8 +49,21 @@ use crate::seq_tracker::SequenceTracker;
 use crate::utils::clamp_allocated_size_bytes;
 use slatedb_txn_obj::ObjectCodec;
 
-pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 2;
-pub(crate) const COMPACTIONS_FORMAT_VERSION: u16 = 1;
+pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 3;
+
+// On-disk manifest envelope versions. Version 3 wraps the same flatbuffer
+// payload as version 1 but adds a CRC32 so readers can detect corruption on
+// the transport (most relevantly, a manifest served from the local disk cache
+// after an unclean shutdown, where the page cache contents may have been
+// lost). Versions 1 and 2 remain readable for backward compatibility.
+const MANIFEST_CRC_PAYLOAD_OFFSET: usize = 6; // u16 version + u32 crc
+
+pub(crate) const COMPACTIONS_FORMAT_VERSION: u16 = 2;
+
+// Compactions envelope versions. Version 2 wraps the v1 flatbuffer payload
+// with a CRC32, mirroring the manifest v3 envelope. Version 1 remains
+// readable for backward compatibility.
+const COMPACTIONS_CRC_PAYLOAD_OFFSET: usize = 6; // u16 version + u32 crc
 pub(crate) const ORIGINAL_SST_FORMAT_VERSION: u16 = SST_FORMAT_VERSION;
 
 /// FlatBuffer verifier options with increased table limit.
@@ -158,7 +171,7 @@ pub(crate) struct FlatBufferManifestCodec {}
 
 impl ObjectCodec<Manifest> for FlatBufferManifestCodec {
     fn encode(&self, manifest: &Manifest) -> Bytes {
-        Self::create_from_manifest_v1(manifest)
+        Self::create_from_manifest_v3(manifest)
     }
 
     fn decode(&self, bytes: &Bytes) -> Result<Manifest, Box<dyn std::error::Error + Send + Sync>> {
@@ -166,25 +179,39 @@ impl ObjectCodec<Manifest> for FlatBufferManifestCodec {
             return Err(Box::new(SlateDBError::EmptyManifest));
         }
         let version = u16::from_be_bytes([bytes[0], bytes[1]]);
-        let unversioned_bytes = bytes.slice(2..);
         match version {
             1 => {
                 let manifest = flatbuffers::root_with_opts::<ManifestV1>(
                     &verifier_options(),
-                    unversioned_bytes.as_ref(),
+                    bytes[2..].as_ref(),
                 )?;
                 Self::manifest_v1(&manifest)
             }
             2 => {
                 let manifest = flatbuffers::root_with_opts::<ManifestV2>(
                     &verifier_options(),
-                    unversioned_bytes.as_ref(),
+                    bytes[2..].as_ref(),
                 )?;
                 Self::manifest_v2(&manifest)
             }
+            3 => {
+                if bytes.len() < MANIFEST_CRC_PAYLOAD_OFFSET {
+                    return Err(Box::new(SlateDBError::ChecksumMismatch));
+                }
+                let expected_crc = u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
+                let payload = bytes.slice(MANIFEST_CRC_PAYLOAD_OFFSET..);
+                if crc32fast::hash(&payload) != expected_crc {
+                    return Err(Box::new(SlateDBError::ChecksumMismatch));
+                }
+                let manifest = flatbuffers::root_with_opts::<ManifestV1>(
+                    &verifier_options(),
+                    payload.as_ref(),
+                )?;
+                Self::manifest_v1(&manifest)
+            }
             _ => Err(Box::new(SlateDBError::InvalidVersion {
                 format_name: "manifest",
-                supported_versions: vec![1, 2],
+                supported_versions: vec![1, 2, 3],
                 actual_version: version,
             })),
         }
@@ -451,6 +478,26 @@ impl FlatBufferManifestCodec {
         db_fb_builder.create_manifest_v1(manifest)
     }
 
+    /// Encode a manifest as v3: a CRC-wrapped v1 flatbuffer. Layout is
+    /// `[u16 BE version = 3][u32 BE crc32 of payload][v1 flatbuffer bytes]`
+    /// where the CRC covers only the flatbuffer payload. Readers validate the
+    /// CRC before parsing so corruption (typically from a cache entry whose
+    /// dirty pages were lost in an unclean shutdown) surfaces as
+    /// `SlateDBError::ChecksumMismatch`, which upper layers turn into a
+    /// cache-invalidate-and-retry against the remote object store.
+    pub(crate) fn create_from_manifest_v3(manifest: &Manifest) -> Bytes {
+        let v1_bytes = Self::create_from_manifest_v1(manifest);
+        // v1_bytes = `[u16 BE = 1][flatbuffer payload]`; strip the v1 version
+        // byte and re-wrap with the v3 envelope.
+        let payload = &v1_bytes[2..];
+        let crc = crc32fast::hash(payload);
+        let mut bytes = BytesMut::with_capacity(MANIFEST_CRC_PAYLOAD_OFFSET + payload.len());
+        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_u32(crc);
+        bytes.put_slice(payload);
+        bytes.freeze()
+    }
+
     #[allow(unused)]
     pub(crate) fn create_from_manifest(manifest: &Manifest) -> Bytes {
         let builder = FlatBufferBuilder::new();
@@ -463,7 +510,7 @@ pub(crate) struct FlatBufferCompactionsCodec {}
 
 impl ObjectCodec<CompactorCompactions> for FlatBufferCompactionsCodec {
     fn encode(&self, compactions: &CompactorCompactions) -> Bytes {
-        Self::create_from_compactions(compactions)
+        Self::create_from_compactions_v2(compactions)
     }
 
     fn decode(
@@ -480,19 +527,35 @@ impl FlatBufferCompactionsCodec {
             return Err(SlateDBError::InvalidCompaction);
         }
         let version = u16::from_be_bytes([bytes[0], bytes[1]]);
-        if version != COMPACTIONS_FORMAT_VERSION {
-            return Err(SlateDBError::InvalidVersion {
+        match version {
+            1 => {
+                let fb = flatbuffers::root_with_opts::<CompactionsV1>(
+                    &verifier_options(),
+                    bytes[2..].as_ref(),
+                )?;
+                Self::compactions(&fb)
+            }
+            2 => {
+                if bytes.len() < COMPACTIONS_CRC_PAYLOAD_OFFSET {
+                    return Err(SlateDBError::ChecksumMismatch);
+                }
+                let expected_crc = u32::from_be_bytes([bytes[2], bytes[3], bytes[4], bytes[5]]);
+                let payload = bytes.slice(COMPACTIONS_CRC_PAYLOAD_OFFSET..);
+                if crc32fast::hash(&payload) != expected_crc {
+                    return Err(SlateDBError::ChecksumMismatch);
+                }
+                let fb = flatbuffers::root_with_opts::<CompactionsV1>(
+                    &verifier_options(),
+                    payload.as_ref(),
+                )?;
+                Self::compactions(&fb)
+            }
+            _ => Err(SlateDBError::InvalidVersion {
                 format_name: "compactions",
-                supported_versions: vec![COMPACTIONS_FORMAT_VERSION],
+                supported_versions: vec![1, 2],
                 actual_version: version,
-            });
+            }),
         }
-        let unversioned_bytes = bytes.slice(2..);
-        let fb = flatbuffers::root_with_opts::<CompactionsV1>(
-            &verifier_options(),
-            unversioned_bytes.as_ref(),
-        )?;
-        Self::compactions(&fb)
     }
 
     pub(crate) fn compactions(
@@ -569,6 +632,22 @@ impl FlatBufferCompactionsCodec {
         let builder = FlatBufferBuilder::new();
         let mut db_fb_builder = DbFlatBufferBuilder::new(builder);
         db_fb_builder.create_compactions(compactions)
+    }
+
+    /// Encode compactions as v2: a CRC-wrapped v1 flatbuffer. Layout is
+    /// `[u16 BE version = 2][u32 BE crc32 of payload][v1 flatbuffer bytes]`.
+    /// Parallels `FlatBufferManifestCodec::create_from_manifest_v3`; the CRC
+    /// lets readers detect cache corruption after an unclean shutdown and
+    /// self-heal via invalidate-and-refetch at the fetching layer.
+    pub(crate) fn create_from_compactions_v2(compactions: &CompactorCompactions) -> Bytes {
+        let v1_bytes = Self::create_from_compactions(compactions);
+        let payload = &v1_bytes[2..];
+        let crc = crc32fast::hash(payload);
+        let mut bytes = BytesMut::with_capacity(COMPACTIONS_CRC_PAYLOAD_OFFSET + payload.len());
+        bytes.put_u16(COMPACTIONS_FORMAT_VERSION);
+        bytes.put_u32(crc);
+        bytes.put_slice(payload);
+        bytes.freeze()
     }
 }
 
@@ -949,7 +1028,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         );
         self.builder.finish(compactions, None);
         let mut bytes = BytesMut::new();
-        bytes.put_u16(COMPACTIONS_FORMAT_VERSION);
+        bytes.put_u16(1);
         bytes.put_slice(self.builder.finished_data());
         bytes.into()
     }
@@ -1034,7 +1113,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         );
         self.builder.finish(manifest, None);
         let mut bytes = BytesMut::new();
-        bytes.put_u16(MANIFEST_FORMAT_VERSION);
+        bytes.put_u16(2);
         bytes.put_slice(self.builder.finished_data());
         bytes.into()
     }
@@ -1245,7 +1324,7 @@ mod tests {
     use bytes::{BufMut, Bytes, BytesMut};
     use chrono::{DateTime, Utc};
 
-    use super::{root_generated, COMPACTIONS_FORMAT_VERSION, MANIFEST_FORMAT_VERSION};
+    use super::{root_generated, MANIFEST_FORMAT_VERSION};
 
     #[test]
     fn test_should_encode_decode_manifest_checkpoints() {
@@ -1431,10 +1510,10 @@ mod tests {
         let v1_bytes = bytes.freeze();
         codec.decode(&v1_bytes).expect("Should decode V1 manifest");
 
-        // Test encode/decode round-trip (currently writes V1 for forward compatibility)
+        // Default encode is v3 (CRC-wrapped v1 payload); confirm it round-trips.
         let manifest = Manifest::initial(ManifestCore::new());
         let encoded = codec.encode(&manifest);
-        assert_eq!(u16::from_be_bytes([encoded[0], encoded[1]]), 1);
+        assert_eq!(u16::from_be_bytes([encoded[0], encoded[1]]), 3);
         codec
             .decode(&encoded)
             .expect("Should decode manifest round-trip");
@@ -1456,7 +1535,7 @@ mod tests {
                     panic!("Expected SlateDBError::InvalidVersion but got {:?}", err);
                 };
                 assert_eq!(*format_name, "manifest");
-                assert_eq!(*supported_versions, vec![1u16, 2]);
+                assert_eq!(*supported_versions, vec![1u16, 2, 3]);
                 assert_eq!(*actual_version, MANIFEST_FORMAT_VERSION + 1);
             }
             _ => panic!("Should fail with version mismatch"),
@@ -1484,10 +1563,7 @@ mod tests {
         let bytes = FlatBufferManifestCodec::create_from_manifest(&manifest);
         let decoded = codec.decode(&bytes).unwrap();
 
-        assert_eq!(
-            u16::from_be_bytes([bytes[0], bytes[1]]),
-            MANIFEST_FORMAT_VERSION
-        );
+        assert_eq!(u16::from_be_bytes([bytes[0], bytes[1]]), 2);
 
         let mut expected = manifest.clone();
         expected.core.wal_object_store_uri = None;
@@ -1604,11 +1680,42 @@ mod tests {
                     panic!("Expected SlateDBError::InvalidVersion but got {:?}", err);
                 };
                 assert_eq!(*format_name, "compactions");
-                assert_eq!(*supported_versions, vec![COMPACTIONS_FORMAT_VERSION]);
+                assert_eq!(*supported_versions, vec![1u16, 2]);
                 assert_eq!(*actual_version, invalid_version);
             }
             _ => panic!("Should fail with version mismatch"),
         }
+    }
+
+    #[test]
+    fn test_should_detect_v2_compactions_payload_checksum_mismatch() {
+        let codec = FlatBufferCompactionsCodec {};
+        let mut bytes = codec.encode(&Compactions::new(1)).to_vec();
+        assert_eq!(u16::from_be_bytes([bytes[0], bytes[1]]), 2);
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xff;
+
+        let err = codec
+            .decode(&Bytes::from(bytes))
+            .expect_err("decode should fail on payload corruption");
+        assert!(matches!(
+            err.downcast_ref::<SlateDBError>(),
+            Some(SlateDBError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_should_decode_legacy_v1_compactions() {
+        // v1 envelope: `[u16 = 1][flatbuffer bytes]`, no CRC. Must remain
+        // readable so upgrades that still have on-remote v1 compactions work.
+        let codec = FlatBufferCompactionsCodec {};
+        let compactions = Compactions::new(7);
+        let v1_bytes = FlatBufferCompactionsCodec::create_from_compactions(&compactions);
+        assert_eq!(u16::from_be_bytes([v1_bytes[0], v1_bytes[1]]), 1);
+        let decoded = codec
+            .decode(&v1_bytes)
+            .expect("v1 compactions should decode");
+        assert_eq!(decoded.compactor_epoch, 7);
     }
 
     #[test]
@@ -1975,7 +2082,7 @@ mod tests {
         );
         fbb.finish(compactions, None);
         let mut bytes = BytesMut::new();
-        bytes.put_u16(COMPACTIONS_FORMAT_VERSION);
+        bytes.put_u16(1);
         bytes.put_slice(fbb.finished_data());
         let bytes = bytes.freeze();
 
@@ -2073,6 +2180,63 @@ mod tests {
             .expect("failed to decode V1 manifest");
 
         assert_eq!(manifest, decoded);
+    }
+
+    #[test]
+    fn test_should_detect_v3_payload_checksum_mismatch() {
+        let manifest = Manifest::initial(ManifestCore::new());
+        let codec = FlatBufferManifestCodec {};
+        let mut bytes = codec.encode(&manifest).to_vec();
+        assert_eq!(u16::from_be_bytes([bytes[0], bytes[1]]), 3);
+
+        // Flip a byte inside the flatbuffer payload.
+        let last = bytes.len() - 1;
+        bytes[last] ^= 0xff;
+
+        let err = codec
+            .decode(&Bytes::from(bytes))
+            .expect_err("decode should fail on payload corruption");
+        assert!(
+            matches!(
+                err.downcast_ref::<SlateDBError>(),
+                Some(SlateDBError::ChecksumMismatch)
+            ),
+            "expected ChecksumMismatch, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_should_detect_v3_crc_field_corruption() {
+        let manifest = Manifest::initial(ManifestCore::new());
+        let codec = FlatBufferManifestCodec {};
+        let mut bytes = codec.encode(&manifest).to_vec();
+        // Flip a bit inside the CRC field itself.
+        bytes[2] ^= 0x01;
+
+        let err = codec
+            .decode(&Bytes::from(bytes))
+            .expect_err("decode should fail when the CRC field is tampered");
+        assert!(matches!(
+            err.downcast_ref::<SlateDBError>(),
+            Some(SlateDBError::ChecksumMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_should_detect_v3_truncated_envelope() {
+        let manifest = Manifest::initial(ManifestCore::new());
+        let codec = FlatBufferManifestCodec {};
+        // Only the version byte is present; the CRC/payload are missing.
+        let mut truncated = BytesMut::new();
+        truncated.put_u16(3);
+        let err = codec
+            .decode(&truncated.freeze())
+            .expect_err("decode should fail on a truncated v3 envelope");
+        assert!(matches!(
+            err.downcast_ref::<SlateDBError>(),
+            Some(SlateDBError::ChecksumMismatch)
+        ));
+        let _ = manifest;
     }
 
     #[test]

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -1,3 +1,4 @@
+use crate::cached_object_store::CachedObjectStore;
 use crate::checkpoint::Checkpoint;
 use crate::config::CheckpointOptions;
 use crate::error::SlateDBError;
@@ -7,7 +8,7 @@ use crate::error::SlateDBError::{
 use crate::flatbuffer_types::FlatBufferManifestCodec;
 use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
 use chrono::Utc;
-use log::debug;
+use log::{debug, warn};
 use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::Serialize;
@@ -15,13 +16,28 @@ use slatedb_common::clock::SystemClock;
 use slatedb_txn_obj::object_store::ObjectStoreSequencedStorageProtocol;
 use slatedb_txn_obj::{
     DirtyObject, FenceableTransactionalObject, MonotonicId, SequencedStorageProtocol,
-    SimpleTransactionalObject, TransactionalObject, TransactionalStorageProtocol,
+    SimpleTransactionalObject, TransactionalObject, TransactionalObjectError,
+    TransactionalStorageProtocol,
 };
 use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
 use uuid::Uuid;
+
+const MANIFEST_SUBDIR: &str = "manifest";
+const MANIFEST_FILE_SUFFIX: &str = "manifest";
+
+fn is_checksum_mismatch(err: &TransactionalObjectError) -> bool {
+    // The codec returns `SlateDBError::ChecksumMismatch` when a manifest fails
+    // its CRC check; it reaches us wrapped as `CallbackError`.
+    if let TransactionalObjectError::CallbackError(inner) = err {
+        if let Some(e) = inner.downcast_ref::<SlateDBError>() {
+            return matches!(e, SlateDBError::ChecksumMismatch);
+        }
+    }
+    false
+}
 
 pub(crate) struct FenceableManifest {
     clock: Arc<dyn SystemClock>,
@@ -459,6 +475,11 @@ where
 
 pub(crate) struct ManifestStore {
     inner: Arc<dyn SequencedStorageProtocol<Manifest>>,
+    /// Absolute path prefix used to compute full cache keys for invalidation.
+    manifest_dir: Path,
+    /// When set, a `ChecksumMismatch` on read invalidates the corresponding
+    /// cache entry and retries against the remote object store.
+    cached_object_store: Option<Arc<CachedObjectStore>>,
 }
 
 impl ManifestStore {
@@ -466,11 +487,71 @@ impl ManifestStore {
         let inner = Arc::new(ObjectStoreSequencedStorageProtocol::<Manifest>::new(
             root_path,
             object_store,
-            "manifest",
-            "manifest",
+            MANIFEST_SUBDIR,
+            MANIFEST_FILE_SUFFIX,
             Box::new(FlatBufferManifestCodec {}),
         ));
-        Self { inner }
+        Self {
+            inner,
+            manifest_dir: root_path.child(MANIFEST_SUBDIR),
+            cached_object_store: None,
+        }
+    }
+
+    /// Attach a `CachedObjectStore` so that reads can self-heal from a
+    /// corrupted cache entry by invalidating it and refetching from the
+    /// remote object store.
+    pub(crate) fn with_cache_invalidator(
+        mut self,
+        cached_object_store: Arc<CachedObjectStore>,
+    ) -> Self {
+        self.cached_object_store = Some(cached_object_store);
+        self
+    }
+
+    fn manifest_path(&self, id: MonotonicId) -> Path {
+        self.manifest_dir
+            .child(format!("{:020}.{}", id.id(), MANIFEST_FILE_SUFFIX))
+    }
+
+    /// If `err` represents a manifest that failed its checksum on decode,
+    /// drop the cached copy so the next read goes to the remote store.
+    async fn invalidate_on_checksum_mismatch(
+        &self,
+        id: MonotonicId,
+        err: &TransactionalObjectError,
+    ) -> bool {
+        let Some(cache) = self.cached_object_store.as_ref() else {
+            return false;
+        };
+        if !is_checksum_mismatch(err) {
+            return false;
+        }
+        let path = self.manifest_path(id);
+        warn!(
+            "manifest failed checksum on read, invalidating cache and retrying once [id={}, path={}]",
+            id.id(),
+            path
+        );
+        if let Err(invalidate_err) = cache.invalidate(&path).await {
+            warn!(
+                "failed to invalidate cached manifest [path={}, error={}]",
+                path, invalidate_err
+            );
+        }
+        true
+    }
+
+    async fn try_read_with_retry(
+        &self,
+        id: MonotonicId,
+    ) -> Result<Option<Manifest>, TransactionalObjectError> {
+        match self.inner.try_read(id).await {
+            Err(err) if self.invalidate_on_checksum_mismatch(id, &err).await => {
+                self.inner.try_read(id).await
+            }
+            other => other,
+        }
     }
 
     /// Delete a manifest from the object store.
@@ -550,9 +631,33 @@ impl ManifestStore {
     pub(crate) async fn try_read_latest_manifest(
         &self,
     ) -> Result<Option<VersionedManifest>, SlateDBError> {
-        Ok(self.inner.try_read_latest().await.map(|opt| {
-            opt.map(|(id, manifest)| VersionedManifest::from_manifest(id.into(), manifest))
-        })?)
+        // Mirrors `ObjectStoreSequencedStorageProtocol::try_read_latest`:
+        // list, take the newest id, read it. If that read returns `None`
+        // (concurrent GC) we re-list. If it returns `ChecksumMismatch`,
+        // `try_read_with_retry` invalidates the cache entry and retries.
+        loop {
+            let files = self
+                .inner
+                .list(std::ops::Bound::Unbounded, std::ops::Bound::Unbounded)
+                .await?;
+            let Some(file) = files.last() else {
+                return Ok(None);
+            };
+            match self.try_read_with_retry(file.id).await? {
+                Some(manifest) => {
+                    return Ok(Some(VersionedManifest::from_manifest(
+                        file.id.into(),
+                        manifest,
+                    )));
+                }
+                None => {
+                    warn!(
+                        "listed manifest missing on read, retrying [location={}]",
+                        file.location
+                    );
+                }
+            }
+        }
     }
 
     pub(crate) async fn read_latest_manifest(&self) -> Result<VersionedManifest, SlateDBError> {
@@ -565,7 +670,7 @@ impl ManifestStore {
         &self,
         id: u64,
     ) -> Result<Option<Manifest>, SlateDBError> {
-        Ok(self.inner.try_read(MonotonicId::new(id)).await?)
+        Ok(self.try_read_with_retry(MonotonicId::new(id)).await?)
     }
 
     pub(crate) async fn read_manifest(&self, id: u64) -> Result<Manifest, SlateDBError> {
@@ -1430,5 +1535,94 @@ mod tests {
             Some(SlateDBError::Fenced)
         ));
         assert!(fm_a.refresh().await.is_ok());
+    }
+
+    /// End-to-end check that a manifest served out of a corrupt cache entry
+    /// self-heals: the CRC check at decode fires `ChecksumMismatch`, the
+    /// ManifestStore invalidates the cache, and the retry succeeds against
+    /// the remote object store.
+    #[tokio::test]
+    async fn test_should_retry_manifest_read_on_cache_corruption() {
+        use crate::cached_object_store::stats::CachedObjectStoreStats;
+        use crate::cached_object_store::{CachedObjectStore, FsCacheStorage};
+        use crate::rand::DbRand;
+        use slatedb_common::metrics::MetricsRecorderHelper;
+
+        let remote = Arc::new(InMemory::new());
+        let tmp = tempfile::Builder::new()
+            .prefix("manifest_cache_corrupt_")
+            .tempdir()
+            .unwrap();
+        let recorder = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            tmp.path().to_path_buf(),
+            None,
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+        ));
+        let part_size = 4 * 1024;
+        let cached = CachedObjectStore::new(
+            remote.clone() as Arc<dyn object_store::ObjectStore>,
+            cache_storage,
+            part_size,
+            false,
+            stats,
+        )
+        .unwrap();
+
+        let ms = Arc::new(
+            ManifestStore::new(
+                &Path::from(ROOT),
+                cached.clone() as Arc<dyn object_store::ObjectStore>,
+            )
+            .with_cache_invalidator(cached.clone()),
+        );
+
+        let _sm = StoredManifest::create_new_db(
+            Arc::clone(&ms),
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        // Warm the cache by reading the manifest through the cached path.
+        let latest = ms.try_read_latest_manifest().await.unwrap().unwrap();
+        let manifest_id = latest.id;
+        assert_eq!(1, manifest_id);
+
+        // Corrupt every cached file for this manifest on disk. This simulates
+        // an unclean shutdown in which pages flushed to disk were lost.
+        let mut corrupted_any = false;
+        for entry in walkdir::WalkDir::new(tmp.path())
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+        {
+            let mut bytes = std::fs::read(entry.path()).unwrap();
+            if !bytes.is_empty() {
+                let last = bytes.len() - 1;
+                bytes[last] ^= 0xff;
+                std::fs::write(entry.path(), bytes).unwrap();
+                corrupted_any = true;
+            }
+        }
+        assert!(
+            corrupted_any,
+            "expected at least one cached file to corrupt"
+        );
+
+        // The retry must invalidate the cache and refetch from the remote store.
+        let refetched = ms.read_manifest(manifest_id).await.unwrap();
+        assert_eq!(refetched, latest.manifest);
+
+        // Without cache invalidation wired up the read would still fail on
+        // the second attempt. Sanity-check by corrupting again and confirming
+        // a fresh read succeeds (the cache is now warm with good bytes).
+        let refetched_again = ms.read_manifest(manifest_id).await.unwrap();
+        assert_eq!(refetched_again, latest.manifest);
     }
 }

--- a/slatedb/src/object_stores.rs
+++ b/slatedb/src/object_stores.rs
@@ -1,4 +1,6 @@
+use crate::cached_object_store::CachedObjectStore;
 use crate::db_state::SsTableId;
+use object_store::path::Path;
 use object_store::ObjectStore;
 use std::sync::Arc;
 
@@ -9,6 +11,12 @@ pub(crate) struct ObjectStores {
     main_object_store: Arc<dyn ObjectStore>,
     /// Optional WAL object store dedicated specifically for WAL.
     wal_object_store: Option<Arc<dyn ObjectStore>>,
+    /// Concrete handle to the main-side local disk cache, if one is in use.
+    /// Needed so higher layers can drop a corrupt cached entry after a
+    /// checksum mismatch and refetch from the remote object store. The WAL
+    /// path is never routed through `CachedObjectStore` today, so there is
+    /// no corresponding WAL invalidator.
+    main_cache: Option<Arc<CachedObjectStore>>,
 }
 
 /// Whether the object store holds the main data path or the WAL.
@@ -37,6 +45,32 @@ impl ObjectStores {
         Self {
             main_object_store,
             wal_object_store,
+            main_cache: None,
+        }
+    }
+
+    pub(crate) fn with_main_cache(mut self, cache: Arc<CachedObjectStore>) -> Self {
+        self.main_cache = Some(cache);
+        self
+    }
+
+    /// Invalidate the cached copy (if any) of the given path on the store
+    /// that serves the supplied SST id. Used by SST readers to drop a
+    /// corrupt cache entry after the SST-level checksum check fails.
+    pub(crate) async fn invalidate_cache_for(&self, id: &SsTableId, path: &Path) {
+        let cache = match id {
+            SsTableId::Compacted(..) => self.main_cache.as_ref(),
+            // WAL is not served through the local disk cache.
+            SsTableId::Wal(..) => None,
+        };
+        if let Some(cache) = cache {
+            if let Err(err) = cache.invalidate(path).await {
+                log::warn!(
+                    "failed to invalidate cached SST entry [path={}, error={}]",
+                    path,
+                    err
+                );
+            }
         }
     }
 

--- a/slatedb/src/store_provider.rs
+++ b/slatedb/src/store_provider.rs
@@ -1,3 +1,4 @@
+use crate::cached_object_store::CachedObjectStore;
 use crate::db_cache::DbCache;
 use crate::format::sst::{BlockTransformer, SsTableFormat};
 use crate::manifest::store::ManifestStore;
@@ -18,6 +19,11 @@ pub(crate) struct DefaultStoreProvider {
     pub(crate) wal_object_store: Option<Arc<dyn ObjectStore>>,
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
     pub(crate) block_transformer: Option<Arc<dyn BlockTransformer>>,
+    /// Concrete handle to the local disk cache, when one is configured,
+    /// so that the `ManifestStore` and `TableStore` built here can
+    /// invalidate cached entries and refetch from the remote object store
+    /// on a `ChecksumMismatch`.
+    pub(crate) cached_object_store: Option<Arc<CachedObjectStore>>,
 }
 
 impl StoreProvider for DefaultStoreProvider {
@@ -26,11 +32,15 @@ impl StoreProvider for DefaultStoreProvider {
             block_transformer: self.block_transformer.clone(),
             ..SsTableFormat::default()
         };
+        let mut object_stores = ObjectStores::new(
+            Arc::clone(&self.object_store),
+            self.wal_object_store.clone(),
+        );
+        if let Some(cache) = &self.cached_object_store {
+            object_stores = object_stores.with_main_cache(cache.clone());
+        }
         Arc::new(TableStore::new(
-            ObjectStores::new(
-                Arc::clone(&self.object_store),
-                self.wal_object_store.clone(),
-            ),
+            object_stores,
             sst_format,
             self.path.clone(),
             self.block_cache.clone(),
@@ -38,9 +48,10 @@ impl StoreProvider for DefaultStoreProvider {
     }
 
     fn manifest_store(&self) -> Arc<ManifestStore> {
-        Arc::new(ManifestStore::new(
-            &self.path,
-            Arc::clone(&self.object_store),
-        ))
+        let store = ManifestStore::new(&self.path, Arc::clone(&self.object_store));
+        match &self.cached_object_store {
+            Some(cache) => Arc::new(store.with_cache_invalidator(cache.clone())),
+            None => Arc::new(store),
+        }
     }
 }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -105,6 +105,36 @@ impl TableStore {
         }
     }
 
+    /// Run an SST read and, if it fails with `ChecksumMismatch`, invalidate
+    /// the local disk cache entry for this SST and retry once. Cache writes
+    /// no longer fsync, so after an unclean shutdown a cached part can come
+    /// back truncated or with lost pages; the SST format's own CRC catches
+    /// that and we convert the error into a self-healing refetch from the
+    /// remote object store. `invalidate_cache_for` is a no-op when there is
+    /// no cache, so this wrapper is safe to use unconditionally.
+    async fn read_with_cache_retry<F, Fut, T>(
+        &self,
+        id: &SsTableId,
+        path: &Path,
+        op: F,
+    ) -> Result<T, SlateDBError>
+    where
+        F: Fn() -> Fut,
+        Fut: std::future::Future<Output = Result<T, SlateDBError>>,
+    {
+        match op().await {
+            Err(SlateDBError::ChecksumMismatch) => {
+                warn!(
+                    "SST failed checksum on read, invalidating cache and retrying once [path={}]",
+                    path
+                );
+                self.object_stores.invalidate_cache_for(id, path).await;
+                op().await
+            }
+            other => other,
+        }
+    }
+
     /// Get the number of blocks for a size specified in bytes.
     /// The returned value will be rounded down to the nearest block.
     pub(crate) fn bytes_to_blocks(&self, bytes: usize) -> usize {
@@ -377,7 +407,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(id);
         let path = self.path(id);
         let obj = ReadOnlyObject { object_store, path };
-        let (info, version) = self.sst_format.read_info_and_version(&obj).await?;
+        let (info, version) = self
+            .read_with_cache_retry(id, &obj.path, || {
+                self.sst_format.read_info_and_version(&obj)
+            })
+            .await?;
         Ok(SsTableHandle::new(*id, version, info))
     }
 
@@ -419,7 +453,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let named_filters = self.sst_format.read_filters(&handle.info, &obj).await?;
+        let named_filters = self
+            .read_with_cache_retry(&handle.id, &obj.path, || {
+                self.sst_format.read_filters(&handle.info, &obj)
+            })
+            .await?;
         if cache_blocks && !named_filters.is_empty() {
             if let Some(ref cache) = self.cache {
                 cache
@@ -452,7 +490,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let stats = self.sst_format.read_stats(&handle.info, &obj).await?;
+        let stats = self
+            .read_with_cache_retry(&handle.id, &obj.path, || {
+                self.sst_format.read_stats(&handle.info, &obj)
+            })
+            .await?;
         if cache_blocks {
             if let Some(ref cache) = self.cache {
                 if let Some(ref stats) = stats {
@@ -491,7 +533,12 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let index = Arc::new(self.sst_format.read_index(&handle.info, &obj).await?);
+        let index = Arc::new(
+            self.read_with_cache_retry(&handle.id, &obj.path, || {
+                self.sst_format.read_index(&handle.info, &obj)
+            })
+            .await?,
+        );
         if cache_blocks {
             if let Some(ref cache) = self.cache {
                 cache
@@ -514,10 +561,16 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let index = self.sst_format.read_index(&handle.info, &obj).await?;
-        self.sst_format
-            .read_blocks(&handle.info, &index, blocks, &obj)
-            .await
+        let index = self
+            .read_with_cache_retry(&handle.id, &obj.path, || {
+                self.sst_format.read_index(&handle.info, &obj)
+            })
+            .await?;
+        self.read_with_cache_retry(&handle.id, &obj.path, || {
+            self.sst_format
+                .read_blocks(&handle.info, &index, blocks.clone(), &obj)
+        })
+        .await
     }
 
     /// Reads specified blocks from an SSTable using the provided index.
@@ -527,6 +580,33 @@ impl TableStore {
     /// using an async fetch for each contiguous range that blocks are not cached.
     /// It can optionally cache newly read blocks.
     pub(crate) async fn read_blocks_using_index(
+        &self,
+        handle: &SsTableHandle,
+        index: Arc<SsTableIndexOwned>,
+        blocks: Range<usize>,
+        cache_blocks: bool,
+    ) -> Result<VecDeque<Arc<Block>>, SlateDBError> {
+        match self
+            .read_blocks_using_index_impl(handle, index.clone(), blocks.clone(), cache_blocks)
+            .await
+        {
+            Err(SlateDBError::ChecksumMismatch) => {
+                let path = self.path(&handle.id);
+                log::warn!(
+                    "SST failed checksum on read, invalidating cache and retrying once [path={}]",
+                    path
+                );
+                self.object_stores
+                    .invalidate_cache_for(&handle.id, &path)
+                    .await;
+                self.read_blocks_using_index_impl(handle, index, blocks, cache_blocks)
+                    .await
+            }
+            other => other,
+        }
+    }
+
+    async fn read_blocks_using_index_impl(
         &self,
         handle: &SsTableHandle,
         index: Arc<SsTableIndexOwned>,
@@ -631,10 +711,16 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let index = self.sst_format.read_index(&handle.info, &obj).await?;
-        self.sst_format
-            .read_block(&handle.info, &index, block, &obj)
-            .await
+        let index = self
+            .read_with_cache_retry(&handle.id, &obj.path, || {
+                self.sst_format.read_index(&handle.info, &obj)
+            })
+            .await?;
+        self.read_with_cache_retry(&handle.id, &obj.path, || {
+            self.sst_format
+                .read_block(&handle.info, &index, block, &obj)
+        })
+        .await
     }
 
     fn path(&self, id: &SsTableId) -> Path {


### PR DESCRIPTION
## Summary

The disk cache is ephemeral (the remote object store is the source of truth), so fsyncing every cache write is unnecessary durability cost. Without fsync an unclean shutdown can leave a cache file truncated or with lost pages, so this change also adds the integrity plumbing needed to self-heal:

SST block CRCs were already in place; this PR only adds the retry wrapper around existing read sites.

Tests cover payload/CRC-field/truncation corruption for both formats and an end-to-end manifest corruption that succeeds via refetch.

## Changes

- Manifest v3 envelope: [u16=3][u32 crc][v1 flatbuffer]; decode validates the CRC, returns ChecksumMismatch. v1/v2 remain readable.
- Compactions v2 envelope: same shape; v1 remains readable.
- LocalCacheEntry::invalidate and CachedObjectStore::invalidate remove the head + part files for a location.
- ManifestStore, CompactionsStore, and TableStore retry once on ChecksumMismatch after invalidating the cache entry so the next read hits the remote store. DefaultStoreProvider plumbs the cache handle through to DbReader. ObjectStores gains with_main_cache + invalidate_cache_for so the retry stays inside the SST layer.


## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
