### PR TITLE
Rename `DbRead` to `DbReadOps`

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -52,7 +52,7 @@ use crate::config::{
     WriteOptions,
 };
 use crate::db_iter::DbIterator;
-use crate::db_read::DbRead;
+use crate::db_read::DbReadOps;
 use crate::db_snapshot::DbSnapshot;
 use crate::db_state::{DbState, SsTableId};
 use crate::db_stats::DbStats;
@@ -1616,7 +1616,7 @@ impl Db {
 }
 
 #[async_trait::async_trait]
-impl DbRead for Db {
+impl DbReadOps for Db {
     async fn get_with_options<K: AsRef<[u8]> + Send>(
         &self,
         key: K,

--- a/slatedb/src/db_read.rs
+++ b/slatedb/src/db_read.rs
@@ -16,7 +16,7 @@ use std::ops::RangeBounds;
 /// The trait is designed to be object-safe, allowing for dynamic dispatch
 /// when needed.
 #[async_trait::async_trait]
-pub trait DbRead {
+pub trait DbReadOps {
     /// Get a value from the database with default read options.
     ///
     /// The `Bytes` object returned contains a slice of an entire

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -3,7 +3,7 @@ use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
 use crate::db_metadata::DbMetadataOps;
-use crate::db_read::DbRead;
+use crate::db_read::DbReadOps;
 use crate::db_stats::DbStats;
 use crate::db_status::{ClosedResultWriter, DbStatus, DbStatusManager};
 use crate::dispatcher::{MessageFactory, MessageHandler, MessageHandlerExecutor};
@@ -1059,7 +1059,7 @@ impl DbReader {
 }
 
 #[async_trait::async_trait]
-impl DbRead for DbReader {
+impl DbReadOps for DbReader {
     async fn get_with_options<K: AsRef<[u8]> + Send>(
         &self,
         key: K,

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -9,7 +9,7 @@ use crate::db_iter::DbIterator;
 use crate::types::KeyValue;
 
 use crate::db::DbInner;
-use crate::DbRead;
+use crate::DbReadOps;
 
 pub struct DbSnapshot {
     snapshot_id: Uuid,
@@ -182,7 +182,7 @@ impl DbSnapshot {
 }
 
 #[async_trait::async_trait]
-impl DbRead for DbSnapshot {
+impl DbReadOps for DbSnapshot {
     async fn get_with_options<K: AsRef<[u8]> + Send>(
         &self,
         key: K,

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -15,7 +15,7 @@ use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
 use crate::transaction_manager::{IsolationLevel, TransactionManager};
 use crate::types::KeyValue;
-use crate::DbRead;
+use crate::DbReadOps;
 
 /// A database transaction that provides atomic read-write operations with
 /// configurable isolation levels. This is the main interface for transactional
@@ -59,7 +59,7 @@ pub struct DbTransaction {
     ///
     /// DbTransaction is not intended for concurrent use; we use `RwLock` (not `RefCell`) for
     /// interior mutability to preserve `Sync` in async contexts. `RefCell` is `!Sync` and would
-    /// make `DbTransaction` `!Sync`, which is incompatible with async code using the `DbRead`
+    /// make `DbTransaction` `!Sync`, which is incompatible with async code using the `DbReadOps`
     /// trait.
     write_batch: RwLock<WriteBatch>,
     /// Reference to the database
@@ -586,7 +586,7 @@ impl DbTransaction {
 }
 
 #[async_trait::async_trait]
-impl DbRead for DbTransaction {
+impl DbReadOps for DbTransaction {
     async fn get_with_options<K: AsRef<[u8]> + Send>(
         &self,
         key: K,

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -47,7 +47,7 @@ pub use db::{Db, DbBuilder, DbReaderBuilder, DbStatus, WriteHandle};
 pub use db_cache::stats as db_cache_stats;
 pub use db_iter::DbIterator;
 pub use db_metadata::DbMetadataOps;
-pub use db_read::DbRead;
+pub use db_read::DbReadOps;
 pub use db_reader::DbReader;
 pub use db_snapshot::DbSnapshot;
 pub use db_transaction::DbTransaction;

--- a/website/src/content/docs/docs/design/readers.mdx
+++ b/website/src/content/docs/docs/design/readers.mdx
@@ -3,7 +3,7 @@ title: Readers
 description: How DbReader serves read-only traffic from a checkpointed manifest
 ---
 
-[`DbReader`](https://docs.rs/slatedb/latest/slatedb/struct.DbReader.html) is SlateDB's read-only handle. It implements the same [`DbRead`](https://docs.rs/slatedb/latest/slatedb/trait.DbRead.html) operations as [`Db`](https://docs.rs/slatedb/latest/slatedb/struct.Db.html), but it does not own a mutable memtable and it does not write WAL records. It reads from a [checkpointed](/docs/design/checkpoints) manifest, the SSTs referenced by that manifest. When WAL replay is enabled, it also updates reader-local immutable memtables from newer WAL SSTs.
+[`DbReader`](https://docs.rs/slatedb/latest/slatedb/struct.DbReader.html) is SlateDB's read-only handle. It implements the same [`DbReadOps`](https://docs.rs/slatedb/latest/slatedb/trait.DbReadOps.html) operations as [`Db`](https://docs.rs/slatedb/latest/slatedb/struct.Db.html), but it does not own a mutable memtable and it does not write WAL records. It reads from a [checkpointed](/docs/design/checkpoints) manifest, the SSTs referenced by that manifest. When WAL replay is enabled, it also updates reader-local immutable memtables from newer WAL SSTs.
 
 ## Opening
 


### PR DESCRIPTION
## Summary

This is pure renaming change. This is the second part of #1532.

## Changes

- Rename DbRead to DbReadOps

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
