### PR TITLE
Drop unused (compacted) external SST IDs

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -728,6 +728,7 @@ impl CompactorState {
             db_state.l0 = new_l0;
             db_state.compacted = new_compacted;
             self.manifest.value.core = db_state;
+            self.manifest.value.prune_external_sst_ids();
             self.update_compaction(&compaction_id, |c| {
                 c.set_status(CompactionStatus::Completed);
             });
@@ -982,6 +983,61 @@ mod tests {
             .map(|h| h.sst.id)
             .collect();
         assert_eq!(expected_ids, found_ids);
+    }
+
+    #[test]
+    fn test_finish_compaction_prunes_external_sst_ids() {
+        use crate::manifest::ExternalDb;
+        use uuid::Uuid;
+
+        let rt = build_runtime();
+        let (_, _, mut state, system_clock, rand) = build_test_state(rt.handle());
+        let before_compaction = state.db_state().clone();
+
+        // Seed external_dbs with a mix of IDs that are currently in L0 (will move to the
+        // compacted sorted run and remain live) and a stale ID that was never in the
+        // manifest (simulating a parent SST already compacted away on a prior cycle).
+        let live_id = before_compaction.l0.front().unwrap().sst.id;
+        let stale_id = SsTableId::Compacted(Ulid::new());
+        state.manifest.value.external_dbs = vec![
+            ExternalDb {
+                path: "/parent/db".to_string(),
+                source_checkpoint_id: Uuid::new_v4(),
+                final_checkpoint_id: Some(Uuid::new_v4()),
+                sst_ids: vec![live_id, stale_id],
+            },
+            ExternalDb {
+                path: "/other/parent".to_string(),
+                source_checkpoint_id: Uuid::new_v4(),
+                final_checkpoint_id: Some(Uuid::new_v4()),
+                sst_ids: vec![stale_id],
+            },
+        ];
+
+        let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
+        let spec = build_l0_compaction(&before_compaction.l0, 0);
+        state
+            .add_compaction(Compaction::new(compaction_id, spec))
+            .expect("failed to add compaction");
+
+        let sr = SortedRun {
+            id: 0,
+            sst_views: before_compaction.l0.iter().cloned().collect(),
+        };
+        state.finish_compaction(compaction_id, sr);
+
+        let external_dbs = &state.manifest().value.external_dbs;
+        assert_eq!(external_dbs.len(), 2, "entries must be retained");
+        assert_eq!(
+            external_dbs[0].sst_ids,
+            vec![live_id],
+            "stale id must be pruned, live id kept"
+        );
+        assert!(
+            external_dbs[1].sst_ids.is_empty(),
+            "fully-stale entry must be retained with empty sst_ids (detach is GC's job)"
+        );
+        assert!(external_dbs[1].final_checkpoint_id.is_some());
     }
 
     #[test]

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -473,6 +473,23 @@ impl Manifest {
     pub(crate) fn has_wal_sst_reference(&self, wal_sst_id: u64) -> bool {
         wal_sst_id > self.core.replay_after_wal_id && wal_sst_id < self.core.next_wal_sst_id
     }
+
+    /// Shrinks each `ExternalDb.sst_ids` to only IDs still referenced by this manifest's
+    /// L0 and compacted sorted runs. `ExternalDb` entries are retained even when their
+    /// `sst_ids` becomes empty — detaching a clone from its parent is done by the GC,
+    /// not here, because it also requires that no live checkpoint references those IDs.
+    pub(crate) fn prune_external_sst_ids(&mut self) {
+        let used_sst_ids: HashSet<SsTableId> = self
+            .core
+            .compacted
+            .iter()
+            .flat_map(|sr| sr.sst_views.iter().map(|v| v.sst.id))
+            .chain(self.core.l0.iter().map(|v| v.sst.id))
+            .collect();
+        for external_db in self.external_dbs.iter_mut() {
+            external_db.sst_ids.retain(|id| used_sst_ids.contains(id));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1121,6 +1138,50 @@ mod tests {
 
         assert_eq!(projected.external_dbs.len(), 1);
         assert_eq!(projected.external_dbs[0].path, "/path/to/db1");
+    }
+
+    #[test]
+    fn test_prune_external_sst_ids_shrinks_and_keeps_entries() {
+        let live_l0 = SsTableId::Compacted(Ulid::new());
+        let live_compacted = SsTableId::Compacted(Ulid::new());
+        let stale_a = SsTableId::Compacted(Ulid::new());
+        let stale_b = SsTableId::Compacted(Ulid::new());
+
+        let mut core = ManifestCore::new();
+        core.l0.push_back(create_sst_view(live_l0, b"a"));
+        core.compacted.push(SortedRun {
+            id: 0,
+            sst_views: vec![create_sst_view(live_compacted, b"b")],
+        });
+
+        let mut manifest = Manifest::initial(core);
+        manifest.external_dbs = vec![
+            // Mix of live and stale IDs: stale ones should be pruned, live kept.
+            ExternalDb {
+                path: "/path/to/partially_referenced".to_string(),
+                source_checkpoint_id: Uuid::new_v4(),
+                final_checkpoint_id: Some(Uuid::new_v4()),
+                sst_ids: vec![live_l0, stale_a, live_compacted],
+            },
+            // No live IDs: entry must be retained (with empty sst_ids) so that GC can
+            // later detach using the final_checkpoint_id.
+            ExternalDb {
+                path: "/path/to/fully_compacted".to_string(),
+                source_checkpoint_id: Uuid::new_v4(),
+                final_checkpoint_id: Some(Uuid::new_v4()),
+                sst_ids: vec![stale_a, stale_b],
+            },
+        ];
+
+        manifest.prune_external_sst_ids();
+
+        assert_eq!(manifest.external_dbs.len(), 2);
+        assert_eq!(
+            manifest.external_dbs[0].sst_ids,
+            vec![live_l0, live_compacted]
+        );
+        assert!(manifest.external_dbs[1].sst_ids.is_empty());
+        assert!(manifest.external_dbs[1].final_checkpoint_id.is_some());
     }
 
     fn create_sst_view(sst_id: SsTableId, first_entry_bytes: &'static [u8; 1]) -> SsTableView {


### PR DESCRIPTION
## Summary

According to [RFC 4 (GC, step 8)](https://github.com/slatedb/slatedb/blob/main/rfcs/0004-checkpoints.md#garbage-collector), cloned database should be detached from its parent once all referenced SSTs are compacted:
> 8. Detach the clone if possible. If list of external databases is non-empty, then for each external database DB:
If DB.sst_ids is empty at the latest version of the manifest and all existing checkpoints, then:
Remove DB.final_checkpoint_id from the external db's manifest.
Update the manifest by removing DB from the list of external databases.

To achieve that, we need to:
1. Remove IDs of unused SSTs from `external_dbs.sst_ids` - on compaction
2. Add a GC task to remove the final checkpoint from the parent DB and remove the external DB - once all live manifest versions have `sst_ids` empty for a given parent

This PR addresses (1).
https://github.com/slatedb/slatedb/issues/314 describes (2)

## Notes for Reviewers

I'm discussing (2) with @rodesai - will probably take on that too.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
