### PR TITLE
Detach parent databases from cloned ones

### DIFF
--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -254,24 +254,28 @@ async fn exec_gc_once(
             wal_options: None,
             compacted_options: None,
             compactions_options: None,
+            detach_options: None,
         },
         GcResource::Wal => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: create_gc_dir_opts(min_age),
             compacted_options: None,
             compactions_options: None,
+            detach_options: None,
         },
         GcResource::Compacted => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: None,
             compacted_options: create_gc_dir_opts(min_age),
             compactions_options: None,
+            detach_options: None,
         },
         GcResource::Compactions => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: None,
             compacted_options: None,
             compactions_options: create_gc_dir_opts(min_age),
+            detach_options: None,
         },
     };
     admin.run_gc_once(gc_opts).await?;
@@ -296,6 +300,7 @@ async fn schedule_gc(
         wal_options: wal_schedule.and_then(create_gc_dir_opts),
         compacted_options: compacted_schedule.and_then(create_gc_dir_opts),
         compactions_options: compactions_schedule.and_then(create_gc_dir_opts),
+        detach_options: None,
     };
 
     admin.run_gc(gc_opts).await?;

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -6,6 +6,7 @@ use slatedb::config::CompactorOptions;
 use slatedb::config::CompressionCodec;
 use slatedb::config::GarbageCollectorDirectoryOptions;
 use slatedb::config::GarbageCollectorOptions;
+use slatedb::config::GarbageCollectorScheduleOptions;
 use slatedb::config::SizeTieredCompactionSchedulerOptions;
 use slatedb::object_store::ObjectStore;
 use slatedb::size_tiered_compaction::SizeTieredCompactionSchedulerSupplier;
@@ -161,11 +162,10 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
                 ),
                 min_age: rng.random_range(Duration::from_millis(20)..Duration::from_secs(900)),
             }),
-            detach_options: Some(GarbageCollectorDirectoryOptions {
+            detach_options: Some(GarbageCollectorScheduleOptions {
                 interval: Some(
                     rng.random_range(Duration::from_millis(1)..Duration::from_secs(600)),
                 ),
-                min_age: rng.random_range(Duration::from_millis(20)..Duration::from_secs(900)),
             }),
         }),
         compactor_options: None,

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -161,6 +161,12 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
                 ),
                 min_age: rng.random_range(Duration::from_millis(20)..Duration::from_secs(900)),
             }),
+            detach_options: Some(GarbageCollectorDirectoryOptions {
+                interval: Some(
+                    rng.random_range(Duration::from_millis(1)..Duration::from_secs(600)),
+                ),
+                min_age: rng.random_range(Duration::from_millis(20)..Duration::from_secs(900)),
+            }),
         }),
         compactor_options: None,
         wal_enabled: rng.random_bool(0.5),

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1188,8 +1188,8 @@ pub struct GarbageCollectorOptions {
     /// manifest or any live checkpoint), the detach pass removes the pinning
     /// checkpoint from the parent and drops the external DB entry from the clone.
     ///
-    /// None means detach is disabled. `min_age` is currently ignored.
-    pub detach_options: Option<GarbageCollectorDirectoryOptions>,
+    /// None means detach is disabled.
+    pub detach_options: Option<GarbageCollectorScheduleOptions>,
 }
 
 impl GarbageCollectorOptions {
@@ -1234,6 +1234,27 @@ pub struct GarbageCollectorDirectoryOptions {
     pub min_age: Duration,
 }
 
+/// Schedule options for a GC task that has no file-age threshold.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct GarbageCollectorScheduleOptions {
+    /// The interval at which the task will run in the background thread.
+    ///
+    /// If set to None, recurring execution is disabled, but a one-time pass
+    /// can still be triggered via
+    /// [`crate::garbage_collector::GarbageCollector::run_gc_once`].
+    #[serde(deserialize_with = "deserialize_option_duration")]
+    #[serde(serialize_with = "serialize_option_duration")]
+    pub interval: Option<Duration>,
+}
+
+impl Default for GarbageCollectorScheduleOptions {
+    fn default() -> Self {
+        Self {
+            interval: Some(DEFAULT_INTERVAL),
+        }
+    }
+}
+
 /// Default options for the garbage collector.
 ///
 /// By default, garbage collection is enabled for all managed directories
@@ -1249,7 +1270,7 @@ impl Default for GarbageCollectorOptions {
             wal_options: Some(GarbageCollectorDirectoryOptions::default()),
             compacted_options: Some(GarbageCollectorDirectoryOptions::default()),
             compactions_options: Some(GarbageCollectorDirectoryOptions::default()),
-            detach_options: Some(GarbageCollectorDirectoryOptions::default()),
+            detach_options: Some(GarbageCollectorScheduleOptions::default()),
         }
     }
 }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1181,6 +1181,15 @@ pub struct GarbageCollectorOptions {
     ///
     /// None means garbage collection is disabled for the compactions directory.
     pub compactions_options: Option<GarbageCollectorDirectoryOptions>,
+
+    /// Garbage collection options for detaching a clone from its parent database(s).
+    ///
+    /// When a clone no longer references any of a parent's SSTs (in its current
+    /// manifest or any live checkpoint), the detach pass removes the pinning
+    /// checkpoint from the parent and drops the external DB entry from the clone.
+    ///
+    /// None means detach is disabled. `min_age` is currently ignored.
+    pub detach_options: Option<GarbageCollectorDirectoryOptions>,
 }
 
 impl GarbageCollectorOptions {
@@ -1189,6 +1198,7 @@ impl GarbageCollectorOptions {
             && self.wal_options.is_none()
             && self.compacted_options.is_none()
             && self.compactions_options.is_none()
+            && self.detach_options.is_none()
     }
 }
 
@@ -1239,6 +1249,7 @@ impl Default for GarbageCollectorOptions {
             wal_options: Some(GarbageCollectorDirectoryOptions::default()),
             compacted_options: Some(GarbageCollectorDirectoryOptions::default()),
             compactions_options: Some(GarbageCollectorDirectoryOptions::default()),
+            detach_options: Some(GarbageCollectorDirectoryOptions::default()),
         }
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6316,6 +6316,7 @@ mod tests {
                 interval: None,
                 min_age: Duration::from_millis(0),
             }),
+            detach_options: None,
         };
 
         let gc = GarbageCollectorBuilder::new(path.clone(), object_store.clone())

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -630,6 +630,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                     uncached_table_store.clone(),
                     manifest_store.clone(),
                     compactions_store.clone(),
+                    retrying_main_object_store.clone(),
                 );
             // Garbage collector only uses tickers, so pass in a dummy rx channel
             let (_, rx) = async_channel::unbounded();
@@ -825,11 +826,13 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
         table_store: Arc<TableStore>,
         manifest_store: Arc<ManifestStore>,
         compactions_store: Arc<CompactionsStore>,
+        object_store: Arc<dyn ObjectStore>,
     ) -> GarbageCollector {
         GarbageCollector::new(
             manifest_store,
             compactions_store,
             table_store,
+            object_store,
             self.options,
             &self.recorder,
             self.system_clock,
@@ -867,7 +870,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
         ));
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(
-                retrying_main_object_store,
+                retrying_main_object_store.clone(),
                 retrying_wal_object_store.clone(),
             ),
             SsTableFormat::default(), // read only SSTs can use default
@@ -878,6 +881,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             manifest_store,
             compactions_store,
             table_store,
+            retrying_main_object_store,
             self.options,
             &self.recorder,
             self.system_clock,

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -26,9 +26,11 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use compacted_gc::CompactedGcTask;
 use compactions_gc::CompactionsGcTask;
+use detach_gc::DetachGcTask;
 use futures::stream::BoxStream;
 use log::{error, info};
 use manifest_gc::ManifestGcTask;
+use object_store::ObjectStore;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorderHelper;
 use slatedb_txn_obj::{DirtyObject, SimpleTransactionalObject, TransactionalObject};
@@ -39,6 +41,7 @@ use wal_gc::WalGcTask;
 
 mod compacted_gc;
 mod compactions_gc;
+mod detach_gc;
 mod manifest_gc;
 pub mod stats;
 mod wal_gc;
@@ -58,6 +61,7 @@ pub(crate) enum GcMessage {
     Compacted,
     Compactions,
     Manifest,
+    Detach,
 }
 
 /// SlateDB's garbage collector.
@@ -85,6 +89,7 @@ pub struct GarbageCollector {
     wal_gc_task: Option<WalGcTask>,
     compacted_gc_task: Option<CompactedGcTask>,
     compactions_gc_task: Option<CompactionsGcTask>,
+    detach_gc_task: Option<DetachGcTask>,
 }
 
 #[async_trait]
@@ -114,6 +119,12 @@ impl MessageHandler<GcMessage> for GarbageCollector {
             tickers.push((
                 opts.interval.unwrap_or(DEFAULT_INTERVAL),
                 Box::new(|| GcMessage::Compactions),
+            ));
+        }
+        if let Some(opts) = self.options.detach_options {
+            tickers.push((
+                opts.interval.unwrap_or(DEFAULT_INTERVAL),
+                Box::new(|| GcMessage::Detach),
             ));
         }
 
@@ -150,6 +161,13 @@ impl MessageHandler<GcMessage> for GarbageCollector {
                     .expect("got compactions tick with unconfigured compactions task");
                 self.run_gc_task(task).await;
             }
+            GcMessage::Detach => {
+                let task = self
+                    .detach_gc_task
+                    .as_ref()
+                    .expect("got detach tick with unconfigured detach task");
+                self.run_gc_task(task).await;
+            }
         }
         Ok(())
     }
@@ -183,6 +201,7 @@ impl GarbageCollector {
         manifest_store: Arc<ManifestStore>,
         compactions_store: Arc<CompactionsStore>,
         table_store: Arc<TableStore>,
+        object_store: Arc<dyn ObjectStore>,
         options: GarbageCollectorOptions,
         recorder: &MetricsRecorderHelper,
         system_clock: Arc<dyn SystemClock>,
@@ -215,6 +234,15 @@ impl GarbageCollector {
         let manifest_gc_task = options.manifest_options.map(|manifest_options| {
             ManifestGcTask::new(manifest_store.clone(), stats.clone(), manifest_options)
         });
+        let detach_gc_task = options.detach_options.map(|detach_options| {
+            DetachGcTask::new(
+                manifest_store.clone(),
+                object_store,
+                system_clock.clone(),
+                stats.clone(),
+                detach_options,
+            )
+        });
         Self {
             manifest_store,
             options,
@@ -224,6 +252,7 @@ impl GarbageCollector {
             wal_gc_task,
             compacted_gc_task,
             compactions_gc_task,
+            detach_gc_task,
         }
     }
 
@@ -234,6 +263,7 @@ impl GarbageCollector {
     /// - WAL SST garbage collection
     /// - Compacted SST garbage collection
     /// - Manifest garbage collection
+    /// - Detach clone from parent garbage
     pub async fn run_gc_once(&self) {
         if let Some(task) = &self.manifest_gc_task {
             self.run_gc_task(task).await;
@@ -245,6 +275,9 @@ impl GarbageCollector {
             self.run_gc_task(task).await;
         }
         if let Some(task) = &self.compactions_gc_task {
+            self.run_gc_task(task).await;
+        }
+        if let Some(task) = &self.detach_gc_task {
             self.run_gc_task(task).await;
         }
 
@@ -1388,12 +1421,14 @@ mod tests {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
             }),
+            detach_options: None,
         };
 
         let gc = GarbageCollector::new(
             manifest_store.clone(),
             compactions_store.clone(),
             table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
             gc_opts,
             recorder,
             Arc::new(DefaultSystemClock::default()),
@@ -1454,12 +1489,14 @@ mod tests {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
             }),
+            detach_options: None,
         };
 
         let mut gc = GarbageCollector::new(
             manifest_store.clone(),
             compactions_store.clone(),
             table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
@@ -1516,12 +1553,14 @@ mod tests {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
             }),
+            detach_options: None,
         };
 
         let gc = GarbageCollector::new(
             manifest_store.clone(),
             compactions_store.clone(),
             table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
@@ -1554,12 +1593,14 @@ mod tests {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(17)),
             }),
+            detach_options: None,
         };
 
         let mut gc = GarbageCollector::new(
             manifest_store,
             compactions_store,
             table_store,
+            Arc::new(object_store::memory::InMemory::new()),
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
@@ -1598,12 +1639,14 @@ mod tests {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),
             }),
+            detach_options: None,
         };
 
         let gc = GarbageCollector::new(
             manifest_store.clone(),
             compactions_store.clone(),
             table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),

--- a/slatedb/src/garbage_collector/detach_gc.rs
+++ b/slatedb/src/garbage_collector/detach_gc.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::GarbageCollectorDirectoryOptions,
+    config::GarbageCollectorScheduleOptions,
     error::SlateDBError,
     manifest::{
         store::{ManifestStore, StoredManifest},
@@ -43,7 +43,7 @@ pub(crate) struct DetachGcTask {
     object_store: Arc<dyn ObjectStore>,
     system_clock: Arc<dyn SystemClock>,
     stats: Arc<GcStats>,
-    detach_options: GarbageCollectorDirectoryOptions,
+    detach_options: GarbageCollectorScheduleOptions,
 }
 
 impl std::fmt::Debug for DetachGcTask {
@@ -60,7 +60,7 @@ impl DetachGcTask {
         object_store: Arc<dyn ObjectStore>,
         system_clock: Arc<dyn SystemClock>,
         stats: Arc<GcStats>,
-        detach_options: GarbageCollectorDirectoryOptions,
+        detach_options: GarbageCollectorScheduleOptions,
     ) -> Self {
         Self {
             manifest_store,
@@ -301,10 +301,7 @@ mod tests {
             object_store,
             clock(),
             new_stats(),
-            GarbageCollectorDirectoryOptions {
-                interval: None,
-                min_age: std::time::Duration::from_secs(0),
-            },
+            GarbageCollectorScheduleOptions { interval: None },
         )
     }
 

--- a/slatedb/src/garbage_collector/detach_gc.rs
+++ b/slatedb/src/garbage_collector/detach_gc.rs
@@ -1,0 +1,464 @@
+use crate::{
+    config::GarbageCollectorDirectoryOptions,
+    error::SlateDBError,
+    manifest::{
+        store::{ManifestStore, StoredManifest},
+        ExternalDb, Manifest,
+    },
+};
+use chrono::{DateTime, Utc};
+use log::{error, info};
+use object_store::ObjectStore;
+use slatedb_common::clock::SystemClock;
+use slatedb_txn_obj::TransactionalObject;
+use std::collections::HashSet;
+use std::sync::Arc;
+use uuid::Uuid;
+
+use super::{GcStats, GcTask};
+
+/// Detaches a clone from its parent database(s) once the clone no longer references
+/// any of the parent's SSTs.
+///
+/// A clone references its parent via an entry in `manifest.external_dbs`. The entry
+/// holds a list of parent SST ids the clone may read (`sst_ids`) and a
+/// `final_checkpoint_id` that pins a checkpoint in the parent's manifest so the
+/// parent's GC does not collect those SSTs.
+///
+/// Compaction on the clone shrinks `sst_ids` as parent SSTs are rewritten into
+/// clone-owned SSTs (see `Manifest::prune_external_sst_ids`). Once `sst_ids` is
+/// empty in the current manifest AND in every manifest version referenced by a live
+/// checkpoint, the clone no longer needs the parent — and this task detaches it:
+///
+/// 1. Delete the pinning `final_checkpoint_id` on the parent (idempotent).
+/// 2. Remove the `ExternalDb` entry from the clone's manifest.
+///
+/// Parent-first order is chosen deliberately: a crash between the two leaves the
+/// clone with a stale `ExternalDb` whose `sst_ids` is empty and whose
+/// `final_checkpoint_id` points to a missing checkpoint — the next tick retries
+/// step 1 as a no-op and completes step 2. The reverse order would leak the
+/// parent's checkpoint forever on a crash.
+pub(crate) struct DetachGcTask {
+    manifest_store: Arc<ManifestStore>,
+    object_store: Arc<dyn ObjectStore>,
+    system_clock: Arc<dyn SystemClock>,
+    stats: Arc<GcStats>,
+    detach_options: GarbageCollectorDirectoryOptions,
+}
+
+impl std::fmt::Debug for DetachGcTask {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DetachGcTask")
+            .field("detach_options", &self.detach_options)
+            .finish()
+    }
+}
+
+impl DetachGcTask {
+    pub(super) fn new(
+        manifest_store: Arc<ManifestStore>,
+        object_store: Arc<dyn ObjectStore>,
+        system_clock: Arc<dyn SystemClock>,
+        stats: Arc<GcStats>,
+        detach_options: GarbageCollectorDirectoryOptions,
+    ) -> Self {
+        Self {
+            manifest_store,
+            object_store,
+            system_clock,
+            stats,
+            detach_options,
+        }
+    }
+
+    async fn find_detachable(
+        &self,
+        manifest_id: u64,
+        manifest: &Manifest,
+    ) -> Result<Vec<ExternalDb>, SlateDBError> {
+        if manifest.external_dbs.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let candidates: Vec<&ExternalDb> = manifest
+            .external_dbs
+            .iter()
+            .filter(|e| e.sst_ids.is_empty() && e.final_checkpoint_id.is_some())
+            .collect();
+
+        if candidates.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let referenced = self
+            .manifest_store
+            .read_referenced_manifests(manifest_id, manifest)
+            .await?;
+
+        let detachable: Vec<ExternalDb> = candidates
+            .into_iter()
+            .filter(|candidate| {
+                let final_id = candidate
+                    .final_checkpoint_id
+                    .expect("candidates must have final_checkpoint_id");
+                referenced.values().all(|other_manifest| {
+                    other_manifest.external_dbs.iter().all(|other| {
+                        other.final_checkpoint_id != Some(final_id) || other.sst_ids.is_empty()
+                    })
+                })
+            })
+            .cloned()
+            .collect();
+
+        Ok(detachable)
+    }
+
+    async fn detach_from_parent(&self, external_db: &ExternalDb) -> Result<(), SlateDBError> {
+        let final_id = external_db
+            .final_checkpoint_id
+            .expect("detachable entries must have final_checkpoint_id");
+
+        let parent_store = Arc::new(ManifestStore::new(
+            &external_db.path.clone().into(),
+            self.object_store.clone(),
+        ));
+        let mut parent_manifest =
+            StoredManifest::load(parent_store, self.system_clock.clone()).await?;
+        parent_manifest.delete_checkpoint(final_id).await
+    }
+}
+
+impl GcTask for DetachGcTask {
+    async fn collect(&self, _utc_now: DateTime<Utc>) -> Result<(), SlateDBError> {
+        let mut stored_manifest =
+            StoredManifest::load(self.manifest_store.clone(), self.system_clock.clone()).await?;
+        let manifest_id = stored_manifest.id();
+        let manifest_snapshot = stored_manifest.manifest().clone();
+
+        let detachable = self
+            .find_detachable(manifest_id, &manifest_snapshot)
+            .await?;
+        if detachable.is_empty() {
+            return Ok(());
+        }
+
+        let mut detached_final_ids: HashSet<Uuid> = HashSet::new();
+        for external_db in &detachable {
+            match self.detach_from_parent(external_db).await {
+                Ok(()) => {
+                    let final_id = external_db
+                        .final_checkpoint_id
+                        .expect("detachable entries must have final_checkpoint_id");
+                    detached_final_ids.insert(final_id);
+                    info!(
+                        "detached clone from parent [parent_path={}, final_checkpoint_id={}]",
+                        external_db.path, final_id
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "failed to delete pinning checkpoint on parent [parent_path={}, error={}]",
+                        external_db.path, e
+                    );
+                }
+            }
+        }
+
+        if detached_final_ids.is_empty() {
+            return Ok(());
+        }
+
+        let detached_count = detached_final_ids.len() as u64;
+
+        stored_manifest
+            .maybe_apply_update(|sr| {
+                let current = sr.object();
+                let retained: Vec<ExternalDb> = current
+                    .external_dbs
+                    .iter()
+                    .filter(|e| {
+                        e.final_checkpoint_id
+                            .map(|id| !detached_final_ids.contains(&id))
+                            .unwrap_or(true)
+                    })
+                    .cloned()
+                    .collect();
+                if retained.len() == current.external_dbs.len() {
+                    Ok(None)
+                } else {
+                    let mut dirty = sr.prepare_dirty()?;
+                    dirty.value.external_dbs = retained;
+                    Ok(Some(dirty))
+                }
+            })
+            .await?;
+
+        for _ in 0..detached_count {
+            self.stats.gc_detach_count.increment(1);
+        }
+
+        Ok(())
+    }
+
+    fn resource(&self) -> &str {
+        "Clone detach"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::CheckpointOptions;
+    use crate::db_state::SsTableId;
+    use crate::manifest::ManifestCore;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use slatedb_common::clock::DefaultSystemClock;
+    use slatedb_txn_obj::TransactionalObject;
+    use ulid::Ulid;
+
+    const PARENT_PATH: &str = "/parent";
+    const CLONE_PATH: &str = "/clone";
+
+    /// Materialize a test setup: shared object store with an initialized parent and an
+    /// initialized clone manifest. Returns (object_store, parent_store, clone_store).
+    async fn build_setup() -> (Arc<dyn ObjectStore>, Arc<ManifestStore>, Arc<ManifestStore>) {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_store = Arc::new(ManifestStore::new(
+            &Path::from(PARENT_PATH),
+            object_store.clone(),
+        ));
+        let clone_store = Arc::new(ManifestStore::new(
+            &Path::from(CLONE_PATH),
+            object_store.clone(),
+        ));
+        let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+        StoredManifest::create_new_db(parent_store.clone(), ManifestCore::new(), clock.clone())
+            .await
+            .unwrap();
+        StoredManifest::create_new_db(clone_store.clone(), ManifestCore::new(), clock.clone())
+            .await
+            .unwrap();
+        (object_store, parent_store, clone_store)
+    }
+
+    fn clock() -> Arc<dyn SystemClock> {
+        Arc::new(DefaultSystemClock::new())
+    }
+
+    fn new_stats() -> Arc<GcStats> {
+        let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+        Arc::new(GcStats::new(&recorder))
+    }
+
+    /// Seed the parent with a checkpoint pinning `final_checkpoint_id`; add a matching
+    /// ExternalDb entry to the clone's manifest with the provided sst_ids.
+    async fn attach_clone_to_parent(
+        parent_store: &Arc<ManifestStore>,
+        clone_store: &Arc<ManifestStore>,
+        final_checkpoint_id: Uuid,
+        sst_ids: Vec<SsTableId>,
+    ) {
+        let mut parent = StoredManifest::load(parent_store.clone(), clock())
+            .await
+            .unwrap();
+        parent
+            .write_checkpoint(
+                final_checkpoint_id,
+                &CheckpointOptions {
+                    lifetime: None,
+                    source: None,
+                    name: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let mut clone = StoredManifest::load(clone_store.clone(), clock())
+            .await
+            .unwrap();
+        clone
+            .maybe_apply_update(|sr| {
+                let mut dirty = sr.prepare_dirty()?;
+                dirty.value.external_dbs.push(ExternalDb {
+                    path: PARENT_PATH.to_string(),
+                    source_checkpoint_id: Uuid::new_v4(),
+                    final_checkpoint_id: Some(final_checkpoint_id),
+                    sst_ids: sst_ids.clone(),
+                });
+                Ok(Some(dirty))
+            })
+            .await
+            .unwrap();
+    }
+
+    fn make_task(
+        clone_store: Arc<ManifestStore>,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> DetachGcTask {
+        DetachGcTask::new(
+            clone_store,
+            object_store,
+            clock(),
+            new_stats(),
+            GarbageCollectorDirectoryOptions {
+                interval: None,
+                min_age: std::time::Duration::from_secs(0),
+            },
+        )
+    }
+
+    async fn parent_has_checkpoint(parent_store: &Arc<ManifestStore>, id: Uuid) -> bool {
+        let parent = StoredManifest::load(parent_store.clone(), clock())
+            .await
+            .unwrap();
+        parent.db_state().find_checkpoint(id).is_some()
+    }
+
+    async fn clone_external_dbs_len(clone_store: &Arc<ManifestStore>) -> usize {
+        let clone = StoredManifest::load(clone_store.clone(), clock())
+            .await
+            .unwrap();
+        clone.manifest().external_dbs.len()
+    }
+
+    #[tokio::test]
+    async fn test_detaches_entry_with_empty_sst_ids() {
+        let (object_store, parent_store, clone_store) = build_setup().await;
+        let final_id = Uuid::new_v4();
+        attach_clone_to_parent(&parent_store, &clone_store, final_id, vec![]).await;
+        assert!(parent_has_checkpoint(&parent_store, final_id).await);
+        assert_eq!(clone_external_dbs_len(&clone_store).await, 1);
+
+        let task = make_task(clone_store.clone(), object_store);
+        task.collect(Utc::now()).await.unwrap();
+
+        assert!(
+            !parent_has_checkpoint(&parent_store, final_id).await,
+            "parent checkpoint should be deleted"
+        );
+        assert_eq!(
+            clone_external_dbs_len(&clone_store).await,
+            0,
+            "clone external_dbs entry should be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skips_entry_with_non_empty_sst_ids() {
+        let (object_store, parent_store, clone_store) = build_setup().await;
+        let final_id = Uuid::new_v4();
+        let live_sst = SsTableId::Compacted(Ulid::new());
+        attach_clone_to_parent(&parent_store, &clone_store, final_id, vec![live_sst]).await;
+
+        let task = make_task(clone_store.clone(), object_store);
+        task.collect(Utc::now()).await.unwrap();
+
+        assert!(
+            parent_has_checkpoint(&parent_store, final_id).await,
+            "parent checkpoint must be retained while clone still references it"
+        );
+        assert_eq!(
+            clone_external_dbs_len(&clone_store).await,
+            1,
+            "clone external_dbs entry must be retained"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skips_entry_held_by_clone_checkpoint() {
+        // The clone had a non-empty sst_ids at a prior manifest version, then compaction
+        // emptied it. A live checkpoint on the clone still references the older manifest
+        // version where sst_ids was non-empty — detach must NOT fire.
+        let (object_store, parent_store, clone_store) = build_setup().await;
+        let final_id = Uuid::new_v4();
+        let live_sst = SsTableId::Compacted(Ulid::new());
+        attach_clone_to_parent(&parent_store, &clone_store, final_id, vec![live_sst]).await;
+
+        // Pin this manifest version (with non-empty sst_ids) via a clone-side checkpoint.
+        let mut clone = StoredManifest::load(clone_store.clone(), clock())
+            .await
+            .unwrap();
+        clone
+            .write_checkpoint(
+                Uuid::new_v4(),
+                &CheckpointOptions {
+                    lifetime: None,
+                    source: None,
+                    name: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Now empty sst_ids in the current manifest.
+        let mut clone = StoredManifest::load(clone_store.clone(), clock())
+            .await
+            .unwrap();
+        clone
+            .maybe_apply_update(|sr| {
+                let mut dirty = sr.prepare_dirty()?;
+                for entry in dirty.value.external_dbs.iter_mut() {
+                    entry.sst_ids.clear();
+                }
+                Ok(Some(dirty))
+            })
+            .await
+            .unwrap();
+
+        let task = make_task(clone_store.clone(), object_store);
+        task.collect(Utc::now()).await.unwrap();
+
+        assert!(
+            parent_has_checkpoint(&parent_store, final_id).await,
+            "parent checkpoint must remain while a clone-side checkpoint still holds non-empty sst_ids"
+        );
+        assert_eq!(clone_external_dbs_len(&clone_store).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_idempotent_when_parent_checkpoint_already_gone() {
+        let (object_store, parent_store, clone_store) = build_setup().await;
+        let final_id = Uuid::new_v4();
+        attach_clone_to_parent(&parent_store, &clone_store, final_id, vec![]).await;
+
+        // Simulate a prior partial detach: parent's checkpoint is already deleted.
+        let mut parent = StoredManifest::load(parent_store.clone(), clock())
+            .await
+            .unwrap();
+        parent.delete_checkpoint(final_id).await.unwrap();
+        assert!(!parent_has_checkpoint(&parent_store, final_id).await);
+
+        let task = make_task(clone_store.clone(), object_store);
+        task.collect(Utc::now()).await.unwrap();
+
+        assert_eq!(
+            clone_external_dbs_len(&clone_store).await,
+            0,
+            "clone-side removal must still complete even though parent checkpoint was already gone"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_detaches_only_matching_entry_among_many() {
+        let (object_store, parent_store, clone_store) = build_setup().await;
+        let detachable_id = Uuid::new_v4();
+        let retained_id = Uuid::new_v4();
+        let live_sst = SsTableId::Compacted(Ulid::new());
+        attach_clone_to_parent(&parent_store, &clone_store, detachable_id, vec![]).await;
+        attach_clone_to_parent(&parent_store, &clone_store, retained_id, vec![live_sst]).await;
+        assert_eq!(clone_external_dbs_len(&clone_store).await, 2);
+
+        let task = make_task(clone_store.clone(), object_store);
+        task.collect(Utc::now()).await.unwrap();
+
+        assert!(!parent_has_checkpoint(&parent_store, detachable_id).await);
+        assert!(parent_has_checkpoint(&parent_store, retained_id).await);
+        let clone = StoredManifest::load(clone_store.clone(), clock())
+            .await
+            .unwrap();
+        let external_dbs = &clone.manifest().external_dbs;
+        assert_eq!(external_dbs.len(), 1);
+        assert_eq!(external_dbs[0].final_checkpoint_id, Some(retained_id));
+    }
+}

--- a/slatedb/src/garbage_collector/stats.rs
+++ b/slatedb/src/garbage_collector/stats.rs
@@ -16,6 +16,7 @@ pub struct GcStats {
     pub gc_wal_count: Arc<dyn CounterFn>,
     pub gc_compacted_count: Arc<dyn CounterFn>,
     pub gc_compactions_count: Arc<dyn CounterFn>,
+    pub gc_detach_count: Arc<dyn CounterFn>,
     pub gc_count: Arc<dyn CounterFn>,
 }
 
@@ -37,6 +38,10 @@ impl GcStats {
             gc_compactions_count: recorder
                 .counter(DELETED_COUNT)
                 .labels(&[("resource", "compactions")])
+                .register(),
+            gc_detach_count: recorder
+                .counter(DELETED_COUNT)
+                .labels(&[("resource", "detach")])
                 .register(),
             gc_count: recorder.counter(GC_COUNT).register(),
         }


### PR DESCRIPTION
## Summary

Implement https://github.com/slatedb/slatedb/issues/314, follow up on https://github.com/slatedb/slatedb/pull/1574

## Changes

`DetachGcTask`:
```
slatedb/src/garbage_collector/detach_gc.rs — DetachGcTask implementing the GcTask trait. collect():
- Loads the clone's current manifest + all live-checkpoint-captured manifest versions via read_referenced_manifests.
- Finds ExternalDb entries whose sst_ids is empty in the current manifest AND in every captured manifest version (matched by final_checkpoint_id).
- Parent-first, for each detachable entry: opens the parent's ManifestStore at ExternalDb.path, calls StoredManifest::delete_checkpoint (idempotent — tolerates missing).
- Records which parent-side deletes succeeded, then via maybe_apply_update on the clone's manifest filters out those ExternalDb entries.
```

Wiring:
```
- garbage_collector.rs — added GcMessage::Detach, DetachGcTask field, ticker registration, handle() dispatch, and inclusion in run_gc_once. Threaded Arc<dyn ObjectStore> through GarbageCollector::new.
- db/builder.rs — added object_store parameter to build_collector; both build() paths now pass retrying_main_object_store.
- config.rs — added detach_options: Option<GarbageCollectorDirectoryOptions> to GarbageCollectorOptions (default: on).
- garbage_collector/stats.rs — added gc_detach_count counter.
- All existing call sites (tests in garbage_collector.rs, db.rs, slatedb-cli, slatedb-dst) updated.
```

Tests:
```
- test_detaches_entry_with_empty_sst_ids — golden path: empty sst_ids, no holding checkpoint → entry removed on clone, checkpoint removed on parent.
- test_skips_entry_with_non_empty_sst_ids — entry retained.
- test_skips_entry_held_by_clone_checkpoint — sst_ids empty in current but non-empty in a checkpointed manifest version → not detached.
- test_idempotent_when_parent_checkpoint_already_gone — simulates crash-between-steps; re-run completes clone-side removal.
- test_detaches_only_matching_entry_among_many — mixed entries, only the detachable one removed.
```

## Notes for Reviewers

1. Related: #1574
2. Race conditions (GC detaches parent while Writer adds a checkpoint that references that parent using a GCed source checkpoint) - should be prevented by CAS when Writer tries to write the manifest
3. In case of a crash, GC is retried and can find final_checkpoint missing - it should continue with removing external_db entry
4. Public API changed: new GC options (`detach_options`).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
