### PR TITLE
Reject merge/merge_with_options when no merge op is confiured

### DIFF
--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -166,10 +166,7 @@ impl WriteBatch {
 
         // Remove them
         for k in keys_to_remove {
-            match self.ops.remove(&k) {
-                Some(WriteOp::Merge(..)) => self.merge_op_count -= 1,
-                _ => {}
-            }
+            if let Some(WriteOp::Merge(..)) = self.ops.remove(&k) { self.merge_op_count -= 1 }
         }
     }
 

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -56,6 +56,7 @@ pub struct WriteBatch {
     /// batch (unrelated to the sequence number of the batch, which is assigned
     /// atomically by the oracle when the batch is committed).
     pub(crate) write_idx: u64,
+    pub(crate) merge_op_count: usize,
 }
 
 impl Default for WriteBatch {
@@ -146,6 +147,7 @@ impl WriteBatch {
             ops: BTreeMap::new(),
             txn_id: None,
             write_idx: 0,
+            merge_op_count: 0,
         }
     }
 
@@ -164,7 +166,10 @@ impl WriteBatch {
 
         // Remove them
         for k in keys_to_remove {
-            self.ops.remove(&k);
+            match self.ops.remove(&k) {
+                Some(WriteOp::Merge(..)) => self.merge_op_count -= 1,
+                _ => {}
+            }
         }
     }
 
@@ -173,6 +178,7 @@ impl WriteBatch {
             ops: self.ops,
             txn_id: Some(txn_id),
             write_idx: self.write_idx,
+            merge_op_count: self.merge_op_count,
         }
     }
 
@@ -286,6 +292,7 @@ impl WriteBatch {
             WriteOp::Merge(key, Bytes::copy_from_slice(value.as_ref()), options.clone()),
         );
 
+        self.merge_op_count += 1;
         self.write_idx += 1;
     }
 
@@ -308,6 +315,10 @@ impl WriteBatch {
 
     pub fn is_empty(&self) -> bool {
         self.ops.is_empty()
+    }
+
+    pub(crate) fn has_merge_ops(&self) -> bool {
+        self.merge_op_count > 0
     }
 
     pub(crate) fn keys(&self) -> HashSet<Bytes> {
@@ -882,6 +893,44 @@ mod tests {
         assert!(batch
             .ops
             .contains_key(&SequencedKey::new(Bytes::from_static(b"key3"), 2)));
+    }
+
+    #[test]
+    fn should_track_merge_presence() {
+        let mut batch = WriteBatch::new();
+        assert!(!batch.has_merge_ops());
+
+        batch.merge(b"key1", b"value1");
+
+        assert!(batch.has_merge_ops());
+        assert_eq!(batch.merge_op_count, 1);
+    }
+
+    #[test]
+    fn should_clear_merge_presence_when_put_overwrites_merge_ops() {
+        let mut batch = WriteBatch::new();
+        batch.merge(b"key1", b"value1");
+        batch.merge(b"key1", b"value2");
+        assert!(batch.has_merge_ops());
+
+        batch.put(b"key1", b"final");
+
+        assert!(!batch.has_merge_ops());
+        assert_eq!(batch.merge_op_count, 0);
+    }
+
+    #[test]
+    fn should_preserve_merge_presence_when_removing_only_one_keys_merges() {
+        let mut batch = WriteBatch::new();
+        batch.merge(b"key1", b"value1");
+        batch.merge(b"key2", b"value2");
+        assert!(batch.has_merge_ops());
+        assert_eq!(batch.merge_op_count, 2);
+
+        batch.delete(b"key1");
+
+        assert!(batch.has_merge_ops());
+        assert_eq!(batch.merge_op_count, 1);
     }
 
     #[test]

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -166,7 +166,9 @@ impl WriteBatch {
 
         // Remove them
         for k in keys_to_remove {
-            if let Some(WriteOp::Merge(..)) = self.ops.remove(&k) { self.merge_op_count -= 1 }
+            if let Some(WriteOp::Merge(..)) = self.ops.remove(&k) {
+                self.merge_op_count -= 1
+            }
         }
     }
 

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -334,6 +334,10 @@ impl WriteBatch {
         default_ttl: Option<u64>,
         merger: Option<MergeOperatorType>,
     ) -> Result<Vec<RowEntry>, SlateDBError> {
+        if merger.is_none() && self.has_merge_ops() {
+            return Err(SlateDBError::MergeOperatorMissing);
+        }
+
         let mut it: Box<dyn RowEntryIterator> = Box::new(WriteBatchIterator::new_with_seq_and_ttl(
             self,
             ..,
@@ -1287,6 +1291,19 @@ mod tests {
         );
         assert_eq!(entries[2].key, Bytes::from_static(b"key3"));
         assert_eq!(entries[2].value, ValueDeletable::Tombstone);
+    }
+
+    #[tokio::test]
+    async fn should_error_extracting_entries_with_merges_without_merge_operator() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"key1", b"value1");
+        batch.merge(b"key2", b"merge1");
+
+        let err = batch
+            .extract_entries(100, 1000, None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, SlateDBError::MergeOperatorMissing));
     }
 
     #[tokio::test]

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -555,10 +555,11 @@ mod tests {
     use proptest::prelude::Just;
     use proptest::strategy::Strategy;
     use proptest::test_runner::Config;
-    use proptest::{prop_oneof, proptest};
+    use proptest::{prop_assume, prop_oneof, proptest};
     use rstest::rstest;
     use slatedb_common::clock::DefaultSystemClock;
     use std::cmp::Ordering;
+    use std::collections::HashSet;
     use std::time::Duration;
 
     async fn write_sst(
@@ -595,6 +596,18 @@ mod tests {
 
         output_ssts.push(writer.close().await.unwrap());
         output_ssts
+    }
+
+    fn has_duplicate_key_seq_specs(
+        l0_specs: &[Vec<(Bytes, u64, ValueDeletable)>],
+        sr_specs: &[Vec<(Bytes, u64, ValueDeletable)>],
+    ) -> bool {
+        let mut seen = HashSet::new();
+        l0_specs
+            .iter()
+            .chain(sr_specs.iter())
+            .flatten()
+            .any(|(key, seq, _value)| !seen.insert((key.clone(), *seq)))
     }
 
     #[rstest]
@@ -1145,6 +1158,7 @@ mod tests {
                 RESUME_POINTS_MIN..=RESUME_POINTS_MAX,
             ),
         )| {
+            prop_assume!(!has_duplicate_key_seq_specs(&l0_specs, &sr_specs));
             let runtime = tokio::runtime::Runtime::new().unwrap();
             runtime.block_on(async {
                 let l0_entry_sets = l0_specs

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6200,6 +6200,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_error_when_writing_batch_with_merge_without_merge_operator() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder("/tmp/test_merge_4_batch_write_fails", object_store.clone())
+            .with_settings(test_db_options(0, 1024, None))
+            .build()
+            .await
+            .unwrap();
+
+        let mut batch = WriteBatch::new();
+        batch.put(b"key1", b"value1");
+        batch.merge(b"key2", b"value2");
+
+        let err = db.write(batch).await.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+
+        assert_eq!(db.get(b"key1").await.unwrap(), None);
+        assert_eq!(db.get(b"key2").await.unwrap(), None);
+    }
+
+    #[tokio::test]
     async fn should_merge_operands_after_reopen() {
         // Given: Database with merge operator, merge operands written
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1304,9 +1304,13 @@ impl Db {
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
-        let mut batch = WriteBatch::new();
-        batch.merge(key, value);
-        self.write(batch).await
+        self.merge_with_options(
+            key,
+            value,
+            &MergeOptions::default(),
+            &WriteOptions::default(),
+        )
+        .await
     }
 
     /// Merge a value into the database with custom `MergeOptions` and `WriteOptions`.
@@ -1369,6 +1373,10 @@ impl Db {
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
+        if self.inner.flush_merge_operator.is_none() {
+            return Err(SlateDBError::MergeOperatorMissing.into());
+        }
+
         let mut batch = WriteBatch::new();
         batch.merge_with_options(key, value, merge_opts);
         self.write_with_options(batch, write_opts).await
@@ -6157,22 +6165,23 @@ mod tests {
             .await
             .unwrap();
 
-        // When: Attempting to merge and then reading
-        // Note: Merge writes succeed, but reads will fail to merge operands
-        db.merge(b"key1", b"value1").await.unwrap();
+        // When: Attempting to merge without a configured merge operator
+        let result = db
+            .merge_with_options(
+                b"key1",
+                b"value1",
+                &MergeOptions::default(),
+                &WriteOptions::default(),
+            )
+            .await;
 
-        // Then: Reading should fail because merge operator is required at read time
-        // The merge operand is stored but can't be merged without an operator
-        let result = db.get(b"key1").await;
-
-        // Verify that reading fails with MergeOperatorMissing error
+        // Then: The write should fail immediately and no value should be persisted
         assert!(
             result.is_err(),
-            "Reading merge operand without merge operator should error"
+            "Merging without a merge operator should error"
         );
         match result {
             Err(e) => {
-                // Expected: reading merge operands without a merge operator should error with MergeOperatorMissing
                 let error_string = format!("{}", e);
                 assert!(
                     error_string.contains("merge operator missing")
@@ -6183,6 +6192,9 @@ mod tests {
             }
             Ok(_) => unreachable!("Should have errored"),
         }
+
+        let result = db.get(b"key1").await.unwrap();
+        assert_eq!(result, None);
     }
 
     #[tokio::test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6157,41 +6157,43 @@ mod tests {
 
     #[tokio::test]
     async fn should_error_when_merging_without_merge_operator() {
-        // Given: Database without merge operator configured
+        // Given: Database with merge operator, merge operands written
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let db = Db::builder("/tmp/test_merge_4", object_store.clone())
+        let path = "/tmp/test_merge_4";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(test_db_options(0, 1024, None))
+            .with_merge_operator(Arc::new(StringConcatMergeOperator))
+            .build()
+            .await
+            .unwrap();
+
+        db.merge(b"key1", b"value1").await.unwrap();
+        db.flush().await.unwrap();
+        db.close().await.unwrap();
+
+        // When: Reopening the DB without a merge operator and then reading
+        let db = Db::builder(path, object_store.clone())
             .with_settings(test_db_options(0, 1024, None))
             .build()
             .await
             .unwrap();
 
-        // When: Attempting to merge without a configured merge operator
-        let result = db
-            .merge_with_options(
-                b"key1",
-                b"value1",
-                &MergeOptions::default(),
-                &WriteOptions::default(),
-            )
-            .await;
+        // Then: Reading should fail because merge operands require a merge operator
+        let err = db.get(b"key1").await.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+    }
 
-        // Then: The write should fail immediately and no value should be persisted
-        assert!(
-            result.is_err(),
-            "Merging without a merge operator should error"
-        );
-        match result {
-            Err(e) => {
-                let error_string = format!("{}", e);
-                assert!(
-                    error_string.contains("merge operator missing")
-                        || error_string.contains("MergeOperatorMissing"),
-                    "Error should be MergeOperatorMissing, got: {:?}",
-                    e
-                );
-            }
-            Ok(_) => unreachable!("Should have errored"),
-        }
+    #[tokio::test]
+    async fn should_error_when_writing_merge_without_merge_operator() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder("/tmp/test_merge_4_write_fails", object_store.clone())
+            .with_settings(test_db_options(0, 1024, None))
+            .build()
+            .await
+            .unwrap();
+
+        let err = db.merge(b"key1", b"value1").await.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
 
         let result = db.get(b"key1").await.unwrap();
         assert_eq!(result, None);

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -435,6 +435,9 @@ impl DbTransaction {
     }
 
     /// Merge a key-value pair into the transaction.
+    ///
+    /// ## Errors
+    /// - `Error`: if no merge operator is configured for the database.
     pub fn merge<K, V>(&self, key: K, value: V) -> Result<(), crate::Error>
     where
         K: AsRef<[u8]>,
@@ -444,6 +447,9 @@ impl DbTransaction {
     }
 
     /// Merge a key-value pair into the transaction with custom options.
+    ///
+    /// ## Errors
+    /// - `Error`: if no merge operator is configured for the database.
     pub fn merge_with_options<K, V>(
         &self,
         key: K,
@@ -454,6 +460,10 @@ impl DbTransaction {
         K: AsRef<[u8]>,
         V: AsRef<[u8]>,
     {
+        if self.db_inner.flush_merge_operator.is_none() {
+            return Err(SlateDBError::MergeOperatorMissing.into());
+        }
+
         self.write_batch
             .write()
             .merge_with_options(key, value, options);
@@ -1677,6 +1687,29 @@ mod tests {
         let value = db.get(b"counter").await.unwrap().unwrap();
         let total = u64::from_le_bytes(value.as_ref().try_into().unwrap());
         assert_eq!(total, EXPECTED);
+    }
+
+    #[tokio::test]
+    async fn test_txn_merge_requires_merge_operator() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::open("test_txn_merge_requires_merge_operator", object_store)
+            .await
+            .unwrap();
+
+        let txn = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        let err = txn
+            .merge_with_options(b"counter", 1u64.to_le_bytes(), &MergeOptions::default())
+            .unwrap_err();
+        let error_string = format!("{}", err);
+        assert!(
+            error_string.contains("merge operator missing")
+                || error_string.contains("MergeOperatorMissing"),
+            "Error should be MergeOperatorMissing, got: {:?}",
+            err
+        );
+
+        txn.commit().await.unwrap();
+        assert_eq!(db.get(b"counter").await.unwrap(), None);
     }
 
     fn test_db_options(

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -1700,13 +1700,7 @@ mod tests {
         let err = txn
             .merge_with_options(b"counter", 1u64.to_le_bytes(), &MergeOptions::default())
             .unwrap_err();
-        let error_string = format!("{}", err);
-        assert!(
-            error_string.contains("merge operator missing")
-                || error_string.contains("MergeOperatorMissing"),
-            "Error should be MergeOperatorMissing, got: {:?}",
-            err
-        );
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
 
         txn.commit().await.unwrap();
         assert_eq!(db.get(b"counter").await.unwrap(), None);


### PR DESCRIPTION
## Summary

`test_execute_compaction_job_resume_matches_full` failed on main yesterday:

https://github.com/slatedb/slatedb/actions/runs/24751920201/job/72416709754

It looks like a sporadic failure. The proptest generated multiple rows that have the same key+seq. The compactor resume operation uses a seek() on merge operator to find the key and then look for the first row entry with the requisite seq. If there are multiple identical (key, seq) tuples, it doesn't account for this. It just uses the first one. But one of the records might have already been processed on the previous (failed/stopped/partial) compaction.

In production, this shouldn't actually happen, but Codex pointed out two places where it does:

- Synthetic/test-built SST inputs. The failing property test was generating raw (key, seq, value) tuples directly in slatedb/src/compactor_executor.rs:1272, so it can create degenerate states that the real DB usually won’t.
- A hand-built WriteBatch or transaction with multiple merge ops on the same key when no merge operator is configured. That path is representable today: merge writes succeed, and reads fail later with MergeOperatorMissing, as shown in slatedb/src/db.rs:6152. That’s not really the intended steady-state path, though.

This PR enforces the invariant more aggressively by preventing merge calls when no merge op is defined. It also updates the prop test to prevent generating multiple rows with the same key+seq.

## Changes

- Reject db.merge/db.merge_with_options calls when no merge operator is configured.
- Reject batch.merge/db.merge_with_options calls when no merge operator is configured.
- Prevent proptest from generating duplicate key/seq rows in test.
- Add tests to verify.

## Notes for Reviewers

Nope!

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏