### PR TITLE
dont copy bytes when decoding row entries during reads

### DIFF
--- a/slatedb/src/block_iterator_v2.rs
+++ b/slatedb/src/block_iterator_v2.rs
@@ -93,7 +93,7 @@ impl<B: BlockLike> AscendingState<B> {
     }
 
     fn decode_entry_at_current_offset(&self) -> Result<(RowEntry, usize), SlateDBError> {
-        let mut data = &self.block.data()[self.offset_in_block..];
+        let mut data = self.block.data().slice(self.offset_in_block..);
         let codec = SstRowCodecV2::new();
         let entry = codec.decode(&mut data)?;
         let bytes_consumed = self.block.data().len() - self.offset_in_block - data.len();
@@ -216,7 +216,7 @@ impl<B: BlockLike> AscendingState<B> {
     }
 
     fn advance_past_current_entry(&mut self) -> Result<(), SlateDBError> {
-        let mut data = &self.block.data()[self.offset_in_block..];
+        let mut data = self.block.data().slice(self.offset_in_block..);
         let codec = SstRowCodecV2::new();
         codec.decode(&mut data)?;
         let bytes_consumed = self.block.data().len() - self.offset_in_block - data.len();
@@ -1372,6 +1372,31 @@ mod tests {
         // next should be "a"
         let kv = iter.next().await.unwrap().unwrap();
         assert_eq!(kv.key.as_ref(), b"a");
+    }
+
+    #[tokio::test]
+    async fn should_return_entry_without_copying() {
+        // given: a block with entries
+        let block = build_test_block(
+            &[(b"apple", b"1"), (b"banana", b"2"), (b"cherry", b"3")],
+            16,
+        );
+        let mut iter = BlockIteratorV2::new_ascending(&block);
+        let data_start = block.data().as_ptr();
+        let data_end = unsafe { data_start.add(block.data().len() - 1) };
+
+        // when/then: assert values reside within block allocation
+        loop {
+            let Some(kv) = iter.next().await.unwrap() else {
+                break;
+            };
+            let Some(v) = kv.value.as_bytes() else {
+                continue;
+            };
+            let v_data = v.as_ptr();
+            assert!(v_data >= data_start);
+            assert!(v_data < data_end);
+        }
     }
 
     // ==================== Property-Based Tests ====================

--- a/slatedb/src/format/row_codec_v2.rs
+++ b/slatedb/src/format/row_codec_v2.rs
@@ -169,20 +169,17 @@ impl SstRowCodecV2 {
     }
 
     /// Decode a V2 row entry from the data buffer.
-    pub(crate) fn decode(&self, data: &mut &[u8]) -> Result<SstRowEntryV2, SlateDBError> {
+    pub(crate) fn decode(&self, data: &mut impl Buf) -> Result<SstRowEntryV2, SlateDBError> {
         let shared_bytes = decode_varint(data);
         let unshared_bytes = decode_varint(data) as usize;
         let value_len = decode_varint(data) as usize;
 
         // Read key_delta
-        let key_suffix = Bytes::copy_from_slice(&data[..unshared_bytes]);
-        *data = &data[unshared_bytes..];
+        let key_suffix = data.copy_to_bytes(unshared_bytes);
 
         // Read value
         let value_bytes = if value_len > 0 {
-            let v = Bytes::copy_from_slice(&data[..value_len]);
-            *data = &data[value_len..];
-            Some(v)
+            Some(data.copy_to_bytes(value_len))
         } else {
             None
         };

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -10,7 +10,7 @@ use crate::iter::{IterationOrder, RowEntryIterator};
 use crate::manifest::ManifestCore;
 use crate::paths::PathResolver;
 use crate::tablestore::TableStore;
-use bytes::{BufMut, Bytes};
+use bytes::{Buf, BufMut, Bytes};
 use futures::FutureExt;
 use log::{error, warn};
 use rand::{Rng, RngCore};
@@ -625,12 +625,11 @@ pub(crate) fn encode_varint(buf: &mut Vec<u8>, mut value: u32) {
 /// Reads bytes from the buffer, advancing the slice, until a byte
 /// without the continuation bit (high bit = 0) is found.
 #[allow(dead_code)]
-pub(crate) fn decode_varint(buf: &mut &[u8]) -> u32 {
+pub(crate) fn decode_varint(buf: &mut impl Buf) -> u32 {
     let mut result = 0u32;
     let mut shift = 0;
     loop {
-        let byte = buf[0];
-        *buf = &buf[1..];
+        let byte = buf.get_u8();
         result |= ((byte & 0x7F) as u32) << shift;
         if byte & 0x80 == 0 {
             break;


### PR DESCRIPTION
## Summary

Don't copy bytes when decoding row entries during reads. I'm seeing lots of overhead from copies for a workload that resides purely in block cache. For my use case (a vector db) I'm reading ~100 300KB posting lists. The main bottleneck at the moment is reading these out of slatedb. Dropping the buffer copy takes the latency down from ~12ms to ~8ms.

## Changes

- change the row entry decoder to take `&mut impl Buf`
- pass &mut Bytes in to decoder from `BlockIterator` so that the returned `RowEntry` points to the same allocation as the block.
- adds a test to verify the value data was not copied

## Notes for Reviewers

- The drawback to this patch is that the returned values can be small slices into comparatively large allocations. If reading out of block cache, the enclosing allocation is 4KB. But if reading from object storage as part of a scan it could be many MBs. So users shouldn't hang on to these buffers. One way to mitigate this would be to add a read option to copy values into a clamped buffer before returning to preserve the previous behaviour.
- Still working on a microbenchmark for block iteration

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
