### PR TITLE
Introduce l0_max_ssts_per_key to mitigate l0_max_ssts pressure after union

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -41,6 +41,7 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
     let min_filter_keys = rng.random_range(100..1000);
     let l0_sst_size_bytes = rng.random_range(MIB_1..MIB_500);
     let l0_max_ssts = rng.random_range(4..8);
+    let l0_max_ssts_per_key = l0_max_ssts;
     let max_unflushed_bytes = rng.random_range(MIB_1..GIB_2);
     let compression_codec_idx = rng.random_range(0..COMPRESSION_CODECS.len());
     let compression_codec =
@@ -56,6 +57,7 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
         min_filter_keys,
         l0_sst_size_bytes,
         l0_max_ssts,
+        l0_max_ssts_per_key,
         max_unflushed_bytes,
         compression_codec,
         compactor_options: Some(build_settings_compactor(&mut *rng)),

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -50,6 +50,7 @@
 //! min_filter_keys = 1000
 //! l0_sst_size_bytes = 67108864
 //! l0_max_ssts = 8
+//! l0_max_ssts_per_key = 8
 //! l0_flush_parallelism = 4
 //! max_unflushed_bytes = 536870912
 //!
@@ -97,6 +98,7 @@
 //!  "min_filter_keys": 1000,
 //!  "l0_sst_size_bytes": 67108864,
 //!  "l0_max_ssts": 8,
+//!  "l0_max_ssts_per_key": 8,
 //!  "l0_flush_parallelism": 4,
 //!  "max_unflushed_bytes": 536870912,
 //!  "compactor_options": {
@@ -147,6 +149,7 @@
 //! min_filter_keys: 1000
 //! l0_sst_size_bytes: 67108864
 //! l0_max_ssts: 8
+//! l0_max_ssts_per_key: 8
 //! l0_flush_parallelism: 1
 //! max_unflushed_bytes: 536870912
 //! compactor_options:
@@ -660,9 +663,27 @@ pub struct Settings {
     ///   secondary readers to see new data.
     pub l0_sst_size_bytes: usize,
 
-    /// Defines the max number of SSTs in l0. Memtables will not be flushed if there are more
-    /// l0 ssts than this value, until compaction can compact the ssts into compacted.
+    /// Defines the max total number of SSTs in L0 across the entire key space. Memtables
+    /// will not be flushed if the total L0 count (including in-flight uploads) would exceed
+    /// this value, until compaction can compact the ssts into compacted.
+    ///
+    /// This cap primarily bounds manifest size and global bookkeeping. Read amplification
+    /// and write backpressure are governed by [`Self::l0_max_ssts_per_key`], which enforces
+    /// a cap on L0 SSTs overlapping any single key. After a manifest union (rescaling),
+    /// the total L0 count can exceed a single source's `l0_max_ssts` while no individual
+    /// key is covered by more than `l0_max_ssts_per_key` SSTs; `l0_max_ssts` should be
+    /// set generously in that case (e.g. `l0_max_ssts_per_key * expected_max_shards`).
     pub l0_max_ssts: usize,
+
+    /// Defines the max number of L0 SSTs whose effective ranges cover any single key.
+    /// Memtables will not be flushed if dispatching a new L0 upload would cause any point
+    /// in the key space to be covered by more L0 SSTs than this value.
+    ///
+    /// This is the per-key analogue of [`Self::l0_max_ssts`]: it bounds the number of L0
+    /// SSTs a point read may need to consult (read amplification) and drives write
+    /// backpressure. Because in-flight uploads have no known key range yet, each reserved
+    /// slot is treated conservatively as contributing to the peak at every point.
+    pub l0_max_ssts_per_key: usize,
 
     /// Number of parallel workers for flushing immutable memtables to L0 SSTs.
     /// Higher values increase L0 flush throughput at the cost of more concurrent
@@ -720,6 +741,7 @@ impl std::fmt::Debug for Settings {
             .field("max_unflushed_bytes", &self.max_unflushed_bytes)
             .field("l0_sst_size_bytes", &self.l0_sst_size_bytes)
             .field("l0_max_ssts", &self.l0_max_ssts)
+            .field("l0_max_ssts_per_key", &self.l0_max_ssts_per_key)
             .field("l0_flush_parallelism", &self.l0_flush_parallelism)
             .field("compactor_options", &self.compactor_options)
             .field("compression_codec", &self.compression_codec)
@@ -917,6 +939,7 @@ impl Default for Settings {
             max_unflushed_bytes: 1_073_741_824,
             l0_sst_size_bytes: 64 * 1024 * 1024,
             l0_max_ssts: 8,
+            l0_max_ssts_per_key: 8,
             l0_flush_parallelism: 4,
             compactor_options: Some(CompactorOptions::default()),
             compression_codec: None,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -5844,6 +5844,7 @@ mod tests {
             manifest_update_timeout: Duration::from_secs(300),
             max_unflushed_bytes: 134_217_728,
             l0_max_ssts: 8,
+            l0_max_ssts_per_key: 8,
             l0_flush_parallelism: 1,
             min_filter_keys,
             l0_sst_size_bytes,
@@ -7318,6 +7319,7 @@ mod tests {
             }),
         );
         settings.l0_max_ssts = 10_000;
+        settings.l0_max_ssts_per_key = 10_000;
         settings.flush_interval = None;
         settings.wal_enabled = false;
 
@@ -7467,6 +7469,7 @@ mod tests {
             }),
         );
         settings.l0_max_ssts = 10_000;
+        settings.l0_max_ssts_per_key = 10_000;
         settings.flush_interval = None;
         settings.wal_enabled = false;
 

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -240,6 +240,106 @@ impl SsTableView {
     }
 }
 
+/// Maximum number of L0 SST views whose effective ranges cover any single key.
+///
+/// A key `p` is covered by an L0 view when `p` lies within the view's effective
+/// range. This is the per-key read-amplification for L0 lookups and is the
+/// quantity bounded by `Settings::l0_max_ssts_per_key`.
+///
+/// Implementation: a sweep over 2·N boundary events. Each L0 view contributes a
+/// "+1" event at its start bound and a "-1" event at its end bound. Events are
+/// sorted by virtual position on a number line that distinguishes `just-before v`,
+/// `at v`, and `just-after v`, so inclusive/exclusive bounds are ordered
+/// correctly. At equal positions, `+1` events sort before `-1` so the peak
+/// counts ranges that touch edge-to-edge at an inclusive boundary.
+/// Complexity: O(N log N) time, O(N) space.
+pub(crate) fn max_l0_overlap(l0: &VecDeque<SsTableView>) -> usize {
+    if l0.is_empty() {
+        return 0;
+    }
+
+    // Sign discriminates ±∞ sentinels from finite positions so derive-Ord
+    // places -∞ first and +∞ last; for finite positions, we sort by (key,
+    // offset) where offset is -1/0/+1 for "just before / at / just after".
+    #[derive(Eq, PartialEq)]
+    struct Pos {
+        sign: i8,
+        key: Bytes,
+        offset: i8,
+    }
+
+    impl Ord for Pos {
+        fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+            self.sign
+                .cmp(&other.sign)
+                .then_with(|| self.key.cmp(&other.key))
+                .then_with(|| self.offset.cmp(&other.offset))
+        }
+    }
+    impl PartialOrd for Pos {
+        fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    let start_pos = |r: &BytesRange| -> Pos {
+        match r.start_bound() {
+            Included(k) => Pos {
+                sign: 0,
+                key: k.clone(),
+                offset: 0,
+            },
+            Excluded(k) => Pos {
+                sign: 0,
+                key: k.clone(),
+                offset: 1,
+            },
+            Unbounded => Pos {
+                sign: -1,
+                key: Bytes::new(),
+                offset: 0,
+            },
+        }
+    };
+    let end_pos = |r: &BytesRange| -> Pos {
+        match r.end_bound() {
+            Included(k) => Pos {
+                sign: 0,
+                key: k.clone(),
+                offset: 0,
+            },
+            Excluded(k) => Pos {
+                sign: 0,
+                key: k.clone(),
+                offset: -1,
+            },
+            Unbounded => Pos {
+                sign: 1,
+                key: Bytes::new(),
+                offset: 0,
+            },
+        }
+    };
+
+    let mut events: Vec<(Pos, i8)> = Vec::with_capacity(l0.len() * 2);
+    for view in l0 {
+        let range = view.compacted_effective_range();
+        events.push((start_pos(range), 1));
+        events.push((end_pos(range), -1));
+    }
+    events.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| b.1.cmp(&a.1)));
+
+    let mut active: i32 = 0;
+    let mut peak: i32 = 0;
+    for (_, delta) in events {
+        active += delta as i32;
+        if active > peak {
+            peak = active;
+        }
+    }
+    peak as usize
+}
+
 /// An identifier for an SSTable, which can be either a WAL SST or a compacted SST.
 #[derive(Clone, PartialEq, Hash, Eq, Copy, Serialize)]
 pub enum SsTableId {
@@ -722,6 +822,7 @@ impl WalIdStore for parking_lot::RwLock<DbState> {
 
 #[cfg(test)]
 mod tests {
+    use crate::bytes_range::BytesRange;
     use crate::checkpoint::Checkpoint;
     use crate::db_state::{DbState, SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
@@ -997,5 +1098,253 @@ mod tests {
             first_entry,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn max_l0_overlap_empty_is_zero() {
+        let l0: std::collections::VecDeque<SsTableView> = std::collections::VecDeque::new();
+        assert_eq!(super::max_l0_overlap(&l0), 0);
+    }
+
+    #[test]
+    fn max_l0_overlap_disjoint_ranges_is_one() {
+        // Simulates a post-union manifest where each source's L0s cover
+        // disjoint key ranges — the peak per-point count stays at 1.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"a", Some(b"b")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"c", Some(b"d")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"e", Some(b"f")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"g", Some(b"h")));
+        assert_eq!(super::max_l0_overlap(&l0), 1);
+    }
+
+    #[test]
+    fn max_l0_overlap_full_overlap_counts_all() {
+        let mut l0 = std::collections::VecDeque::new();
+        for _ in 0..4 {
+            l0.push_back(create_compacted_sst_view_with_bounds(b"a", Some(b"z")));
+        }
+        assert_eq!(super::max_l0_overlap(&l0), 4);
+    }
+
+    #[test]
+    fn max_l0_overlap_partial_overlap() {
+        // A: [a, c], B: [b, d]. At B.start=b, both A and B contain b.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"a", Some(b"c")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"b", Some(b"d")));
+        assert_eq!(super::max_l0_overlap(&l0), 2);
+    }
+
+    #[test]
+    fn max_l0_overlap_mixed_disjoint_groups() {
+        // Two disjoint groups of 3 overlapping SSTs each. Peak is 3, not 6.
+        let mut l0 = std::collections::VecDeque::new();
+        for _ in 0..3 {
+            l0.push_back(create_compacted_sst_view_with_bounds(b"a", Some(b"c")));
+        }
+        for _ in 0..3 {
+            l0.push_back(create_compacted_sst_view_with_bounds(b"m", Some(b"p")));
+        }
+        assert_eq!(super::max_l0_overlap(&l0), 3);
+    }
+
+    #[test]
+    fn max_l0_overlap_single_point_range_is_one() {
+        // A view whose first_entry == last_entry covers exactly one key.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"k", Some(b"k")));
+        assert_eq!(super::max_l0_overlap(&l0), 1);
+    }
+
+    #[test]
+    fn max_l0_overlap_many_point_ranges_same_key() {
+        // N coincident point ranges [k, k] all cover key k → peak N.
+        let mut l0 = std::collections::VecDeque::new();
+        for _ in 0..5 {
+            l0.push_back(create_compacted_sst_view_with_bounds(b"k", Some(b"k")));
+        }
+        assert_eq!(super::max_l0_overlap(&l0), 5);
+    }
+
+    #[test]
+    fn max_l0_overlap_mixed_point_and_longer_ranges_at_same_key() {
+        // Two point ranges [k, k] and two longer ranges [k, z] all cover k.
+        // Peak at k is 4; past k, only the two longer ranges remain.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"k", Some(b"k")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"k", Some(b"k")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"k", Some(b"z")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"k", Some(b"z")));
+        assert_eq!(super::max_l0_overlap(&l0), 4);
+    }
+
+    #[test]
+    fn max_l0_overlap_edge_touching_inclusive_counts_both() {
+        // [a, b] and [b, c]: both contain b → peak 2.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"a", Some(b"b")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"b", Some(b"c")));
+        assert_eq!(super::max_l0_overlap(&l0), 2);
+    }
+
+    #[test]
+    fn max_l0_overlap_edge_touching_exclusive_end_is_disjoint() {
+        // [a, b) and [b, c]: no point is in both → peak 1.
+        // First view has an Excluded end at b via a visible_range projection.
+        let a = Bytes::copy_from_slice(b"a");
+        let b = Bytes::copy_from_slice(b"b");
+        let v1 = create_compacted_sst_view_with_bounds(b"a", Some(b"b")).with_visible_range(
+            BytesRange::new(
+                std::ops::Bound::Included(a),
+                std::ops::Bound::Excluded(b.clone()),
+            ),
+        );
+        let v2 = create_compacted_sst_view_with_bounds(b"b", Some(b"c"));
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(v1);
+        l0.push_back(v2);
+        assert_eq!(super::max_l0_overlap(&l0), 1);
+    }
+
+    #[test]
+    fn max_l0_overlap_unbounded_end_single_view() {
+        // A view with first_entry but no last_entry has effective_range
+        // [first, Unbounded) — still one view, peak 1.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"a", None));
+        assert_eq!(super::max_l0_overlap(&l0), 1);
+    }
+
+    #[test]
+    fn max_l0_overlap_unbounded_ends_share_tail() {
+        // [a, ∞) and [b, ∞) both extend to +∞, so they overlap at every
+        // point ≥ b. Peak is 2.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"a", None));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"b", None));
+        assert_eq!(super::max_l0_overlap(&l0), 2);
+    }
+
+    #[test]
+    fn max_l0_overlap_mixed_bounded_and_unbounded_end() {
+        // [a, m] ends at m; [b, ∞) starts before m and extends past it.
+        // They coexist on [b, m]. Peak is 2.
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(create_compacted_sst_view_with_bounds(b"a", Some(b"m")));
+        l0.push_back(create_compacted_sst_view_with_bounds(b"b", None));
+        assert_eq!(super::max_l0_overlap(&l0), 2);
+    }
+
+    #[test]
+    fn max_l0_overlap_unbounded_end_via_visible_range() {
+        // visible_range = [m, Unbounded) applied to a physical [a, z] view.
+        // Effective range becomes [m, z] (physical end clamps the Unbounded).
+        // Pair with [n, ∞): overlap on [n, z]. Peak is 2.
+        let m = Bytes::copy_from_slice(b"m");
+        let projected = create_compacted_sst_view_with_bounds(b"a", Some(b"z")).with_visible_range(
+            BytesRange::new(std::ops::Bound::Included(m), std::ops::Bound::Unbounded),
+        );
+        let open = create_compacted_sst_view_with_bounds(b"n", None);
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(projected);
+        l0.push_back(open);
+        assert_eq!(super::max_l0_overlap(&l0), 2);
+    }
+
+    #[test]
+    fn max_l0_overlap_respects_visible_range() {
+        // Two views whose physical ranges overlap but whose visible_range
+        // projections are disjoint should not count as overlapping.
+        let lo = Bytes::copy_from_slice(b"a");
+        let mid = Bytes::copy_from_slice(b"m");
+        let hi = Bytes::copy_from_slice(b"z");
+        let v1 = create_compacted_sst_view_with_bounds(b"a", Some(b"z")).with_visible_range(
+            BytesRange::new(
+                std::ops::Bound::Included(lo.clone()),
+                std::ops::Bound::Excluded(mid.clone()),
+            ),
+        );
+        let v2 = create_compacted_sst_view_with_bounds(b"a", Some(b"z")).with_visible_range(
+            BytesRange::new(
+                std::ops::Bound::Included(mid),
+                std::ops::Bound::Included(hi),
+            ),
+        );
+        let mut l0 = std::collections::VecDeque::new();
+        l0.push_back(v1);
+        l0.push_back(v2);
+        assert_eq!(super::max_l0_overlap(&l0), 1);
+    }
+
+    #[test]
+    fn max_l0_overlap_proptest_matches_naive() {
+        use proptest::prelude::{prop_oneof, Just, ProptestConfig, Strategy};
+
+        // Generate views with Included starts and end bounds drawn from
+        // {Included, Excluded, Unbounded}. The keyspace is intentionally
+        // small (alphabet 0..3, length 1..=3) so generated views frequently
+        // overlap and the brute-force reference exercises real cases.
+        #[derive(Debug, Clone)]
+        enum EndKind {
+            Inclusive(Bytes),
+            Exclusive(Bytes),
+            Unbounded,
+        }
+        #[derive(Debug, Clone)]
+        struct ViewSpec {
+            start: Bytes,
+            end: EndKind,
+        }
+
+        let key = vec(0u8..3u8, 1..=3).prop_map(Bytes::from);
+        let end = prop_oneof![
+            Just(EndKind::Unbounded),
+            key.clone().prop_map(EndKind::Inclusive),
+            key.clone().prop_map(EndKind::Exclusive),
+        ];
+        let spec =
+            (key, end).prop_filter_map("non-empty effective range", |(start, end)| match &end {
+                EndKind::Inclusive(k) if k < &start => None,
+                EndKind::Exclusive(k) if k <= &start => None,
+                _ => Some(ViewSpec { start, end }),
+            });
+
+        proptest!(ProptestConfig::with_cases(256), |(specs in vec(spec, 0..=8))| {
+            let mut l0 = std::collections::VecDeque::new();
+            for s in &specs {
+                let view = match &s.end {
+                    EndKind::Inclusive(end) => {
+                        create_compacted_sst_view_with_bounds(&s.start, Some(end))
+                    }
+                    EndKind::Unbounded => {
+                        create_compacted_sst_view_with_bounds(&s.start, None)
+                    }
+                    EndKind::Exclusive(end) => create_compacted_sst_view_with_bounds(
+                        &s.start, None,
+                    )
+                    .with_visible_range(BytesRange::new(
+                        std::ops::Bound::Included(s.start.clone()),
+                        std::ops::Bound::Excluded(end.clone()),
+                    )),
+                };
+                l0.push_back(view);
+            }
+
+            // Naive reference: every view's start is Included, so the peak of
+            // the sweep is always achieved at some view's start key. Counting
+            // covers at each start key and taking the max is sufficient.
+            let naive = specs
+                .iter()
+                .map(|s| {
+                    l0.iter()
+                        .filter(|v| v.compacted_effective_range().contains(&s.start))
+                        .count()
+                })
+                .max()
+                .unwrap_or(0);
+
+            assert_eq!(super::max_l0_overlap(&l0), naive);
+        });
     }
 }

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -1817,6 +1817,7 @@ mod tests {
             manifest_update_timeout: std::time::Duration::from_secs(300),
             max_unflushed_bytes: 134_217_728,
             l0_max_ssts: 8,
+            l0_max_ssts_per_key: 8,
             l0_flush_parallelism: 1,
             min_filter_keys,
             l0_sst_size_bytes,

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -199,11 +199,18 @@ impl FlushTracker {
     }
 
     fn available_l0_slots(&self) -> usize {
-        let l0_len = self.inner.state.read().state().core().tree.l0.len();
-        self.inner
-            .settings
-            .l0_max_ssts
-            .saturating_sub(l0_len + self.frontier.reserved_l0_slots())
+        let (l0_len, peak) = {
+            let state = self.inner.state.read().state();
+            let l0 = &state.core().tree.l0;
+            (l0.len(), crate::db_state::max_l0_overlap(l0))
+        };
+        let reserved = self.frontier.reserved_l0_slots();
+        let settings = &self.inner.settings;
+        let total_slots = settings.l0_max_ssts.saturating_sub(l0_len + reserved);
+        // Each reserved (in-flight) upload is treated as +1 at every point
+        // because its output key range is not yet known.
+        let per_key_slots = settings.l0_max_ssts_per_key.saturating_sub(peak + reserved);
+        total_slots.min(per_key_slots)
     }
 
     fn dispatch_ready_memtables(&mut self) -> Result<(), SlateDBError> {
@@ -522,12 +529,16 @@ mod tests {
     }
 
     fn seeded_l0_handle(first_key: &[u8]) -> SsTableHandle {
+        seeded_l0_handle_with_bounds(first_key, None)
+    }
+
+    fn seeded_l0_handle_with_bounds(first_key: &[u8], last_key: Option<&[u8]>) -> SsTableHandle {
         SsTableHandle::new(
             SsTableId::Compacted(ulid::Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo {
                 first_entry: Some(Bytes::copy_from_slice(first_key)),
-                last_entry: None,
+                last_entry: last_key.map(Bytes::copy_from_slice),
                 index_offset: 0,
                 index_len: 0,
                 filter_offset: 0,
@@ -539,6 +550,47 @@ mod tests {
                 filter_format: FilterFormat::default(),
             },
         )
+    }
+
+    async fn set_remote_l0_disjoint(
+        path: &str,
+        object_store: Arc<dyn ObjectStore>,
+        ranges: &[(&[u8], &[u8])],
+    ) {
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store));
+        let mut stored_manifest =
+            StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
+                .await
+                .unwrap();
+        let mut dirty = stored_manifest.prepare_dirty().unwrap();
+        dirty.value.core.tree.l0.clear();
+        for (first, last) in ranges {
+            dirty.value.core.tree.l0.push_back(SsTableView::new(
+                ulid::Ulid::new(),
+                seeded_l0_handle_with_bounds(first, Some(last)),
+            ));
+        }
+        stored_manifest.update(dirty).await.unwrap();
+    }
+
+    fn set_local_l0_disjoint(harness: &TestHarness, ranges: &[(&[u8], &[u8])]) {
+        let mut guard = harness.inner.state.write();
+        guard.modify(|modifier| {
+            modifier.state.manifest.value.core.tree.l0.clear();
+            for (first, last) in ranges {
+                modifier
+                    .state
+                    .manifest
+                    .value
+                    .core
+                    .tree
+                    .l0
+                    .push_back(SsTableView::new(
+                        ulid::Ulid::new(),
+                        seeded_l0_handle_with_bounds(first, Some(last)),
+                    ));
+            }
+        });
     }
 
     async fn set_remote_l0_len(path: &str, object_store: Arc<dyn ObjectStore>, l0_len: usize) {
@@ -873,6 +925,93 @@ mod tests {
                 .unwrap();
             assert_eq!(result.durable_seq, 1);
         }
+
+        flusher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn flush_proceeds_when_l0_total_high_but_disjoint_ranges() {
+        // Mirrors a post-rescaling (union) manifest: L0 total exceeds the
+        // single-source `l0_max_ssts`, but each L0 covers a disjoint key
+        // range so no point is covered by more than one L0. The per-key cap
+        // should allow flushes to proceed.
+        let settings = Settings {
+            l0_max_ssts: 100,
+            l0_max_ssts_per_key: 2,
+            manifest_poll_interval: Duration::from_millis(10),
+            ..Settings::default()
+        };
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_flusher_per_key_disjoint",
+            settings,
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let ranges: &[(&[u8], &[u8])] = &[
+            (b"a0", b"a9"),
+            (b"b0", b"b9"),
+            (b"c0", b"c9"),
+            (b"d0", b"d9"),
+            (b"e0", b"e9"),
+        ];
+        set_local_l0_disjoint(&harness, ranges);
+        set_remote_l0_disjoint(&harness.path, Arc::clone(&harness.object_store), ranges).await;
+        let flusher = start_flusher(harness);
+        freeze_value_imm(&flusher.inner, b"k1", b"v1", 41);
+
+        let result = timeout(Duration::from_secs(5), flusher.flush(FlushTarget::All))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.durable_seq, 1);
+
+        flusher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn flush_blocked_by_per_key_cap_when_ranges_overlap() {
+        // A single wide-range L0 covers the whole key space. With per-key
+        // cap of 1, the peak overlap is already 1 so flushes must block
+        // until L0 drains.
+        let settings = Settings {
+            l0_max_ssts: 100,
+            l0_max_ssts_per_key: 1,
+            manifest_poll_interval: Duration::from_millis(10),
+            ..Settings::default()
+        };
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_flusher_per_key_blocks",
+            settings,
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let ranges: &[(&[u8], &[u8])] = &[(b"aaa", b"zzz")];
+        set_local_l0_disjoint(&harness, ranges);
+        set_remote_l0_disjoint(&harness.path, Arc::clone(&harness.object_store), ranges).await;
+        let path = harness.path.clone();
+        let object_store = Arc::clone(&harness.object_store);
+        let flusher = start_flusher(harness);
+        freeze_value_imm(&flusher.inner, b"k1", b"v1", 42);
+
+        let flush = flusher.flush(FlushTarget::All);
+        tokio::pin!(flush);
+        // Blocked — per-key cap reached.
+        assert!(timeout(Duration::from_millis(100), &mut flush)
+            .await
+            .is_err());
+
+        // Drain L0 locally and remotely; flush should now progress.
+        {
+            let mut guard = flusher.inner.state.write();
+            guard.modify(|modifier| modifier.state.manifest.value.core.tree.l0.clear());
+        }
+        set_remote_l0_disjoint(&path, object_store, &[]).await;
+
+        let result = timeout(Duration::from_secs(5), &mut flush)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.durable_seq, 1);
 
         flusher.shutdown().await;
     }


### PR DESCRIPTION
## Summary

After a union operation, the number of L0 SSTs might exceed `l0_max_ssts` - which will block memtable flushes, and hence writes (as soon as max unflushed bytes is also reached).

However, the union invariant is that the merged databases are non-overlapping implying that their L0 SSTs do not overlap. Therefore, a Point Read for a given key mostly likely doesn't has to check all L0 SSTs - so the back-pressure is applied unnecessarily.

What we actually want to achieve is applying back-pressure when the maximum number of L0 **per key** reaches a threshold.

This PR introduces `l0_max_ssts_per_key` for that purpose.

The number of L0 per key is computed using a sweep algorithm in `O(nlogn)` time (where n is the number of SST views). Since this computation might be performed more often than the actual flush; and the number of SSTs can be substantial after union; this algorithm was chosen over a simpler `n^2` approach.

(the issue was also discussed in https://docs.google.com/document/d/1omOYhQ9AQSqJ6-_IcGPdsYj0z1YYNXagYnxYkpbBik0/edit?usp=sharing)

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
