### PR TITLE
block iter microbench + zero-copy key decode

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run microbenchmark
-        run: cargo bench -- --output-format bencher | tee output.txt
+        run: cargo bench --features bench-internal -- --output-format bencher | tee output.txt
 
       - name: Download nightly microbenchmark data
         uses: actions/cache/restore@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -294,7 +294,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run benchmark
-        run: cargo bench -- --output-format bencher | tee output.txt
+        run: cargo bench --features bench-internal -- --output-format bencher | tee output.txt
 
       - name: Download nightly benchmark data
         uses: actions/cache/restore@v4

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -107,6 +107,7 @@ zstd = ["dep:zstd"]
 wal_disable = []
 moka = ["dep:moka"]
 foyer = ["dep:foyer"]
+bench-internal = []
 test-util = [
     "tokio/test-util",
     "slatedb-common/test-util",
@@ -145,6 +146,11 @@ bench = false
 [[bench]]
 name = "db_operations"
 harness = false
+
+[[bench]]
+name = "block_iterator_v2"
+harness = false
+required-features = ["bench-internal"]
 
 [lints]
 workspace = true

--- a/slatedb/benches/block_iterator_v2.rs
+++ b/slatedb/benches/block_iterator_v2.rs
@@ -1,0 +1,56 @@
+// our microbenchmarks use pprof, but it doesn't work on windows
+#![cfg(not(windows))]
+
+// Run with: cargo bench --features bench-internal --bench block_iterator_v2
+// The `bench-internal` feature gates `slatedb::block_iterator_v2_bench`. That
+// pub fn builds the block and yields iteration as a closure so this bench
+// doesn't need crate-private items.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
+use slatedb::BlockIteratorV2BenchConfig;
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // Small values: pool of 16B-key/512B-value entries filling a 4KB block.
+    slatedb::block_iterator_v2_bench(
+        BlockIteratorV2BenchConfig {
+            block_size: 4096,
+            key_size: 16,
+            value_size: 512,
+            num_entries: 32,
+        },
+        |inner| {
+            c.bench_function("block_iterator_v2_iterate_small_values", |b| {
+                b.iter(|| inner());
+            });
+        },
+    );
+
+    // Single 100KB value in a nominally 4KB block. The builder's
+    // oversized-entry rule accepts the first entry unconditionally, so the
+    // block data expands to ~100KB with exactly one row.
+    slatedb::block_iterator_v2_bench(
+        BlockIteratorV2BenchConfig {
+            block_size: 4096,
+            key_size: 16,
+            value_size: 100 * 1024,
+            num_entries: 1,
+        },
+        |inner| {
+            c.bench_function("block_iterator_v2_iterate_large_value", |b| {
+                b.iter(|| inner());
+            });
+        },
+    );
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(1_000)
+        // This only runs when `--profile-time <num_seconds>` is set
+        .with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/slatedb/benches/block_iterator_v2.rs
+++ b/slatedb/benches/block_iterator_v2.rs
@@ -8,12 +8,12 @@
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
-use slatedb::BlockIteratorV2BenchConfig;
+use slatedb::block_iterator_v2_benches::BlockIteratorV2BenchConfig;
 
 #[allow(clippy::redundant_closure)]
 fn criterion_benchmark(c: &mut Criterion) {
     // Small values: pool of 16B-key/512B-value entries filling a 4KB block.
-    slatedb::block_iterator_v2_bench(
+    slatedb::block_iterator_v2_benches::block_iterator_v2_bench(
         BlockIteratorV2BenchConfig {
             block_size: 4096,
             key_size: 16,
@@ -30,7 +30,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Single 100KB value in a nominally 4KB block. The builder's
     // oversized-entry rule accepts the first entry unconditionally, so the
     // block data expands to ~100KB with exactly one row.
-    slatedb::block_iterator_v2_bench(
+    slatedb::block_iterator_v2_benches::block_iterator_v2_bench(
         BlockIteratorV2BenchConfig {
             block_size: 4096,
             key_size: 16,

--- a/slatedb/benches/block_iterator_v2.rs
+++ b/slatedb/benches/block_iterator_v2.rs
@@ -10,6 +10,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 use slatedb::BlockIteratorV2BenchConfig;
 
+#[allow(clippy::redundant_closure)]
 fn criterion_benchmark(c: &mut Criterion) {
     // Small values: pool of 16B-key/512B-value entries filling a 4KB block.
     slatedb::block_iterator_v2_bench(

--- a/slatedb/src/block_iterator_v2.rs
+++ b/slatedb/src/block_iterator_v2.rs
@@ -469,71 +469,76 @@ impl<B: BlockLike> RowEntryIterator for DescendingBlockIteratorV2<B> {
 }
 
 #[cfg(feature = "bench-internal")]
-pub struct BlockIteratorV2BenchConfig {
-    /// Target block size passed to the builder. The builder accepts a first
-    /// entry that exceeds this (oversized-entry rule), so a single large value
-    /// will expand the block past `block_size`.
-    pub block_size: usize,
-    pub key_size: usize,
-    pub value_size: usize,
-    /// Upper bound on entries generated and fed to the builder. Fewer may
-    /// land in the block if it fills up first.
-    pub num_entries: usize,
-}
+pub mod benches {
+    use bytes::Bytes;
+    use super::BlockIteratorV2;
 
-#[cfg(feature = "bench-internal")]
-#[allow(clippy::panic)]
-pub fn block_iterator_v2_bench<F>(config: BlockIteratorV2BenchConfig, mut run_bench: F)
-where
-    F: FnMut(&mut dyn FnMut()),
-{
-    use crate::format::sst::BlockBuilder;
-    use crate::iter::RowEntryIterator;
-    use crate::types::{RowEntry, ValueDeletable};
-    use futures::executor::block_on;
-    use rand::RngCore;
-
-    const SEED: u64 = 0x51A7_EDBB_E4C4;
-
-    let rand = crate::rand::DbRand::new(SEED);
-    let mut rng = rand.rng();
-    let mut pool: Vec<(Bytes, Bytes)> = (0..config.num_entries)
-        .map(|_| {
-            let mut key = vec![0u8; config.key_size];
-            rng.fill_bytes(&mut key);
-            let mut value = vec![0u8; config.value_size];
-            rng.fill_bytes(&mut value);
-            (Bytes::from(key), Bytes::from(value))
-        })
-        .collect();
-    pool.sort_by(|a, b| a.0.cmp(&b.0));
-    pool.dedup_by(|a, b| a.0 == b.0);
-
-    let mut builder = BlockBuilder::new_v2(config.block_size);
-    for (seq, (key, value)) in pool.into_iter().enumerate() {
-        let entry = RowEntry::new(
-            key,
-            ValueDeletable::Value(value),
-            seq as u64 + 1,
-            None,
-            None,
-        );
-        match builder.add(entry) {
-            Ok(true) => {}
-            Ok(false) => break,
-            Err(e) => panic!("failed to add entry: {e:?}"),
-        }
+    #[cfg(feature = "bench-internal")]
+    pub struct BlockIteratorV2BenchConfig {
+        /// Target block size passed to the builder. The builder accepts a first
+        /// entry that exceeds this (oversized-entry rule), so a single large value
+        /// will expand the block past `block_size`.
+        pub block_size: usize,
+        pub key_size: usize,
+        pub value_size: usize,
+        /// Upper bound on entries generated and fed to the builder. Fewer may
+        /// land in the block if it fills up first.
+        pub num_entries: usize,
     }
-    let block = builder.build().expect("failed to build block");
 
-    run_bench(&mut || {
-        block_on(async {
-            let mut iter = BlockIteratorV2::new_ascending(&block);
-            while let Some(entry) = iter.next().await.expect("iterator error") {
-                std::hint::black_box(entry);
+    #[allow(clippy::panic)]
+    pub fn block_iterator_v2_bench<F>(config: BlockIteratorV2BenchConfig, mut run_bench: F)
+    where
+        F: FnMut(&mut dyn FnMut()),
+    {
+        use crate::format::sst::BlockBuilder;
+        use crate::iter::RowEntryIterator;
+        use crate::types::{RowEntry, ValueDeletable};
+        use futures::executor::block_on;
+        use rand::RngCore;
+
+        const SEED: u64 = 0x51A7_EDBB_E4C4;
+
+        let rand = crate::rand::DbRand::new(SEED);
+        let mut rng = rand.rng();
+        let mut pool: Vec<(Bytes, Bytes)> = (0..config.num_entries)
+            .map(|_| {
+                let mut key = vec![0u8; config.key_size];
+                rng.fill_bytes(&mut key);
+                let mut value = vec![0u8; config.value_size];
+                rng.fill_bytes(&mut value);
+                (Bytes::from(key), Bytes::from(value))
+            })
+            .collect();
+        pool.sort_by(|a, b| a.0.cmp(&b.0));
+        pool.dedup_by(|a, b| a.0 == b.0);
+
+        let mut builder = BlockBuilder::new_v2(config.block_size);
+        for (seq, (key, value)) in pool.into_iter().enumerate() {
+            let entry = RowEntry::new(
+                key,
+                ValueDeletable::Value(value),
+                seq as u64 + 1,
+                None,
+                None,
+            );
+            match builder.add(entry) {
+                Ok(true) => {}
+                Ok(false) => break,
+                Err(e) => panic!("failed to add entry: {e:?}"),
             }
+        }
+        let block = builder.build().expect("failed to build block");
+
+        run_bench(&mut || {
+            block_on(async {
+                let mut iter = BlockIteratorV2::new_ascending(&block);
+                while let Some(entry) = iter.next().await.expect("iterator error") {
+                    std::hint::black_box(entry);
+                }
+            });
         });
-    });
+    }
 }
 
 #[cfg(test)]

--- a/slatedb/src/block_iterator_v2.rs
+++ b/slatedb/src/block_iterator_v2.rs
@@ -70,7 +70,7 @@ impl<B: BlockLike> BlockIteratorV2<B> {
 
     fn decode_first_key_at_restart(block: &B, restart_idx: usize) -> Bytes {
         let restart_offset = block.offsets()[restart_idx] as usize;
-        let mut data = &block.data()[restart_offset..];
+        let mut data = block.data().slice(restart_offset..);
         let codec = SstRowCodecV2::new();
         let (shared_bytes, key_suffix) = codec.decode_key_only(&mut data);
         assert_eq!(shared_bytes, 0, "restart point should have shared_bytes=0");
@@ -113,7 +113,7 @@ impl<B: BlockLike> AscendingState<B> {
     }
 
     fn decode_key_at_offset(&self, offset: usize, prev_key: &[u8]) -> Bytes {
-        let mut data = &self.block.data()[offset..];
+        let mut data = self.block.data().slice(offset..);
         let codec = SstRowCodecV2::new();
         let (shared_bytes, key_suffix) = codec.decode_key_only(&mut data);
         let shared = shared_bytes as usize;
@@ -466,6 +466,73 @@ impl<B: BlockLike> RowEntryIterator for DescendingBlockIteratorV2<B> {
         self.exhausted = true;
         Ok(())
     }
+}
+
+#[cfg(feature = "bench-internal")]
+pub struct BlockIteratorV2BenchConfig {
+    /// Target block size passed to the builder. The builder accepts a first
+    /// entry that exceeds this (oversized-entry rule), so a single large value
+    /// will expand the block past `block_size`.
+    pub block_size: usize,
+    pub key_size: usize,
+    pub value_size: usize,
+    /// Upper bound on entries generated and fed to the builder. Fewer may
+    /// land in the block if it fills up first.
+    pub num_entries: usize,
+}
+
+#[cfg(feature = "bench-internal")]
+pub fn block_iterator_v2_bench<F>(config: BlockIteratorV2BenchConfig, mut run_bench: F)
+where
+    F: FnMut(&mut dyn FnMut()),
+{
+    use crate::format::sst::BlockBuilder;
+    use crate::iter::RowEntryIterator;
+    use crate::types::{RowEntry, ValueDeletable};
+    use futures::executor::block_on;
+    use rand::{RngCore, SeedableRng};
+    use rand_xoshiro::Xoshiro256PlusPlus;
+
+    const SEED: u64 = 0x51A7EDB_BE4C4;
+
+    let mut rng = Xoshiro256PlusPlus::seed_from_u64(SEED);
+    let mut pool: Vec<(Bytes, Bytes)> = (0..config.num_entries)
+        .map(|_| {
+            let mut key = vec![0u8; config.key_size];
+            rng.fill_bytes(&mut key);
+            let mut value = vec![0u8; config.value_size];
+            rng.fill_bytes(&mut value);
+            (Bytes::from(key), Bytes::from(value))
+        })
+        .collect();
+    pool.sort_by(|a, b| a.0.cmp(&b.0));
+    pool.dedup_by(|a, b| a.0 == b.0);
+
+    let mut builder = BlockBuilder::new_v2(config.block_size);
+    for (seq, (key, value)) in pool.into_iter().enumerate() {
+        let entry = RowEntry::new(
+            key,
+            ValueDeletable::Value(value),
+            seq as u64 + 1,
+            None,
+            None,
+        );
+        match builder.add(entry) {
+            Ok(true) => {}
+            Ok(false) => break,
+            Err(e) => panic!("failed to add entry: {e:?}"),
+        }
+    }
+    let block = builder.build().expect("failed to build block");
+
+    run_bench(&mut || {
+        block_on(async {
+            let mut iter = BlockIteratorV2::new_ascending(&block);
+            while let Some(entry) = iter.next().await.expect("iterator error") {
+                std::hint::black_box(entry);
+            }
+        });
+    });
 }
 
 #[cfg(test)]

--- a/slatedb/src/block_iterator_v2.rs
+++ b/slatedb/src/block_iterator_v2.rs
@@ -491,7 +491,7 @@ where
     use crate::iter::RowEntryIterator;
     use crate::types::{RowEntry, ValueDeletable};
     use futures::executor::block_on;
-    use rand::{RngCore};
+    use rand::RngCore;
 
     const SEED: u64 = 0x51A7_EDBB_E4C4;
 

--- a/slatedb/src/block_iterator_v2.rs
+++ b/slatedb/src/block_iterator_v2.rs
@@ -470,8 +470,8 @@ impl<B: BlockLike> RowEntryIterator for DescendingBlockIteratorV2<B> {
 
 #[cfg(feature = "bench-internal")]
 pub mod benches {
-    use bytes::Bytes;
     use super::BlockIteratorV2;
+    use bytes::Bytes;
 
     #[cfg(feature = "bench-internal")]
     pub struct BlockIteratorV2BenchConfig {

--- a/slatedb/src/block_iterator_v2.rs
+++ b/slatedb/src/block_iterator_v2.rs
@@ -482,6 +482,7 @@ pub struct BlockIteratorV2BenchConfig {
 }
 
 #[cfg(feature = "bench-internal")]
+#[allow(clippy::panic)]
 pub fn block_iterator_v2_bench<F>(config: BlockIteratorV2BenchConfig, mut run_bench: F)
 where
     F: FnMut(&mut dyn FnMut()),
@@ -490,12 +491,12 @@ where
     use crate::iter::RowEntryIterator;
     use crate::types::{RowEntry, ValueDeletable};
     use futures::executor::block_on;
-    use rand::{RngCore, SeedableRng};
-    use rand_xoshiro::Xoshiro256PlusPlus;
+    use rand::{RngCore};
 
-    const SEED: u64 = 0x51A7EDB_BE4C4;
+    const SEED: u64 = 0x51A7_EDBB_E4C4;
 
-    let mut rng = Xoshiro256PlusPlus::seed_from_u64(SEED);
+    let rand = crate::rand::DbRand::new(SEED);
+    let mut rng = rand.rng();
     let mut pool: Vec<(Bytes, Bytes)> = (0..config.num_entries)
         .map(|_| {
             let mut key = vec![0u8; config.key_size];

--- a/slatedb/src/format/row_codec_v2.rs
+++ b/slatedb/src/format/row_codec_v2.rs
@@ -221,13 +221,12 @@ impl SstRowCodecV2 {
 
     /// Decode only the key portion for seek optimization.
     /// Returns (shared_bytes, key_suffix).
-    pub(crate) fn decode_key_only(&self, data: &mut &[u8]) -> (u32, Bytes) {
+    pub(crate) fn decode_key_only(&self, data: &mut impl Buf) -> (u32, Bytes) {
         let shared_bytes = decode_varint(data);
         let unshared_bytes = decode_varint(data) as usize;
         let _value_len = decode_varint(data);
 
-        let key_suffix = Bytes::copy_from_slice(&data[..unshared_bytes]);
-        *data = &data[unshared_bytes..];
+        let key_suffix = data.copy_to_bytes(unshared_bytes);
 
         (shared_bytes, key_suffix)
     }

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -94,7 +94,7 @@ mod blob;
 mod block_iterator;
 mod block_iterator_v2;
 #[cfg(feature = "bench-internal")]
-pub use block_iterator_v2::{block_iterator_v2_bench, BlockIteratorV2BenchConfig};
+pub use block_iterator_v2::benches as block_iterator_v2_benches;
 #[cfg(any(test, feature = "bencher"))]
 mod bytes_generator;
 mod bytes_range;

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -93,6 +93,8 @@ mod batch_write;
 mod blob;
 mod block_iterator;
 mod block_iterator_v2;
+#[cfg(feature = "bench-internal")]
+pub use block_iterator_v2::{block_iterator_v2_bench, BlockIteratorV2BenchConfig};
 #[cfg(any(test, feature = "bencher"))]
 mod bytes_generator;
 mod bytes_range;


### PR DESCRIPTION
## Summary

- adds a microbenchmark for block iteration - this is written by Claude
- avoid copying keys when decoding key only

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
