### PR TITLE
Minor code cleanup for `DbReader` impls and wal_buffer flush

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1664,7 +1664,7 @@ impl DbReadOps for Db {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, crate::Error> {
-        self.get_with_options(key, options).await
+        Db::get_with_options(self, key, options).await
     }
 
     async fn get_key_value_with_options<K: AsRef<[u8]> + Send>(
@@ -1672,7 +1672,7 @@ impl DbReadOps for Db {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
-        self.get_key_value_with_options(key, options).await
+        Db::get_key_value_with_options(self, key, options).await
     }
 
     async fn scan_with_options<K, T>(
@@ -1684,7 +1684,7 @@ impl DbReadOps for Db {
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
     {
-        self.scan_with_options(range, options).await
+        Db::scan_with_options(self, range, options).await
     }
 
     async fn scan_prefix_with_options<P>(
@@ -1695,7 +1695,7 @@ impl DbReadOps for Db {
     where
         P: AsRef<[u8]> + Send,
     {
-        self.scan_prefix_with_options(prefix, options).await
+        Db::scan_prefix_with_options(self, prefix, options).await
     }
 }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1081,7 +1081,7 @@ impl DbReadOps for DbReader {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, crate::Error> {
-        self.get_with_options(key, options).await
+        DbReader::get_with_options(self, key, options).await
     }
 
     async fn get_key_value_with_options<K: AsRef<[u8]> + Send>(
@@ -1089,7 +1089,7 @@ impl DbReadOps for DbReader {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
-        self.get_key_value_with_options(key, options).await
+        DbReader::get_key_value_with_options(self, key, options).await
     }
 
     async fn scan_with_options<K, T>(
@@ -1101,7 +1101,7 @@ impl DbReadOps for DbReader {
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
     {
-        self.scan_with_options(range, options).await
+        DbReader::scan_with_options(self, range, options).await
     }
 
     async fn scan_prefix_with_options<P>(
@@ -1112,7 +1112,7 @@ impl DbReadOps for DbReader {
     where
         P: AsRef<[u8]> + Send,
     {
-        self.scan_prefix_with_options(prefix, options).await
+        DbReader::scan_prefix_with_options(self, prefix, options).await
     }
 }
 

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -203,7 +203,7 @@ impl DbReadOps for DbSnapshot {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, crate::Error> {
-        self.get_with_options(key, options).await
+        DbSnapshot::get_with_options(self, key, options).await
     }
 
     async fn get_key_value_with_options<K: AsRef<[u8]> + Send>(
@@ -211,7 +211,7 @@ impl DbReadOps for DbSnapshot {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
-        self.get_key_value_with_options(key, options).await
+        DbSnapshot::get_key_value_with_options(self, key, options).await
     }
 
     async fn scan_with_options<K, T>(
@@ -223,7 +223,7 @@ impl DbReadOps for DbSnapshot {
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
     {
-        self.scan_with_options(range, options).await
+        DbSnapshot::scan_with_options(self, range, options).await
     }
 
     async fn scan_prefix_with_options<P>(
@@ -234,7 +234,7 @@ impl DbReadOps for DbSnapshot {
     where
         P: AsRef<[u8]> + Send,
     {
-        self.scan_prefix_with_options(prefix, options).await
+        DbSnapshot::scan_prefix_with_options(self, prefix, options).await
     }
 }
 

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -615,7 +615,7 @@ impl DbReadOps for DbTransaction {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<Bytes>, crate::Error> {
-        self.get_with_options(key, options).await
+        DbTransaction::get_with_options(self, key, options).await
     }
 
     async fn get_key_value_with_options<K: AsRef<[u8]> + Send>(
@@ -623,7 +623,7 @@ impl DbReadOps for DbTransaction {
         key: K,
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
-        self.get_key_value_with_options(key, options).await
+        DbTransaction::get_key_value_with_options(self, key, options).await
     }
 
     async fn scan_with_options<K, T>(
@@ -635,7 +635,7 @@ impl DbReadOps for DbTransaction {
         K: AsRef<[u8]> + Send,
         T: RangeBounds<K> + Send,
     {
-        self.scan_with_options(range, options).await
+        DbTransaction::scan_with_options(self, range, options).await
     }
 
     async fn scan_prefix_with_options<P>(
@@ -646,7 +646,7 @@ impl DbReadOps for DbTransaction {
     where
         P: AsRef<[u8]> + Send,
     {
-        self.scan_prefix_with_options(prefix, options).await
+        DbTransaction::scan_prefix_with_options(self, prefix, options).await
     }
 }
 

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt};
 use log::{error, trace};
-use tokio::{runtime::Handle, select, sync::oneshot};
+use tokio::{runtime::Handle, sync::oneshot};
 use tracing::instrument;
 
 use crate::clock::MonotonicClock;
@@ -323,11 +323,7 @@ impl WalBufferManager {
     pub(crate) async fn flush(&self) -> Result<(), SlateDBError> {
         let (result_tx, result_rx) = oneshot::channel();
         self.send_flush_request(Some(result_tx))?;
-        select! {
-            result = result_rx => {
-                result?
-            }
-        }
+        result_rx.await?
     }
 
     /// Returns the list of immutable WALs that need to be flushed.


### PR DESCRIPTION
Follow up from a previous PR https://github.com/slatedb/slatedb/pull/1557#discussion_r3127606355 
The main follow up is about that `DbReader` methods are the same names as the inherent methods and in order to avoid just shadowing the trait methods, I used the pattern of `Type::method(self, ....` to explicitly invoke the needed method. 
A similar pattern is mentioned [here](https://doc.rust-lang.org/book/ch20-02-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name). 

Also cleaning up a tokio `select!` with single branch. 