### PR TITLE
Implement RFC-0023: targeted block-cache warming and eviction

### DIFF
--- a/rfcs/0023-cache-manager.md
+++ b/rfcs/0023-cache-manager.md
@@ -95,59 +95,33 @@ pub enum CacheTarget {
     /// Warm the SST data blocks that overlap the supplied key range.
     ///
     /// This also warms the SST index, since block planning depends on it.
-    ///
-    /// Callers can select all data blocks in an SST by passing an unbounded
-    /// range, for example `(..)`.
-    Data(BytesRange),
+    /// The payload is a standard `(Bound, Bound)` pair that implements
+    /// `RangeBounds<Bytes>`.
+    Data((Bound<Bytes>, Bound<Bytes>)),
 }
 
-/// Per-target outcome from `warm_sst()`. One entry is returned for each
-/// target the caller requested.
-pub struct WarmResult {
-    pub target: CacheTarget,
-    pub outcome: Result<WarmBlocks, crate::Error>,
-}
-
-pub struct WarmBlocks {
-    /// Offsets of blocks newly inserted into the block cache by this call.
-    pub blocks_warmed: Vec<u64>,
-    /// Offsets of blocks skipped because they were already cached.
-    pub blocks_skipped: Vec<u64>,
-}
-
-pub struct EvictBlocks {
-    /// Offsets of blocks removed from the block cache.
-    pub blocks_evicted: Vec<u64>,
+impl CacheTarget {
+    /// Construct a [`CacheTarget::Data`] from any `RangeBounds<impl AsRef<[u8]>>`,
+    /// mirroring the [`Db::scan`] signature. Pass `..` to warm all data blocks.
+    pub fn data<K, T>(range: T) -> Self
+    where
+        K: AsRef<[u8]>,
+        T: RangeBounds<K>;
 }
 
 /// Trait for block-cache warming and eviction operations.
-///
-/// Implemented by both [`Db`](crate::Db) and [`DbReader`](crate::DbReader) so
-/// callers can use the same methods against either handle.
 #[async_trait::async_trait]
 pub trait DbCacheManagerOps {
-    /// Warms selected cache content for one SST.
-    ///
-    /// Returns an entry per requested target, each carrying the per-target
-    /// outcome. Callers fan out over SSTs themselves (for example with
-    /// `FuturesUnordered`) to get the concurrency they want.
-    ///
-    /// If no block cache is configured, logs a warning and returns an empty
-    /// list.
+    /// Warms selected cache content for one SST. Short-circuits on the first
+    /// failing target.
     async fn warm_sst(
         &self,
         sst_id: SsTableId,
         targets: &[CacheTarget],
-    ) -> Result<Vec<WarmResult>, crate::Error>;
+    ) -> Result<(), crate::Error>;
 
     /// Best-effort eviction of block-cache entries for one SST.
-    ///
-    /// If no block cache is configured, logs a warning and returns empty
-    /// `EvictBlocks`.
-    async fn evict_cached_sst(
-        &self,
-        sst_id: SsTableId,
-    ) -> Result<EvictBlocks, crate::Error>;
+    async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error>;
 }
 ```
 
@@ -165,8 +139,10 @@ This API makes three deliberate choices.
    their own concurrency primitive. This keeps the API small and pushes
    policy (parallelism, rate-limiting, ordering) to the caller.
 
-`warm_sst()` returns per-target outcomes instead of failing the whole call on
-the first target that fails.
+Both methods return `Result<(), crate::Error>`. Per-target visibility (what was
+warmed, what was skipped, how many blocks moved through the cache) belongs in
+cache-manager metrics, not the return value. A richer return shape can be added
+later in a backwards-compatible way (see Alternatives).
 
 ### Warm Targets
 
@@ -175,23 +151,23 @@ the first target that fails.
 - `CacheTarget::Index` warms the SST index.
 - `CacheTarget::Filters` warms all filters on the SST, if any exist.
 - `CacheTarget::Stats` warms the SST stats block, if one exists.
-- `CacheTarget::Data(BytesRange)` warms the data blocks that overlap the
-  supplied key range. It also warms the SST index, since data-block planning
-  depends on that index.
+- `CacheTarget::Data((Bound<Bytes>, Bound<Bytes>))` warms the data blocks that
+  overlap the supplied key range. It also warms the SST index, since data-block
+  planning depends on that index.
 
 `warm_sst()` accepts multiple targets for the same call. A caller can warm
 only metadata, data ranges plus their required indexes, or both. Batching
 targets into one call lets SlateDB share the SST index read across
 `CacheTarget::Index` and `CacheTarget::Data(_)`.
 
-For data warming, SlateDB uses the same range model it already uses elsewhere:
-`BytesRange` describes key intervals, and overlapping target ranges in a
-single call are coalesced before the read. If the caller provides redundant
-ranges, SlateDB should not fetch the same block twice.
+For data warming, callers pass any standard `RangeBounds` through
+`CacheTarget::data(range)`, mirroring the `Db::scan<K, T>(range: T)` signature.
+Overlapping target ranges in a single call are not coalesced upfront; the
+block cache's per-block lookup in `read_blocks_using_index` prevents duplicate
+object-store fetches.
 
-`BytesRange` can also express "all data" with an unbounded range, so
-`CacheTarget::Data(..)` is enough for full-SST data warming. This RFC does not
-need a separate `AllData` target.
+`CacheTarget::data(..)` expresses "all data" with an unbounded range, so
+full-SST data warming does not need a separate `AllData` target.
 
 `CacheTarget::Data(...)` implies `CacheTarget::Index` as part of the API
 contract, because SlateDB cannot warm data blocks without using the index to
@@ -222,15 +198,18 @@ For each `CacheTarget::Data(range)`, SlateDB:
 2. Skips the target if that intersection is empty.
 3. Reads the SST index if it has not already done so for this call.
 4. Uses the index to map the overlapping key range to block intervals.
-5. Coalesces overlapping intervals.
-6. Reads those blocks through
-   `TableStore::read_blocks_using_index(..., cache=true)`.
 
-If the SST is not reachable from the current manifest, `warm_sst()` returns an
-empty result list. It does not try to recreate a previous session's cache
-contents. If a block cache implementation persists entries across restarts,
-callers decide whether rewarming is worth the cost of redundant cache lookups,
-which is non-trivial for large ranges even when every block hits.
+For each `CacheTarget::Data(_)`, SlateDB warms the covered block ranges
+through `TableStore::read_blocks_using_index(..., cache=true)`. That reader
+consults the block cache per block and fetches only uncached ones, so
+overlapping targets in the same call do not double-fetch.
+
+If the SST is not reachable from the current manifest, `warm_sst()` returns
+`Ok(())` without doing any work. It does not try to recreate a previous
+session's cache contents. If a block cache implementation persists entries
+across restarts, callers decide whether rewarming is worth the cost of
+redundant cache lookups, which is non-trivial for large ranges even when every
+block hits.
 
 ### Best-Effort Eviction
 
@@ -278,9 +257,8 @@ and it matches the real read path.
 
 It is still a side effect, not a goal of this RFC.
 
-- If no block cache is configured, both methods log a warning and return an
-  empty result (empty list for `warm_sst`, empty `EvictBlocks` for
-  `evict_cached_sst`).
+- If no block cache is configured, both methods log a warning and return
+  `Ok(())` without doing any work.
 - Eviction only targets SlateDB block-cache entries.
 - Object-store cache behavior stays unchanged.
 
@@ -292,20 +270,17 @@ two caches behind one policy surface.
 
 These APIs should not put database availability at risk.
 
-- `warm_sst()` and `evict_cached_sst()` return `Err` for call-level failures,
-  such as database shutdown or invalid request setup.
-- For `warm_sst()`, per-target failures are reported inside each `WarmResult`
-  (`outcome: Err(...)`) rather than by aborting the call. One failing target
-  does not prevent other targets in the same call from succeeding.
+- `warm_sst()` short-circuits on the first failing target and returns `Err`.
+  Targets processed before the failure may already have inserted blocks into
+  the cache; that partial state is left alone.
+- `evict_cached_sst()` returns `Err` if the index read or any cache removal
+  fails. Partial eviction is acceptable.
 - Cross-SST orchestration is the caller's responsibility. A caller fanning out
   over many SSTs decides whether one failing `warm_sst()` or
   `evict_cached_sst()` should short-circuit the rest.
 
-Warming is not atomic. If one target inside a `warm_sst()` call fails, other
-targets may already have inserted blocks into the cache. Eviction is not
-atomic either. If `evict_cached_sst()` fails partway through, SlateDB may
-already have removed some of the SST's cache entries. That is acceptable. The
-contract is best effort plus reporting, not transactional cache state.
+Neither method is atomic. The contract is best effort, not transactional
+cache state.
 
 ## Impact Analysis
 
@@ -493,6 +468,21 @@ We could bake warming into `Db::open()` or builder setup. This RFC does not do
 that. Some users will want to block on warm-up before serving reads. Others will
 want to skip it, or make that decision with external state. The lower-level API
 keeps that choice with the caller.
+
+**Rich return types: `Vec<WarmResult>` with per-target `WarmBlocks` / `EvictBlocks`**
+
+An earlier draft had `warm_sst()` return a `Vec<WarmResult>` (one entry per
+target, each with its own `Result<WarmBlocks, Error>` payload listing block
+offsets), and `evict_cached_sst()` return an `EvictBlocks` listing every
+offset the call attempted to remove. It also meant per-target failures could
+be reported without aborting the whole call.
+
+We rejected it because metrics cover the same ground more cheaply: warm/evict
+counts, durations, per-target breakdowns, and error counts are all recordable
+without shaping a struct into the public API. A `Result<(), Error>` is easier
+to commit to for a v1 and can be widened backwards-compatibly later (for
+example via a `warm_sst_detailed()` variant, or by returning an opaque handle)
+if a real caller shows up needing that detail.
 
 **Plural `warm_ssts(&[SsTableId], &[CacheTarget])`**
 

--- a/slatedb/src/bytes_range.rs
+++ b/slatedb/src/bytes_range.rs
@@ -57,6 +57,10 @@ impl BytesRange {
         inner.non_empty().then_some(Self { inner })
     }
 
+    pub(crate) fn unbounded() -> Self {
+        Self::new(Unbounded, Unbounded)
+    }
+
     pub(crate) fn new_empty() -> Self {
         Self {
             inner: ComparableRange::new(

--- a/slatedb/src/bytes_range.rs
+++ b/slatedb/src/bytes_range.rs
@@ -50,6 +50,13 @@ impl BytesRange {
         Self { inner }
     }
 
+    /// Build a `BytesRange` without panicking on empty ranges. Returns `None`
+    /// when the bounds describe an empty key interval.
+    pub(crate) fn try_new(start_bound: Bound<Bytes>, end_bound: Bound<Bytes>) -> Option<Self> {
+        let inner = ComparableRange::new(start_bound, end_bound);
+        inner.non_empty().then_some(Self { inner })
+    }
+
     pub(crate) fn new_empty() -> Self {
         Self {
             inner: ComparableRange::new(

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1634,20 +1634,6 @@ impl Db {
         Ok(txn)
     }
 
-    /// See [`DbCacheManagerOps::warm_sst`].
-    pub async fn warm_sst(
-        &self,
-        sst_id: SsTableId,
-        targets: &[CacheTarget],
-    ) -> Result<(), crate::Error> {
-        <Self as DbCacheManagerOps>::warm_sst(self, sst_id, targets).await
-    }
-
-    /// See [`DbCacheManagerOps::evict_cached_sst`].
-    pub async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error> {
-        <Self as DbCacheManagerOps>::evict_cached_sst(self, sst_id).await
-    }
-
     /// Resolve an object store from a URL.
     ///
     /// ## Arguments

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -22,6 +22,7 @@
 
 pub use crate::db_status::DbStatus;
 
+use crate::db_cache_manager::{self, CacheTarget, DbCacheManagerOps};
 use crate::db_metadata::DbMetadataOps;
 use std::ops::RangeBounds;
 use std::sync::Arc;
@@ -1633,6 +1634,20 @@ impl Db {
         Ok(txn)
     }
 
+    /// See [`DbCacheManagerOps::warm_sst`].
+    pub async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: &[CacheTarget],
+    ) -> Result<(), crate::Error> {
+        <Self as DbCacheManagerOps>::warm_sst(self, sst_id, targets).await
+    }
+
+    /// See [`DbCacheManagerOps::evict_cached_sst`].
+    pub async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error> {
+        <Self as DbCacheManagerOps>::evict_cached_sst(self, sst_id).await
+    }
+
     /// Resolve an object store from a URL.
     ///
     /// ## Arguments
@@ -1727,6 +1742,24 @@ impl Db {
     /// See [`DbMetadataOps::status`].
     pub fn status(&self) -> DbStatus {
         <Self as DbMetadataOps>::status(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl DbCacheManagerOps for Db {
+    async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: &[CacheTarget],
+    ) -> Result<(), crate::Error> {
+        self.inner.check_closed()?;
+        let manifest = self.manifest();
+        db_cache_manager::warm_sst_impl(&self.inner.table_store, &manifest, sst_id, targets).await
+    }
+
+    async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error> {
+        self.inner.check_closed()?;
+        db_cache_manager::evict_cached_sst_impl(&self.inner.table_store, sst_id).await
     }
 }
 

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -1,4 +1,3 @@
-use std::ops::Bound::Unbounded;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
@@ -8,7 +7,7 @@ use log::{debug, warn};
 use tokio::sync::OnceCell;
 
 use crate::bytes_range::BytesRange;
-use crate::db_state::{SsTableHandle, SsTableId};
+use crate::db_state::{SsTableHandle, SsTableId, SsTableView};
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::manifest::VersionedManifest;
@@ -89,22 +88,27 @@ pub(crate) async fn warm_sst_impl(
         return Ok(());
     }
 
-    let visible_ranges: Vec<BytesRange> = manifest
+    // Reuse the handle embedded in the manifest view instead of calling
+    // `open_sst`, which would issue an extra object_store GET for info+version.
+    // All matching views share the same physical handle, so grab the first.
+    let matching: Vec<&SsTableView> = manifest
         .l0()
         .iter()
         .chain(manifest.compacted().iter().flat_map(|run| &run.sst_views))
         .filter(|view| view.sst.id == sst_id)
-        .filter_map(|view| view.calculate_view_range(BytesRange::new(Unbounded, Unbounded)))
         .collect();
-    if visible_ranges.is_empty() {
+    let Some(first) = matching.first() else {
         debug!(
             "warm_sst: SST {:?} not reachable from current manifest",
             sst_id
         );
         return Ok(());
-    }
-
-    let handle = table_store.open_sst(&sst_id).await?;
+    };
+    let handle = first.sst.clone();
+    let visible_ranges: Vec<BytesRange> = matching
+        .iter()
+        .filter_map(|v| v.calculate_view_range(BytesRange::unbounded()))
+        .collect();
     // Shared lazy index — populated at most once, so parallel target fanout
     // can share a single object-store read.
     let index_cell: OnceCell<Result<Arc<SsTableIndexOwned>, SlateDBError>> = OnceCell::new();
@@ -143,6 +147,22 @@ pub(crate) async fn evict_cached_sst_impl(
     Ok(())
 }
 
+/// Clamp a requested data range against the SST's visible views, returning the
+/// sub-ranges to warm. Empty result means there is nothing to do — either the
+/// request collapses to empty bounds, or it overlaps no visible view.
+fn plan_warm_intersections(
+    visible_ranges: &[BytesRange],
+    data_range: &(Bound<Bytes>, Bound<Bytes>),
+) -> Vec<BytesRange> {
+    let Some(requested) = BytesRange::try_new(data_range.0.clone(), data_range.1.clone()) else {
+        return Vec::new();
+    };
+    visible_ranges
+        .iter()
+        .filter_map(|v| v.intersect(&requested))
+        .collect()
+}
+
 async fn warm_data(
     table_store: &Arc<TableStore>,
     handle: &SsTableHandle,
@@ -151,22 +171,11 @@ async fn warm_data(
     data_range: &(Bound<Bytes>, Bound<Bytes>),
     sst_id: &SsTableId,
 ) -> Result<(), crate::Error> {
-    let Some(requested) = BytesRange::try_new(data_range.0.clone(), data_range.1.clone()) else {
-        debug!(
-            "warm_sst: SST {:?} data target range {:?} collapses to empty, skipping",
-            sst_id, data_range
-        );
-        return Ok(());
-    };
-
-    let intersections: Vec<BytesRange> = visible_ranges
-        .iter()
-        .filter_map(|v| v.intersect(&requested))
-        .collect();
+    let intersections = plan_warm_intersections(visible_ranges, data_range);
     if intersections.is_empty() {
         debug!(
-            "warm_sst: SST {:?} data target range {:?} does not overlap visible ranges",
-            sst_id, requested
+            "warm_sst: SST {:?} data range {:?} has no blocks to warm",
+            sst_id, data_range
         );
         return Ok(());
     }
@@ -240,53 +249,65 @@ async fn ensure_index(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ops::Bound::Unbounded;
+
     use crate::config::{FlushOptions, FlushType, PutOptions, Settings, WriteOptions};
     use crate::db::Db;
-    use crate::db_cache::stats as cache_stats;
     use crate::db_cache::{CachedKey, DbCache};
     use object_store::memory::InMemory;
     use object_store::ObjectStore;
-    use slatedb_common::metrics::{lookup_metric_with_labels, DefaultMetricsRecorder};
 
     // Compile-time check: the trait is object-safe.
     fn _assert_object_safe(_: &dyn DbCacheManagerOps) {}
 
     const PATH: &str = "/cache_manager_test";
 
-    async fn open_db_single_sst_with_metrics(
-        object_store: Arc<dyn ObjectStore>,
-    ) -> (Db, Arc<DefaultMetricsRecorder>) {
+    async fn open_db_single_sst(object_store: Arc<dyn ObjectStore>) -> Db {
         // No l0_sst_size_bytes cap so one flush yields a single SST whose cache
         // we can then inspect in isolation.
-        let metrics = Arc::new(DefaultMetricsRecorder::new());
-        let db = Db::builder(PATH, object_store)
+        Db::builder(PATH, object_store)
             .with_settings(Settings {
                 flush_interval: None,
                 ..Default::default()
             })
-            .with_metrics_recorder(metrics.clone())
             .build()
             .await
-            .expect("failed to open db");
-        (db, metrics)
+            .expect("failed to open db")
     }
 
-    fn data_block_misses(metrics: &Arc<DefaultMetricsRecorder>) -> i64 {
-        lookup_metric_with_labels(
-            metrics,
-            cache_stats::ACCESS_COUNT,
-            &[("entry_kind", "data_block"), ("result", "miss")],
-        )
-        .unwrap_or(0)
+    /// For each data block in the SST (ordered), returns whether it is
+    /// currently present in the block cache. Used by tests to assert cache
+    /// population directly instead of going through metrics.
+    async fn cached_block_mask(table_store: &Arc<TableStore>, sst_id: SsTableId) -> Vec<bool> {
+        let handle = table_store.open_sst(&sst_id).await.expect("open_sst");
+        let index = table_store
+            .read_index(&handle, false)
+            .await
+            .expect("read_index");
+        let cache = table_store.cache().expect("cache configured").clone();
+        let num_blocks = index.borrow().block_meta().len();
+        let mut mask = Vec::with_capacity(num_blocks);
+        for i in 0..num_blocks {
+            let offset = index.borrow().block_meta().get(i).offset();
+            let key: CachedKey = (sst_id, offset).into();
+            mask.push(cache.get_block(&key).await.unwrap().is_some());
+        }
+        mask
     }
 
-    fn data_block_hits(metrics: &Arc<DefaultMetricsRecorder>) -> i64 {
-        lookup_metric_with_labels(
-            metrics,
-            cache_stats::ACCESS_COUNT,
-            &[("entry_kind", "data_block"), ("result", "hit")],
-        )
-        .unwrap_or(0)
+    async fn is_key_cached(table_store: &Arc<TableStore>, sst_id: SsTableId, key: &[u8]) -> bool {
+        let handle = table_store.open_sst(&sst_id).await.expect("open_sst");
+        let index = table_store
+            .read_index(&handle, false)
+            .await
+            .expect("read_index");
+        let block_idx =
+            partitions_covering_range(&index.borrow(), Bound::Included(key), Bound::Included(key))
+                .start;
+        let offset = index.borrow().block_meta().get(block_idx).offset();
+        let cache = table_store.cache().expect("cache configured").clone();
+        let cache_key: CachedKey = (sst_id, offset).into();
+        cache.get_block(&cache_key).await.unwrap().is_some()
     }
 
     async fn flush_to_l0(db: &Db) {
@@ -362,48 +383,104 @@ mod tests {
     }
 
     #[test]
-    fn should_reject_empty_data_range_during_planning() {
-        // given: reversed bounds
-        let start = Bound::Included(Bytes::from_static(b"z"));
-        let end = Bound::Excluded(Bytes::from_static(b"a"));
+    fn should_plan_no_intersections_for_collapsed_range() {
+        // given: reversed bounds collapse to an empty interval
+        let visible = [BytesRange::unbounded()];
+        let data = (
+            Bound::Included(Bytes::from_static(b"z")),
+            Bound::Excluded(Bytes::from_static(b"a")),
+        );
 
         // when
-        let range = BytesRange::try_new(start, end);
+        let out = plan_warm_intersections(&visible, &data);
 
         // then
-        assert!(range.is_none());
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn should_plan_no_intersections_when_request_outside_visible_view() {
+        // given: visible view starts at key000032, request ends before it
+        let visible = [BytesRange::from_ref("key000032".as_bytes()..)];
+        let data = (
+            Bound::Included(Bytes::from_static(b"key000000")),
+            Bound::Excluded(Bytes::from_static(b"key000010")),
+        );
+
+        // when
+        let out = plan_warm_intersections(&visible, &data);
+
+        // then
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn should_plan_intersection_clamped_to_visible_view() {
+        // given: visible view is the upper half; request is full range
+        let visible = [BytesRange::from_ref("key000032".as_bytes()..)];
+        let data = (Unbounded, Unbounded);
+
+        // when
+        let out = plan_warm_intersections(&visible, &data);
+
+        // then: one range clamped to the visible view
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0], BytesRange::from_ref("key000032".as_bytes()..));
+    }
+
+    #[test]
+    fn should_plan_union_across_multiple_visible_views() {
+        // given: two disjoint visible views over the same SST
+        let visible = [
+            BytesRange::from_ref("key000000".as_bytes().."key000016".as_bytes()),
+            BytesRange::from_ref("key000048".as_bytes()..),
+        ];
+        let data = (Unbounded, Unbounded);
+
+        // when
+        let out = plan_warm_intersections(&visible, &data);
+
+        // then: both views are returned
+        assert_eq!(out.len(), 2);
+        assert_eq!(
+            out[0],
+            BytesRange::from_ref("key000000".as_bytes().."key000016".as_bytes()),
+        );
+        assert_eq!(out[1], BytesRange::from_ref("key000048".as_bytes()..));
     }
 
     #[tokio::test]
-    async fn should_serve_get_from_cache_after_warming_full_range() {
+    async fn should_cache_all_blocks_when_warming_full_range() {
         // given: a single-SST DB with its cache evicted
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 64).await;
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
         db.evict_cached_sst(sst_id).await.expect("evict");
 
-        // when: we warm all data blocks, then read a key
+        // when
         db.warm_sst(sst_id, &[CacheTarget::data::<&[u8], _>(..)])
             .await
             .expect("warm_sst");
-        let misses_after_warm = data_block_misses(&metrics);
-        let hits_before_get = data_block_hits(&metrics);
-        db.get(b"key000032").await.expect("get");
 
-        // then: the read only produced hits — no new misses
-        assert_eq!(data_block_misses(&metrics), misses_after_warm);
-        assert!(data_block_hits(&metrics) > hits_before_get);
+        // then: every data block is in cache
+        let mask = cached_block_mask(&db.inner.table_store, sst_id).await;
+        assert!(!mask.is_empty(), "expected SST to have data blocks");
+        assert!(
+            mask.iter().all(|&b| b),
+            "expected all blocks cached, got {:?}",
+            mask,
+        );
 
         db.close().await.expect("close");
     }
 
     #[tokio::test]
-    async fn should_serve_only_warmed_range_from_cache() {
+    async fn should_cache_only_requested_sub_range() {
         // given: a single-SST DB with its cache evicted
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 64).await;
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
@@ -414,19 +491,14 @@ mod tests {
             .await
             .expect("warm_sst");
 
-        // then: a read inside the warmed range hits, a read below misses
-        let misses_before_warmed_read = data_block_misses(&metrics);
-        db.get(b"key000040").await.expect("get warmed");
-        assert_eq!(
-            data_block_misses(&metrics),
-            misses_before_warmed_read,
-            "read in warmed range should hit",
-        );
-
-        db.get(b"key000000").await.expect("get unwarmed");
+        // then: a key above the boundary is cached, a key below is not
         assert!(
-            data_block_misses(&metrics) > misses_before_warmed_read,
-            "read outside warmed range should miss",
+            is_key_cached(&db.inner.table_store, sst_id, b"key000040").await,
+            "block containing key000040 should be cached",
+        );
+        assert!(
+            !is_key_cached(&db.inner.table_store, sst_id, b"key000000").await,
+            "block containing key000000 should not be cached",
         );
 
         db.close().await.expect("close");
@@ -436,7 +508,7 @@ mod tests {
     async fn should_return_closed_after_db_close() {
         // given: a closed DB with a known SST
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, _) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 8).await;
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
@@ -471,7 +543,7 @@ mod tests {
     async fn should_warm_only_within_visible_view_range() {
         // given: a single-SST DB whose cache is empty
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 64).await;
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
@@ -494,109 +566,14 @@ mod tests {
         .await
         .expect("warm_sst_impl");
 
-        // then: a read inside the visible range hits, a read below it misses
-        let misses_after_warm = data_block_misses(&metrics);
-        db.get(b"key000040").await.expect("get in visible range");
-        assert_eq!(
-            data_block_misses(&metrics),
-            misses_after_warm,
-            "read inside visible range should hit warmed blocks",
-        );
-
-        db.get(b"key000000").await.expect("get below visible range");
+        // then: a block inside the visible view is cached, a block below is not
         assert!(
-            data_block_misses(&metrics) > misses_after_warm,
-            "read below visible range should miss",
+            is_key_cached(&db.inner.table_store, sst_id, b"key000040").await,
+            "block inside visible view should be cached",
         );
-
-        db.close().await.expect("close");
-    }
-
-    #[tokio::test]
-    async fn should_skip_warming_when_requested_range_outside_visible_view() {
-        // given: a single-SST DB whose cache is empty
-        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
-        write_keys(&db, 64).await;
-        flush_to_l0(&db).await;
-        let sst_id = first_l0_sst_id(&db);
-        db.evict_cached_sst(sst_id).await.expect("evict");
-
-        // and: a manifest that restricts the view to the upper half
-        let mut manifest = db.manifest();
-        project_l0_view(
-            &mut manifest,
-            BytesRange::from_ref("key000032".as_bytes()..),
-        );
-
-        // when: we warm a data range that falls entirely below the visible view
-        let misses_before_warm = data_block_misses(&metrics);
-        warm_sst_impl(
-            &db.inner.table_store,
-            &manifest,
-            sst_id,
-            &[CacheTarget::data(
-                b"key000000".as_slice()..b"key000010".as_slice(),
-            )],
-        )
-        .await
-        .expect("warm_sst_impl");
-
-        // then: warming was a no-op — no blocks fetched, and a later read in that
-        // sub-range still misses
-        assert_eq!(data_block_misses(&metrics), misses_before_warm);
-        db.get(b"key000005").await.expect("get");
-        assert!(data_block_misses(&metrics) > misses_before_warm);
-
-        db.close().await.expect("close");
-    }
-
-    #[tokio::test]
-    async fn should_warm_union_of_multiple_views_referencing_same_sst() {
-        // given: a single-SST DB whose cache is empty
-        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
-        write_keys(&db, 64).await;
-        flush_to_l0(&db).await;
-        let sst_id = first_l0_sst_id(&db);
-        db.evict_cached_sst(sst_id).await.expect("evict");
-
-        // and: a manifest with two L0 views of the same SST — one restricted to
-        // the low quarter, one to the high quarter, leaving the middle unmapped
-        let mut manifest = db.manifest();
-        let l0 = &mut manifest.manifest.core.l0;
-        let original = l0.pop_front().expect("expected at least one L0 view");
-        let low = original.with_visible_range(BytesRange::from_ref(
-            "key000000".as_bytes().."key000016".as_bytes(),
-        ));
-        let high = original.with_visible_range(BytesRange::from_ref("key000048".as_bytes()..));
-        l0.push_front(high);
-        l0.push_front(low);
-
-        // when: we warm the full range
-        warm_sst_impl(
-            &db.inner.table_store,
-            &manifest,
-            sst_id,
-            &[CacheTarget::data::<&[u8], _>(..)],
-        )
-        .await
-        .expect("warm_sst_impl");
-
-        // then: reads in either visible view hit; a read in the gap between views misses
-        let misses_after_warm = data_block_misses(&metrics);
-        db.get(b"key000008").await.expect("get in low view");
-        db.get(b"key000056").await.expect("get in high view");
-        assert_eq!(
-            data_block_misses(&metrics),
-            misses_after_warm,
-            "reads inside either visible view should hit warmed blocks",
-        );
-
-        db.get(b"key000032").await.expect("get in gap");
         assert!(
-            data_block_misses(&metrics) > misses_after_warm,
-            "read in the gap between visible views should miss",
+            !is_key_cached(&db.inner.table_store, sst_id, b"key000000").await,
+            "block below visible view should not be cached",
         );
 
         db.close().await.expect("close");
@@ -606,40 +583,39 @@ mod tests {
     async fn should_return_ok_when_sst_not_in_manifest() {
         // given: a DB with one flushed SST and a fresh unknown SST id
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 8).await;
         flush_to_l0(&db).await;
-        let misses_before = data_block_misses(&metrics);
         let unknown_id = SsTableId::Compacted(ulid::Ulid::new());
 
-        // when: we warm an SST that isn't reachable from the manifest
+        // when / then: warming an unreachable SST is a no-op that returns Ok.
+        // Any attempted IO against a non-existent SST would surface as Err, so
+        // the Ok return is itself proof that no work happened.
         db.warm_sst(unknown_id, &[CacheTarget::data::<&[u8], _>(..)])
             .await
             .expect("warm_sst should no-op for unreachable SST");
-
-        // then: no data-block IO happened
-        assert_eq!(data_block_misses(&metrics), misses_before);
 
         db.close().await.expect("close");
     }
 
     #[tokio::test]
-    async fn should_short_circuit_on_target_failure() {
-        // given: a flushed SST whose underlying object has been deleted out
-        // from under the DB, leaving the manifest reference dangling
+    async fn should_return_err_on_target_failure() {
+        // given: a flushed SST whose cache has been evicted and whose
+        // underlying object has then been deleted, so target reads must go to
+        // object store and will fail
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 64).await;
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
         db.inner
             .table_store
             .delete_sst(&sst_id)
             .await
             .expect("delete_sst");
 
-        // when: we warm two targets; the first IO will fail
-        let misses_before = data_block_misses(&metrics);
+        // when: we warm a target whose underlying IO will fail
         let result = db
             .warm_sst(
                 sst_id,
@@ -647,13 +623,8 @@ mod tests {
             )
             .await;
 
-        // then: warm_sst surfaces the error and the Data target is never attempted
+        // then: the failure is surfaced to the caller
         assert!(result.is_err(), "warm_sst should return Err");
-        assert_eq!(
-            data_block_misses(&metrics),
-            misses_before,
-            "later targets must not be attempted after a failure",
-        );
 
         db.close().await.expect("close");
     }
@@ -771,24 +742,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_miss_cache_after_eviction() {
+    async fn should_evict_all_blocks_from_cache() {
         // given: a warmed SST
         let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        let db = open_db_single_sst(os).await;
         write_keys(&db, 64).await;
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
         db.warm_sst(sst_id, &[CacheTarget::data::<&[u8], _>(..)])
             .await
             .expect("warm_sst");
+        let mask_before = cached_block_mask(&db.inner.table_store, sst_id).await;
+        assert!(
+            mask_before.iter().all(|&b| b),
+            "expected all blocks cached after warm"
+        );
 
-        // when: we evict the SST and then read a key
+        // when
         db.evict_cached_sst(sst_id).await.expect("evict");
-        let misses_before_get = data_block_misses(&metrics);
-        db.get(b"key000032").await.expect("get");
 
-        // then: the read produced a cache miss
-        assert!(data_block_misses(&metrics) > misses_before_get);
+        // then: no blocks remain in cache
+        let mask_after = cached_block_mask(&db.inner.table_store, sst_id).await;
+        assert!(
+            mask_after.iter().all(|&b| !b),
+            "expected no blocks cached after eviction, got {:?}",
+            mask_after,
+        );
 
         db.close().await.expect("close");
     }

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -1,0 +1,506 @@
+use std::ops::Bound::Unbounded;
+use std::ops::{Bound, RangeBounds};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use log::{debug, warn};
+use tokio::sync::OnceCell;
+
+use crate::bytes_range::BytesRange;
+use crate::db_state::{SsTableHandle, SsTableId, SsTableView};
+use crate::error::SlateDBError;
+use crate::flatbuffer_types::SsTableIndexOwned;
+use crate::manifest::VersionedManifest;
+use crate::partitioned_keyspace::partitions_covering_range;
+use crate::tablestore::TableStore;
+
+/// Cache content that [`DbCacheManagerOps::warm_sst`] should populate.
+#[derive(Clone, Debug)]
+pub enum CacheTarget {
+    /// Warm all filters on the SST, if any exist.
+    Filters,
+    /// Warm the SST index.
+    Index,
+    /// Warm the SST stats block, if one exists.
+    Stats,
+    /// Warm the SST data blocks that overlap the supplied key range.
+    ///
+    /// Also warms the SST index, since block planning depends on it.
+    Data((Bound<Bytes>, Bound<Bytes>)),
+}
+
+impl CacheTarget {
+    /// Convenience constructor for [`CacheTarget::Data`] that accepts any
+    /// [`RangeBounds`], mirroring the `Db::scan` signature. Pass `..` to
+    /// warm all data blocks.
+    pub fn data<K, T>(range: T) -> Self
+    where
+        K: AsRef<[u8]>,
+        T: RangeBounds<K>,
+    {
+        let start = range
+            .start_bound()
+            .map(|b| Bytes::copy_from_slice(b.as_ref()));
+        let end = range
+            .end_bound()
+            .map(|b| Bytes::copy_from_slice(b.as_ref()));
+        CacheTarget::Data((start, end))
+    }
+}
+
+/// Trait for block-cache warming and eviction operations.
+#[async_trait]
+pub trait DbCacheManagerOps {
+    /// Warms selected cache content for one SST.
+    ///
+    /// Callers fan out over SSTs themselves (for example with
+    /// `FuturesUnordered`) to get the concurrency they want. Per-target
+    /// outcomes are reflected in cache-manager metrics, not the return value.
+    ///
+    /// Returns `Err` on the first failing target. If no block cache is
+    /// configured, or if the SST is not reachable from the current manifest,
+    /// the call is a no-op that returns `Ok(())`.
+    async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: &[CacheTarget],
+    ) -> Result<(), crate::Error>;
+
+    /// Best-effort eviction of block-cache entries for one SST.
+    ///
+    /// If no block cache is configured, logs a warning and returns `Ok(())`.
+    /// Does not check whether the SST is still live in the current manifest —
+    /// callers own that policy.
+    async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error>;
+}
+
+pub(crate) async fn warm_sst_impl(
+    table_store: &Arc<TableStore>,
+    manifest: &VersionedManifest,
+    sst_id: SsTableId,
+    targets: &[CacheTarget],
+) -> Result<(), crate::Error> {
+    if targets.is_empty() {
+        return Ok(());
+    }
+    if table_store.cache().is_none() {
+        warn!("warm_sst called on a Db without a block cache configured");
+        return Ok(());
+    }
+
+    let visible_ranges = collect_visible_ranges(manifest, &sst_id);
+    if visible_ranges.is_empty() {
+        debug!(
+            "warm_sst: SST {:?} not reachable from current manifest",
+            sst_id
+        );
+        return Ok(());
+    }
+
+    let handle = table_store.open_sst(&sst_id).await?;
+    // Shared lazy index — populated at most once, so parallel target fanout
+    // can share a single object-store read.
+    let index_cell: OnceCell<Result<Arc<SsTableIndexOwned>, SlateDBError>> = OnceCell::new();
+
+    for target in targets {
+        match target {
+            CacheTarget::Filters => warm_filters(table_store, &handle).await?,
+            CacheTarget::Index => warm_index(table_store, &handle, &index_cell).await?,
+            CacheTarget::Stats => warm_stats(table_store, &handle).await?,
+            CacheTarget::Data(data_range) => {
+                warm_data(
+                    table_store,
+                    &handle,
+                    &index_cell,
+                    &visible_ranges,
+                    data_range,
+                    &sst_id,
+                )
+                .await?
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn evict_cached_sst_impl(
+    table_store: &Arc<TableStore>,
+    sst_id: SsTableId,
+) -> Result<(), crate::Error> {
+    if table_store.cache().is_none() {
+        warn!("evict_cached_sst called on a Db without a block cache configured");
+        return Ok(());
+    }
+    let handle = table_store.open_sst(&sst_id).await?;
+    table_store.evict_sst_from_cache(&handle).await;
+    Ok(())
+}
+
+async fn warm_data(
+    table_store: &Arc<TableStore>,
+    handle: &SsTableHandle,
+    index_cell: &OnceCell<Result<Arc<SsTableIndexOwned>, SlateDBError>>,
+    visible_ranges: &[BytesRange],
+    data_range: &(Bound<Bytes>, Bound<Bytes>),
+    sst_id: &SsTableId,
+) -> Result<(), crate::Error> {
+    let Some(requested) = BytesRange::try_new(data_range.0.clone(), data_range.1.clone()) else {
+        debug!(
+            "warm_sst: SST {:?} data target range {:?} collapses to empty, skipping",
+            sst_id, data_range
+        );
+        return Ok(());
+    };
+
+    let intersections: Vec<BytesRange> = visible_ranges
+        .iter()
+        .filter_map(|v| v.intersect(&requested))
+        .collect();
+    if intersections.is_empty() {
+        debug!(
+            "warm_sst: SST {:?} data target range {:?} does not overlap visible ranges",
+            sst_id, requested
+        );
+        return Ok(());
+    }
+
+    let index = ensure_index(table_store, handle, index_cell).await?;
+    for r in &intersections {
+        let block_range = partitions_covering_range(
+            &index.borrow(),
+            r.start_bound().map(|b| b.as_ref()),
+            r.end_bound().map(|b| b.as_ref()),
+        );
+        if block_range.is_empty() {
+            continue;
+        }
+        table_store
+            .read_blocks_using_index(handle, index.clone(), block_range, true)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn warm_index(
+    table_store: &Arc<TableStore>,
+    handle: &SsTableHandle,
+    index_cell: &OnceCell<Result<Arc<SsTableIndexOwned>, SlateDBError>>,
+) -> Result<(), crate::Error> {
+    ensure_index(table_store, handle, index_cell).await?;
+    Ok(())
+}
+
+async fn warm_filters(
+    table_store: &Arc<TableStore>,
+    handle: &SsTableHandle,
+) -> Result<(), crate::Error> {
+    // filter_len == 0 means "no filters"; filter_offset aliases index_offset
+    // in that case and cannot be meaningfully probed or warmed.
+    if handle.info.filter_len == 0 {
+        return Ok(());
+    }
+    table_store.read_filters(handle, true).await?;
+    Ok(())
+}
+
+async fn warm_stats(
+    table_store: &Arc<TableStore>,
+    handle: &SsTableHandle,
+) -> Result<(), crate::Error> {
+    // stats_len == 0 means "no stats block"; stats_offset is 0 in that case
+    // and collides with the first data block's cache key.
+    if handle.info.stats_len == 0 {
+        return Ok(());
+    }
+    table_store.read_stats(handle, true).await?;
+    Ok(())
+}
+
+async fn ensure_index(
+    table_store: &Arc<TableStore>,
+    handle: &SsTableHandle,
+    index_cell: &OnceCell<Result<Arc<SsTableIndexOwned>, SlateDBError>>,
+) -> Result<Arc<SsTableIndexOwned>, SlateDBError> {
+    let result: &Result<Arc<SsTableIndexOwned>, SlateDBError> = index_cell
+        .get_or_init(|| async { table_store.read_index(handle, true).await })
+        .await;
+    match result {
+        Ok(index) => Ok(index.clone()),
+        Err(e) => Err(e.clone()),
+    }
+}
+
+fn collect_visible_ranges(manifest: &VersionedManifest, sst_id: &SsTableId) -> Vec<BytesRange> {
+    let mut ranges = Vec::new();
+    for view in manifest.l0().iter() {
+        if view.sst.id == *sst_id {
+            push_effective_range(view, &mut ranges);
+        }
+    }
+    for run in manifest.compacted().iter() {
+        for view in &run.sst_views {
+            if view.sst.id == *sst_id {
+                push_effective_range(view, &mut ranges);
+            }
+        }
+    }
+    ranges
+}
+
+fn push_effective_range(view: &SsTableView, ranges: &mut Vec<BytesRange>) {
+    if let Some(effective) = view.calculate_view_range(unbounded_range()) {
+        ranges.push(effective);
+    }
+}
+
+fn unbounded_range() -> BytesRange {
+    BytesRange::new(Unbounded, Unbounded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{FlushOptions, FlushType, PutOptions, Settings, WriteOptions};
+    use crate::db::Db;
+    use crate::db_cache::stats as cache_stats;
+    use object_store::memory::InMemory;
+    use object_store::ObjectStore;
+    use slatedb_common::metrics::{lookup_metric_with_labels, DefaultMetricsRecorder};
+
+    // Compile-time check: the trait is object-safe.
+    fn _assert_object_safe(_: &dyn DbCacheManagerOps) {}
+
+    const PATH: &str = "/cache_manager_test";
+
+    async fn open_db_single_sst_with_metrics(
+        object_store: Arc<dyn ObjectStore>,
+    ) -> (Db, Arc<DefaultMetricsRecorder>) {
+        // No l0_sst_size_bytes cap so one flush yields a single SST whose cache
+        // we can then inspect in isolation.
+        let metrics = Arc::new(DefaultMetricsRecorder::new());
+        let db = Db::builder(PATH, object_store)
+            .with_settings(Settings {
+                flush_interval: None,
+                ..Default::default()
+            })
+            .with_metrics_recorder(metrics.clone())
+            .build()
+            .await
+            .expect("failed to open db");
+        (db, metrics)
+    }
+
+    fn data_block_misses(metrics: &Arc<DefaultMetricsRecorder>) -> i64 {
+        lookup_metric_with_labels(
+            metrics,
+            cache_stats::ACCESS_COUNT,
+            &[("entry_kind", "data_block"), ("result", "miss")],
+        )
+        .unwrap_or(0)
+    }
+
+    fn data_block_hits(metrics: &Arc<DefaultMetricsRecorder>) -> i64 {
+        lookup_metric_with_labels(
+            metrics,
+            cache_stats::ACCESS_COUNT,
+            &[("entry_kind", "data_block"), ("result", "hit")],
+        )
+        .unwrap_or(0)
+    }
+
+    async fn flush_to_l0(db: &Db) {
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("failed to flush memtable");
+    }
+
+    async fn write_keys(db: &Db, count: usize) {
+        // Pad values so the resulting SST spans several blocks; otherwise
+        // small values pack into a single block and range-scoped warming
+        // cannot be distinguished from whole-SST warming.
+        let padding = vec![b'x'; 256];
+        for i in 0..count {
+            let key = format!("key{:06}", i);
+            let mut value = format!("value{:06}", i).into_bytes();
+            value.extend_from_slice(&padding);
+            db.put_with_options(
+                key.as_bytes(),
+                &value,
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                },
+            )
+            .await
+            .expect("put failed");
+        }
+    }
+
+    fn first_l0_sst_id(db: &Db) -> SsTableId {
+        let manifest = db.manifest();
+        manifest
+            .l0()
+            .iter()
+            .next()
+            .map(|v| v.sst.id)
+            .expect("expected at least one L0 SST")
+    }
+
+    fn data_bounds(target: &CacheTarget) -> &(Bound<Bytes>, Bound<Bytes>) {
+        match target {
+            CacheTarget::Data(bounds) => bounds,
+            _ => panic!("expected Data variant"),
+        }
+    }
+
+    #[test]
+    fn should_build_data_target_from_closed_range() {
+        // given
+        let range = b"a".as_slice()..b"z".as_slice();
+
+        // when
+        let target = CacheTarget::data(range);
+
+        // then
+        let (start, end) = data_bounds(&target);
+        assert_eq!(start, &Bound::Included(Bytes::from_static(b"a")));
+        assert_eq!(end, &Bound::Excluded(Bytes::from_static(b"z")));
+    }
+
+    #[test]
+    fn should_build_data_target_from_unbounded_range() {
+        // given / when
+        let target = CacheTarget::data::<&[u8], _>(..);
+
+        // then
+        let (start, end) = data_bounds(&target);
+        assert_eq!(start, &Unbounded);
+        assert_eq!(end, &Unbounded);
+    }
+
+    #[test]
+    fn should_reject_empty_data_range_during_planning() {
+        // given: reversed bounds
+        let start = Bound::Included(Bytes::from_static(b"z"));
+        let end = Bound::Excluded(Bytes::from_static(b"a"));
+
+        // when
+        let range = BytesRange::try_new(start, end);
+
+        // then
+        assert!(range.is_none());
+    }
+
+    #[tokio::test]
+    async fn should_serve_get_from_cache_after_warming_full_range() {
+        // given: a single-SST DB with its cache evicted
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        // when: we warm all data blocks, then read a key
+        db.warm_sst(sst_id, &[CacheTarget::data::<&[u8], _>(..)])
+            .await
+            .expect("warm_sst");
+        let misses_after_warm = data_block_misses(&metrics);
+        let hits_before_get = data_block_hits(&metrics);
+        db.get(b"key000032").await.expect("get");
+
+        // then: the read only produced hits — no new misses
+        assert_eq!(data_block_misses(&metrics), misses_after_warm);
+        assert!(data_block_hits(&metrics) > hits_before_get);
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_serve_only_warmed_range_from_cache() {
+        // given: a single-SST DB with its cache evicted
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        // when: we warm only the upper half of the keyspace
+        db.warm_sst(sst_id, &[CacheTarget::data(b"key000032".as_slice()..)])
+            .await
+            .expect("warm_sst");
+
+        // then: a read inside the warmed range hits, a read below misses
+        let misses_before_warmed_read = data_block_misses(&metrics);
+        db.get(b"key000040").await.expect("get warmed");
+        assert_eq!(
+            data_block_misses(&metrics),
+            misses_before_warmed_read,
+            "read in warmed range should hit",
+        );
+
+        db.get(b"key000000").await.expect("get unwarmed");
+        assert!(
+            data_block_misses(&metrics) > misses_before_warmed_read,
+            "read outside warmed range should miss",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_return_closed_after_db_close() {
+        // given: a closed DB with a known SST
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, _) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 8).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.close().await.expect("close");
+
+        // when / then: both ops reject the call with Closed
+        let warm_err = db
+            .warm_sst(sst_id, &[CacheTarget::Index])
+            .await
+            .expect_err("warm_sst on closed db");
+        assert_eq!(
+            warm_err.kind(),
+            crate::ErrorKind::Closed(crate::CloseReason::Clean),
+        );
+        let evict_err = db
+            .evict_cached_sst(sst_id)
+            .await
+            .expect_err("evict_cached_sst on closed db");
+        assert_eq!(
+            evict_err.kind(),
+            crate::ErrorKind::Closed(crate::CloseReason::Clean),
+        );
+    }
+
+    #[tokio::test]
+    async fn should_miss_cache_after_eviction() {
+        // given: a warmed SST
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.warm_sst(sst_id, &[CacheTarget::data::<&[u8], _>(..)])
+            .await
+            .expect("warm_sst");
+
+        // when: we evict the SST and then read a key
+        db.evict_cached_sst(sst_id).await.expect("evict");
+        let misses_before_get = data_block_misses(&metrics);
+        db.get(b"key000032").await.expect("get");
+
+        // then: the read produced a cache miss
+        assert!(data_block_misses(&metrics) > misses_before_get);
+
+        db.close().await.expect("close");
+    }
+}

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -8,7 +8,7 @@ use log::{debug, warn};
 use tokio::sync::OnceCell;
 
 use crate::bytes_range::BytesRange;
-use crate::db_state::{SsTableHandle, SsTableId, SsTableView};
+use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::manifest::VersionedManifest;
@@ -89,7 +89,13 @@ pub(crate) async fn warm_sst_impl(
         return Ok(());
     }
 
-    let visible_ranges = collect_visible_ranges(manifest, &sst_id);
+    let visible_ranges: Vec<BytesRange> = manifest
+        .l0()
+        .iter()
+        .chain(manifest.compacted().iter().flat_map(|run| &run.sst_views))
+        .filter(|view| view.sst.id == sst_id)
+        .filter_map(|view| view.calculate_view_range(BytesRange::new(Unbounded, Unbounded)))
+        .collect();
     if visible_ranges.is_empty() {
         debug!(
             "warm_sst: SST {:?} not reachable from current manifest",
@@ -231,39 +237,13 @@ async fn ensure_index(
     }
 }
 
-fn collect_visible_ranges(manifest: &VersionedManifest, sst_id: &SsTableId) -> Vec<BytesRange> {
-    let mut ranges = Vec::new();
-    for view in manifest.l0().iter() {
-        if view.sst.id == *sst_id {
-            push_effective_range(view, &mut ranges);
-        }
-    }
-    for run in manifest.compacted().iter() {
-        for view in &run.sst_views {
-            if view.sst.id == *sst_id {
-                push_effective_range(view, &mut ranges);
-            }
-        }
-    }
-    ranges
-}
-
-fn push_effective_range(view: &SsTableView, ranges: &mut Vec<BytesRange>) {
-    if let Some(effective) = view.calculate_view_range(unbounded_range()) {
-        ranges.push(effective);
-    }
-}
-
-fn unbounded_range() -> BytesRange {
-    BytesRange::new(Unbounded, Unbounded)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::{FlushOptions, FlushType, PutOptions, Settings, WriteOptions};
     use crate::db::Db;
     use crate::db_cache::stats as cache_stats;
+    use crate::db_cache::{CachedKey, DbCache};
     use object_store::memory::InMemory;
     use object_store::ObjectStore;
     use slatedb_common::metrics::{lookup_metric_with_labels, DefaultMetricsRecorder};
@@ -479,6 +459,315 @@ mod tests {
             evict_err.kind(),
             crate::ErrorKind::Closed(crate::CloseReason::Clean),
         );
+    }
+
+    fn project_l0_view(manifest: &mut VersionedManifest, visible_range: BytesRange) {
+        let l0 = &mut manifest.manifest.core.l0;
+        let view = l0.pop_front().expect("expected at least one L0 view");
+        l0.push_front(view.with_visible_range(visible_range));
+    }
+
+    #[tokio::test]
+    async fn should_warm_only_within_visible_view_range() {
+        // given: a single-SST DB whose cache is empty
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        // and: a manifest snapshot that restricts the SST view to the upper half
+        let mut manifest = db.manifest();
+        project_l0_view(
+            &mut manifest,
+            BytesRange::from_ref("key000032".as_bytes()..),
+        );
+
+        // when: we warm the full range through the projected manifest
+        warm_sst_impl(
+            &db.inner.table_store,
+            &manifest,
+            sst_id,
+            &[CacheTarget::data::<&[u8], _>(..)],
+        )
+        .await
+        .expect("warm_sst_impl");
+
+        // then: a read inside the visible range hits, a read below it misses
+        let misses_after_warm = data_block_misses(&metrics);
+        db.get(b"key000040").await.expect("get in visible range");
+        assert_eq!(
+            data_block_misses(&metrics),
+            misses_after_warm,
+            "read inside visible range should hit warmed blocks",
+        );
+
+        db.get(b"key000000").await.expect("get below visible range");
+        assert!(
+            data_block_misses(&metrics) > misses_after_warm,
+            "read below visible range should miss",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_skip_warming_when_requested_range_outside_visible_view() {
+        // given: a single-SST DB whose cache is empty
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        // and: a manifest that restricts the view to the upper half
+        let mut manifest = db.manifest();
+        project_l0_view(
+            &mut manifest,
+            BytesRange::from_ref("key000032".as_bytes()..),
+        );
+
+        // when: we warm a data range that falls entirely below the visible view
+        let misses_before_warm = data_block_misses(&metrics);
+        warm_sst_impl(
+            &db.inner.table_store,
+            &manifest,
+            sst_id,
+            &[CacheTarget::data(
+                b"key000000".as_slice()..b"key000010".as_slice(),
+            )],
+        )
+        .await
+        .expect("warm_sst_impl");
+
+        // then: warming was a no-op — no blocks fetched, and a later read in that
+        // sub-range still misses
+        assert_eq!(data_block_misses(&metrics), misses_before_warm);
+        db.get(b"key000005").await.expect("get");
+        assert!(data_block_misses(&metrics) > misses_before_warm);
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_warm_union_of_multiple_views_referencing_same_sst() {
+        // given: a single-SST DB whose cache is empty
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        // and: a manifest with two L0 views of the same SST — one restricted to
+        // the low quarter, one to the high quarter, leaving the middle unmapped
+        let mut manifest = db.manifest();
+        let l0 = &mut manifest.manifest.core.l0;
+        let original = l0.pop_front().expect("expected at least one L0 view");
+        let low = original.with_visible_range(BytesRange::from_ref(
+            "key000000".as_bytes().."key000016".as_bytes(),
+        ));
+        let high = original.with_visible_range(BytesRange::from_ref("key000048".as_bytes()..));
+        l0.push_front(high);
+        l0.push_front(low);
+
+        // when: we warm the full range
+        warm_sst_impl(
+            &db.inner.table_store,
+            &manifest,
+            sst_id,
+            &[CacheTarget::data::<&[u8], _>(..)],
+        )
+        .await
+        .expect("warm_sst_impl");
+
+        // then: reads in either visible view hit; a read in the gap between views misses
+        let misses_after_warm = data_block_misses(&metrics);
+        db.get(b"key000008").await.expect("get in low view");
+        db.get(b"key000056").await.expect("get in high view");
+        assert_eq!(
+            data_block_misses(&metrics),
+            misses_after_warm,
+            "reads inside either visible view should hit warmed blocks",
+        );
+
+        db.get(b"key000032").await.expect("get in gap");
+        assert!(
+            data_block_misses(&metrics) > misses_after_warm,
+            "read in the gap between visible views should miss",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_return_ok_when_sst_not_in_manifest() {
+        // given: a DB with one flushed SST and a fresh unknown SST id
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 8).await;
+        flush_to_l0(&db).await;
+        let misses_before = data_block_misses(&metrics);
+        let unknown_id = SsTableId::Compacted(ulid::Ulid::new());
+
+        // when: we warm an SST that isn't reachable from the manifest
+        db.warm_sst(unknown_id, &[CacheTarget::data::<&[u8], _>(..)])
+            .await
+            .expect("warm_sst should no-op for unreachable SST");
+
+        // then: no data-block IO happened
+        assert_eq!(data_block_misses(&metrics), misses_before);
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_short_circuit_on_target_failure() {
+        // given: a flushed SST whose underlying object has been deleted out
+        // from under the DB, leaving the manifest reference dangling
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (db, metrics) = open_db_single_sst_with_metrics(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.inner
+            .table_store
+            .delete_sst(&sst_id)
+            .await
+            .expect("delete_sst");
+
+        // when: we warm two targets; the first IO will fail
+        let misses_before = data_block_misses(&metrics);
+        let result = db
+            .warm_sst(
+                sst_id,
+                &[CacheTarget::Index, CacheTarget::data::<&[u8], _>(..)],
+            )
+            .await;
+
+        // then: warm_sst surfaces the error and the Data target is never attempted
+        assert!(result.is_err(), "warm_sst should return Err");
+        assert_eq!(
+            data_block_misses(&metrics),
+            misses_before,
+            "later targets must not be attempted after a failure",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    // Opens a DB whose tiny fixture SST still carries filters (default
+    // min_filter_keys=1000 would suppress them), flushes one SST, and evicts
+    // its cache entries so meta sections start empty.
+    async fn open_db_with_evicted_meta_sections() -> (Db, SsTableId, SsTableHandle, Arc<dyn DbCache>)
+    {
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder(PATH, os)
+            .with_settings(Settings {
+                flush_interval: None,
+                min_filter_keys: 1,
+                ..Default::default()
+            })
+            .build()
+            .await
+            .expect("failed to open db");
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+        let sst_id = first_l0_sst_id(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        let table_store = db.inner.table_store.clone();
+        let handle = table_store.open_sst(&sst_id).await.expect("open_sst");
+        let cache = table_store.cache().expect("cache configured").clone();
+        (db, sst_id, handle, cache)
+    }
+
+    #[tokio::test]
+    async fn should_populate_cache_for_filters_target() {
+        // given
+        let (db, sst_id, handle, cache) = open_db_with_evicted_meta_sections().await;
+        let filter_key: CachedKey = (sst_id, handle.info.filter_offset).into();
+        let index_key: CachedKey = (sst_id, handle.info.index_offset).into();
+        let stats_key: CachedKey = (sst_id, handle.info.stats_offset).into();
+        assert!(handle.info.filter_len > 0, "expected SST to carry filters");
+        assert!(cache.get_filter(&filter_key).await.unwrap().is_none());
+
+        // when
+        db.warm_sst(sst_id, &[CacheTarget::Filters])
+            .await
+            .expect("warm_sst");
+
+        // then: only the filter section was fetched
+        assert!(cache.get_filter(&filter_key).await.unwrap().is_some());
+        assert!(
+            cache.get_index(&index_key).await.unwrap().is_none(),
+            "filters target must not fetch the index",
+        );
+        assert!(
+            cache.get_stats(&stats_key).await.unwrap().is_none(),
+            "filters target must not fetch stats",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_populate_cache_for_index_target() {
+        // given
+        let (db, sst_id, handle, cache) = open_db_with_evicted_meta_sections().await;
+        let filter_key: CachedKey = (sst_id, handle.info.filter_offset).into();
+        let index_key: CachedKey = (sst_id, handle.info.index_offset).into();
+        let stats_key: CachedKey = (sst_id, handle.info.stats_offset).into();
+        assert!(cache.get_index(&index_key).await.unwrap().is_none());
+
+        // when
+        db.warm_sst(sst_id, &[CacheTarget::Index])
+            .await
+            .expect("warm_sst");
+
+        // then: only the index section was fetched
+        assert!(cache.get_index(&index_key).await.unwrap().is_some());
+        assert!(
+            cache.get_filter(&filter_key).await.unwrap().is_none(),
+            "index target must not fetch filters",
+        );
+        assert!(
+            cache.get_stats(&stats_key).await.unwrap().is_none(),
+            "index target must not fetch stats",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_populate_cache_for_stats_target() {
+        // given
+        let (db, sst_id, handle, cache) = open_db_with_evicted_meta_sections().await;
+        let filter_key: CachedKey = (sst_id, handle.info.filter_offset).into();
+        let index_key: CachedKey = (sst_id, handle.info.index_offset).into();
+        let stats_key: CachedKey = (sst_id, handle.info.stats_offset).into();
+        assert!(handle.info.stats_len > 0, "expected SST to carry stats");
+        assert!(cache.get_stats(&stats_key).await.unwrap().is_none());
+
+        // when
+        db.warm_sst(sst_id, &[CacheTarget::Stats])
+            .await
+            .expect("warm_sst");
+
+        // then: only the stats section was fetched
+        assert!(cache.get_stats(&stats_key).await.unwrap().is_some());
+        assert!(
+            cache.get_filter(&filter_key).await.unwrap().is_none(),
+            "stats target must not fetch filters",
+        );
+        assert!(
+            cache.get_index(&index_key).await.unwrap().is_none(),
+            "stats target must not fetch the index",
+        );
+
+        db.close().await.expect("close");
     }
 
     #[tokio::test]

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -2,8 +2,10 @@ use crate::bytes_range::BytesRange;
 use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
+use crate::db_cache_manager::{self, CacheTarget, DbCacheManagerOps};
 use crate::db_metadata::DbMetadataOps;
 use crate::db_read::DbReadOps;
+use crate::db_state::SsTableId;
 use crate::db_stats::DbStats;
 use crate::db_status::{ClosedResultWriter, DbStatus, DbStatusManager};
 use crate::dispatcher::{MessageFactory, MessageHandler, MessageHandlerExecutor};
@@ -1072,6 +1074,20 @@ impl DbReader {
 
         Ok(())
     }
+
+    /// See [`DbCacheManagerOps::warm_sst`].
+    pub async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: &[CacheTarget],
+    ) -> Result<(), crate::Error> {
+        <Self as DbCacheManagerOps>::warm_sst(self, sst_id, targets).await
+    }
+
+    /// See [`DbCacheManagerOps::evict_cached_sst`].
+    pub async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error> {
+        <Self as DbCacheManagerOps>::evict_cached_sst(self, sst_id).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -1145,6 +1161,24 @@ impl DbReader {
     /// See [`DbMetadataOps::status`].
     pub fn status(&self) -> DbStatus {
         <Self as DbMetadataOps>::status(self)
+    }
+}
+
+#[async_trait]
+impl DbCacheManagerOps for DbReader {
+    async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: &[CacheTarget],
+    ) -> Result<(), crate::Error> {
+        self.inner.check_closed()?;
+        let manifest = self.manifest();
+        db_cache_manager::warm_sst_impl(&self.inner.table_store, &manifest, sst_id, targets).await
+    }
+
+    async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error> {
+        self.inner.check_closed()?;
+        db_cache_manager::evict_cached_sst_impl(&self.inner.table_store, sst_id).await
     }
 }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1074,20 +1074,6 @@ impl DbReader {
 
         Ok(())
     }
-
-    /// See [`DbCacheManagerOps::warm_sst`].
-    pub async fn warm_sst(
-        &self,
-        sst_id: SsTableId,
-        targets: &[CacheTarget],
-    ) -> Result<(), crate::Error> {
-        <Self as DbCacheManagerOps>::warm_sst(self, sst_id, targets).await
-    }
-
-    /// See [`DbCacheManagerOps::evict_cached_sst`].
-    pub async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), crate::Error> {
-        <Self as DbCacheManagerOps>::evict_cached_sst(self, sst_id).await
-    }
 }
 
 #[async_trait::async_trait]

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -45,6 +45,7 @@ pub use compactor_state::VersionedCompactions;
 pub use config::{Settings, SstBlockSize};
 pub use db::{Db, DbBuilder, DbReaderBuilder, DbStatus, WriteHandle};
 pub use db_cache::stats as db_cache_stats;
+pub use db_cache_manager::{CacheTarget, DbCacheManagerOps};
 pub use db_iter::DbIterator;
 pub use db_metadata::DbMetadataOps;
 pub use db_read::DbReadOps;
@@ -108,6 +109,7 @@ mod compactor_state_protocols;
 #[allow(dead_code)]
 mod comparable_range;
 mod db;
+mod db_cache_manager;
 mod db_common;
 mod db_iter;
 mod db_metadata;

--- a/slatedb/src/partitioned_keyspace.rs
+++ b/slatedb/src/partitioned_keyspace.rs
@@ -1,3 +1,5 @@
+use std::ops::{Bound, Range};
+
 /// Represents a set of keys that are partitioned into multiple partitions, where each
 /// partition stores some range of keys and the keys in a given partition are greater than
 /// or equal to all keys from the previous partitions. The space is a multiset, so a given key
@@ -78,6 +80,33 @@ pub(crate) fn last_partition_including_key<T: RangePartitionedKeySpace>(
         return None;
     }
     Some(part_point - 1)
+}
+
+/// Returns the half-open range of partitions that overlap `[start, end)`. Used for mapping
+/// key ranges to SST block ranges (range scans, cache warming).
+pub(crate) fn partitions_covering_range<T: RangePartitionedKeySpace>(
+    keyspace: &T,
+    start: Bound<&[u8]>,
+    end: Bound<&[u8]>,
+) -> Range<usize> {
+    let start_idx = match start {
+        Bound::Included(k) | Bound::Excluded(k) => {
+            first_partition_including_or_after_key(keyspace, k)
+        }
+        Bound::Unbounded => 0,
+    };
+    let end_idx_exclusive = match end {
+        Bound::Included(k) => last_partition_including_key(keyspace, k)
+            .map(|p| p + 1)
+            .unwrap_or(start_idx),
+        Bound::Excluded(k) => match last_partition_including_key(keyspace, k) {
+            None => start_idx,
+            Some(p) if k == keyspace.partition_first_key(p) => p,
+            Some(p) => p + 1,
+        },
+        Bound::Unbounded => keyspace.partitions(),
+    };
+    start_idx..end_idx_exclusive
 }
 
 #[cfg(test)]

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -14,7 +14,7 @@ use crate::db_state::{SsTableId, SsTableView};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::filter_policy::{FilterQuery, FilterTarget, NamedFilter};
-use crate::flatbuffer_types::{SsTableIndex, SsTableIndexOwned};
+use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::format::block::Block;
 use crate::{
     iter::{init_optional_iterator, IterationOrder, RowEntryIterator},
@@ -385,46 +385,6 @@ impl<'a> InternalSstIterator<'a> {
         init_optional_iterator(iter).await
     }
 
-    fn last_block_with_data_including_key(index: &SsTableIndex, key: &[u8]) -> Option<usize> {
-        partitioned_keyspace::last_partition_including_key(index, key)
-    }
-
-    fn first_block_with_data_including_or_after_key(index: &SsTableIndex, key: &[u8]) -> usize {
-        partitioned_keyspace::first_partition_including_or_after_key(index, key)
-    }
-
-    fn blocks_covering_view(index: &SsTableIndex, view: &SstView) -> Range<usize> {
-        let start_block_id = match view.start_key() {
-            Included(k) | Excluded(k) => {
-                Self::first_block_with_data_including_or_after_key(index, k)
-            }
-            Unbounded => 0,
-        };
-
-        let end_block_id_exclusive = match view.end_key() {
-            Included(k) => Self::last_block_with_data_including_key(index, k)
-                .map(|b| b + 1)
-                .unwrap_or(start_block_id),
-            Excluded(k) => {
-                let block_index = Self::last_block_with_data_including_key(index, k);
-                match block_index {
-                    None => start_block_id,
-                    Some(block_index) => {
-                        let block = index.block_meta().get(block_index);
-                        if k == block.first_key().bytes() {
-                            block_index
-                        } else {
-                            block_index + 1
-                        }
-                    }
-                }
-            }
-            Unbounded => index.block_meta().len(),
-        };
-
-        start_block_id..end_block_id_exclusive
-    }
-
     /// Spawns fetch tasks for blocks based on iteration order.
     ///
     /// For ascending order: Fetches blocks forward from `next_block_idx_to_fetch`, incrementing it
@@ -610,8 +570,11 @@ impl<'a> InternalSstIterator<'a> {
                 .table_store
                 .read_index(&self.view.table_as_ref().sst, self.options.cache_blocks)
                 .await?;
-            let block_idx_range =
-                InternalSstIterator::blocks_covering_view(&index.borrow(), &self.view);
+            let block_idx_range = partitioned_keyspace::partitions_covering_range(
+                &index.borrow(),
+                self.view.start_key(),
+                self.view.end_key(),
+            );
             self.block_idx_range = block_idx_range.clone();
             // For descending order, start from the end and work backwards
             self.next_block_idx_to_fetch = match self.options.order {
@@ -780,10 +743,13 @@ impl RowEntryIterator for InternalSstIterator<'_> {
             // For ascending order, find the first block with or after the key
             let block_idx = match self.options.order {
                 IterationOrder::Ascending => {
-                    Self::first_block_with_data_including_or_after_key(&index.borrow(), next_key)
+                    partitioned_keyspace::first_partition_including_or_after_key(
+                        &index.borrow(),
+                        next_key,
+                    )
                 }
                 IterationOrder::Descending => {
-                    Self::last_block_with_data_including_key(&index.borrow(), next_key)
+                    partitioned_keyspace::last_partition_including_key(&index.borrow(), next_key)
                         .unwrap_or(self.block_idx_range.start)
                 }
             };

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -658,6 +658,56 @@ impl TableStore {
         self.sst_format
             .estimate_encoded_size_wal(num_entries, size_entries)
     }
+
+    pub(crate) fn cache(&self) -> Option<&Arc<dyn DbCache>> {
+        self.cache.as_ref()
+    }
+
+    /// Best-effort removal of all cache entries associated with the given SST:
+    /// data blocks, index, filters, and stats. Returns the offsets whose
+    /// cache removal was attempted.
+    pub(crate) async fn evict_sst_from_cache(&self, handle: &SsTableHandle) {
+        let Some(ref cache) = self.cache else {
+            return;
+        };
+        // Best effort: if we can't read the index we can't enumerate blocks,
+        // so log and skip. Remaining entries will age out under normal pressure.
+        let index = match self.read_index(handle, false).await {
+            Ok(index) => index,
+            Err(e) => {
+                warn!(
+                    "evict_sst_from_cache: failed to read index for SST {:?}: {}",
+                    handle.id, e
+                );
+                return;
+            }
+        };
+        {
+            let index_borrow = index.borrow();
+            let meta = index_borrow.block_meta();
+            for block_num in 0..meta.len() {
+                let offset = meta.get(block_num).offset();
+                cache.remove(&(handle.id, offset).into()).await;
+            }
+        }
+        cache
+            .remove(&(handle.id, handle.info.index_offset).into())
+            .await;
+        // Only evict filter/stats when those sections exist. Otherwise
+        // SsTableInfo's filter_offset collides with index_offset (filter_len
+        // == 0) and stats_offset collides with the first data block
+        // (stats_offset == 0).
+        if handle.info.filter_len > 0 {
+            cache
+                .remove(&(handle.id, handle.info.filter_offset).into())
+                .await;
+        }
+        if handle.info.stats_len > 0 {
+            cache
+                .remove(&(handle.id, handle.info.stats_offset).into())
+                .await;
+        }
+    }
 }
 
 async fn write_sst_in_object_store(


### PR DESCRIPTION
## Summary

Implementing RFC-0023 with a few modifications:

1. Change the return type to just be `Result<()>` for now. The code became a bit convoluted when trying to track which blocks were actually warmed and which weren't and it isn't very helpful to just tell the caller which blocks were attempted to be warmed. I think it's better to just look at foyer stats.
2. I made a small modification to the `Data` enum variant so that it's easier to load

fixes #1516 

## Changes

- Implement RFC-0023
- Refactor scan so that we can reuse the `partitions_covering_range` method. Claude

## Notes for Reviewers

**UPDATE**: rejected, we're going to just ask folk to discover it manually.

Claude suggested re-exporting these methods directly on Db/DbReader:

```rs
    pub async fn warm_sst(
        &self,
        sst_id: SsTableId,
        targets: &[CacheTarget],
    ) -> Result<(), crate::Error> {
        <Self as DbCacheManagerOps>::warm_sst(self, sst_id, targets).await
    }
```

I thought it was a good idea so it's more discoverable but I'm happy not doing that.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
