### PR TITLE
Factor LsmTreeState out of ManifestCore

### DIFF
--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -327,7 +327,7 @@ mod tests {
             ..Settings::default()
         };
         test_checkpoint_scope_all(db_options, |manifest| {
-            manifest.core.l0.front().unwrap().clone()
+            manifest.core.tree.l0.front().unwrap().clone()
         })
         .await;
     }
@@ -357,7 +357,7 @@ mod tests {
         let latest_manifest = manifest_store.read_latest_manifest().await.unwrap();
 
         assert_eq!(latest_manifest.id, checkpoint.manifest_id);
-        assert_eq!(latest_manifest.manifest.core.l0.len(), 1);
+        assert_eq!(latest_manifest.manifest.core.tree.l0.len(), 1);
         assert!(
             latest_manifest.manifest.core.last_l0_seq >= 2,
             "expected checkpoint flush to advance last_l0_seq, got {}",
@@ -367,7 +367,15 @@ mod tests {
         assert_flushed_entry(
             Arc::clone(&object_store),
             path,
-            &latest_manifest.manifest.core.l0.front().unwrap().sst.id,
+            &latest_manifest
+                .manifest
+                .core
+                .tree
+                .l0
+                .front()
+                .unwrap()
+                .sst
+                .id,
             (&Bytes::from_static(b"k2"), &Bytes::from_static(b"v2")),
         )
         .await;
@@ -384,7 +392,7 @@ mod tests {
             ..Settings::default()
         };
         test_checkpoint_scope_all(db_options, |manifest| {
-            manifest.core.l0.front().unwrap().clone()
+            manifest.core.tree.l0.front().unwrap().clone()
         })
         .await;
     }

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -1001,7 +1001,7 @@ mod tests {
         parent_db.flush().await.unwrap();
         let manifest = parent_db.manifest();
         assert!(
-            !manifest.manifest.core.l0.is_empty(),
+            !manifest.manifest.core.tree.l0.is_empty(),
             "expected cloned state to include L0 data"
         );
         assert!(
@@ -1091,7 +1091,7 @@ mod tests {
         parent_db.flush().await.unwrap();
         let manifest = parent_db.manifest();
         assert!(
-            !manifest.manifest.core.l0.is_empty(),
+            !manifest.manifest.core.tree.l0.is_empty(),
             "expected cloned state to include L0 data"
         );
         assert!(

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -277,6 +277,7 @@ impl CompactionExecuteBench {
         let state = manifest.db_state();
         let spec = job.spec();
         let srs_by_id: HashMap<_, _> = state
+            .tree
             .compacted
             .iter()
             .map(|sr| (sr.id, sr.clone()))

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -178,12 +178,13 @@ pub trait CompactionScheduler: Send + Sync {
             CompactionRequest::Full => {
                 let manifest = state.manifest().core();
                 let sources = manifest
+                    .tree
                     .compacted
                     .iter()
                     .map(|sr| SourceId::SortedRun(sr.id))
                     .collect::<Vec<_>>();
                 if sources.is_empty() {
-                    if !manifest.l0.is_empty() {
+                    if !manifest.tree.l0.is_empty() {
                         error!(
                             "rejected full compaction: L0-only input is invalid because Full excludes L0 SSTs"
                         );
@@ -191,6 +192,7 @@ pub trait CompactionScheduler: Send + Sync {
                     return Err(crate::Error::from(SlateDBError::InvalidCompaction));
                 }
                 let destination = manifest
+                    .tree
                     .compacted
                     .iter()
                     .map(|sr| sr.id)
@@ -617,10 +619,18 @@ impl CompactorEventHandler {
         use crate::db_state::{SortedRun, SsTableView};
         use std::collections::HashMap;
 
-        let views_by_id: HashMap<Ulid, &SsTableView> =
-            db_state.l0.iter().map(|view| (view.id, view)).collect();
-        let srs_by_id: HashMap<u32, &SortedRun> =
-            db_state.compacted.iter().map(|sr| (sr.id, sr)).collect();
+        let views_by_id: HashMap<Ulid, &SsTableView> = db_state
+            .tree
+            .l0
+            .iter()
+            .map(|view| (view.id, view))
+            .collect();
+        let srs_by_id: HashMap<u32, &SortedRun> = db_state
+            .tree
+            .compacted
+            .iter()
+            .map(|sr| (sr.id, sr))
+            .collect();
 
         compaction
             .spec()
@@ -699,11 +709,13 @@ impl CompactorEventHandler {
         // Validate compaction sources exist in DB state
         let db_state = self.state().db_state();
         let l0_view_ids = db_state
+            .tree
             .l0
             .iter()
             .map(|view| view.id)
             .collect::<std::collections::HashSet<_>>();
         let sr_ids = db_state
+            .tree
             .compacted
             .iter()
             .map(|sr| sr.id)
@@ -722,6 +734,7 @@ impl CompactorEventHandler {
             let highest_id = self
                 .state()
                 .db_state()
+                .tree
                 .compacted
                 .first()
                 .map_or(0, |sr| sr.id + 1);
@@ -888,8 +901,9 @@ impl CompactorEventHandler {
         let sorted_runs = compaction.get_sorted_runs(db_state);
         let spec = compaction.spec();
         // if there are no SRs when we compact L0 then the resulting SR is the last sorted run.
-        let is_dest_last_run = db_state.compacted.is_empty()
+        let is_dest_last_run = db_state.tree.compacted.is_empty()
             || db_state
+                .tree
                 .compacted
                 .last()
                 .is_some_and(|sr| spec.destination() == sr.id);
@@ -1165,7 +1179,7 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        for run in db_state.compacted {
+        for run in db_state.tree.compacted {
             for sst in run.sst_views {
                 let mut iter = SstIterator::new_borrowed_initialized(
                     ..,
@@ -1201,10 +1215,10 @@ mod tests {
         let scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
             |state| {
                 // compact when there are at least 2 SSTs in L0 (one for key 'a' and one for key 'b')
-                state.manifest().core().l0.len() == 2 ||
+                state.manifest().core().tree.l0.len() == 2 ||
                 // or when there is one SST in L0 and one in L1 (one for delete key 'a' and one for compacted key 'a'+'b')
-                (state.manifest().core().l0.len() == 1
-                    && state.manifest().core().compacted.len() == 1)
+                (state.manifest().core().tree.l0.len() == 1
+                    && state.manifest().core().tree.compacted.len() == 1)
             },
         )));
 
@@ -1234,8 +1248,8 @@ mod tests {
         let db_state = await_compaction(&db, Some(system_clock.clone()))
             .await
             .unwrap();
-        assert_eq!(db_state.compacted.len(), 1);
-        assert_eq!(db_state.l0.len(), 0, "{:?}", db_state.l0);
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        assert_eq!(db_state.tree.l0.len(), 0, "{:?}", db_state.tree.l0);
 
         // put tombstone for key a into L0
         db.delete_with_options(
@@ -1251,10 +1265,10 @@ mod tests {
         // Then:
         // we should now have a tombstone in L0 and a value in L1
         let db_state = get_db_state(manifest_store.clone()).await;
-        assert_eq!(db_state.l0.len(), 1, "{:?}", db_state.l0);
-        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.tree.l0.len(), 1, "{:?}", db_state.tree.l0);
+        assert_eq!(db_state.tree.compacted.len(), 1);
 
-        let l0 = db_state.l0.front().unwrap();
+        let l0 = db_state.tree.l0.front().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
             ..,
             l0,
@@ -1270,14 +1284,14 @@ mod tests {
 
         let db_state = await_compacted_compaction(
             manifest_store.clone(),
-            db_state.compacted,
+            db_state.tree.compacted,
             Some(system_clock.clone()),
         )
         .await
         .unwrap();
-        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.tree.compacted.len(), 1);
 
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1310,10 +1324,10 @@ mod tests {
         let scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
             |state| {
                 // compact when there are at least 2 SSTs in L0
-                state.manifest().core().l0.len() == 2 ||
+                state.manifest().core().tree.l0.len() == 2 ||
                 // or when there is one SST in L0 and one in L1
-                (state.manifest().core().l0.len() == 1
-                    && state.manifest().core().compacted.len() == 1)
+                (state.manifest().core().tree.l0.len() == 1
+                    && state.manifest().core().tree.compacted.len() == 1)
             },
         )));
 
@@ -1347,8 +1361,8 @@ mod tests {
         let db_state = await_compaction(&db, Some(system_clock.clone()))
             .await
             .unwrap();
-        assert_eq!(db_state.compacted.len(), 1);
-        assert_eq!(db_state.l0.len(), 0, "{:?}", db_state.l0);
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        assert_eq!(db_state.tree.l0.len(), 0, "{:?}", db_state.tree.l0);
 
         // Now delete key 'a', creating a tombstone (seq=3)
         db.delete_with_options(
@@ -1363,20 +1377,20 @@ mod tests {
 
         // We should now have a tombstone for 'a' in L0 and both 'a' and 'b' values in L1
         let db_state = get_db_state(manifest_store.clone()).await;
-        assert_eq!(db_state.l0.len(), 1, "{:?}", db_state.l0);
-        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.tree.l0.len(), 1, "{:?}", db_state.tree.l0);
+        assert_eq!(db_state.tree.compacted.len(), 1);
 
         // Trigger compaction of L0 (tombstone) + L1 (values)
         let db_state = await_compacted_compaction(
             manifest_store.clone(),
-            db_state.compacted,
+            db_state.tree.compacted,
             Some(system_clock.clone()),
         )
         .await
         .unwrap();
-        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.tree.compacted.len(), 1);
 
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1421,7 +1435,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
         let options = db_options(None);
 
@@ -1510,8 +1524,8 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1554,7 +1568,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
         let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
 
@@ -1627,7 +1641,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| !state.manifest().core().l0.is_empty(),
+            |state| !state.manifest().core().tree.l0.is_empty(),
         )));
         let options = db_options(None);
 
@@ -1681,7 +1695,7 @@ mod tests {
 
         let db_state = await_compaction(&db, Some(system_clock.clone())).await;
         let db_state = db_state.expect("db was not compacted");
-        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.tree.compacted.len(), 1);
         // Save current tick since we advanced it in `await_compaction`. We'll use it
         // later to verify the create_ts of the merged and normal entries.
         let expected_tick = system_clock.now().timestamp_millis();
@@ -1724,8 +1738,8 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1762,7 +1776,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
         let options = db_options(None);
 
@@ -1841,8 +1855,8 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -1879,7 +1893,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 3,
+            |state| state.manifest().core().tree.l0.len() >= 3,
         )));
         let options = db_options(None);
 
@@ -1970,8 +1984,8 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2012,7 +2026,7 @@ mod tests {
         let insert_clock = Arc::new(MockSystemClock::new());
 
         let scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
 
         let mut options = db_options(None);
@@ -2065,11 +2079,11 @@ mod tests {
         let db_state = await_compaction(&db, Some(insert_clock.clone()))
             .await
             .unwrap();
-        assert_eq!(db_state.compacted.len(), 1);
+        assert_eq!(db_state.tree.compacted.len(), 1);
         assert_eq!(db_state.last_l0_clock_tick, 20);
 
         // then: the compacted SST should only contain the non-expired merge
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2099,7 +2113,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
         let options = db_options(None);
 
@@ -2188,7 +2202,7 @@ mod tests {
                 .unwrap();
         let db_state = stored_manifest.db_state();
         assert!(
-            !db_state.compacted.is_empty(),
+            !db_state.tree.compacted.is_empty(),
             "compaction should have occurred"
         );
     }
@@ -2201,7 +2215,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
         let options = db_options(None);
 
@@ -2281,12 +2295,12 @@ mod tests {
                 .unwrap();
         let db_state = stored_manifest.db_state();
         assert!(
-            !db_state.compacted.is_empty(),
+            !db_state.tree.compacted.is_empty(),
             "compaction should have occurred"
         );
 
         // The compacted sorted run should contain both merge operations separately
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2333,7 +2347,7 @@ mod tests {
         let os = Arc::new(InMemory::new());
         let system_clock = Arc::new(MockSystemClock::new());
         let compaction_scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
-            |state| state.manifest().core().l0.len() >= 2,
+            |state| state.manifest().core().tree.l0.len() >= 2,
         )));
         let options = db_options(None);
 
@@ -2397,11 +2411,11 @@ mod tests {
                 .unwrap();
         let db_state = stored_manifest.db_state();
         assert!(
-            !db_state.compacted.is_empty(),
+            !db_state.tree.compacted.is_empty(),
             "compaction should have occurred"
         );
 
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2525,9 +2539,9 @@ mod tests {
         // then: key 1 should be expired (expire_at=10 < compaction_time),
         //       key 2 should survive (expire_at=i64::MAX), key 3 has no expiry
         let db_state = db_state.expect("db was not compacted");
-        assert!(db_state.last_compacted_l0_sst_view_id.is_some());
-        assert_eq!(db_state.compacted.len(), 1);
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        assert!(db_state.tree.last_compacted_l0_sst_view_id.is_some());
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -2648,10 +2662,10 @@ mod tests {
 
         // then:
         let db_state = db_state.expect("db was not compacted");
-        assert!(db_state.last_compacted_l0_sst_view_id.is_some());
-        assert_eq!(db_state.compacted.len(), 1);
+        assert!(db_state.tree.last_compacted_l0_sst_view_id.is_some());
+        assert_eq!(db_state.tree.compacted.len(), 1);
         assert_eq!(db_state.last_l0_clock_tick, 70);
-        let compacted = &db_state.compacted.first().unwrap().sst_views;
+        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -2865,8 +2879,8 @@ mod tests {
             SST_FORMAT_VERSION_LATEST,
             l0_info.clone(),
         ));
-        dirty.value.core.l0 = VecDeque::from(vec![l0_view_newest, l0_view_oldest]);
-        dirty.value.core.compacted = vec![
+        dirty.value.core.tree.l0 = VecDeque::from(vec![l0_view_newest, l0_view_oldest]);
+        dirty.value.core.tree.compacted = vec![
             SortedRun {
                 id: 2,
                 sst_views: vec![SsTableView::identity(SsTableHandle::new(
@@ -2966,8 +2980,8 @@ mod tests {
             SST_FORMAT_VERSION_LATEST,
             l0_info,
         ));
-        core.l0 = VecDeque::from(vec![l0_view_first, l0_view_second]);
-        core.compacted = vec![
+        core.tree.l0 = VecDeque::from(vec![l0_view_first, l0_view_second]);
+        core.tree.compacted = vec![
             SortedRun {
                 id: 5,
                 sst_views: vec![SsTableView::identity(SsTableHandle::new(
@@ -3008,7 +3022,7 @@ mod tests {
             first_entry: Some(Bytes::from_static(b"a")),
             ..SsTableInfo::default()
         };
-        core.l0 = VecDeque::from(vec![
+        core.tree.l0 = VecDeque::from(vec![
             SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(Ulid::from_parts(1, 0)),
                 SST_FORMAT_VERSION_LATEST,
@@ -3125,7 +3139,7 @@ mod tests {
         async fn write_l0(&mut self) {
             let mut rng = rng::new_test_rng(None);
             let manifest = self.manifest.refresh().await.unwrap();
-            let l0s = manifest.core.l0.len();
+            let l0s = manifest.core.tree.l0.len();
             // TODO: add an explicit flush_memtable fn to db and use that instead
             let mut k = vec![0u8; self.options.l0_sst_size_bytes];
             rng.fill_bytes(&mut k);
@@ -3133,7 +3147,7 @@ mod tests {
             self.db.flush().await.unwrap();
             loop {
                 let manifest = self.manifest.refresh().await.unwrap().clone();
-                if manifest.core.l0.len() > l0s {
+                if manifest.core.tree.l0.len() > l0s {
                     break;
                 }
             }
@@ -3142,6 +3156,7 @@ mod tests {
         async fn build_l0_compaction(&mut self) -> CompactionSpec {
             let db_state = self.latest_db_state().await;
             let l0_ids_to_compact: Vec<SourceId> = db_state
+                .tree
                 .l0
                 .iter()
                 .map(|h| SourceId::SstView(h.id))
@@ -3236,10 +3251,18 @@ mod tests {
 
         // then:
         let db_state = fixture.latest_db_state().await;
-        assert_eq!(db_state.l0.len(), 1);
-        assert_eq!(db_state.compacted.len(), 1);
-        let l0_id = db_state.l0.front().unwrap().sst.id.unwrap_compacted_id();
+        assert_eq!(db_state.tree.l0.len(), 1);
+        assert_eq!(db_state.tree.compacted.len(), 1);
+        let l0_id = db_state
+            .tree
+            .l0
+            .front()
+            .unwrap()
+            .sst
+            .id
+            .unwrap_compacted_id();
         let compacted_l0s: Vec<Ulid> = db_state
+            .tree
             .compacted
             .first()
             .unwrap()
@@ -3249,7 +3272,7 @@ mod tests {
             .collect();
         assert!(!compacted_l0s.contains(&l0_id));
         assert_eq!(
-            db_state.last_compacted_l0_sst_view_id.unwrap(),
+            db_state.tree.last_compacted_l0_sst_view_id.unwrap(),
             compaction
                 .sources()
                 .first()
@@ -3587,14 +3610,14 @@ mod tests {
         // Create an L0 so the submitted compaction has valid sources.
         let mut rng = rng::new_test_rng(None);
         let manifest = stored_manifest.refresh().await.unwrap();
-        let l0s = manifest.core.l0.len();
+        let l0s = manifest.core.tree.l0.len();
         let mut k = vec![0u8; options.l0_sst_size_bytes];
         rng.fill_bytes(&mut k);
         db.put(&k, &[b'x'; 10]).await.unwrap();
         db.flush().await.unwrap();
         loop {
             let manifest = stored_manifest.refresh().await.unwrap().clone();
-            if manifest.core.l0.len() > l0s {
+            if manifest.core.tree.l0.len() > l0s {
                 break;
             }
         }
@@ -3602,6 +3625,7 @@ mod tests {
         // Seed the compactions store with a Submitted compaction before handler startup.
         let db_state = stored_manifest.refresh().await.unwrap().core.clone();
         let sources = db_state
+            .tree
             .l0
             .iter()
             .map(|h| SourceId::SstView(h.id))
@@ -3650,7 +3674,7 @@ mod tests {
         let db_state = handler.state().db_state().clone();
         let output_sr = SortedRun {
             id: jobs[0].destination,
-            sst_views: db_state.l0.iter().cloned().collect(),
+            sst_views: db_state.tree.l0.iter().cloned().collect(),
         };
         let msg = CompactorMessage::CompactionJobFinished {
             id: compaction_id,
@@ -3769,7 +3793,7 @@ mod tests {
         let db_state = fixture.latest_db_state().await;
         let output_sr = SortedRun {
             id: compaction.destination(),
-            sst_views: db_state.l0.iter().cloned().collect(),
+            sst_views: db_state.tree.l0.iter().cloned().collect(),
         };
         let msg = CompactorMessage::CompactionJobFinished {
             id: job.id,
@@ -3841,6 +3865,7 @@ mod tests {
             .unwrap();
         let l0_ids: Vec<SourceId> = old_manifest
             .core
+            .tree
             .l0
             .iter()
             .map(|view| SourceId::SstView(view.id))
@@ -4001,8 +4026,8 @@ mod tests {
         fixture.write_l0().await;
         fixture.handler.handle_ticker().await.unwrap();
         let state = fixture.latest_db_state().await;
-        let sr_id = state.compacted.first().unwrap().id;
-        let l0_view_id = state.l0.front().unwrap().id;
+        let sr_id = state.tree.compacted.first().unwrap().id;
+        let l0_view_id = state.tree.l0.front().unwrap().id;
         let mixed = CompactionSpec::new(
             vec![SourceId::SortedRun(sr_id), SourceId::SstView(l0_view_id)],
             sr_id,
@@ -4020,17 +4045,20 @@ mod tests {
         fixture.handler.handle_ticker().await.unwrap();
 
         let state = fixture.latest_db_state().await;
-        assert!(state.l0.len() >= 2);
+        assert!(state.tree.l0.len() >= 2);
 
         // Build first L0 compaction from the oldest L0
-        let first_l0 = CompactionSpec::new(vec![SourceId::SstView(state.l0.back().unwrap().id)], 0);
+        let first_l0 =
+            CompactionSpec::new(vec![SourceId::SstView(state.tree.l0.back().unwrap().id)], 0);
         // Inject and schedule it so it becomes active
         fixture.scheduler.inject_compaction(first_l0.clone());
         fixture.handler.handle_ticker().await.unwrap();
 
         // Build second L0 compaction from the newest L0 (disjoint sources)
-        let second_l0 =
-            CompactionSpec::new(vec![SourceId::SstView(state.l0.front().unwrap().id)], 1);
+        let second_l0 = CompactionSpec::new(
+            vec![SourceId::SstView(state.tree.l0.front().unwrap().id)],
+            1,
+        );
         let err = fixture.handler.validate_compaction(&second_l0).unwrap_err();
         assert!(matches!(err, SlateDBError::InvalidCompaction));
     }
@@ -4093,8 +4121,8 @@ mod tests {
                 )
             };
 
-            let empty_l0 = core_db_state.l0.is_empty();
-            let compaction_ran = !core_db_state.compacted.is_empty();
+            let empty_l0 = core_db_state.tree.l0.is_empty();
+            let compaction_ran = !core_db_state.tree.compacted.is_empty();
             if empty_wal && empty_memtable && empty_l0 && compaction_ran {
                 return Some(core_db_state);
             }
@@ -4116,7 +4144,7 @@ mod tests {
                 clock.as_ref().advance(Duration::from_millis(60000)).await;
             }
             let db_state = get_db_state(manifest_store.clone()).await;
-            if !db_state.compacted.eq(&old_compacted) {
+            if !db_state.tree.compacted.eq(&old_compacted) {
                 return Some(db_state);
             }
             None

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -8,7 +8,7 @@ use ulid::Ulid;
 
 use crate::db_state::{SortedRun, SsTableHandle, SsTableView};
 use crate::error::SlateDBError;
-use crate::manifest::{Manifest, ManifestCore};
+use crate::manifest::{LsmTreeState, Manifest, ManifestCore};
 use slatedb_txn_obj::DirtyObject;
 
 /// Identifier for a compaction input source.
@@ -205,8 +205,12 @@ impl Compaction {
     /// ## Arguments
     /// - `db_state`: The current core DB state from the manifest.
     pub(crate) fn get_sorted_runs(&self, db_state: &ManifestCore) -> Vec<SortedRun> {
-        let srs_by_id: HashMap<u32, &SortedRun> =
-            db_state.compacted.iter().map(|sr| (sr.id, sr)).collect();
+        let srs_by_id: HashMap<u32, &SortedRun> = db_state
+            .tree
+            .compacted
+            .iter()
+            .map(|sr| (sr.id, sr))
+            .collect();
 
         self.spec
             .sources()
@@ -221,8 +225,12 @@ impl Compaction {
     /// ## Arguments
     /// - `db_state`: The current core DB state from the manifest.
     pub(crate) fn get_l0_sst_views(&self, db_state: &ManifestCore) -> Vec<SsTableView> {
-        let sst_views_by_id: HashMap<Ulid, &SsTableView> =
-            db_state.l0.iter().map(|view| (view.id, view)).collect();
+        let sst_views_by_id: HashMap<Ulid, &SsTableView> = db_state
+            .tree
+            .l0
+            .iter()
+            .map(|view| (view.id, view))
+            .collect();
 
         self.spec
             .sources()
@@ -573,9 +581,9 @@ impl CompactorState {
     pub(crate) fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyObject<Manifest>) {
         // the writer may have added more l0 SSTs. Add these to our l0 list.
         let my_db_state = self.db_state();
-        let last_compacted_l0 = my_db_state.last_compacted_l0_sst_view_id;
+        let last_compacted_l0 = my_db_state.tree.last_compacted_l0_sst_view_id;
         let mut merged_l0s = VecDeque::new();
-        let writer_l0 = &remote_manifest.value.core.l0;
+        let writer_l0 = &remote_manifest.value.core.tree.l0;
         for writer_l0_sst in writer_l0 {
             // todo: this is brittle. we are relying on the l0 list always being updated in
             //       an expected order. We should instead encode the ordering in the l0 SST IDs
@@ -593,10 +601,12 @@ impl CompactorState {
         // write out the merged core db state and manifest
         let merged = ManifestCore {
             initialized: remote_manifest.value.core.initialized,
-            last_compacted_l0_sst_view_id: my_db_state.last_compacted_l0_sst_view_id,
-            last_compacted_l0_sst_id: my_db_state.last_compacted_l0_sst_id,
-            l0: merged_l0s,
-            compacted: my_db_state.compacted.clone(),
+            tree: LsmTreeState {
+                last_compacted_l0_sst_view_id: my_db_state.tree.last_compacted_l0_sst_view_id,
+                last_compacted_l0_sst_id: my_db_state.tree.last_compacted_l0_sst_id,
+                l0: merged_l0s,
+                compacted: my_db_state.tree.compacted.clone(),
+            },
             next_wal_sst_id: remote_manifest.value.core.next_wal_sst_id,
             replay_after_wal_id: remote_manifest.value.core.replay_after_wal_id,
             last_l0_clock_tick: remote_manifest.value.core.last_l0_clock_tick,
@@ -629,6 +639,7 @@ impl CompactorState {
         }
         if self
             .db_state()
+            .tree
             .compacted
             .iter()
             .any(|sr| sr.id == spec.destination())
@@ -690,6 +701,7 @@ impl CompactorState {
                 .filter_map(|id| id.maybe_unwrap_sorted_run())
                 .collect();
             let new_l0: VecDeque<SsTableView> = db_state
+                .tree
                 .l0
                 .iter()
                 .filter(|l0| !compaction_l0s.contains(&l0.id))
@@ -697,7 +709,7 @@ impl CompactorState {
                 .collect();
             let mut new_compacted = Vec::new();
             let mut inserted = false;
-            for compacted in db_state.compacted.iter() {
+            for compacted in db_state.tree.compacted.iter() {
                 if !inserted && output_sr.id >= compacted.id {
                     new_compacted.push(output_sr.clone());
                     inserted = true;
@@ -717,16 +729,17 @@ impl CompactorState {
             if let Some(view_id) = first_source.maybe_unwrap_sst_view() {
                 // if there are l0s, the newest must be the first entry in sources.
                 // TODO: validate that this is the case
-                db_state.last_compacted_l0_sst_view_id = Some(view_id);
+                db_state.tree.last_compacted_l0_sst_view_id = Some(view_id);
                 // Resolve the SST ID from the view before it's removed from l0.
-                db_state.last_compacted_l0_sst_id = db_state
+                db_state.tree.last_compacted_l0_sst_id = db_state
+                    .tree
                     .l0
                     .iter()
                     .find(|v| v.id == view_id)
                     .map(|v| v.sst.id.unwrap_compacted_id());
             }
-            db_state.l0 = new_l0;
-            db_state.compacted = new_compacted;
+            db_state.tree.l0 = new_l0;
+            db_state.tree.compacted = new_compacted;
             self.manifest.value.core = db_state;
             self.manifest.value.prune_external_sst_ids();
             self.update_compaction(&compaction_id, |c| {
@@ -929,7 +942,7 @@ mod tests {
         let (_, _, mut state, system_clock, rand) = build_test_state(rt.handle());
 
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
-        let spec = build_l0_compaction(&state.db_state().l0, 0);
+        let spec = build_l0_compaction(&state.db_state().tree.l0, 0);
         // when:
         let compaction = Compaction::new(compaction_id, spec.clone());
         state
@@ -950,14 +963,14 @@ mod tests {
         let (_, _, mut state, system_clock, rand) = build_test_state(rt.handle());
         let before_compaction = state.db_state().clone();
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
-        let spec = build_l0_compaction(&before_compaction.l0, 0);
+        let spec = build_l0_compaction(&before_compaction.tree.l0, 0);
         let compaction = Compaction::new(compaction_id, spec);
         state
             .add_compaction(compaction)
             .expect("failed to add compaction");
 
         // when:
-        let compacted_ssts = before_compaction.l0.iter().cloned().collect();
+        let compacted_ssts = before_compaction.tree.l0.iter().cloned().collect();
         let sr = SortedRun {
             id: 0,
             sst_views: compacted_ssts,
@@ -966,15 +979,16 @@ mod tests {
 
         // then:
         assert_eq!(
-            state.db_state().last_compacted_l0_sst_view_id,
-            Some(before_compaction.l0.front().unwrap().id)
+            state.db_state().tree.last_compacted_l0_sst_view_id,
+            Some(before_compaction.tree.l0.front().unwrap().id)
         );
-        assert_eq!(state.db_state().l0.len(), 0);
-        assert_eq!(state.db_state().compacted.len(), 1);
-        assert_eq!(state.db_state().compacted.first().unwrap().id, sr.id);
+        assert_eq!(state.db_state().tree.l0.len(), 0);
+        assert_eq!(state.db_state().tree.compacted.len(), 1);
+        assert_eq!(state.db_state().tree.compacted.first().unwrap().id, sr.id);
         let expected_ids: Vec<SsTableId> = sr.sst_views.iter().map(|h| h.sst.id).collect();
         let found_ids: Vec<SsTableId> = state
             .db_state()
+            .tree
             .compacted
             .first()
             .unwrap()
@@ -997,7 +1011,7 @@ mod tests {
         // Seed external_dbs with a mix of IDs that are currently in L0 (will move to the
         // compacted sorted run and remain live) and a stale ID that was never in the
         // manifest (simulating a parent SST already compacted away on a prior cycle).
-        let live_id = before_compaction.l0.front().unwrap().sst.id;
+        let live_id = before_compaction.tree.l0.front().unwrap().sst.id;
         let stale_id = SsTableId::Compacted(Ulid::new());
         state.manifest.value.external_dbs = vec![
             ExternalDb {
@@ -1015,14 +1029,14 @@ mod tests {
         ];
 
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
-        let spec = build_l0_compaction(&before_compaction.l0, 0);
+        let spec = build_l0_compaction(&before_compaction.tree.l0, 0);
         state
             .add_compaction(Compaction::new(compaction_id, spec))
             .expect("failed to add compaction");
 
         let sr = SortedRun {
             id: 0,
-            sst_views: before_compaction.l0.iter().cloned().collect(),
+            sst_views: before_compaction.tree.l0.iter().cloned().collect(),
         };
         state.finish_compaction(compaction_id, sr);
 
@@ -1047,14 +1061,14 @@ mod tests {
         let (_, _, mut state, system_clock, rand) = build_test_state(rt.handle());
         let before_compaction = state.db_state().clone();
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
-        let spec = build_l0_compaction(&before_compaction.l0, 0);
+        let spec = build_l0_compaction(&before_compaction.tree.l0, 0);
         let compaction = Compaction::new(compaction_id, spec);
         state
             .add_compaction(compaction)
             .expect("failed to add compaction");
 
         // when:
-        let compacted_ssts = before_compaction.l0.iter().cloned().collect();
+        let compacted_ssts = before_compaction.tree.l0.iter().cloned().collect();
         let sr = SortedRun {
             id: 0,
             sst_views: compacted_ssts,
@@ -1074,22 +1088,28 @@ mod tests {
         let db = build_db(os.clone(), rt.handle());
         rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48])).unwrap();
         rt.block_on(db.put(&[b'j'; 16], &[b'k'; 48])).unwrap();
-        wait_for_manifest_with_l0_len(&mut sm, rt.handle(), state.db_state().l0.len() + 1);
+        wait_for_manifest_with_l0_len(&mut sm, rt.handle(), state.db_state().tree.l0.len() + 1);
 
         // when:
         state.merge_remote_manifest(sm.prepare_dirty().unwrap());
 
         // then:
-        assert!(state.db_state().last_compacted_l0_sst_view_id.is_none());
+        assert!(state
+            .db_state()
+            .tree
+            .last_compacted_l0_sst_view_id
+            .is_none());
         let expected_merged_l0s: Vec<Ulid> = sm
             .manifest()
             .core
+            .tree
             .l0
             .iter()
             .map(|t| t.sst.id.unwrap_compacted_id())
             .collect();
         let merged_l0s: Vec<Ulid> = state
             .db_state()
+            .tree
             .l0
             .iter()
             .map(|h| h.sst.id.unwrap_compacted_id())
@@ -1103,7 +1123,7 @@ mod tests {
         let rt = build_runtime();
         let (os, mut sm, mut state, system_clock, rand) = build_test_state(rt.handle());
         // compact the last sst
-        let original_l0s = &state.db_state().clone().l0;
+        let original_l0s = &state.db_state().clone().tree.l0;
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
         let spec = CompactionSpec::new(vec![SstView(original_l0s.back().unwrap().id)], 0);
         let compaction = Compaction::new(compaction_id, spec);
@@ -1137,6 +1157,7 @@ mod tests {
         let new_l0 = sm
             .manifest()
             .core
+            .tree
             .l0
             .front()
             .unwrap()
@@ -1145,14 +1166,15 @@ mod tests {
             .unwrap_compacted_id();
         expected_merged_l0s.push_front(new_l0);
         let merged_l0: VecDeque<Ulid> = db_state
+            .tree
             .l0
             .iter()
             .map(|h| h.sst.id.unwrap_compacted_id())
             .collect();
         assert_eq!(merged_l0, expected_merged_l0s);
         assert_eq!(
-            compacted_to_description(&db_state.compacted),
-            compacted_to_description(&db_state_before_merge.compacted)
+            compacted_to_description(&db_state.tree.compacted),
+            compacted_to_description(&db_state_before_merge.tree.compacted)
         );
         assert_eq!(
             db_state.replay_after_wal_id,
@@ -1167,7 +1189,7 @@ mod tests {
         let rt = build_runtime();
         let (os, mut sm, mut state, system_clock, rand) = build_test_state(rt.handle());
         // compact the last sst
-        let original_l0s = &state.db_state().clone().l0;
+        let original_l0s = &state.db_state().clone().tree.l0;
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
 
         let spec = CompactionSpec::new(original_l0s.iter().map(|h| SstView(h.id)).collect(), 0);
@@ -1182,7 +1204,7 @@ mod tests {
                 sst_views: original_l0s.clone().into(),
             },
         );
-        assert_eq!(state.db_state().l0.len(), 0);
+        assert_eq!(state.db_state().tree.l0.len(), 0);
         // open a new db and write another l0
         let db = build_db(os.clone(), rt.handle());
         rt.block_on(db.put(&[b'a'; 16], &[b'b'; 48])).unwrap();
@@ -1198,6 +1220,7 @@ mod tests {
         let new_l0 = sm
             .manifest()
             .core
+            .tree
             .l0
             .front()
             .unwrap()
@@ -1206,6 +1229,7 @@ mod tests {
             .unwrap_compacted_id();
         expected_merged_l0s.push_front(new_l0);
         let merged_l0: VecDeque<Ulid> = db_state
+            .tree
             .l0
             .iter()
             .map(|h| h.sst.id.unwrap_compacted_id())
@@ -1243,7 +1267,7 @@ mod tests {
         let rt = build_runtime();
         let (_os, mut _sm, mut state, system_clock, rand) = build_test_state(rt.handle());
         // compact the last sst
-        let original_l0s = &state.db_state().clone().l0;
+        let original_l0s = &state.db_state().clone().tree.l0;
         let compaction_id = rand.rng().gen_ulid(system_clock.as_ref());
         let spec = CompactionSpec::new(
             original_l0s
@@ -1266,8 +1290,8 @@ mod tests {
         // given:
         let rt = build_runtime();
         let (_os, mut _sm, mut state, system_clock, rand) = build_test_state(rt.handle());
-        let original_l0s = &state.db_state().clone().l0;
-        let original_srs = &state.db_state().clone().compacted;
+        let original_l0s = &state.db_state().clone().tree.l0;
+        let original_srs = &state.db_state().clone().tree.compacted;
         // L0: from 4th onward (index > 2)
         let l0_sources = original_l0s.iter().skip(3).map(|h| SourceId::SstView(h.id));
 
@@ -1352,7 +1376,7 @@ mod tests {
     ) {
         run_for(Duration::from_secs(30), || {
             let manifest = tokio_handle.block_on(stored_manifest.refresh()).unwrap();
-            if manifest.core.l0.len() == len {
+            if manifest.core.tree.l0.len() == len {
                 return Some(manifest.core.clone());
             }
             None

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -398,7 +398,7 @@ mod tests {
     fn test_compactor_state_to_view() {
         let mut manifest = Manifest::initial(ManifestCore::new());
         manifest.compactor_epoch = 11;
-        manifest.core.last_compacted_l0_sst_view_id = Some(Ulid::from_parts(5, 0));
+        manifest.core.tree.last_compacted_l0_sst_view_id = Some(Ulid::from_parts(5, 0));
 
         let mut compactions = Compactions::new(manifest.compactor_epoch);
         let compaction_id = Ulid::from_parts(10, 0);

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1968,8 +1968,8 @@ mod tests {
 
         // estimate_size on L0 views should return non-zero
         let manifest = db.manifest();
-        assert!(!manifest.manifest.core.l0.is_empty());
-        for view in &manifest.manifest.core.l0 {
+        assert!(!manifest.manifest.core.tree.l0.is_empty());
+        for view in &manifest.manifest.core.tree.l0 {
             assert!(view.estimate_size() > 0);
         }
 
@@ -1980,7 +1980,7 @@ mod tests {
             loop {
                 {
                     let state = db_poll.inner.state.read();
-                    if !state.state().core().compacted.is_empty() {
+                    if !state.state().core().tree.compacted.is_empty() {
                         return;
                     }
                 }
@@ -1991,9 +1991,9 @@ mod tests {
         .unwrap();
 
         let manifest = db.manifest();
-        assert!(!manifest.manifest.core.compacted.is_empty());
+        assert!(!manifest.manifest.core.tree.compacted.is_empty());
 
-        for sr in &manifest.manifest.core.compacted {
+        for sr in &manifest.manifest.core.tree.compacted {
             // A range covering all keys returns results
             let covering = sr
                 .tables_covering_range(Bytes::from_static(b"k0000")..Bytes::from_static(b"k0100"));
@@ -2595,8 +2595,8 @@ mod tests {
         db.flush().await.unwrap();
 
         let state = db.inner.state.read().view();
-        assert_eq!(1, state.state.manifest.value.core.l0.len());
-        let view = state.state.manifest.value.core.l0.front().unwrap();
+        assert_eq!(1, state.state.manifest.value.core.tree.l0.len());
+        let view = state.state.manifest.value.core.tree.l0.front().unwrap();
         let index = db
             .inner
             .table_store
@@ -3396,13 +3396,13 @@ mod tests {
 
         let state = wait_for_manifest_condition(
             &mut stored_manifest,
-            |s| !s.l0.is_empty(),
+            |s| !s.tree.l0.is_empty(),
             Duration::from_secs(30),
         )
         .await;
-        assert_eq!(state.l0.len(), 1);
+        assert_eq!(state.tree.l0.len(), 1);
 
-        let l0 = state.l0.front().unwrap();
+        let l0 = state.tree.l0.front().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
             ..,
             l0,
@@ -3472,7 +3472,7 @@ mod tests {
         }
 
         let manifest = stored_manifest.refresh().await.unwrap();
-        let l0 = &manifest.core.l0;
+        let l0 = &manifest.core.tree.l0;
         assert_eq!(l0.len(), 3);
         let sst_iter_options = SstIteratorOptions::default();
 
@@ -3541,7 +3541,7 @@ mod tests {
         {
             let guard = kv_store.inner.state.read();
             assert!(guard.state().imm_memtable.is_empty());
-            assert_eq!(guard.state().core().l0.len(), 0);
+            assert_eq!(guard.state().core().tree.l0.len(), 0);
         }
 
         // This put() triggers a freeze.
@@ -3563,7 +3563,7 @@ mod tests {
             Duration::from_secs(30),
         )
         .await;
-        assert_eq!(db_state.l0.len(), 1);
+        assert_eq!(db_state.tree.l0.len(), 1);
 
         // Run MAX_WAL_FLUSHES_BEFORE_L0_FLUSH more put()/flush() cycles
         // and see if the threshold triggers again.
@@ -3579,7 +3579,7 @@ mod tests {
         // Verify no more memtables were frozen or L0 flush happened.
         {
             let guard = kv_store.inner.state.read();
-            assert_eq!(guard.state().core().l0.len(), 1);
+            assert_eq!(guard.state().core().tree.l0.len(), 1);
         }
 
         // This put() triggers a freeze.
@@ -3597,7 +3597,7 @@ mod tests {
             Duration::from_secs(30),
         )
         .await;
-        assert_eq!(db_state.l0.len(), 2); // We should have two L0 flushes.
+        assert_eq!(db_state.tree.l0.len(), 2); // We should have two L0 flushes.
 
         kv_store.close().await.unwrap();
     }
@@ -3663,7 +3663,7 @@ mod tests {
 
         // Get initial state
         let initial_manifest = stored_manifest.refresh().await.unwrap();
-        let initial_l0_count = initial_manifest.core.l0.len();
+        let initial_l0_count = initial_manifest.core.tree.l0.len();
 
         let initial_flush_count =
             lookup_metric(&metrics_recorder, IMMUTABLE_MEMTABLE_FLUSHES).unwrap();
@@ -3679,13 +3679,13 @@ mod tests {
         // Wait for the flush to complete and manifest to be updated
         let db_state = wait_for_manifest_condition(
             &mut stored_manifest,
-            |s| s.l0.len() > initial_l0_count,
+            |s| s.tree.l0.len() > initial_l0_count,
             Duration::from_secs(30),
         )
         .await;
 
         // Verify that a new SST was created in L0
-        assert_eq!(db_state.l0.len(), initial_l0_count + 1);
+        assert_eq!(db_state.tree.l0.len(), initial_l0_count + 1);
 
         // Verify that the flush metrics were updated
         let final_flush_count =
@@ -3705,7 +3705,7 @@ mod tests {
         assert_eq!(retrieved_value2.as_ref(), value2);
 
         // Verify the data exists in the newly created SST
-        let latest_sst = db_state.l0.back().unwrap();
+        let latest_sst = db_state.tree.l0.back().unwrap();
         let sst_iter_options = SstIteratorOptions::default();
         let mut iter = SstIterator::new_borrowed_initialized(
             ..,
@@ -4557,7 +4557,7 @@ mod tests {
             loop {
                 {
                     let db_state = db_poll.inner.state.read();
-                    if !db_state.state().core().compacted.is_empty() {
+                    if !db_state.state().core().tree.compacted.is_empty() {
                         return;
                     }
                 }
@@ -4974,8 +4974,8 @@ mod tests {
         assert_eq!(db_state.state.imm_memtable.len(), 1);
 
         // verify that we have no L0 SSTs because memtables should have failed to flush
-        assert_eq!(db_state.state.core().l0.len(), 0);
-        assert_eq!(db_state.state.core().compacted.len(), 0);
+        assert_eq!(db_state.state.core().tree.l0.len(), 0);
+        assert_eq!(db_state.state.core().tree.compacted.len(), 0);
 
         // one empty wal and one wal for the first put
         assert_eq!(
@@ -5102,7 +5102,7 @@ mod tests {
                 // flushed (await_durable in the put()'s above only wait for the writes to hit
                 // the WAL before returning).
                 should_compact_l0.store(true, Ordering::SeqCst);
-                s.last_compacted_l0_sst_view_id.is_some() && s.l0.is_empty()
+                s.tree.last_compacted_l0_sst_view_id.is_some() && s.tree.l0.is_empty()
             },
             Duration::from_secs(10),
         )
@@ -5110,8 +5110,8 @@ mod tests {
         let manifest = db.manifest();
         info!(
             "1 l0: {} {}",
-            manifest.manifest.core.l0.len(),
-            manifest.manifest.core.compacted.len()
+            manifest.manifest.core.tree.l0.len(),
+            manifest.manifest.core.tree.compacted.len()
         );
 
         // write more l0s and wait for compaction
@@ -5128,7 +5128,7 @@ mod tests {
                 // flushed (await_durable in the put()'s above only wait for the writes to hit
                 // the WAL before returning).
                 should_compact_l0.store(true, Ordering::SeqCst);
-                s.last_compacted_l0_sst_view_id.is_some() && s.l0.is_empty()
+                s.tree.last_compacted_l0_sst_view_id.is_some() && s.tree.l0.is_empty()
             },
             Duration::from_secs(10),
         )
@@ -5136,8 +5136,8 @@ mod tests {
         let manifest = db.manifest();
         info!(
             "2 l0: {} {}",
-            manifest.manifest.core.l0.len(),
-            manifest.manifest.core.compacted.len()
+            manifest.manifest.core.tree.l0.len(),
+            manifest.manifest.core.tree.compacted.len()
         );
         // write another l0
         db.put(&[b'a'; 32], &[128u8; 32]).await.unwrap();
@@ -5151,8 +5151,8 @@ mod tests {
             let manifest = db.manifest();
             info!(
                 "3 l0: {} {}",
-                manifest.manifest.core.l0.len(),
-                manifest.manifest.core.compacted.len()
+                manifest.manifest.core.tree.l0.len(),
+                manifest.manifest.core.tree.compacted.len()
             );
             let val = db.get([b'a' + i; 32]).await.unwrap();
             assert_eq!(val, Some(Bytes::copy_from_slice(&[1u8 + i; 32])));
@@ -6443,11 +6443,11 @@ mod tests {
             .await
             .expect("failed to read latest manifest");
         assert_eq!(
-            manifest.manifest.core.l0.len(),
+            manifest.manifest.core.tree.l0.len(),
             1,
             "expected exactly one L0 SST in manifest"
         );
-        let l0_id = manifest.manifest.core.l0[0].sst.id;
+        let l0_id = manifest.manifest.core.tree.l0[0].sst.id;
         assert_eq!(
             l0_id, ssts[0].id,
             "expected SST {:?} but found SST {:?}",
@@ -7158,6 +7158,7 @@ mod tests {
                         state
                             .state()
                             .core()
+                            .tree
                             .l0
                             .iter()
                             .map(|t| t.estimate_size())
@@ -7168,6 +7169,7 @@ mod tests {
                         state
                             .state()
                             .core()
+                            .tree
                             .compacted
                             .iter()
                             .map(|t| t.estimate_size())
@@ -7176,6 +7178,7 @@ mod tests {
                     if state
                         .state()
                         .core()
+                        .tree
                         .compacted
                         .first()
                         .is_some_and(|sr| sr.sst_views.len() > 1)
@@ -7307,6 +7310,7 @@ mod tests {
                         state
                             .state()
                             .core()
+                            .tree
                             .l0
                             .iter()
                             .map(|t| t.estimate_size())
@@ -7317,6 +7321,7 @@ mod tests {
                         state
                             .state()
                             .core()
+                            .tree
                             .compacted
                             .iter()
                             .map(|t| t.estimate_size())
@@ -7325,6 +7330,7 @@ mod tests {
                     if state
                         .state()
                         .core()
+                        .tree
                         .compacted
                         .first()
                         .is_some_and(|sr| sr.sst_views.len() > 1)

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -534,7 +534,7 @@ mod tests {
     }
 
     fn project_l0_view(manifest: &mut VersionedManifest, visible_range: BytesRange) {
-        let l0 = &mut manifest.manifest.core.l0;
+        let l0 = &mut manifest.manifest.core.tree.l0;
         let view = l0.pop_front().expect("expected at least one L0 view");
         l0.push_front(view.with_visible_range(visible_range));
     }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -246,9 +246,10 @@ impl DbReaderInner {
     fn should_reestablish_checkpoint(&self, latest: &ManifestCore) -> bool {
         let read_guard = self.state.read();
         let current_state = read_guard.core();
-        latest.last_compacted_l0_sst_view_id != current_state.last_compacted_l0_sst_view_id
+        latest.tree.last_compacted_l0_sst_view_id
+            != current_state.tree.last_compacted_l0_sst_view_id
             || latest.last_l0_seq > current_state.last_l0_seq
-            || latest.compacted != current_state.compacted
+            || latest.tree.compacted != current_state.tree.compacted
     }
 
     async fn replace_checkpoint(
@@ -2554,7 +2555,7 @@ mod tests {
         let start = tokio::time::Instant::now();
         loop {
             let manifest = stored_manifest.refresh().await.unwrap();
-            if manifest.core.l0.len() == 1 {
+            if manifest.core.tree.l0.len() == 1 {
                 break;
             }
             assert!(
@@ -2567,7 +2568,7 @@ mod tests {
         let timeout = Duration::from_secs(30);
         let start = tokio::time::Instant::now();
         loop {
-            if reader.inner.state.read().manifest.core.l0.len() == 1 {
+            if reader.inner.state.read().manifest.core.tree.l0.len() == 1 {
                 break;
             }
             // The reader poller may observe the pre-flush manifest on one tick and

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -1,7 +1,7 @@
 use crate::bytes_range::BytesRange;
 use crate::config::CompressionCodec;
 use crate::error::SlateDBError;
-use crate::manifest::{Manifest, ManifestCore};
+use crate::manifest::{LsmTreeState, Manifest, ManifestCore};
 use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
 use crate::reader::DbStateReader;
 use crate::wal_id::WalIdStore;
@@ -632,13 +632,18 @@ impl<'a> StateModifier<'a> {
     pub(crate) fn merge_remote_manifest(&mut self, mut remote_manifest: DirtyObject<Manifest>) {
         // The compactor removes tables from l0_last_compacted, so we
         // only want to keep the tables up to there.
-        let l0_last_compacted_view_id = &remote_manifest.value.core.last_compacted_l0_sst_view_id;
-        let l0_last_compacted_sst_id = &remote_manifest.value.core.last_compacted_l0_sst_id;
+        let l0_last_compacted_view_id = &remote_manifest
+            .value
+            .core
+            .tree
+            .last_compacted_l0_sst_view_id;
+        let l0_last_compacted_sst_id = &remote_manifest.value.core.tree.last_compacted_l0_sst_id;
         let new_l0 = if l0_last_compacted_view_id.is_some() || l0_last_compacted_sst_id.is_some() {
             self.state
                 .manifest
                 .value
                 .core
+                .tree
                 .l0
                 .iter()
                 .cloned()
@@ -658,16 +663,30 @@ impl<'a> StateModifier<'a> {
                 })
                 .collect()
         } else {
-            self.state.manifest.value.core.l0.iter().cloned().collect()
+            self.state
+                .manifest
+                .value
+                .core
+                .tree
+                .l0
+                .iter()
+                .cloned()
+                .collect()
         };
 
         let my_db_state = self.state.core();
         remote_manifest.value.core = ManifestCore {
             initialized: my_db_state.initialized,
-            last_compacted_l0_sst_view_id: remote_manifest.value.core.last_compacted_l0_sst_view_id,
-            last_compacted_l0_sst_id: remote_manifest.value.core.last_compacted_l0_sst_id,
-            l0: new_l0,
-            compacted: remote_manifest.value.core.compacted,
+            tree: LsmTreeState {
+                last_compacted_l0_sst_view_id: remote_manifest
+                    .value
+                    .core
+                    .tree
+                    .last_compacted_l0_sst_view_id,
+                last_compacted_l0_sst_id: remote_manifest.value.core.tree.last_compacted_l0_sst_id,
+                l0: new_l0,
+                compacted: remote_manifest.value.core.tree.compacted,
+            },
             next_wal_sst_id: my_db_state.next_wal_sst_id,
             replay_after_wal_id: my_db_state.replay_after_wal_id,
             last_l0_clock_tick: my_db_state.last_l0_clock_tick,
@@ -754,8 +773,12 @@ mod tests {
         // mimic the compactor popping off l0s
         let mut compactor_state = new_dirty_manifest();
         compactor_state.value.core = db_state.state.core().clone();
-        let last_compacted = compactor_state.value.core.l0.pop_back().unwrap();
-        compactor_state.value.core.last_compacted_l0_sst_view_id = Some(last_compacted.id);
+        let last_compacted = compactor_state.value.core.tree.l0.pop_back().unwrap();
+        compactor_state
+            .value
+            .core
+            .tree
+            .last_compacted_l0_sst_view_id = Some(last_compacted.id);
 
         // when:
         db_state.merge_remote_manifest(compactor_state.clone());
@@ -764,6 +787,7 @@ mod tests {
         let expected: Vec<SsTableId> = compactor_state
             .value
             .core
+            .tree
             .l0
             .iter()
             .map(|l0| l0.sst.id)
@@ -771,6 +795,7 @@ mod tests {
         let merged: Vec<SsTableId> = db_state
             .state
             .core()
+            .tree
             .l0
             .iter()
             .map(|l0| l0.sst.id)
@@ -783,7 +808,7 @@ mod tests {
         // given:
         let mut db_state = DbState::new(new_dirty_manifest());
         add_l0s_to_dbstate(&mut db_state, 4);
-        let l0s = db_state.state.core().l0.clone();
+        let l0s = db_state.state.core().tree.l0.clone();
 
         // when:
         db_state.merge_remote_manifest(new_dirty_manifest());
@@ -793,6 +818,7 @@ mod tests {
         let merged: Vec<SsTableId> = db_state
             .state
             .core()
+            .tree
             .l0
             .iter()
             .map(|l0| l0.sst.id)
@@ -855,7 +881,7 @@ mod tests {
             );
             let view: SsTableView = SsTableView::identity(handle);
             db_state.modify(|modifier| {
-                modifier.state.manifest.value.core.l0.push_front(view);
+                modifier.state.manifest.value.core.tree.l0.push_front(view);
                 modifier.state.manifest.value.core.replay_after_wal_id =
                     imm.recent_flushed_wal_id();
             });

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -43,7 +43,7 @@ use crate::flatbuffer_types::root_generated::{
     UuidArgs,
 };
 use crate::format::sst::SST_FORMAT_VERSION;
-use crate::manifest::{ExternalDb, Manifest, ManifestCore};
+use crate::manifest::{ExternalDb, LsmTreeState, Manifest, ManifestCore};
 use crate::partitioned_keyspace::RangePartitionedKeySpace;
 use crate::seq_tracker::SequenceTracker;
 use crate::utils::clamp_allocated_size_bytes;
@@ -305,11 +305,13 @@ impl FlatBufferManifestCodec {
             .unwrap_or_default();
         let core = ManifestCore {
             initialized: manifest.initialized(),
-            // In V1, view IDs are SST IDs, so both fields are the same.
-            last_compacted_l0_sst_view_id: l0_last_compacted,
-            last_compacted_l0_sst_id: l0_last_compacted,
-            l0,
-            compacted,
+            tree: LsmTreeState {
+                // In V1, view IDs are SST IDs, so both fields are the same.
+                last_compacted_l0_sst_view_id: l0_last_compacted,
+                last_compacted_l0_sst_id: l0_last_compacted,
+                l0,
+                compacted,
+            },
             next_wal_sst_id: manifest.wal_id_last_seen() + 1,
             replay_after_wal_id: manifest.replay_after_wal_id(),
             last_l0_seq: manifest.last_l0_seq(),
@@ -423,11 +425,13 @@ impl FlatBufferManifestCodec {
             .unwrap_or_default();
         let core = ManifestCore {
             initialized: manifest.initialized(),
-            last_compacted_l0_sst_view_id: l0_last_compacted,
-            // Not persisted in V2; populated at runtime by finish_compaction.
-            last_compacted_l0_sst_id: None,
-            l0,
-            compacted,
+            tree: LsmTreeState {
+                last_compacted_l0_sst_view_id: l0_last_compacted,
+                // Not persisted in V2; populated at runtime by finish_compaction.
+                last_compacted_l0_sst_id: None,
+                l0,
+                compacted,
+            },
             next_wal_sst_id: manifest.wal_id_last_seen() + 1,
             replay_after_wal_id: manifest.replay_after_wal_id(),
             last_l0_seq: manifest.last_l0_seq(),
@@ -960,12 +964,12 @@ impl<'b> DbFlatBufferBuilder<'b> {
         // Collect all unique SSTs from l0 and compacted runs.
         let mut unique_ssts: std::collections::HashMap<Ulid, &SsTableHandle> =
             std::collections::HashMap::new();
-        for view in core.l0.iter() {
+        for view in core.tree.l0.iter() {
             if let SsTableId::Compacted(ulid) = view.sst.id {
                 unique_ssts.entry(ulid).or_insert(&view.sst);
             }
         }
-        for sr in core.compacted.iter() {
+        for sr in core.tree.compacted.iter() {
             for view in sr.sst_views.iter() {
                 if let SsTableId::Compacted(ulid) = view.sst.id {
                     unique_ssts.entry(ulid).or_insert(&view.sst);
@@ -980,12 +984,12 @@ impl<'b> DbFlatBufferBuilder<'b> {
             self.builder.create_vector(sst_offsets.as_ref())
         };
 
-        let l0 = self.add_compacted_sst_views(core.l0.iter());
+        let l0 = self.add_compacted_sst_views(core.tree.l0.iter());
         let mut l0_last_compacted = None;
-        if let Some(ulid) = core.last_compacted_l0_sst_view_id.as_ref() {
+        if let Some(ulid) = core.tree.last_compacted_l0_sst_view_id.as_ref() {
             l0_last_compacted = Some(self.add_compacted_sst_id(ulid))
         }
-        let compacted = self.add_sorted_runs_v2(&core.compacted);
+        let compacted = self.add_sorted_runs_v2(&core.tree.compacted);
         let checkpoints = self.add_checkpoints(&core.checkpoints);
         let external_dbs = if manifest.external_dbs.is_empty() {
             None
@@ -1043,6 +1047,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         let core = &manifest.core;
 
         let l0: Vec<WIPOffset<CompactedSsTable>> = core
+            .tree
             .l0
             .iter()
             .map(|view| self.add_compacted_sst_from_view(view))
@@ -1051,10 +1056,10 @@ impl<'b> DbFlatBufferBuilder<'b> {
 
         // V1's l0_last_compacted is an SST ID, not a view ID.
         let mut l0_last_compacted = None;
-        if let Some(sst_id) = core.last_compacted_l0_sst_id.as_ref() {
+        if let Some(sst_id) = core.tree.last_compacted_l0_sst_id.as_ref() {
             l0_last_compacted = Some(self.add_compacted_sst_id(sst_id))
         }
-        let compacted = self.add_sorted_runs_v1(&core.compacted);
+        let compacted = self.add_sorted_runs_v1(&core.tree.compacted);
         let checkpoints = self.add_checkpoints(&core.checkpoints);
         let external_dbs = if manifest.external_dbs.is_empty() {
             None
@@ -1333,11 +1338,11 @@ mod tests {
 
         // given:
         let mut manifest = Manifest::initial(ManifestCore::new());
-        manifest.core.l0 = VecDeque::from(vec![
+        manifest.core.tree.l0 = VecDeque::from(vec![
             new_sst_handle(b"a", None),
             new_sst_handle(b"a", Some(BytesRange::from_ref("c"..="d"))),
         ]);
-        manifest.core.compacted = vec![
+        manifest.core.tree.compacted = vec![
             SortedRun {
                 id: 0,
                 sst_views: vec![
@@ -1716,7 +1721,7 @@ mod tests {
     fn test_should_encode_decode_manifest_sst_with_version_set() {
         // given: a manifest with one L0 SST and one sorted run SST
         let mut manifest = Manifest::initial(ManifestCore::new());
-        manifest.core.l0 = VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
+        manifest.core.tree.l0 = VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
             SsTableId::Compacted(ulid::Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo {
@@ -1724,7 +1729,7 @@ mod tests {
                 ..Default::default()
             },
         ))]);
-        manifest.core.compacted = vec![SortedRun {
+        manifest.core.tree.compacted = vec![SortedRun {
             id: 1,
             sst_views: vec![SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(ulid::Ulid::new()),
@@ -1743,11 +1748,13 @@ mod tests {
 
         // then:
         assert_eq!(
-            decoded.core.l0[0].sst.format_version,
+            decoded.core.tree.l0[0].sst.format_version,
             SST_FORMAT_VERSION_LATEST
         );
         assert_eq!(
-            decoded.core.compacted[0].sst_views[0].sst.format_version,
+            decoded.core.tree.compacted[0].sst_views[0]
+                .sst
+                .format_version,
             SST_FORMAT_VERSION_LATEST
         );
         assert_eq!(manifest, decoded);
@@ -1847,11 +1854,13 @@ mod tests {
 
         // then: format_version should default to ORIGINAL_SST_FORMAT_VERSION
         assert_eq!(
-            decoded.core.l0[0].sst.format_version,
+            decoded.core.tree.l0[0].sst.format_version,
             super::ORIGINAL_SST_FORMAT_VERSION
         );
         assert_eq!(
-            decoded.core.compacted[0].sst_views[0].sst.format_version,
+            decoded.core.tree.compacted[0].sst_views[0]
+                .sst
+                .format_version,
             super::ORIGINAL_SST_FORMAT_VERSION
         );
     }
@@ -2011,11 +2020,11 @@ mod tests {
         }
 
         let mut manifest = Manifest::initial(ManifestCore::new());
-        manifest.core.l0 = VecDeque::from(vec![
+        manifest.core.tree.l0 = VecDeque::from(vec![
             new_view(b"a", None),
             new_view(b"b", Some(BytesRange::from_ref("c"..="d"))),
         ]);
-        manifest.core.compacted = vec![
+        manifest.core.tree.compacted = vec![
             SortedRun {
                 id: 1,
                 sst_views: vec![
@@ -2031,9 +2040,9 @@ mod tests {
                 ],
             },
         ];
-        manifest.core.last_compacted_l0_sst_view_id = Some(manifest.core.l0[0].id);
-        manifest.core.last_compacted_l0_sst_id =
-            Some(manifest.core.l0[0].sst.id.unwrap_compacted_id());
+        manifest.core.tree.last_compacted_l0_sst_view_id = Some(manifest.core.tree.l0[0].id);
+        manifest.core.tree.last_compacted_l0_sst_id =
+            Some(manifest.core.tree.l0[0].sst.id.unwrap_compacted_id());
         manifest.writer_epoch = 42;
         manifest.compactor_epoch = 7;
         manifest.core.next_wal_sst_id = 10;
@@ -2080,7 +2089,7 @@ mod tests {
         // When view IDs equal SST IDs (identity views), V1 and V2 should decode
         // to the same in-memory Manifest.
         let mut manifest = Manifest::initial(ManifestCore::new());
-        manifest.core.l0 = VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
+        manifest.core.tree.l0 = VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
             SsTableId::Compacted(ulid::Ulid::new()),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo {
@@ -2088,7 +2097,7 @@ mod tests {
                 ..Default::default()
             },
         ))]);
-        manifest.core.compacted = vec![SortedRun {
+        manifest.core.tree.compacted = vec![SortedRun {
             id: 1,
             sst_views: vec![SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(ulid::Ulid::new()),

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1039,13 +1039,15 @@ mod tests {
         // Create a manifest
         let mut state = ManifestCore::new();
         state
+            .tree
             .l0
             .push_back(SsTableView::identity(l0_sst_handle.clone()));
         state
+            .tree
             .l0
             .push_back(SsTableView::identity(active_expired_l0_sst_handle.clone()));
         // Dont' push inactive_expired_l0_sst_handle
-        state.compacted.push(SortedRun {
+        state.tree.compacted.push(SortedRun {
             id: 1,
             // Don't add inactive_expired_sst_handle
             sst_views: vec![
@@ -1080,10 +1082,12 @@ mod tests {
         let manifests = manifest_store.list_manifests(..).await.unwrap();
         assert_eq!(manifests.len(), 1);
         let current_manifest = manifest_store.read_latest_manifest().await.unwrap();
-        assert_eq!(current_manifest.manifest.core.l0.len(), 2);
-        assert_eq!(current_manifest.manifest.core.compacted.len(), 1);
+        assert_eq!(current_manifest.manifest.core.tree.l0.len(), 2);
+        assert_eq!(current_manifest.manifest.core.tree.compacted.len(), 1);
         assert_eq!(
-            current_manifest.manifest.core.compacted[0].sst_views.len(),
+            current_manifest.manifest.core.tree.compacted[0]
+                .sst_views
+                .len(),
             2
         );
 
@@ -1115,10 +1119,12 @@ mod tests {
         assert!(!remaining_ids.contains(&inactive_expired_l0_sst_handle.id));
         assert!(!remaining_ids.contains(&inactive_expired_sst_handle.id));
         let current_manifest = manifest_store.read_latest_manifest().await.unwrap();
-        assert_eq!(current_manifest.manifest.core.l0.len(), 2);
-        assert_eq!(current_manifest.manifest.core.compacted.len(), 1);
+        assert_eq!(current_manifest.manifest.core.tree.l0.len(), 2);
+        assert_eq!(current_manifest.manifest.core.tree.compacted.len(), 1);
         assert_eq!(
-            current_manifest.manifest.core.compacted[0].sst_views.len(),
+            current_manifest.manifest.core.tree.compacted[0]
+                .sst_views
+                .len(),
             2
         );
     }
@@ -1154,16 +1160,17 @@ mod tests {
         // Create an initial manifest with active and active checkpoint tables
         let mut state = ManifestCore::new();
         state
+            .tree
             .l0
             .push_back(SsTableView::identity(active_l0_sst_handle.clone()));
-        state.l0.push_back(SsTableView::identity(
+        state.tree.l0.push_back(SsTableView::identity(
             active_checkpoint_l0_sst_handle.clone(),
         ));
-        state.compacted.push(SortedRun {
+        state.tree.compacted.push(SortedRun {
             id: 1,
             sst_views: vec![SsTableView::identity(active_sst_handle.clone())],
         });
-        state.compacted.push(SortedRun {
+        state.tree.compacted.push(SortedRun {
             id: 2,
             sst_views: vec![SsTableView::identity(active_checkpoint_sst_handle.clone())],
         });
@@ -1181,8 +1188,8 @@ mod tests {
 
         // Now drop the active tables from the checkpoint
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
-        dirty.value.core.l0.truncate(1);
-        dirty.value.core.compacted.truncate(1);
+        dirty.value.core.tree.l0.truncate(1);
+        dirty.value.core.tree.compacted.truncate(1);
         stored_manifest.update(dirty).await.unwrap();
 
         // Start the garbage collector
@@ -1337,11 +1344,11 @@ mod tests {
                 assert!(wal_ssts.contains(&SsTableId::Wal(wal_sst_id)));
             }
 
-            for view in &manifest.core.l0 {
+            for view in &manifest.core.tree.l0 {
                 assert!(compacted_ssts.contains(&view.sst.id));
             }
 
-            for sr in &manifest.core.compacted {
+            for sr in &manifest.core.tree.compacted {
                 for view in &sr.sst_views {
                     assert!(compacted_ssts.contains(&view.sst.id));
                 }
@@ -1775,8 +1782,11 @@ mod tests {
         let inactive_expired_handle = create_sst(table_store.clone(), expired_ms).await;
 
         let mut state = ManifestCore::new();
-        state.l0.push_back(SsTableView::identity(active_l0_handle));
-        state.compacted.push(SortedRun {
+        state
+            .tree
+            .l0
+            .push_back(SsTableView::identity(active_l0_handle));
+        state.tree.compacted.push(SortedRun {
             id: 1,
             sst_views: vec![SsTableView::identity(active_handle)],
         });

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -71,12 +71,12 @@ impl CompactedGcTask {
             .await?;
         let mut active_ssts = HashSet::new();
         for manifest in active_manifests.values() {
-            for sr in manifest.core.compacted.iter() {
+            for sr in manifest.core.tree.compacted.iter() {
                 for view in sr.sst_views.iter() {
                     active_ssts.insert(view.sst.id);
                 }
             }
-            for view in manifest.core.l0.iter() {
+            for view in manifest.core.tree.l0.iter() {
                 active_ssts.insert(view.sst.id);
             }
         }
@@ -101,15 +101,16 @@ impl CompactedGcTask {
     /// - The newest L0 timestamp if any L0s exist, otherwise a conservative fallback
     ///   (last compacted L0 or Unix epoch).
     async fn newest_l0_dt(&self, manifest: &Manifest) -> Result<DateTime<Utc>, SlateDBError> {
-        let l0_timestamps = if !manifest.core.l0.is_empty() {
+        let l0_timestamps = if !manifest.core.tree.l0.is_empty() {
             // Use active L0's if some exist
             manifest
                 .core
+                .tree
                 .l0
                 .iter()
                 .map(|view| DateTime::<Utc>::from(view.sst.id.unwrap_compacted_id().datetime()))
                 .collect::<Vec<_>>()
-        } else if let Some(l0_last_compacted) = manifest.core.last_compacted_l0_sst_view_id {
+        } else if let Some(l0_last_compacted) = manifest.core.tree.last_compacted_l0_sst_view_id {
             // Else fall back to the last compacted L0, which can serve as a conservative barrier
             vec![DateTime::<Utc>::from(l0_last_compacted.datetime())]
         } else {
@@ -316,6 +317,7 @@ mod tests {
         dirty
             .value
             .core
+            .tree
             .l0
             .push_back(SsTableView::identity(active_handle));
         stored_manifest.update(dirty).await.unwrap();
@@ -421,6 +423,7 @@ mod tests {
         dirty
             .value
             .core
+            .tree
             .l0
             .push_back(SsTableView::identity(manifest_handle));
         stored_manifest.update(dirty).await.unwrap();
@@ -514,6 +517,7 @@ mod tests {
         dirty
             .value
             .core
+            .tree
             .l0
             .push_back(SsTableView::identity(active_handle));
         stored_manifest.update(dirty).await.unwrap();
@@ -607,6 +611,7 @@ mod tests {
         dirty_manifest
             .value
             .core
+            .tree
             .l0
             .push_back(SsTableView::identity(l0_handle));
         stored_manifest.update(dirty_manifest).await.unwrap();

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -20,15 +20,11 @@ pub(crate) mod store;
 
 pub use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
 
-/// Internal immutable in-memory view of a `.manifest` file.
-#[derive(Clone, PartialEq, Serialize, Debug)]
-pub(crate) struct ManifestCore {
-    /// Flag to indicate whether initialization has finished. When creating the initial manifest for
-    /// a root db (one that is not a clone), this flag will be set to true. When creating the initial
-    /// manifest for a clone db, this flag will be set to false and then updated to true once clone
-    /// initialization has completed.
-    pub initialized: bool,
-
+/// Per-LSM-tree state. Shared shape between the unsegmented tree (held directly
+/// on `ManifestCore`) and — once segmented compaction is wired up — each named
+/// segment.
+#[derive(Clone, Default, PartialEq, Serialize, Debug)]
+pub(crate) struct LsmTreeState {
     /// The last compacted l0 SstView ID.
     pub last_compacted_l0_sst_view_id: Option<ulid::Ulid>,
 
@@ -42,6 +38,23 @@ pub(crate) struct ManifestCore {
 
     /// A list of the sorted runs that are valid to read in the `compacted` folder.
     pub compacted: Vec<SortedRun>,
+}
+
+/// Internal immutable in-memory view of a `.manifest` file.
+#[derive(Clone, PartialEq, Serialize, Debug)]
+pub(crate) struct ManifestCore {
+    /// Flag to indicate whether initialization has finished. When creating the initial manifest for
+    /// a root db (one that is not a clone), this flag will be set to true. When creating the initial
+    /// manifest for a clone db, this flag will be set to false and then updated to true once clone
+    /// initialization has completed.
+    pub initialized: bool,
+
+    /// LSM state for data that is not associated with any named segment. When
+    /// segmentation is not configured this is the only tree; once segmented
+    /// compaction is wired up, named segments will sit alongside it as a
+    /// sibling `segments` list.
+    #[serde(flatten)]
+    pub tree: LsmTreeState,
 
     /// The next WAL SST ID to be assigned when creating a new WAL SST. The manifest FlatBuffer
     /// contains `wal_id_last_seen`, which is always one less than this value.
@@ -83,10 +96,7 @@ impl ManifestCore {
     pub(crate) fn new() -> Self {
         Self {
             initialized: true,
-            last_compacted_l0_sst_view_id: None,
-            last_compacted_l0_sst_id: None,
-            l0: VecDeque::new(),
-            compacted: vec![],
+            tree: LsmTreeState::default(),
             next_wal_sst_id: 1,
             replay_after_wal_id: 0,
             last_l0_clock_tick: i64::MIN,
@@ -112,8 +122,9 @@ impl ManifestCore {
     }
 
     pub(crate) fn log_db_runs(&self) {
-        let l0s: Vec<_> = self.l0.iter().map(|l0| l0.estimate_size()).collect();
+        let l0s: Vec<_> = self.tree.l0.iter().map(|l0| l0.estimate_size()).collect();
         let compacted: Vec<_> = self
+            .tree
             .compacted
             .iter()
             .map(|sr| (sr.id, sr.estimate_size()))
@@ -183,22 +194,22 @@ impl VersionedManifest {
 
     /// Returns the last compacted L0 SST view ID, if any.
     pub fn last_compacted_l0_sst_view_id(&self) -> Option<ulid::Ulid> {
-        self.manifest.core.last_compacted_l0_sst_view_id
+        self.manifest.core.tree.last_compacted_l0_sst_view_id
     }
 
     /// Returns the last compacted L0 SST ID, if any.
     pub fn last_compacted_l0_sst_id(&self) -> Option<ulid::Ulid> {
-        self.manifest.core.last_compacted_l0_sst_id
+        self.manifest.core.tree.last_compacted_l0_sst_id
     }
 
     /// Returns the current L0 SST views.
     pub fn l0(&self) -> &VecDeque<SsTableView> {
-        &self.manifest.core.l0
+        &self.manifest.core.tree.l0
     }
 
     /// Returns the current compacted sorted runs.
     pub fn compacted(&self) -> &Vec<SortedRun> {
-        &self.manifest.core.compacted
+        &self.manifest.core.tree.compacted
     }
 
     /// Returns the next WAL SST ID to assign.
@@ -286,10 +297,11 @@ impl Manifest {
 
         let parent_owned_sst_ids = parent_manifest
             .core
+            .tree
             .compacted
             .iter()
             .flat_map(|sr| sr.sst_views.iter().map(|s| s.sst.id))
-            .chain(parent_manifest.core.l0.iter().map(|s| s.sst.id))
+            .chain(parent_manifest.core.tree.l0.iter().map(|s| s.sst.id))
             .filter(|id| !parent_external_sst_ids.contains(id))
             .collect();
 
@@ -311,7 +323,7 @@ impl Manifest {
     pub(crate) fn projected(source_manifest: &Manifest, range: BytesRange) -> Manifest {
         let mut projected = source_manifest.clone();
         let mut sorter_runs_filtered = vec![];
-        for sorter_run in &projected.core.compacted {
+        for sorter_run in &projected.core.tree.compacted {
             let sst_views = Self::filter_view_handles(&sorter_run.sst_views, false, &range);
             if !sst_views.is_empty() {
                 sorter_runs_filtered.push(SortedRun {
@@ -320,15 +332,17 @@ impl Manifest {
                 });
             }
         }
-        projected.core.l0 = Self::filter_view_handles(&projected.core.l0, true, &range).into();
-        projected.core.compacted = sorter_runs_filtered;
+        projected.core.tree.l0 =
+            Self::filter_view_handles(&projected.core.tree.l0, true, &range).into();
+        projected.core.tree.compacted = sorter_runs_filtered;
         // drop unused external_dbs
         let used_sst_ids: HashSet<SsTableId> = projected
             .core
+            .tree
             .compacted
             .iter()
             .flat_map(|sr| sr.sst_views.iter().map(|v| v.sst.id))
-            .chain(projected.core.l0.iter().map(|v| v.sst.id))
+            .chain(projected.core.tree.l0.iter().map(|v| v.sst.id))
             .collect();
         projected
             .external_dbs
@@ -401,12 +415,12 @@ impl Manifest {
                 });
             }
             // Then, we can add all the l0 ssts
-            for sst in &manifest.core.l0 {
-                core.l0.push_back(sst.clone());
+            for sst in &manifest.core.tree.l0 {
+                core.tree.l0.push_back(sst.clone());
             }
             // Finally, we can add all the sorted runs
-            for sorted_run in &manifest.core.compacted {
-                core.compacted.push(sorted_run.clone());
+            for sorted_run in &manifest.core.tree.compacted {
+                core.tree.compacted.push(sorted_run.clone());
             }
 
             let owned_ssts = manifest.owned_ssts();
@@ -421,7 +435,7 @@ impl Manifest {
         }
 
         // Renumber sorted runs to ensure sequential IDs without duplicates
-        for (idx, sorted_run) in core.compacted.iter_mut().enumerate() {
+        for (idx, sorted_run) in core.tree.compacted.iter_mut().enumerate() {
             sorted_run.id = idx as u32;
         }
 
@@ -439,8 +453,9 @@ impl Manifest {
     fn range(&self) -> Option<BytesRange> {
         let mut start_bound = None;
         let mut end_bound = None;
-        let all_views = self.core.l0.iter().chain(
+        let all_views = self.core.tree.l0.iter().chain(
             self.core
+                .tree
                 .compacted
                 .iter()
                 .flat_map(|sr| sr.sst_views.iter()),
@@ -495,10 +510,11 @@ impl Manifest {
         // Owned SSTs = SSTs in core not already delegated to an external_db
         let owned_sst_ids: Vec<SsTableId> = self
             .core
+            .tree
             .compacted
             .iter()
             .flat_map(|sr| sr.sst_views.iter().map(|s| s.sst.id))
-            .chain(self.core.l0.iter().map(|s| s.sst.id))
+            .chain(self.core.tree.l0.iter().map(|s| s.sst.id))
             .filter(|id| !source_external_sst_ids.contains(id))
             .collect();
         owned_sst_ids
@@ -515,10 +531,11 @@ impl Manifest {
     pub(crate) fn prune_external_sst_ids(&mut self) {
         let used_sst_ids: HashSet<SsTableId> = self
             .core
+            .tree
             .compacted
             .iter()
             .flat_map(|sr| sr.sst_views.iter().map(|v| v.sst.id))
-            .chain(self.core.l0.iter().map(|v| v.sst.id))
+            .chain(self.core.tree.l0.iter().map(|v| v.sst.id))
             .collect();
         for external_db in self.external_dbs.iter_mut() {
             external_db.sst_ids.retain(|id| used_sst_ids.contains(id));
@@ -950,9 +967,9 @@ mod tests {
         );
 
         // After union, we should have 5 SRs with IDs 0, 1, 2, 3, 4
-        assert_eq!(union.core.compacted.len(), 5);
+        assert_eq!(union.core.tree.compacted.len(), 5);
 
-        let sr_ids: Vec<u32> = union.core.compacted.iter().map(|sr| sr.id).collect();
+        let sr_ids: Vec<u32> = union.core.tree.compacted.iter().map(|sr| sr.id).collect();
         assert_eq!(sr_ids, vec![0, 1, 2, 3, 4], "SR IDs should be sequential");
 
         // Verify no duplicates
@@ -1149,7 +1166,7 @@ mod tests {
         for entry in &manifest.l0 {
             let sst_id = sst_id_fn(entry.sst_alias);
             let view_id = sst_id.unwrap_compacted_id();
-            core.l0.push_back(SsTableView::new_projected(
+            core.tree.l0.push_back(SsTableView::new_projected(
                 view_id,
                 SsTableHandle::new(
                     sst_id,
@@ -1163,7 +1180,7 @@ mod tests {
             ));
         }
         for (idx, sorted_run) in manifest.sorted_runs.iter().enumerate() {
-            core.compacted.push(SortedRun {
+            core.tree.compacted.push(SortedRun {
                 id: idx as u32,
                 sst_views: sorted_run
                     .iter()
@@ -1197,11 +1214,11 @@ mod tests {
         let sst_aliases: HashMap<SsTableId, String> =
             sst_ids.iter().map(|(k, v)| (*v, k.clone())).collect();
 
-        if actual.core.l0 != expected.core.l0 {
+        if actual.core.tree.l0 != expected.core.tree.l0 {
             let mut error_msg = String::from("Manifest L0 mismatch.\n\nActual: \n");
 
             // Format actual L0 entries
-            for (idx, handle) in actual.core.l0.iter().enumerate() {
+            for (idx, handle) in actual.core.tree.l0.iter().enumerate() {
                 let id_str = sst_aliases
                     .get(&handle.sst.id)
                     .map(|a| a.as_str())
@@ -1221,7 +1238,7 @@ mod tests {
                     .map(format_range)
                     .unwrap_or_else(|| "None".to_string());
 
-                let result = if expected.core.l0.get(idx) == Some(handle) {
+                let result = if expected.core.tree.l0.get(idx) == Some(handle) {
                     ""
                 } else {
                     " --> Unexpected"
@@ -1240,7 +1257,7 @@ mod tests {
             error_msg.push_str("\nExpected: \n");
 
             // Format expected L0 entries
-            for (idx, handle) in expected.core.l0.iter().enumerate() {
+            for (idx, handle) in expected.core.tree.l0.iter().enumerate() {
                 let id_str = sst_aliases.get(&handle.sst.id).unwrap();
 
                 let first_entry = handle
@@ -1270,7 +1287,7 @@ mod tests {
         }
 
         assert_eq!(
-            actual.core.compacted, expected.core.compacted,
+            actual.core.tree.compacted, expected.core.tree.compacted,
             "Sorted runs do not match."
         );
     }
@@ -1300,10 +1317,10 @@ mod tests {
 
         let mut core = ManifestCore::new();
 
-        core.l0.push_back(create_sst_view(sst_id_1, b"a")); // inside projection_range
-        core.l0.push_back(create_sst_view(sst_id_2, b"c")); // outside projection_range
-        core.l0.push_back(create_sst_view(sst_id_3, b"d")); // outside projection_range
-        core.l0.push_back(create_sst_view(sst_id_4, b"e")); // outside projection_range
+        core.tree.l0.push_back(create_sst_view(sst_id_1, b"a")); // inside projection_range
+        core.tree.l0.push_back(create_sst_view(sst_id_2, b"c")); // outside projection_range
+        core.tree.l0.push_back(create_sst_view(sst_id_3, b"d")); // outside projection_range
+        core.tree.l0.push_back(create_sst_view(sst_id_4, b"e")); // outside projection_range
 
         let mut manifest = Manifest::initial(core);
 
@@ -1338,8 +1355,8 @@ mod tests {
         let stale_b = SsTableId::Compacted(Ulid::new());
 
         let mut core = ManifestCore::new();
-        core.l0.push_back(create_sst_view(live_l0, b"a"));
-        core.compacted.push(SortedRun {
+        core.tree.l0.push_back(create_sst_view(live_l0, b"a"));
+        core.tree.compacted.push(SortedRun {
             id: 0,
             sst_views: vec![create_sst_view(live_compacted, b"b")],
         });

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -476,6 +476,7 @@ impl ManifestWriterHandler {
                     .manifest
                     .value
                     .core
+                    .tree
                     .l0
                     .push_front(SsTableView::new(
                         self.db.rand.rng().gen_ulid(self.db.system_clock.as_ref()),
@@ -608,7 +609,7 @@ impl ManifestWriterHandler {
             self.db
                 .db_stats
                 .l0_sst_count
-                .set(cow.core().l0.len() as i64);
+                .set(cow.core().tree.l0.len() as i64);
             cow.manifest.clone()
         };
         self.db

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -199,7 +199,7 @@ impl FlushTracker {
     }
 
     fn available_l0_slots(&self) -> usize {
-        let l0_len = self.inner.state.read().state().core().l0.len();
+        let l0_len = self.inner.state.read().state().core().tree.l0.len();
         self.inner
             .settings
             .l0_max_ssts
@@ -548,9 +548,9 @@ mod tests {
                 .await
                 .unwrap();
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
-        dirty.value.core.l0.clear();
+        dirty.value.core.tree.l0.clear();
         for idx in 0..l0_len {
-            dirty.value.core.l0.push_back(SsTableView::new(
+            dirty.value.core.tree.l0.push_back(SsTableView::new(
                 ulid::Ulid::new(),
                 seeded_l0_handle(format!("seed-{idx}").as_bytes()),
             ));
@@ -561,13 +561,14 @@ mod tests {
     fn set_local_l0_len(harness: &TestHarness, l0_len: usize) {
         let mut guard = harness.inner.state.write();
         guard.modify(|modifier| {
-            modifier.state.manifest.value.core.l0.clear();
+            modifier.state.manifest.value.core.tree.l0.clear();
             for idx in 0..l0_len {
                 modifier
                     .state
                     .manifest
                     .value
                     .core
+                    .tree
                     .l0
                     .push_back(SsTableView::new(
                         ulid::Ulid::new(),
@@ -862,7 +863,7 @@ mod tests {
             // Clear both local and remote L0 so the flusher can make progress.
             {
                 let mut guard = flusher.inner.state.write();
-                guard.modify(|modifier| modifier.state.manifest.value.core.l0.clear());
+                guard.modify(|modifier| modifier.state.manifest.value.core.tree.l0.clear());
             }
             set_remote_l0_len(&path, object_store, 0).await;
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -152,8 +152,11 @@ impl Reader {
             })
             .collect::<Vec<_>>();
 
-        let max_parallel =
-            compute_max_parallel(db_state.core().l0.len(), &db_state.core().compacted, 4);
+        let max_parallel = compute_max_parallel(
+            db_state.core().tree.l0.len(),
+            &db_state.core().tree.compacted,
+            4,
+        );
 
         let (l0_iters, sr_iters) = if let Some(point_key) = range.as_point() {
             let l0 = self.build_point_l0_iters(
@@ -195,7 +198,7 @@ impl Reader {
         db_stats: Option<DbStats>,
     ) -> Result<VecDeque<Box<dyn RowEntryIterator + 'a>>, SlateDBError> {
         let mut iters = VecDeque::new();
-        for sst in &db_state.core().l0 {
+        for sst in &db_state.core().tree.l0 {
             let iterator = SstIterator::new_owned_with_stats(
                 range.clone(),
                 sst.clone(),
@@ -219,7 +222,7 @@ impl Reader {
         db_stats: Option<DbStats>,
     ) -> Result<VecDeque<Box<dyn RowEntryIterator + 'a>>, SlateDBError> {
         let mut iters = VecDeque::new();
-        for sr in &db_state.core().compacted {
+        for sr in &db_state.core().tree.compacted {
             for handle in sr.tables_covering_point_key(key) {
                 let iterator = SstIterator::new_owned_with_stats(
                     range.clone(),
@@ -247,7 +250,7 @@ impl Reader {
         let table_store = self.table_store.clone();
         let sst_iter_options = sst_iter_options.clone();
         build_concurrent(
-            db_state.core().l0.iter().cloned(),
+            db_state.core().tree.l0.iter().cloned(),
             max_parallel,
             move |sst| {
                 let table_store = table_store.clone();
@@ -281,6 +284,7 @@ impl Reader {
         let table_store = self.table_store.clone();
         let overlapping: Vec<_> = db_state
             .core()
+            .tree
             .compacted
             .iter()
             .filter(|sr| sr.overlaps_range(range))
@@ -566,7 +570,10 @@ mod tests {
                 return Ok(());
             }
             let sst_handle = self.build_sst(entries).await?;
-            self.core.l0.push_front(SsTableView::identity(sst_handle));
+            self.core
+                .tree
+                .l0
+                .push_front(SsTableView::identity(sst_handle));
             Ok(())
         }
 
@@ -582,14 +589,20 @@ mod tests {
             let sst_handle = self.build_sst(entries).await?;
 
             // Find or create the sorted run
-            if let Some(sr) = self.core.compacted.iter_mut().find(|sr| sr.id == sr_id) {
+            if let Some(sr) = self
+                .core
+                .tree
+                .compacted
+                .iter_mut()
+                .find(|sr| sr.id == sr_id)
+            {
                 sr.sst_views.push(SsTableView::identity(sst_handle));
             } else {
                 let new_sr = SortedRun {
                     id: sr_id,
                     sst_views: vec![SsTableView::identity(sst_handle)],
                 };
-                self.core.compacted.push(new_sr);
+                self.core.tree.compacted.push(new_sr);
             }
             Ok(())
         }

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -213,6 +213,7 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
         let sources_logical_order: Vec<SourceId> = state
             .manifest()
             .core()
+            .tree
             .l0
             .iter()
             .map(|view| SourceId::SstView(view.id))
@@ -220,6 +221,7 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
                 state
                     .manifest()
                     .core()
+                    .tree
                     .compacted
                     .iter()
                     .map(|sr| SourceId::SortedRun(sr.id)),
@@ -376,6 +378,7 @@ impl SizeTieredCompactionScheduler {
         db_state: &ManifestCore,
     ) -> (Vec<CompactionSource>, Vec<CompactionSource>) {
         let collected_l0: Vec<CompactionSource> = db_state
+            .tree
             .l0
             .iter()
             .map(|l0| CompactionSource {
@@ -385,6 +388,7 @@ impl SizeTieredCompactionScheduler {
             .collect();
 
         let collected_sr = db_state
+            .tree
             .compacted
             .iter()
             .map(|sr| CompactionSource {
@@ -433,7 +437,7 @@ mod tests {
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::store::test_utils::new_dirty_manifest;
-    use crate::manifest::ManifestCore;
+    use crate::manifest::{LsmTreeState, ManifestCore};
     use crate::seq_tracker::SequenceTracker;
     use crate::size_tiered_compaction::{
         SizeTieredCompactionScheduler, SizeTieredCompactionSchedulerSupplier,
@@ -838,7 +842,7 @@ mod tests {
         let state =
             &create_compactor_state(create_db_state(VecDeque::new(), vec![create_sr2(0, 2)]));
 
-        let mut l0 = state.db_state().l0.clone();
+        let mut l0 = state.db_state().tree.l0.clone();
         let request = create_l0_compaction(l0.make_contiguous(), 0);
         let mut new_sources: Vec<SourceId> = request.sources().clone();
         new_sources.push(SourceId::SortedRun(5));
@@ -859,7 +863,7 @@ mod tests {
             vec![create_sr2(0, 2), create_sr2(1, 2)],
         ));
 
-        let srs = state.db_state().compacted.clone();
+        let srs = state.db_state().tree.compacted.clone();
         let compaction = create_sr_compaction(srs.iter().map(|sr| sr.id).collect());
         // when:
         let result = scheduler.validate(&state.into(), &compaction);
@@ -905,10 +909,12 @@ mod tests {
     fn create_db_state(l0: VecDeque<SsTableView>, srs: Vec<SortedRun>) -> ManifestCore {
         ManifestCore {
             initialized: true,
-            last_compacted_l0_sst_view_id: None,
-            last_compacted_l0_sst_id: None,
-            l0,
-            compacted: srs,
+            tree: LsmTreeState {
+                last_compacted_l0_sst_view_id: None,
+                last_compacted_l0_sst_id: None,
+                l0,
+                compacted: srs,
+            },
             next_wal_sst_id: 0,
             replay_after_wal_id: 0,
             last_l0_seq: 0,

--- a/slatedb/src/sst_reader.rs
+++ b/slatedb/src/sst_reader.rs
@@ -312,10 +312,10 @@ mod tests {
         let reader = SstReader::new(path, store, None, None);
 
         assert!(
-            !manifest.manifest.core.l0.is_empty(),
+            !manifest.manifest.core.tree.l0.is_empty(),
             "expected at least one L0 SST"
         );
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader
             .open(view.sst.id.unwrap_compacted_id())
             .await
@@ -331,7 +331,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
 
         assert_eq!(sst_file.id(), view.sst.id.unwrap_compacted_id());
@@ -343,7 +343,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let stats = sst_file.stats().await.unwrap();
 
@@ -361,7 +361,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let index = sst_file.index().await.unwrap();
 
@@ -382,7 +382,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
 
         let stats = sst_file
@@ -408,7 +408,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let index = sst_file.index().await.unwrap();
         assert!(!index.is_empty());
@@ -447,7 +447,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let num_blocks = sst_file.index().await.unwrap().len();
 
@@ -460,7 +460,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let index = sst_file.index().await.unwrap();
 
@@ -477,7 +477,7 @@ mod tests {
         let (store, path, manifest) = setup_db_with_l0().await;
         let reader = SstReader::new(path, store, None, None);
 
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let metadata = sst_file.metadata().await.unwrap();
 
@@ -558,7 +558,7 @@ mod tests {
 
         // Reading with the correct transformer should succeed
         let reader = SstReader::new(path, object_store.clone(), None, Some(transformer));
-        let view = &manifest.manifest.core.l0[0];
+        let view = &manifest.manifest.core.tree.l0[0];
         let sst_file = reader.open_with_handle(view.sst.clone()).unwrap();
         let stats = sst_file.stats().await.unwrap().expect("expected stats");
         assert_eq!(stats.num_puts, 5);

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -374,13 +374,14 @@ impl CompactionScheduler for OnDemandCompactionScheduler {
 
         // Create a compaction of all SSTs from L0 and all sorted runs
         let mut sources: Vec<SourceId> = db_state
+            .tree
             .l0
             .iter()
             .map(|view| SourceId::SstView(view.id))
             .collect();
 
         // Add SSTs from all sorted runs
-        for sr in &db_state.compacted {
+        for sr in &db_state.tree.compacted {
             sources.push(SourceId::SortedRun(sr.id));
         }
 

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -661,20 +661,23 @@ pub(crate) async fn preload_cache_from_manifest(
     match preload_level {
         Some(PreloadLevel::AllSst) => {
             let mut all_sst_paths: Vec<object_store::path::Path> = Vec::with_capacity(
-                core.l0.len()
+                core.tree.l0.len()
                     + core
+                        .tree
                         .compacted
                         .iter()
                         .map(|sr| sr.sst_views.len())
                         .sum::<usize>(),
             );
             all_sst_paths.extend(
-                core.l0
+                core.tree
+                    .l0
                     .iter()
                     .map(|view| path_resolver.table_path(&view.sst.id)),
             );
             all_sst_paths.extend(
-                core.compacted
+                core.tree
+                    .compacted
                     .iter()
                     .flat_map(|sr| &sr.sst_views)
                     .map(|view| path_resolver.table_path(&view.sst.id)),
@@ -690,6 +693,7 @@ pub(crate) async fn preload_cache_from_manifest(
         }
         Some(PreloadLevel::L0Sst) => {
             let l0_sst_paths: Vec<object_store::path::Path> = core
+                .tree
                 .l0
                 .iter()
                 .map(|view| path_resolver.table_path(&view.sst.id))


### PR DESCRIPTION
First foray into RFC 24. The updated manifest will carry both the current (unsegmented) LSM tree as well as per-segment trees. This patch factors out the shared state in the manifest into an `LsmTreeState` and updates references. In a later patch, we will use this to define the per-segment LSM trees.

Thank you for the review! 🙏
