### PR TITLE
Expose warm_sst and evict_cached_sst on uniffi Db and DbReader

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -661,6 +661,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_evict_cached_sst()
+		})
+		if checksum != 60099 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_evict_cached_sst: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_db_flush()
 		})
 		if checksum != 42157 {
@@ -814,6 +823,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_warm_sst()
+		})
+		if checksum != 8802 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_warm_sst: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_db_write()
 		})
 		if checksum != 29016 {
@@ -828,6 +846,15 @@ func uniffiCheckChecksums() {
 		if checksum != 13580 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_write_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_evict_cached_sst()
+		})
+		if checksum != 31819 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_evict_cached_sst: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -918,6 +945,15 @@ func uniffiCheckChecksums() {
 		if checksum != 4488 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_status: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbreader_warm_sst()
+		})
+		if checksum != 26897 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbreader_warm_sst: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -2649,6 +2685,10 @@ type DbInterface interface {
 	Delete(key []byte) (WriteHandle, error)
 	// Deletes `key` using custom write options.
 	DeleteWithOptions(key []byte, options WriteOptions) (WriteHandle, error)
+	// Best-effort eviction of block-cache entries for one SST.
+	//
+	// If no block cache is configured, returns `Ok(())`.
+	EvictCachedSst(sstId SsTableId) error
 	// Flushes the default storage layer.
 	Flush() error
 	// Flushes according to the provided flush options.
@@ -2686,6 +2726,12 @@ type DbInterface interface {
 	Snapshot() (*DbSnapshot, error)
 	// Returns the latest database status snapshot.
 	Status() DbStatus
+	// Warms selected cache content for one SST.
+	//
+	// Returns `Err` on the first failing target. If no block cache is
+	// configured, or if the SST is not reachable from the current manifest,
+	// the call is a no-op that returns `Ok(())`.
+	WarmSst(sstId SsTableId, targets []CacheTarget) error
 	// Applies all operations in `batch` atomically.
 	//
 	// The provided batch is consumed and cannot be reused afterwards.
@@ -2805,6 +2851,40 @@ func (_self *Db) DeleteWithOptions(key []byte, options WriteOptions) (WriteHandl
 	}
 
 	return res, err
+}
+
+// Best-effort eviction of block-cache entries for one SST.
+//
+// If no block cache is configured, returns `Ok(())`.
+func (_self *Db) EvictCachedSst(sstId SsTableId) error {
+	_pointer := _self.ffiObject.incrementPointer("*Db")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_db_evict_cached_sst(
+			_pointer, FfiConverterSsTableIdINSTANCE.Lower(sstId)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
 }
 
 // Flushes the default storage layer.
@@ -3374,6 +3454,42 @@ func (_self *Db) Status() DbStatus {
 				_pointer, _uniffiStatus),
 		}
 	}))
+}
+
+// Warms selected cache content for one SST.
+//
+// Returns `Err` on the first failing target. If no block cache is
+// configured, or if the SST is not reachable from the current manifest,
+// the call is a no-op that returns `Ok(())`.
+func (_self *Db) WarmSst(sstId SsTableId, targets []CacheTarget) error {
+	_pointer := _self.ffiObject.incrementPointer("*Db")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_db_warm_sst(
+			_pointer, FfiConverterSsTableIdINSTANCE.Lower(sstId), FfiConverterSequenceCacheTargetINSTANCE.Lower(targets)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
 }
 
 // Applies all operations in `batch` atomically.
@@ -3972,6 +4088,10 @@ func (_ FfiDestroyerDbIterator) Destroy(value *DbIterator) {
 
 // Read-only database handle opened by [`crate::DbReaderBuilder`].
 type DbReaderInterface interface {
+	// Best-effort eviction of block-cache entries for one SST.
+	//
+	// If no block cache is configured, returns `Ok(())`.
+	EvictCachedSst(sstId SsTableId) error
 	// Reads the current value for `key`.
 	Get(key []byte) (*[]byte, error)
 	// Reads the current row version for `key`, including metadata.
@@ -3992,11 +4112,51 @@ type DbReaderInterface interface {
 	Shutdown() error
 	// Returns the latest reader status snapshot.
 	Status() DbStatus
+	// Warms selected cache content for one SST.
+	//
+	// Returns `Err` on the first failing target. If no block cache is
+	// configured, or if the SST is not reachable from the current manifest,
+	// the call is a no-op that returns `Ok(())`.
+	WarmSst(sstId SsTableId, targets []CacheTarget) error
 }
 
 // Read-only database handle opened by [`crate::DbReaderBuilder`].
 type DbReader struct {
 	ffiObject FfiObject
+}
+
+// Best-effort eviction of block-cache entries for one SST.
+//
+// If no block cache is configured, returns `Ok(())`.
+func (_self *DbReader) EvictCachedSst(sstId SsTableId) error {
+	_pointer := _self.ffiObject.incrementPointer("*DbReader")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_dbreader_evict_cached_sst(
+			_pointer, FfiConverterSsTableIdINSTANCE.Lower(sstId)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
 }
 
 // Reads the current value for `key`.
@@ -4321,6 +4481,42 @@ func (_self *DbReader) Status() DbStatus {
 				_pointer, _uniffiStatus),
 		}
 	}))
+}
+
+// Warms selected cache content for one SST.
+//
+// Returns `Err` on the first failing target. If no block cache is
+// configured, or if the SST is not reachable from the current manifest,
+// the call is a no-op that returns `Ok(())`.
+func (_self *DbReader) WarmSst(sstId SsTableId, targets []CacheTarget) error {
+	_pointer := _self.ffiObject.incrementPointer("*DbReader")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_dbreader_warm_sst(
+			_pointer, FfiConverterSsTableIdINSTANCE.Lower(sstId), FfiConverterSequenceCacheTargetINSTANCE.Lower(targets)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
 }
 func (object *DbReader) Destroy() {
 	runtime.SetFinalizer(object, nil)
@@ -9388,6 +9584,98 @@ func (_ FfiDestroyerWriteOptions) Destroy(value WriteOptions) {
 	value.Destroy()
 }
 
+// Cache content that [`crate::Db::warm_sst`] should populate.
+type CacheTarget interface {
+	Destroy()
+}
+
+// Warm all filters on the SST, if any exist.
+type CacheTargetFilters struct {
+}
+
+func (e CacheTargetFilters) Destroy() {
+}
+
+// Warm the SST index.
+type CacheTargetIndex struct {
+}
+
+func (e CacheTargetIndex) Destroy() {
+}
+
+// Warm the SST stats block, if one exists.
+type CacheTargetStats struct {
+}
+
+func (e CacheTargetStats) Destroy() {
+}
+
+// Warm the SST data blocks that overlap `range`. Also warms the index,
+// since block planning depends on it.
+type CacheTargetData struct {
+	Range KeyRange
+}
+
+func (e CacheTargetData) Destroy() {
+	FfiDestroyerKeyRange{}.Destroy(e.Range)
+}
+
+type FfiConverterCacheTarget struct{}
+
+var FfiConverterCacheTargetINSTANCE = FfiConverterCacheTarget{}
+
+func (c FfiConverterCacheTarget) Lift(rb RustBufferI) CacheTarget {
+	return LiftFromRustBuffer[CacheTarget](c, rb)
+}
+
+func (c FfiConverterCacheTarget) Lower(value CacheTarget) C.RustBuffer {
+	return LowerIntoRustBuffer[CacheTarget](c, value)
+}
+
+func (c FfiConverterCacheTarget) LowerExternal(value CacheTarget) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[CacheTarget](c, value))
+}
+func (FfiConverterCacheTarget) Read(reader io.Reader) CacheTarget {
+	id := readInt32(reader)
+	switch id {
+	case 1:
+		return CacheTargetFilters{}
+	case 2:
+		return CacheTargetIndex{}
+	case 3:
+		return CacheTargetStats{}
+	case 4:
+		return CacheTargetData{
+			FfiConverterKeyRangeINSTANCE.Read(reader),
+		}
+	default:
+		panic(fmt.Sprintf("invalid enum value %v in FfiConverterCacheTarget.Read()", id))
+	}
+}
+
+func (FfiConverterCacheTarget) Write(writer io.Writer, value CacheTarget) {
+	switch variant_value := value.(type) {
+	case CacheTargetFilters:
+		writeInt32(writer, 1)
+	case CacheTargetIndex:
+		writeInt32(writer, 2)
+	case CacheTargetStats:
+		writeInt32(writer, 3)
+	case CacheTargetData:
+		writeInt32(writer, 4)
+		FfiConverterKeyRangeINSTANCE.Write(writer, variant_value.Range)
+	default:
+		_ = variant_value
+		panic(fmt.Sprintf("invalid enum value `%v` in FfiConverterCacheTarget.Write", value))
+	}
+}
+
+type FfiDestroyerCacheTarget struct{}
+
+func (_ FfiDestroyerCacheTarget) Destroy(value CacheTarget) {
+	value.Destroy()
+}
+
 // Reason a database or reader reports itself as closed.
 type CloseReason uint
 
@@ -12003,6 +12291,53 @@ type FfiDestroyerSequenceVersionedManifest struct{}
 func (FfiDestroyerSequenceVersionedManifest) Destroy(sequence []VersionedManifest) {
 	for _, value := range sequence {
 		FfiDestroyerVersionedManifest{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceCacheTarget struct{}
+
+var FfiConverterSequenceCacheTargetINSTANCE = FfiConverterSequenceCacheTarget{}
+
+func (c FfiConverterSequenceCacheTarget) Lift(rb RustBufferI) []CacheTarget {
+	return LiftFromRustBuffer[[]CacheTarget](c, rb)
+}
+
+func (c FfiConverterSequenceCacheTarget) Read(reader io.Reader) []CacheTarget {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]CacheTarget, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterCacheTargetINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceCacheTarget) Lower(value []CacheTarget) C.RustBuffer {
+	return LowerIntoRustBuffer[[]CacheTarget](c, value)
+}
+
+func (c FfiConverterSequenceCacheTarget) LowerExternal(value []CacheTarget) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[[]CacheTarget](c, value))
+}
+
+func (c FfiConverterSequenceCacheTarget) Write(writer io.Writer, value []CacheTarget) {
+	if len(value) > math.MaxInt32 {
+		panic("[]CacheTarget is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterCacheTargetINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceCacheTarget struct{}
+
+func (FfiDestroyerSequenceCacheTarget) Destroy(sequence []CacheTarget) {
+	for _, value := range sequence {
+		FfiDestroyerCacheTarget{}.Destroy(value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -791,6 +791,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_db_delete(uint64_t ptr, RustBuffer key
 uint64_t uniffi_slatedb_uniffi_fn_method_db_delete_with_options(uint64_t ptr, RustBuffer key, RustBuffer options
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_EVICT_CACHED_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_EVICT_CACHED_SST
+uint64_t uniffi_slatedb_uniffi_fn_method_db_evict_cached_sst(uint64_t ptr, RustBuffer sst_id
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_FLUSH
 uint64_t uniffi_slatedb_uniffi_fn_method_db_flush(uint64_t ptr
@@ -876,6 +881,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_db_snapshot(uint64_t ptr
 RustBuffer uniffi_slatedb_uniffi_fn_method_db_status(uint64_t ptr, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WARM_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WARM_SST
+uint64_t uniffi_slatedb_uniffi_fn_method_db_warm_sst(uint64_t ptr, RustBuffer sst_id, RustBuffer targets
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_WRITE
 uint64_t uniffi_slatedb_uniffi_fn_method_db_write(uint64_t ptr, uint64_t batch
@@ -919,6 +929,11 @@ uint64_t uniffi_slatedb_uniffi_fn_clone_dbreader(uint64_t handle, RustCallStatus
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_FREE_DBREADER
 void uniffi_slatedb_uniffi_fn_free_dbreader(uint64_t handle, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_EVICT_CACHED_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_EVICT_CACHED_SST
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_evict_cached_sst(uint64_t ptr, RustBuffer sst_id
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_GET
@@ -969,6 +984,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_shutdown(uint64_t ptr
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_STATUS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_STATUS
 RustBuffer uniffi_slatedb_uniffi_fn_method_dbreader_status(uint64_t ptr, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_WARM_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBREADER_WARM_SST
+uint64_t uniffi_slatedb_uniffi_fn_method_dbreader_warm_sst(uint64_t ptr, RustBuffer sst_id, RustBuffer targets
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_DBSNAPSHOT
@@ -1996,6 +2016,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_db_delete_with_options(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_EVICT_CACHED_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_EVICT_CACHED_SST
+uint16_t uniffi_slatedb_uniffi_checksum_method_db_evict_cached_sst(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_FLUSH
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_FLUSH
 uint16_t uniffi_slatedb_uniffi_checksum_method_db_flush(void
@@ -2098,6 +2124,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_db_status(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_WARM_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_WARM_SST
+uint16_t uniffi_slatedb_uniffi_checksum_method_db_warm_sst(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_WRITE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_WRITE
 uint16_t uniffi_slatedb_uniffi_checksum_method_db_write(void
@@ -2107,6 +2139,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_db_write(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_WRITE_WITH_OPTIONS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_WRITE_WITH_OPTIONS
 uint16_t uniffi_slatedb_uniffi_checksum_method_db_write_with_options(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_EVICT_CACHED_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_EVICT_CACHED_SST
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_evict_cached_sst(void
     
 );
 #endif
@@ -2167,6 +2205,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_shutdown(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_STATUS
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_STATUS
 uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_status(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_WARM_SST
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBREADER_WARM_SST
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbreader_warm_sst(void
     
 );
 #endif

--- a/bindings/node/tests/db.test.mjs
+++ b/bindings/node/tests/db.test.mjs
@@ -2,13 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  AdminBuilder,
+  CacheTarget,
   CloseReason,
   FlushType,
   IsolationLevel,
+  SsTableId,
   WriteBatch,
 } from "../index.js";
 import {
   ConcatMergeOperator,
+  TEST_DB_PATH,
   bytes,
   createCleanup,
   drainIterator,
@@ -362,4 +366,47 @@ test("db writer fencing reports closed reason", async (t) => {
     { reason: CloseReason.Fenced },
   );
   assert.match(error.message, /detected newer DB client/);
+});
+
+test("db warm_sst and evict_cached_sst", async (t) => {
+  const cleanup = createCleanup(t);
+  const store = cleanup.track(newMemoryStore());
+  const db = await openDb(store, { cleanup });
+  const admin = cleanup.track(new AdminBuilder(TEST_DB_PATH, store).build(), {
+    shutdown: false,
+  });
+
+  await db.put_with_options(
+    bytes("alpha"),
+    bytes("one"),
+    putOptions(),
+    writeOptions(false),
+  );
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const manifest = await admin.read_manifest(undefined);
+  assert.ok(manifest.l0.length > 0);
+  const sstId = manifest.l0[0].sst.id;
+
+  await db.warm_sst(sstId, [
+    CacheTarget.Filters(),
+    CacheTarget.Index(),
+    CacheTarget.Stats(),
+    CacheTarget.Data(fullRange()),
+  ]);
+
+  // Empty-range Data target is a no-op (not an invalid-range error).
+  await db.warm_sst(sstId, [
+    CacheTarget.Data({
+      start: bytes("z"),
+      start_inclusive: true,
+      end: bytes("a"),
+      end_inclusive: true,
+    }),
+  ]);
+
+  // Unknown SST is a no-op, not an error.
+  await db.warm_sst(SsTableId.Wal(999_999n), [CacheTarget.Index()]);
+
+  await db.evict_cached_sst(sstId);
 });

--- a/bindings/node/tests/reader.test.mjs
+++ b/bindings/node/tests/reader.test.mjs
@@ -2,10 +2,13 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  AdminBuilder,
+  CacheTarget,
   CloseReason,
   DbReaderBuilder,
   ErrorData,
   FlushType,
+  SsTableId,
   WriteBatch,
 } from "../index.js";
 import {
@@ -371,4 +374,49 @@ test("reader rejects invalid key ranges", async (t) => {
     end_inclusive: false,
   }));
   requireRows(await drainIterator(emptyStartScan), ["seed"], ["value"]);
+});
+
+test("reader warm_sst and evict_cached_sst", async (t) => {
+  const cleanup = createCleanup(t);
+  const store = cleanup.track(newMemoryStore());
+  const db = await openDb(store, { cleanup });
+
+  await db.put_with_options(
+    bytes("alpha"),
+    bytes("one"),
+    putOptions(),
+    writeOptions(false),
+  );
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const reader = await openReader(store, { cleanup });
+  const admin = cleanup.track(new AdminBuilder(TEST_DB_PATH, store).build(), {
+    shutdown: false,
+  });
+
+  const manifest = await admin.read_manifest(undefined);
+  assert.ok(manifest.l0.length > 0);
+  const sstId = manifest.l0[0].sst.id;
+
+  await reader.warm_sst(sstId, [
+    CacheTarget.Filters(),
+    CacheTarget.Index(),
+    CacheTarget.Stats(),
+    CacheTarget.Data(fullRange()),
+  ]);
+
+  // Empty-range Data target is a no-op (not an invalid-range error).
+  await reader.warm_sst(sstId, [
+    CacheTarget.Data({
+      start: bytes("z"),
+      start_inclusive: true,
+      end: bytes("a"),
+      end_inclusive: true,
+    }),
+  ]);
+
+  // Unknown SST is a no-op, not an error.
+  await reader.warm_sst(SsTableId.Wal(999_999n), [CacheTarget.Index()]);
+
+  await reader.evict_cached_sst(sstId);
 });

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -7,9 +7,10 @@ use crate::db_snapshot::DbSnapshot;
 use crate::db_transaction::DbTransaction;
 use crate::error::Error;
 use crate::iterator::DbIterator;
-use crate::types::{DbStatus, KeyRange, KeyValue, WriteHandle};
+use crate::types::{CacheTarget, DbStatus, KeyRange, KeyValue, SsTableId, WriteHandle};
 use crate::validation::{validate_key, validate_key_value};
 use crate::write_batch::WriteBatch;
+use slatedb::DbCacheManagerOps;
 
 /// A writable SlateDB handle.
 #[derive(uniffi::Object)]
@@ -238,5 +239,30 @@ impl Db {
     ) -> Result<Arc<DbTransaction>, Error> {
         let tx = self.inner.begin(isolation_level.into()).await?;
         Ok(Arc::new(DbTransaction::new(tx)))
+    }
+
+    /// Warms selected cache content for one SST.
+    ///
+    /// Returns `Err` on the first failing target. If no block cache is
+    /// configured, or if the SST is not reachable from the current manifest,
+    /// the call is a no-op that returns `Ok(())`.
+    pub async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: Vec<CacheTarget>,
+    ) -> Result<(), Error> {
+        let sst_id = sst_id.into_core()?;
+        let targets: Vec<_> = targets.into_iter().map(CacheTarget::into_core).collect();
+        self.inner.warm_sst(sst_id, &targets).await?;
+        Ok(())
+    }
+
+    /// Best-effort eviction of block-cache entries for one SST.
+    ///
+    /// If no block cache is configured, returns `Ok(())`.
+    pub async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), Error> {
+        let sst_id = sst_id.into_core()?;
+        self.inner.evict_cached_sst(sst_id).await?;
+        Ok(())
     }
 }

--- a/bindings/uniffi/src/db_reader.rs
+++ b/bindings/uniffi/src/db_reader.rs
@@ -3,9 +3,10 @@ use std::sync::Arc;
 use crate::config::{ReadOptions, ScanOptions};
 use crate::error::Error;
 use crate::iterator::DbIterator;
-use crate::types::{DbStatus, KeyRange};
+use crate::types::{CacheTarget, DbStatus, KeyRange, SsTableId};
 use crate::validation::validate_key;
 use crate::KeyValue;
+use slatedb::DbCacheManagerOps;
 
 /// Read-only database handle opened by [`crate::DbReaderBuilder`].
 #[derive(uniffi::Object)]
@@ -118,5 +119,30 @@ impl DbReader {
     #[uniffi::method(name = "shutdown")]
     pub async fn close(&self) -> Result<(), Error> {
         self.inner.close().await.map_err(Into::into)
+    }
+
+    /// Warms selected cache content for one SST.
+    ///
+    /// Returns `Err` on the first failing target. If no block cache is
+    /// configured, or if the SST is not reachable from the current manifest,
+    /// the call is a no-op that returns `Ok(())`.
+    pub async fn warm_sst(
+        &self,
+        sst_id: SsTableId,
+        targets: Vec<CacheTarget>,
+    ) -> Result<(), Error> {
+        let sst_id = sst_id.into_core()?;
+        let targets: Vec<_> = targets.into_iter().map(CacheTarget::into_core).collect();
+        self.inner.warm_sst(sst_id, &targets).await?;
+        Ok(())
+    }
+
+    /// Best-effort eviction of block-cache entries for one SST.
+    ///
+    /// If no block cache is configured, returns `Ok(())`.
+    pub async fn evict_cached_sst(&self, sst_id: SsTableId) -> Result<(), Error> {
+        let sst_id = sst_id.into_core()?;
+        self.inner.evict_cached_sst(sst_id).await?;
+        Ok(())
     }
 }

--- a/bindings/uniffi/src/error.rs
+++ b/bindings/uniffi/src/error.rs
@@ -29,6 +29,9 @@ pub(crate) enum SlateDbError {
     #[error("invalid compaction_id ULID: {source}")]
     InvalidCompactionId { source: ulid::DecodeError },
 
+    #[error("invalid SST ULID: {source}")]
+    InvalidSsTableId { source: ulid::DecodeError },
+
     #[error("invalid timestamp seconds: {timestamp_secs}")]
     InvalidTimestampSeconds { timestamp_secs: i64 },
 

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -39,10 +39,10 @@ pub use metrics::{
 pub use object_store::ObjectStore;
 pub use settings::Settings;
 pub use types::{
-    Checkpoint, Compaction, CompactionSpec, CompactionStatus, CompactorStateView, CompressionCodec,
-    DbStatus, ExternalDb, FilterFormat, KeyRange, KeyValue, RowEntry, RowEntryKind, SortedRun,
-    SourceId, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType, VersionedCompactions,
-    VersionedManifest, WriteHandle,
+    CacheTarget, Checkpoint, Compaction, CompactionSpec, CompactionStatus, CompactorStateView,
+    CompressionCodec, DbStatus, ExternalDb, FilterFormat, KeyRange, KeyValue, RowEntry,
+    RowEntryKind, SortedRun, SourceId, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType,
+    VersionedCompactions, VersionedManifest, WriteHandle,
 };
 pub use wal_reader::{WalFile, WalFileIterator, WalFileMetadata, WalReader};
 pub use write_batch::WriteBatch;

--- a/bindings/uniffi/src/types.rs
+++ b/bindings/uniffi/src/types.rs
@@ -12,8 +12,10 @@ use slatedb::manifest::{
     SsTableId as CoreSsTableId, SsTableInfo as CoreSsTableInfo, SsTableView as CoreSsTableView,
     VersionedManifest as CoreVersionedManifest,
 };
+use slatedb::CacheTarget as CoreCacheTarget;
 use slatedb::ValueDeletable;
 use slatedb::{Checkpoint as CoreCheckpoint, VersionedCompactions as CoreVersionedCompactions};
+use ulid::Ulid;
 
 use crate::error::{CloseReason, SlateDbError};
 
@@ -69,7 +71,14 @@ impl KeyRange {
             }
         }
 
-        Ok((
+        Ok(self.into_bounds_unchecked())
+    }
+
+    /// Converts to bounds without scan-style non-empty validation. Intended for
+    /// cache-warming paths where the core layer treats empty or reversed ranges
+    /// as a no-op.
+    pub(crate) fn into_bounds_unchecked(self) -> KeyBounds {
+        (
             match self.start {
                 Some(start) if self.start_inclusive => Bound::Included(start),
                 Some(start) => Bound::Excluded(start),
@@ -80,7 +89,7 @@ impl KeyRange {
                 Some(end) => Bound::Excluded(end),
                 None => Bound::Unbounded,
             },
-        ))
+        )
     }
 }
 
@@ -456,6 +465,57 @@ impl From<&CoreSsTableId> for SsTableId {
         match value {
             CoreSsTableId::Wal(id) => Self::Wal(*id),
             CoreSsTableId::Compacted(id) => Self::Compacted(id.to_string()),
+        }
+    }
+}
+
+impl SsTableId {
+    pub(crate) fn into_core(self) -> Result<CoreSsTableId, SlateDbError> {
+        Ok(match self {
+            SsTableId::Wal(id) => CoreSsTableId::Wal(id),
+            SsTableId::Compacted(id) => {
+                let ulid = Ulid::from_string(&id)
+                    .map_err(|source| SlateDbError::InvalidSsTableId { source })?;
+                CoreSsTableId::Compacted(ulid)
+            }
+        })
+    }
+}
+
+/// Cache content that [`crate::Db::warm_sst`] should populate.
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum CacheTarget {
+    /// Warm all filters on the SST, if any exist.
+    Filters,
+    /// Warm the SST index.
+    Index,
+    /// Warm the SST stats block, if one exists.
+    Stats,
+    /// Warm the SST data blocks that overlap `range`. Also warms the index,
+    /// since block planning depends on it.
+    Data { range: KeyRange },
+}
+
+impl CacheTarget {
+    pub(crate) fn into_core(self) -> CoreCacheTarget {
+        match self {
+            CacheTarget::Filters => CoreCacheTarget::Filters,
+            CacheTarget::Index => CoreCacheTarget::Index,
+            CacheTarget::Stats => CoreCacheTarget::Stats,
+            CacheTarget::Data { range } => {
+                let (start, end) = range.into_bounds_unchecked();
+                let start = match start {
+                    Bound::Included(v) => Bound::Included(Bytes::from(v)),
+                    Bound::Excluded(v) => Bound::Excluded(Bytes::from(v)),
+                    Bound::Unbounded => Bound::Unbounded,
+                };
+                let end = match end {
+                    Bound::Included(v) => Bound::Included(Bytes::from(v)),
+                    Bound::Excluded(v) => Bound::Excluded(Bytes::from(v)),
+                    Bound::Unbounded => Bound::Unbounded,
+                };
+                CoreCacheTarget::Data((start, end))
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Wraps the DbCacheManagerOps API added in RFC-0023 (#1585) so that the uniffi-generated Go, Java, Python, and Node bindings can drive targeted block-cache warming and eviction. Adds a CacheTarget uniffi enum and regenerates the checked-in Go bindings.

Generated with Claude Opus 4.7 xhigh

## Changes

- bindings for uniffi warm_sst and evict_cached_sst

## Notes for Reviewers

I only reviewed the rust part of the code, though it seems like some javascript tests were generated as well.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
