### PR TITLE
Bump flatc in PR workflow to 25.2.10

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -70,11 +70,11 @@ jobs:
           # Allow script to fetch base ref/commits if needed
           fetch-depth: 0
 
-      # Install specific version of flatc (24.3.25)
+      # Install specific version of flatc (25.2.10)
       # NOTE: when changing the flatc version adapt slatedb/src/generated/README.md
       - name: Install flatc
         run: |
-          wget https://github.com/google/flatbuffers/releases/download/v24.3.25/Linux.flatc.binary.g++-13.zip
+          wget https://github.com/google/flatbuffers/releases/download/v25.2.10/Linux.flatc.binary.g++-13.zip
           unzip Linux.flatc.binary.g++-13.zip
           sudo mv flatc /usr/local/bin/
 

--- a/slatedb/src/generated/README.md
+++ b/slatedb/src/generated/README.md
@@ -6,18 +6,18 @@ This folder contains the generated [flatbuffer](https://flatbuffers.dev/) code. 
 
 To generate `.rs` files from `.fbs` files:
 
-1. Install [flatc](https://github.com/google/flatbuffers) version 24.3.25.
+1. Install [flatc](https://github.com/google/flatbuffers) version 25.2.10.
 2. Run `flatc -o slatedb/src/generated --rust --gen-all schemas/root.fbs` from the project root.
     - `--gen-all` is required because including other schemas [does not work well](https://github.com/google/flatbuffers/issues/5275).
 
 **NOTE:**
 You can install it with `brew install flatbuffers` if you're using Homebrew.
-If the installed version is not 24.3.25, might need to do the following:
+If the installed version is not 25.2.10, might need to do the following:
 1. Create a local homebrew tap directory: `mkdir -p <tap dir>/Formula`
 2. Make the local homebrew tap directory a git repo:
    3. `cd <tap dir>`
    3. `git init`
-2. Copy the formula for the 24.3.25 version from https://github.com/Homebrew/homebrew-core/blob/4089fb01c8b18caa34d29bbeafe561af5fe36aa5/Formula/f/flatbuffers.rb to `<tap-dir>/Formula/flatbuffers.rb`
+2. Copy the formula for the 25.2.10 version from https://github.com/Homebrew/homebrew-core/blob/55adf8627f4d7e96996d6d6433f25a8161636661/Formula/f/flatbuffers.rb to `<tap-dir>/Formula/flatbuffers.rb`
 3. Add the file to the git repo:
    1. `git add .`
    2. `git commit -m "Initial commit"`


### PR DESCRIPTION
Cargo.toml uses flatbuffers 25.2.10. This just updates the PR workflow to use the same version.