### PR TITLE
write_options: support user supplied seqno

### DIFF
--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -277,6 +277,7 @@ impl From<WriteOptions> for slatedb::config::WriteOptions {
     fn from(value: WriteOptions) -> Self {
         slatedb::config::WriteOptions {
             await_durable: value.await_durable,
+            ..Default::default()
         }
     }
 }

--- a/examples/src/azure_blob_storage.rs
+++ b/examples/src/azure_blob_storage.rs
@@ -26,6 +26,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Writing 1000 keys without waiting for flush");
     let write_options = slatedb::config::WriteOptions {
         await_durable: false,
+        ..Default::default()
     };
     for i in 0..1000 {
         db.put_with_options(

--- a/examples/src/google_cloud_storage.rs
+++ b/examples/src/google_cloud_storage.rs
@@ -25,6 +25,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Writing 1000 keys without waiting for flush");
     let write_options = slatedb::config::WriteOptions {
         await_durable: false,
+        ..Default::default()
     };
     for i in 0..1000 {
         db.put_with_options(

--- a/slatedb-bencher/src/main.rs
+++ b/slatedb-bencher/src/main.rs
@@ -81,6 +81,7 @@ async fn exec_benchmark_db(path: Path, object_store: Arc<dyn ObjectStore>, args:
     let (config, memory_cache) = args.db_args.config().unwrap();
     let write_options = WriteOptions {
         await_durable: args.await_durable,
+        ..Default::default()
     };
 
     let mut builder = Db::builder(path.clone(), object_store.clone()).with_settings(config);
@@ -153,6 +154,7 @@ async fn exec_benchmark_transaction(
     let (config, memory_cache) = args.db_args.config().unwrap();
     let write_options = WriteOptions {
         await_durable: args.await_durable,
+        ..Default::default()
     };
 
     let mut builder = Db::builder(path.clone(), object_store.clone()).with_settings(config);

--- a/slatedb/benches/db_operations.rs
+++ b/slatedb/benches/db_operations.rs
@@ -26,6 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1290,6 +1290,7 @@ mod tests {
         };
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         // Two grandparents, each with a single-key SST. Disjoint ranges are required

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -129,7 +129,22 @@ impl DbInner {
         #[cfg(dst)]
         // Force the current timestamp for DST operations. See #719 for details.
         let now = options.now;
-        let commit_seq = self.oracle.next_seq();
+        // If the user supplied a sequence number, validate that it's strictly greater
+        // than the current max and advance the oracle. No CAS loop is needed here because
+        // write_batch is always called from a single-writer event loop.
+        let commit_seq = if options.seqnum > 0 {
+            let current = self.oracle.last_seq();
+            if options.seqnum <= current {
+                return Err(SlateDBError::InvalidSequenceNumber {
+                    provided: options.seqnum,
+                    current,
+                });
+            }
+            self.oracle.advance_last_seq(options.seqnum);
+            options.seqnum
+        } else {
+            self.oracle.next_seq()
+        };
 
         // Check for transaction conflicts before proceeding with the write batch
         // if this batch is part of a transaction.
@@ -278,5 +293,100 @@ mod tests {
         let result = done_rx.await.unwrap();
         assert!(result.is_ok());
         assert!(!handler.is_first_write);
+    }
+
+    #[tokio::test]
+    async fn test_user_defined_seqnum() {
+        let object_store = Arc::new(InMemory::new());
+        let db = Db::open("/tmp/test_user_defined_seqnum", object_store)
+            .await
+            .unwrap();
+
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone());
+
+        // Write with a user-defined seqnum
+        let mut batch = WriteBatch::new();
+        batch.put(b"key1", b"value1");
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        handler
+            .handle(WriteBatchMessage {
+                batch,
+                options: WriteOptions {
+                    seqnum: 42,
+                    ..Default::default()
+                },
+                done: done_tx,
+            })
+            .await
+            .unwrap();
+        let (write_handle, _) = done_rx.await.unwrap().unwrap();
+        assert_eq!(write_handle.seqnum(), 42);
+
+        // Write without a seqnum and verify auto-assigned is > 42
+        let mut batch = WriteBatch::new();
+        batch.put(b"key2", b"value2");
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        handler
+            .handle(WriteBatchMessage {
+                batch,
+                options: WriteOptions::default(),
+                done: done_tx,
+            })
+            .await
+            .unwrap();
+        let (write_handle, _) = done_rx.await.unwrap().unwrap();
+        assert!(write_handle.seqnum() > 42);
+    }
+
+    #[tokio::test]
+    async fn test_user_defined_seqnum_rejects_lower_value() {
+        let object_store = Arc::new(InMemory::new());
+        let db = Db::open(
+            "/tmp/test_user_defined_seqnum_rejects_lower_value",
+            object_store,
+        )
+        .await
+        .unwrap();
+
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone());
+
+        // First, do a normal write to advance the oracle
+        let mut batch = WriteBatch::new();
+        batch.put(b"key1", b"value1");
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        handler
+            .handle(WriteBatchMessage {
+                batch,
+                options: WriteOptions::default(),
+                done: done_tx,
+            })
+            .await
+            .unwrap();
+        let (write_handle, _) = done_rx.await.unwrap().unwrap();
+        let first_seq = write_handle.seqnum();
+
+        // Try to write with a seqnum <= the current max
+        let mut batch = WriteBatch::new();
+        batch.put(b"key2", b"value2");
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        handler
+            .handle(WriteBatchMessage {
+                batch,
+                options: WriteOptions {
+                    seqnum: 1,
+                    ..Default::default()
+                },
+                done: done_tx,
+            })
+            .await
+            .unwrap();
+        let result = done_rx.await.unwrap();
+        assert!(matches!(
+            result,
+            Err(SlateDBError::InvalidSequenceNumber {
+                provided: 1,
+                current,
+            }) if current == first_seq
+        ));
     }
 }

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -970,6 +970,7 @@ mod tests {
             .unwrap();
         let write_options = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
         let put_options = PutOptions::default();
         let l0_and_wal_data = [
@@ -1060,6 +1061,7 @@ mod tests {
             .unwrap();
         let write_options = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
         let put_options = PutOptions::default();
         let l0_and_wal_data = [

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1154,6 +1154,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -1166,6 +1167,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -1262,6 +1264,7 @@ mod tests {
             &[b'a'; 16],
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1375,6 +1378,7 @@ mod tests {
             &[b'a'; 16],
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1467,6 +1471,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1477,6 +1482,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1487,6 +1493,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1499,6 +1506,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1509,6 +1517,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1519,6 +1528,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1603,6 +1613,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1619,6 +1630,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1673,6 +1685,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1683,6 +1696,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1693,6 +1707,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1713,6 +1728,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1723,6 +1739,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1733,6 +1750,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1808,6 +1826,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1818,6 +1837,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1830,6 +1850,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1840,6 +1861,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1850,6 +1872,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1925,6 +1948,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1935,6 +1959,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1947,6 +1972,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1957,6 +1983,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1969,6 +1996,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -1979,6 +2007,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2064,6 +2093,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: true,
+                ..Default::default()
             },
         )
         .await
@@ -2077,6 +2107,7 @@ mod tests {
             &crate::config::MergeOptions { ttl: Ttl::NoExpiry },
             &WriteOptions {
                 await_durable: true,
+                ..Default::default()
             },
         )
         .await
@@ -2145,6 +2176,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2155,6 +2187,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2165,6 +2198,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2178,6 +2212,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2188,6 +2223,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2249,6 +2285,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2259,6 +2296,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2273,6 +2311,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2283,6 +2322,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2386,6 +2426,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2401,6 +2442,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2501,6 +2543,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2516,6 +2559,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2531,6 +2575,7 @@ mod tests {
             &PutOptions { ttl: Ttl::NoExpiry },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2612,6 +2657,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2625,6 +2671,7 @@ mod tests {
             &PutOptions { ttl: Ttl::Default },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2640,6 +2687,7 @@ mod tests {
             &PutOptions { ttl: Ttl::NoExpiry },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2656,6 +2704,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -449,6 +449,11 @@ pub struct WriteOptions {
     #[cfg(dst)]
     /// Force the current timestamp for DST operations. See #719 for details.
     pub now: i64,
+    /// An optional user-defined sequence number for this write. When non-zero, the
+    /// provided value is used instead of the internally generated sequence number.
+    /// The value must be strictly greater than the current maximum sequence number
+    /// or the write will fail with an `InvalidSequenceNumber` error.
+    pub seqnum: u64,
 }
 
 impl Default for WriteOptions {
@@ -458,6 +463,7 @@ impl Default for WriteOptions {
             await_durable: true,
             #[cfg(dst)]
             now: 0,
+            seqnum: 0,
         }
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2327,6 +2327,7 @@ mod tests {
                                 &PutOptions::default(),
                                 &WriteOptions {
                                     await_durable: false,
+                                    ..Default::default()
                                 },
                             )
                             .await
@@ -2376,6 +2377,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -2412,6 +2414,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -2470,6 +2473,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2521,6 +2525,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2565,6 +2570,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2599,6 +2605,7 @@ mod tests {
         let put_options = PutOptions::default();
         let write_options = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
         let get_memory_options = ReadOptions::new().with_durability_filter(Memory);
         let get_remote_options = ReadOptions::new().with_durability_filter(Remote);
@@ -2658,6 +2665,7 @@ mod tests {
                 },
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -3405,6 +3413,7 @@ mod tests {
             &[b'b'; 4],
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -3454,6 +3463,7 @@ mod tests {
                 .unwrap();
         let write_options = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         db.put_with_options(
@@ -3473,6 +3483,7 @@ mod tests {
         // at this put_with_options call.
         let write_options = WriteOptions {
             await_durable: true,
+            ..Default::default()
         };
         clock.set(10);
         db.put_with_options(
@@ -3611,6 +3622,7 @@ mod tests {
 
         let write_options: WriteOptions = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
         let put_options = PutOptions::default();
 
@@ -3732,6 +3744,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -3746,6 +3759,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -3842,6 +3856,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -3910,6 +3925,7 @@ mod tests {
                 .unwrap();
         let write_options = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
         let put_options = PutOptions::default();
 
@@ -4022,6 +4038,7 @@ mod tests {
 
         let write_options = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         async fn put_with_timestamp(
@@ -4155,6 +4172,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4169,6 +4187,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4232,6 +4251,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4293,6 +4313,7 @@ mod tests {
         let metrics_recorder_clone = metrics_recorder.clone();
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         fail_parallel::cfg(fp_registry.clone(), "write-wal-sst-io-error", "pause").unwrap();
@@ -4376,6 +4397,7 @@ mod tests {
         .unwrap();
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         // Write enough data to leave bytes buffered in the WAL while avoiding
@@ -4527,6 +4549,7 @@ mod tests {
         // do all flushes manually
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         // do a few writes that will result in l0 flushes
@@ -4634,6 +4657,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -4644,6 +4668,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -4654,6 +4679,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -4786,6 +4812,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4839,6 +4866,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4887,6 +4915,7 @@ mod tests {
                 "foo".as_bytes(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4950,6 +4979,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -4961,6 +4991,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -5276,6 +5307,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -5458,6 +5490,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: true,
+                    ..Default::default()
                 },
             )
             .await
@@ -5509,6 +5542,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -5523,7 +5557,7 @@ mod tests {
                 b"1",
                 &PutOptions::default(),
                 &WriteOptions {
-                    await_durable: false,
+                    await_durable: false, ..Default::default()
                 },
             )
             .await
@@ -5556,6 +5590,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -5575,7 +5610,7 @@ mod tests {
                 b"1",
                 &PutOptions::default(),
                 &WriteOptions {
-                    await_durable: false,
+                    await_durable: false, ..Default::default()
                 },
             )
             .await
@@ -5657,6 +5692,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -5668,6 +5704,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -5928,6 +5965,7 @@ mod tests {
             let put_option = PutOptions::default();
             let write_option = WriteOptions {
                 await_durable: false,
+                ..Default::default()
             };
             db.put_with_options(key.as_bytes(), value.clone(), &put_option, &write_option)
                 .await
@@ -6334,6 +6372,7 @@ mod tests {
         // do a write and flush memtable only (not wal)
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
         db.put_with_options(&b"foo", &b"bar", &PutOptions::default(), &write_opts)
             .await
@@ -6564,6 +6603,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -6723,6 +6763,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6742,6 +6783,7 @@ mod tests {
                 &put_opts,
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6756,6 +6798,7 @@ mod tests {
                 b"key1",
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6773,6 +6816,7 @@ mod tests {
                 batch,
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6803,6 +6847,7 @@ mod tests {
                 batch,
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6820,6 +6865,7 @@ mod tests {
                 batch,
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6836,6 +6882,7 @@ mod tests {
                 batch,
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6859,6 +6906,7 @@ mod tests {
                 WriteBatch::new(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -6989,6 +7037,7 @@ mod tests {
         .unwrap();
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         // Establish and flush seq=1 so the L0 manifest writer has a known
@@ -7390,6 +7439,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7400,6 +7450,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7486,6 +7537,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7501,6 +7553,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -7637,6 +7690,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7654,6 +7708,7 @@ mod tests {
                 &MergeOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await
@@ -7753,6 +7808,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7785,6 +7841,7 @@ mod tests {
         };
         let write_opts = WriteOptions {
             await_durable: false,
+            ..Default::default()
         };
 
         clock.set(100);
@@ -7860,6 +7917,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7874,6 +7932,7 @@ mod tests {
             },
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -7998,6 +8057,7 @@ mod tests {
             batch,
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -8041,6 +8101,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -8052,6 +8113,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -8091,6 +8153,7 @@ mod tests {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -304,6 +304,7 @@ mod tests {
                 &PutOptions::default(),
                 &WriteOptions {
                     await_durable: false,
+                    ..Default::default()
                 },
             )
             .await

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -2497,6 +2497,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2507,6 +2508,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2549,6 +2551,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -2559,6 +2562,7 @@ mod tests {
             &MergeOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -760,6 +760,7 @@ mod tests {
                     &PutOptions::default(),
                     &WriteOptions {
                         await_durable: false,
+                        ..Default::default()
                     },
                 )
                 .await

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -970,6 +970,7 @@ mod tests {
         // Commit without waiting for durability
         txn.commit_with_options(&WriteOptions {
             await_durable: false,
+            ..Default::default()
         })
         .await
         .unwrap();
@@ -1851,6 +1852,7 @@ mod tests {
         let handle = txn
             .commit_with_options(&WriteOptions {
                 await_durable: false,
+                ..Default::default()
             })
             .await
             .unwrap()
@@ -1868,6 +1870,7 @@ mod tests {
         let handle = txn
             .commit_with_options(&WriteOptions {
                 await_durable: false,
+                ..Default::default()
             })
             .await
             .unwrap()
@@ -1882,6 +1885,7 @@ mod tests {
         let handle = txn
             .commit_with_options(&WriteOptions {
                 await_durable: false,
+                ..Default::default()
             })
             .await
             .unwrap()
@@ -1901,6 +1905,7 @@ mod tests {
         let result = txn
             .commit_with_options(&WriteOptions {
                 await_durable: false,
+                ..Default::default()
             })
             .await
             .unwrap();

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -245,6 +245,11 @@ pub(crate) enum SlateDBError {
 
     #[error("unexpected tombstone encountered where a value was expected")]
     UnexpectedTombstone,
+
+    #[error(
+        "invalid sequence number, must be greater than the current max. provided=`{provided}`, current=`{current}`"
+    )]
+    InvalidSequenceNumber { provided: u64, current: u64 },
 }
 
 impl From<TransactionalObjectError> for SlateDBError {
@@ -532,6 +537,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::IteratorNotInitialized => Error::invalid(msg),
             SlateDBError::InvalidSequenceOrder { .. } => Error::data(msg),
             SlateDBError::InvalidEnvironmentVariable { .. } => Error::invalid(msg),
+            SlateDBError::InvalidSequenceNumber { .. } => Error::invalid(msg),
             SlateDBError::EmptyBatch => Error::invalid(msg),
 
             // Data errors

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -253,7 +253,10 @@ pub(crate) async fn seed_database(
     await_durable: bool,
 ) -> Result<(), crate::Error> {
     let put_options = PutOptions::default();
-    let write_options = WriteOptions { await_durable };
+    let write_options = WriteOptions {
+        await_durable,
+        ..Default::default()
+    };
 
     for (key, value) in table.iter() {
         db.put_with_options(key, value, &put_options, &write_options)

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -58,6 +58,7 @@ async fn test_replay_wal_then_write() {
             &PutOptions::default(),
             &WriteOptions {
                 await_durable: false,
+                ..Default::default()
             },
         )
         .await
@@ -90,6 +91,7 @@ async fn test_replay_wal_then_write() {
         &PutOptions::default(),
         &WriteOptions {
             await_durable: false,
+            ..Default::default()
         },
     )
     .await
@@ -243,6 +245,7 @@ async fn test_concurrent_writers_and_readers() {
                         &PutOptions::default(),
                         &WriteOptions {
                             await_durable: false,
+                            ..Default::default()
                         },
                     )
                     .await

--- a/website/src/content/docs/docs/design/writes.mdx
+++ b/website/src/content/docs/docs/design/writes.mdx
@@ -32,3 +32,44 @@ flowchart TD
     J & L --> M[Write SSTable to Object Storage]
     M --> N[Send Durability Notification]
 ```
+
+## User-supplied sequence numbers
+
+Every committed write batch is stamped with a `u64` sequence number. By default SlateDB's internal *oracle* — a monotonic counter shared by all writers — assigns one as the batch is dequeued from the write channel. [`WriteOptions::seqnum`](https://docs.rs/slatedb/latest/slatedb/config/struct.WriteOptions.html#structfield.seqnum) lets the caller override that counter and stamp the batch with a specific value instead.
+
+### Semantics
+
+The default value is `0`, which means *"let the oracle assign the seqnum"*. Sequence numbers issued by the oracle start at `1`, so `0` is unambiguously a sentinel. Any non-zero value is treated as a request to commit at that exact sequence number, subject to one rule:
+
+- The supplied seqnum must be **strictly greater** than the current max sequence number known to the database. Otherwise the write fails with a [`slatedb::Error`](https://docs.rs/slatedb/latest/slatedb/enum.Error.html) of kind `Invalid`, with the message `invalid sequence number, must be greater than the current max. provided=..., current=...`.
+
+When the check passes, the oracle is advanced to the supplied value, so subsequent auto-assigned writes resume above it. User-supplied and oracle-assigned writes can be mixed freely as long as the seqnums monotonically increase across the write stream.
+
+```rust
+use slatedb::config::{PutOptions, WriteOptions};
+
+// Stamp this write with seqnum = 42 (e.g., the offset returned by your
+// external WAL after appending the record).
+let opts = WriteOptions { seqnum: 42, ..Default::default() };
+db.put_with_options(b"key", b"value", &PutOptions::default(), &opts).await?;
+```
+
+### Ordering responsibility
+
+Sequence numbers are assigned on the single-writer event loop that drains the write channel — but the *caller* picks the value before the batch is enqueued. That means concurrent writers on your side can race:
+
+```text
+thread A: pick seqnum 1, send batch to channel
+thread B: pick seqnum 2, send batch to channel
+```
+
+If the OS schedules thread B's send before thread A's, the seqnum `2` batch arrives first, advances the oracle, and the seqnum `1` batch is rejected as no-longer-greater-than-current.
+
+To avoid this, funnel all writes that use `seqnum` through a single ordering agent on your side — typically the same component that assigned the seqnums (e.g., the producer that appends to your external log). One writer, one channel, no races. If you genuinely need multiple writer threads, serialize them behind a mutex or a single-producer queue before calling `put`/`write`.
+
+### Caveats
+
+- **Non-contiguous seqnums.** Auto-assigned seqnums are not guaranteed to be strictly contiguous either (the memtable flusher tolerates gaps), so user-supplied jumps are consistent with existing behavior. Anything that relies on dense seqnums — don't.
+- **Recovery.** On restart, SlateDB recovers the max seqnum from the manifest and any unflushed WAL. If you continue assigning seqnums from your external log, make sure the next value is above whatever SlateDB recovered, or your first post-restart write will be rejected.
+- **Transactions.** Conflict detection still works on user-supplied seqnums — the read/write set is tracked against the snapshot's seqnum and the commit seqnum, regardless of who picked them. Just keep the monotonic-increase invariant.
+- **`await_durable`.** `seqnum` is independent of the `await_durable` flag; both can be set on the same `WriteOptions`. The oracle is advanced as soon as the batch is processed by the write loop, before durability is confirmed. The seqno the oracle tracks is still bumped, so if the write fails the seqno is still consumed.


### PR DESCRIPTION
## Summary

In cases when using an external WAL, it's really nice to be able to
allow specifying custom seqno. The alternative is the user of slatedb
needs to store the mapping of seqnos and that becomes cumbersome and
has implications on memory usage and write performance of storing the
mapping.

Fixes https://github.com/slatedb/slatedb/issues/1335 (just the seqno I think other things mentioned in this issue are related to other things that have seperate issues).

## Changes

- Adds a `seqno` field to the `WriteOptions` struct. To preserve existing behavior use `WriteOptions::default()`.

## Notes for Reviewers

There are a few choices for WriteOptions.seqno use `u64`, use `Option<u64>` or use `Option<NonZero<u64>>`. `Some(0)` for option 2 is not valid ever (seqnos start at 1). The `NonZero` type is a bit clunky IMO so I decided to use a bare `u64`. Happy to make changes here depending on what is most "inline" with the project style.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
