### PR TITLE
Wake backpressure waiters when DB is fenced or closed

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -4387,8 +4387,8 @@ mod tests {
             .unwrap();
         assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
 
-        // Start backpressure on a cloned inner handle. With the current bug, this
-        // task waits only on WAL/memtable progress and ignores later fencing.
+        // Start backpressure on a cloned inner handle. This parks the task on
+        // the same wait path used by writers before they enqueue a batch.
         let inner = db.inner.clone();
         let mut backpressure_task =
             tokio::spawn(async move { inner.maybe_apply_backpressure().await });
@@ -4414,8 +4414,8 @@ mod tests {
             .status_manager
             .write_result(Err(SlateDBError::Fenced));
 
-        // A fixed implementation should wake promptly on the fence signal. The
-        // current implementation times out here because no WAL flush will notify it.
+        // The lifecycle signal should wake the waiter promptly even though no
+        // WAL flush or memtable upload will notify it.
         let result = tokio::time::timeout(Duration::from_secs(5), &mut backpressure_task).await;
         if result.is_err() {
             backpressure_task.abort();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -4345,6 +4345,87 @@ mod tests {
         let _ = join_handle.await;
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_backpressure_waiter_exits_when_db_is_fenced() {
+        // Build a DB whose WAL will not flush on a timer and whose backpressure
+        // threshold is low enough for one write to exceed it.
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut options = test_db_options(0, 1024 * 1024, None);
+        options.flush_interval = None;
+        options.max_unflushed_bytes = 1;
+
+        // Use a metrics recorder so the test can observe when the spawned task
+        // has actually entered maybe_apply_backpressure().
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let db = Db::builder(
+            "/tmp/test_backpressure_waiter_exits_when_db_is_fenced",
+            object_store,
+        )
+        .with_settings(options)
+        .with_metrics_recorder(metrics_recorder.clone())
+        .build()
+        .await
+        .unwrap();
+        let write_opts = WriteOptions {
+            await_durable: false,
+        };
+
+        // Write enough data to leave bytes buffered in the WAL while avoiding
+        // any automatic WAL or memtable flush.
+        let large_value = vec![b'x'; 8 * 1024];
+        db.put_with_options(b"key1", &large_value, &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
+
+        // Start backpressure on a cloned inner handle. With the current bug, this
+        // task waits only on WAL/memtable progress and ignores later fencing.
+        let inner = db.inner.clone();
+        let mut backpressure_task =
+            tokio::spawn(async move { inner.maybe_apply_backpressure().await });
+
+        // Wait until the task has observed the buffered WAL bytes and incremented
+        // the backpressure counter, proving it is inside the wait path.
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if lookup_metric(&metrics_recorder, crate::db_stats::BACKPRESSURE_COUNT)
+                    .is_some_and(|v| v > 0)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for backpressure to be applied");
+
+        // Simulate the DB being fenced while the writer is already parked in
+        // backpressure.
+        db.inner
+            .status_manager
+            .write_result(Err(SlateDBError::Fenced));
+
+        // A fixed implementation should wake promptly on the fence signal. The
+        // current implementation times out here because no WAL flush will notify it.
+        let result = tokio::time::timeout(Duration::from_secs(5), &mut backpressure_task).await;
+        if result.is_err() {
+            backpressure_task.abort();
+            let _ = backpressure_task.await;
+        }
+        db.close().await.unwrap();
+
+        // Assert that the waiter exits with the terminal fenced error, not a
+        // successful write path or some unrelated task failure.
+        let backpressure_result = result
+            .expect("backpressure waiter did not exit after DB was fenced")
+            .expect("backpressure task panicked");
+        assert!(
+            matches!(backpressure_result, Err(SlateDBError::Fenced)),
+            "expected fenced error, got {:?}",
+            backpressure_result
+        );
+    }
+
     #[tokio::test]
     async fn test_apply_backpressure_to_memtable_flush() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -360,6 +360,7 @@ impl DbInner {
     #[inline]
     pub(crate) async fn maybe_apply_backpressure(&self) -> Result<(), SlateDBError> {
         loop {
+            self.check_closed()?;
             let (wal_size_bytes, imm_memtable_size_bytes) = {
                 let wal_size_bytes = self.wal_buffer.estimated_bytes()?;
                 let imm_memtable_size_bytes = {
@@ -438,10 +439,18 @@ impl DbInner {
                 };
 
                 let timeout_fut = self.system_clock.sleep(Duration::from_secs(30));
+                let await_closed = async {
+                    let mut watcher = self.status_manager.result_reader();
+                    match watcher.await_value().await {
+                        Ok(()) => Err(SlateDBError::Closed),
+                        Err(e) => Err(e),
+                    }
+                };
 
                 tokio::select! {
                     result = await_memtable_uploaded => result?,
                     result = await_flush_wal => result?,
+                    result = await_closed => result?,
                     _ = timeout_fut => {
                         warn!("backpressure timeout: waited 30s, no memtable/WAL flushed yet");
                     }


### PR DESCRIPTION
## Summary

I am experimenting with fencing the DB in our deterministic simulation tests. One of the runs was hanging. It appears to get stuck in maybe_apply_backpressure after the DB has been fenced. The backpressure loop waits for memtable upload, WAL flush, or a 30s timeout, but did not also wake on the DB lifecycle signal.

## Changes

- Check DB closed/fenced status on each backpressure loop iteration.
- Add the DB status watcher to the backpressure `select!` so parked writers return `Closed` or `Fenced` promptly.
- Add a regression test that parks a writer in WAL backpressure, fences the DB, and asserts the waiter exits with `SlateDBError::Fenced`.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
