### PR TITLE
Check `Db` fencing in DSTs

### DIFF
--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -222,6 +222,8 @@ Each registered actor instance receives its own `ActorCtx`.
 
 - `name()` for actor identity
 - `rand()` for actor-local deterministic randomness
+- `startup_ctx()` to reuse the startup path, object stores, clock, failpoint
+  registry, and startup RNG when reopening a database
 - `db()` to read the currently installed shared `Arc<Db>`
 - `swap_db(new_db)` to replace the shared DB handle for all actors
 - `swap_compactor(new_compactor)` to replace the shared standalone compactor handle

--- a/slatedb-dst/src/actors/fencer.rs
+++ b/slatedb-dst/src/actors/fencer.rs
@@ -80,7 +80,7 @@ impl Actor for DbFencerActor {
         let old_db = ctx.swap_db(next_db);
 
         // Verify the old DB is fenced.
-        match old_db.get(b"foo").await {
+        match old_db.put(b"foo", b"bar").await {
             Err(err) if matches!(err.kind(), ErrorKind::Closed(CloseReason::Fenced)) => {}
             result => panic!("old db was not fenced as expected [result={result:?}]"),
         }

--- a/slatedb-dst/src/actors/fencer.rs
+++ b/slatedb-dst/src/actors/fencer.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use log::info;
-use slatedb::config::{PutOptions, WriteOptions};
 use slatedb::{CloseReason, Db, Error, ErrorKind};
 use tracing::instrument;
 
@@ -74,16 +73,22 @@ impl DbFencerActor {
 impl Actor for DbFencerActor {
     #[instrument(level = "debug", skip_all, fields(name = %ctx.name()))]
     async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        // Make a new DB, fencing the old one.
         let Some(next_db) = self.open_replacement_db(ctx).await? else {
             return Ok(());
         };
         let old_db = ctx.swap_db(next_db);
 
-        self.assert_old_db_fenced(ctx, &old_db).await;
+        // Verify the old DB is fenced.
+        match old_db.get(b"foo").await {
+            Err(err) if matches!(err.kind(), ErrorKind::Closed(CloseReason::Fenced)) => {}
+            result => panic!("old db was not fenced as expected [result={result:?}]"),
+        }
         old_db.close().await?;
 
         info!("db fencing complete [name={}]", ctx.name());
 
+        // Wait for the restart interval before allowing the next generation to start.
         let shutdown_token = ctx.shutdown_token();
         let system_clock = ctx.system_clock();
         tokio::select! {
@@ -116,23 +121,6 @@ impl DbFencerActor {
                 }
                 result => return result.map(Some),
             }
-        }
-    }
-
-    async fn assert_old_db_fenced(&self, ctx: &ActorCtx, old_db: &Db) {
-        let probe_key = format!("__slatedb_dst/db_fencer/{}/probe", ctx.name());
-        let result = old_db
-            .put_with_options(
-                probe_key.as_bytes(),
-                b"fence-probe",
-                &PutOptions::default(),
-                &WriteOptions::default(),
-            )
-            .await;
-
-        match result {
-            Err(err) if matches!(err.kind(), ErrorKind::Closed(CloseReason::Fenced)) => {}
-            result => panic!("old db was not fenced as expected [result={result:?}]"),
         }
     }
 }

--- a/slatedb-dst/src/actors/fencer.rs
+++ b/slatedb-dst/src/actors/fencer.rs
@@ -1,0 +1,166 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use log::info;
+use slatedb::config::{PutOptions, WriteOptions};
+use slatedb::{CloseReason, Db, Error, ErrorKind};
+use tracing::instrument;
+
+use crate::{Actor, ActorCtx};
+
+type DbFactoryFuture = Pin<Box<dyn Future<Output = Result<Arc<Db>, Error>> + Send + 'static>>;
+type DbFactory = Box<dyn Fn(ActorCtx) -> DbFactoryFuture + Send + Sync + 'static>;
+
+/// Wraps actors that may race with a DB replacement and observe the old handle
+/// after it has been fenced.
+pub struct SuppressFenced<A> {
+    inner: A,
+}
+
+impl<A> SuppressFenced<A> {
+    pub fn new(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl<A> Actor for SuppressFenced<A>
+where
+    A: Actor,
+{
+    async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        match self.inner.run(ctx).await {
+            Err(error) if matches!(error.kind(), ErrorKind::Closed(CloseReason::Fenced)) => Ok(()),
+            result => result,
+        }
+    }
+
+    async fn finish(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        self.inner.finish(ctx).await
+    }
+}
+
+/// Configuration for the database fencing DST actor.
+#[derive(Clone, Debug)]
+pub struct DbFencerActorOptions {
+    /// How long the actor waits between DB replacement attempts.
+    pub restart_interval: Duration,
+    /// The minimum number of completed fencings required before shutdown.
+    pub min_fencings: u64,
+}
+
+/// Reopens the shared database in a loop and verifies each old handle is fenced.
+pub struct DbFencerActor {
+    actor_options: DbFencerActorOptions,
+    db_factory: DbFactory,
+    completed_fencings: u64,
+}
+
+impl DbFencerActor {
+    pub fn new<F, Fut>(actor_options: DbFencerActorOptions, db_factory: F) -> Result<Self, Error>
+    where
+        F: Fn(ActorCtx) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<Arc<Db>, Error>> + Send + 'static,
+    {
+        info!("db fencer actor created [options={:?}]", actor_options);
+        Ok(Self {
+            actor_options,
+            db_factory: Box::new(move |ctx| Box::pin(db_factory(ctx))),
+            completed_fencings: 0,
+        })
+    }
+}
+
+#[async_trait]
+impl Actor for DbFencerActor {
+    #[instrument(level = "debug", skip_all, fields(name = %ctx.name()))]
+    async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        let Some(next_db) = self.open_replacement_db(ctx).await? else {
+            return Ok(());
+        };
+        let old_db = ctx.swap_db(next_db);
+
+        self.assert_old_db_fenced(ctx, &old_db).await;
+        old_db.close().await?;
+
+        self.completed_fencings += 1;
+        info!(
+            "db fencing complete [name={}, completed_fencings={}]",
+            ctx.name(),
+            self.completed_fencings
+        );
+
+        let shutdown_token = ctx.shutdown_token();
+        let system_clock = ctx.system_clock();
+        tokio::select! {
+            biased;
+            _ = shutdown_token.cancelled() => {}
+            _ = system_clock.sleep(self.actor_options.restart_interval) => {}
+        }
+
+        Ok(())
+    }
+
+    async fn finish(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        assert!(
+            self.completed_fencings >= self.actor_options.min_fencings,
+            "db fencer completed {} fencings but expected at least {} [name={}]",
+            self.completed_fencings,
+            self.actor_options.min_fencings,
+            ctx.name(),
+        );
+        Ok(())
+    }
+}
+
+impl DbFencerActor {
+    async fn open_replacement_db(&self, ctx: &ActorCtx) -> Result<Option<Arc<Db>>, Error> {
+        loop {
+            let result = if self.completed_fencings >= self.actor_options.min_fencings {
+                let shutdown_token = ctx.shutdown_token();
+                let open_db = (self.db_factory)(ctx.clone());
+                tokio::select! {
+                    biased;
+                    _ = shutdown_token.cancelled() => return Ok(None),
+                    result = open_db => result,
+                }
+            } else {
+                (self.db_factory)(ctx.clone()).await
+            };
+
+            match result {
+                Err(err) if matches!(err.kind(), ErrorKind::Unavailable) => {
+                    info!(
+                        "db replacement open failed with unavailable, retrying [name={}]",
+                        ctx.name()
+                    );
+                }
+                result => return result.map(Some),
+            }
+        }
+    }
+
+    async fn assert_old_db_fenced(&self, ctx: &ActorCtx, old_db: &Db) {
+        let probe_key = format!(
+            "__slatedb_dst/db_fencer/{}/{}",
+            ctx.name(),
+            self.completed_fencings
+        );
+        let result = old_db
+            .put_with_options(
+                probe_key.as_bytes(),
+                b"fence-probe",
+                &PutOptions::default(),
+                &WriteOptions::default(),
+            )
+            .await;
+
+        match result {
+            Err(err) if matches!(err.kind(), ErrorKind::Closed(CloseReason::Fenced)) => {}
+            result => panic!("old db was not fenced as expected [result={result:?}]"),
+        }
+    }
+}

--- a/slatedb-dst/src/actors/fencer.rs
+++ b/slatedb-dst/src/actors/fencer.rs
@@ -48,15 +48,12 @@ where
 pub struct DbFencerActorOptions {
     /// How long the actor waits between DB replacement attempts.
     pub restart_interval: Duration,
-    /// The minimum number of completed fencings required before shutdown.
-    pub min_fencings: u64,
 }
 
 /// Reopens the shared database in a loop and verifies each old handle is fenced.
 pub struct DbFencerActor {
     actor_options: DbFencerActorOptions,
     db_factory: DbFactory,
-    completed_fencings: u64,
 }
 
 impl DbFencerActor {
@@ -69,7 +66,6 @@ impl DbFencerActor {
         Ok(Self {
             actor_options,
             db_factory: Box::new(move |ctx| Box::pin(db_factory(ctx))),
-            completed_fencings: 0,
         })
     }
 }
@@ -86,12 +82,7 @@ impl Actor for DbFencerActor {
         self.assert_old_db_fenced(ctx, &old_db).await;
         old_db.close().await?;
 
-        self.completed_fencings += 1;
-        info!(
-            "db fencing complete [name={}, completed_fencings={}]",
-            ctx.name(),
-            self.completed_fencings
-        );
+        info!("db fencing complete [name={}]", ctx.name());
 
         let shutdown_token = ctx.shutdown_token();
         let system_clock = ctx.system_clock();
@@ -103,32 +94,17 @@ impl Actor for DbFencerActor {
 
         Ok(())
     }
-
-    async fn finish(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
-        assert!(
-            self.completed_fencings >= self.actor_options.min_fencings,
-            "db fencer completed {} fencings but expected at least {} [name={}]",
-            self.completed_fencings,
-            self.actor_options.min_fencings,
-            ctx.name(),
-        );
-        Ok(())
-    }
 }
 
 impl DbFencerActor {
     async fn open_replacement_db(&self, ctx: &ActorCtx) -> Result<Option<Arc<Db>>, Error> {
         loop {
-            let result = if self.completed_fencings >= self.actor_options.min_fencings {
-                let shutdown_token = ctx.shutdown_token();
-                let open_db = (self.db_factory)(ctx.clone());
-                tokio::select! {
-                    biased;
-                    _ = shutdown_token.cancelled() => return Ok(None),
-                    result = open_db => result,
-                }
-            } else {
-                (self.db_factory)(ctx.clone()).await
+            let shutdown_token = ctx.shutdown_token();
+            let open_db = (self.db_factory)(ctx.clone());
+            let result = tokio::select! {
+                biased;
+                _ = shutdown_token.cancelled() => return Ok(None),
+                result = open_db => result,
             };
 
             match result {
@@ -144,11 +120,7 @@ impl DbFencerActor {
     }
 
     async fn assert_old_db_fenced(&self, ctx: &ActorCtx, old_db: &Db) {
-        let probe_key = format!(
-            "__slatedb_dst/db_fencer/{}/{}",
-            ctx.name(),
-            self.completed_fencings
-        );
+        let probe_key = format!("__slatedb_dst/db_fencer/{}/probe", ctx.name());
         let result = old_db
             .put_with_options(
                 probe_key.as_bytes(),

--- a/slatedb-dst/src/actors/mod.rs
+++ b/slatedb-dst/src/actors/mod.rs
@@ -14,6 +14,7 @@
 
 pub mod bank;
 pub mod compactor;
+pub mod fencer;
 pub mod flusher;
 pub mod shutdown;
 pub mod suppress_errors;
@@ -21,6 +22,7 @@ pub mod workload;
 
 pub use self::bank::{initialize_accounts, AuditorActor, BankOptions, TransferActor};
 pub use self::compactor::{CompactorActor, CompactorActorOptions};
+pub use self::fencer::{DbFencerActor, DbFencerActorOptions, SuppressFenced};
 pub use self::flusher::FlusherActor;
 pub use self::shutdown::ShutdownActor;
 pub use self::suppress_errors::SuppressErrorActor;

--- a/slatedb-dst/src/actors/mod.rs
+++ b/slatedb-dst/src/actors/mod.rs
@@ -16,12 +16,14 @@ pub mod bank;
 pub mod compactor;
 pub mod flusher;
 pub mod shutdown;
+pub mod suppress_errors;
 pub mod workload;
 
 pub use self::bank::{initialize_accounts, AuditorActor, BankOptions, TransferActor};
 pub use self::compactor::{CompactorActor, CompactorActorOptions};
 pub use self::flusher::FlusherActor;
 pub use self::shutdown::ShutdownActor;
+pub use self::suppress_errors::SuppressErrorActor;
 pub use self::workload::{WorkloadActor, WorkloadActorOptions};
 
 /// Emit one progress log line every N completed steps for the looping actors.

--- a/slatedb-dst/src/actors/suppress_errors.rs
+++ b/slatedb-dst/src/actors/suppress_errors.rs
@@ -1,0 +1,123 @@
+use async_trait::async_trait;
+use slatedb::Error;
+
+use crate::{Actor, ActorCtx};
+
+/// Decorates an actor by suppressing selected errors from `run`.
+pub struct SuppressErrorActor<A, F> {
+    inner: A,
+    should_suppress: F,
+}
+
+impl<A, F> SuppressErrorActor<A, F> {
+    pub fn new(inner: A, should_suppress: F) -> Self {
+        Self {
+            inner,
+            should_suppress,
+        }
+    }
+}
+
+#[async_trait]
+impl<A, F> Actor for SuppressErrorActor<A, F>
+where
+    A: Actor,
+    F: Fn(&Error) -> bool + Send + 'static,
+{
+    async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        match self.inner.run(ctx).await {
+            Err(error) if (self.should_suppress)(&error) => Ok(()),
+            result => result,
+        }
+    }
+
+    async fn finish(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+        self.inner.finish(ctx).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use slatedb::config::Settings;
+    use slatedb::{CloseReason, Db, Error, ErrorKind};
+
+    use super::SuppressErrorActor;
+    use crate::{Actor, ActorCtx, Harness};
+
+    struct ErrorThenShutdownActor {
+        runs: Arc<AtomicUsize>,
+        error: fn() -> Error,
+    }
+
+    impl ErrorThenShutdownActor {
+        fn new(runs: Arc<AtomicUsize>, error: fn() -> Error) -> Self {
+            Self { runs, error }
+        }
+    }
+
+    #[async_trait]
+    impl Actor for ErrorThenShutdownActor {
+        async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
+            if self.runs.fetch_add(1, Ordering::SeqCst) == 0 {
+                Err((self.error)())
+            } else {
+                ctx.shutdown_token().cancel();
+                Ok(())
+            }
+        }
+    }
+
+    fn test_harness<A: Actor>(name: &'static str, actor: A) -> Harness {
+        Harness::new(name, 7, move |ctx| async move {
+            let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
+                .with_system_clock(ctx.system_clock())
+                .with_settings(Settings {
+                    compactor_options: None,
+                    garbage_collector_options: None,
+                    ..Settings::default()
+                })
+                .build()
+                .await?;
+
+            Ok(Arc::new(db))
+        })
+        .actor("test-actor", actor)
+    }
+
+    #[test]
+    fn should_suppress_matching_run_error() {
+        let runs = Arc::new(AtomicUsize::new(0));
+        let actor = SuppressErrorActor::new(
+            ErrorThenShutdownActor::new(runs.clone(), || {
+                Error::closed("fenced".to_string(), CloseReason::Fenced)
+            }),
+            |error: &Error| matches!(error.kind(), ErrorKind::Closed(CloseReason::Fenced)),
+        );
+
+        test_harness("suppress-matching-error", actor)
+            .run()
+            .expect("matching error should be suppressed");
+
+        assert_eq!(runs.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn should_propagate_non_matching_run_error() {
+        let runs = Arc::new(AtomicUsize::new(0));
+        let actor = SuppressErrorActor::new(
+            ErrorThenShutdownActor::new(runs.clone(), || Error::unavailable("retry".to_string())),
+            |error: &Error| matches!(error.kind(), ErrorKind::Closed(CloseReason::Fenced)),
+        );
+
+        let error = test_harness("propagate-non-matching-error", actor)
+            .run()
+            .expect_err("non-matching error should be propagated");
+
+        assert_eq!(error.kind(), ErrorKind::Unavailable);
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+    }
+}

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -74,6 +74,14 @@ impl ActorCtx {
         self.rand.as_ref()
     }
 
+    /// Returns the startup context shared by this harness run.
+    ///
+    /// This exposes the database path, object stores, clock, failpoint
+    /// registry, and startup RNG used by the database factory.
+    pub fn startup_ctx(&self) -> &StartupCtx {
+        &self.shared.startup_ctx
+    }
+
     /// Returns the current database handle from the shared harness slot.
     ///
     /// ## Returns
@@ -111,7 +119,7 @@ impl ActorCtx {
     /// ## Arguments
     /// - `duration`: The amount of simulated time to add.
     pub async fn advance_time(&self, duration: Duration) {
-        self.shared.system_clock.advance(duration).await;
+        self.shared.startup_ctx.system_clock.advance(duration).await;
     }
 
     /// Returns the root path used to open the database under test.
@@ -119,7 +127,7 @@ impl ActorCtx {
     /// ## Returns
     /// - `&Path`: The path configured for the harness run.
     pub fn path(&self) -> &Path {
-        &self.shared.path
+        self.shared.startup_ctx.path()
     }
 
     /// Returns the wrapped main object store used by the harness.
@@ -128,7 +136,7 @@ impl ActorCtx {
     /// - `Arc<dyn ObjectStore>`: The main object store wrapped with
     ///   deterministic clock behavior.
     pub fn main_object_store(&self) -> Arc<dyn ObjectStore> {
-        Arc::clone(&self.shared.main_object_store)
+        self.shared.startup_ctx.main_object_store()
     }
 
     /// Returns the wrapped WAL object store, if one was configured.
@@ -137,7 +145,7 @@ impl ActorCtx {
     /// - `Option<Arc<dyn ObjectStore>>`: The WAL store wrapped with
     ///   deterministic clock behavior, or `None`.
     pub fn wal_object_store(&self) -> Option<Arc<dyn ObjectStore>> {
-        self.shared.wal_object_store.clone()
+        self.shared.startup_ctx.wal_object_store()
     }
 
     /// Returns the shared system clock used by the harness.
@@ -145,7 +153,7 @@ impl ActorCtx {
     /// ## Returns
     /// - `Arc<dyn SystemClock>`: The clock backing time-sensitive test behavior.
     pub fn system_clock(&self) -> Arc<dyn SystemClock> {
-        Arc::clone(&self.shared.system_clock)
+        self.shared.startup_ctx.system_clock()
     }
 
     /// Returns the shared failpoint registry for the harness run.
@@ -154,7 +162,7 @@ impl ActorCtx {
     /// - `Arc<FailPointRegistry>`: The registry used to configure failpoints in
     ///   participating components.
     pub fn fp_registry(&self) -> Arc<FailPointRegistry> {
-        Arc::clone(&self.shared.fp_registry)
+        self.shared.startup_ctx.fp_registry()
     }
 
     /// Returns the shared shutdown token for the current harness run.
@@ -237,11 +245,7 @@ impl StartupCtx {
 
 #[derive(Clone)]
 struct HarnessCtx {
-    path: Path,
-    main_object_store: Arc<dyn ObjectStore>,
-    wal_object_store: Option<Arc<dyn ObjectStore>>,
-    system_clock: Arc<dyn SystemClock>,
-    fp_registry: Arc<FailPointRegistry>,
+    startup_ctx: StartupCtx,
     db_slot: Arc<RwLock<Arc<Db>>>,
     compactor_slot: Arc<RwLock<Option<Compactor>>>,
     shutdown_token: CancellationToken,
@@ -533,14 +537,10 @@ impl Harness {
             rand: Arc::new(DbRand::new(startup_seed)),
         };
 
-        let db = startup_factory(startup_ctx).await?;
+        let db = startup_factory(startup_ctx.clone()).await?;
 
         let shared = HarnessCtx {
-            path,
-            main_object_store,
-            wal_object_store,
-            system_clock: system_clock.clone(),
-            fp_registry,
+            startup_ctx,
             db_slot: Arc::new(RwLock::new(db)),
             compactor_slot: Arc::new(RwLock::new(None)),
             shutdown_token: CancellationToken::new(),
@@ -562,6 +562,9 @@ impl Harness {
                 let shutdown_token = ctx.shutdown_token();
                 while !shutdown_token.is_cancelled() {
                     actor.run(&ctx).await?;
+                    // Keep hot actors from monopolizing the current-thread runtime when
+                    // their awaited operations complete without parking.
+                    tokio::task::yield_now().await;
                 }
                 actor.finish(&ctx).await
             });

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -9,21 +9,22 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use rand::{Rng, RngCore};
 use rstest::rstest;
-use slatedb::{Db, DbRand};
+use slatedb::{Db, DbRand, Error};
 use slatedb_common::clock::MockSystemClock;
 use slatedb_dst::{
     actors::{
         initialize_accounts, AuditorActor, BankOptions, CompactorActor, CompactorActorOptions,
-        ShutdownActor, TransferActor,
+        DbFencerActor, DbFencerActorOptions, ShutdownActor, SuppressFenced, TransferActor,
     },
     utils::{build_settings, build_settings_compactor, build_toxic},
     DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
+    StartupCtx,
 };
 use tempfile::TempDir;
 
 #[rstest]
-#[cfg_attr(not(slow), case::regular(200_000))]
-#[cfg_attr(slow, case::slow(2_000_000))]
+#[cfg_attr(not(slow), case::regular(25_000))]
+#[cfg_attr(slow, case::slow(250_000))]
 fn test_dst_bank_with_toxics(
     #[case] shutdown_at_ms: i64,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -61,40 +62,16 @@ fn test_dst_bank_with_toxics(
     let bank_options = random_bank_options(&rand);
     info!("dst bank options: {bank_options:?}");
     let audit_interval = Duration::from_millis(1000);
+    let fencer_restart_interval = Duration::from_secs(120);
     let compactor_options = build_settings_compactor(&mut *rand.rng());
 
     let harness = Harness::new("bank", seed, {
         let bank_options = bank_options.clone();
         move |ctx| async move {
-            let db_seed = ctx.rand().rng().next_u64();
-            let mut settings = build_settings(ctx.rand()).await;
+            let db = open_bank_db(ctx).await?;
+            initialize_accounts(db.as_ref(), &bank_options).await?;
 
-            // Clock ticks in the harness and `Toxic` clock advances go _very_ fast.
-            // This can cause the auditor's scan to appear to take longer than 15
-            // minutes. Since the compactor sets a checkpoint with a 15m timeout before
-            // updating the manifest, scans that take longer than 15m can result in a
-            // "FileNotFound" if the GC removes an SST in the scan after the checkpoint
-            // expires. Disable `compacted` GC until #319 is done.
-            settings
-                .garbage_collector_options
-                .as_mut()
-                .expect("build_settings should configure garbage collection")
-                .compacted_options = None;
-
-            // The test registers the standalone compactor actor below.
-            settings.compactor_options = None;
-
-            let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
-                .with_wal_object_store(ctx.wal_object_store().expect("configured"))
-                .with_system_clock(ctx.system_clock())
-                .with_fp_registry(ctx.fp_registry())
-                .with_seed(db_seed)
-                .with_settings(settings)
-                .build()
-                .await?;
-            initialize_accounts(&db, &bank_options).await?;
-
-            Ok(Arc::new(db))
+            Ok(db)
         }
     })
     .with_rand(rand)
@@ -105,19 +82,47 @@ fn test_dst_bank_with_toxics(
     .with_clock_advance(1..=5);
 
     let harness = harness
-        .actor("transfer-1", TransferActor::new(bank_options.clone())?)
-        .actor("transfer-2", TransferActor::new(bank_options.clone())?)
-        .actor("transfer-3", TransferActor::new(bank_options.clone())?)
-        .actor("transfer-4", TransferActor::new(bank_options.clone())?)
-        .actor("transfer-5", TransferActor::new(bank_options.clone())?)
-        .actor("transfer-6", TransferActor::new(bank_options.clone())?)
+        .actor(
+            "transfer-1",
+            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+        )
+        .actor(
+            "transfer-2",
+            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+        )
+        .actor(
+            "transfer-3",
+            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+        )
+        .actor(
+            "transfer-4",
+            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+        )
+        .actor(
+            "transfer-5",
+            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+        )
+        .actor(
+            "transfer-6",
+            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+        )
         .actor(
             "auditor-1",
-            AuditorActor::new(bank_options.clone(), audit_interval)?,
+            SuppressFenced::new(AuditorActor::new(bank_options.clone(), audit_interval)?),
         )
         .actor(
             "auditor-2",
-            AuditorActor::new(bank_options, audit_interval)?,
+            SuppressFenced::new(AuditorActor::new(bank_options, audit_interval)?),
+        )
+        .actor(
+            "db-fencer",
+            DbFencerActor::new(
+                DbFencerActorOptions {
+                    restart_interval: fencer_restart_interval,
+                    min_fencings: 1,
+                },
+                |ctx| async move { open_bank_db(ctx.startup_ctx().clone()).await },
+            )?,
         )
         .actor(
             "compactor",
@@ -131,6 +136,43 @@ fn test_dst_bank_with_toxics(
     harness.run()?;
 
     Ok(())
+}
+
+async fn open_bank_db(ctx: StartupCtx) -> Result<Arc<Db>, Error> {
+    let db_seed = ctx.rand().rng().next_u64();
+    let mut settings = build_settings(ctx.rand()).await;
+
+    // Clock ticks in the harness and `Toxic` clock advances go _very_ fast.
+    // This can cause the auditor's scan to appear to take longer than 15
+    // minutes. Since the compactor sets a checkpoint with a 15m timeout before
+    // updating the manifest, scans that take longer than 15m can result in a
+    // "FileNotFound" if the GC removes an SST in the scan after the checkpoint
+    // expires. Disable `compacted` GC until #319 is done.
+    settings
+        .garbage_collector_options
+        .as_mut()
+        .expect("build_settings should configure garbage collection")
+        .compacted_options = None;
+
+    // The test registers the standalone compactor actor below.
+    settings.compactor_options = None;
+
+    // DB fencing currently relies on WAL barrier files.
+    #[cfg(feature = "wal_disable")]
+    {
+        settings.wal_enabled = true;
+    }
+
+    let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
+        .with_wal_object_store(ctx.wal_object_store().expect("configured"))
+        .with_system_clock(ctx.system_clock())
+        .with_fp_registry(ctx.fp_registry())
+        .with_seed(db_seed)
+        .with_settings(settings)
+        .build()
+        .await?;
+
+    Ok(Arc::new(db))
 }
 
 fn random_bank_options(rand: &DbRand) -> BankOptions {

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -23,8 +23,8 @@ use slatedb_dst::{
 use tempfile::TempDir;
 
 #[rstest]
-#[cfg_attr(not(slow), case::regular(25_000))]
-#[cfg_attr(slow, case::slow(250_000))]
+#[cfg_attr(not(slow), case::regular(200_000))]
+#[cfg_attr(slow, case::slow(2_000_000))]
 fn test_dst_bank_with_toxics(
     #[case] shutdown_at_ms: i64,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -119,7 +119,6 @@ fn test_dst_bank_with_toxics(
             DbFencerActor::new(
                 DbFencerActorOptions {
                     restart_interval: fencer_restart_interval,
-                    min_fencings: 1,
                 },
                 |ctx| async move { open_bank_db(ctx.startup_ctx().clone()).await },
             )?,

--- a/slatedb-dst/tests/determinism.rs
+++ b/slatedb-dst/tests/determinism.rs
@@ -54,7 +54,7 @@ type TestResult<T> = Result<T, TestError>;
 /// fails or panics.
 #[rstest]
 #[cfg_attr(not(slow), case::regular(4, 200))]
-#[cfg_attr(slow, case::slow(4, 2_000))]
+#[cfg_attr(slow, case::slow(2, 1_000))]
 fn test_dst_is_deterministic(
     #[case] simulations: u32,
     #[case] shutdown_at_ms: i64,


### PR DESCRIPTION
## Summary

DST currently includes a compactor.rs, which restarts the compactor every so often. This behavior fences the old compactor, thereby validating that compactor fencing works as expected.

This PR adds similar behavior for `Db` fencing.

## Changes

- Add `fencer.rs`, which contains an actor that creates a new `Db` every so often
- Add a `SuppressErrorActor` decorator, which suppresses errors if set
- Provide a `SuppressFenced` actor to suppress fencing errors
- Add `Db` fencing actor to `bank.rs` test
- Expose `StartupCtx` in `Harness`'s `ActorCtx` to simplify `Db` recreation in actors
- Speed up slow determinism tests a bit by reducing the number of clock ticks

## Notes for Reviewers

I opted not to include `Db` fencing in the determinism.rs checks because it would require changes `workload.rs`. That workload keeps an oracle right now. The oracle gets updated every time a put returns, but if we fence, the put might return then fail before the write is durable (we are not waiting for remote durability). I didn't want to add remote durability writes to workload.rs because it would really slow down and serialize the test.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
