### PR TITLE
Another PR for Thundering Herd Issue

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -35,7 +35,7 @@ pub(crate) struct CachedObjectStore {
     // Deduplicates concurrent HEAD requests for the same path after a cache miss.
     head_flights: SingleFlight<Path, ObjectMeta>,
     // Deduplicates concurrent prefetch/GET requests for the same path after a cache miss.
-    prefetch_flights: SingleFlight<Path, (ObjectMeta, Attributes)>,
+    prefetch_flights: SingleFlight<(Path, Option<GetRangeKey>), (ObjectMeta, Attributes)>,
     // Deduplicates concurrent fetches of the same part after a cache miss.
     // Keyed on (path, part_id) so multiple readers needing the same part share one fetch.
     part_flights: SingleFlight<(Path, PartID), Bytes>,
@@ -397,15 +397,18 @@ impl CachedObjectStore {
         // Parts not covered by the winning caller's range are handled by read_part's
         // own object-store fallback, so correctness is maintained.
         self.prefetch_flights
-            .call(location.clone(), || async {
-                let get_result = self.object_store.get_opts(location, opts).await?;
-                let result_meta = get_result.meta.clone();
-                let result_attrs = get_result.attributes.clone();
-                if self.resolve_root(location, &result_meta.location) {
-                    self.save_get_result(get_result).await.ok();
-                }
-                Ok((result_meta, result_attrs))
-            })
+            .call(
+                (location.clone(), opts.range.clone().map(Into::into)),
+                || async {
+                    let get_result = self.object_store.get_opts(location, opts).await?;
+                    let result_meta = get_result.meta.clone();
+                    let result_attrs = get_result.attributes.clone();
+                    if self.resolve_root(location, &result_meta.location) {
+                        self.save_get_result(get_result).await.ok();
+                    }
+                    Ok((result_meta, result_attrs))
+                },
+            )
             .await
     }
 
@@ -757,6 +760,25 @@ pub(crate) enum InvalidGetRange {
 
     #[error("Range started at {start} and ended at {end}")]
     Inconsistent { start: u64, end: u64 },
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone)]
+/// A mirror of [`object_store::GetRange`] that implements [`Hash`] and [`Eq`],
+/// allowing it to be used as a key in hash-based collections (e.g. `SingleFlight`).
+enum GetRangeKey {
+    Bounded(Range<u64>),
+    Offset(u64),
+    Suffix(u64),
+}
+
+impl From<GetRange> for GetRangeKey {
+    fn from(range: GetRange) -> Self {
+        match range {
+            GetRange::Bounded(r) => GetRangeKey::Bounded(r),
+            GetRange::Offset(o) => GetRangeKey::Offset(o),
+            GetRange::Suffix(s) => GetRangeKey::Suffix(s),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -795,7 +795,7 @@ mod tests {
     use crate::cached_object_store::storage_fs::FsCacheEntry;
     use crate::cached_object_store::storage_fs::FsCacheStorage;
     use crate::rand::DbRand;
-    use crate::test_utils::gen_rand_bytes;
+    use crate::test_utils::{gen_rand_bytes, FlakyObjectStore, SlowObjectStore};
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::MetricsRecorderHelper;
 
@@ -1587,5 +1587,425 @@ mod tests {
             let cached_parts = entry.cached_parts().await.unwrap();
             assert_eq!(cached_parts.len(), 0); // No parts should be cached
         }
+    }
+
+    /// Helper to build a CachedObjectStore backed by an InstrumentedObjectStore so
+    /// we can assert on the number of actual object-store requests made.
+    fn build_instrumented_cached_store(
+        inner: Arc<dyn ObjectStore>,
+    ) -> (
+        Arc<slatedb_common::metrics::DefaultMetricsRecorder>,
+        Arc<CachedObjectStore>,
+    ) {
+        use crate::instrumented_object_store::{InstrumentedObjectStore, ObjectStoreComponent};
+        use crate::object_stores::ObjectStoreType;
+        use slatedb_common::metrics::test_recorder_helper;
+
+        let (recorder, helper) = test_recorder_helper();
+        let instrumented = Arc::new(InstrumentedObjectStore::new(
+            inner,
+            &helper,
+            ObjectStoreComponent::Db,
+            ObjectStoreType::Main,
+        ));
+
+        let test_cache_folder = new_test_cache_folder();
+        let noop_helper = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&noop_helper));
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            test_cache_folder,
+            None,
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            1000,
+        ));
+
+        let cached_store = CachedObjectStore::new(
+            instrumented as Arc<dyn ObjectStore>,
+            cache_storage,
+            1024,
+            false,
+            stats,
+        )
+        .unwrap();
+
+        (recorder, cached_store)
+    }
+
+    fn get_request_count(
+        recorder: &slatedb_common::metrics::DefaultMetricsRecorder,
+        api: &str,
+    ) -> i64 {
+        use crate::instrumented_object_store::stats::REQUEST_COUNT;
+        use slatedb_common::metrics::lookup_metric_with_labels;
+
+        let labels = [
+            ("component", "db"),
+            ("store_type", "main"),
+            ("op", "get"),
+            ("api", api),
+        ];
+        lookup_metric_with_labels(recorder, REQUEST_COUNT, &labels).unwrap_or(0)
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_deduplicates_concurrent_head_requests() {
+        // Set up an object in the backing store, then wrap it with SlowObjectStore
+        // to inject a pause so concurrent callers overlap in time.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_head_dedup");
+        mem.put(&path, PutPayload::from_bytes(gen_rand_bytes(512)))
+            .await
+            .unwrap();
+
+        let slow = Arc::new(SlowObjectStore::new(
+            mem,
+            std::time::Duration::from_millis(50),
+        ));
+        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+
+        // Launch many concurrent head requests for the same path.
+        // The 50ms delay ensures they all register before the first one completes.
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let store = cached_store.clone();
+            let p = path.clone();
+            handles.push(tokio::spawn(async move { store.cached_head(&p).await }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+
+        // SingleFlight should collapse them into a single actual GET (head: true) request.
+        let count = get_request_count(&recorder, "get");
+        assert_eq!(
+            count, 1,
+            "expected 1 actual object store request, got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_deduplicates_concurrent_get_opts_requests() {
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_get_dedup");
+        let payload = gen_rand_bytes(2048);
+        mem.put(&path, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        let slow = Arc::new(SlowObjectStore::new(
+            mem,
+            std::time::Duration::from_millis(50),
+        ));
+        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+
+        // Launch many concurrent get_opts requests for the same path and range.
+        // The 50ms delay guarantees they pile up behind the SingleFlight.
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let store = cached_store.clone();
+            let p = path.clone();
+            handles.push(tokio::spawn(async move {
+                let opts = GetOptions {
+                    range: Some(GetRange::Bounded(0..1024)),
+                    ..Default::default()
+                };
+                let result = store.cached_get_opts(&p, opts).await?;
+                result.bytes().await
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+
+        // The prefetch SingleFlight should collapse all prefetch GETs into one.
+        // Part reads may also be deduplicated. Total GET count should be much less than 10.
+        let count = get_request_count(&recorder, "get");
+        assert!(
+            count <= 2,
+            "expected at most 2 actual object store requests (prefetch + maybe 1 part), got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_allows_independent_paths() {
+        // Requests to different paths should NOT be deduplicated, even with pauses.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let paths: Vec<Path> = (0..5)
+            .map(|i| Path::from(format!("data/independent_{}", i)))
+            .collect();
+        for p in &paths {
+            mem.put(p, PutPayload::from_bytes(gen_rand_bytes(512)))
+                .await
+                .unwrap();
+        }
+
+        let slow = Arc::new(SlowObjectStore::new(
+            mem,
+            std::time::Duration::from_millis(50),
+        ));
+        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+
+        let mut handles = Vec::new();
+        for p in &paths {
+            let store = cached_store.clone();
+            let p = p.clone();
+            handles.push(tokio::spawn(async move { store.cached_head(&p).await }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+
+        // Each distinct path should result in its own request.
+        let count = get_request_count(&recorder, "get");
+        assert_eq!(
+            count, 5,
+            "expected 5 actual object store requests (one per path), got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_deduplicates_concurrent_part_fetches() {
+        // When multiple readers need the same uncached part, only one fetch should occur.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_part_dedup");
+        // Create an object spanning multiple parts (part_size = 1024).
+        let payload = gen_rand_bytes(4096);
+        mem.put(&path, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        let slow = Arc::new(SlowObjectStore::new(
+            mem,
+            std::time::Duration::from_millis(50),
+        ));
+        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+
+        // First, prime the metadata cache so that cached_get_opts doesn't prefetch.
+        let prime_opts = GetOptions {
+            range: None,
+            ..Default::default()
+        };
+        let result = cached_store
+            .cached_get_opts(&path, prime_opts)
+            .await
+            .unwrap();
+        let _ = result.bytes().await.unwrap();
+
+        // Record baseline after priming.
+        let baseline = get_request_count(&recorder, "get");
+
+        // Now issue concurrent requests that all need the same part (part 0).
+        // The delay ensures they overlap and hit the part_flights SingleFlight.
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let store = cached_store.clone();
+            let p = path.clone();
+            handles.push(tokio::spawn(async move {
+                let opts = GetOptions {
+                    range: Some(GetRange::Bounded(0..512)),
+                    ..Default::default()
+                };
+                let result = store.cached_get_opts(&p, opts).await?;
+                result.bytes().await
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+
+        // After the initial prime, subsequent reads for already-cached parts should
+        // not require additional object store requests (served from cache).
+        let after = get_request_count(&recorder, "get");
+        let additional = after - baseline;
+        assert!(
+            additional <= 1,
+            "expected at most 1 additional request for part dedup, got {additional}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_different_ranges_are_independent() {
+        // Requests with different ranges should be treated as separate flights.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_range_independent");
+        let payload = gen_rand_bytes(4096);
+        mem.put(&path, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        let slow = Arc::new(SlowObjectStore::new(
+            mem,
+            std::time::Duration::from_millis(50),
+        ));
+        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+
+        let ranges = vec![
+            Some(GetRange::Bounded(0..1024)),
+            Some(GetRange::Bounded(1024..2048)),
+            Some(GetRange::Suffix(512)),
+        ];
+
+        let mut handles = Vec::new();
+        for range in ranges {
+            let store = cached_store.clone();
+            let p = path.clone();
+            handles.push(tokio::spawn(async move {
+                let opts = GetOptions {
+                    range,
+                    ..Default::default()
+                };
+                store.cached_get_opts(&p, opts).await
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap().unwrap();
+        }
+
+        // Each distinct range key should trigger its own prefetch request.
+        let count = get_request_count(&recorder, "get");
+        assert!(
+            count >= 3,
+            "expected at least 3 object store requests (one per distinct range), got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_head_retries_after_transient_error() {
+        // When the underlying store fails transiently, the SingleFlight should
+        // propagate the error and allow the next caller to retry successfully.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_head_retry");
+        mem.put(&path, PutPayload::from_bytes(gen_rand_bytes(512)))
+            .await
+            .unwrap();
+
+        // Wrap with FlakyObjectStore that fails the first head request.
+        let flaky = Arc::new(FlakyObjectStore::new(mem, 0).with_head_failures(1));
+        let (_, cached_store) = build_instrumented_cached_store(flaky.clone());
+
+        // First call should fail because FlakyObjectStore fails the first get_opts
+        // (cached_head uses get_opts with head:true internally).
+        // Note: FlakyObjectStore's head failures affect `head()` not `get_opts()`,
+        // but cached_head calls get_opts. Let's verify the retry path works by
+        // calling twice sequentially.
+        let result1 = cached_store.cached_head(&path).await;
+        // The first call goes through get_opts (not head), so it should succeed.
+        assert!(result1.is_ok());
+
+        // Second call should also succeed (served from cache or SingleFlight).
+        let result2 = cached_store.cached_head(&path).await;
+        assert!(result2.is_ok());
+        assert_eq!(result1.unwrap().size, result2.unwrap().size);
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_get_opts_with_flaky_store_first_failure() {
+        // Validates that when the underlying store returns a transient error,
+        // the SingleFlight does not cache the error and subsequent calls succeed.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_get_flaky");
+        let payload = gen_rand_bytes(2048);
+        mem.put(&path, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        // FlakyObjectStore with 1 put failure (we use put failures to set it up,
+        // but get_opts passes through). Instead, use get_range failures to test
+        // the part_flights path. First let's just verify normal get_opts works.
+        let flaky = Arc::new(FlakyObjectStore::new(mem.clone(), 0));
+        let (recorder, cached_store) = build_instrumented_cached_store(flaky);
+
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(0..1024)),
+            ..Default::default()
+        };
+        let result = cached_store.cached_get_opts(&path, opts).await;
+        assert!(result.is_ok());
+
+        let bytes = result.unwrap().bytes().await.unwrap();
+        assert_eq!(&bytes[..], &payload[..1024]);
+
+        // Verify the request went through exactly once for the prefetch.
+        let count = get_request_count(&recorder, "get");
+        assert!(
+            count >= 1,
+            "expected at least 1 request through FlakyObjectStore, got {count}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_concurrent_callers_see_same_error() {
+        // When the underlying store fails, all concurrent waiters on the same
+        // SingleFlight key should receive an error (not hang forever), and the
+        // next call should be able to retry fresh.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        // Intentionally do NOT put anything at this path so get_opts returns NotFound.
+        let path = Path::from("data/nonexistent");
+
+        let slow = Arc::new(SlowObjectStore::new(
+            mem,
+            std::time::Duration::from_millis(50),
+        ));
+        let (_, cached_store) = build_instrumented_cached_store(slow);
+
+        // Launch concurrent head requests for a non-existent path.
+        // All should fail with NotFound, none should hang.
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let store = cached_store.clone();
+            let p = path.clone();
+            handles.push(tokio::spawn(async move { store.cached_head(&p).await }));
+        }
+
+        for handle in handles {
+            let result = handle.await.unwrap();
+            assert!(result.is_err(), "expected error for non-existent path");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_part_fetch_with_get_range_failures() {
+        // Validates that when fetching parts fails transiently, the SingleFlight
+        // does not permanently cache the failure, and retries succeed.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_part_flaky");
+        let payload = gen_rand_bytes(4096);
+        mem.put(&path, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        // Use a FlakyObjectStore that fails the first get_range call.
+        let flaky = Arc::new(FlakyObjectStore::new(mem, 0).with_get_range_failures(1));
+        let (_, cached_store) = build_instrumented_cached_store(flaky.clone());
+
+        // First, prime metadata via a full get (get_opts doesn't use get_range).
+        let prime_opts = GetOptions {
+            range: None,
+            ..Default::default()
+        };
+        let result = cached_store
+            .cached_get_opts(&path, prime_opts)
+            .await
+            .unwrap();
+        let _ = result.bytes().await.unwrap();
+
+        // Now try reading — the parts should be cached from the full get above,
+        // so even though get_range is flaky, we should succeed from cache.
+        let opts = GetOptions {
+            range: Some(GetRange::Bounded(0..512)),
+            ..Default::default()
+        };
+        let result = cached_store.cached_get_opts(&path, opts).await;
+        assert!(result.is_ok());
+        let bytes = result.unwrap().bytes().await.unwrap();
+        assert_eq!(&bytes[..], &payload[..512]);
     }
 }

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -1661,6 +1661,7 @@ mod tests {
 
         // Wrap with a gate-controlled store so we can block callers deterministically.
         let gated = Arc::new(GatedObjectStore::new(mem));
+        gated.get_opts_gate.close();
         let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch many concurrent head requests for the same path.
@@ -1673,11 +1674,15 @@ mod tests {
 
         // Wait until exactly 1 caller arrives at the gate (SingleFlight dedup
         // ensures only one caller reaches get_opts).
-        gated.wait_for_arrivals(1).await;
-        assert_eq!(gated.arrivals(), 1, "SingleFlight should let only 1 through");
+        gated.get_opts_gate.wait_for_arrivals(1).await;
+        assert_eq!(
+            gated.get_opts_gate.arrivals(),
+            1,
+            "SingleFlight should let only 1 through"
+        );
 
         // Release the gate — success path.
-        gated.release();
+        gated.get_opts_gate.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1701,6 +1706,7 @@ mod tests {
             .unwrap();
 
         let gated = Arc::new(GatedObjectStore::new(mem));
+        gated.get_opts_gate.close();
         let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch many concurrent get_opts requests for the same path and range.
@@ -1719,11 +1725,15 @@ mod tests {
         }
 
         // Wait for the single winning caller to arrive at the gate.
-        gated.wait_for_arrivals(1).await;
-        assert_eq!(gated.arrivals(), 1, "SingleFlight should let only 1 through");
+        gated.get_opts_gate.wait_for_arrivals(1).await;
+        assert_eq!(
+            gated.get_opts_gate.arrivals(),
+            1,
+            "SingleFlight should let only 1 through"
+        );
 
         // Release — success.
-        gated.release();
+        gated.get_opts_gate.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1752,6 +1762,7 @@ mod tests {
         }
 
         let gated = Arc::new(GatedObjectStore::new(mem));
+        gated.get_opts_gate.close();
         let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         let mut handles = Vec::new();
@@ -1762,15 +1773,15 @@ mod tests {
         }
 
         // Each distinct path has its own SingleFlight key, so all 5 should arrive.
-        gated.wait_for_arrivals(5).await;
+        gated.get_opts_gate.wait_for_arrivals(5).await;
         assert_eq!(
-            gated.arrivals(),
+            gated.get_opts_gate.arrivals(),
             5,
             "different keys should each pass through SingleFlight independently"
         );
 
         // Release all.
-        gated.release();
+        gated.get_opts_gate.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1795,6 +1806,7 @@ mod tests {
             .unwrap();
 
         let gated = Arc::new(GatedObjectStore::new(mem));
+        gated.get_opts_gate.close();
         let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         let ranges = vec![
@@ -1817,15 +1829,15 @@ mod tests {
         }
 
         // Each distinct range maps to a different key, so all 3 should arrive.
-        gated.wait_for_arrivals(3).await;
+        gated.get_opts_gate.wait_for_arrivals(3).await;
         assert_eq!(
-            gated.arrivals(),
+            gated.get_opts_gate.arrivals(),
             3,
             "different ranges should each pass through SingleFlight independently"
         );
 
         // Release all.
-        gated.release();
+        gated.get_opts_gate.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1850,6 +1862,7 @@ mod tests {
             .unwrap();
 
         let gated = Arc::new(GatedObjectStore::new(mem));
+        gated.get_opts_gate.close();
         let (_, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch concurrent head requests.
@@ -1861,11 +1874,19 @@ mod tests {
         }
 
         // Wait for the single winning caller to arrive at the gate.
-        gated.wait_for_arrivals(1).await;
+        gated.get_opts_gate.wait_for_arrivals(1).await;
 
         // Inject failure, then release.
-        gated.set_should_fail(true);
-        gated.release();
+        gated
+            .get_opts_gate
+            .set_error(|| object_store::Error::Generic {
+                store: "test",
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "injected test failure",
+                )),
+            });
+        gated.get_opts_gate.release();
 
         // All callers should see an error.
         for handle in handles {
@@ -1885,6 +1906,7 @@ mod tests {
             .unwrap();
 
         let gated = Arc::new(GatedObjectStore::new(mem));
+        gated.get_opts_gate.close();
         let (_, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // First call — configure failure.
@@ -1892,21 +1914,29 @@ mod tests {
         let p = path.clone();
         let handle = tokio::spawn(async move { store.cached_head(&p).await });
 
-        gated.wait_for_arrivals(1).await;
-        gated.set_should_fail(true);
-        gated.release();
+        gated.get_opts_gate.wait_for_arrivals(1).await;
+        gated
+            .get_opts_gate
+            .set_error(|| object_store::Error::Generic {
+                store: "test",
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "injected test failure",
+                )),
+            });
+        gated.get_opts_gate.release();
 
         let result = handle.await.unwrap();
         assert!(result.is_err(), "first call should fail");
 
         // Second call — configure success.
-        gated.set_should_fail(false);
+        gated.get_opts_gate.clear_error();
         let store = cached_store.clone();
         let p = path.clone();
         let handle = tokio::spawn(async move { store.cached_head(&p).await });
 
-        gated.wait_for_arrivals(2).await;
-        gated.release();
+        gated.get_opts_gate.wait_for_arrivals(2).await;
+        gated.get_opts_gate.release();
 
         let result = handle.await.unwrap();
         assert!(result.is_ok(), "second call should succeed after retry");

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -12,6 +12,8 @@ use slatedb_common::clock::SystemClock;
 use std::{ops::Range, sync::Arc};
 use tokio::sync::OnceCell;
 
+use crate::single_flight::SingleFlight;
+
 use crate::cached_object_store::admission::AdmissionPicker;
 use crate::cached_object_store::storage::{LocalCacheStorage, PartID};
 use crate::error::SlateDBError;
@@ -30,6 +32,13 @@ pub(crate) struct CachedObjectStore {
     // Absolute path of the root folder relative to the bucket. See #1319.
     resolved_root: Arc<OnceCell<Path>>,
     stats: Arc<CachedObjectStoreStats>,
+    // Deduplicates concurrent HEAD requests for the same path after a cache miss.
+    head_flights: SingleFlight<Path, ObjectMeta>,
+    // Deduplicates concurrent prefetch/GET requests for the same path after a cache miss.
+    prefetch_flights: SingleFlight<Path, (ObjectMeta, Attributes)>,
+    // Deduplicates concurrent fetches of the same part after a cache miss.
+    // Keyed on (path, part_id) so multiple readers needing the same part share one fetch.
+    part_flights: SingleFlight<(Path, PartID), Bytes>,
 }
 
 impl CachedObjectStore {
@@ -52,6 +61,9 @@ impl CachedObjectStore {
             admission_picker: AdmissionPicker::default(),
             cache_puts,
             resolved_root: Arc::new(OnceCell::new()),
+            head_flights: SingleFlight::new(),
+            prefetch_flights: SingleFlight::new(),
+            part_flights: SingleFlight::new(),
         }))
     }
 
@@ -254,22 +266,27 @@ impl CachedObjectStore {
             }
         }
 
-        let result = self
-            .object_store
-            .get_opts(
-                location,
-                GetOptions {
-                    range: None,
-                    head: true,
-                    ..Default::default()
-                },
-            )
-            .await?;
-        let meta = result.meta.clone();
-        if self.resolve_root(location, &meta.location) {
-            self.save_get_result(result).await.ok();
-        }
-        Ok(meta)
+        // Cache miss — deduplicate concurrent HEAD requests for the same path.
+        self.head_flights
+            .call(location.clone(), || async {
+                let result = self
+                    .object_store
+                    .get_opts(
+                        location,
+                        GetOptions {
+                            range: None,
+                            head: true,
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                let meta = result.meta.clone();
+                if self.resolve_root(location, &meta.location) {
+                    self.save_get_result(result).await.ok();
+                }
+                Ok(meta)
+            })
+            .await
     }
 
     pub(crate) async fn cached_get_opts(
@@ -375,16 +392,21 @@ impl CachedObjectStore {
             opts.range = Some(self.align_get_range(range));
         }
 
-        let get_result = self.object_store.get_opts(location, opts).await?;
-        let result_meta = get_result.meta.clone();
-        let result_attrs = get_result.attributes.clone();
-        // swallow the error on saving to disk here (the disk might be already full), just fallback
-        // to the object store.
-        // TODO: add a warning log here.
-        if self.resolve_root(location, &result_meta.location) {
-            self.save_get_result(get_result).await.ok();
-        }
-        Ok((result_meta, result_attrs))
+        // Cache miss — deduplicate concurrent prefetch requests for the same path.
+        // Only one caller performs the fetch+save; others share the metadata result.
+        // Parts not covered by the winning caller's range are handled by read_part's
+        // own object-store fallback, so correctness is maintained.
+        self.prefetch_flights
+            .call(location.clone(), || async {
+                let get_result = self.object_store.get_opts(location, opts).await?;
+                let result_meta = get_result.meta.clone();
+                let result_attrs = get_result.attributes.clone();
+                if self.resolve_root(location, &result_meta.location) {
+                    self.save_get_result(get_result).await.ok();
+                }
+                Ok((result_meta, result_attrs))
+            })
+            .await
     }
 
     /// save the GetResult to the disk cache, a GetResult may be transformed into multiple part
@@ -513,47 +535,50 @@ impl CachedObjectStore {
                 }
             }
 
-            // Cache miss, so we need to fetch from the object store.
-            let part_range = Range {
-                start: (part_id * this.part_size_bytes) as u64,
-                end: ((part_id + 1) * this.part_size_bytes) as u64,
-            };
-            let get_result = this
-                .object_store
-                .get_opts(
-                    &location,
-                    GetOptions {
-                        range: Some(GetRange::Bounded(part_range)),
-                        ..Default::default()
-                    },
-                )
-                .await?;
+            // Cache miss — deduplicate concurrent fetches of the same part.
+            // The SingleFlight fetches the full part and saves it to cache; each
+            // caller then slices out their own range_in_part.
+            let bytes = this
+                .part_flights
+                .call((location.clone(), part_id), || async {
+                    let part_range = Range {
+                        start: (part_id * this.part_size_bytes) as u64,
+                        end: ((part_id + 1) * this.part_size_bytes) as u64,
+                    };
+                    let get_result = this
+                        .object_store
+                        .get_opts(
+                            &location,
+                            GetOptions {
+                                range: Some(GetRange::Bounded(part_range)),
+                                ..Default::default()
+                            },
+                        )
+                        .await?;
 
-            // Get the cache entry again after successful get so we can cache the part.
-            let cache_entry = if this.resolve_root(&location, &get_result.meta.location) {
-                this.cache_location_for(&location).map(|cache_location| {
-                    this.cache_storage
-                        .entry(&cache_location, this.part_size_bytes)
+                    let cache_entry = if this.resolve_root(&location, &get_result.meta.location) {
+                        this.cache_location_for(&location).map(|cache_location| {
+                            this.cache_storage
+                                .entry(&cache_location, this.part_size_bytes)
+                        })
+                    } else {
+                        None
+                    };
+
+                    let bytes = if let Some(entry) = cache_entry {
+                        let meta = get_result.meta.clone();
+                        let attrs = get_result.attributes.clone();
+                        let bytes = get_result.bytes().await?;
+                        entry.save_head((&meta, &attrs)).await.ok();
+                        entry.save_part(part_id, bytes.clone()).await.ok();
+                        bytes
+                    } else {
+                        get_result.bytes().await?
+                    };
+
+                    Ok::<_, object_store::Error>(bytes)
                 })
-            } else {
-                // If the root resolution fails, we won't be able to derive a canonical cache
-                // key. Skip saving to cache to avoid poisoning the cache with unsafe keys.
-                None
-            };
-
-            // Save the head and the part to cache for future accesses. Just read the bytes
-            // if we still can't derive a canonical cache key.
-            let bytes = if let Some(entry) = cache_entry {
-                // Save the head and the part to cache for future accesses.
-                let meta = get_result.meta.clone();
-                let attrs = get_result.attributes.clone();
-                let bytes = get_result.bytes().await?;
-                entry.save_head((&meta, &attrs)).await.ok();
-                entry.save_part(part_id, bytes.clone()).await.ok();
-                bytes
-            } else {
-                get_result.bytes().await?
-            };
+                .await?;
 
             Ok(Bytes::copy_from_slice(&bytes.slice(range_in_part)))
         })

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -795,7 +795,7 @@ mod tests {
     use crate::cached_object_store::storage_fs::FsCacheEntry;
     use crate::cached_object_store::storage_fs::FsCacheStorage;
     use crate::rand::DbRand;
-    use crate::test_utils::{gen_rand_bytes, FlakyObjectStore, SlowObjectStore};
+    use crate::test_utils::{gen_rand_bytes, FlakyObjectStore, GatedObjectStore};
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::MetricsRecorderHelper;
 
@@ -1652,22 +1652,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_flight_deduplicates_concurrent_head_requests() {
-        // Set up an object in the backing store, then wrap it with SlowObjectStore
-        // to inject a pause so concurrent callers overlap in time.
+        // Set up an object in the backing store.
         let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
         let path = Path::from("data/test_head_dedup");
         mem.put(&path, PutPayload::from_bytes(gen_rand_bytes(512)))
             .await
             .unwrap();
 
-        let slow = Arc::new(SlowObjectStore::new(
-            mem,
-            std::time::Duration::from_millis(50),
-        ));
-        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+        // Wrap with a gate-controlled store so we can block callers deterministically.
+        let gated = Arc::new(GatedObjectStore::new(mem));
+        let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch many concurrent head requests for the same path.
-        // The 50ms delay ensures they all register before the first one completes.
         let mut handles = Vec::new();
         for _ in 0..10 {
             let store = cached_store.clone();
@@ -1675,11 +1671,19 @@ mod tests {
             handles.push(tokio::spawn(async move { store.cached_head(&p).await }));
         }
 
+        // Wait until exactly 1 caller arrives at the gate (SingleFlight dedup
+        // ensures only one caller reaches get_opts).
+        gated.wait_for_arrivals(1).await;
+        assert_eq!(gated.arrivals(), 1, "SingleFlight should let only 1 through");
+
+        // Release the gate — success path.
+        gated.release();
+
         for handle in handles {
             handle.await.unwrap().unwrap();
         }
 
-        // SingleFlight should collapse them into a single actual GET (head: true) request.
+        // SingleFlight should collapse them into a single actual GET request.
         let count = get_request_count(&recorder, "get");
         assert_eq!(
             count, 1,
@@ -1696,14 +1700,10 @@ mod tests {
             .await
             .unwrap();
 
-        let slow = Arc::new(SlowObjectStore::new(
-            mem,
-            std::time::Duration::from_millis(50),
-        ));
-        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+        let gated = Arc::new(GatedObjectStore::new(mem));
+        let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch many concurrent get_opts requests for the same path and range.
-        // The 50ms delay guarantees they pile up behind the SingleFlight.
         let mut handles = Vec::new();
         for _ in 0..10 {
             let store = cached_store.clone();
@@ -1717,6 +1717,13 @@ mod tests {
                 result.bytes().await
             }));
         }
+
+        // Wait for the single winning caller to arrive at the gate.
+        gated.wait_for_arrivals(1).await;
+        assert_eq!(gated.arrivals(), 1, "SingleFlight should let only 1 through");
+
+        // Release — success.
+        gated.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1733,7 +1740,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_flight_allows_independent_paths() {
-        // Requests to different paths should NOT be deduplicated, even with pauses.
+        // Requests to different paths should NOT be deduplicated.
         let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
         let paths: Vec<Path> = (0..5)
             .map(|i| Path::from(format!("data/independent_{}", i)))
@@ -1744,11 +1751,8 @@ mod tests {
                 .unwrap();
         }
 
-        let slow = Arc::new(SlowObjectStore::new(
-            mem,
-            std::time::Duration::from_millis(50),
-        ));
-        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+        let gated = Arc::new(GatedObjectStore::new(mem));
+        let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         let mut handles = Vec::new();
         for p in &paths {
@@ -1756,6 +1760,17 @@ mod tests {
             let p = p.clone();
             handles.push(tokio::spawn(async move { store.cached_head(&p).await }));
         }
+
+        // Each distinct path has its own SingleFlight key, so all 5 should arrive.
+        gated.wait_for_arrivals(5).await;
+        assert_eq!(
+            gated.arrivals(),
+            5,
+            "different keys should each pass through SingleFlight independently"
+        );
+
+        // Release all.
+        gated.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1770,67 +1785,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_single_flight_deduplicates_concurrent_part_fetches() {
-        // When multiple readers need the same uncached part, only one fetch should occur.
-        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
-        let path = Path::from("data/test_part_dedup");
-        // Create an object spanning multiple parts (part_size = 1024).
-        let payload = gen_rand_bytes(4096);
-        mem.put(&path, PutPayload::from_bytes(payload.clone()))
-            .await
-            .unwrap();
-
-        let slow = Arc::new(SlowObjectStore::new(
-            mem,
-            std::time::Duration::from_millis(50),
-        ));
-        let (recorder, cached_store) = build_instrumented_cached_store(slow);
-
-        // First, prime the metadata cache so that cached_get_opts doesn't prefetch.
-        let prime_opts = GetOptions {
-            range: None,
-            ..Default::default()
-        };
-        let result = cached_store
-            .cached_get_opts(&path, prime_opts)
-            .await
-            .unwrap();
-        let _ = result.bytes().await.unwrap();
-
-        // Record baseline after priming.
-        let baseline = get_request_count(&recorder, "get");
-
-        // Now issue concurrent requests that all need the same part (part 0).
-        // The delay ensures they overlap and hit the part_flights SingleFlight.
-        let mut handles = Vec::new();
-        for _ in 0..10 {
-            let store = cached_store.clone();
-            let p = path.clone();
-            handles.push(tokio::spawn(async move {
-                let opts = GetOptions {
-                    range: Some(GetRange::Bounded(0..512)),
-                    ..Default::default()
-                };
-                let result = store.cached_get_opts(&p, opts).await?;
-                result.bytes().await
-            }));
-        }
-
-        for handle in handles {
-            handle.await.unwrap().unwrap();
-        }
-
-        // After the initial prime, subsequent reads for already-cached parts should
-        // not require additional object store requests (served from cache).
-        let after = get_request_count(&recorder, "get");
-        let additional = after - baseline;
-        assert!(
-            additional <= 1,
-            "expected at most 1 additional request for part dedup, got {additional}"
-        );
-    }
-
-    #[tokio::test]
     async fn test_single_flight_different_ranges_are_independent() {
         // Requests with different ranges should be treated as separate flights.
         let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
@@ -1840,11 +1794,8 @@ mod tests {
             .await
             .unwrap();
 
-        let slow = Arc::new(SlowObjectStore::new(
-            mem,
-            std::time::Duration::from_millis(50),
-        ));
-        let (recorder, cached_store) = build_instrumented_cached_store(slow);
+        let gated = Arc::new(GatedObjectStore::new(mem));
+        let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         let ranges = vec![
             Some(GetRange::Bounded(0..1024)),
@@ -1865,6 +1816,17 @@ mod tests {
             }));
         }
 
+        // Each distinct range maps to a different key, so all 3 should arrive.
+        gated.wait_for_arrivals(3).await;
+        assert_eq!(
+            gated.arrivals(),
+            3,
+            "different ranges should each pass through SingleFlight independently"
+        );
+
+        // Release all.
+        gated.release();
+
         for handle in handles {
             handle.await.unwrap().unwrap();
         }
@@ -1878,86 +1840,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_single_flight_head_retries_after_transient_error() {
-        // When the underlying store fails transiently, the SingleFlight should
-        // propagate the error and allow the next caller to retry successfully.
+    async fn test_single_flight_concurrent_callers_see_gate_failure() {
+        // When the gate is configured to fail, all concurrent waiters on the
+        // same SingleFlight key should receive an error (not hang forever).
         let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
-        let path = Path::from("data/test_head_retry");
+        let path = Path::from("data/test_gate_failure");
         mem.put(&path, PutPayload::from_bytes(gen_rand_bytes(512)))
             .await
             .unwrap();
 
-        // Wrap with FlakyObjectStore that fails the first head request.
-        let flaky = Arc::new(FlakyObjectStore::new(mem, 0).with_head_failures(1));
-        let (_, cached_store) = build_instrumented_cached_store(flaky.clone());
+        let gated = Arc::new(GatedObjectStore::new(mem));
+        let (_, cached_store) = build_instrumented_cached_store(gated.clone());
 
-        // First call should fail because FlakyObjectStore fails the first get_opts
-        // (cached_head uses get_opts with head:true internally).
-        // Note: FlakyObjectStore's head failures affect `head()` not `get_opts()`,
-        // but cached_head calls get_opts. Let's verify the retry path works by
-        // calling twice sequentially.
-        let result1 = cached_store.cached_head(&path).await;
-        // The first call goes through get_opts (not head), so it should succeed.
-        assert!(result1.is_ok());
-
-        // Second call should also succeed (served from cache or SingleFlight).
-        let result2 = cached_store.cached_head(&path).await;
-        assert!(result2.is_ok());
-        assert_eq!(result1.unwrap().size, result2.unwrap().size);
-    }
-
-    #[tokio::test]
-    async fn test_single_flight_get_opts_with_flaky_store_first_failure() {
-        // Validates that when the underlying store returns a transient error,
-        // the SingleFlight does not cache the error and subsequent calls succeed.
-        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
-        let path = Path::from("data/test_get_flaky");
-        let payload = gen_rand_bytes(2048);
-        mem.put(&path, PutPayload::from_bytes(payload.clone()))
-            .await
-            .unwrap();
-
-        // FlakyObjectStore with 1 put failure (we use put failures to set it up,
-        // but get_opts passes through). Instead, use get_range failures to test
-        // the part_flights path. First let's just verify normal get_opts works.
-        let flaky = Arc::new(FlakyObjectStore::new(mem.clone(), 0));
-        let (recorder, cached_store) = build_instrumented_cached_store(flaky);
-
-        let opts = GetOptions {
-            range: Some(GetRange::Bounded(0..1024)),
-            ..Default::default()
-        };
-        let result = cached_store.cached_get_opts(&path, opts).await;
-        assert!(result.is_ok());
-
-        let bytes = result.unwrap().bytes().await.unwrap();
-        assert_eq!(&bytes[..], &payload[..1024]);
-
-        // Verify the request went through exactly once for the prefetch.
-        let count = get_request_count(&recorder, "get");
-        assert!(
-            count >= 1,
-            "expected at least 1 request through FlakyObjectStore, got {count}"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_single_flight_concurrent_callers_see_same_error() {
-        // When the underlying store fails, all concurrent waiters on the same
-        // SingleFlight key should receive an error (not hang forever), and the
-        // next call should be able to retry fresh.
-        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
-        // Intentionally do NOT put anything at this path so get_opts returns NotFound.
-        let path = Path::from("data/nonexistent");
-
-        let slow = Arc::new(SlowObjectStore::new(
-            mem,
-            std::time::Duration::from_millis(50),
-        ));
-        let (_, cached_store) = build_instrumented_cached_store(slow);
-
-        // Launch concurrent head requests for a non-existent path.
-        // All should fail with NotFound, none should hang.
+        // Launch concurrent head requests.
         let mut handles = Vec::new();
         for _ in 0..5 {
             let store = cached_store.clone();
@@ -1965,10 +1860,56 @@ mod tests {
             handles.push(tokio::spawn(async move { store.cached_head(&p).await }));
         }
 
+        // Wait for the single winning caller to arrive at the gate.
+        gated.wait_for_arrivals(1).await;
+
+        // Inject failure, then release.
+        gated.set_should_fail(true);
+        gated.release();
+
+        // All callers should see an error.
         for handle in handles {
             let result = handle.await.unwrap();
-            assert!(result.is_err(), "expected error for non-existent path");
+            assert!(result.is_err(), "expected error when gate injects failure");
         }
+    }
+
+    #[tokio::test]
+    async fn test_single_flight_retries_after_gate_failure() {
+        // After a failure, the SingleFlight should not cache the error,
+        // allowing the next call to succeed fresh.
+        let mem: Arc<dyn ObjectStore> = Arc::new(object_store::memory::InMemory::new());
+        let path = Path::from("data/test_retry_after_fail");
+        mem.put(&path, PutPayload::from_bytes(gen_rand_bytes(512)))
+            .await
+            .unwrap();
+
+        let gated = Arc::new(GatedObjectStore::new(mem));
+        let (_, cached_store) = build_instrumented_cached_store(gated.clone());
+
+        // First call — configure failure.
+        let store = cached_store.clone();
+        let p = path.clone();
+        let handle = tokio::spawn(async move { store.cached_head(&p).await });
+
+        gated.wait_for_arrivals(1).await;
+        gated.set_should_fail(true);
+        gated.release();
+
+        let result = handle.await.unwrap();
+        assert!(result.is_err(), "first call should fail");
+
+        // Second call — configure success.
+        gated.set_should_fail(false);
+        let store = cached_store.clone();
+        let p = path.clone();
+        let handle = tokio::spawn(async move { store.cached_head(&p).await });
+
+        gated.wait_for_arrivals(2).await;
+        gated.release();
+
+        let result = handle.await.unwrap();
+        assert!(result.is_ok(), "second call should succeed after retry");
     }
 
     #[tokio::test]

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -403,6 +403,9 @@ impl CachedObjectStore {
                     let get_result = self.object_store.get_opts(location, opts).await?;
                     let result_meta = get_result.meta.clone();
                     let result_attrs = get_result.attributes.clone();
+                    // swallow the error on saving to disk here (the disk might be already full), just fallback
+                    // to the object store.
+                    // TODO: add a warning log here
                     if self.resolve_root(location, &result_meta.location) {
                         self.save_get_result(get_result).await.ok();
                     }
@@ -538,7 +541,8 @@ impl CachedObjectStore {
                 }
             }
 
-            // Cache miss — deduplicate concurrent fetches of the same part.
+            // Cache miss, so we need to fetch from the object store.
+            // Read Part — deduplicate concurrent fetches of the same part.
             // The SingleFlight fetches the full part and saves it to cache; each
             // caller then slices out their own range_in_part.
             let bytes = this
@@ -559,16 +563,22 @@ impl CachedObjectStore {
                         )
                         .await?;
 
+                    // Get the cache entry again after successful get so we can cache the part.
                     let cache_entry = if this.resolve_root(&location, &get_result.meta.location) {
                         this.cache_location_for(&location).map(|cache_location| {
                             this.cache_storage
                                 .entry(&cache_location, this.part_size_bytes)
                         })
                     } else {
+                        // If the root resolution fails, we won't be able to derive a canonical cache
+                        // key. Skip saving to cache to avoid poisoning the cache with unsafe keys.
                         None
                     };
 
+                    // Save the head and the part to cache for future accesses. Just read the bytes
+                    // if we still can't derive a canonical cache key.
                     let bytes = if let Some(entry) = cache_entry {
+                        // Save the head and the part to cache for future accesses.
                         let meta = get_result.meta.clone();
                         let attrs = get_result.attributes.clone();
                         let bytes = get_result.bytes().await?;

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -144,6 +144,7 @@ mod rand;
 mod reader;
 mod retention_iterator;
 mod retrying_object_store;
+mod single_flight;
 mod snapshot_manager;
 mod sorted_run_iterator;
 mod sst_builder;

--- a/slatedb/src/single_flight.rs
+++ b/slatedb/src/single_flight.rs
@@ -114,18 +114,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        sync::{
-            atomic::{
-                AtomicUsize,
-                Ordering::{AcqRel, Acquire},
-            },
-            Arc,
+    use std::sync::{
+        atomic::{
+            AtomicUsize,
+            Ordering::{AcqRel, Acquire},
         },
-        time::Duration,
+        Arc,
     };
 
-    use futures::{stream::FuturesUnordered, StreamExt};
+    use tokio::sync::Notify;
 
     use super::*;
 
@@ -133,52 +130,25 @@ mod tests {
     async fn direct_call() {
         let group = SingleFlight::new();
         let result = group
-            .call("key", || async {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-                Ok::<_, ()>("Result".to_string())
-            })
+            .call("key", || async { Ok::<_, ()>("Result".to_string()) })
             .await;
         assert_eq!(result, Ok("Result".to_string()));
     }
 
     #[tokio::test]
     async fn parallel_call() {
-        let call_counter = AtomicUsize::default();
-
-        let group = SingleFlight::new();
-        let futures = FuturesUnordered::new();
-        for _ in 0..10 {
-            futures.push(group.call("key", || async {
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                call_counter.fetch_add(1, AcqRel);
-                Ok::<_, ()>("Result".to_string())
-            }));
-        }
-
-        assert!(
-            futures
-                .all(|out| async move { out == Ok("Result".to_string()) })
-                .await
-        );
-        assert_eq!(
-            call_counter.load(Acquire),
-            1,
-            "future should only be executed once"
-        );
-    }
-
-    #[tokio::test]
-    async fn parallel_call_spawned() {
         let call_counter = Arc::new(AtomicUsize::default());
+        let gate = Arc::new(Notify::new());
 
-        let group = SingleFlight::<&'static str, String>::new();
+        let group = SingleFlight::<&str, String>::new();
         let mut handles = Vec::new();
         for _ in 0..10 {
             let g = group.clone();
             let counter = call_counter.clone();
+            let gate = gate.clone();
             handles.push(tokio::spawn(async move {
                 g.call("key", || async move {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    gate.notified().await;
                     counter.fetch_add(1, AcqRel);
                     Ok::<_, ()>("Result".to_string())
                 })
@@ -186,8 +156,17 @@ mod tests {
             }));
         }
 
+        // Let all tasks register in the map.
+        tokio::task::yield_now().await;
+
+        // Release the single winner.
+        gate.notify_one();
+
         for handle in handles {
-            assert_eq!(handle.await.unwrap(), Ok("Result".to_string()));
+            assert_eq!(
+                handle.await.expect("task panicked"),
+                Ok("Result".to_string())
+            );
         }
         assert_eq!(
             call_counter.load(Acquire),
@@ -200,14 +179,17 @@ mod tests {
     async fn different_keys_are_independent() {
         let counter_a = Arc::new(AtomicUsize::default());
         let counter_b = Arc::new(AtomicUsize::default());
+        let gate_a = Arc::new(Notify::new());
+        let gate_b = Arc::new(Notify::new());
 
         let group = SingleFlight::<&'static str, String>::new();
 
         let g = group.clone();
         let ca = counter_a.clone();
+        let ga = gate_a.clone();
         let handle_a = tokio::spawn(async move {
             g.call("key_a", || async move {
-                tokio::time::sleep(Duration::from_millis(50)).await;
+                ga.notified().await;
                 ca.fetch_add(1, AcqRel);
                 Ok::<_, ()>("A".to_string())
             })
@@ -216,17 +198,25 @@ mod tests {
 
         let g = group.clone();
         let cb = counter_b.clone();
+        let gb = gate_b.clone();
         let handle_b = tokio::spawn(async move {
             g.call("key_b", || async move {
-                tokio::time::sleep(Duration::from_millis(50)).await;
+                gb.notified().await;
                 cb.fetch_add(1, AcqRel);
                 Ok::<_, ()>("B".to_string())
             })
             .await
         });
 
-        assert_eq!(handle_a.await.unwrap(), Ok("A".to_string()));
-        assert_eq!(handle_b.await.unwrap(), Ok("B".to_string()));
+        // Let both tasks register.
+        tokio::task::yield_now().await;
+
+        // Release both independently.
+        gate_a.notify_one();
+        gate_b.notify_one();
+
+        assert_eq!(handle_a.await.expect("task panicked"), Ok("A".to_string()));
+        assert_eq!(handle_b.await.expect("task panicked"), Ok("B".to_string()));
         assert_eq!(counter_a.load(Acquire), 1);
         assert_eq!(counter_b.load(Acquire), 1);
     }
@@ -280,17 +270,23 @@ mod tests {
     async fn error_with_concurrent_waiters() {
         // When the initializer fails, a concurrent waiter gets to retry with its own func.
         let group = SingleFlight::<&str, String>::new();
-        let call_counter = AtomicUsize::default();
+        let call_counter = Arc::new(AtomicUsize::default());
+        let gate = Arc::new(Notify::new());
 
-        let fut_1 = group.call("key", || async {
-            tokio::time::sleep(Duration::from_millis(10)).await;
-            call_counter.fetch_add(1, AcqRel);
+        let counter = call_counter.clone();
+        let g = gate.clone();
+        let fut_1 = group.call("key", || async move {
+            g.notified().await;
+            counter.fetch_add(1, AcqRel);
             Err::<String, _>("fail")
         });
         let fut_2 = group.call("key", || async {
             call_counter.fetch_add(1, AcqRel);
             Ok::<_, &str>("recovered".to_string())
         });
+
+        // Release the first caller so it fails.
+        gate.notify_one();
 
         let (r1, r2) = tokio::join!(fut_1, fut_2);
         assert_eq!(r1, Err("fail"));
@@ -308,10 +304,7 @@ mod tests {
         struct K(i32);
         let group = SingleFlight::new();
         let result = group
-            .call(K(1), || async {
-                tokio::time::sleep(Duration::from_millis(1)).await;
-                Ok::<_, ()>("Result".to_string())
-            })
+            .call(K(1), || async { Ok::<_, ()>("Result".to_string()) })
             .await;
         assert_eq!(result, Ok("Result".to_string()));
     }
@@ -319,38 +312,57 @@ mod tests {
     #[tokio::test]
     async fn late_joiner_shares_result() {
         let group = SingleFlight::<String, String>::new();
+        let gate = Arc::new(Notify::new());
 
-        // Spawn early so it registers in the map while it's running.
+        // Spawn early so it registers in the map while it's blocked on the gate.
         let g = group.clone();
+        let gate_clone = gate.clone();
         let early_handle = tokio::spawn(async move {
-            g.call("key".to_string(), || async {
-                tokio::time::sleep(Duration::from_millis(100)).await;
+            g.call("key".to_string(), || async move {
+                gate_clone.notified().await;
                 Ok::<_, ()>("Result".to_string())
             })
             .await
         });
 
-        // Give early time to register and start sleeping.
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        // Yield so the spawned task registers in the map.
+        tokio::task::yield_now().await;
 
-        // Late caller should find the existing entry and share the result.
-        let late_result = group
-            .call("key".to_string(), || async { panic!("unexpected") })
-            .await;
+        // Late caller finds the existing entry — its func should never run.
+        let late_fut = group.call("key".to_string(), || async { panic!("unexpected") });
+
+        // Release the gate so the first caller completes.
+        gate.notify_one();
+
+        let (early_result, late_result) = tokio::join!(early_handle, late_fut);
+        assert_eq!(
+            early_result.expect("task panicked"),
+            Ok("Result".to_string())
+        );
         assert_eq!(late_result, Ok::<_, ()>("Result".to_string()));
-        assert_eq!(early_handle.await.unwrap(), Ok("Result".to_string()));
     }
 
     #[tokio::test]
     async fn cancel_allows_next_caller_to_proceed() {
         let group = SingleFlight::new();
 
-        // Start a slow computation, then cancel it.
-        let fut_cancel = group.call("key".to_string(), || async {
-            tokio::time::sleep(Duration::from_millis(2000)).await;
-            Ok::<_, ()>("cancelled".to_string())
+        // Start a call that will never complete on its own.
+        let handle = tokio::spawn({
+            let g = group.clone();
+            async move {
+                g.call("key".to_string(), || {
+                    std::future::pending::<Result<String, ()>>()
+                })
+                .await
+            }
         });
-        let _ = tokio::time::timeout(Duration::from_millis(10), fut_cancel).await;
+
+        // Let it register.
+        tokio::task::yield_now().await;
+
+        // Cancel it.
+        handle.abort();
+        let _ = handle.await;
 
         // The next caller should run fresh since the previous was cancelled.
         let result = group
@@ -369,15 +381,14 @@ mod tests {
 
         let g = group.clone();
         let initializer = tokio::spawn(async move {
-            g.call("key".to_string(), || async {
-                tokio::time::sleep(Duration::from_millis(2000)).await;
-                Ok::<_, ()>("slow".to_string())
+            g.call("key".to_string(), || {
+                std::future::pending::<Result<String, ()>>()
             })
             .await
         });
 
         // Let the initializer register.
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        tokio::task::yield_now().await;
 
         // Start a concurrent waiter on the same key.
         let g = group.clone();
@@ -389,33 +400,47 @@ mod tests {
             .await
         });
 
-        // Give the waiter time to register and start waiting.
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        // Let the waiter register and start waiting.
+        tokio::task::yield_now().await;
 
         // Cancel the initializer.
         initializer.abort();
         let _ = initializer.await;
 
         // The waiter should retry and succeed.
-        let result = waiter.await.unwrap();
+        let result = waiter.await.expect("task panicked");
         assert_eq!(result, Ok("retried".to_string()));
     }
 
     #[tokio::test]
-    async fn concurrent_callers_share_slow_result() {
-        // Two concurrent callers via join! — second should not run its func.
-        let group = SingleFlight::new();
+    async fn concurrent_callers_share_result() {
+        // Two concurrent callers — second should not run its func.
+        let group = SingleFlight::<String, String>::new();
+        let gate = Arc::new(Notify::new());
 
-        let begin = tokio::time::Instant::now();
-        let fut_1 = group.call("key".to_string(), || async {
-            tokio::time::sleep(Duration::from_millis(200)).await;
-            Ok::<_, ()>("Result1".to_string())
+        // Spawn the first caller so it registers and blocks on the gate.
+        let g = group.clone();
+        let gate_clone = gate.clone();
+        let handle = tokio::spawn(async move {
+            g.call("key".to_string(), || async move {
+                gate_clone.notified().await;
+                Ok::<_, ()>("Result1".to_string())
+            })
+            .await
         });
+
+        // Let the spawned task register in the map.
+        tokio::task::yield_now().await;
+
+        // Second caller finds the existing entry — its func should never run.
         let fut_2 = group.call("key".to_string(), || async { panic!("should not execute") });
-        let (v1, v2) = tokio::join!(fut_1, fut_2);
-        assert_eq!(v1, Ok("Result1".to_string()));
+
+        // Release the gate so the first caller completes.
+        gate.notify_one();
+
+        let (v1, v2) = tokio::join!(handle, fut_2);
+        assert_eq!(v1.expect("task panicked"), Ok("Result1".to_string()));
         assert_eq!(v2, Ok::<_, ()>("Result1".to_string()));
-        assert!(begin.elapsed() >= Duration::from_millis(200));
     }
 
     #[tokio::test]
@@ -439,11 +464,23 @@ mod tests {
     async fn map_is_cleaned_up_after_cancel() {
         let group = SingleFlight::new();
 
-        let fut = group.call("key".to_string(), || async {
-            tokio::time::sleep(Duration::from_millis(2000)).await;
-            Ok::<_, ()>("never".to_string())
+        // Start a call that will never complete on its own.
+        let handle = tokio::spawn({
+            let g = group.clone();
+            async move {
+                g.call("key".to_string(), || {
+                    std::future::pending::<Result<String, ()>>()
+                })
+                .await
+            }
         });
-        let _ = tokio::time::timeout(Duration::from_millis(10), fut).await;
+
+        // Let it register.
+        tokio::task::yield_now().await;
+
+        // Cancel it.
+        handle.abort();
+        let _ = handle.await;
 
         // The internal map should be empty after cancellation.
         let in_flight = group.in_flight.lock();

--- a/slatedb/src/single_flight.rs
+++ b/slatedb/src/single_flight.rs
@@ -103,7 +103,7 @@ where
         let value = guard
             .cell
             .as_ref()
-            .unwrap()
+            .expect("cell is always Some until Drop")
             .get_or_try_init(func)
             .await
             .cloned();

--- a/slatedb/src/single_flight.rs
+++ b/slatedb/src/single_flight.rs
@@ -1,0 +1,455 @@
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    future::Future,
+    hash::Hash,
+    sync::Arc,
+};
+
+use parking_lot::Mutex as SyncMutex;
+use tokio::sync::OnceCell;
+
+type InFlightMap<K, T> = Arc<SyncMutex<HashMap<K, Arc<OnceCell<T>>>>>;
+
+// EntryGuard is an RAII handle that removes the map entry on drop once no other
+// callers hold a reference to it. This keeps the map from growing unboundedly and
+// ensures that after all callers for a key complete (or are cancelled), subsequent
+// calls start fresh rather than observing stale state.
+struct EntryGuard<'a, K: Hash + Eq, T> {
+    cell: Option<Arc<OnceCell<T>>>,
+    key: &'a K,
+    in_flight: &'a InFlightMap<K, T>,
+}
+
+impl<'a, K, T> Drop for EntryGuard<'a, K, T>
+where
+    K: Hash + Eq,
+{
+    fn drop(&mut self) {
+        let mut in_flight = self.in_flight.lock();
+        // Drop our Arc *before* checking the count so we don't count ourselves.
+        drop(self.cell.take());
+        // If the only remaining Arc is the one inside the map itself, nobody else
+        // is waiting on this cell anymore—safe to clean up.
+        if in_flight
+            .get(self.key)
+            .is_some_and(|cell| Arc::strong_count(cell) == 1)
+        {
+            in_flight.remove(self.key);
+        }
+    }
+}
+
+/// SingleFlight deduplicates concurrent calls for the same key, ensuring only one
+/// execution is in-flight at a time while sharing the result with all waiters.
+#[derive(Debug, Clone)]
+pub(crate) struct SingleFlight<K, T> {
+    in_flight: InFlightMap<K, T>,
+}
+
+impl<K, T> Default for SingleFlight<K, T> {
+    fn default() -> Self {
+        Self {
+            in_flight: Default::default(),
+        }
+    }
+}
+
+impl<K, T> SingleFlight<K, T>
+where
+    K: Hash + Eq + Clone,
+{
+    /// Create a new SingleFlight group.
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Execute and return the value for a given function, making sure that only one
+    /// operation is in-flight at a given moment. If a duplicate call comes in, that caller will
+    /// wait until the original call completes and return the same value.
+    pub(crate) async fn call<F, Fut, E>(&self, key: K, func: F) -> Result<T, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+        T: Clone,
+    {
+        // Acquire (or create) the shared cell for this key while briefly holding the lock.
+        // The lock is released before any async work begins.
+        let guard = {
+            let mut in_flight = self.in_flight.lock();
+            match in_flight.entry(key.clone()) {
+                // Another caller is already in-flight for this key—share their cell.
+                Entry::Occupied(occupied_entry) => EntryGuard {
+                    cell: Some(occupied_entry.get().clone()),
+                    key: &key,
+                    in_flight: &self.in_flight,
+                },
+                // First caller for this key—insert a fresh OnceCell for others to find.
+                Entry::Vacant(vacant_entry) => {
+                    let e = Arc::new(OnceCell::new());
+                    vacant_entry.insert(e.clone());
+                    EntryGuard {
+                        cell: Some(e),
+                        key: &key,
+                        in_flight: &self.in_flight,
+                    }
+                }
+            }
+        };
+
+        // get_or_try_init ensures only one caller runs `func`; others await the result.
+        // On error, the OnceCell remains uninitialized so the next waiter can retry
+        // with its own func (important for transient failures).
+        let value = guard
+            .cell
+            .as_ref()
+            .unwrap()
+            .get_or_try_init(func)
+            .await
+            .cloned();
+
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{
+                AtomicUsize,
+                Ordering::{AcqRel, Acquire},
+            },
+            Arc,
+        },
+        time::Duration,
+    };
+
+    use futures::{stream::FuturesUnordered, StreamExt};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn direct_call() {
+        let group = SingleFlight::new();
+        let result = group
+            .call("key", || async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok::<_, ()>("Result".to_string())
+            })
+            .await;
+        assert_eq!(result, Ok("Result".to_string()));
+    }
+
+    #[tokio::test]
+    async fn parallel_call() {
+        let call_counter = AtomicUsize::default();
+
+        let group = SingleFlight::new();
+        let futures = FuturesUnordered::new();
+        for _ in 0..10 {
+            futures.push(group.call("key", || async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                call_counter.fetch_add(1, AcqRel);
+                Ok::<_, ()>("Result".to_string())
+            }));
+        }
+
+        assert!(
+            futures
+                .all(|out| async move { out == Ok("Result".to_string()) })
+                .await
+        );
+        assert_eq!(
+            call_counter.load(Acquire),
+            1,
+            "future should only be executed once"
+        );
+    }
+
+    #[tokio::test]
+    async fn parallel_call_spawned() {
+        let call_counter = Arc::new(AtomicUsize::default());
+
+        let group = SingleFlight::<&'static str, String>::new();
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let g = group.clone();
+            let counter = call_counter.clone();
+            handles.push(tokio::spawn(async move {
+                g.call("key", || async move {
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    counter.fetch_add(1, AcqRel);
+                    Ok::<_, ()>("Result".to_string())
+                })
+                .await
+            }));
+        }
+
+        for handle in handles {
+            assert_eq!(handle.await.unwrap(), Ok("Result".to_string()));
+        }
+        assert_eq!(
+            call_counter.load(Acquire),
+            1,
+            "future should only be executed once"
+        );
+    }
+
+    #[tokio::test]
+    async fn different_keys_are_independent() {
+        let counter_a = Arc::new(AtomicUsize::default());
+        let counter_b = Arc::new(AtomicUsize::default());
+
+        let group = SingleFlight::<&'static str, String>::new();
+
+        let g = group.clone();
+        let ca = counter_a.clone();
+        let handle_a = tokio::spawn(async move {
+            g.call("key_a", || async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                ca.fetch_add(1, AcqRel);
+                Ok::<_, ()>("A".to_string())
+            })
+            .await
+        });
+
+        let g = group.clone();
+        let cb = counter_b.clone();
+        let handle_b = tokio::spawn(async move {
+            g.call("key_b", || async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                cb.fetch_add(1, AcqRel);
+                Ok::<_, ()>("B".to_string())
+            })
+            .await
+        });
+
+        assert_eq!(handle_a.await.unwrap(), Ok("A".to_string()));
+        assert_eq!(handle_b.await.unwrap(), Ok("B".to_string()));
+        assert_eq!(counter_a.load(Acquire), 1);
+        assert_eq!(counter_b.load(Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn sequential_calls_run_fresh() {
+        // After a call completes, a new call to the same key should execute its own func.
+        let call_counter = AtomicUsize::default();
+
+        let group = SingleFlight::new();
+
+        let result = group
+            .call("key", || async {
+                call_counter.fetch_add(1, AcqRel);
+                Ok::<_, ()>("first".to_string())
+            })
+            .await;
+        assert_eq!(result, Ok("first".to_string()));
+
+        let result = group
+            .call("key", || async {
+                call_counter.fetch_add(1, AcqRel);
+                Ok::<_, ()>("second".to_string())
+            })
+            .await;
+        assert_eq!(result, Ok("second".to_string()));
+
+        assert_eq!(
+            call_counter.load(Acquire),
+            2,
+            "each sequential call should execute independently"
+        );
+    }
+
+    #[tokio::test]
+    async fn error_propagates_and_next_caller_retries() {
+        let group = SingleFlight::<&str, String>::new();
+
+        // First call fails.
+        let result: Result<String, &str> = group.call("key", || async { Err("oops") }).await;
+        assert_eq!(result, Err("oops"));
+
+        // Next call should run its own func (not get the cached error).
+        let result = group
+            .call("key", || async { Ok::<_, &str>("recovered".to_string()) })
+            .await;
+        assert_eq!(result, Ok("recovered".to_string()));
+    }
+
+    #[tokio::test]
+    async fn error_with_concurrent_waiters() {
+        // When the initializer fails, a concurrent waiter gets to retry with its own func.
+        let group = SingleFlight::<&str, String>::new();
+        let call_counter = AtomicUsize::default();
+
+        let fut_1 = group.call("key", || async {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            call_counter.fetch_add(1, AcqRel);
+            Err::<String, _>("fail")
+        });
+        let fut_2 = group.call("key", || async {
+            call_counter.fetch_add(1, AcqRel);
+            Ok::<_, &str>("recovered".to_string())
+        });
+
+        let (r1, r2) = tokio::join!(fut_1, fut_2);
+        assert_eq!(r1, Err("fail"));
+        assert_eq!(r2, Ok("recovered".to_string()));
+        assert_eq!(
+            call_counter.load(Acquire),
+            2,
+            "both funcs should have been called since the first failed"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_with_custom_key() {
+        #[derive(Clone, PartialEq, Eq, Hash)]
+        struct K(i32);
+        let group = SingleFlight::new();
+        let result = group
+            .call(K(1), || async {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                Ok::<_, ()>("Result".to_string())
+            })
+            .await;
+        assert_eq!(result, Ok("Result".to_string()));
+    }
+
+    #[tokio::test]
+    async fn late_joiner_shares_result() {
+        let group = SingleFlight::<String, String>::new();
+
+        // Spawn early so it registers in the map while it's running.
+        let g = group.clone();
+        let early_handle = tokio::spawn(async move {
+            g.call("key".to_string(), || async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                Ok::<_, ()>("Result".to_string())
+            })
+            .await
+        });
+
+        // Give early time to register and start sleeping.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Late caller should find the existing entry and share the result.
+        let late_result = group
+            .call("key".to_string(), || async { panic!("unexpected") })
+            .await;
+        assert_eq!(late_result, Ok::<_, ()>("Result".to_string()));
+        assert_eq!(early_handle.await.unwrap(), Ok("Result".to_string()));
+    }
+
+    #[tokio::test]
+    async fn cancel_allows_next_caller_to_proceed() {
+        let group = SingleFlight::new();
+
+        // Start a slow computation, then cancel it.
+        let fut_cancel = group.call("key".to_string(), || async {
+            tokio::time::sleep(Duration::from_millis(2000)).await;
+            Ok::<_, ()>("cancelled".to_string())
+        });
+        let _ = tokio::time::timeout(Duration::from_millis(10), fut_cancel).await;
+
+        // The next caller should run fresh since the previous was cancelled.
+        let result = group
+            .call("key".to_string(), || async {
+                Ok::<_, ()>("fresh".to_string())
+            })
+            .await;
+        assert_eq!(result, Ok("fresh".to_string()));
+    }
+
+    #[tokio::test]
+    async fn cancel_with_concurrent_waiter() {
+        // If the initializer is cancelled but another caller is also waiting,
+        // the waiter should get to retry.
+        let group = SingleFlight::<String, String>::new();
+
+        let g = group.clone();
+        let initializer = tokio::spawn(async move {
+            g.call("key".to_string(), || async {
+                tokio::time::sleep(Duration::from_millis(2000)).await;
+                Ok::<_, ()>("slow".to_string())
+            })
+            .await
+        });
+
+        // Let the initializer register.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Start a concurrent waiter on the same key.
+        let g = group.clone();
+        let waiter = tokio::spawn(async move {
+            g.call("key".to_string(), || async {
+                // This func runs if the waiter gets to retry after cancellation.
+                Ok::<_, ()>("retried".to_string())
+            })
+            .await
+        });
+
+        // Give the waiter time to register and start waiting.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        // Cancel the initializer.
+        initializer.abort();
+        let _ = initializer.await;
+
+        // The waiter should retry and succeed.
+        let result = waiter.await.unwrap();
+        assert_eq!(result, Ok("retried".to_string()));
+    }
+
+    #[tokio::test]
+    async fn concurrent_callers_share_slow_result() {
+        // Two concurrent callers via join! — second should not run its func.
+        let group = SingleFlight::new();
+
+        let begin = tokio::time::Instant::now();
+        let fut_1 = group.call("key".to_string(), || async {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok::<_, ()>("Result1".to_string())
+        });
+        let fut_2 = group.call("key".to_string(), || async { panic!("should not execute") });
+        let (v1, v2) = tokio::join!(fut_1, fut_2);
+        assert_eq!(v1, Ok("Result1".to_string()));
+        assert_eq!(v2, Ok::<_, ()>("Result1".to_string()));
+        assert!(begin.elapsed() >= Duration::from_millis(200));
+    }
+
+    #[tokio::test]
+    async fn map_is_cleaned_up_after_completion() {
+        let group = SingleFlight::new();
+
+        // Run a call to completion.
+        let _ = group
+            .call("key", || async { Ok::<_, ()>("done".to_string()) })
+            .await;
+
+        // The internal map should be empty.
+        let in_flight = group.in_flight.lock();
+        assert!(
+            in_flight.is_empty(),
+            "map should be empty after all callers complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn map_is_cleaned_up_after_cancel() {
+        let group = SingleFlight::new();
+
+        let fut = group.call("key".to_string(), || async {
+            tokio::time::sleep(Duration::from_millis(2000)).await;
+            Ok::<_, ()>("never".to_string())
+        });
+        let _ = tokio::time::timeout(Duration::from_millis(10), fut).await;
+
+        // The internal map should be empty after cancellation.
+        let in_flight = group.in_flight.lock();
+        assert!(
+            in_flight.is_empty(),
+            "map should be empty after cancellation"
+        );
+    }
+}

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -778,59 +778,70 @@ impl ObjectStore for FlakyObjectStore {
     }
 }
 
-/// A gate-controlled ObjectStore wrapper for deterministic concurrency testing.
+/// A per-operation gate for deterministic concurrency testing.
 ///
-/// Instead of using time-based delays, this store blocks `get_opts` and `head`
-/// callers at an explicit gate. Tests control exactly when callers proceed and
-/// whether they see a success or an injected error.
-///
-/// # Usage pattern (mirrors `single_flight.rs` tests)
-/// ```ignore
-/// let inner = Arc::new(InMemory::new());
-/// let gated = Arc::new(GatedObjectStore::new(inner));
-///
-/// // Spawn concurrent callers (they block at the gate inside get_opts)
-/// // ...
-///
-/// // Wait until the expected number of callers have arrived at the gate
-/// gated.wait_for_arrivals(1).await;
-///
-/// // Release them — success path
-/// gated.release();
-///
-/// // Or: inject failure before releasing
-/// gated.set_should_fail(true);
-/// gated.release();
-/// ```
-#[derive(Debug)]
-pub(crate) struct GatedObjectStore {
-    inner: Arc<dyn ObjectStore>,
-    /// When true, callers blocked at the gate are allowed to proceed.
-    gate_open: std::sync::atomic::AtomicBool,
-    /// Tracks how many callers have arrived at the gate.
+/// Each gate starts **open** (pass-through). Call [`close()`](Self::close) to block
+/// callers, then [`release()`](Self::release) to let them proceed. Use
+/// [`set_error`](Self::set_error) before releasing to inject a specific error.
+pub(crate) struct Gate {
+    open: std::sync::atomic::AtomicBool,
     arrival_count: AtomicUsize,
-    /// If true, `get_opts`/`head` return an error after the gate opens.
-    should_fail: std::sync::atomic::AtomicBool,
+    /// If `Some`, callers receive the produced error after the gate opens.
+    error_fn: std::sync::Mutex<Option<Box<dyn Fn() -> object_store::Error + Send + Sync>>>,
 }
 
-impl GatedObjectStore {
-    pub(crate) fn new(inner: Arc<dyn ObjectStore>) -> Self {
+impl fmt::Debug for Gate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Gate")
+            .field("open", &self.open)
+            .field("arrival_count", &self.arrival_count)
+            .field("has_error", &self.error_fn.lock().unwrap().is_some())
+            .finish()
+    }
+}
+
+impl Default for Gate {
+    fn default() -> Self {
         Self {
-            inner,
-            gate_open: std::sync::atomic::AtomicBool::new(false),
+            open: std::sync::atomic::AtomicBool::new(true),
             arrival_count: AtomicUsize::new(0),
-            should_fail: std::sync::atomic::AtomicBool::new(false),
+            error_fn: std::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl Gate {
+    /// Create a gate that starts closed (callers will block).
+    #[allow(dead_code)]
+    pub(crate) fn closed() -> Self {
+        Self {
+            open: std::sync::atomic::AtomicBool::new(false),
+            ..Default::default()
         }
     }
 
-    /// Configure whether callers should see an error after the gate opens.
-    pub(crate) fn set_should_fail(&self, fail: bool) {
-        self.should_fail.store(fail, Ordering::Release);
+    /// Close the gate so subsequent callers block.
+    pub(crate) fn close(&self) {
+        self.open.store(false, Ordering::Release);
     }
 
-    /// Release all callers currently blocked at the gate.
+    /// Open the gate, allowing all blocked (and future) callers to proceed.
     pub(crate) fn release(&self) {
-        self.gate_open.store(true, Ordering::Release);
+        self.open.store(true, Ordering::Release);
+    }
+
+    /// Set an error factory. After the gate opens, callers will receive the
+    /// error produced by `f` instead of proceeding to the inner store.
+    pub(crate) fn set_error<F>(&self, f: F)
+    where
+        F: Fn() -> object_store::Error + Send + Sync + 'static,
+    {
+        *self.error_fn.lock().unwrap() = Some(Box::new(f));
+    }
+
+    /// Clear any previously set error, restoring success behavior.
+    pub(crate) fn clear_error(&self) {
+        *self.error_fn.lock().unwrap() = None;
     }
 
     /// Wait until at least `n` callers have arrived at the gate.
@@ -840,33 +851,82 @@ impl GatedObjectStore {
         }
     }
 
-    /// How many callers are currently blocked at the gate.
+    /// How many callers have arrived at the gate (cumulative).
     pub(crate) fn arrivals(&self) -> usize {
         self.arrival_count.load(Ordering::Acquire)
     }
 
-    /// Block at the gate until released by the test.
-    async fn wait_at_gate(&self) -> object_store::Result<()> {
-        // Signal arrival so the test knows we are blocked.
+    /// Block at this gate until released. Returns the configured error (if any)
+    /// or `Ok(())` to let the caller proceed to the inner store.
+    async fn wait(&self) -> object_store::Result<()> {
+        // Signal arrival.
         self.arrival_count.fetch_add(1, Ordering::AcqRel);
 
-        // Spin-yield until the gate is opened. This is race-free: no
-        // notification can be "missed" since we just check an atomic flag.
-        while !self.gate_open.load(Ordering::Acquire) {
+        // Spin-yield until the gate is opened.
+        while !self.open.load(Ordering::Acquire) {
             tokio::task::yield_now().await;
         }
 
-        // Check outcome.
-        if self.should_fail.load(Ordering::Acquire) {
-            Err(object_store::Error::Generic {
-                store: "GatedObjectStore",
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "injected gate failure",
-                )),
-            })
+        // Check if an error is configured.
+        if let Some(error_fn) = self.error_fn.lock().unwrap().as_ref() {
+            Err(error_fn())
         } else {
             Ok(())
+        }
+    }
+}
+
+/// A gate-controlled ObjectStore wrapper for deterministic concurrency testing.
+///
+/// Each ObjectStore method has its own [`Gate`] that can be independently closed,
+/// released, and configured to inject errors. Gates default to **open** (pass-through).
+///
+/// # Usage pattern (mirrors `single_flight.rs` tests)
+/// ```ignore
+/// let inner = Arc::new(InMemory::new());
+/// let gated = Arc::new(GatedObjectStore::new(inner));
+///
+/// // Close the gate for the method under test.
+/// gated.get_opts_gate.close();
+///
+/// // Spawn concurrent callers (they block at the gate inside get_opts)
+/// // ...
+///
+/// // Wait until the expected number of callers have arrived.
+/// gated.get_opts_gate.wait_for_arrivals(1).await;
+///
+/// // Release them — success path.
+/// gated.get_opts_gate.release();
+///
+/// // Or: inject failure before releasing.
+/// gated.get_opts_gate.set_should_fail(true);
+/// gated.get_opts_gate.release();
+/// ```
+#[derive(Debug)]
+pub(crate) struct GatedObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    pub(crate) get_opts_gate: Gate,
+    pub(crate) head_gate: Gate,
+    pub(crate) put_opts_gate: Gate,
+    pub(crate) put_multipart_gate: Gate,
+    pub(crate) put_multipart_opts_gate: Gate,
+    pub(crate) delete_gate: Gate,
+    pub(crate) copy_gate: Gate,
+    pub(crate) rename_gate: Gate,
+}
+
+impl GatedObjectStore {
+    pub(crate) fn new(inner: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            inner,
+            get_opts_gate: Gate::default(),
+            head_gate: Gate::default(),
+            put_opts_gate: Gate::default(),
+            put_multipart_gate: Gate::default(),
+            put_multipart_opts_gate: Gate::default(),
+            delete_gate: Gate::default(),
+            copy_gate: Gate::default(),
+            rename_gate: Gate::default(),
         }
     }
 }
@@ -884,12 +944,12 @@ impl ObjectStore for GatedObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
-        self.wait_at_gate().await?;
+        self.get_opts_gate.wait().await?;
         self.inner.get_opts(location, options).await
     }
 
     async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        self.wait_at_gate().await?;
+        self.head_gate.wait().await?;
         self.inner.head(location).await
     }
 
@@ -899,6 +959,7 @@ impl ObjectStore for GatedObjectStore {
         payload: PutPayload,
         opts: OS_PutOptions,
     ) -> object_store::Result<PutResult> {
+        self.put_opts_gate.wait().await?;
         self.inner.put_opts(location, payload, opts).await
     }
 
@@ -906,6 +967,7 @@ impl ObjectStore for GatedObjectStore {
         &self,
         location: &Path,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.put_multipart_gate.wait().await?;
         self.inner.put_multipart(location).await
     }
 
@@ -914,10 +976,12 @@ impl ObjectStore for GatedObjectStore {
         location: &Path,
         opts: object_store::PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.put_multipart_opts_gate.wait().await?;
         self.inner.put_multipart_opts(location, opts).await
     }
 
     async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        self.delete_gate.wait().await?;
         self.inner.delete(location).await
     }
 
@@ -938,18 +1002,22 @@ impl ObjectStore for GatedObjectStore {
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.copy_gate.wait().await?;
         self.inner.copy(from, to).await
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.rename_gate.wait().await?;
         self.inner.rename(from, to).await
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.copy_gate.wait().await?;
         self.inner.copy_if_not_exists(from, to).await
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.rename_gate.wait().await?;
         self.inner.rename_if_not_exists(from, to).await
     }
 }

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -778,40 +778,118 @@ impl ObjectStore for FlakyObjectStore {
     }
 }
 
-/// An ObjectStore wrapper that injects an artificial delay into `get_opts` and `head`,
-/// ensuring that concurrent callers truly overlap in time so deduplication logic
-/// (e.g. SingleFlight) is deterministically exercised.
+/// A gate-controlled ObjectStore wrapper for deterministic concurrency testing.
+///
+/// Instead of using time-based delays, this store blocks `get_opts` and `head`
+/// callers at an explicit gate. Tests control exactly when callers proceed and
+/// whether they see a success or an injected error.
+///
+/// # Usage pattern (mirrors `single_flight.rs` tests)
+/// ```ignore
+/// let inner = Arc::new(InMemory::new());
+/// let gated = Arc::new(GatedObjectStore::new(inner));
+///
+/// // Spawn concurrent callers (they block at the gate inside get_opts)
+/// // ...
+///
+/// // Wait until the expected number of callers have arrived at the gate
+/// gated.wait_for_arrivals(1).await;
+///
+/// // Release them — success path
+/// gated.release();
+///
+/// // Or: inject failure before releasing
+/// gated.set_should_fail(true);
+/// gated.release();
+/// ```
 #[derive(Debug)]
-pub(crate) struct SlowObjectStore {
+pub(crate) struct GatedObjectStore {
     inner: Arc<dyn ObjectStore>,
-    delay: Duration,
+    /// When true, callers blocked at the gate are allowed to proceed.
+    gate_open: std::sync::atomic::AtomicBool,
+    /// Tracks how many callers have arrived at the gate.
+    arrival_count: AtomicUsize,
+    /// If true, `get_opts`/`head` return an error after the gate opens.
+    should_fail: std::sync::atomic::AtomicBool,
 }
 
-impl SlowObjectStore {
-    pub(crate) fn new(inner: Arc<dyn ObjectStore>, delay: Duration) -> Self {
-        Self { inner, delay }
+impl GatedObjectStore {
+    pub(crate) fn new(inner: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            inner,
+            gate_open: std::sync::atomic::AtomicBool::new(false),
+            arrival_count: AtomicUsize::new(0),
+            should_fail: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Configure whether callers should see an error after the gate opens.
+    pub(crate) fn set_should_fail(&self, fail: bool) {
+        self.should_fail.store(fail, Ordering::Release);
+    }
+
+    /// Release all callers currently blocked at the gate.
+    pub(crate) fn release(&self) {
+        self.gate_open.store(true, Ordering::Release);
+    }
+
+    /// Wait until at least `n` callers have arrived at the gate.
+    pub(crate) async fn wait_for_arrivals(&self, n: usize) {
+        while self.arrival_count.load(Ordering::Acquire) < n {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// How many callers are currently blocked at the gate.
+    pub(crate) fn arrivals(&self) -> usize {
+        self.arrival_count.load(Ordering::Acquire)
+    }
+
+    /// Block at the gate until released by the test.
+    async fn wait_at_gate(&self) -> object_store::Result<()> {
+        // Signal arrival so the test knows we are blocked.
+        self.arrival_count.fetch_add(1, Ordering::AcqRel);
+
+        // Spin-yield until the gate is opened. This is race-free: no
+        // notification can be "missed" since we just check an atomic flag.
+        while !self.gate_open.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+
+        // Check outcome.
+        if self.should_fail.load(Ordering::Acquire) {
+            Err(object_store::Error::Generic {
+                store: "GatedObjectStore",
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "injected gate failure",
+                )),
+            })
+        } else {
+            Ok(())
+        }
     }
 }
 
-impl fmt::Display for SlowObjectStore {
+impl fmt::Display for GatedObjectStore {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "SlowObjectStore({})", self.inner)
+        write!(f, "GatedObjectStore({})", self.inner)
     }
 }
 
 #[async_trait]
-impl ObjectStore for SlowObjectStore {
+impl ObjectStore for GatedObjectStore {
     async fn get_opts(
         &self,
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
-        tokio::time::sleep(self.delay).await;
+        self.wait_at_gate().await?;
         self.inner.get_opts(location, options).await
     }
 
     async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        tokio::time::sleep(self.delay).await;
+        self.wait_at_gate().await?;
         self.inner.head(location).await
     }
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -843,10 +843,7 @@ impl ObjectStore for SlowObjectStore {
         self.inner.delete(location).await
     }
 
-    fn list(
-        &self,
-        prefix: Option<&Path>,
-    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
         self.inner.list(prefix)
     }
 
@@ -858,10 +855,7 @@ impl ObjectStore for SlowObjectStore {
         self.inner.list_with_offset(prefix, offset)
     }
 
-    async fn list_with_delimiter(
-        &self,
-        prefix: Option<&Path>,
-    ) -> object_store::Result<ListResult> {
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
         self.inner.list_with_delimiter(prefix).await
     }
 
@@ -881,7 +875,6 @@ impl ObjectStore for SlowObjectStore {
         self.inner.rename_if_not_exists(from, to).await
     }
 }
-
 
 pub(crate) struct StringConcatMergeOperator;
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -778,6 +778,111 @@ impl ObjectStore for FlakyObjectStore {
     }
 }
 
+/// An ObjectStore wrapper that injects an artificial delay into `get_opts` and `head`,
+/// ensuring that concurrent callers truly overlap in time so deduplication logic
+/// (e.g. SingleFlight) is deterministically exercised.
+#[derive(Debug)]
+pub(crate) struct SlowObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    delay: Duration,
+}
+
+impl SlowObjectStore {
+    pub(crate) fn new(inner: Arc<dyn ObjectStore>, delay: Duration) -> Self {
+        Self { inner, delay }
+    }
+}
+
+impl fmt::Display for SlowObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "SlowObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for SlowObjectStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        tokio::time::sleep(self.delay).await;
+        self.inner.head(location).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: OS_PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&Path>,
+    ) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.rename(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        self.inner.rename_if_not_exists(from, to).await
+    }
+}
+
+
 pub(crate) struct StringConcatMergeOperator;
 
 impl MergeOperator for StringConcatMergeOperator {


### PR DESCRIPTION
## Summary

I found the thundering herd problem in my own tests. It would even cause up to 80% kernal cpu usage. 

https://github.com/slatedb/slatedb/pull/1564 I saw another pr in relation to this issue, but I think there are still some underlying issues in its implementation that this pr address. Like how the OnceCell is removed from the map. It doesn't handle drops.

AI Summary:
### Summary

Introduces a `SingleFlight` utility and applies it to `CachedObjectStore` to prevent thundering-herd behavior when multiple tasks concurrently request the same uncached object. After a local cache miss, only one task now performs the remote fetch while others await the shared result.

### Motivation

When many readers concurrently access the same uncached SST file (e.g. during compaction or after a cold start), each cache miss previously triggered an independent GET request to the object store. This wastes bandwidth, increases latency under contention, and can trigger rate limits on cloud storage backends.

### Changes

**New: `slatedb/src/single_flight.rs`**

A lightweight single-flight / call-coalescing primitive (based on `singleflight-async`, MIT/Apache-2.0). Key design points:

- `OnceCell`-backed: the first caller initializes; concurrent callers await the same cell via `get_or_try_init`.
- Errors are not cached — on failure the cell remains uninitialized, allowing the next waiter to retry with its own closure.
- RAII cleanup (`EntryGuard`) removes map entries once all callers complete or are cancelled, preventing unbounded growth.
- Comprehensive test coverage: parallel calls, cancellation, error retry, sequential freshness, and map cleanup.

**Modified: `slatedb/src/cached_object_store/object_store.rs`**

Three `SingleFlight` instances added to `CachedObjectStore`:

| Field | Key | Deduplicates |
|-------|-----|--------------|
| `head_flights` | `Path` | Concurrent HEAD requests after cache miss |
| `prefetch_flights` | `Path` | Concurrent prefetch/GET+save in `maybe_prefetch_range` |
| `part_flights` | `(Path, PartID)` | Concurrent individual part fetches in `read_part` |

In each case the pattern is: check local cache → on miss, enter SingleFlight → one winner fetches from the object store and saves to cache → all waiters share the result.

### Testing

All existing `cached_object_store` and `single_flight` tests pass. The SingleFlight module includes 14 dedicated tests covering the happy path, concurrency, error propagation, cancellation, and cleanup invariants.


## Changes

- added slatedb/src/single_flight.rs and updated slatedb/src/cached_object_store/object_store.rs to inline requests to object_store.

## Notes for Reviewers

Theres unit tests around the correctness of SingleFlight, but the more eyes there the better. The code updates in object_store are mainly reusing the same code in conjunction with SingleFlight. Also if there's anything I missed in terms of correctness for the caching keys.

Also there's probably an optimization to make it so that we eliminate the small race condition between cache check and SingleFlight fetch which would still allow at back to back requests, but that is probably not worth the overhead. 

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
