### PR TITLE
Attach SST path to ChecksumMismatch errors

### DIFF
--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -426,7 +426,7 @@ mod tests {
         .await
         .unwrap();
 
-        iter.invalidated_error = Some(SlateDBError::ChecksumMismatch);
+        iter.invalidated_error = Some(SlateDBError::ChecksumMismatch { path: None });
 
         let result = iter.next().await;
         let err = result.expect_err("Failed to return invalidated iterator");

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -18,8 +18,8 @@ pub(crate) enum SlateDBError {
     #[error("io error")]
     IoError(#[from] Arc<std::io::Error>),
 
-    #[error("checksum mismatch")]
-    ChecksumMismatch,
+    #[error("checksum mismatch{}", .path.as_ref().map(|p| format!(" in {p}")).unwrap_or_default())]
+    ChecksumMismatch { path: Option<Path> },
 
     #[error("empty SSTable")]
     EmptySSTable,
@@ -245,6 +245,17 @@ pub(crate) enum SlateDBError {
 
     #[error("unexpected tombstone encountered where a value was expected")]
     UnexpectedTombstone,
+}
+
+impl SlateDBError {
+    pub(crate) fn with_path(self, path: &Path) -> Self {
+        match self {
+            SlateDBError::ChecksumMismatch { path: None } => SlateDBError::ChecksumMismatch {
+                path: Some(path.clone()),
+            },
+            other => other,
+        }
+    }
 }
 
 impl From<TransactionalObjectError> for SlateDBError {
@@ -560,7 +571,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::EmptyBlockMeta => Error::data(msg),
             SlateDBError::InvalidFilterBlock => Error::data(msg),
             SlateDBError::EmptySSTable => Error::data(msg),
-            SlateDBError::ChecksumMismatch => Error::data(msg),
+            SlateDBError::ChecksumMismatch { .. } => Error::data(msg),
             SlateDBError::CloneExternalDbMissing => Error::data(msg),
             SlateDBError::CloneIncorrectExternalDbCheckpoint { .. } => Error::data(msg),
             SlateDBError::CloneIncorrectFinalCheckpoint { .. } => Error::data(msg),

--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -212,7 +212,7 @@ impl SsTableInfo {
         let data = raw_info.slice(..raw_info.len() - 4).clone();
         let checksum = raw_info.slice(raw_info.len() - 4..).get_u32();
         if checksum != crc32fast::hash(&data) {
-            return Err(SlateDBError::ChecksumMismatch);
+            return Err(SlateDBError::ChecksumMismatch { path: None });
         }
 
         let info = sst_codec.decode(&data)?;
@@ -1008,7 +1008,7 @@ impl SsTableFormat {
         let checksum = crc32fast::hash(&data_bytes);
         let stored_checksum = checksum_bytes.get_u32();
         if checksum != stored_checksum {
-            return Err(SlateDBError::ChecksumMismatch);
+            return Err(SlateDBError::ChecksumMismatch { path: None });
         }
         Ok(data_bytes)
     }

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -970,7 +970,7 @@ mod tests {
 
         assert!(matches!(
             format.validate_checksum(corrupted_bytes.into()),
-            Err(SlateDBError::ChecksumMismatch)
+            Err(SlateDBError::ChecksumMismatch { .. })
         ));
     }
 

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -377,7 +377,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(id);
         let path = self.path(id);
         let obj = ReadOnlyObject { object_store, path };
-        let (info, version) = self.sst_format.read_info_and_version(&obj).await?;
+        let (info, version) = self
+            .sst_format
+            .read_info_and_version(&obj)
+            .await
+            .map_err(|e| e.with_path(&obj.path))?;
         Ok(SsTableHandle::new(*id, version, info))
     }
 
@@ -386,7 +390,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(id);
         let path = self.path(id);
         let obj = ReadOnlyObject { object_store, path };
-        let (_, version) = self.sst_format.read_info_and_version(&obj).await?;
+        let (_, version) = self
+            .sst_format
+            .read_info_and_version(&obj)
+            .await
+            .map_err(|e| e.with_path(&obj.path))?;
         Ok(version)
     }
 
@@ -419,7 +427,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let named_filters = self.sst_format.read_filters(&handle.info, &obj).await?;
+        let named_filters = self
+            .sst_format
+            .read_filters(&handle.info, &obj)
+            .await
+            .map_err(|e| e.with_path(&obj.path))?;
         if cache_blocks && !named_filters.is_empty() {
             if let Some(ref cache) = self.cache {
                 cache
@@ -452,7 +464,11 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let stats = self.sst_format.read_stats(&handle.info, &obj).await?;
+        let stats = self
+            .sst_format
+            .read_stats(&handle.info, &obj)
+            .await
+            .map_err(|e| e.with_path(&obj.path))?;
         if cache_blocks {
             if let Some(ref cache) = self.cache {
                 if let Some(ref stats) = stats {
@@ -491,7 +507,12 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let index = Arc::new(self.sst_format.read_index(&handle.info, &obj).await?);
+        let index = Arc::new(
+            self.sst_format
+                .read_index(&handle.info, &obj)
+                .await
+                .map_err(|e| e.with_path(&obj.path))?,
+        );
         if cache_blocks {
             if let Some(ref cache) = self.cache {
                 cache
@@ -514,10 +535,15 @@ impl TableStore {
         let object_store = self.object_stores.store_for(&handle.id);
         let path = self.path(&handle.id);
         let obj = ReadOnlyObject { object_store, path };
-        let index = self.sst_format.read_index(&handle.info, &obj).await?;
+        let index = self
+            .sst_format
+            .read_index(&handle.info, &obj)
+            .await
+            .map_err(|e| e.with_path(&obj.path))?;
         self.sst_format
             .read_blocks(&handle.info, &index, blocks, &obj)
             .await
+            .map_err(|e| e.with_path(&obj.path))
     }
 
     /// Reads specified blocks from an SSTable using the provided index.
@@ -590,6 +616,7 @@ impl TableStore {
                 self.sst_format
                     .read_blocks(&handle.info, index_ref, range.clone(), obj_ref)
                     .await
+                    .map_err(|e| e.with_path(&obj_ref.path))
             }
         }))
         .await;
@@ -1031,6 +1058,53 @@ mod tests {
         // write another wal sst with the same id.
         let result = ts.write_sst(&wal_id, table2, false).await;
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+    }
+
+    #[tokio::test]
+    async fn test_checksum_mismatch_error_includes_path() {
+        let os = Arc::new(InMemory::new());
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            format,
+            Path::from(ROOT),
+            None,
+        ));
+        let id = SsTableId::Compacted(ulid::Ulid::new());
+
+        let mut writer = ts.table_writer(id);
+        writer
+            .add(RowEntry::new_value(&[b'a'; 16], &[1u8; 16], 0))
+            .await
+            .unwrap();
+        writer.close().await.unwrap();
+
+        let sst_path = ts.path(&id);
+        let original = os.get(&sst_path).await.unwrap().bytes().await.unwrap();
+        let mut corrupted = original.to_vec();
+        corrupted[0] ^= 0x01;
+        os.put(&sst_path, corrupted.into()).await.unwrap();
+
+        let handle = ts.open_sst(&id).await.unwrap();
+        let err = match ts.read_blocks(&handle, 0..1).await {
+            Err(e) => e,
+            Ok(_) => panic!("expected checksum mismatch"),
+        };
+        assert!(
+            matches!(err, error::SlateDBError::ChecksumMismatch { path: Some(ref p) } if p == &sst_path),
+            "expected ChecksumMismatch tagged with sst path, got {err:?}"
+        );
+
+        let public_msg = error::Error::from(err).to_string();
+        let expected = format!("checksum mismatch in {sst_path}");
+        assert!(
+            public_msg.contains(&expected),
+            "public error message {public_msg:?} did not contain {expected:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Add SST path when there is a ChecksumMismatch. Slatedb should tell the caller where the corruption is. We had corruption in a staging environment from an ~OOMKill that we caused, but it appears that the data in object storage was corrupted from the write being killed partially~. Real issue was our application was misconfigured and caused object store cache corruption.

Instead of seeing `Data error: checksum mismatch` we want to know which SST is the issue, so we can fix it.

## Changes

Map the error to use with_path if it is a checksum mismatch error. I used map_err instead of passing an optional path all the way down.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
