### PR TITLE
Audit bank DST using `DbSnapshot` and `DbReader` as well

### DIFF
--- a/slatedb-dst/src/actors/bank/auditor.rs
+++ b/slatedb-dst/src/actors/bank/auditor.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
-use log::info;
 use rand::RngCore;
 use slatedb::config::DbReaderOptions;
 use slatedb::{DbReadOps, DbReader, Error};
+use tracing::{info, instrument};
 
 use crate::{Actor, ActorCtx};
 
@@ -68,30 +68,16 @@ impl AuditorActor {
 
 #[async_trait]
 impl Actor for AuditorActor {
+    #[instrument(level = "debug", skip_all, fields(name = %ctx.name(), view = %self.view.name(), step = self.step))]
     async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
         let view = self.view.clone();
-        let view_name = view.name();
         match view {
             BankAuditView::Regular => {
-                audit_bank_view(
-                    ctx.db().as_ref(),
-                    &self.bank,
-                    ctx.name(),
-                    self.step,
-                    view_name,
-                )
-                .await?;
+                audit_bank_view(ctx.db().as_ref(), &self.bank, self.step).await?;
             }
             BankAuditView::Snapshot => {
                 let snapshot = ctx.db().snapshot().await?;
-                audit_bank_view(
-                    snapshot.as_ref(),
-                    &self.bank,
-                    ctx.name(),
-                    self.step,
-                    view_name,
-                )
-                .await?;
+                audit_bank_view(snapshot.as_ref(), &self.bank, self.step).await?;
             }
             BankAuditView::Reader { options } => {
                 if self.reader.is_none() {
@@ -101,17 +87,12 @@ impl Actor for AuditorActor {
                     .reader
                     .as_ref()
                     .expect("bank reader auditor should have opened a reader");
-                audit_bank_view(reader, &self.bank, ctx.name(), self.step, view_name).await?;
+                audit_bank_view(reader, &self.bank, self.step).await?;
             }
         };
 
         self.step += 1;
-        info!(
-            "bank auditor step complete [name={}, view={}, step={}]",
-            ctx.name(),
-            view_name,
-            self.step
-        );
+        info!("bank auditor step complete");
 
         let shutdown_token = ctx.shutdown_token();
         let system_clock = ctx.system_clock();
@@ -145,13 +126,7 @@ async fn open_bank_reader(ctx: &ActorCtx, options: DbReaderOptions) -> Result<Db
     builder.build().await
 }
 
-async fn audit_bank_view<R>(
-    reader: &R,
-    bank: &BankAccounts,
-    actor_name: &str,
-    step: u64,
-    view_name: &str,
-) -> Result<(), Error>
+async fn audit_bank_view<R>(reader: &R, bank: &BankAccounts, step: u64) -> Result<(), Error>
 where
     R: DbReadOps + Sync,
 {
@@ -163,7 +138,7 @@ where
         let account_id = bank.parse_account_id(kv.key.as_ref())?;
         assert!(
             !seen[account_id],
-            "duplicate bank account key observed during {view_name} audit [name={actor_name}, step={step}, key={}]",
+            "duplicate bank account key observed during audit [step={step}, key={}]",
             String::from_utf8_lossy(kv.key.as_ref()),
         );
 
@@ -175,13 +150,13 @@ where
     assert_eq!(
         observed_count,
         bank.account_count(),
-        "bank {view_name} audit observed {observed_count} accounts but expected {} [name={actor_name}, step={step}]",
+        "bank audit observed {observed_count} accounts but expected {} [step={step}]",
         bank.account_count(),
     );
     assert_eq!(
         total,
         bank.expected_total(),
-        "bank {view_name} audit total mismatch: observed {total} expected {} [name={actor_name}, step={step}]",
+        "bank audit total mismatch: observed {total} expected {} [step={step}]",
         bank.expected_total(),
     );
 

--- a/slatedb-dst/src/actors/bank/auditor.rs
+++ b/slatedb-dst/src/actors/bank/auditor.rs
@@ -2,25 +2,65 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use log::info;
-use slatedb::Error;
+use rand::RngCore;
+use slatedb::config::DbReaderOptions;
+use slatedb::{DbReadOps, DbReader, Error};
 
 use crate::{Actor, ActorCtx};
 
 use super::{BankAccounts, BankOptions};
 
-/// Repeatedly audits the bank by summing one scan view over all account rows.
-#[derive(Debug)]
+/// Read view used by the bank auditor.
+#[derive(Clone)]
+pub enum BankAuditView {
+    /// Audit the current shared `Db` handle.
+    Regular,
+    /// Audit a new point-in-time `DbSnapshot` from the current shared `Db`.
+    Snapshot,
+    /// Audit a long-lived read-only `DbReader`.
+    Reader { options: DbReaderOptions },
+}
+
+impl BankAuditView {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::Regular => "db",
+            Self::Snapshot => "db_snapshot",
+            Self::Reader { .. } => "db_reader",
+        }
+    }
+}
+
+impl Default for BankAuditView {
+    fn default() -> Self {
+        Self::Regular
+    }
+}
+
+/// Repeatedly audits the bank by summing one read view over all account rows.
 pub struct AuditorActor {
     bank: BankAccounts,
     audit_interval: Duration,
+    view: BankAuditView,
+    reader: Option<DbReader>,
     step: u64,
 }
 
 impl AuditorActor {
     pub fn new(options: BankOptions, audit_interval: Duration) -> Result<Self, Error> {
+        Self::new_with_view(options, audit_interval, BankAuditView::default())
+    }
+
+    pub fn new_with_view(
+        options: BankOptions,
+        audit_interval: Duration,
+        view: BankAuditView,
+    ) -> Result<Self, Error> {
         Ok(Self {
             bank: BankAccounts::new(options)?,
             audit_interval,
+            view,
+            reader: None,
             step: 0,
         })
     }
@@ -29,51 +69,52 @@ impl AuditorActor {
 #[async_trait]
 impl Actor for AuditorActor {
     async fn run(&mut self, ctx: &ActorCtx) -> Result<(), Error> {
-        let shutdown_token = ctx.shutdown_token();
-        let system_clock = ctx.system_clock();
-        let mut total = 0u128;
-        let mut seen = vec![false; self.bank.account_count()];
-        let mut iter = ctx
-            .db()
-            .scan_prefix(self.bank.scan_prefix().as_bytes())
-            .await?;
-
-        while let Some(kv) = iter.next().await? {
-            let account_id = self.bank.parse_account_id(kv.key.as_ref())?;
-            if seen[account_id] {
-                panic!(
-                    "duplicate bank account key observed during audit: {}",
-                    String::from_utf8_lossy(kv.key.as_ref()),
-                );
+        let view = self.view.clone();
+        let view_name = view.name();
+        match view {
+            BankAuditView::Regular => {
+                audit_bank_view(
+                    ctx.db().as_ref(),
+                    &self.bank,
+                    ctx.name(),
+                    self.step,
+                    view_name,
+                )
+                .await?;
             }
-
-            seen[account_id] = true;
-            total += u128::from(self.bank.decode_balance(kv.value.as_ref())?);
-        }
-
-        let observed_count = seen.iter().filter(|present| **present).count();
-        assert_eq!(
-            observed_count,
-            self.bank.account_count(),
-            "bank audit observed {} accounts but expected {}",
-            observed_count,
-            self.bank.account_count(),
-        );
-        assert_eq!(
-            total,
-            self.bank.expected_total(),
-            "bank audit total mismatch: observed {} expected {}",
-            total,
-            self.bank.expected_total(),
-        );
+            BankAuditView::Snapshot => {
+                let snapshot = ctx.db().snapshot().await?;
+                audit_bank_view(
+                    snapshot.as_ref(),
+                    &self.bank,
+                    ctx.name(),
+                    self.step,
+                    view_name,
+                )
+                .await?;
+            }
+            BankAuditView::Reader { options } => {
+                if self.reader.is_none() {
+                    self.reader = Some(open_bank_reader(ctx, options).await?);
+                }
+                let reader = self
+                    .reader
+                    .as_ref()
+                    .expect("bank reader auditor should have opened a reader");
+                audit_bank_view(reader, &self.bank, ctx.name(), self.step, view_name).await?;
+            }
+        };
 
         self.step += 1;
         info!(
-            "bank auditor step complete [name={}, step={}]",
+            "bank auditor step complete [name={}, view={}, step={}]",
             ctx.name(),
+            view_name,
             self.step
         );
 
+        let shutdown_token = ctx.shutdown_token();
+        let system_clock = ctx.system_clock();
         tokio::select! {
             biased;
             _ = shutdown_token.cancelled() => {}
@@ -82,4 +123,67 @@ impl Actor for AuditorActor {
 
         Ok(())
     }
+
+    async fn finish(&mut self, _ctx: &ActorCtx) -> Result<(), Error> {
+        if let Some(reader) = self.reader.take() {
+            reader.close().await?;
+        }
+        Ok(())
+    }
+}
+
+async fn open_bank_reader(ctx: &ActorCtx, options: DbReaderOptions) -> Result<DbReader, Error> {
+    let mut builder = DbReader::builder(ctx.path().clone(), ctx.main_object_store())
+        .with_options(options)
+        .with_system_clock(ctx.system_clock())
+        .with_seed(ctx.rand().rng().next_u64());
+
+    if let Some(wal_object_store) = ctx.wal_object_store() {
+        builder = builder.with_wal_object_store(wal_object_store);
+    }
+
+    builder.build().await
+}
+
+async fn audit_bank_view<R>(
+    reader: &R,
+    bank: &BankAccounts,
+    actor_name: &str,
+    step: u64,
+    view_name: &str,
+) -> Result<(), Error>
+where
+    R: DbReadOps + Sync,
+{
+    let mut total = 0u128;
+    let mut seen = vec![false; bank.account_count()];
+    let mut iter = reader.scan_prefix(bank.scan_prefix().as_bytes()).await?;
+
+    while let Some(kv) = iter.next().await? {
+        let account_id = bank.parse_account_id(kv.key.as_ref())?;
+        assert!(
+            !seen[account_id],
+            "duplicate bank account key observed during {view_name} audit [name={actor_name}, step={step}, key={}]",
+            String::from_utf8_lossy(kv.key.as_ref()),
+        );
+
+        seen[account_id] = true;
+        total += u128::from(bank.decode_balance(kv.value.as_ref())?);
+    }
+
+    let observed_count = seen.iter().filter(|present| **present).count();
+    assert_eq!(
+        observed_count,
+        bank.account_count(),
+        "bank {view_name} audit observed {observed_count} accounts but expected {} [name={actor_name}, step={step}]",
+        bank.account_count(),
+    );
+    assert_eq!(
+        total,
+        bank.expected_total(),
+        "bank {view_name} audit total mismatch: observed {total} expected {} [name={actor_name}, step={step}]",
+        bank.expected_total(),
+    );
+
+    Ok(())
 }

--- a/slatedb-dst/src/actors/bank/mod.rs
+++ b/slatedb-dst/src/actors/bank/mod.rs
@@ -4,7 +4,7 @@ mod transfer;
 use slatedb::config::{PutOptions, WriteOptions};
 use slatedb::{Db, DbTransaction, Error};
 
-pub use self::auditor::AuditorActor;
+pub use self::auditor::{AuditorActor, BankAuditView};
 pub use self::transfer::TransferActor;
 
 const BALANCE_BYTES: usize = std::mem::size_of::<u64>();

--- a/slatedb-dst/src/actors/mod.rs
+++ b/slatedb-dst/src/actors/mod.rs
@@ -20,7 +20,9 @@ pub mod shutdown;
 pub mod suppress_errors;
 pub mod workload;
 
-pub use self::bank::{initialize_accounts, AuditorActor, BankOptions, TransferActor};
+pub use self::bank::{
+    initialize_accounts, AuditorActor, BankAuditView, BankOptions, TransferActor,
+};
 pub use self::compactor::{CompactorActor, CompactorActorOptions};
 pub use self::fencer::{DbFencerActor, DbFencerActorOptions, SuppressFenced};
 pub use self::flusher::FlusherActor;

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -64,7 +64,6 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
         wal_enabled: rng.random_bool(0.5),
         ..Default::default()
     };
-
     settings
 }
 
@@ -78,7 +77,6 @@ pub fn build_reader_options(rand: &DbRand) -> DbReaderOptions {
     let checkpoint_lifetime =
         rng.random_range(min_checkpoint_lifetime..Duration::from_secs(4 * 60 * 60));
     let max_memtable_bytes = rng.random_range((MIB_1 as u64)..=(MIB_500 as u64));
-
     DbReaderOptions {
         manifest_poll_interval,
         checkpoint_lifetime,
@@ -91,7 +89,6 @@ pub fn build_reader_options(rand: &DbRand) -> DbReaderOptions {
 pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
     let min_compaction_sources = rng.random_range(2..=4);
     let max_compaction_sources = rng.random_range(min_compaction_sources..=16);
-
     CompactorOptions {
         poll_interval: rng.random_range(Duration::from_millis(1)..Duration::from_secs(5)),
         manifest_update_timeout: rng

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use rand::Rng;
 use slatedb::config::{
-    CompactorOptions, CompressionCodec, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
-    GarbageCollectorScheduleOptions, SizeTieredCompactionSchedulerOptions,
+    CompactorOptions, CompressionCodec, DbReaderOptions, GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions, GarbageCollectorScheduleOptions, SizeTieredCompactionSchedulerOptions,
 };
 use slatedb::{DbRand, Settings};
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -66,6 +66,25 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
     };
 
     settings
+}
+
+/// Builds randomized deterministic reader options for DST scenarios.
+pub fn build_reader_options(rand: &DbRand) -> DbReaderOptions {
+    let mut rng = rand.rng();
+    let manifest_poll_interval =
+        rng.random_range(Duration::from_millis(100)..Duration::from_secs(5));
+    // Lifetime must always be greater than twice the poll interval.
+    let min_checkpoint_lifetime = manifest_poll_interval * 2 + Duration::from_micros(1);
+    let checkpoint_lifetime =
+        rng.random_range(min_checkpoint_lifetime..Duration::from_secs(4 * 60 * 60));
+    let max_memtable_bytes = rng.random_range((MIB_1 as u64)..=(MIB_500 as u64));
+
+    DbReaderOptions {
+        manifest_poll_interval,
+        checkpoint_lifetime,
+        max_memtable_bytes,
+        ..DbReaderOptions::default()
+    }
 }
 
 /// Builds randomized deterministic compactor options for DST scenarios.

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -9,12 +9,14 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use rand::{Rng, RngCore};
 use rstest::rstest;
+use slatedb::config::DbReaderOptions;
 use slatedb::{Db, DbRand, Error};
 use slatedb_common::clock::MockSystemClock;
 use slatedb_dst::{
     actors::{
-        initialize_accounts, AuditorActor, BankOptions, CompactorActor, CompactorActorOptions,
-        DbFencerActor, DbFencerActorOptions, ShutdownActor, SuppressFenced, TransferActor,
+        initialize_accounts, AuditorActor, BankAuditView, BankOptions, CompactorActor,
+        CompactorActorOptions, DbFencerActor, DbFencerActorOptions, ShutdownActor, SuppressFenced,
+        TransferActor,
     },
     utils::{build_settings, build_settings_compactor, build_toxic},
     DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
@@ -62,6 +64,11 @@ fn test_dst_bank_with_toxics(
     let bank_options = random_bank_options(&rand);
     info!("dst bank options: {bank_options:?}");
     let audit_interval = Duration::from_millis(1000);
+    let reader_options = DbReaderOptions {
+        manifest_poll_interval: Duration::from_millis(500),
+        checkpoint_lifetime: Duration::from_secs(60 * 60),
+        ..DbReaderOptions::default()
+    };
     let fencer_restart_interval = Duration::from_secs(120);
     let compactor_options = build_settings_compactor(&mut *rand.rng());
 
@@ -107,12 +114,26 @@ fn test_dst_bank_with_toxics(
             SuppressFenced::new(TransferActor::new(bank_options.clone())?),
         )
         .actor(
-            "auditor-1",
+            "regular-auditor",
             SuppressFenced::new(AuditorActor::new(bank_options.clone(), audit_interval)?),
         )
         .actor(
-            "auditor-2",
-            SuppressFenced::new(AuditorActor::new(bank_options, audit_interval)?),
+            "snapshot-auditor",
+            SuppressFenced::new(AuditorActor::new_with_view(
+                bank_options.clone(),
+                audit_interval,
+                BankAuditView::Snapshot,
+            )?),
+        )
+        .actor(
+            "reader-auditor",
+            AuditorActor::new_with_view(
+                bank_options,
+                audit_interval,
+                BankAuditView::Reader {
+                    options: reader_options,
+                },
+            )?,
         )
         .actor(
             "db-fencer",

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -9,7 +9,6 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use rand::{Rng, RngCore};
 use rstest::rstest;
-use slatedb::config::DbReaderOptions;
 use slatedb::{Db, DbRand, Error};
 use slatedb_common::clock::MockSystemClock;
 use slatedb_dst::{
@@ -18,7 +17,7 @@ use slatedb_dst::{
         CompactorActorOptions, DbFencerActor, DbFencerActorOptions, ShutdownActor, SuppressFenced,
         TransferActor,
     },
-    utils::{build_settings, build_settings_compactor, build_toxic},
+    utils::{build_reader_options, build_settings, build_settings_compactor, build_toxic},
     DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
     StartupCtx,
 };
@@ -64,11 +63,7 @@ fn test_dst_bank_with_toxics(
     let bank_options = random_bank_options(&rand);
     info!("dst bank options: {bank_options:?}");
     let audit_interval = Duration::from_millis(1000);
-    let reader_options = DbReaderOptions {
-        manifest_poll_interval: Duration::from_millis(500),
-        checkpoint_lifetime: Duration::from_secs(60 * 60),
-        ..DbReaderOptions::default()
-    };
+    let reader_options = build_reader_options(&rand);
     let fencer_restart_interval = Duration::from_secs(120);
     let compactor_options = build_settings_compactor(&mut *rand.rng());
 


### PR DESCRIPTION
## Summary

What is being changed and why?

## Changes

- Add `BankAuditView` to define what kind of reader the auditor should use
- Add snapshot and reader auditors to `bank.rs`
- Add `build_reader_options` `utils.rs` helper

## Notes for Reviewers

NA

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
