### PR TITLE
Make DST harness failure aware

### DIFF
--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -24,8 +24,9 @@ internal path dependency rather than from crates.io.
   compactor, shutdown, and bank-transfer/auditor actors
 - `DeterministicLocalFilesystem`: filesystem-backed `ObjectStore` with stable
   metadata, in-memory attribute preservation, and deterministic listing behavior
-- `FailingObjectStore`: `ObjectStore` wrapper that injects deterministic
-  latency, bandwidth, reset-peer, slow-close, and synthetic HTTP failures
+- `FailingObjectStore`: harness-installed `ObjectStore` wrapper that injects
+  deterministic latency, bandwidth, reset-peer, slow-close, and synthetic HTTP
+  failures
 - `Toxic`: fault-injection building blocks
 - `HttpFailBefore` and `HttpStatusError`: synthetic HTTP failures injected
   before request dispatch
@@ -38,15 +39,15 @@ The harness is built around one root seed:
 
 1. `Harness::new(name, seed, factory)` creates the root `DbRand`.
 2. The harness derives seeds for the Tokio runtime, database startup
-   (`StartupCtx::rand()`), and the harness-owned background clock task.
+   (`StartupCtx::rand()`), the harness-owned background clock task, and the
+   failure controller.
 3. The simulation runs on a seeded current-thread Tokio runtime.
 4. After startup, the harness derives one actor-local seed per registered actor
    (`ActorCtx::rand()`).
-5. The harness wraps the configured main and optional WAL object stores with an
-   internal clock-aware layer that reports deterministic `last_modified`
-   metadata.
-6. If your scenario uses `FailingObjectStore`, seed its controller explicitly
-   so fault sampling stays reproducible.
+5. The harness wraps the configured main and optional WAL object stores with
+   internal fault-injecting and clock-aware layers.
+6. The harness owns a seeded failure controller and exposes it through
+   `StartupCtx::failure_controller()`.
 7. The shared `MockSystemClock` advances from the harness-owned background
    clock task, when your test advances it explicitly, or when a configured
    toxic adds latency/bandwidth/slow-close delay.
@@ -101,12 +102,11 @@ use std::time::Duration;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use rand::RngCore;
-use slatedb::{Db, DbRand};
+use slatedb::Db;
 use slatedb_common::clock::MockSystemClock;
 use slatedb_dst::{
     actors::{ShutdownActor, WorkloadActor, WorkloadActorOptions}, utils::build_settings,
-    DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
-    Operation, StreamDirection, Toxic, ToxicKind,
+    DeterministicLocalFilesystem, Harness, Operation, StreamDirection, Toxic, ToxicKind,
 };
 use tempfile::TempDir;
 
@@ -119,32 +119,25 @@ fn dst_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(&wal_dir)?;
 
     let system_clock = Arc::new(MockSystemClock::new());
-    let failures = FailingObjectStoreController::new(Arc::new(DbRand::new(11)));
-    failures.add_toxic(Toxic {
-        name: "put-latency".into(),
-        kind: ToxicKind::Latency {
-            latency: Duration::from_millis(2),
-            jitter: Duration::from_millis(3),
-        },
-        direction: StreamDirection::Upstream,
-        toxicity: 1.0,
-        operations: vec![Operation::PutOpts],
-        path_prefix: None,
-    });
-
-    let main_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?),
-        failures.clone(),
-        system_clock.clone(),
-    ));
-    let wal_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?),
-        failures,
-        system_clock.clone(),
-    ));
+    let main_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?);
+    let wal_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?);
     let shutdown_at_millis = 10i64;
     let workload_options = WorkloadActorOptions::default();
     let harness = Harness::new("smoke", 7, move |ctx| async move {
+        ctx.failure_controller().add_toxic(Toxic {
+            name: "put-latency".into(),
+            kind: ToxicKind::Latency {
+                latency: Duration::from_millis(2),
+                jitter: Duration::from_millis(3),
+            },
+            direction: StreamDirection::Upstream,
+            toxicity: 1.0,
+            operations: vec![Operation::PutOpts],
+            path_prefix: None,
+        });
+
         let db_seed = ctx.rand().rng().next_u64();
         let settings = build_settings(ctx.rand()).await;
 
@@ -184,8 +177,10 @@ fn dst_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
 - `with_system_clock(clock)`: injects a shared `MockSystemClock`
 - `with_clock_advance(min_ms..=max_ms)`: overrides the inclusive millisecond
   range used by the harness-owned background clock task
-- `with_main_object_store(store)`: replaces the default in-memory main store
-- `with_wal_object_store(store)`: configures a separate WAL store
+- `with_main_object_store(store)`: replaces the default in-memory main base
+  store, which the harness wraps before use
+- `with_wal_object_store(store)`: configures a separate WAL base store, which
+  the harness wraps before use
 - `actor(name, actor)`: registers one actor instance under a unique name
 - `run()`: builds the seeded runtime, starts the harness-owned background
   clock task, opens the DB, spawns one Tokio task per registered actor, and
@@ -205,6 +200,7 @@ to the database builder.
 - `wal_object_store()`
 - `system_clock()`
 - `fp_registry()`
+- `failure_controller()`
 - `rand()`
 
 Typical startup responsibilities:
@@ -213,6 +209,7 @@ Typical startup responsibilities:
 - build randomized deterministic settings with `utils::build_settings(...)`
 - open `Db::builder(...)` using the harness-provided object stores and clock
 - pass through the shared failpoint registry
+- install initial object-store toxics with `ctx.failure_controller()`
 
 ### `ActorCtx`
 
@@ -223,7 +220,7 @@ Each registered actor instance receives its own `ActorCtx`.
 - `name()` for actor identity
 - `rand()` for actor-local deterministic randomness
 - `startup_ctx()` to reuse the startup path, object stores, clock, failpoint
-  registry, and startup RNG when reopening a database
+  registry, failure controller, and startup RNG when reopening a database
 - `db()` to read the currently installed shared `Arc<Db>`
 - `swap_db(new_db)` to replace the shared DB handle for all actors
 - `swap_compactor(new_compactor)` to replace the shared standalone compactor handle
@@ -251,14 +248,13 @@ callback.
 
 ## Failure injection
 
-To inject faults, wrap the relevant object stores with `FailingObjectStore`
-before passing them to the harness. Reuse the same
-`FailingObjectStoreController` anywhere you want a shared fault configuration,
-for example across the main store and WAL store.
+The harness wraps configured object stores with `FailingObjectStore`
+automatically. To inject faults, get the shared controller from
+`StartupCtx::failure_controller()` during startup or through
+`ActorCtx::startup_ctx().failure_controller()` while actors are running.
 
 ### Controller operations
 
-- `FailingObjectStoreController::new(rand)`: creates a deterministic controller
 - `add_toxic(toxic)`: appends a toxic to the active set
 - `clear_toxics()`: removes all toxics
 - `set_http_fail_before(failure)`: installs a synthetic HTTP failure policy
@@ -303,12 +299,9 @@ Supported `ToxicKind` values:
 is dispatched to the wrapped store.
 
 ```rust,ignore
-use std::sync::Arc;
+use slatedb_dst::{HttpFailBefore, Operation};
 
-use slatedb::DbRand;
-use slatedb_dst::{FailingObjectStoreController, HttpFailBefore, Operation};
-
-let failures = FailingObjectStoreController::new(Arc::new(DbRand::new(7)));
+let failures = ctx.failure_controller();
 failures.set_http_fail_before(HttpFailBefore {
     percentage: 100,
     status_code: 503,

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -637,6 +637,10 @@ impl Harness {
             }
         }
 
+        let failure_controller = shared.startup_ctx.failure_controller();
+        failure_controller.clear_toxics();
+        failure_controller.clear_http_failures();
+
         let db_result = shared.db_slot.write().close().await;
         let compactor_result = match shared.compactor_slot.write().take() {
             Some(compactor) => compactor.stop().await,

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -27,6 +27,7 @@ use slatedb_common::clock::SystemClock;
 use slatedb_common::MockSystemClock;
 
 use crate::clocked_object_store::ClockedObjectStore;
+use crate::failing_object_store::{FailingObjectStore, FailingObjectStoreController};
 
 type DbFactoryFuture = Pin<Box<dyn Future<Output = Result<Arc<Db>, Error>> + Send + 'static>>;
 type StartupFactory = Box<dyn FnOnce(StartupCtx) -> DbFactoryFuture + Send + 'static>;
@@ -49,7 +50,8 @@ struct ActorRegistration {
 ///
 /// The context exposes deterministic randomness, the shared database slot,
 /// clock-wrapped object stores, the shared shutdown token, and test
-/// infrastructure such as the failpoint registry and mock clock.
+/// infrastructure such as the failpoint registry, mock clock, and shared
+/// failure controller.
 #[derive(Clone)]
 pub struct ActorCtx {
     name: String,
@@ -77,7 +79,8 @@ impl ActorCtx {
     /// Returns the startup context shared by this harness run.
     ///
     /// This exposes the database path, object stores, clock, failpoint
-    /// registry, and startup RNG used by the database factory.
+    /// registry, failure controller, and startup RNG used by the database
+    /// factory.
     pub fn startup_ctx(&self) -> &StartupCtx {
         &self.shared.startup_ctx
     }
@@ -134,7 +137,7 @@ impl ActorCtx {
     ///
     /// ## Returns
     /// - `Arc<dyn ObjectStore>`: The main object store wrapped with
-    ///   deterministic clock behavior.
+    ///   deterministic fault-injection and clock behavior.
     pub fn main_object_store(&self) -> Arc<dyn ObjectStore> {
         self.shared.startup_ctx.main_object_store()
     }
@@ -143,7 +146,7 @@ impl ActorCtx {
     ///
     /// ## Returns
     /// - `Option<Arc<dyn ObjectStore>>`: The WAL store wrapped with
-    ///   deterministic clock behavior, or `None`.
+    ///   deterministic fault-injection and clock behavior, or `None`.
     pub fn wal_object_store(&self) -> Option<Arc<dyn ObjectStore>> {
         self.shared.startup_ctx.wal_object_store()
     }
@@ -178,14 +181,15 @@ impl ActorCtx {
 /// Startup context passed to the database factory configured with
 /// [`Harness::new`].
 ///
-/// The startup context exposes clock-wrapped object stores and shared
-/// infrastructure before actors begin running.
+/// The startup context exposes fault-injecting, clock-wrapped object stores and
+/// shared infrastructure before actors begin running.
 pub struct StartupCtx {
     path: Path,
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     system_clock: Arc<dyn SystemClock>,
     fp_registry: Arc<FailPointRegistry>,
+    failure_controller: FailingObjectStoreController,
     rand: Arc<DbRand>,
 }
 
@@ -202,7 +206,7 @@ impl StartupCtx {
     ///
     /// ## Returns
     /// - `Arc<dyn ObjectStore>`: The main object store wrapped for
-    ///   deterministic clock behavior.
+    ///   deterministic fault-injection and clock behavior.
     pub fn main_object_store(&self) -> Arc<dyn ObjectStore> {
         Arc::clone(&self.main_object_store)
     }
@@ -232,6 +236,18 @@ impl StartupCtx {
     ///   the database under test.
     pub fn fp_registry(&self) -> Arc<FailPointRegistry> {
         Arc::clone(&self.fp_registry)
+    }
+
+    /// Returns the shared failure controller for the harness object stores.
+    ///
+    /// Tests may use the controller to install, clear, or replace object-store
+    /// toxics before opening the database or while actors are running.
+    ///
+    /// ## Returns
+    /// - `FailingObjectStoreController`: A cloneable handle to the controller
+    ///   used by the harness-wrapped main and WAL object stores.
+    pub fn failure_controller(&self) -> FailingObjectStoreController {
+        self.failure_controller.clone()
     }
 
     /// Returns the startup-local deterministic random number generator.
@@ -308,8 +324,8 @@ impl Drop for ClockDriver {
 /// Builder and executor for deterministic SlateDB scenario tests.
 ///
 /// A harness owns the seeded runtime configuration, shared mock clock,
-/// failpoint registry, clock-wrapped object stores, and the shared database
-/// slot visible to all registered actors.
+/// failpoint registry, fault-injecting clock-wrapped object stores, and the
+/// shared database slot visible to all registered actors.
 pub struct Harness {
     name: String,
     rand: Arc<DbRand>,
@@ -327,8 +343,8 @@ impl Harness {
     ///
     /// ## Arguments
     /// - `name`: Scenario name used when deriving the default database path.
-    /// - `seed`: Root seed used to derive deterministic randomness for startup
-    ///   and actor-local RNGs.
+    /// - `seed`: Root seed used to derive deterministic randomness for startup,
+    ///   fault injection, and actor-local RNGs.
     /// - `factory`: A function that receives a [`StartupCtx`] and returns the
     ///   database handle that actors should share.
     ///
@@ -368,8 +384,8 @@ impl Harness {
     /// Overrides the root deterministic random number generator.
     ///
     /// ## Arguments
-    /// - `rand`: The RNG to use for deriving runtime, startup, and actor-local
-    ///   seeds.
+    /// - `rand`: The RNG to use for deriving runtime, startup, fault-injection,
+    ///   and actor-local seeds.
     ///
     /// ## Returns
     /// - `Harness`: The updated harness builder.
@@ -418,7 +434,9 @@ impl Harness {
     /// Replaces the default in-memory main object store.
     ///
     /// ## Arguments
-    /// - `store`: The object store to wrap and expose as the harness main store.
+    /// - `store`: The base object store that the harness will wrap with
+    ///   deterministic fault injection and clock behavior before exposing it as
+    ///   the main store.
     ///
     /// ## Returns
     /// - `Harness`: The updated harness builder.
@@ -430,7 +448,9 @@ impl Harness {
     /// Configures an optional WAL object store for the harness.
     ///
     /// ## Arguments
-    /// - `store`: The object store to wrap and expose as the harness WAL store.
+    /// - `store`: The base object store that the harness will wrap with
+    ///   deterministic fault injection and clock behavior before exposing it as
+    ///   the WAL store.
     ///
     /// ## Returns
     /// - `Harness`: The updated harness builder.
@@ -478,6 +498,7 @@ impl Harness {
         let runtime_seed = self.rand.rng().next_u64();
         let startup_seed = self.rand.rng().next_u64();
         let clock_seed = self.rand.rng().next_u64();
+        let failure_seed = self.rand.rng().next_u64();
         let system_clock: Arc<dyn SystemClock> = self.system_clock.clone();
         let clock_advance_ms = self.clock_advance_ms.clone();
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -491,13 +512,13 @@ impl Harness {
                 Arc::new(DbRand::new(clock_seed)),
                 clock_advance_ms,
             );
-            let result = self.run_inner(startup_seed).await;
+            let result = self.run_inner(startup_seed, failure_seed).await;
             clock_driver.shutdown().await;
             result
         })
     }
 
-    async fn run_inner(self, startup_seed: u64) -> Result<(), Error> {
+    async fn run_inner(self, startup_seed: u64, failure_seed: u64) -> Result<(), Error> {
         let Harness {
             name,
             rand,
@@ -519,13 +540,27 @@ impl Harness {
         let path = path.unwrap_or_else(|| Path::from(format!("dst/{name}/seed-{seed:016x}")));
         let system_clock: Arc<dyn SystemClock> = system_clock;
         let fp_registry = Arc::new(FailPointRegistry::new());
-        let main_object_store: Arc<dyn ObjectStore> = Arc::new(ClockedObjectStore::new(
+        let failure_controller =
+            FailingObjectStoreController::new(Arc::new(DbRand::new(failure_seed)));
+        let failing_main_object_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
             main_object_store.clone(),
+            failure_controller.clone(),
+            system_clock.clone(),
+        ));
+        let main_object_store: Arc<dyn ObjectStore> = Arc::new(ClockedObjectStore::new(
+            failing_main_object_store,
             system_clock.clone(),
         ));
         let wal_object_store = wal_object_store.map(|store| {
-            Arc::new(ClockedObjectStore::new(store.clone(), system_clock.clone()))
-                as Arc<dyn ObjectStore>
+            let failing_wal_object_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
+                store.clone(),
+                failure_controller.clone(),
+                system_clock.clone(),
+            ));
+            Arc::new(ClockedObjectStore::new(
+                failing_wal_object_store,
+                system_clock.clone(),
+            )) as Arc<dyn ObjectStore>
         });
 
         let startup_ctx = StartupCtx {
@@ -534,6 +569,7 @@ impl Harness {
             wal_object_store: wal_object_store.clone(),
             system_clock: Arc::clone(&system_clock),
             fp_registry: Arc::clone(&fp_registry),
+            failure_controller,
             rand: Arc::new(DbRand::new(startup_seed)),
         };
 

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -18,8 +18,7 @@ use slatedb_dst::{
         TransferActor,
     },
     utils::{build_reader_options, build_settings, build_settings_compactor, build_toxic},
-    DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
-    StartupCtx,
+    DeterministicLocalFilesystem, Harness, StartupCtx,
 };
 use tempfile::TempDir;
 

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -17,8 +17,7 @@ use slatedb_dst::{
         DbFencerActor, DbFencerActorOptions, ShutdownActor, SuppressFenced, TransferActor,
     },
     utils::{build_settings, build_settings_compactor, build_toxic},
-    DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
-    StartupCtx,
+    DeterministicLocalFilesystem, Harness, StartupCtx,
 };
 use tempfile::TempDir;
 
@@ -39,25 +38,10 @@ fn test_dst_bank_with_toxics(
     let rand = Arc::new(DbRand::new(seed));
     let system_clock = Arc::new(MockSystemClock::new());
 
-    // Build a shared toxic controller with randomized toxics.
-    let failure_seed = rand.rng().next_u64();
-    let failure_rand = Arc::new(DbRand::new(failure_seed));
-    let failures = FailingObjectStoreController::new(failure_rand.clone());
-    for index in 0..10 {
-        let toxic = build_toxic(failure_rand.as_ref(), "bank", index);
-        failures.add_toxic(toxic);
-    }
-
-    let main_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?),
-        failures.clone(),
-        system_clock.clone(),
-    ));
-    let wal_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?),
-        failures,
-        system_clock.clone(),
-    ));
+    let main_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?);
+    let wal_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?);
 
     let bank_options = random_bank_options(&rand);
     info!("dst bank options: {bank_options:?}");
@@ -68,6 +52,11 @@ fn test_dst_bank_with_toxics(
     let harness = Harness::new("bank", seed, {
         let bank_options = bank_options.clone();
         move |ctx| async move {
+            let failures = ctx.failure_controller();
+            for index in 0..10 {
+                failures.add_toxic(build_toxic(ctx.rand(), ctx.path().as_ref(), index));
+            }
+
             let db = open_bank_db(ctx).await?;
             initialize_accounts(db.as_ref(), &bank_options).await?;
 

--- a/slatedb-dst/tests/determinism.rs
+++ b/slatedb-dst/tests/determinism.rs
@@ -33,8 +33,8 @@ use slatedb_dst::{
         CompactorActor, CompactorActorOptions, FlusherActor, ShutdownActor, WorkloadActor,
         WorkloadActorOptions,
     },
-    utils::build_settings,
-    DeterministicLocalFilesystem, Harness, Operation, StreamDirection, Toxic, ToxicKind,
+    utils::{build_settings, build_toxic},
+    DeterministicLocalFilesystem, Harness,
 };
 use tempfile::TempDir;
 use tracing::instrument;
@@ -179,17 +179,10 @@ fn run_seed_once(seed: u64, shutdown_at_ms: i64) -> TestResult<(u64, DateTime<Ut
         ..CompactorOptions::default()
     };
     let harness = Harness::new("determinism", seed, move |ctx| async move {
-        ctx.failure_controller().add_toxic(Toxic {
-            name: "put-latency".into(),
-            kind: ToxicKind::Latency {
-                latency: Duration::from_millis(1),
-                jitter: Duration::from_millis(3),
-            },
-            direction: StreamDirection::Upstream,
-            toxicity: 1.0,
-            operations: vec![Operation::PutOpts],
-            path_prefix: None,
-        });
+        let failures = ctx.failure_controller();
+        for index in 0..10 {
+            failures.add_toxic(build_toxic(ctx.rand(), ctx.path().as_ref(), index));
+        }
 
         let db_seed = ctx.rand().rng().next_u64();
         let mut settings = build_settings(ctx.rand()).await;

--- a/slatedb-dst/tests/determinism.rs
+++ b/slatedb-dst/tests/determinism.rs
@@ -34,8 +34,7 @@ use slatedb_dst::{
         WorkloadActorOptions,
     },
     utils::build_settings,
-    DeterministicLocalFilesystem, FailingObjectStore, FailingObjectStoreController, Harness,
-    Operation, StreamDirection, Toxic, ToxicKind,
+    DeterministicLocalFilesystem, Harness, Operation, StreamDirection, Toxic, ToxicKind,
 };
 use tempfile::TempDir;
 use tracing::instrument;
@@ -148,11 +147,12 @@ fn run_seed_is_deterministic(
 /// state after the harness shuts down.
 ///
 /// Each invocation builds a fresh temporary main and WAL object-store root,
-/// fresh root RNG, fresh mock clock, and fresh fault-injection controller. The
-/// harness then opens a real `Db`, starts workload, flusher, compactor, and
-/// shutdown actors, and runs until the shutdown actor cancels the simulation.
-/// Returning the next root RNG value and current mock-clock time gives callers a
-/// compact fingerprint of the deterministic execution path.
+/// fresh root RNG, and fresh mock clock. The harness then owns the
+/// fault-injection controller, opens a real `Db`, starts workload, flusher,
+/// compactor, and shutdown actors, and runs until the shutdown actor cancels
+/// the simulation. Returning the next root RNG value and current mock-clock
+/// time gives callers a compact fingerprint of the deterministic execution
+/// path.
 #[instrument(level = "debug", skip_all, fields(seed = seed))]
 fn run_seed_once(seed: u64, shutdown_at_ms: i64) -> TestResult<(u64, DateTime<Utc>)> {
     let tempdir = TempDir::new()?;
@@ -163,29 +163,10 @@ fn run_seed_once(seed: u64, shutdown_at_ms: i64) -> TestResult<(u64, DateTime<Ut
 
     let rand = Arc::new(DbRand::new(seed));
     let system_clock = Arc::new(MockSystemClock::new());
-    let failure_seed = rand.rng().next_u64();
-    let failures = FailingObjectStoreController::new(Arc::new(DbRand::new(failure_seed)));
-    failures.add_toxic(Toxic {
-        name: "put-latency".into(),
-        kind: ToxicKind::Latency {
-            latency: Duration::from_millis(1),
-            jitter: Duration::from_millis(3),
-        },
-        direction: StreamDirection::Upstream,
-        toxicity: 1.0,
-        operations: vec![Operation::PutOpts],
-        path_prefix: None,
-    });
-    let main_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?),
-        failures.clone(),
-        system_clock.clone(),
-    ));
-    let wal_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?),
-        failures,
-        system_clock.clone(),
-    ));
+    let main_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?);
+    let wal_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?);
     let workload_options = WorkloadActorOptions::default();
     let compactor_options = CompactorOptions {
         poll_interval: Duration::from_millis(10),
@@ -198,6 +179,18 @@ fn run_seed_once(seed: u64, shutdown_at_ms: i64) -> TestResult<(u64, DateTime<Ut
         ..CompactorOptions::default()
     };
     let harness = Harness::new("determinism", seed, move |ctx| async move {
+        ctx.failure_controller().add_toxic(Toxic {
+            name: "put-latency".into(),
+            kind: ToxicKind::Latency {
+                latency: Duration::from_millis(1),
+                jitter: Duration::from_millis(3),
+            },
+            direction: StreamDirection::Upstream,
+            toxicity: 1.0,
+            operations: vec![Operation::PutOpts],
+            path_prefix: None,
+        });
+
         let db_seed = ctx.rand().rng().next_u64();
         let mut settings = build_settings(ctx.rand()).await;
 


### PR DESCRIPTION
## Summary

The DST can occasionally hang on shutdown when injecting toxics with reasonably high probability of failure. This happens because the WAL GC does a `list()`, which is actually multiple calls bundled into one. This makes it almost impossible for a single list() to complete. We then retry the list() forever.

I've moved the FailingObjectStore wrapping into Harness. This allows the harness to clear the toxics prior to closing the db and compactor, and also allows actors to more elegantly adjust toxics mid-run. Notably, it does _not_ help actors during their own `finish` phases; they still need to adjust toxics themselves if they have issues.

## Changes

- See commits.

## Notes for Reviewers

NA

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
