### PR TITLE
Pluggable filters implementation - Part 4

### DIFF
--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -146,5 +146,9 @@ bench = false
 name = "db_operations"
 harness = false
 
+[[bench]]
+name = "scan_prefix_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/slatedb/benches/scan_prefix_bench.rs
+++ b/slatedb/benches/scan_prefix_bench.rs
@@ -1,0 +1,269 @@
+// our microbenchmarks use pprof, but it doesn't work on windows
+#![cfg(not(windows))]
+
+//! Compares `scan_prefix` with and without a prefix bloom filter.
+//!
+//! - 100 L0 SSTs, 100 distinct 6-byte prefixes, queried prefix lives in 10.
+//! - Sentinel keys span the keyspace so only the filter can prune.
+//! - Store throttled at 10ms/GET to simulate object store latency
+//! - Meta cache is configured to holds filter/index, data blocks
+//!   uncached so SST reads pay a real GET.
+//! - Sentinel keys are inserted per SST to make sure indecies can't filter out
+//!   SSTs.
+//!
+//! Run: cargo bench -p slatedb --bench scan_prefix_bench
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use object_store::memory::InMemory;
+use object_store::throttle::{ThrottleConfig, ThrottledStore};
+use pprof::criterion::{Output, PProfProfiler};
+use slatedb::config::{
+    DurabilityLevel, FlushOptions, FlushType, PutOptions, ScanOptions, Settings, WriteOptions,
+};
+use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
+use slatedb::db_cache::SplitCache;
+use slatedb::{BloomFilterPolicy, Db, FilterPolicy, PrefixExtractor, PrefixTarget};
+use tokio::runtime::Runtime;
+
+const NUM_PREFIXES: usize = 100;
+const PREFIXES_PER_FLUSH: usize = 10;
+const VERSIONS_PER_FLUSH: usize = 5;
+const NUM_FLUSHES: usize = 100;
+const PREFIX_LEN: usize = 6;
+const QUERY_PREFIX: &[u8; 6] = b"pk0095";
+const GET_LATENCY: Duration = Duration::from_millis(10);
+
+struct FixedPrefixExtractor {
+    len: usize,
+    name: String,
+}
+
+impl FixedPrefixExtractor {
+    fn new(len: usize) -> Self {
+        Self {
+            len,
+            name: format!("fixed{}", len),
+        }
+    }
+}
+
+impl PrefixExtractor for FixedPrefixExtractor {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+        let input = match target {
+            PrefixTarget::Point(k) => k.as_ref(),
+            PrefixTarget::Prefix(p) => p.as_ref(),
+        };
+        (input.len() >= self.len).then_some(self.len)
+    }
+}
+
+fn make_key(prefix_idx: usize, version: u64) -> Vec<u8> {
+    format!("pk{:04}:{:08}", prefix_idx, version).into_bytes()
+}
+
+fn make_throttled_store() -> Arc<ThrottledStore<InMemory>> {
+    Arc::new(ThrottledStore::new(
+        InMemory::new(),
+        ThrottleConfig::default(),
+    ))
+}
+
+fn enable_throttle(store: &ThrottledStore<InMemory>) {
+    store.config_mut(|cfg| {
+        cfg.wait_get_per_call = GET_LATENCY;
+    });
+}
+
+fn disable_throttle(store: &ThrottledStore<InMemory>) {
+    store.config_mut(|cfg| {
+        cfg.wait_get_per_call = Duration::ZERO;
+    });
+}
+
+// Cache filter and index blocks (so the filter check itself is free) but not
+// data blocks, so each surviving SST still pays the throttled GET cost.
+fn meta_only_cache() -> Arc<SplitCache> {
+    let meta = Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
+        max_capacity: 256 * 1024 * 1024,
+        ..Default::default()
+    }));
+    Arc::new(
+        SplitCache::new()
+            .with_block_cache(None)
+            .with_meta_cache(Some(meta))
+            .build(),
+    )
+}
+
+fn base_settings() -> Settings {
+    Settings {
+        min_filter_keys: 0,
+        l0_sst_size_bytes: 256 * 1024 * 1024,
+        l0_max_ssts: NUM_FLUSHES + 10,
+        compactor_options: None,
+        ..Settings::default()
+    }
+}
+
+fn scan_options() -> ScanOptions {
+    ScanOptions {
+        // Don't cache data blocks during the bench: we want every iteration
+        // to pay the throttled GET cost for whichever SSTs the scan touches.
+        cache_blocks: false,
+        durability_filter: DurabilityLevel::Remote,
+        ..ScanOptions::default()
+    }
+}
+
+async fn populate(db: &Db) {
+    let write_opts = WriteOptions {
+        await_durable: false,
+    };
+    let put_opts = PutOptions::default();
+    let mut next_version = [0u64; NUM_PREFIXES];
+    for round in 0..NUM_FLUSHES {
+        // Sentinel keys ensure every SST's key range overlaps with every
+        // prefix range, so without the filter the scan must visit them all.
+        let lo = format!("aa_sentinel_{:04}", round).into_bytes();
+        let hi = format!("zz_sentinel_{:04}", round).into_bytes();
+        db.put_with_options(&lo, b"s", &put_opts, &write_opts)
+            .await
+            .expect("put failed");
+        db.put_with_options(&hi, b"s", &put_opts, &write_opts)
+            .await
+            .expect("put failed");
+
+        let start_px = (round * PREFIXES_PER_FLUSH) % NUM_PREFIXES;
+        for i in 0..PREFIXES_PER_FLUSH {
+            let px = (start_px + i) % NUM_PREFIXES;
+            for _ in 0..VERSIONS_PER_FLUSH {
+                let v = next_version[px];
+                next_version[px] += 1;
+                let key = make_key(px, v);
+                db.put_with_options(&key, &key, &put_opts, &write_opts)
+                    .await
+                    .expect("put failed");
+            }
+        }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("flush failed");
+    }
+}
+
+async fn warmup_meta_cache(db: &Db) {
+    // Use cache_blocks=true here so filter and index blocks get inserted into
+    // the meta cache; the bench itself runs with cache_blocks=false so each
+    // surviving SST still pays the throttled GET cost for its data blocks.
+    let warmup_opts = ScanOptions {
+        cache_blocks: true,
+        durability_filter: DurabilityLevel::Remote,
+        ..ScanOptions::default()
+    };
+    let mut iter = db
+        .scan_prefix_with_options(b"pk0000", &warmup_opts)
+        .await
+        .expect("warmup scan_prefix failed");
+    while iter
+        .next()
+        .await
+        .expect("warmup iterator next failed")
+        .is_some()
+    {}
+}
+
+struct BenchDb {
+    db: Db,
+    store: Arc<ThrottledStore<InMemory>>,
+}
+
+async fn build_db(path: &str, filter_policies: Vec<Arc<dyn FilterPolicy>>) -> BenchDb {
+    let store = make_throttled_store();
+    let db = Db::builder(path, store.clone())
+        .with_settings(base_settings())
+        .with_db_cache(meta_only_cache())
+        .with_filter_policies(filter_policies)
+        .build()
+        .await
+        .expect("failed to build db");
+    populate(&db).await;
+    warmup_meta_cache(&db).await;
+    enable_throttle(&store);
+    BenchDb { db, store }
+}
+
+fn bench_scan_prefix(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to create runtime");
+
+    let no_filter = runtime.block_on(build_db("/bench/no_filter", vec![]));
+    let prefix_bloom = runtime.block_on(build_db(
+        "/bench/prefix_bloom",
+        vec![Arc::new(BloomFilterPolicy::new(10).with_prefix_extractor(
+            Arc::new(FixedPrefixExtractor::new(PREFIX_LEN)),
+        ))],
+    ));
+
+    let mut group = c.benchmark_group("scan_prefix");
+    group.sample_size(20);
+
+    // Note: with `prefix_bloom`, `first_entry` and `full_scan` come out at
+    // similar latencies. The merge iterator has to read the first block of
+    // every SST that passes the filter to find the globally smallest key, so
+    // `first_entry` already pays one data block GET per surviving SST and
+    // `full_scan` adds little on top.
+    for (label, bench_db) in [("no_filter", &no_filter), ("prefix_bloom", &prefix_bloom)] {
+        group.bench_function(BenchmarkId::new("first_entry", label), |b| {
+            b.to_async(&runtime).iter(|| async {
+                let mut iter = bench_db
+                    .db
+                    .scan_prefix_with_options(Bytes::from_static(QUERY_PREFIX), &scan_options())
+                    .await
+                    .expect("scan_prefix failed");
+                let entry = iter.next().await.expect("iterator next failed");
+                assert!(entry.is_some());
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("full_scan", label), |b| {
+            b.to_async(&runtime).iter(|| async {
+                let mut iter = bench_db
+                    .db
+                    .scan_prefix_with_options(Bytes::from_static(QUERY_PREFIX), &scan_options())
+                    .await
+                    .expect("scan_prefix failed");
+                let mut count = 0usize;
+                while iter.next().await.expect("iterator next failed").is_some() {
+                    count += 1;
+                }
+                assert!(count > 0);
+            });
+        });
+    }
+    group.finish();
+
+    disable_throttle(&no_filter.store);
+    disable_throttle(&prefix_bloom.store);
+    runtime.block_on(async {
+        no_filter.db.close().await.expect("close failed");
+        prefix_bloom.db.close().await.expect("close failed");
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    targets = bench_scan_prefix
+}
+
+criterion_main!(benches);

--- a/slatedb/src/iter.rs
+++ b/slatedb/src/iter.rs
@@ -57,19 +57,6 @@ pub(crate) trait TrackedRowEntryIterator: RowEntryIterator {
     fn bytes_processed(&self) -> u64;
 }
 
-/// Initializes the iterator contained in the option, propagating `None` unchanged.
-pub(crate) async fn init_optional_iterator<T: RowEntryIterator>(
-    iter: Option<T>,
-) -> Result<Option<T>, SlateDBError> {
-    match iter {
-        Some(mut it) => {
-            it.init().await?;
-            Ok(Some(it))
-        }
-        None => Ok(None),
-    }
-}
-
 #[async_trait]
 impl<'a> RowEntryIterator for Box<dyn RowEntryIterator + 'a> {
     async fn init(&mut self) -> Result<(), SlateDBError> {

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -18,7 +18,7 @@ use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::format::block::Block;
 use crate::prefix_extractor::PrefixTarget;
 use crate::{
-    iter::{init_optional_iterator, IterationOrder, RowEntryIterator},
+    iter::{IterationOrder, RowEntryIterator},
     partitioned_keyspace,
     tablestore::TableStore,
     types::RowEntry,
@@ -335,16 +335,6 @@ impl<'a> InternalSstIterator<'a> {
         Self::new(view, table_store, options).map(Some)
     }
 
-    async fn new_owned_initialized<T: RangeBounds<Bytes>>(
-        range: T,
-        table: SsTableView,
-        table_store: Arc<TableStore>,
-        options: SstIteratorOptions,
-    ) -> Result<Option<Self>, SlateDBError> {
-        let iter = Self::new_owned(range, table, table_store, options)?;
-        init_optional_iterator(iter).await
-    }
-
     fn new_borrowed<T: RangeBounds<Bytes>>(
         range: T,
         table: &'a SsTableView,
@@ -356,16 +346,6 @@ impl<'a> InternalSstIterator<'a> {
         };
         let view = SstView::Borrowed(table, view_range);
         Self::new(view, table_store, options).map(Some)
-    }
-
-    async fn new_borrowed_initialized<T: RangeBounds<Bytes>>(
-        range: T,
-        table: &'a SsTableView,
-        table_store: Arc<TableStore>,
-        options: SstIteratorOptions,
-    ) -> Result<Option<Self>, SlateDBError> {
-        let iter = Self::new_borrowed(range, table, table_store, options)?;
-        init_optional_iterator(iter).await
     }
 
     fn for_key(
@@ -380,16 +360,6 @@ impl<'a> InternalSstIterator<'a> {
             table_store,
             options,
         )
-    }
-
-    async fn for_key_initialized(
-        table: &'a SsTableView,
-        key: &'a [u8],
-        table_store: Arc<TableStore>,
-        options: SstIteratorOptions,
-    ) -> Result<Option<Self>, SlateDBError> {
-        let iter = Self::for_key(table, key, table_store, options)?;
-        init_optional_iterator(iter).await
     }
 
     /// Spawns fetch tasks for blocks based on iteration order.
@@ -944,15 +914,22 @@ impl<'a> SstIterator<'a> {
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
-        let internal =
-            InternalSstIterator::new_owned_initialized(range, table, table_store, options).await?;
+        // Construct the inner iterator without initializing it. The filter
+        // is evaluated first so that an SST whose filter rules out the query
+        // never pays for an index or data block read.
+        let internal = InternalSstIterator::new_owned(range, table, table_store, options)?;
         match internal {
             Some(inner) => {
                 let mut iterator = Self::from_internal(inner, None);
-                if let SstIteratorDelegate::Filter(inner) = &mut iterator.delegate {
-                    inner.init().await?;
-                    if inner.is_filtered_out() {
-                        return Ok(None);
+                match &mut iterator.delegate {
+                    SstIteratorDelegate::Filter(filter_iter) => {
+                        filter_iter.init().await?;
+                        if filter_iter.is_filtered_out() {
+                            return Ok(None);
+                        }
+                    }
+                    SstIteratorDelegate::Direct(inner_iter) => {
+                        inner_iter.init().await?;
                     }
                 }
                 Ok(Some(iterator))
@@ -989,16 +966,19 @@ impl<'a> SstIterator<'a> {
         table_store: Arc<TableStore>,
         options: SstIteratorOptions,
     ) -> Result<Option<Self>, SlateDBError> {
-        let internal =
-            InternalSstIterator::new_borrowed_initialized(range, table, table_store, options)
-                .await?;
+        let internal = InternalSstIterator::new_borrowed(range, table, table_store, options)?;
         match internal {
             Some(inner) => {
                 let mut iterator = Self::from_internal(inner, None);
-                if let SstIteratorDelegate::Filter(inner) = &mut iterator.delegate {
-                    inner.init().await?;
-                    if inner.is_filtered_out() {
-                        return Ok(None);
+                match &mut iterator.delegate {
+                    SstIteratorDelegate::Filter(filter_iter) => {
+                        filter_iter.init().await?;
+                        if filter_iter.is_filtered_out() {
+                            return Ok(None);
+                        }
+                    }
+                    SstIteratorDelegate::Direct(inner_iter) => {
+                        inner_iter.init().await?;
                     }
                 }
                 Ok(Some(iterator))
@@ -1027,15 +1007,19 @@ impl<'a> SstIterator<'a> {
         options: SstIteratorOptions,
         db_stats: Option<DbStats>,
     ) -> Result<Option<Self>, SlateDBError> {
-        let internal =
-            InternalSstIterator::for_key_initialized(table, key, table_store, options).await?;
+        let internal = InternalSstIterator::for_key(table, key, table_store, options)?;
         match internal {
             Some(inner) => {
                 let mut iterator = Self::from_internal(inner, db_stats);
-                if let SstIteratorDelegate::Filter(inner) = &mut iterator.delegate {
-                    inner.init().await?;
-                    if inner.is_filtered_out() {
-                        return Ok(None);
+                match &mut iterator.delegate {
+                    SstIteratorDelegate::Filter(filter_iter) => {
+                        filter_iter.init().await?;
+                        if filter_iter.is_filtered_out() {
+                            return Ok(None);
+                        }
+                    }
+                    SstIteratorDelegate::Direct(inner_iter) => {
+                        inner_iter.init().await?;
                     }
                 }
                 Ok(Some(iterator))

--- a/slatedb/tests/prefix_filter.rs
+++ b/slatedb/tests/prefix_filter.rs
@@ -1,0 +1,374 @@
+//! Integration tests for the prefix bloom filter.
+//!
+//! Two test modules:
+//!   * [`composite_filters`]: integration tests that configure two filter
+//!     policies on a single DB (one full-key, one conditional prefix) and
+//!     verify reads work after closing/reopening with policies in a different
+//!     order.
+//!   * [`prop_test`]: a property test asserting that `scan_prefix` returns the
+//!     same results with and without a prefix bloom filter configured. The
+//!     filter must never introduce false negatives.
+
+mod composite_filters {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use slatedb::config::{
+        FlushOptions, FlushType, PutOptions, ScanOptions, Settings, WriteOptions,
+    };
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::ObjectStore;
+    use slatedb::{BloomFilterPolicy, Db, FilterPolicy, PrefixExtractor, PrefixTarget};
+
+    const SAMPLE_USERS: &[&[u8]] = &[
+        b"u:alice", b"u:bob", b"u:carol", b"u:dave", b"u:eve", b"u:frank",
+    ];
+    const SAMPLE_NON_USERS: &[&[u8]] = &[
+        b"session:s1",
+        b"session:s2",
+        b"metric:m1",
+        b"metric:m2",
+        b"metric:m3",
+    ];
+
+    /// Conditional prefix extractor that extracts a fixed-length prefix only
+    /// for inputs that begin with `marker`. Inputs not starting with `marker`
+    /// return `None`, meaning they are not hashed into the prefix bloom (build
+    /// time) and the prefix bloom is bypassed for scans whose prefix does not
+    /// start with `marker` (read time).
+    ///
+    /// The extracted length is `marker.len() + extra_len`, so for
+    /// `marker = "u:"` and `extra_len = 4` the input `"u:alice"` extracts
+    /// `"u:ali"` (6 bytes) and `"session:1"` extracts nothing.
+    struct ConditionalPrefixExtractor {
+        marker: Bytes,
+        extra_len: usize,
+        name: String,
+    }
+
+    impl ConditionalPrefixExtractor {
+        fn new(marker: &[u8], extra_len: usize) -> Self {
+            Self {
+                marker: Bytes::copy_from_slice(marker),
+                extra_len,
+                name: format!(
+                    "cond:{}:{}",
+                    std::str::from_utf8(marker).expect("marker must be utf8"),
+                    extra_len
+                ),
+            }
+        }
+    }
+
+    impl PrefixExtractor for ConditionalPrefixExtractor {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let input = match target {
+                PrefixTarget::Point(k) => k.as_ref(),
+                PrefixTarget::Prefix(p) => p.as_ref(),
+            };
+            let total = self.marker.len() + self.extra_len;
+            if input.len() >= total && input.starts_with(self.marker.as_ref()) {
+                Some(total)
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Composite policies under test: a full-key bloom paired with a prefix
+    /// bloom that only fires for keys starting with `"u:"`.
+    fn composite_policies() -> Vec<Arc<dyn FilterPolicy>> {
+        vec![
+            // Full-key bloom for every key.
+            Arc::new(BloomFilterPolicy::new(10)),
+            // Prefix bloom that only fires for keys starting with "u:".
+            Arc::new(
+                BloomFilterPolicy::new(10)
+                    .with_whole_key_filtering(false)
+                    .with_prefix_extractor(Arc::new(ConditionalPrefixExtractor::new(b"u:", 4))),
+            ),
+        ]
+    }
+
+    fn base_settings() -> Settings {
+        Settings {
+            min_filter_keys: 0,
+            compactor_options: None,
+            ..Settings::default()
+        }
+    }
+
+    async fn flush_memtable(db: &Db) {
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("memtable flush failed");
+    }
+
+    async fn write_sample_data(db: &Db) {
+        let put = PutOptions::default();
+        let write = WriteOptions {
+            await_durable: false,
+        };
+        // Write each batch in its own SST so multiple SSTs participate in the
+        // read path and the filter has something to actually skip.
+        for batch in [SAMPLE_USERS, SAMPLE_NON_USERS] {
+            for (i, key) in batch.iter().enumerate() {
+                let value = format!(
+                    "v{}-{}",
+                    std::str::from_utf8(key).expect("sample key must be utf8"),
+                    i
+                )
+                .into_bytes();
+                db.put_with_options(key, &value, &put, &write)
+                    .await
+                    .expect("put failed");
+            }
+            flush_memtable(db).await;
+        }
+    }
+
+    async fn assert_reads_consistent(db: &Db) {
+        // Every written key is readable.
+        for key in SAMPLE_USERS.iter().chain(SAMPLE_NON_USERS.iter()) {
+            let got = db.get(key).await.expect("get failed");
+            assert!(got.is_some(), "expected key {:?} to be present", key);
+        }
+        // Absent keys return None. The full-key bloom and (for "u:" keys) the
+        // prefix bloom must agree on absence.
+        for absent in [
+            b"u:nope__".as_slice(),
+            b"u:zzzzzz".as_slice(),
+            b"session:nope".as_slice(),
+            b"metric:nope".as_slice(),
+        ] {
+            let got = db.get(absent).await.expect("get failed");
+            assert!(got.is_none(), "expected absent key {:?}", absent);
+        }
+        // scan_prefix on the prefix-extracted domain returns all matching keys.
+        let mut iter = db
+            .scan_prefix_with_options(b"u:", &ScanOptions::default())
+            .await
+            .expect("scan_prefix failed");
+        let mut keys = Vec::new();
+        while let Some(kv) = iter.next().await.expect("iterator next failed") {
+            keys.push(kv.key.to_vec());
+        }
+        keys.sort();
+        let mut expected: Vec<Vec<u8>> = SAMPLE_USERS.iter().map(|k| k.to_vec()).collect();
+        expected.sort();
+        assert_eq!(keys, expected, "scan_prefix(b\"u:\") mismatch");
+
+        // scan_prefix outside the extractor's domain still works: the prefix
+        // bloom is bypassed (extractor returns None) and the full-key bloom
+        // is irrelevant for prefix scans, so all SSTs are visited.
+        let mut iter = db
+            .scan_prefix_with_options(b"metric:", &ScanOptions::default())
+            .await
+            .expect("scan_prefix failed");
+        let mut keys = Vec::new();
+        while let Some(kv) = iter.next().await.expect("iterator next failed") {
+            keys.push(kv.key.to_vec());
+        }
+        keys.sort();
+        let mut expected: Vec<Vec<u8>> = SAMPLE_NON_USERS
+            .iter()
+            .filter(|k| k.starts_with(b"metric:"))
+            .map(|k| k.to_vec())
+            .collect();
+        expected.sort();
+        assert_eq!(keys, expected, "scan_prefix(b\"metric:\") mismatch");
+    }
+
+    async fn open_db(
+        path: &str,
+        store: Arc<dyn ObjectStore>,
+        policies: Vec<Arc<dyn FilterPolicy>>,
+    ) -> Db {
+        Db::builder(path, store)
+            .with_settings(base_settings())
+            .with_filter_policies(policies)
+            .build()
+            .await
+            .expect("failed to build db")
+    }
+
+    #[tokio::test]
+    async fn composite_policies_lifecycle() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/test/composite_reopen";
+
+        let db = open_db(path, store.clone(), composite_policies()).await;
+        write_sample_data(&db).await;
+        assert_reads_consistent(&db).await;
+        db.close().await.expect("close failed");
+
+        // Reopen with the policies in reversed order. Filter sub-blocks are
+        // matched by policy name, so order should not matter.
+        let mut reversed = composite_policies();
+        reversed.reverse();
+        let db = open_db(path, store.clone(), reversed).await;
+        assert_reads_consistent(&db).await;
+        db.close().await.expect("close failed");
+    }
+}
+
+mod prop_test {
+    use std::sync::Arc;
+
+    use proptest::collection::vec;
+    use proptest::prelude::*;
+    use slatedb::config::{PutOptions, ScanOptions, Settings, WriteOptions};
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::{BloomFilterPolicy, Db, FilterPolicy, PrefixExtractor, PrefixTarget};
+    use tokio::runtime::Runtime;
+
+    const PREFIX_LEN: usize = 3;
+
+    /// Fixed-length prefix extractor: returns `Some(len)` whenever the input is
+    /// at least `len` bytes. Always extracts the same `len`, so it is
+    /// truncation safe for `Prefix` targets.
+    struct FixedPrefixExtractor {
+        len: usize,
+        name: String,
+    }
+
+    impl FixedPrefixExtractor {
+        fn new(len: usize) -> Self {
+            Self {
+                len,
+                name: format!("fixed{}", len),
+            }
+        }
+    }
+
+    impl PrefixExtractor for FixedPrefixExtractor {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let input = match target {
+                PrefixTarget::Point(k) => k.as_ref(),
+                PrefixTarget::Prefix(p) => p.as_ref(),
+            };
+            (input.len() >= self.len).then_some(self.len)
+        }
+    }
+
+    fn settings() -> Settings {
+        Settings {
+            min_filter_keys: 0,
+            compactor_options: None,
+            ..Settings::default()
+        }
+    }
+
+    async fn build_db(path: &str, filter_policies: Vec<Arc<dyn FilterPolicy>>) -> Db {
+        Db::builder(path, Arc::new(InMemory::new()))
+            .with_settings(settings())
+            .with_filter_policies(filter_policies)
+            .build()
+            .await
+            .expect("failed to build db")
+    }
+
+    async fn write_keys(db: &Db, keys: &[Vec<u8>]) {
+        let put_opts = PutOptions::default();
+        let write_opts = WriteOptions {
+            await_durable: false,
+        };
+        for (i, key) in keys.iter().enumerate() {
+            let value = format!("v{}", i).into_bytes();
+            db.put_with_options(key, &value, &put_opts, &write_opts)
+                .await
+                .expect("put failed");
+            // Flush every few keys so writes spread across multiple SSTs and
+            // the filter has something to skip.
+            if i % 8 == 7 {
+                db.flush().await.expect("flush failed");
+            }
+        }
+        db.flush().await.expect("flush failed");
+    }
+
+    async fn collect_prefix_scan(db: &Db, prefix: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let mut iter = db
+            .scan_prefix_with_options(prefix, &ScanOptions::default())
+            .await
+            .expect("scan_prefix failed");
+        let mut out = Vec::new();
+        while let Some(kv) = iter.next().await.expect("iterator next failed") {
+            out.push((kv.key.to_vec(), kv.value.to_vec()));
+        }
+        out
+    }
+
+    // Keys are 3 to 8 bytes from a small alphabet so collisions on the 3-byte
+    // prefix are likely; that's the case where the bloom filter actually has
+    // hashes to compare against.
+    fn key_strategy() -> impl Strategy<Value = Vec<u8>> {
+        vec(
+            prop_oneof![Just(b'a'), Just(b'b'), Just(b'c'), Just(b'd')],
+            3..=8,
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig {
+            cases: 64,
+            ..ProptestConfig::default()
+        })]
+
+        #[test]
+        fn prefix_scan_matches_with_and_without_filter(
+            keys in vec(key_strategy(), 1..50),
+            query_seed in any::<u8>(),
+        ) {
+            let runtime = Runtime::new().expect("failed to create runtime");
+            runtime.block_on(async {
+                let db_no_filter = build_db("/test/no_filter", vec![]).await;
+                let db_with_filter = build_db(
+                    "/test/with_filter",
+                    vec![Arc::new(
+                        BloomFilterPolicy::new(10).with_prefix_extractor(
+                            Arc::new(FixedPrefixExtractor::new(PREFIX_LEN)),
+                        ),
+                    )],
+                )
+                .await;
+
+                write_keys(&db_no_filter, &keys).await;
+                write_keys(&db_with_filter, &keys).await;
+
+                // Build a candidate set of prefixes: every distinct full-length
+                // prefix from the input, plus a couple guaranteed-absent ones.
+                let mut prefixes: Vec<Vec<u8>> = keys
+                    .iter()
+                    .filter(|k| k.len() >= PREFIX_LEN)
+                    .map(|k| k[..PREFIX_LEN].to_vec())
+                    .collect();
+                prefixes.sort();
+                prefixes.dedup();
+                prefixes.push(b"zzz".to_vec());
+                prefixes.push(b"xyz".to_vec());
+
+                let pick = prefixes[query_seed as usize % prefixes.len()].clone();
+
+                let no_filter_results = collect_prefix_scan(&db_no_filter, &pick).await;
+                let with_filter_results = collect_prefix_scan(&db_with_filter, &pick).await;
+
+                prop_assert_eq!(no_filter_results, with_filter_results);
+
+                db_no_filter.close().await.expect("close failed");
+                db_with_filter.close().await.expect("close failed");
+                Ok(())
+            })?;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

What is being changed and why?

The change includes: 
- A change in the SST iter to only init and read first block if the SST is not filtered out. 
- A prop test, integration test with 2 policies and a benchmark.  

Results for the benchmark: 
```
scan_prefix/first_entry/no_filter
                        time:   [299.70 ms 300.63 ms 301.48 ms]
                        change: [-0.0620% +0.3586% +0.7667%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild
Benchmarking scan_prefix/full_scan/no_filter: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 6.1s, or reduce sample count to 10.
scan_prefix/full_scan/no_filter
                        time:   [299.85 ms 301.28 ms 302.88 ms]
                        change: [+0.3487% +0.9250% +1.5198%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild
Benchmarking scan_prefix/first_entry/prefix_bloom: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 7.6s, enable flat sampling, or reduce sample count to 10.
scan_prefix/first_entry/prefix_bloom
                        time:   [35.844 ms 36.067 ms 36.281 ms]
                        change: [-1.0993% -0.3395% +0.4276%] (p = 0.40 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild
Benchmarking scan_prefix/full_scan/prefix_bloom: Warming up for 3.0000 s
Warning: Unable to complete 20 samples in 5.0s. You may wish to increase target time to 7.6s, enable flat sampling, or reduce sample count to 10.
scan_prefix/full_scan/prefix_bloom
                        time:   [36.192 ms 36.282 ms 36.362 ms]
                        change: [-0.2387% +0.3352% +0.8333%] (p = 0.24 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) low mild
  ```

towards https://github.com/slatedb/slatedb/issues/1334

## Changes

The implementation of the RFC-22 will be broken into multiple PRs, it will be broken down to: 
- Defining the traits for pluggable filters **[MERGED]**
- Migrate the existing bloom filter to use the new traits **[MERGED]**
- Wire the usage of array of composite filters in SST format and read/write paths. (no public configs changes) **[MERGED]**
- Support for serialization and deserialization for filters in foyer hybrid cache. **[MERGED]**
- Wire prefix scan through the filter evaluation path (no prefix bloom filter defined yet)  **[MERGED]**
- Add prefix bloom filter support to BloomFilterPolicy  **[MERGED]**
- Metrics for prefix bloom filter usage  **[MERGED]**
- Expose `with_filter_policies` on builders and remove old filter configs.  **[MERGED]**
- Add the `filter_context` to the read APIs **[MERGED]**
- [x] Integration tests for pluggable filter policies
- [x] Prefix scan filter benchmarks

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
