### PR TITLE
Add `MergeOperator` load to `bank.rs` DST

### DIFF
--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -11,6 +11,8 @@ real `slatedb::Db`:
 - deterministic main and optional WAL object-store stacks
 - a shared installed `Arc<slatedb::Db>` slot that actors can read or replace
 - actor-local `slatedb::DbRand` instances derived from the root seed
+- an optional shared `MergeOperator` handle for scenarios that exercise merge
+  operands
 
 This is primarily a test crate for SlateDB itself and is currently
 `publish = false`. It is intended to be used from a workspace checkout or as an
@@ -141,14 +143,16 @@ fn dst_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
         let db_seed = ctx.rand().rng().next_u64();
         let settings = build_settings(ctx.rand()).await;
 
-        let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
+        let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
             .with_wal_object_store(ctx.wal_object_store().expect("configured"))
             .with_system_clock(ctx.system_clock())
             .with_fp_registry(ctx.fp_registry())
             .with_seed(db_seed)
-            .with_settings(settings)
-            .build()
-            .await?;
+            .with_settings(settings);
+        if let Some(merge_operator) = ctx.merge_operator() {
+            builder = builder.with_merge_operator(merge_operator);
+        }
+        let db = builder.build().await?;
 
         Ok(Arc::new(db))
     })
@@ -181,6 +185,8 @@ fn dst_smoke_test() -> Result<(), Box<dyn std::error::Error>> {
   store, which the harness wraps before use
 - `with_wal_object_store(store)`: configures a separate WAL base store, which
   the harness wraps before use
+- `with_merge_operator(merge_operator)`: configures an optional shared
+  `MergeOperator` handle for SlateDB writers, readers, and standalone compactors
 - `actor(name, actor)`: registers one actor instance under a unique name
 - `run()`: builds the seeded runtime, starts the harness-owned background
   clock task, opens the DB, spawns one Tokio task per registered actor, and
@@ -200,6 +206,7 @@ to the database builder.
 - `wal_object_store()`
 - `system_clock()`
 - `fp_registry()`
+- `merge_operator()`
 - `failure_controller()`
 - `rand()`
 
@@ -209,6 +216,8 @@ Typical startup responsibilities:
 - build randomized deterministic settings with `utils::build_settings(...)`
 - open `Db::builder(...)` using the harness-provided object stores and clock
 - pass through the shared failpoint registry
+- pass `ctx.merge_operator()` to `DbBuilder::with_merge_operator(...)` when it
+  is present
 - install initial object-store toxics with `ctx.failure_controller()`
 
 ### `ActorCtx`
@@ -228,6 +237,8 @@ Each registered actor instance receives its own `ActorCtx`.
 - `advance_time(duration)` to move the shared mock clock forward
 - `path()`, `main_object_store()`, `wal_object_store()`
 - `system_clock()` and `fp_registry()`
+- `merge_operator()` to reuse the shared merge operator when opening readers,
+  compactors, or replacement DB handles
 
 `swap_db(...)` is useful for reopen scenarios and tests that intentionally
 replace the database instance mid-run.

--- a/slatedb-dst/src/actors/bank/auditor.rs
+++ b/slatedb-dst/src/actors/bank/auditor.rs
@@ -123,6 +123,10 @@ async fn open_bank_reader(ctx: &ActorCtx, options: DbReaderOptions) -> Result<Db
         builder = builder.with_wal_object_store(wal_object_store);
     }
 
+    if let Some(merge_operator) = ctx.merge_operator() {
+        builder = builder.with_merge_operator(merge_operator);
+    }
+
     builder.build().await
 }
 

--- a/slatedb-dst/src/actors/bank/mod.rs
+++ b/slatedb-dst/src/actors/bank/mod.rs
@@ -1,13 +1,14 @@
 mod auditor;
 mod transfer;
 
+use bytes::Bytes;
 use slatedb::config::{PutOptions, WriteOptions};
-use slatedb::{Db, DbTransaction, Error};
+use slatedb::{Db, DbTransaction, Error, MergeOperator, MergeOperatorError};
 
 pub use self::auditor::{AuditorActor, BankAuditView};
-pub use self::transfer::TransferActor;
+pub use self::transfer::{TransferActor, TransferMode};
 
-const BALANCE_BYTES: usize = std::mem::size_of::<u64>();
+const ACCUMULATOR_BYTES: usize = std::mem::size_of::<i64>();
 
 /// Configuration for the deterministic bank workload.
 #[derive(Clone, Debug)]
@@ -20,7 +21,7 @@ pub struct BankOptions {
     pub initial_balance: u64,
     /// Maximum amount sampled for a transfer step.
     pub max_transfer: u64,
-    /// Size in bytes for each account value. The first eight bytes encode the balance.
+    /// Size in bytes for each account value. The first eight bytes encode the signed accumulator.
     pub value_size_bytes: usize,
 }
 
@@ -40,13 +41,21 @@ impl BankOptions {
             "bank workload max_transfer must be greater than zero"
         );
         assert!(
-            self.expected_total() <= u128::from(u64::MAX),
-            "bank workload expected_total must fit within u64 balances"
+            self.initial_balance <= i64::MAX as u64,
+            "bank workload initial_balance must fit within i64 balances"
         );
         assert!(
-            self.value_size_bytes >= BALANCE_BYTES,
+            self.max_transfer <= i64::MAX as u64,
+            "bank workload max_transfer must fit within i64 deltas"
+        );
+        assert!(
+            self.expected_total() <= i64::MAX as u128,
+            "bank workload expected_total must fit within i64 balances"
+        );
+        assert!(
+            self.value_size_bytes >= ACCUMULATOR_BYTES,
             "bank workload value_size_bytes must be at least {}",
-            BALANCE_BYTES
+            ACCUMULATOR_BYTES
         );
         Ok(())
     }
@@ -59,7 +68,7 @@ impl Default for BankOptions {
             account_count: 32,
             initial_balance: 10_000,
             max_transfer: 100,
-            value_size_bytes: BALANCE_BYTES,
+            value_size_bytes: ACCUMULATOR_BYTES,
         }
     }
 }
@@ -86,6 +95,56 @@ pub async fn initialize_accounts(db: &Db, options: &BankOptions) -> Result<(), E
     db.flush().await?;
 
     Ok(())
+}
+
+/// Bank merge operator for fixed-size signed account accumulator payloads.
+#[derive(Debug)]
+pub struct BankMergeOperator {
+    value_size_bytes: usize,
+}
+
+impl BankMergeOperator {
+    /// Creates a merge operator for payloads encoded with the provided bank options.
+    pub fn new(options: &BankOptions) -> Result<Self, Error> {
+        options.validate()?;
+        Ok(Self {
+            value_size_bytes: options.value_size_bytes,
+        })
+    }
+}
+
+impl MergeOperator for BankMergeOperator {
+    fn merge(
+        &self,
+        key: &Bytes,
+        existing_value: Option<Bytes>,
+        value: Bytes,
+    ) -> Result<Bytes, MergeOperatorError> {
+        self.merge_batch(key, existing_value, std::slice::from_ref(&value))
+    }
+
+    fn merge_batch(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<Bytes, MergeOperatorError> {
+        let mut total = existing_value
+            .as_ref()
+            .map(|value| decode_accumulator(value.as_ref(), self.value_size_bytes))
+            .unwrap_or(0);
+
+        for operand in operands {
+            total = total
+                .checked_add(decode_accumulator(operand.as_ref(), self.value_size_bytes))
+                .expect("bank merge overflowed signed accumulator");
+        }
+
+        Ok(Bytes::from(encode_accumulator(
+            total,
+            self.value_size_bytes,
+        )))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -160,35 +219,22 @@ impl BankAccounts {
     }
 
     fn encode_balance(&self, balance: u64) -> Vec<u8> {
-        debug_assert!(self.options.value_size_bytes >= BALANCE_BYTES);
+        let balance = i64::try_from(balance).expect("bank balance must fit within i64");
+        encode_accumulator(balance, self.options.value_size_bytes)
+    }
 
-        let mut value = vec![0; self.options.value_size_bytes];
-        value[..BALANCE_BYTES].copy_from_slice(&balance.to_le_bytes());
-        value
+    fn encode_delta(&self, delta: i64) -> Vec<u8> {
+        encode_accumulator(delta, self.options.value_size_bytes)
     }
 
     fn decode_balance(&self, bytes: &[u8]) -> Result<u64, Error> {
-        assert_eq!(
-            bytes.len(),
-            self.options.value_size_bytes,
-            "bank balance value must be exactly {} bytes, got {}",
-            self.options.value_size_bytes,
-            bytes.len(),
-        );
+        let balance = decode_accumulator(bytes, self.options.value_size_bytes);
         assert!(
-            self.options.value_size_bytes >= BALANCE_BYTES,
-            "bank balance value_size_bytes must be at least {}",
-            BALANCE_BYTES,
+            balance >= 0,
+            "bank balance must be non-negative, got {}",
+            balance
         );
-
-        let balance: [u8; BALANCE_BYTES] = bytes[..BALANCE_BYTES].try_into().unwrap_or_else(|_| {
-            panic!(
-                "bank balance value must include an {} byte balance prefix, got {}",
-                BALANCE_BYTES,
-                bytes.len(),
-            )
-        });
-        Ok(u64::from_le_bytes(balance))
+        Ok(balance as u64)
     }
 
     async fn load_balance(&self, txn: &DbTransaction, key: &[u8]) -> Result<u64, Error> {
@@ -198,5 +244,194 @@ impl BankAccounts {
             .expect("bank account missing during transfer");
 
         self.decode_balance(balance.as_ref())
+    }
+}
+
+fn encode_accumulator(accumulator: i64, value_size_bytes: usize) -> Vec<u8> {
+    debug_assert!(value_size_bytes >= ACCUMULATOR_BYTES);
+
+    let mut value = vec![0; value_size_bytes];
+    value[..ACCUMULATOR_BYTES].copy_from_slice(&accumulator.to_le_bytes());
+    value
+}
+
+fn decode_accumulator(bytes: &[u8], value_size_bytes: usize) -> i64 {
+    assert_eq!(
+        bytes.len(),
+        value_size_bytes,
+        "bank account value must be exactly {} bytes, got {}",
+        value_size_bytes,
+        bytes.len(),
+    );
+    assert!(
+        value_size_bytes >= ACCUMULATOR_BYTES,
+        "bank account value_size_bytes must be at least {}",
+        ACCUMULATOR_BYTES,
+    );
+    assert!(
+        bytes[ACCUMULATOR_BYTES..].iter().all(|byte| *byte == 0),
+        "bank account value padding must be zero",
+    );
+
+    let accumulator: [u8; ACCUMULATOR_BYTES] =
+        bytes[..ACCUMULATOR_BYTES].try_into().unwrap_or_else(|_| {
+            panic!(
+                "bank account value must include an {} byte accumulator prefix, got {}",
+                ACCUMULATOR_BYTES,
+                bytes.len(),
+            )
+        });
+    i64::from_le_bytes(accumulator)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+
+    use super::*;
+
+    fn test_options(value_size_bytes: usize) -> BankOptions {
+        BankOptions {
+            prefix: "test-acct".to_string(),
+            account_count: 4,
+            initial_balance: 100,
+            max_transfer: 10,
+            value_size_bytes,
+        }
+    }
+
+    fn test_bank(value_size_bytes: usize) -> BankAccounts {
+        BankAccounts::new(test_options(value_size_bytes)).unwrap()
+    }
+
+    fn test_operator(value_size_bytes: usize) -> BankMergeOperator {
+        BankMergeOperator::new(&test_options(value_size_bytes)).unwrap()
+    }
+
+    #[test]
+    fn should_encode_and_decode_fixed_size_balance() {
+        let bank = test_bank(16);
+
+        let encoded = bank.encode_balance(42);
+
+        assert_eq!(encoded.len(), 16);
+        assert_eq!(&encoded[..ACCUMULATOR_BYTES], &42i64.to_le_bytes());
+        assert!(encoded[ACCUMULATOR_BYTES..].iter().all(|byte| *byte == 0));
+        assert_eq!(bank.decode_balance(&encoded).unwrap(), 42);
+    }
+
+    #[test]
+    fn should_encode_positive_and_negative_deltas() {
+        let bank = test_bank(16);
+
+        let credit = bank.encode_delta(17);
+        let debit = bank.encode_delta(-9);
+
+        assert_eq!(decode_accumulator(&credit, 16), 17);
+        assert_eq!(decode_accumulator(&debit, 16), -9);
+    }
+
+    #[test]
+    fn should_merge_deltas_without_base() {
+        let operator = test_operator(16);
+        let bank = test_bank(16);
+        let operands = [
+            Bytes::from(bank.encode_delta(10)),
+            Bytes::from(bank.encode_delta(-3)),
+        ];
+
+        let result = operator
+            .merge_batch(&Bytes::from_static(b"acct/0"), None, &operands)
+            .unwrap();
+
+        assert_eq!(decode_accumulator(result.as_ref(), 16), 7);
+    }
+
+    #[test]
+    fn should_merge_deltas_with_base_or_partial_value() {
+        let operator = test_operator(16);
+        let bank = test_bank(16);
+        let base = Bytes::from(bank.encode_balance(100));
+        let operands = [
+            Bytes::from(bank.encode_delta(-20)),
+            Bytes::from(bank.encode_delta(5)),
+        ];
+
+        let result = operator
+            .merge_batch(&Bytes::from_static(b"acct/0"), Some(base), &operands)
+            .unwrap();
+
+        assert_eq!(decode_accumulator(result.as_ref(), 16), 85);
+        assert_eq!(bank.decode_balance(result.as_ref()).unwrap(), 85);
+    }
+
+    #[test]
+    fn should_preserve_regrouping_equivalence() {
+        let operator = test_operator(16);
+        let bank = test_bank(16);
+        let key = Bytes::from_static(b"acct/0");
+        let base = Bytes::from(bank.encode_balance(100));
+        let a = Bytes::from(bank.encode_delta(10));
+        let b = Bytes::from(bank.encode_delta(-4));
+        let c = Bytes::from(bank.encode_delta(7));
+
+        let direct = operator
+            .merge_batch(&key, Some(base.clone()), &[a.clone(), b.clone(), c.clone()])
+            .unwrap();
+        let partial = operator
+            .merge_batch(&key, None, &[a.clone(), b.clone()])
+            .unwrap();
+        let regrouped = operator
+            .merge_batch(&key, Some(base), &[partial, c])
+            .unwrap();
+
+        assert_eq!(direct, regrouped);
+        assert_eq!(decode_accumulator(regrouped.as_ref(), 16), 113);
+    }
+
+    #[test]
+    fn should_panic_on_malformed_payload_size() {
+        let operator = test_operator(16);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            operator
+                .merge_batch(
+                    &Bytes::from_static(b"acct/0"),
+                    None,
+                    &[Bytes::from_static(b"short")],
+                )
+                .unwrap();
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_panic_on_arithmetic_overflow() {
+        let operator = test_operator(16);
+        let operands = [
+            Bytes::from(encode_accumulator(i64::MAX, 16)),
+            Bytes::from(encode_accumulator(1, 16)),
+        ];
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            operator
+                .merge_batch(&Bytes::from_static(b"acct/0"), None, &operands)
+                .unwrap();
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_panic_when_decoding_negative_balance() {
+        let bank = test_bank(16);
+        let negative = bank.encode_delta(-1);
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = bank.decode_balance(&negative);
+        }));
+
+        assert!(result.is_err());
     }
 }

--- a/slatedb-dst/src/actors/bank/transfer.rs
+++ b/slatedb-dst/src/actors/bank/transfer.rs
@@ -8,17 +8,29 @@ use crate::{Actor, ActorCtx};
 
 use super::{BankAccounts, BankOptions};
 
+/// Write style used by a bank transfer actor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TransferMode {
+    /// Commit absolute account balances with put operations.
+    Put,
+    /// Commit signed debit and credit deltas with merge operations.
+    Merge,
+}
+
 /// Repeatedly transfers funds between deterministic account pairs.
 #[derive(Debug)]
 pub struct TransferActor {
     bank: BankAccounts,
+    mode: TransferMode,
     step: u64,
 }
 
 impl TransferActor {
-    pub fn new(options: BankOptions) -> Result<Self, Error> {
+    /// Creates a transfer actor that uses the requested write mode for its lifetime.
+    pub fn new(options: BankOptions, mode: TransferMode) -> Result<Self, Error> {
         Ok(Self {
             bank: BankAccounts::new(options)?,
+            mode,
             step: 0,
         })
     }
@@ -56,11 +68,21 @@ impl Actor for TransferActor {
                     .checked_add(transfer_amount)
                     .expect("bank transfer overflowed destination account balance");
 
-                let updated_from_value = self.bank.encode_balance(from_balance - transfer_amount);
-                let updated_to_value = self.bank.encode_balance(updated_to_balance);
-
-                txn.put(from_key.as_bytes(), updated_from_value)?;
-                txn.put(to_key.as_bytes(), updated_to_value)?;
+                match self.mode {
+                    TransferMode::Put => {
+                        let updated_from_value =
+                            self.bank.encode_balance(from_balance - transfer_amount);
+                        let updated_to_value = self.bank.encode_balance(updated_to_balance);
+                        txn.put(from_key.as_bytes(), updated_from_value)?;
+                        txn.put(to_key.as_bytes(), updated_to_value)?;
+                    }
+                    TransferMode::Merge => {
+                        let transfer_delta = i64::try_from(transfer_amount)
+                            .expect("bank transfer amount must fit within i64");
+                        txn.merge(from_key.as_bytes(), self.bank.encode_delta(-transfer_delta))?;
+                        txn.merge(to_key.as_bytes(), self.bank.encode_delta(transfer_delta))?;
+                    }
+                }
 
                 match txn.commit_with_options(&write_options).await {
                     Ok(_) => break,

--- a/slatedb-dst/src/actors/compactor.rs
+++ b/slatedb-dst/src/actors/compactor.rs
@@ -124,9 +124,15 @@ impl CompactorActor {
     }
 
     fn compactor_builder(&self, ctx: &ActorCtx) -> CompactorBuilder<object_store::path::Path> {
-        CompactorBuilder::new(ctx.path().clone(), ctx.main_object_store())
+        let mut builder = CompactorBuilder::new(ctx.path().clone(), ctx.main_object_store())
             .with_options(self.actor_options.compactor_options.clone())
             .with_system_clock(ctx.system_clock())
-            .with_seed(ctx.rand().rng().next_u64())
+            .with_seed(ctx.rand().rng().next_u64());
+
+        if let Some(merge_operator) = ctx.merge_operator() {
+            builder = builder.with_merge_operator(merge_operator);
+        }
+
+        builder
     }
 }

--- a/slatedb-dst/src/actors/mod.rs
+++ b/slatedb-dst/src/actors/mod.rs
@@ -21,7 +21,8 @@ pub mod suppress_errors;
 pub mod workload;
 
 pub use self::bank::{
-    initialize_accounts, AuditorActor, BankAuditView, BankOptions, TransferActor,
+    initialize_accounts, AuditorActor, BankAuditView, BankMergeOperator, BankOptions,
+    TransferActor, TransferMode,
 };
 pub use self::compactor::{CompactorActor, CompactorActorOptions};
 pub use self::fencer::{DbFencerActor, DbFencerActorOptions, SuppressFenced};

--- a/slatedb-dst/src/actors/suppress_errors.rs
+++ b/slatedb-dst/src/actors/suppress_errors.rs
@@ -73,15 +73,17 @@ mod tests {
 
     fn test_harness<A: Actor>(name: &'static str, actor: A) -> Harness {
         Harness::new(name, 7, move |ctx| async move {
-            let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
+            let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
                 .with_system_clock(ctx.system_clock())
                 .with_settings(Settings {
                     compactor_options: None,
                     garbage_collector_options: None,
                     ..Settings::default()
-                })
-                .build()
-                .await?;
+                });
+            if let Some(merge_operator) = ctx.merge_operator() {
+                builder = builder.with_merge_operator(merge_operator);
+            }
+            let db = builder.build().await?;
 
             Ok(Arc::new(db))
         })

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 
 use fail_parallel::FailPointRegistry;
 use slatedb::compactor::Compactor;
-use slatedb::{Db, DbRand, Error};
+use slatedb::{Db, DbRand, Error, MergeOperator};
 use slatedb_common::clock::SystemClock;
 use slatedb_common::MockSystemClock;
 
@@ -79,8 +79,8 @@ impl ActorCtx {
     /// Returns the startup context shared by this harness run.
     ///
     /// This exposes the database path, object stores, clock, failpoint
-    /// registry, failure controller, and startup RNG used by the database
-    /// factory.
+    /// registry, failure controller, optional merge operator, and startup RNG
+    /// used by the database factory.
     pub fn startup_ctx(&self) -> &StartupCtx {
         &self.shared.startup_ctx
     }
@@ -168,6 +168,19 @@ impl ActorCtx {
         self.shared.startup_ctx.fp_registry()
     }
 
+    /// Returns the merge operator configured for this harness run, if any.
+    ///
+    /// Components that open a `Db`, `DbReader`, or standalone `Compactor`
+    /// against a database that may contain merge operands should pass this
+    /// handle through to the corresponding SlateDB builder.
+    ///
+    /// ## Returns
+    /// - `Option<Arc<dyn MergeOperator + Send + Sync>>`: The shared
+    ///   merge-operator handle, or `None`.
+    pub fn merge_operator(&self) -> Option<Arc<dyn MergeOperator + Send + Sync>> {
+        self.shared.startup_ctx.merge_operator()
+    }
+
     /// Returns the shared shutdown token for the current harness run.
     ///
     /// Actors may call `cancel()` to request harness shutdown, or observe the
@@ -190,6 +203,7 @@ pub struct StartupCtx {
     system_clock: Arc<dyn SystemClock>,
     fp_registry: Arc<FailPointRegistry>,
     failure_controller: FailingObjectStoreController,
+    merge_operator: Option<Arc<dyn MergeOperator + Send + Sync>>,
     rand: Arc<DbRand>,
 }
 
@@ -236,6 +250,18 @@ impl StartupCtx {
     ///   the database under test.
     pub fn fp_registry(&self) -> Arc<FailPointRegistry> {
         Arc::clone(&self.fp_registry)
+    }
+
+    /// Returns the merge operator configured for this harness run, if any.
+    ///
+    /// Startup factories should pass this handle to `DbBuilder` when opening a
+    /// database that may write or read merge operands.
+    ///
+    /// ## Returns
+    /// - `Option<Arc<dyn MergeOperator + Send + Sync>>`: The shared
+    ///   merge-operator handle, or `None`.
+    pub fn merge_operator(&self) -> Option<Arc<dyn MergeOperator + Send + Sync>> {
+        self.merge_operator.clone()
     }
 
     /// Returns the shared failure controller for the harness object stores.
@@ -334,6 +360,7 @@ pub struct Harness {
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     clock_advance_ms: RangeInclusive<u64>,
+    merge_operator: Option<Arc<dyn MergeOperator + Send + Sync>>,
     startup_factory: StartupFactory,
     actors: Vec<ActorRegistration>,
 }
@@ -364,6 +391,7 @@ impl Harness {
             main_object_store: Arc::new(InMemory::new()),
             wal_object_store: None,
             clock_advance_ms: 1..=5,
+            merge_operator: None,
             startup_factory: Box::new(move |ctx| Box::pin(factory(ctx))),
             actors: Vec::new(),
         }
@@ -459,6 +487,26 @@ impl Harness {
         self
     }
 
+    /// Configures the merge operator shared by DST components.
+    ///
+    /// The handle is exposed through [`StartupCtx::merge_operator`] and
+    /// [`ActorCtx::merge_operator`]. Built-in DST components that open
+    /// read-only readers or standalone compactors pass it through automatically.
+    /// Startup factories remain responsible for passing it to `DbBuilder`.
+    ///
+    /// ## Arguments
+    /// - `merge_operator`: The merge operator handle to use for this harness run.
+    ///
+    /// ## Returns
+    /// - `Harness`: The updated harness builder.
+    pub fn with_merge_operator(
+        mut self,
+        merge_operator: Arc<dyn MergeOperator + Send + Sync>,
+    ) -> Self {
+        self.merge_operator = Some(merge_operator);
+        self
+    }
+
     /// Registers one actor task under a unique logical name.
     ///
     /// ## Arguments
@@ -527,6 +575,7 @@ impl Harness {
             main_object_store,
             wal_object_store,
             clock_advance_ms: _,
+            merge_operator,
             startup_factory,
             actors,
         } = self;
@@ -570,6 +619,7 @@ impl Harness {
             system_clock: Arc::clone(&system_clock),
             fp_registry: Arc::clone(&fp_registry),
             failure_controller,
+            merge_operator,
             rand: Arc::new(DbRand::new(startup_seed)),
         };
 

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -13,9 +13,9 @@ use slatedb::{Db, DbRand, Error};
 use slatedb_common::clock::MockSystemClock;
 use slatedb_dst::{
     actors::{
-        initialize_accounts, AuditorActor, BankAuditView, BankOptions, CompactorActor,
-        CompactorActorOptions, DbFencerActor, DbFencerActorOptions, ShutdownActor, SuppressFenced,
-        TransferActor,
+        initialize_accounts, AuditorActor, BankAuditView, BankMergeOperator, BankOptions,
+        CompactorActor, CompactorActorOptions, DbFencerActor, DbFencerActorOptions, ShutdownActor,
+        SuppressFenced, TransferActor, TransferMode,
     },
     utils::{build_reader_options, build_settings, build_settings_compactor, build_toxic},
     DeterministicLocalFilesystem, Harness, StartupCtx,
@@ -50,6 +50,7 @@ fn test_dst_bank_with_toxics(
     let reader_options = build_reader_options(&rand);
     let fencer_restart_interval = Duration::from_secs(120);
     let compactor_options = build_settings_compactor(&mut *rand.rng());
+    let merge_operator = Arc::new(BankMergeOperator::new(&bank_options)?);
 
     let harness = Harness::new("bank", seed, {
         let bank_options = bank_options.clone();
@@ -70,32 +71,42 @@ fn test_dst_bank_with_toxics(
     .with_path(Path::from("bank"))
     .with_main_object_store(main_store)
     .with_wal_object_store(wal_store)
+    .with_merge_operator(merge_operator)
     .with_clock_advance(1..=5);
 
     let harness = harness
         .actor(
             "transfer-1",
-            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+            SuppressFenced::new(TransferActor::new(bank_options.clone(), TransferMode::Put)?),
         )
         .actor(
             "transfer-2",
-            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+            SuppressFenced::new(TransferActor::new(bank_options.clone(), TransferMode::Put)?),
         )
         .actor(
             "transfer-3",
-            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+            SuppressFenced::new(TransferActor::new(bank_options.clone(), TransferMode::Put)?),
         )
         .actor(
             "transfer-4",
-            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+            SuppressFenced::new(TransferActor::new(
+                bank_options.clone(),
+                TransferMode::Merge,
+            )?),
         )
         .actor(
             "transfer-5",
-            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+            SuppressFenced::new(TransferActor::new(
+                bank_options.clone(),
+                TransferMode::Merge,
+            )?),
         )
         .actor(
             "transfer-6",
-            SuppressFenced::new(TransferActor::new(bank_options.clone())?),
+            SuppressFenced::new(TransferActor::new(
+                bank_options.clone(),
+                TransferMode::Merge,
+            )?),
         )
         .actor(
             "regular-auditor",

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -167,14 +167,18 @@ async fn open_bank_db(ctx: StartupCtx) -> Result<Arc<Db>, Error> {
         settings.wal_enabled = true;
     }
 
-    let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
+    let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
         .with_wal_object_store(ctx.wal_object_store().expect("configured"))
         .with_system_clock(ctx.system_clock())
         .with_fp_registry(ctx.fp_registry())
         .with_seed(db_seed)
-        .with_settings(settings)
-        .build()
-        .await?;
+        .with_settings(settings);
+
+    if let Some(merge_operator) = ctx.merge_operator() {
+        builder = builder.with_merge_operator(merge_operator);
+    }
+
+    let db = builder.build().await?;
 
     Ok(Arc::new(db))
 }

--- a/slatedb-dst/tests/determinism.rs
+++ b/slatedb-dst/tests/determinism.rs
@@ -195,14 +195,16 @@ fn run_seed_once(seed: u64, shutdown_at_ms: i64) -> TestResult<(u64, DateTime<Ut
         // Disable since we're using the standalone compactor actor.
         settings.compactor_options = None;
 
-        let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
+        let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
             .with_wal_object_store(ctx.wal_object_store().expect("configured"))
             .with_system_clock(ctx.system_clock())
             .with_fp_registry(ctx.fp_registry())
             .with_seed(db_seed)
-            .with_settings(settings)
-            .build()
-            .await?;
+            .with_settings(settings);
+        if let Some(merge_operator) = ctx.merge_operator() {
+            builder = builder.with_merge_operator(merge_operator);
+        }
+        let db = builder.build().await?;
         Ok(Arc::new(db))
     })
     .with_rand(Arc::clone(&rand))


### PR DESCRIPTION
## Summary

Adds merge-operator support to the DST harness and uses it in the bank workload so deterministic simulations exercise merge operands alongside regular put-based writes.

## Changes

- Add optional `MergeOperator` plumbing to `Harness`, `StartupCtx`, and `ActorCtx`
- Pass the configured merge operator through DB, reader, and standalone compactor builders used by DST components
- Add `BankMergeOperator` for fixed-size signed account accumulator payloads
- Add `TransferMode::{Put, Merge}` so bank transfer actors can mix put-based balance writes with merge-based debit/credit deltas
- Update the bank DST to run both put and merge transfer actors under toxics, fencing, readers, snapshots, and compaction

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
