### PR TITLE
[db_cache] pass shards to Foyer cache builder

### DIFF
--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -442,10 +442,7 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, func(t *testing.T, builder *slatedb.DbBuilder) {
 		t.Helper()
-		blockCache, err := slatedb.DbCacheNewMokaCache(slatedb.MokaCacheOptions{
-			MaxCapacity: 128 * 1024 * 1024,
-			Shards:      runtime.NumCPU(),
-		})
+		blockCache, err := slatedb.DbCacheNewMokaCache(slatedb.MokaCacheOptions{MaxCapacity: 128 * 1024 * 1024})
 		if err != nil {
 			t.Fatalf("NewMokaCache: %v", err)
 		}

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"runtime"
 
 	slatedb "slatedb.io/slatedb-go/uniffi"
 )
@@ -441,11 +442,17 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 	store := newMemoryStore(t)
 	handle := openTestDB(t, store, func(t *testing.T, builder *slatedb.DbBuilder) {
 		t.Helper()
-		blockCache, err := slatedb.DbCacheNewMokaCache(slatedb.MokaCacheOptions{MaxCapacity: 128 * 1024 * 1024})
+		blockCache, err := slatedb.DbCacheNewMokaCache(slatedb.MokaCacheOptions{
+			MaxCapacity: 128 * 1024 * 1024,
+			Shards: runtime.NumCPU(),
+		})
 		if err != nil {
 			t.Fatalf("NewMokaCache: %v", err)
 		}
-		metaCache, err := slatedb.DbCacheNewFoyerCache(slatedb.FoyerCacheOptions{MaxCapacity: 256 * 1024 * 1024})
+		metaCache, err := slatedb.DbCacheNewFoyerCache(slatedb.FoyerCacheOptions{
+			MaxCapacity: 256 * 1024 * 1024,
+			Shards: runtime.NumCPU(),
+		})
 		if err != nil {
 			t.Fatalf("NewFoyerCache: %v", err)
 		}

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
-	"runtime"
 
 	slatedb "slatedb.io/slatedb-go/uniffi"
 )
@@ -444,14 +444,14 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 		t.Helper()
 		blockCache, err := slatedb.DbCacheNewMokaCache(slatedb.MokaCacheOptions{
 			MaxCapacity: 128 * 1024 * 1024,
-			Shards: runtime.NumCPU(),
+			Shards:      runtime.NumCPU(),
 		})
 		if err != nil {
 			t.Fatalf("NewMokaCache: %v", err)
 		}
 		metaCache, err := slatedb.DbCacheNewFoyerCache(slatedb.FoyerCacheOptions{
 			MaxCapacity: 256 * 1024 * 1024,
-			Shards: runtime.NumCPU(),
+			Shards:      runtime.NumCPU(),
 		})
 		if err != nil {
 			t.Fatalf("NewFoyerCache: %v", err)

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -448,7 +448,7 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 		}
 		metaCache, err := slatedb.DbCacheNewFoyerCache(slatedb.FoyerCacheOptions{
 			MaxCapacity: 256 * 1024 * 1024,
-			Shards:      runtime.NumCPU(),
+			Shards:      uint64(runtime.NumCPU()),
 		})
 		if err != nil {
 			t.Fatalf("NewFoyerCache: %v", err)

--- a/slatedb/src/db_cache/foyer.rs
+++ b/slatedb/src/db_cache/foyer.rs
@@ -80,11 +80,10 @@ impl FoyerCache {
     }
 
     pub fn new_with_opts(options: FoyerCacheOptions) -> Self {
-        let builder = foyer::CacheBuilder::new(options.max_capacity as _)
-            .with_weighter(|_, v: &CachedEntry| v.size());
-
-        let cache = builder.build();
-
+        let cache = foyer::CacheBuilder::new(options.max_capacity as _)
+            .with_weighter(|_, v: &CachedEntry| v.size())
+            .with_shards(options.shards)
+            .build();
         Self { inner: cache }
     }
 }


### PR DESCRIPTION
## Summary

`FoyerCacheOptions.shards` it's not currently used. This PR will enable it again.

## Changes
n/a

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
