### PR TITLE
Fix WAL replay boundary when replayed batches flush to L0

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8226,85 +8226,58 @@ mod tests {
             ..Default::default()
         };
 
-        // Write a large record and flush it into its own WAL. With the smaller
-        // replay settings below, this becomes the first replayed memtable and
-        // is the only memtable that reaches L0 before the second simulated
-        // crash.
-        let l0_flushed_key = b"l0-flushed-replay-batch";
-        let l0_flushed_value = vec![b'a'; 1024];
-        let l0_flushed_write = source
-            .put_with_options(
-                l0_flushed_key,
-                &l0_flushed_value,
-                &PutOptions::default(),
-                &write_opts,
-            )
-            .await
-            .unwrap();
-        source
-            .flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
+        // Write two records, each flushed into its own WAL. With the smaller
+        // replay settings below, these WALs are replayed into the first
+        // memtable, and that memtable is the only one that reaches L0 before
+        // the second simulated crash.
+        let l0_flushed_records = [
+            (b"l0-flushed-replay-batch-1".as_slice(), vec![b'a'; 128]),
+            (b"l0-flushed-replay-batch-2".as_slice(), vec![b'b'; 1024]),
+        ];
+        let mut l0_flushed_seq = 0;
+        let mut first_l0_flushed_wal_id = 0;
+        for (i, (key, value)) in l0_flushed_records.iter().enumerate() {
+            let write = source
+                .put_with_options(*key, value, &PutOptions::default(), &write_opts)
+                .await
+                .unwrap();
+            source
+                .flush_with_options(FlushOptions {
+                    flush_type: FlushType::Wal,
+                })
+                .await
+                .unwrap();
+            if i == 0 {
+                first_l0_flushed_wal_id = source.inner.wal_buffer.recent_flushed_wal_id();
+            }
+            l0_flushed_seq = write.seqnum();
+        }
+        let l0_flushed_boundary_wal_id = source.inner.wal_buffer.recent_flushed_wal_id();
+        assert!(l0_flushed_boundary_wal_id > first_l0_flushed_wal_id);
 
-        // Write several smaller records, flushing each into a separate WAL. On
-        // replay, these WALs are grouped into a later replayed memtable. The
-        // first L0 must publish only the first replayed memtable's WAL boundary,
-        // leaving these records eligible for replay after the next reopen.
-        let unflushed_replay_key_1 = b"unflushed-replay-batch-1";
-        let unflushed_replay_value_1 = vec![b'b'; 128];
-        source
-            .put_with_options(
-                unflushed_replay_key_1,
-                &unflushed_replay_value_1,
-                &PutOptions::default(),
-                &write_opts,
-            )
-            .await
-            .unwrap();
-        source
-            .flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
-
-        let unflushed_replay_key_2 = b"unflushed-replay-batch-2";
-        let unflushed_replay_value_2 = vec![b'c'; 128];
-        source
-            .put_with_options(
-                unflushed_replay_key_2,
-                &unflushed_replay_value_2,
-                &PutOptions::default(),
-                &write_opts,
-            )
-            .await
-            .unwrap();
-        source
-            .flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
-
-        let unflushed_replay_key_3 = b"unflushed-replay-batch-3";
-        let unflushed_replay_value_3 = vec![b'd'; 128];
-        source
-            .put_with_options(
-                unflushed_replay_key_3,
-                &unflushed_replay_value_3,
-                &PutOptions::default(),
-                &write_opts,
-            )
-            .await
-            .unwrap();
-        source
-            .flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
+        // Write several smaller records, each flushed into a separate WAL. On
+        // replay, these WALs remain after the first replayed memtable's WAL
+        // boundary, so they must still be eligible for replay after the next
+        // reopen.
+        let unflushed_replay_records = [
+            (b"unflushed-replay-batch-1".as_slice(), vec![b'c'; 128]),
+            (b"unflushed-replay-batch-2".as_slice(), vec![b'd'; 128]),
+            (b"unflushed-replay-batch-3".as_slice(), vec![b'e'; 128]),
+        ];
+        for (key, value) in &unflushed_replay_records {
+            source
+                .put_with_options(*key, value, &PutOptions::default(), &write_opts)
+                .await
+                .unwrap();
+            source
+                .flush_with_options(FlushOptions {
+                    flush_type: FlushType::Wal,
+                })
+                .await
+                .unwrap();
+        }
+        let final_source_wal_id = source.inner.wal_buffer.recent_flushed_wal_id();
+        assert!(final_source_wal_id >= l0_flushed_boundary_wal_id + 2);
 
         // Recover with a much smaller replay target so WAL replay splits into
         // multiple replayed memtables. Limit L0 to one table so only the first
@@ -8323,8 +8296,9 @@ mod tests {
             .unwrap();
 
         // Wait until the manifest has durably published that first replayed
-        // memtable. The manifest now has one L0 with last_l0_seq equal to the
-        // first write's sequence number.
+        // memtable. The manifest now has one L0 with last_l0_seq and
+        // replay_after_wal_id matching the first replayed memtable's actual
+        // sequence and WAL boundaries.
         let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
         let mut stored_manifest =
             StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
@@ -8332,11 +8306,16 @@ mod tests {
                 .unwrap();
         let first_l0_manifest = wait_for_manifest_condition(
             &mut stored_manifest,
-            |state| !state.tree.l0.is_empty() && state.last_l0_seq >= l0_flushed_write.seqnum(),
-            Duration::from_secs(10),
+            |state| !state.tree.l0.is_empty() && state.last_l0_seq >= l0_flushed_seq,
+            Duration::from_secs(60),
         )
         .await;
-        assert_eq!(first_l0_manifest.last_l0_seq, l0_flushed_write.seqnum());
+        assert_eq!(first_l0_manifest.last_l0_seq, l0_flushed_seq);
+        assert_eq!(
+            first_l0_manifest.replay_after_wal_id,
+            l0_flushed_boundary_wal_id
+        );
+        assert!(final_source_wal_id >= first_l0_manifest.replay_after_wal_id + 2);
         assert_eq!(first_l0_manifest.tree.l0.len(), 1);
 
         // Second recovery: simulate crashing after only the first replayed
@@ -8349,24 +8328,20 @@ mod tests {
             .await
             .unwrap();
 
-        // The L0-flushed key is present from L0. The later keys must still come
-        // from WAL replay because they were not covered by the published L0
-        // boundary.
-        assert_eq!(
-            recovered.get(l0_flushed_key).await.unwrap(),
-            Some(Bytes::copy_from_slice(&l0_flushed_value))
-        );
-        assert_eq!(
-            recovered.get(unflushed_replay_key_1).await.unwrap(),
-            Some(Bytes::copy_from_slice(&unflushed_replay_value_1))
-        );
-        assert_eq!(
-            recovered.get(unflushed_replay_key_2).await.unwrap(),
-            Some(Bytes::copy_from_slice(&unflushed_replay_value_2))
-        );
-        assert_eq!(
-            recovered.get(unflushed_replay_key_3).await.unwrap(),
-            Some(Bytes::copy_from_slice(&unflushed_replay_value_3))
-        );
+        // The L0-flushed keys are present from L0. The later keys must still
+        // come from WAL replay because they were not covered by the published
+        // L0 boundary.
+        for (key, value) in &l0_flushed_records {
+            assert_eq!(
+                recovered.get(*key).await.unwrap(),
+                Some(Bytes::copy_from_slice(value))
+            );
+        }
+        for (key, value) in &unflushed_replay_records {
+            assert_eq!(
+                recovered.get(*key).await.unwrap(),
+                Some(Bytes::copy_from_slice(value))
+            );
+        }
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8204,4 +8204,159 @@ mod tests {
         );
         db.close().await.unwrap();
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_wal_replay_l0_boundary_does_not_skip_unflushed_replay_batches() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_wal_replay_l0_boundary_does_not_skip_unflushed_replay_batches";
+
+        // Start with a large L0/WAL size so the source writer only creates WAL
+        // files. The data stays out of L0 until recovery replays it.
+        let mut source_settings = test_db_options(0, 16 * 1024, None);
+        source_settings.flush_interval = None;
+
+        let source = Db::builder(path, object_store.clone())
+            .with_settings(source_settings)
+            .build()
+            .await
+            .unwrap();
+
+        let write_opts = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+
+        // Write a large first record and flush it into its own WAL. With the
+        // smaller replay settings below, this becomes the first replayed
+        // memtable and is the only memtable that reaches L0 before the second
+        // simulated crash.
+        let first_key = b"first-replay-batch";
+        let first_value = vec![b'a'; 1024];
+        let first = source
+            .put_with_options(first_key, &first_value, &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        // Write several smaller records, flushing each into a separate WAL. On
+        // replay, these WALs are grouped into a later replayed memtable. The
+        // buggy path publishes the first L0 as if it also covered some of these
+        // later WALs.
+        let lost_key = b"lost-replay-batch";
+        let lost_value = vec![b'b'; 128];
+        source
+            .put_with_options(lost_key, &lost_value, &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        let also_lost_key = b"also-lost-replay-batch";
+        let also_lost_value = vec![b'c'; 128];
+        source
+            .put_with_options(
+                also_lost_key,
+                &also_lost_value,
+                &PutOptions::default(),
+                &write_opts,
+            )
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        let survivor_key = b"survivor-replay-batch";
+        let survivor_value = vec![b'd'; 128];
+        source
+            .put_with_options(
+                survivor_key,
+                &survivor_value,
+                &PutOptions::default(),
+                &write_opts,
+            )
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        // Recover with a much smaller replay target so WAL replay splits into
+        // multiple replayed memtables. Limit L0 to one table so only the first
+        // replayed memtable can be flushed before the next reopen.
+        let mut replay_settings = test_db_options(0, 512, None);
+        replay_settings.flush_interval = None;
+        replay_settings.l0_max_ssts = 1;
+        replay_settings.l0_max_ssts_per_key = 1;
+
+        // First recovery: replay the WAL and allow the first replayed memtable
+        // to publish to L0.
+        let _first_recovery = Db::builder(path, object_store.clone())
+            .with_settings(replay_settings.clone())
+            .build()
+            .await
+            .unwrap();
+
+        // Wait until the manifest has durably published that first replayed
+        // memtable. The manifest now has one L0 with last_l0_seq equal to the
+        // first write's sequence number.
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let mut stored_manifest =
+            StoredManifest::load(manifest_store, Arc::new(DefaultSystemClock::new()))
+                .await
+                .unwrap();
+        let first_l0_manifest = wait_for_manifest_condition(
+            &mut stored_manifest,
+            |state| !state.tree.l0.is_empty() && state.last_l0_seq >= first.seqnum(),
+            Duration::from_secs(10),
+        )
+        .await;
+        assert_eq!(first_l0_manifest.last_l0_seq, first.seqnum());
+        assert_eq!(first_l0_manifest.tree.l0.len(), 1);
+
+        // Second recovery: simulate crashing after only the first replayed
+        // memtable reached L0. Correct recovery must replay the WALs after that
+        // first memtable's actual boundary, not after the later replay batch's
+        // last_wal_id - 1.
+        let recovered = Db::builder(path, object_store.clone())
+            .with_settings(replay_settings)
+            .build()
+            .await
+            .unwrap();
+
+        // The first key is present from L0. The later keys must come from WAL
+        // replay; today, lost_key fails here because the first L0 was published
+        // with a replay_after_wal_id that skipped its WAL.
+        assert_eq!(
+            recovered.get(first_key).await.unwrap(),
+            Some(Bytes::copy_from_slice(&first_value))
+        );
+        assert_eq!(
+            recovered.get(lost_key).await.unwrap(),
+            Some(Bytes::copy_from_slice(&lost_value))
+        );
+        assert_eq!(
+            recovered.get(also_lost_key).await.unwrap(),
+            Some(Bytes::copy_from_slice(&also_lost_value))
+        );
+        assert_eq!(
+            recovered.get(survivor_key).await.unwrap(),
+            Some(Bytes::copy_from_slice(&survivor_value))
+        );
+    }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8226,46 +8226,16 @@ mod tests {
             ..Default::default()
         };
 
-        // Write a large first record and flush it into its own WAL. With the
-        // smaller replay settings below, this becomes the first replayed
-        // memtable and is the only memtable that reaches L0 before the second
-        // simulated crash.
-        let first_key = b"first-replay-batch";
-        let first_value = vec![b'a'; 1024];
-        let first = source
-            .put_with_options(first_key, &first_value, &PutOptions::default(), &write_opts)
-            .await
-            .unwrap();
-        source
-            .flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
-
-        // Write several smaller records, flushing each into a separate WAL. On
-        // replay, these WALs are grouped into a later replayed memtable. The
-        // first L0 must publish only the first replayed memtable's WAL boundary,
-        // leaving these later WALs eligible for replay after the next reopen.
-        let lost_key = b"lost-replay-batch";
-        let lost_value = vec![b'b'; 128];
-        source
-            .put_with_options(lost_key, &lost_value, &PutOptions::default(), &write_opts)
-            .await
-            .unwrap();
-        source
-            .flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
-
-        let also_lost_key = b"also-lost-replay-batch";
-        let also_lost_value = vec![b'c'; 128];
-        source
+        // Write a large record and flush it into its own WAL. With the smaller
+        // replay settings below, this becomes the first replayed memtable and
+        // is the only memtable that reaches L0 before the second simulated
+        // crash.
+        let l0_flushed_key = b"l0-flushed-replay-batch";
+        let l0_flushed_value = vec![b'a'; 1024];
+        let l0_flushed_write = source
             .put_with_options(
-                also_lost_key,
-                &also_lost_value,
+                l0_flushed_key,
+                &l0_flushed_value,
                 &PutOptions::default(),
                 &write_opts,
             )
@@ -8278,12 +8248,52 @@ mod tests {
             .await
             .unwrap();
 
-        let survivor_key = b"survivor-replay-batch";
-        let survivor_value = vec![b'd'; 128];
+        // Write several smaller records, flushing each into a separate WAL. On
+        // replay, these WALs are grouped into a later replayed memtable. The
+        // first L0 must publish only the first replayed memtable's WAL boundary,
+        // leaving these records eligible for replay after the next reopen.
+        let unflushed_replay_key_1 = b"unflushed-replay-batch-1";
+        let unflushed_replay_value_1 = vec![b'b'; 128];
         source
             .put_with_options(
-                survivor_key,
-                &survivor_value,
+                unflushed_replay_key_1,
+                &unflushed_replay_value_1,
+                &PutOptions::default(),
+                &write_opts,
+            )
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        let unflushed_replay_key_2 = b"unflushed-replay-batch-2";
+        let unflushed_replay_value_2 = vec![b'c'; 128];
+        source
+            .put_with_options(
+                unflushed_replay_key_2,
+                &unflushed_replay_value_2,
+                &PutOptions::default(),
+                &write_opts,
+            )
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        let unflushed_replay_key_3 = b"unflushed-replay-batch-3";
+        let unflushed_replay_value_3 = vec![b'd'; 128];
+        source
+            .put_with_options(
+                unflushed_replay_key_3,
+                &unflushed_replay_value_3,
                 &PutOptions::default(),
                 &write_opts,
             )
@@ -8322,11 +8332,11 @@ mod tests {
                 .unwrap();
         let first_l0_manifest = wait_for_manifest_condition(
             &mut stored_manifest,
-            |state| !state.tree.l0.is_empty() && state.last_l0_seq >= first.seqnum(),
+            |state| !state.tree.l0.is_empty() && state.last_l0_seq >= l0_flushed_write.seqnum(),
             Duration::from_secs(10),
         )
         .await;
-        assert_eq!(first_l0_manifest.last_l0_seq, first.seqnum());
+        assert_eq!(first_l0_manifest.last_l0_seq, l0_flushed_write.seqnum());
         assert_eq!(first_l0_manifest.tree.l0.len(), 1);
 
         // Second recovery: simulate crashing after only the first replayed
@@ -8339,23 +8349,24 @@ mod tests {
             .await
             .unwrap();
 
-        // The first key is present from L0. The later keys must still come from
-        // WAL replay because they were not covered by the published L0.
+        // The L0-flushed key is present from L0. The later keys must still come
+        // from WAL replay because they were not covered by the published L0
+        // boundary.
         assert_eq!(
-            recovered.get(first_key).await.unwrap(),
-            Some(Bytes::copy_from_slice(&first_value))
+            recovered.get(l0_flushed_key).await.unwrap(),
+            Some(Bytes::copy_from_slice(&l0_flushed_value))
         );
         assert_eq!(
-            recovered.get(lost_key).await.unwrap(),
-            Some(Bytes::copy_from_slice(&lost_value))
+            recovered.get(unflushed_replay_key_1).await.unwrap(),
+            Some(Bytes::copy_from_slice(&unflushed_replay_value_1))
         );
         assert_eq!(
-            recovered.get(also_lost_key).await.unwrap(),
-            Some(Bytes::copy_from_slice(&also_lost_value))
+            recovered.get(unflushed_replay_key_2).await.unwrap(),
+            Some(Bytes::copy_from_slice(&unflushed_replay_value_2))
         );
         assert_eq!(
-            recovered.get(survivor_key).await.unwrap(),
-            Some(Bytes::copy_from_slice(&survivor_value))
+            recovered.get(unflushed_replay_key_3).await.unwrap(),
+            Some(Bytes::copy_from_slice(&unflushed_replay_value_3))
         );
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8245,8 +8245,8 @@ mod tests {
 
         // Write several smaller records, flushing each into a separate WAL. On
         // replay, these WALs are grouped into a later replayed memtable. The
-        // buggy path publishes the first L0 as if it also covered some of these
-        // later WALs.
+        // first L0 must publish only the first replayed memtable's WAL boundary,
+        // leaving these later WALs eligible for replay after the next reopen.
         let lost_key = b"lost-replay-batch";
         let lost_value = vec![b'b'; 128];
         source
@@ -8330,18 +8330,17 @@ mod tests {
         assert_eq!(first_l0_manifest.tree.l0.len(), 1);
 
         // Second recovery: simulate crashing after only the first replayed
-        // memtable reached L0. Correct recovery must replay the WALs after that
-        // first memtable's actual boundary, not after the later replay batch's
-        // last_wal_id - 1.
+        // memtable reached L0. Recovery must resume after that first
+        // memtable's actual WAL boundary, not after the later replay batch's
+        // boundary.
         let recovered = Db::builder(path, object_store.clone())
             .with_settings(replay_settings)
             .build()
             .await
             .unwrap();
 
-        // The first key is present from L0. The later keys must come from WAL
-        // replay; today, lost_key fails here because the first L0 was published
-        // with a replay_after_wal_id that skipped its WAL.
+        // The first key is present from L0. The later keys must still come from
+        // WAL replay because they were not covered by the published L0.
         assert_eq!(
             recovered.get(first_key).await.unwrap(),
             Some(Bytes::copy_from_slice(&first_value))

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -62,21 +62,14 @@ impl DbInner {
         &self,
         replayed_memtable: ReplayedMemtable,
     ) -> Result<(), SlateDBError> {
+        let current_memtable_wal_id = self.wal_buffer.recent_flushed_wal_id();
         let mut guard = self.state.write();
 
-        // a WAL might contain the data across multiple memtables. we can only consider
-        // last_wal_id - 1 as the recent persisted wal id when the memtable is reconstructed.
-        // or when we need to replay again, we might risks to lose some WAL entries.
-        let recent_flushed_wal_id = if replayed_memtable.last_wal_id > 0 {
-            replayed_memtable.last_wal_id - 1
-        } else {
-            0
-        };
-        // Keep recent_flushed_wal_id ahead of imm_memtable WAL IDs so
-        // maybe_freeze_memtable's subtraction doesn't underflow.
-        self.wal_buffer
-            .advance_recent_flushed_wal_id(recent_flushed_wal_id);
-        self.freeze_memtable(&mut guard, recent_flushed_wal_id)?;
+        // The active memtable was installed by the previous replay step, so its
+        // durable WAL boundary is the WAL buffer's current boundary. Stamp the
+        // frozen table with that boundary before advancing the buffer for the new
+        // replayed memtable.
+        self.freeze_memtable(&mut guard, current_memtable_wal_id)?;
 
         let last_wal = replayed_memtable.last_wal_id;
         guard.modify(|modifier| modifier.state.manifest.value.core.next_wal_sst_id = last_wal + 1);
@@ -94,6 +87,7 @@ impl DbInner {
 
         // replace the memtable
         guard.replace_memtable(replayed_memtable.table);
+        self.wal_buffer.advance_recent_flushed_wal_id(last_wal);
         let dirty_manifest = guard.state().manifest.clone();
         drop(guard);
         self.status_manager.report_manifest(dirty_manifest.into());


### PR DESCRIPTION
## Summary

The bank.rs DST failed a couple of nights ago:

https://github.com/slatedb/slatedb/actions/runs/25248453430/job/74036588175

If a DB crashes during WAL replay, this can happen:

```
t0: wal1 replayed into active memtable
t1: wal2/wal3 replay begins; this freezes the wal1 memtable
t2: wal1 memtable flushes to L0
t3: manifest records that L0 with replay_after_wal_id = wal3 - 1
t4: crash before wal2/wal3 are flushed to L0
```

On recovery, if there were more WALs (e.g. wal2, wal3) that weren't yet replayed, they get dropped because the manifest write stores the highest WAL ID as the next WAL ID rather than the next successfully replayed WAL ID.

## Changes

- Added regression coverage for partial WAL replay flushes
- Freeze replay memtables with their own WAL boundary
- Advance the WAL boundary after installing replayed data

## Notes for Reviewers

Review in commit order.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
