### PR TITLE
Misc DST harness improvements

### DIFF
--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -37,5 +37,6 @@ walkdir = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 tempfile = { workspace = true }
+
 [lints]
 workspace = true

--- a/slatedb-dst/src/actors/bank/auditor.rs
+++ b/slatedb-dst/src/actors/bank/auditor.rs
@@ -92,7 +92,11 @@ impl Actor for AuditorActor {
         };
 
         self.step += 1;
-        info!("bank auditor step complete [name={}, step={}]", ctx.name(), self.step);
+        info!(
+            "bank auditor step complete [name={}, step={}]",
+            ctx.name(),
+            self.step
+        );
 
         let shutdown_token = ctx.shutdown_token();
         let system_clock = ctx.system_clock();

--- a/slatedb-dst/src/actors/bank/auditor.rs
+++ b/slatedb-dst/src/actors/bank/auditor.rs
@@ -92,7 +92,7 @@ impl Actor for AuditorActor {
         };
 
         self.step += 1;
-        info!("bank auditor step complete");
+        info!("bank auditor step complete [name={}, step={}]", ctx.name(), self.step);
 
         let shutdown_token = ctx.shutdown_token();
         let system_clock = ctx.system_clock();

--- a/slatedb-dst/src/actors/shutdown.rs
+++ b/slatedb-dst/src/actors/shutdown.rs
@@ -30,7 +30,16 @@ impl Actor for ShutdownActor {
         let now = system_clock.now();
 
         if now >= self.shutdown_at {
+            info!("shutdown deadline reached, cancelling shutdown token [name={}, shutdown_at={}, now={}]", ctx.name(), self.shutdown_at, now);
+
+            // Clear any configured toxics to avoid interfering with the shutdown process.
+            let failure_controller = ctx.startup_ctx().failure_controller();
+            failure_controller.clear_toxics();
+            failure_controller.clear_http_failures();
+
+            // Cancel the shutdown token to signal the harness to stop.
             shutdown_token.cancel();
+
             return Ok(());
         }
 
@@ -42,13 +51,9 @@ impl Actor for ShutdownActor {
 
         tokio::select! {
             biased;
+            // Something else cancelled before we reached the deadline.
             _ = shutdown_token.cancelled() => {}
-            _ = system_clock.sleep(remaining) => {
-                if system_clock.now() >= self.shutdown_at {
-                    info!("shutdown deadline reached, cancelling shutdown token");
-                    shutdown_token.cancel();
-                }
-            }
+            _ = system_clock.sleep(remaining) => {}
         }
 
         Ok(())

--- a/slatedb-dst/src/failing_object_store.rs
+++ b/slatedb-dst/src/failing_object_store.rs
@@ -288,17 +288,17 @@ impl FailingObjectStore {
             match toxic {
                 ToxicKind::Latency { latency, jitter } => {
                     self.clock
-                        .advance(*latency + self.controller.sample_jitter(*jitter))
+                        .sleep(*latency + self.controller.sample_jitter(*jitter))
                         .await;
                 }
                 ToxicKind::Bandwidth { bytes_per_sec } => {
                     if let Some(delay) = bandwidth_delay(size_bytes, *bytes_per_sec) {
-                        self.clock.advance(delay).await;
+                        self.clock.sleep(delay).await;
                     }
                 }
                 ToxicKind::ResetPeer => return Err(reset_peer_error()),
                 ToxicKind::SlowClose { delay } if allow_slow_close => {
-                    self.clock.advance(*delay).await;
+                    self.clock.sleep(*delay).await;
                 }
                 ToxicKind::SlowClose { .. } => {}
             }

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -548,7 +548,6 @@ impl Harness {
         let system_clock: Arc<dyn SystemClock> = self.system_clock.clone();
         let clock_advance_ms = self.clock_advance_ms.clone();
         let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_time()
             .rng_seed(RngSeed::from_bytes(&runtime_seed.to_le_bytes()))
             .build_local(Default::default())
             .expect("failed to build dst harness runtime");
@@ -579,8 +578,8 @@ impl Harness {
             "dst harness requires at least one actor"
         );
 
-        let seed = rand.seed();
-        let path = path.unwrap_or_else(|| Path::from(format!("dst/{name}/seed-{seed:016x}")));
+        let path_seed = rand.seed();
+        let path = path.unwrap_or_else(|| Path::from(format!("dst/{name}/{path_seed:016x}")));
         let system_clock: Arc<dyn SystemClock> = system_clock;
         let fp_registry = Arc::new(FailPointRegistry::new());
         let failure_controller = FailingObjectStoreController::new(Arc::clone(&rand));
@@ -688,6 +687,7 @@ impl Harness {
             Some(compactor) => compactor.stop().await,
             None => Ok(()),
         };
+        info!("dst harness final rand [value={}]", rand.rng().next_u64());
         db_result?;
         compactor_result
     }

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -48,8 +48,8 @@ struct ActorRegistration {
 
 /// Per-actor context passed to each registered harness task.
 ///
-/// The context exposes deterministic randomness, the shared database slot,
-/// clock-wrapped object stores, the shared shutdown token, and test
+/// The context exposes shared deterministic randomness, the shared database
+/// slot, clock-wrapped object stores, the shared shutdown token, and test
 /// infrastructure such as the failpoint registry, mock clock, and shared
 /// failure controller.
 #[derive(Clone)]
@@ -68,10 +68,10 @@ impl ActorCtx {
         &self.name
     }
 
-    /// Returns the actor-local deterministic random number generator.
+    /// Returns the shared deterministic random number generator.
     ///
     /// ## Returns
-    /// - `&DbRand`: The seeded RNG derived from the harness seed for this actor.
+    /// - `&DbRand`: The seeded RNG shared by this harness run.
     pub fn rand(&self) -> &DbRand {
         self.rand.as_ref()
     }
@@ -276,10 +276,10 @@ impl StartupCtx {
         self.failure_controller.clone()
     }
 
-    /// Returns the startup-local deterministic random number generator.
+    /// Returns the shared deterministic random number generator.
     ///
     /// ## Returns
-    /// - `&DbRand`: The seeded RNG reserved for database initialization.
+    /// - `&DbRand`: The seeded RNG shared by this harness run.
     pub fn rand(&self) -> &DbRand {
         self.rand.as_ref()
     }
@@ -370,8 +370,8 @@ impl Harness {
     ///
     /// ## Arguments
     /// - `name`: Scenario name used when deriving the default database path.
-    /// - `seed`: Root seed used to derive deterministic randomness for startup,
-    ///   fault injection, and actor-local RNGs.
+    /// - `seed`: Root seed used for deterministic randomness throughout the
+    ///   harness run.
     /// - `factory`: A function that receives a [`StartupCtx`] and returns the
     ///   database handle that actors should share.
     ///
@@ -412,8 +412,8 @@ impl Harness {
     /// Overrides the root deterministic random number generator.
     ///
     /// ## Arguments
-    /// - `rand`: The RNG to use for deriving runtime, startup, fault-injection,
-    ///   and actor-local seeds.
+    /// - `rand`: The RNG to share across startup, fault injection, the clock
+    ///   driver, and actors.
     ///
     /// ## Returns
     /// - `Harness`: The updated harness builder.
@@ -544,9 +544,7 @@ impl Harness {
     ///   an actor returned or joined with an error.
     pub fn run(self) -> Result<(), Error> {
         let runtime_seed = self.rand.rng().next_u64();
-        let startup_seed = self.rand.rng().next_u64();
-        let clock_seed = self.rand.rng().next_u64();
-        let failure_seed = self.rand.rng().next_u64();
+        let clock_rand = Arc::clone(&self.rand);
         let system_clock: Arc<dyn SystemClock> = self.system_clock.clone();
         let clock_advance_ms = self.clock_advance_ms.clone();
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -555,18 +553,14 @@ impl Harness {
             .build_local(Default::default())
             .expect("failed to build dst harness runtime");
         runtime.block_on(async move {
-            let clock_driver = ClockDriver::spawn(
-                system_clock,
-                Arc::new(DbRand::new(clock_seed)),
-                clock_advance_ms,
-            );
-            let result = self.run_inner(startup_seed, failure_seed).await;
+            let clock_driver = ClockDriver::spawn(system_clock, clock_rand, clock_advance_ms);
+            let result = self.run_inner().await;
             clock_driver.shutdown().await;
             result
         })
     }
 
-    async fn run_inner(self, startup_seed: u64, failure_seed: u64) -> Result<(), Error> {
+    async fn run_inner(self) -> Result<(), Error> {
         let Harness {
             name,
             rand,
@@ -589,8 +583,7 @@ impl Harness {
         let path = path.unwrap_or_else(|| Path::from(format!("dst/{name}/seed-{seed:016x}")));
         let system_clock: Arc<dyn SystemClock> = system_clock;
         let fp_registry = Arc::new(FailPointRegistry::new());
-        let failure_controller =
-            FailingObjectStoreController::new(Arc::new(DbRand::new(failure_seed)));
+        let failure_controller = FailingObjectStoreController::new(Arc::clone(&rand));
         let failing_main_object_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
             main_object_store.clone(),
             failure_controller.clone(),
@@ -620,7 +613,7 @@ impl Harness {
             fp_registry: Arc::clone(&fp_registry),
             failure_controller,
             merge_operator,
-            rand: Arc::new(DbRand::new(startup_seed)),
+            rand: Arc::clone(&rand),
         };
 
         let db = startup_factory(startup_ctx.clone()).await?;
@@ -636,12 +629,11 @@ impl Harness {
         let mut join_set = JoinSet::new();
         let mut actor_names = HashMap::new();
         for registration in actors {
-            let actor_seed = rand.rng().next_u64();
             let name = registration.name;
             let mut actor = registration.actor;
             let ctx = ActorCtx {
                 name: name.clone(),
-                rand: Arc::new(DbRand::new(actor_seed)),
+                rand: Arc::clone(&rand),
                 shared: shared.clone(),
             };
             let handle = join_set.spawn(async move {

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -315,7 +315,7 @@ impl ClockDriver {
                         .advance(Duration::from_millis(advance_ms))
                         .await;
                     steps += 1;
-                    if steps % 100_000 == 0 {
+                    if steps % 10_000 == 0 {
                         info!(
                             "clock driver advanced [steps={steps}, time={:?}]",
                             system_clock.now()
@@ -687,7 +687,7 @@ impl Harness {
             Some(compactor) => compactor.stop().await,
             None => Ok(()),
         };
-        info!("dst harness final rand [value={}]", rand.rng().next_u64());
+        info!("final random [value={}]", rand.rng().next_u64());
         db_result?;
         compactor_result
     }

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -28,7 +28,7 @@ use tempfile::TempDir;
 fn test_dst_bank_with_toxics(
     #[case] shutdown_at_ms: i64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let seed = rand::random::<u64>();
+    let seed = 12523239368982655918; //rand::random::<u64>();
     info!("dst bank seed: {seed}");
     let tempdir = TempDir::new()?;
     let main_dir = tempdir.path().join("main");

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -28,7 +28,7 @@ use tempfile::TempDir;
 fn test_dst_bank_with_toxics(
     #[case] shutdown_at_ms: i64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let seed = 12523239368982655918; //rand::random::<u64>();
+    let seed = rand::random::<u64>();
     info!("dst bank seed: {seed}");
     let tempdir = TempDir::new()?;
     let main_dir = tempdir.path().join("main");


### PR DESCRIPTION
## Summary

While debugging #1625, I found a few ways to improve the DST harness. See the changes section

## Changes

- Clear toxics on shutdown to lessen shutdown time. No point in testing after the test is complete.
- Sleep instead of advance clock in failing object store. Was seeing massive clock jumps that are unrealistic.
- Thread a single rand RNG through harness rather than creating new ones. Makes final-u64 checks more accurate.
- Improve logging througout.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
