### PR TITLE
Export instrumented_object_store metric name constants

### DIFF
--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -259,7 +259,7 @@ impl ObjectStore for InstrumentedObjectStore {
     }
 }
 
-pub(crate) mod stats {
+pub mod stats {
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -276,10 +276,9 @@ pub(crate) mod stats {
         };
     }
 
-    pub(crate) const REQUEST_COUNT: &str = object_store_stat_name!("request_count");
-    pub(crate) const ERROR_COUNT: &str = object_store_stat_name!("error_count");
-    pub(crate) const REQUEST_DURATION_SECONDS: &str =
-        object_store_stat_name!("request_duration_seconds");
+    pub const REQUEST_COUNT: &str = object_store_stat_name!("request_count");
+    pub const ERROR_COUNT: &str = object_store_stat_name!("error_count");
+    pub const REQUEST_DURATION_SECONDS: &str = object_store_stat_name!("request_duration_seconds");
 
     /// Pre-registered [`RequestMetrics`] for every object store API that
     /// SlateDB calls.

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -58,6 +58,7 @@ pub use filter_policy::{
 pub use format::sst::BlockTransformer;
 pub use garbage_collector::stats as garbage_collector_stats;
 pub use garbage_collector::GarbageCollectorBuilder;
+pub use instrumented_object_store::stats as instrumented_object_store_stats;
 pub use iter::IterationOrder;
 pub use manifest::VersionedManifest;
 pub use merge_operator::{MergeOperator, MergeOperatorError};


### PR DESCRIPTION
## Summary

Export metric name constants (REQUEST_COUNT, ERROR_COUNT, REQUEST_DURATION_SECONDS) public so users can import them instead of adding hardcoded metric names, just like the existing pattern used by db_stats, cached_object_store_stats, db_cache_stats, and garbage_collector_stats.

## Changes

- export instrumented object store metric names

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
