### PR TITLE
Fix missing seqno in WriteOptions

### DIFF
--- a/slatedb/benches/scan_prefix_bench.rs
+++ b/slatedb/benches/scan_prefix_bench.rs
@@ -130,6 +130,7 @@ fn scan_options() -> ScanOptions {
 async fn populate(db: &Db) {
     let write_opts = WriteOptions {
         await_durable: false,
+        seqnum: 0,
     };
     let put_opts = PutOptions::default();
     let mut next_version = [0u64; NUM_PREFIXES];

--- a/slatedb/tests/prefix_filter.rs
+++ b/slatedb/tests/prefix_filter.rs
@@ -114,6 +114,7 @@ mod composite_filters {
         let put = PutOptions::default();
         let write = WriteOptions {
             await_durable: false,
+            seqnum: 0,
         };
         // Write each batch in its own SST so multiple SSTs participate in the
         // read path and the filter has something to actually skip.
@@ -282,6 +283,7 @@ mod prop_test {
         let put_opts = PutOptions::default();
         let write_opts = WriteOptions {
             await_durable: false,
+            seqnum: 0,
         };
         for (i, key) in keys.iter().enumerate() {
             let value = format!("v{}", i).into_bytes();


### PR DESCRIPTION
Fixing `WriteOptions` missing `seqno` after https://github.com/slatedb/slatedb/pull/1618 was merged. 