### PR TITLE
Do not rebuild table on upload retry

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -1474,7 +1474,7 @@ mod tests {
         let encoded_sst = sst_builder.build().await.unwrap();
         let id = SsTableId::Compacted(Ulid::new());
         let l0 = table_store
-            .write_sst(&id, encoded_sst, false)
+            .write_sst(&id, &encoded_sst, false)
             .await
             .unwrap();
         let retention_min_seq_num = 2;
@@ -1619,7 +1619,7 @@ mod tests {
         let encoded_sst = sst_builder.build().await.unwrap();
         let id = SsTableId::Compacted(Ulid::new());
         let l0 = table_store
-            .write_sst(&id, encoded_sst, false)
+            .write_sst(&id, &encoded_sst, false)
             .await
             .unwrap();
 
@@ -1720,7 +1720,7 @@ mod tests {
         let encoded_sst = sst_builder.build().await.unwrap();
         let id = SsTableId::Compacted(Ulid::new());
         let l0 = table_store
-            .write_sst(&id, encoded_sst, false)
+            .write_sst(&id, &encoded_sst, false)
             .await
             .unwrap();
 
@@ -1786,7 +1786,7 @@ mod tests {
         let encoded_sst = sst_builder.build().await.unwrap();
         let id = SsTableId::Compacted(Ulid::new());
         let l0 = table_store
-            .write_sst(&id, encoded_sst, false)
+            .write_sst(&id, &encoded_sst, false)
             .await
             .unwrap();
 

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -29,7 +29,7 @@ impl DbInner {
         &self,
         id: &db_state::SsTableId,
         imm_table: Arc<KVTable>,
-        encoded_sst: EncodedSsTable,
+        encoded_sst: &EncodedSsTable,
         write_cache: bool,
     ) -> Result<SsTableHandle, SlateDBError> {
         let handle = self
@@ -50,7 +50,7 @@ impl DbInner {
         write_cache: bool,
     ) -> Result<SsTableHandle, SlateDBError> {
         let encoded_sst = self.build_imm_sst(imm_table.clone()).await?;
-        self.upload_compacted_sst(id, imm_table, encoded_sst, write_cache)
+        self.upload_compacted_sst(id, imm_table, &encoded_sst, write_cache)
             .await
     }
 

--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -225,7 +225,7 @@ pub(crate) struct EncodedSsTableBlock {
     /// offset of the block within the SST
     pub(crate) offset: u64,
     /// uncompressed and untransformed block
-    pub(crate) block: Block,
+    pub(crate) block: Arc<Block>,
     /// compressed and transformed block
     pub(crate) encoded_bytes: Bytes,
 }
@@ -283,7 +283,7 @@ impl EncodedSsTableBlockBuilder {
         .await?;
         Ok(EncodedSsTableBlock {
             offset: self.offset,
-            block,
+            block: Arc::new(block),
             encoded_bytes: Bytes::from(compressed_and_transformed_block),
         })
     }

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -803,7 +803,7 @@ mod tests {
         let mut sst = table_store.table_builder();
         sst.add(RowEntry::new_value(b"key", b"value", 0)).await?;
         let table1 = sst.build().await?;
-        table_store.write_sst(table_id, table1, false).await?;
+        table_store.write_sst(table_id, &table1, false).await?;
         Ok(())
     }
 
@@ -940,7 +940,7 @@ mod tests {
             .unwrap();
 
         let table1 = sst1.build().await.unwrap();
-        table_store.write_sst(&id1, table1, false).await.unwrap();
+        table_store.write_sst(&id1, &table1, false).await.unwrap();
 
         let id2 = SsTableId::Wal(2);
         let mut sst2 = table_store.table_builder();
@@ -948,7 +948,7 @@ mod tests {
             .await
             .unwrap();
         let table2 = sst2.build().await.unwrap();
-        table_store.write_sst(&id2, table2, false).await.unwrap();
+        table_store.write_sst(&id2, &table2, false).await.unwrap();
 
         // Set the both WAL SST file to be a day old
         let now_minus_24h_1 = set_modified(
@@ -1287,7 +1287,7 @@ mod tests {
             .await
             .unwrap();
         let table = sst.build().await.unwrap();
-        table_store.write_sst(&sst_id, table, false).await.unwrap()
+        table_store.write_sst(&sst_id, &table, false).await.unwrap()
     }
 
     /// Set the modified time of a file to be a certain number of seconds ago.

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -303,15 +303,15 @@ mod tests {
         let sst_active_recent = build_test_sst(&format, 1).await;
 
         table_store
-            .write_sst(&id_to_delete, sst_to_delete, false)
+            .write_sst(&id_to_delete, &sst_to_delete, false)
             .await
             .unwrap();
         table_store
-            .write_sst(&id_within_min_age, sst_within_min_age, false)
+            .write_sst(&id_within_min_age, &sst_within_min_age, false)
             .await
             .unwrap();
         let active_handle = table_store
-            .write_sst(&id_active_recent, sst_active_recent, false)
+            .write_sst(&id_active_recent, &sst_active_recent, false)
             .await
             .unwrap();
 
@@ -409,15 +409,15 @@ mod tests {
         let sst_newer = build_test_sst(&format, 1).await;
 
         table_store
-            .write_sst(&id_to_delete, sst_to_delete, false)
+            .write_sst(&id_to_delete, &sst_to_delete, false)
             .await
             .unwrap();
         let manifest_handle = table_store
-            .write_sst(&id_manifest, sst_manifest, false)
+            .write_sst(&id_manifest, &sst_manifest, false)
             .await
             .unwrap();
         table_store
-            .write_sst(&id_newer, sst_newer, false)
+            .write_sst(&id_newer, &sst_newer, false)
             .await
             .unwrap();
 
@@ -502,15 +502,15 @@ mod tests {
         let sst_barrier = build_test_sst(&format, 1).await;
         let sst_to_newer = build_test_sst(&format, 1).await;
         table_store
-            .write_sst(&id_to_delete, sst_to_delete, false)
+            .write_sst(&id_to_delete, &sst_to_delete, false)
             .await
             .unwrap();
         table_store
-            .write_sst(&id_barrier, sst_barrier, false)
+            .write_sst(&id_barrier, &sst_barrier, false)
             .await
             .unwrap();
         let active_handle = table_store
-            .write_sst(&id_to_newer, sst_to_newer, false)
+            .write_sst(&id_to_newer, &sst_to_newer, false)
             .await
             .unwrap();
 
@@ -608,7 +608,7 @@ mod tests {
         // Newest L0 in the manifest has a later timestamp (9_000ms).
         let l0_id = SsTableId::Compacted(ulid::Ulid::from_parts(9_000, 0));
         let l0_handle = table_store
-            .write_sst(&l0_id, build_test_sst(&format, 1).await, false)
+            .write_sst(&l0_id, &build_test_sst(&format, 1).await, false)
             .await
             .unwrap();
         let mut dirty_manifest = stored_manifest.prepare_dirty().unwrap();
@@ -626,7 +626,7 @@ mod tests {
         table_store
             .write_sst(
                 &compaction_output_id,
-                build_test_sst(&format, 1).await,
+                &build_test_sst(&format, 1).await,
                 false,
             )
             .await

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -164,9 +164,9 @@ impl UploadHandler {
     }
 
     async fn upload_with_retry(&self, job: &UploadJob) -> Result<UploadedMemtable, SlateDBError> {
+        let encoded_sst = self.db.build_imm_sst(job.imm_memtable.table()).await?;
         loop {
-            let encoded_sst = self.db.build_imm_sst(job.imm_memtable.table()).await?;
-            match self.try_upload_once(job, encoded_sst).await {
+            match self.try_upload_once(job, &encoded_sst).await {
                 Ok(success) => return Ok(success),
                 Err(e) => {
                     // When the WAL is enabled and the database is shutting
@@ -188,11 +188,8 @@ impl UploadHandler {
     async fn try_upload_once(
         &self,
         job: &UploadJob,
-        encoded_sst: EncodedSsTable,
+        encoded_sst: &EncodedSsTable,
     ) -> Result<UploadedMemtable, SlateDBError> {
-        // TODO: consider changing the low-level upload path so failed uploads
-        // return ownership of the built SST. That would let the worker build
-        // once and retry uploads without rebuilding.
         let first_seq = job
             .imm_memtable
             .table()

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -625,7 +625,7 @@ mod tests {
 
             let encoded = builder.build().await?;
             let id = SsTableId::Compacted(Ulid::new());
-            self.table_store.write_sst(&id, encoded, false).await
+            self.table_store.write_sst(&id, &encoded, false).await
         }
     }
 

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -285,7 +285,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+        let handle = table_store.write_sst(&id, &encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
             sst_views: vec![SsTableView::identity(handle)],
@@ -338,7 +338,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         let id1 = SsTableId::Compacted(ulid::Ulid::new());
-        let handle1 = table_store.write_sst(&id1, encoded, false).await.unwrap();
+        let handle1 = table_store.write_sst(&id1, &encoded, false).await.unwrap();
         let mut builder = table_store.table_builder();
         builder
             .add_value(b"key3", b"value3", Some(3), None)
@@ -346,7 +346,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         let id2 = SsTableId::Compacted(ulid::Ulid::new());
-        let handle2 = table_store.write_sst(&id2, encoded, false).await.unwrap();
+        let handle2 = table_store.write_sst(&id2, &encoded, false).await.unwrap();
         let sr = SortedRun {
             id: 0,
             sst_views: vec![
@@ -563,7 +563,7 @@ mod tests {
 
             let encoded = builder.build().await.unwrap();
             let id = SsTableId::Compacted(ulid::Ulid::new());
-            let handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+            let handle = table_store.write_sst(&id, &encoded, false).await.unwrap();
             ssts.push(SsTableView::identity(handle));
         }
 
@@ -613,7 +613,7 @@ mod tests {
             }
             let encoded = builder.build().await.unwrap();
             let id = SsTableId::Compacted(ulid::Ulid::new());
-            table_store.write_sst(&id, encoded, false).await.unwrap()
+            table_store.write_sst(&id, &encoded, false).await.unwrap()
         }
 
         async fn build_sst_v2(
@@ -627,7 +627,7 @@ mod tests {
             }
             let encoded = builder.build().await.unwrap();
             let id = SsTableId::Compacted(ulid::Ulid::new());
-            table_store.write_sst(&id, encoded, false).await.unwrap()
+            table_store.write_sst(&id, &encoded, false).await.unwrap()
         }
 
         #[tokio::test]

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -460,7 +460,7 @@ mod tests {
         assert!(size_with_filter > size_without_filter); // Should be larger due to filter
     }
 
-    fn next_block_to_iter(builder: &mut EncodedSsTableBuilder) -> BlockIteratorLatest<Block> {
+    fn next_block_to_iter(builder: &mut EncodedSsTableBuilder) -> BlockIteratorLatest<Arc<Block>> {
         let block = builder.next_block();
         assert!(block.is_some());
         let block = block.unwrap().block;
@@ -611,7 +611,7 @@ mod tests {
                 .read_block_raw(&sst.info, &index, i, &bytes)
                 .await
                 .unwrap();
-            assert!(encoded_block.block == read_block);
+            assert!(*encoded_block.block == read_block);
         }
     }
 
@@ -658,7 +658,7 @@ mod tests {
 
         // write sst and validate that the handle returned has the correct content.
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(wal_id), encoded, false)
+            .write_sst(&SsTableId::Wal(wal_id), &encoded, false)
             .await
             .unwrap();
         assert_eq!(encoded_info, sst_handle.info);
@@ -730,7 +730,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let encoded_info = encoded.info.clone();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
@@ -797,7 +797,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let encoded_info = encoded.info.clone();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
 
@@ -936,7 +936,7 @@ mod tests {
 
         // write sst and validate that the handle returned has the correct content.
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         assert_eq!(encoded_info, sst_handle.info);
@@ -1054,7 +1054,7 @@ mod tests {
 
         let sst_id = SsTableId::Wal(0);
         let sst_handle =
-            SsTableView::identity(table_store.write_sst(&sst_id, encoded, false).await?)
+            SsTableView::identity(table_store.write_sst(&sst_id, &encoded, false).await?)
                 .with_visible_range(BytesRange::from_ref("c"..="f"));
 
         let expected_entries = vec![
@@ -1177,7 +1177,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let encoded_info = encoded.info.clone();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
 
@@ -1231,7 +1231,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
 
@@ -1324,7 +1324,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
 
@@ -1388,7 +1388,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(1), encoded, false)
+            .write_sst(&SsTableId::Wal(1), &encoded, false)
             .await
             .unwrap();
 
@@ -1485,7 +1485,7 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let stats = table_store
@@ -1554,7 +1554,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let stats = table_store
@@ -1596,7 +1596,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let stats = table_store
@@ -1661,7 +1661,7 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let sst_handle = table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let stats = table_store
@@ -1739,7 +1739,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -1136,7 +1136,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
@@ -1378,7 +1378,7 @@ mod tests {
         let sst = writer
             .write_sst(
                 &SsTableId::Compacted(ulid::Ulid::new()),
-                builder.build().await.unwrap(),
+                &builder.build().await.unwrap(),
                 false,
             )
             .await
@@ -1470,7 +1470,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap())
+        SsTableView::identity(table_store.write_sst(&id, &encoded, false).await.unwrap())
     }
 
     #[tokio::test]
@@ -1508,7 +1508,7 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(0), encoded, false)
+            .write_sst(&SsTableId::Wal(0), &encoded, false)
             .await
             .unwrap();
         let sst_handle = table_store.open_sst(&SsTableId::Wal(0)).await.unwrap();
@@ -1727,7 +1727,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let sst_handle =
-            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
+            SsTableView::identity(table_store.write_sst(&id, &encoded, false).await.unwrap());
 
         // Initialize iterator in descending order with full range
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -1907,7 +1907,7 @@ mod tests {
             .unwrap();
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        table_store.write_sst(&id, encoded, false).await.unwrap();
+        table_store.write_sst(&id, &encoded, false).await.unwrap();
         let sst_handle = table_store.open_sst(&id).await.unwrap();
 
         let sst_iter_options = SstIteratorOptions {
@@ -1986,7 +1986,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap())
+        SsTableView::identity(table_store.write_sst(&id, &encoded, false).await.unwrap())
     }
 
     #[tokio::test]
@@ -2121,7 +2121,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let sst_handle =
-            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
+            SsTableView::identity(table_store.write_sst(&id, &encoded, false).await.unwrap());
 
         // when: iterating over all keys
         let sst_iter_options = SstIteratorOptions {
@@ -2183,7 +2183,7 @@ mod tests {
 
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        let sst_handle = table_store.write_sst(&id, encoded, false).await.unwrap();
+        let sst_handle = table_store.write_sst(&id, &encoded, false).await.unwrap();
 
         // Verify we have multiple blocks
         let index = table_store.read_index(&sst_handle, true).await.unwrap();
@@ -2251,7 +2251,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let sst_handle =
-            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
+            SsTableView::identity(table_store.write_sst(&id, &encoded, false).await.unwrap());
 
         // when: searching for a non-existent key (odd number)
         let mut iter = SstIterator::for_key_with_stats_initialized(
@@ -2303,7 +2303,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let sst_handle =
-            SsTableView::identity(table_store.write_sst(&id, encoded, false).await.unwrap());
+            SsTableView::identity(table_store.write_sst(&id, &encoded, false).await.unwrap());
 
         // when: seeking past the last key
         let iter = SstIterator::new_borrowed_initialized(
@@ -2362,7 +2362,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        table_store.write_sst(&id, encoded, false).await.unwrap();
+        table_store.write_sst(&id, &encoded, false).await.unwrap();
         let sst_handle = table_store.open_sst(&id).await.unwrap();
 
         let index = table_store.read_index(&sst_handle, true).await.unwrap();
@@ -2498,7 +2498,7 @@ mod tests {
         }
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
-        table_store.write_sst(&id, encoded, false).await.unwrap();
+        table_store.write_sst(&id, &encoded, false).await.unwrap();
         let sst_handle = table_store.open_sst(&id).await.unwrap();
 
         let index = table_store.read_index(&sst_handle, true).await.unwrap();

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -197,7 +197,7 @@ impl TableStore {
     pub(crate) async fn write_sst(
         &self,
         id: &SsTableId,
-        encoded_sst: EncodedSsTable,
+        encoded_sst: &EncodedSsTable,
         write_cache: bool,
     ) -> Result<SsTableHandle, SlateDBError> {
         fail_point!(
@@ -220,27 +220,32 @@ impl TableStore {
 
         if let Some(ref cache) = self.cache {
             if write_cache {
-                for block in encoded_sst.unconsumed_blocks {
-                    let offset = block.offset;
-                    let block = Arc::new(block.block);
+                for block in &encoded_sst.unconsumed_blocks {
                     cache
-                        .insert((*id, offset).into(), CachedEntry::with_block(block))
+                        .insert(
+                            (*id, block.offset).into(),
+                            CachedEntry::with_block(Arc::clone(&block.block)),
+                        )
                         .await;
                 }
                 cache
                     .insert(
                         (*id, encoded_sst.info.index_offset).into(),
-                        CachedEntry::with_sst_index(Arc::new(encoded_sst.index)),
+                        CachedEntry::with_sst_index(Arc::new(encoded_sst.index.clone())),
                     )
                     .await;
             }
         }
-        self.cache_filters(*id, encoded_sst.info.filter_offset, encoded_sst.filters)
-            .await;
+        self.cache_filters(
+            *id,
+            encoded_sst.info.filter_offset,
+            encoded_sst.filters.clone(),
+        )
+        .await;
         Ok(SsTableHandle::new(
             *id,
             encoded_sst.format_version,
-            encoded_sst.info,
+            encoded_sst.info.clone(),
         ))
     }
 
@@ -1047,7 +1052,7 @@ mod tests {
             .await
             .unwrap();
         let table = sst1.build().await.unwrap();
-        ts.write_sst(&wal_id, table, false).await.unwrap();
+        ts.write_sst(&wal_id, &table, false).await.unwrap();
 
         let mut sst2 = ts.table_builder();
         sst2.add(RowEntry::new_value(b"key", b"value", 0))
@@ -1056,7 +1061,7 @@ mod tests {
         let table2 = sst2.build().await.unwrap();
 
         // write another wal sst with the same id.
-        let result = ts.write_sst(&wal_id, table2, false).await;
+        let result = ts.write_sst(&wal_id, &table2, false).await;
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
     }
 
@@ -1280,7 +1285,7 @@ mod tests {
             .unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let handle = writer
-            .write_sst(&id, builder.build().await.unwrap(), false)
+            .write_sst(&id, &builder.build().await.unwrap(), false)
             .await
             .unwrap();
 
@@ -1338,7 +1343,7 @@ mod tests {
             .unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let handle = writer
-            .write_sst(&id, builder.build().await.unwrap(), false)
+            .write_sst(&id, &builder.build().await.unwrap(), false)
             .await
             .unwrap();
 
@@ -1402,7 +1407,7 @@ mod tests {
         let sst_bytes = sst.remaining_as_bytes();
         let sst_info = sst.info.clone();
 
-        ts.write_sst(&id, sst, true).await.unwrap();
+        ts.write_sst(&id, &sst, true).await.unwrap();
 
         let index = ts
             .sst_format
@@ -1447,7 +1452,7 @@ mod tests {
         let sst_bytes = sst.remaining_as_bytes();
         let sst_info = sst.info.clone();
 
-        ts.write_sst(&id, sst, false).await.unwrap();
+        ts.write_sst(&id, &sst, false).await.unwrap();
 
         let index = ts
             .sst_format
@@ -1659,7 +1664,7 @@ mod tests {
         let expected_bytes = sst.remaining_as_bytes();
 
         // When writing via TableStore (should retry once)
-        ts.write_sst(&id, sst, false).await.unwrap();
+        ts.write_sst(&id, &sst, false).await.unwrap();
 
         // Then: a retry happened
         assert!(flaky.put_attempts() >= 2);

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -1095,7 +1095,7 @@ mod tests {
             .unwrap();
         let encoded_sst = sst_builder.build().await.unwrap();
         let _sst1 = table_store
-            .write_sst(&SsTableId::Compacted(Ulid::new()), encoded_sst, false)
+            .write_sst(&SsTableId::Compacted(Ulid::new()), &encoded_sst, false)
             .await
             .unwrap();
 
@@ -1110,7 +1110,7 @@ mod tests {
             .unwrap();
         let encoded_sst = sst_builder.build().await.unwrap();
         let sst2 = table_store
-            .write_sst(&SsTableId::Compacted(Ulid::new()), encoded_sst, false)
+            .write_sst(&SsTableId::Compacted(Ulid::new()), &encoded_sst, false)
             .await
             .unwrap();
 
@@ -1148,7 +1148,7 @@ mod tests {
             .unwrap();
         let encoded_sst = sst_builder.build().await.unwrap();
         let sst = table_store
-            .write_sst(&SsTableId::Compacted(Ulid::new()), encoded_sst, false)
+            .write_sst(&SsTableId::Compacted(Ulid::new()), &encoded_sst, false)
             .await
             .unwrap();
 

--- a/slatedb/src/wal/wal_sst_builder.rs
+++ b/slatedb/src/wal/wal_sst_builder.rs
@@ -288,7 +288,9 @@ mod tests {
     use crate::test_utils::assert_iterator;
     use crate::types::ValueDeletable;
 
-    fn next_block_to_iter(builder: &mut EncodedWalSsTableBuilder) -> BlockIteratorLatest<Block> {
+    fn next_block_to_iter(
+        builder: &mut EncodedWalSsTableBuilder,
+    ) -> BlockIteratorLatest<Arc<Block>> {
         let block = builder.next_block();
         assert!(block.is_some());
         let block = block.unwrap().block;

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -386,7 +386,7 @@ impl WalBufferManager {
 
         let encoded_sst = sst_builder.build().await?;
         self.table_store
-            .write_sst(&SsTableId::Wal(wal_id), encoded_sst, false)
+            .write_sst(&SsTableId::Wal(wal_id), &encoded_sst, false)
             .await?;
 
         self.mono_clock.fetch_max_last_durable_tick(last_tick);

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -421,7 +421,7 @@ mod tests {
             }
             let encoded_sst = builder.build().await.unwrap();
             table_store
-                .write_sst(&SsTableId::Wal(wal_id as u64 + 1), encoded_sst, false)
+                .write_sst(&SsTableId::Wal(wal_id as u64 + 1), &encoded_sst, false)
                 .await
                 .unwrap();
         }
@@ -488,7 +488,7 @@ mod tests {
         }
         let encoded_sst = builder.build().await.unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(1), encoded_sst, false)
+            .write_sst(&SsTableId::Wal(1), &encoded_sst, false)
             .await
             .unwrap();
 
@@ -547,7 +547,7 @@ mod tests {
         }
         let encoded_sst = builder.build().await.unwrap();
         table_store
-            .write_sst(&SsTableId::Wal(1), encoded_sst, false)
+            .write_sst(&SsTableId::Wal(1), &encoded_sst, false)
             .await
             .unwrap();
 


### PR DESCRIPTION
Pass `EncodedSsTable` by reference in `write_sst`. This fixes the TODO in the l0 uploader: we shouldn't need to rebuild the SST after every upload retry. This is achieved by using `Arc<Block>` in `EncodedSsTableBlock`, which is what the cache wants anyway.

Thank you for the review! 🙏
