### PR TITLE
[object_store] add request metrics for list operations

### DIFF
--- a/slatedb-common/src/metrics.rs
+++ b/slatedb-common/src/metrics.rs
@@ -1006,9 +1006,6 @@ pub fn lookup_metric_with_labels(
     labels: &[(&str, &str)],
 ) -> Option<i64> {
     let snap = recorder.snapshot();
-    snap.all().iter().for_each(|m| {
-        println!("{} {:?} {:?}", m.name, m.labels, m.value)
-    });
     snap.by_name_and_labels(name, labels)
         .map(|m| match &m.value {
             MetricValue::Counter(v) => *v as i64,

--- a/slatedb-common/src/metrics.rs
+++ b/slatedb-common/src/metrics.rs
@@ -1006,6 +1006,9 @@ pub fn lookup_metric_with_labels(
     labels: &[(&str, &str)],
 ) -> Option<i64> {
     let snap = recorder.snapshot();
+    snap.all().iter().for_each(|m| {
+        println!("{} {:?} {:?}", m.name, m.labels, m.value)
+    });
     snap.by_name_and_labels(name, labels)
         .map(|m| match &m.value {
             MetricValue::Counter(v) => *v as i64,

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -286,6 +286,7 @@ pub mod stats {
     pub const REQUEST_COUNT: &str = object_store_stat_name!("request_count");
     pub const ERROR_COUNT: &str = object_store_stat_name!("error_count");
     pub const REQUEST_DURATION_SECONDS: &str = object_store_stat_name!("request_duration_seconds");
+    const REQUEST_COUNT_DESCRIPTION: &str = "Object store API requests";
 
     /// Pre-registered [`RequestMetrics`] for every object store API that
     /// SlateDB calls.
@@ -328,12 +329,12 @@ pub mod stats {
                 head: RequestMetrics::new(recorder, component, store_type, "get", "head"),
                 list: recorder
                     .counter(REQUEST_COUNT)
-                    .description("Object store API requests")
+                    .description(REQUEST_COUNT_DESCRIPTION)
                     .labels(&get_labels(component, store_type, "get", "list"))
                     .register(),
                 list_with_offset: recorder
                     .counter(REQUEST_COUNT)
-                    .description("Object store API requests")
+                    .description(REQUEST_COUNT_DESCRIPTION)
                     .labels(&get_labels(
                         component,
                         store_type,
@@ -418,7 +419,7 @@ pub mod stats {
             Self {
                 request_count: recorder
                     .counter(REQUEST_COUNT)
-                    .description("Object store API requests")
+                    .description(REQUEST_COUNT_DESCRIPTION)
                     .labels(&labels)
                     .register(),
                 error_count: recorder

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -457,27 +457,13 @@ mod tests {
     use slatedb_common::metrics::{lookup_metric_with_labels, test_recorder_helper, MetricValue};
 
     use crate::instrumented_object_store::stats::{
-        ERROR_COUNT, REQUEST_COUNT, REQUEST_DURATION_SECONDS,
+        get_labels, ERROR_COUNT, REQUEST_COUNT, REQUEST_DURATION_SECONDS,
     };
     use crate::instrumented_object_store::{InstrumentedObjectStore, ObjectStoreComponent};
     use crate::object_stores::ObjectStoreType;
     use crate::rand::DbRand;
     use crate::retrying_object_store::RetryingObjectStore;
     use crate::test_utils::FlakyObjectStore;
-
-    fn labels(
-        component: &'static str,
-        store_type: &'static str,
-        op: &'static str,
-        api: &'static str,
-    ) -> [(&'static str, &'static str); 4] {
-        [
-            ("component", component),
-            ("store_type", store_type),
-            ("op", op),
-            ("api", api),
-        ]
-    }
 
     fn histogram_count(
         recorder: &slatedb_common::metrics::DefaultMetricsRecorder,
@@ -509,13 +495,19 @@ mod tests {
         store.put(&path, "hello".into()).await.unwrap();
         let _ = store.get(&path).await.unwrap().bytes().await.unwrap();
         store.delete(&path).await.unwrap();
+        let _ = store.list(None);
 
         // then:
         assert_eq!(
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "put", "put")
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "put"
+                )
             ),
             Some(1)
         );
@@ -523,7 +515,12 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "get", "get")
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "get",
+                    "list"
+                )
             ),
             Some(1)
         );
@@ -531,20 +528,62 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "delete", "delete"),
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "get",
+                    "get"
+                )
             ),
             Some(1)
         );
         assert_eq!(
-            histogram_count(&recorder, &labels("db", "main", "put", "put")),
+            lookup_metric_with_labels(
+                &recorder,
+                REQUEST_COUNT,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "delete",
+                    "delete"
+                ),
+            ),
             Some(1)
         );
         assert_eq!(
-            histogram_count(&recorder, &labels("db", "main", "get", "get")),
+            histogram_count(
+                &recorder,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "put"
+                )
+            ),
             Some(1)
         );
         assert_eq!(
-            histogram_count(&recorder, &labels("db", "main", "delete", "delete")),
+            histogram_count(
+                &recorder,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "get",
+                    "get"
+                )
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            histogram_count(
+                &recorder,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "delete",
+                    "delete"
+                )
+            ),
             Some(1)
         );
     }
@@ -571,12 +610,26 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "get", "head")
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "get",
+                    "head"
+                )
             ),
             Some(1)
         );
         assert_eq!(
-            lookup_metric_with_labels(&recorder, ERROR_COUNT, &labels("db", "main", "get", "head")),
+            lookup_metric_with_labels(
+                &recorder,
+                ERROR_COUNT,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "get",
+                    "head"
+                )
+            ),
             Some(1)
         );
     }
@@ -610,7 +663,12 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "put", "put")
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "put"
+                )
             ),
             Some(3)
         );
@@ -639,7 +697,12 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "put", "multipart_init"),
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "multipart_init"
+                ),
             ),
             Some(1)
         );
@@ -647,7 +710,12 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "put", "multipart_part"),
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "multipart_part"
+                ),
             ),
             Some(1)
         );
@@ -655,7 +723,12 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "put", "multipart_complete"),
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "multipart_complete"
+                ),
             ),
             Some(1)
         );
@@ -685,20 +758,42 @@ mod tests {
             lookup_metric_with_labels(
                 &recorder,
                 REQUEST_COUNT,
-                &labels("db", "main", "put", "put")
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "put"
+                )
             ),
             Some(1)
         );
         assert_eq!(
-            lookup_metric_with_labels(&recorder, ERROR_COUNT, &labels("db", "main", "put", "put")),
+            lookup_metric_with_labels(
+                &recorder,
+                ERROR_COUNT,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "put",
+                    "put"
+                )
+            ),
             Some(0)
         );
         assert_eq!(
-            lookup_metric_with_labels(&recorder, REQUEST_COUNT, &labels("gc", "wal", "put", "put")),
+            lookup_metric_with_labels(
+                &recorder,
+                REQUEST_COUNT,
+                &get_labels(ObjectStoreComponent::Gc, ObjectStoreType::Wal, "put", "put")
+            ),
             Some(1)
         );
         assert_eq!(
-            lookup_metric_with_labels(&recorder, ERROR_COUNT, &labels("gc", "wal", "put", "put")),
+            lookup_metric_with_labels(
+                &recorder,
+                ERROR_COUNT,
+                &get_labels(ObjectStoreComponent::Gc, ObjectStoreType::Wal, "put", "put")
+            ),
             Some(1)
         );
     }

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -23,7 +23,6 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Instant;
 
-use crate::object_stores::ObjectStoreType;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
@@ -34,6 +33,8 @@ use object_store::{
     PutMultipartOptions, PutOptions, PutPayload, PutResult,
 };
 use slatedb_common::metrics::MetricsRecorderHelper;
+
+use crate::object_stores::ObjectStoreType;
 
 /// Which SlateDB component is issuing object store requests.
 ///

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -20,12 +20,16 @@
 #![allow(clippy::disallowed_methods, clippy::disallowed_types)]
 
 use std::ops::Range;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::time::Instant;
 
+use crate::instrumented_object_store_stats::RequestMetrics;
+use crate::object_stores::ObjectStoreType;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
+use futures::stream::{BoxStream, Stream, StreamExt};
 use futures::FutureExt;
 use object_store::path::Path;
 use object_store::{
@@ -33,8 +37,6 @@ use object_store::{
     PutMultipartOptions, PutOptions, PutPayload, PutResult,
 };
 use slatedb_common::metrics::MetricsRecorderHelper;
-
-use crate::object_stores::ObjectStoreType;
 
 /// Which SlateDB component is issuing object store requests.
 ///
@@ -141,6 +143,70 @@ impl MultipartUpload for InstrumentedMultipartUpload {
     }
 }
 
+struct InstrumentedStream {
+    inner: BoxStream<'static, object_store::Result<ObjectMeta>>,
+    start: Instant,
+    stats: Arc<stats::ObjectStoreStats>,
+    stream_complete: bool,
+    is_list_with_offset: bool,
+}
+
+impl InstrumentedStream {
+    fn new(
+        inner: BoxStream<'static, object_store::Result<ObjectMeta>>,
+        stats: Arc<stats::ObjectStoreStats>,
+        is_list_with_offset: bool,
+    ) -> Self {
+        Self {
+            inner,
+            start: Instant::now(),
+            stats,
+            stream_complete: false,
+            is_list_with_offset,
+        }
+    }
+
+    fn get_request_metrics(&self) -> &RequestMetrics {
+        if self.is_list_with_offset {
+            return &self.stats.list_with_offset;
+        }
+        &self.stats.list
+    }
+}
+
+impl Stream for InstrumentedStream {
+    type Item = object_store::Result<ObjectMeta>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.stream_complete {
+            return Poll::Ready(None);
+        }
+
+        match self.inner.poll_next_unpin(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => {
+                self.stream_complete = true;
+                // Stream completed successfully after yielding items_seen items
+                self.get_request_metrics()
+                    .record(self.start.elapsed(), true);
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Err(e))) => {
+                self.stream_complete = true;
+                // Stream failed with an error
+                self.get_request_metrics()
+                    .record(self.start.elapsed(), false);
+                Poll::Ready(Some(Err(e)))
+            }
+            result => result,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+}
+
 #[async_trait]
 impl ObjectStore for InstrumentedObjectStore {
     async fn get_opts(
@@ -227,7 +293,11 @@ impl ObjectStore for InstrumentedObjectStore {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
-        self.inner.list(prefix)
+        Box::pin(InstrumentedStream::new(
+            self.inner.list(prefix),
+            Arc::clone(&self.stats),
+            false,
+        ))
     }
 
     fn list_with_offset(
@@ -235,11 +305,20 @@ impl ObjectStore for InstrumentedObjectStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
-        self.inner.list_with_offset(prefix, offset)
+        Box::pin(InstrumentedStream::new(
+            self.inner.list_with_offset(prefix, offset),
+            Arc::clone(&self.stats),
+            true,
+        ))
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
-        self.inner.list_with_delimiter(prefix).await
+        let start = Instant::now();
+        let result = self.inner.list_with_delimiter(prefix).await;
+        self.stats
+            .list_with_delimiter
+            .record(start.elapsed(), result.is_ok());
+        result
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
@@ -292,6 +371,9 @@ pub mod stats {
         pub(crate) get_range: RequestMetrics,
         pub(crate) get_ranges: RequestMetrics,
         pub(crate) head: RequestMetrics,
+        pub(crate) list: RequestMetrics,
+        pub(crate) list_with_offset: RequestMetrics,
+        pub(crate) list_with_delimiter: RequestMetrics,
         pub(crate) put: RequestMetrics,
         pub(crate) multipart_init: RequestMetrics,
         pub(crate) multipart_part: RequestMetrics,
@@ -316,6 +398,21 @@ pub mod stats {
                     "get_ranges",
                 ),
                 head: RequestMetrics::new(recorder, component, store_type, "get", "head"),
+                list: RequestMetrics::new(recorder, component, store_type, "get", "list"),
+                list_with_offset: RequestMetrics::new(
+                    recorder,
+                    component,
+                    store_type,
+                    "get",
+                    "list_with_offset",
+                ),
+                list_with_delimiter: RequestMetrics::new(
+                    recorder,
+                    component,
+                    store_type,
+                    "get",
+                    "list_with_delimiter",
+                ),
                 put: RequestMetrics::new(recorder, component, store_type, "put", "put"),
                 multipart_init: RequestMetrics::new(
                     recorder,

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -20,16 +20,13 @@
 #![allow(clippy::disallowed_methods, clippy::disallowed_types)]
 
 use std::ops::Range;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 use std::time::Instant;
 
-use crate::instrumented_object_store_stats::RequestMetrics;
 use crate::object_stores::ObjectStoreType;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::{BoxStream, Stream, StreamExt};
+use futures::stream::BoxStream;
 use futures::FutureExt;
 use object_store::path::Path;
 use object_store::{
@@ -143,70 +140,6 @@ impl MultipartUpload for InstrumentedMultipartUpload {
     }
 }
 
-struct InstrumentedStream {
-    inner: BoxStream<'static, object_store::Result<ObjectMeta>>,
-    start: Instant,
-    stats: Arc<stats::ObjectStoreStats>,
-    stream_complete: bool,
-    is_list_with_offset: bool,
-}
-
-impl InstrumentedStream {
-    fn new(
-        inner: BoxStream<'static, object_store::Result<ObjectMeta>>,
-        stats: Arc<stats::ObjectStoreStats>,
-        is_list_with_offset: bool,
-    ) -> Self {
-        Self {
-            inner,
-            start: Instant::now(),
-            stats,
-            stream_complete: false,
-            is_list_with_offset,
-        }
-    }
-
-    fn get_request_metrics(&self) -> &RequestMetrics {
-        if self.is_list_with_offset {
-            return &self.stats.list_with_offset;
-        }
-        &self.stats.list
-    }
-}
-
-impl Stream for InstrumentedStream {
-    type Item = object_store::Result<ObjectMeta>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if self.stream_complete {
-            return Poll::Ready(None);
-        }
-
-        match self.inner.poll_next_unpin(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(None) => {
-                self.stream_complete = true;
-                // Stream completed successfully after yielding items_seen items
-                self.get_request_metrics()
-                    .record(self.start.elapsed(), true);
-                Poll::Ready(None)
-            }
-            Poll::Ready(Some(Err(e))) => {
-                self.stream_complete = true;
-                // Stream failed with an error
-                self.get_request_metrics()
-                    .record(self.start.elapsed(), false);
-                Poll::Ready(Some(Err(e)))
-            }
-            result => result,
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
-    }
-}
-
 #[async_trait]
 impl ObjectStore for InstrumentedObjectStore {
     async fn get_opts(
@@ -293,11 +226,8 @@ impl ObjectStore for InstrumentedObjectStore {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
-        Box::pin(InstrumentedStream::new(
-            self.inner.list(prefix),
-            Arc::clone(&self.stats),
-            false,
-        ))
+        self.stats.list.increment(1);
+        self.inner.list(prefix)
     }
 
     fn list_with_offset(
@@ -305,11 +235,8 @@ impl ObjectStore for InstrumentedObjectStore {
         prefix: Option<&Path>,
         offset: &Path,
     ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
-        Box::pin(InstrumentedStream::new(
-            self.inner.list_with_offset(prefix, offset),
-            Arc::clone(&self.stats),
-            true,
-        ))
+        self.stats.list_with_offset.increment(1);
+        self.inner.list_with_offset(prefix, offset)
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
@@ -371,8 +298,8 @@ pub mod stats {
         pub(crate) get_range: RequestMetrics,
         pub(crate) get_ranges: RequestMetrics,
         pub(crate) head: RequestMetrics,
-        pub(crate) list: RequestMetrics,
-        pub(crate) list_with_offset: RequestMetrics,
+        pub(crate) list: Arc<dyn CounterFn>,
+        pub(crate) list_with_offset: Arc<dyn CounterFn>,
         pub(crate) list_with_delimiter: RequestMetrics,
         pub(crate) put: RequestMetrics,
         pub(crate) multipart_init: RequestMetrics,
@@ -398,14 +325,21 @@ pub mod stats {
                     "get_ranges",
                 ),
                 head: RequestMetrics::new(recorder, component, store_type, "get", "head"),
-                list: RequestMetrics::new(recorder, component, store_type, "get", "list"),
-                list_with_offset: RequestMetrics::new(
-                    recorder,
-                    component,
-                    store_type,
-                    "get",
-                    "list_with_offset",
-                ),
+                list: recorder
+                    .counter(REQUEST_COUNT)
+                    .description("Object store API requests")
+                    .labels(&get_labels(component, store_type, "get", "list"))
+                    .register(),
+                list_with_offset: recorder
+                    .counter(REQUEST_COUNT)
+                    .description("Object store API requests")
+                    .labels(&get_labels(
+                        component,
+                        store_type,
+                        "get",
+                        "list_with_offset",
+                    ))
+                    .register(),
                 list_with_delimiter: RequestMetrics::new(
                     recorder,
                     component,
@@ -440,6 +374,20 @@ pub mod stats {
         }
     }
 
+    pub(crate) fn get_labels(
+        component: ObjectStoreComponent,
+        store_type: ObjectStoreType,
+        op: &'static str,
+        api: &'static str,
+    ) -> [(&'static str, &'static str); 4] {
+        [
+            ("component", component.as_str()),
+            ("store_type", store_type.as_str()),
+            ("op", op),
+            ("api", api),
+        ]
+    }
+
     /// Metrics for a single object store API (e.g. `get` or `put`).
     ///
     /// Each instance holds three pre-registered metric handles that
@@ -464,12 +412,7 @@ pub mod stats {
             op: &'static str,
             api: &'static str,
         ) -> Self {
-            let labels = [
-                ("component", component.as_str()),
-                ("store_type", store_type.as_str()),
-                ("op", op),
-                ("api", api),
-            ];
+            let labels = get_labels(component, store_type, op, api);
 
             Self {
                 request_count: recorder


### PR DESCRIPTION
## Summary

These metrics provide visibility to how many list calls SlateDB makes.

## Changes

New `list*` metrics were added to instrumented object store stats.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
