### PR TITLE
Use exponential HEAD probe + binary search for last_seen_wal_id

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1962,14 +1962,14 @@ mod tests {
             .unwrap()
             .id;
 
-        // Inject a failpoint on WAL listing before flushing so it is active
+        // Inject a failpoint on WAL probing before flushing so it is active
         // when the poller fires. With the buggy replay_new_wals=true,
-        // reestablish_checkpoint calls last_seen_wal_id() which lists WAL SSTs
+        // reestablish_checkpoint calls last_seen_wal_id() which probes WAL SSTs
         // and hits this failpoint. With the fix (replay_new_wals=false), the
-        // WAL listing is skipped entirely.
+        // WAL probing is skipped entirely.
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
-            "list-wal-ssts",
+            "probe-wal-ssts",
             "return",
         )
         .unwrap();

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -289,8 +289,11 @@ impl DbReaderInner {
         if self.options.skip_wal_replay {
             return Ok(());
         }
-        let last_seen_wal_id = self.table_store.last_seen_wal_id().await?;
         let last_replayed_wal_id = self.state.read().last_wal_id;
+        let last_seen_wal_id = self
+            .table_store
+            .last_seen_wal_id(last_replayed_wal_id)
+            .await?;
         if last_seen_wal_id > last_replayed_wal_id {
             let current_checkpoint = Arc::clone(&self.state.read());
             let mut imm_memtable = current_checkpoint.imm_memtable().clone();
@@ -477,7 +480,7 @@ impl DbReaderInner {
                 (core.replay_after_wal_id, core.last_l0_seq)
             };
         let wal_id_end = if replay_new_wals {
-            table_store.last_seen_wal_id().await? + 1
+            table_store.last_seen_wal_id(replay_after_wal_id).await? + 1
         } else {
             core.next_wal_sst_id
         };
@@ -1836,7 +1839,7 @@ mod tests {
 
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
-            "list-wal-ssts",
+            "probe-wal-ssts",
             "return",
         )
         .unwrap();

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -133,6 +133,8 @@ impl TableStore {
             Err(SlateDBError::from(std::io::Error::other("oops")))
         });
 
+        // 8 probes per round amortizes tail latency on one RTT while keeping
+        // the concurrent HEAD fan-out bounded against the object store.
         const ROUND_SIZE: u32 = 8;
         // 2^48 ahead is ~280 trillion WALs; far past any plausible gap. Beyond
         // this we give up rather than overflow / loop forever.
@@ -140,17 +142,27 @@ impl TableStore {
 
         let object_store = self.object_stores.store_of(ObjectStoreType::Wal);
 
-        // Phase 1: bracket the frontier using parallel exponential probes.
-        // `lo_offset`: highest probed offset known to exist (None until we see one).
-        // `hi_offset`: lowest probed offset known to NOT exist.
-        let mut lo_offset: Option<u64> = None;
-        let mut hi_offset: Option<u64> = None;
+        // ---- Phase 1: bracket the frontier with exponential probes. ----
+        //
+        // Probe at offsets 2^0, 2^1, ..., 2^MAX_EXP above `start_after`.
+        // Contiguity (existence is monotone-decreasing in id) means the
+        // moment one probe misses, every higher offset is also guaranteed
+        // missing -- so we can stop at the first miss and treat that
+        // offset as the upper bound on the answer. The highest hit so far
+        // is the lower bound.
+        let mut lo_offset: Option<u64> = None; // highest offset known to exist
+        let mut hi_offset: Option<u64> = None; // lowest offset known to NOT exist
         let mut next_exp: u32 = 0;
 
         while hi_offset.is_none() {
             if next_exp >= MAX_EXP {
+                // Object store appears to contain ids past our sanity cap;
+                // bail rather than overflow `start_after + offset`.
                 return Err(SlateDBError::InvalidDBState);
             }
+
+            // Fire ROUND_SIZE probes in parallel at offsets 2^next_exp..2^end_exp.
+            // One round = one network RTT regardless of how many probes it contains.
             let end_exp = (next_exp + ROUND_SIZE).min(MAX_EXP);
             let exps: Vec<u32> = (next_exp..end_exp).collect();
             let probes = exps.iter().map(|&e| {
@@ -160,6 +172,10 @@ impl TableStore {
                 async move { wal_object_exists(&store, &path).await }
             });
             let results = join_all(probes).await;
+
+            // Walk the round in offset order. Track the last hit as `lo_offset`,
+            // then stop at the first miss -- anything past that miss in the
+            // round is wasted info because we're about to switch to binary search.
             for (e, r) in exps.iter().zip(results) {
                 let offset = 1u64 << e;
                 if r? {
@@ -174,23 +190,37 @@ impl TableStore {
 
         let hi = hi_offset.expect("loop only exits when hi is set");
         let lo = match lo_offset {
-            None => return Ok(start_after), // start_after + 1 itself missing
+            // Round 0's smallest offset (1) didn't exist, so no WALs are
+            // visible above the hint -- the frontier IS `start_after`.
+            None => return Ok(start_after),
             Some(o) => o,
         };
 
-        // Phase 2: binary search for the exact frontier in offsets (lo, hi).
-        // Invariant: offset = lo exists, offset = hi does not.
+        // ---- Phase 2: binary search the open interval (lo, hi). ----
+        //
+        // Invariants entering the loop:
+        //   * offset = lo  exists       (highest from Phase 1)
+        //   * offset = hi  does not     (first miss from Phase 1)
+        // So the largest existing offset lives in [lo, hi - 1]. Search
+        // strictly above lo (left = lo + 1) so we never re-probe a slot
+        // whose state we already know.
         let mut left = lo + 1;
         let mut right = hi;
         while left < right {
             let mid = left + (right - left) / 2;
             let path = self.path(&SsTableId::Wal(start_after + mid));
             if wal_object_exists(object_store, &path).await? {
+                // `mid` exists, so the answer is mid or higher; discard
+                // everything at-or-below mid.
                 left = mid + 1;
             } else {
+                // `mid` is missing, so the answer is strictly below mid.
                 right = mid;
             }
         }
+
+        // Loop exits with left == right pointing at the lowest offset known
+        // to not exist; the highest existing offset is one below that.
         Ok(start_after + left - 1)
     }
 
@@ -1916,101 +1946,36 @@ mod tests {
         ))
     }
 
+    // Boundary values picked from the algorithm:
+    //   - ROUND_SIZE=8 -> first round probes offsets 1, 2, 4, ..., 128
+    //   - 2nd round starts at offset 256
+    // The (8, 16, 128, 256) cluster pins answers at probe offsets; the
+    // surrounding values (7/9, 127/129, 255/257) pin binary search inside
+    // each round. start_after=100 with stale ids 1..=100 also catches
+    // regressions where the start_after offset is dropped from the probe path.
+    #[rstest]
     #[tokio::test]
-    async fn should_return_start_after_when_no_wals_exist() {
-        // given: an empty WAL directory
-        let store = make_store();
-        let ts = make_ts(store);
-
-        // when: probing with various start_after values
-        let from_zero = ts.last_seen_wal_id(0).await.unwrap();
-        let from_hint = ts.last_seen_wal_id(42).await.unwrap();
-
-        // then: each call returns its own start_after
-        assert_eq!(from_zero, 0);
-        assert_eq!(from_hint, 42);
-    }
-
-    #[tokio::test]
-    async fn should_find_max_wal_id_when_resolved_in_first_round() {
-        // given: WAL ids 1..=5, all within the first round's probe range (offsets 1..=128)
+    async fn should_find_max_wal_id(
+        #[values(0, 100)] start_after: u64,
+        #[values(0, 1, 5, 7, 8, 9, 16, 127, 128, 129, 200, 255, 256, 257)] n_above: u64,
+    ) {
+        // given: stale ids at/below the hint (must be ignored) and n_above
+        // contiguous ids above the hint.
         let store = make_store();
         let ts = make_ts(store.clone());
-        for id in 1..=5 {
+        for id in 1..=start_after {
+            put_wal_id(&ts, &store, id).await;
+        }
+        for id in (start_after + 1)..=(start_after + n_above) {
             put_wal_id(&ts, &store, id).await;
         }
 
-        // when: probing from 0
-        let result = ts.last_seen_wal_id(0).await.unwrap();
+        // when: probing with start_after as the hint
+        let result = ts.last_seen_wal_id(start_after).await.unwrap();
 
-        // then: the highest id is found
-        assert_eq!(result, 5);
-    }
-
-    #[tokio::test]
-    async fn should_find_max_wal_id_when_answer_at_power_of_two() {
-        // given: exactly 16 WAL ids -- the answer aligns with probe offset 16
-        let store = make_store();
-        let ts = make_ts(store.clone());
-        for id in 1..=16 {
-            put_wal_id(&ts, &store, id).await;
-        }
-
-        // when: probing from 0
-        let result = ts.last_seen_wal_id(0).await.unwrap();
-
-        // then: binary search resolves the exact frontier
-        assert_eq!(result, 16);
-    }
-
-    #[tokio::test]
-    async fn should_find_max_wal_id_when_answer_exceeds_first_round() {
-        // given: 200 WAL ids -- past the first round's largest offset (128),
-        //        forcing a second exponential round at offsets 256..=32768
-        let store = make_store();
-        let ts = make_ts(store.clone());
-        for id in 1..=200 {
-            put_wal_id(&ts, &store, id).await;
-        }
-
-        // when: probing from 0
-        let result = ts.last_seen_wal_id(0).await.unwrap();
-
-        // then: the doubling phase brackets and binsearch finds the frontier
-        assert_eq!(result, 200);
-    }
-
-    #[tokio::test]
-    async fn should_find_max_when_start_after_skips_lower_ids() {
-        // given: WAL ids 101..=103 written, simulating recovery where
-        //        replay_after_wal_id = 100 (ids 1..=100 already replayed/compacted)
-        let store = make_store();
-        let ts = make_ts(store.clone());
-        for id in 101..=103 {
-            put_wal_id(&ts, &store, id).await;
-        }
-
-        // when: probing with start_after = 100
-        let result = ts.last_seen_wal_id(100).await.unwrap();
-
-        // then: probes begin at id 101 and find the high water mark
-        assert_eq!(result, 103);
-    }
-
-    #[tokio::test]
-    async fn should_return_start_after_when_all_ids_are_below_hint() {
-        // given: only old WAL ids exist, all below the hint
-        let store = make_store();
-        let ts = make_ts(store.clone());
-        for id in 1..=5 {
-            put_wal_id(&ts, &store, id).await;
-        }
-
-        // when: probing with start_after = 50
-        let result = ts.last_seen_wal_id(50).await.unwrap();
-
-        // then: the probe ignores ids below the hint and returns start_after
-        assert_eq!(result, 50);
+        // then: the high water mark above the hint is returned; if no ids
+        // exist above the hint, start_after itself is returned.
+        assert_eq!(result, start_after + n_above);
     }
 
     #[tokio::test]

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -111,10 +111,87 @@ impl TableStore {
         bytes.div_ceil(self.sst_format.block_size)
     }
 
-    pub(crate) async fn last_seen_wal_id(&self) -> Result<u64, SlateDBError> {
-        let wal_ssts = self.list_wal_ssts(..).await?;
-        let last_wal_id = wal_ssts.last().map(|md| md.id.unwrap_wal_id());
-        Ok(last_wal_id.unwrap_or(0))
+    /// Find the highest WAL SST id present in the object store at or above
+    /// `start_after + 1`, returning `start_after` if none exist.
+    ///
+    /// `start_after` should be a known lower bound (e.g. `replay_after_wal_id`
+    /// from the manifest, or the highest already-replayed WAL id). Passing 0
+    /// scans the entire WAL id space.
+    ///
+    /// Two phases:
+    ///   1. Parallel exponential probe at offsets `2^0, 2^1, ..., 2^k` from
+    ///      `start_after`. One RTT per round of 8 exponents. Brackets the
+    ///      frontier between two adjacent powers of two.
+    ///   2. Sequential binary search inside the bracketed range to find the
+    ///      exact frontier.
+    ///
+    /// Relies on the fencing protocol's contiguity invariant: "id exists" is
+    /// monotone-decreasing in id, so binary search is sound. Total HEAD count
+    /// is `O(log N)` for a gap of size N, vs `O(N)` for a windowed scan.
+    pub(crate) async fn last_seen_wal_id(&self, start_after: u64) -> Result<u64, SlateDBError> {
+        fail_point!(Arc::clone(&self.fp_registry), "probe-wal-ssts", |_| {
+            Err(SlateDBError::from(std::io::Error::other("oops")))
+        });
+
+        const ROUND_SIZE: u32 = 8;
+        // 2^48 ahead is ~280 trillion WALs; far past any plausible gap. Beyond
+        // this we give up rather than overflow / loop forever.
+        const MAX_EXP: u32 = 48;
+
+        let object_store = self.object_stores.store_of(ObjectStoreType::Wal);
+
+        // Phase 1: bracket the frontier using parallel exponential probes.
+        // `lo_offset`: highest probed offset known to exist (None until we see one).
+        // `hi_offset`: lowest probed offset known to NOT exist.
+        let mut lo_offset: Option<u64> = None;
+        let mut hi_offset: Option<u64> = None;
+        let mut next_exp: u32 = 0;
+
+        while hi_offset.is_none() {
+            if next_exp >= MAX_EXP {
+                return Err(SlateDBError::InvalidDBState);
+            }
+            let end_exp = (next_exp + ROUND_SIZE).min(MAX_EXP);
+            let exps: Vec<u32> = (next_exp..end_exp).collect();
+            let probes = exps.iter().map(|&e| {
+                let offset = 1u64 << e;
+                let path = self.path(&SsTableId::Wal(start_after + offset));
+                let store = object_store.clone();
+                async move { wal_object_exists(&store, &path).await }
+            });
+            let results = join_all(probes).await;
+            for (e, r) in exps.iter().zip(results) {
+                let offset = 1u64 << e;
+                if r? {
+                    lo_offset = Some(offset);
+                } else {
+                    hi_offset = Some(offset);
+                    break;
+                }
+            }
+            next_exp = end_exp;
+        }
+
+        let hi = hi_offset.expect("loop only exits when hi is set");
+        let lo = match lo_offset {
+            None => return Ok(start_after), // start_after + 1 itself missing
+            Some(o) => o,
+        };
+
+        // Phase 2: binary search for the exact frontier in offsets (lo, hi).
+        // Invariant: offset = lo exists, offset = hi does not.
+        let mut left = lo + 1;
+        let mut right = hi;
+        while left < right {
+            let mid = left + (right - left) / 2;
+            let path = self.path(&SsTableId::Wal(start_after + mid));
+            if wal_object_exists(object_store, &path).await? {
+                left = mid + 1;
+            } else {
+                right = mid;
+            }
+        }
+        Ok(start_after + left - 1)
     }
 
     /// Gracefully close the block cache, flushing in-memory entries to disk.
@@ -768,6 +845,17 @@ impl TableStore {
                 .remove(&(handle.id, handle.info.stats_offset).into())
                 .await;
         }
+    }
+}
+
+async fn wal_object_exists(
+    object_store: &Arc<dyn ObjectStore>,
+    path: &Path,
+) -> Result<bool, SlateDBError> {
+    match object_store.head(path).await {
+        Ok(_) => Ok(true),
+        Err(object_store::Error::NotFound { .. }) => Ok(false),
+        Err(e) => Err(SlateDBError::from(e)),
     }
 }
 
@@ -1817,6 +1905,119 @@ mod tests {
         } else {
             assert_eq!(count_ssts_in(&main_store).await, 3);
         }
+    }
+
+    async fn put_wal_id(ts: &TableStore, store: &Arc<dyn ObjectStore>, id: u64) {
+        store
+            .put(&ts.path(&SsTableId::Wal(id)), Bytes::new().into())
+            .await
+            .unwrap();
+    }
+
+    fn make_ts(store: Arc<dyn ObjectStore>) -> Arc<TableStore> {
+        Arc::new(TableStore::new(
+            ObjectStores::new(store, None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ))
+    }
+
+    #[tokio::test]
+    async fn should_return_start_after_when_no_wals_exist() {
+        // given: an empty WAL directory
+        let store = make_store();
+        let ts = make_ts(store);
+
+        // when: probing with various start_after values
+        let from_zero = ts.last_seen_wal_id(0).await.unwrap();
+        let from_hint = ts.last_seen_wal_id(42).await.unwrap();
+
+        // then: each call returns its own start_after
+        assert_eq!(from_zero, 0);
+        assert_eq!(from_hint, 42);
+    }
+
+    #[tokio::test]
+    async fn should_find_max_wal_id_when_resolved_in_first_round() {
+        // given: WAL ids 1..=5, all within the first round's probe range (offsets 1..=128)
+        let store = make_store();
+        let ts = make_ts(store.clone());
+        for id in 1..=5 {
+            put_wal_id(&ts, &store, id).await;
+        }
+
+        // when: probing from 0
+        let result = ts.last_seen_wal_id(0).await.unwrap();
+
+        // then: the highest id is found
+        assert_eq!(result, 5);
+    }
+
+    #[tokio::test]
+    async fn should_find_max_wal_id_when_answer_at_power_of_two() {
+        // given: exactly 16 WAL ids -- the answer aligns with probe offset 16
+        let store = make_store();
+        let ts = make_ts(store.clone());
+        for id in 1..=16 {
+            put_wal_id(&ts, &store, id).await;
+        }
+
+        // when: probing from 0
+        let result = ts.last_seen_wal_id(0).await.unwrap();
+
+        // then: binary search resolves the exact frontier
+        assert_eq!(result, 16);
+    }
+
+    #[tokio::test]
+    async fn should_find_max_wal_id_when_answer_exceeds_first_round() {
+        // given: 200 WAL ids -- past the first round's largest offset (128),
+        //        forcing a second exponential round at offsets 256..=32768
+        let store = make_store();
+        let ts = make_ts(store.clone());
+        for id in 1..=200 {
+            put_wal_id(&ts, &store, id).await;
+        }
+
+        // when: probing from 0
+        let result = ts.last_seen_wal_id(0).await.unwrap();
+
+        // then: the doubling phase brackets and binsearch finds the frontier
+        assert_eq!(result, 200);
+    }
+
+    #[tokio::test]
+    async fn should_find_max_when_start_after_skips_lower_ids() {
+        // given: WAL ids 101..=103 written, simulating recovery where
+        //        replay_after_wal_id = 100 (ids 1..=100 already replayed/compacted)
+        let store = make_store();
+        let ts = make_ts(store.clone());
+        for id in 101..=103 {
+            put_wal_id(&ts, &store, id).await;
+        }
+
+        // when: probing with start_after = 100
+        let result = ts.last_seen_wal_id(100).await.unwrap();
+
+        // then: probes begin at id 101 and find the high water mark
+        assert_eq!(result, 103);
+    }
+
+    #[tokio::test]
+    async fn should_return_start_after_when_all_ids_are_below_hint() {
+        // given: only old WAL ids exist, all below the hint
+        let store = make_store();
+        let ts = make_ts(store.clone());
+        for id in 1..=5 {
+            put_wal_id(&ts, &store, id).await;
+        }
+
+        // when: probing with start_after = 50
+        let result = ts.last_seen_wal_id(50).await.unwrap();
+
+        // then: the probe ignores ids below the hint and returns start_after
+        assert_eq!(result, 50);
     }
 
     #[tokio::test]

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -240,14 +240,7 @@ impl TableStore {
         &self,
         wal_id_last_compacted: u64,
     ) -> Result<u64, SlateDBError> {
-        Ok(self
-            .list_wal_ssts(wal_id_last_compacted..)
-            .await?
-            .into_iter()
-            .map(|wal_sst| wal_sst.id.unwrap_wal_id())
-            .max()
-            .unwrap_or(wal_id_last_compacted)
-            + 1)
+        Ok(self.last_seen_wal_id(wal_id_last_compacted).await? + 1)
     }
 
     pub(crate) fn table_writer(&self, id: SsTableId) -> EncodedSsTableWriter<'_> {

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -304,7 +304,9 @@ mod tests {
             table_store: Arc<TableStore>,
         ) -> Result<Self, SlateDBError> {
             let wal_id_start = db_state.replay_after_wal_id + 1;
-            let wal_id_end = table_store.last_seen_wal_id().await?;
+            let wal_id_end = table_store
+                .last_seen_wal_id(db_state.replay_after_wal_id)
+                .await?;
             let wal_id_range = wal_id_start..(wal_id_end + 1);
             Self::range(wal_id_range, db_state, options, table_store).await
         }


### PR DESCRIPTION
## Summary

`last_seen_wal_id` used to LIST the entire WAL prefix and take the max id, so cost grew linearly with un-deleted compacted WAL objects. Replace it with parallel `HEAD` probes at doubling offsets above `start_after`, then a binary search inside the bracketed range. The fencing protocol writes WAL ids contiguously, so existence is monotone-decreasing in id and binary search is sound.

Callers pass the highest-known id as `start_after`:
- `WalReplayIterator::range`: `replay_after_wal_id`
- `DbReaderInner::initial_replay`: `replay_after_wal_id`
- `DbReaderInner::periodic_replay`: `last_wal_id`

`HEAD` count is `O(log gap)`; `LIST` is no longer issued.

## Benchmark

Ran on a `t3.small` in us-west-2 against a same-region S3 bucket. I reimplemented both algorithms in Python with `aiobotocore` so the measurement covers only the algorithm, not the rest of the slatedb stack. Test matrix: populations `N ∈ {1k, 10k, 100k}` crossed with gaps `∈ {1, 10, 100, 1000}`, 5 timed iterations per cell after 2 warmup cycles, alternating `LIST` and `Probe`.

| N | gap | LIST p50 | Probe p50 | LIST reqs | Probe reqs | latency speedup | LIST cost | Probe cost |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1k   | 1    | 210 ms   | 22 ms    | 1   | 8  | 9.65×       | 5 µ$   | 3.2 µ$  |
| 1k   | 10   | 189 ms   | 61 ms    | 1   | 11 | 3.08×       | 5 µ$   | 4.4 µ$  |
| 1k   | 100  | 208 ms   | 106 ms   | 1   | 14 | 1.96×       | 5 µ$   | 5.6 µ$  |
| 1k   | 1000 | 206 ms   | 160 ms   | 1   | 25 | 1.29×       | 5 µ$   | 10 µ$   |
| 10k  | 1    | 2228 ms  | 20 ms    | 10  | 8  | 109.84×     | 50 µ$  | 3.2 µ$  |
| 10k  | 10   | 2184 ms  | 60 ms    | 10  | 11 | 36.27×      | 50 µ$  | 4.4 µ$  |
| 10k  | 100  | 2086 ms  | 99 ms    | 10  | 14 | 21.19×      | 50 µ$  | 5.6 µ$  |
| 10k  | 1000 | 2076 ms  | 188 ms   | 10  | 25 | 11.04×      | 50 µ$  | 10 µ$   |
| 100k | 1    | 21459 ms | 26 ms    | 100 | 8  | **839.27×** | 500 µ$ | 3.2 µ$  |
| 100k | 10   | 21677 ms | 59 ms    | 100 | 11 | 369.30×     | 500 µ$ | 4.4 µ$  |
| 100k | 100  | 20794 ms | 92 ms    | 100 | 14 | 226.12×     | 500 µ$ | 5.6 µ$  |
| 100k | 1000 | 21427 ms | 191 ms   | 100 | 25 | 112.35×     | 500 µ$ | 10 µ$   |

Costs are per call, in microdollars (1 µ$ = $0.000001), using us-west-2 list pricing: `$0.005/1k LIST`, `$0.0004/1k HEAD`.

- Probe latency is independent of prefix population: 20–26 ms p50 at `gap=1` regardless of `N`.
- LIST scales linearly at ~200 ms per 1k objects. Each page took longer than an unloaded HEAD or GET, consistent with adaptive throttling on rapid same-prefix LISTs.
- The realistic recovery case is a small gap on a dirty prefix. At `N=100k, gap=1` the call drops from 21.5s to 26 ms and from 500 µ$ to 3.2 µ$.
- Cost flips for small clean prefixes: at `N=1k, gap≥100`, probe issues more HEADs than the single LIST it replaces, so API spend goes up modestly even though latency still wins. Production prefixes accumulate compacted-WAL leftovers, so this regime is unlikely.

5 iterations per cell to keep S3 costs down; p99 numbers are noisier than they look.
