### PR TITLE
Make MAX_WAL_FLUSHES_BEFORE_L0_FLUSH configurable

### DIFF
--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -675,7 +675,10 @@ pub struct Settings {
     /// The maximum number of WAL flushes that can occur before the active memtable is
     /// frozen and flushed to L0, regardless of memtable size.
     ///
-    /// This bounds the amount of WAL data that needs to be replayed on recovery: once
+    /// For databases with low write throughput, this can cause data to be available in
+    /// L0 SSTs sooner, making it accessible to readers.
+    ///
+    /// This also bounds the amount of WAL data that needs to be replayed on recovery: once
     /// this many WAL flushes have occurred since the last memtable freeze, the active
     /// memtable will be frozen even if it has not reached `l0_sst_size_bytes`.
     pub max_wal_flushes_before_l0_flush: u64,

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -49,6 +49,7 @@
 //! manifest_update_timeout = "300s"
 //! min_filter_keys = 1000
 //! l0_sst_size_bytes = 67108864
+//! max_wal_flushes_before_l0_flush = 4096
 //! l0_max_ssts = 8
 //! l0_max_ssts_per_key = 8
 //! l0_flush_parallelism = 4
@@ -97,6 +98,7 @@
 //!  "manifest_update_timeout": "300s",
 //!  "min_filter_keys": 1000,
 //!  "l0_sst_size_bytes": 67108864,
+//!  "max_wal_flushes_before_l0_flush": 4096,
 //!  "l0_max_ssts": 8,
 //!  "l0_max_ssts_per_key": 8,
 //!  "l0_flush_parallelism": 4,
@@ -148,6 +150,7 @@
 //! manifest_update_timeout: '300s'
 //! min_filter_keys: 1000
 //! l0_sst_size_bytes: 67108864
+//! max_wal_flushes_before_l0_flush: 4096
 //! l0_max_ssts: 8
 //! l0_max_ssts_per_key: 8
 //! l0_flush_parallelism: 1
@@ -669,6 +672,14 @@ pub struct Settings {
     ///   secondary readers to see new data.
     pub l0_sst_size_bytes: usize,
 
+    /// The maximum number of WAL flushes that can occur before the active memtable is
+    /// frozen and flushed to L0, regardless of memtable size.
+    ///
+    /// This bounds the amount of WAL data that needs to be replayed on recovery: once
+    /// this many WAL flushes have occurred since the last memtable freeze, the active
+    /// memtable will be frozen even if it has not reached `l0_sst_size_bytes`.
+    pub max_wal_flushes_before_l0_flush: u64,
+
     /// Defines the max total number of SSTs in L0 across the entire key space. Memtables
     /// will not be flushed if the total L0 count (including in-flight uploads) would exceed
     /// this value, until compaction can compact the ssts into compacted.
@@ -746,6 +757,10 @@ impl std::fmt::Debug for Settings {
             .field("min_filter_keys", &self.min_filter_keys)
             .field("max_unflushed_bytes", &self.max_unflushed_bytes)
             .field("l0_sst_size_bytes", &self.l0_sst_size_bytes)
+            .field(
+                "max_wal_flushes_before_l0_flush",
+                &self.max_wal_flushes_before_l0_flush,
+            )
             .field("l0_max_ssts", &self.l0_max_ssts)
             .field("l0_max_ssts_per_key", &self.l0_max_ssts_per_key)
             .field("l0_flush_parallelism", &self.l0_flush_parallelism)
@@ -944,6 +959,7 @@ impl Default for Settings {
             min_filter_keys: 1000,
             max_unflushed_bytes: 1_073_741_824,
             l0_sst_size_bytes: 64 * 1024 * 1024,
+            max_wal_flushes_before_l0_flush: 4096,
             l0_max_ssts: 8,
             l0_max_ssts_per_key: 8,
             l0_flush_parallelism: 4,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3600,7 +3600,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_put_flushes_memtable_after_max_wal_flushes() {
-        const MAX_WAL_FLUSHES_BEFORE_L0_FLUSH: u64 = 16;
+        const MAX_WAL_FLUSHES_BEFORE_L0_FLUSH: u64 = 4096;
 
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_flush_memtable_max_wal_flushes";

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1853,7 +1853,6 @@ mod tests {
         GarbageCollectorOptions, ObjectStoreCacheOptions, PutOptions, Settings, Ttl, WriteOptions,
     };
     use crate::db::builder::GarbageCollectorBuilder;
-    use crate::db_common::MAX_WAL_FLUSHES_BEFORE_L0_FLUSH;
     use crate::db_stats::IMMUTABLE_MEMTABLE_FLUSHES;
     use crate::format::sst::SsTableFormat;
     use crate::instrumented_object_store::stats::{
@@ -3601,11 +3600,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_put_flushes_memtable_after_max_wal_flushes() {
+        const MAX_WAL_FLUSHES_BEFORE_L0_FLUSH: u64 = 16;
+
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_flush_memtable_max_wal_flushes";
 
         let mut settings = test_db_options(0, usize::MAX, None);
         settings.flush_interval = None; // Disable flushing
+        settings.max_wal_flushes_before_l0_flush = MAX_WAL_FLUSHES_BEFORE_L0_FLUSH;
 
         let kv_store = Db::builder(path, object_store.clone())
             .with_settings(settings)
@@ -6027,6 +6029,7 @@ mod tests {
             l0_flush_parallelism: 1,
             min_filter_keys,
             l0_sst_size_bytes,
+            max_wal_flushes_before_l0_flush: 4096,
             compactor_options,
             compression_codec: None,
             object_store_cache_options: ObjectStoreCacheOptions::default(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -402,6 +402,12 @@ impl<P: Into<Path>> DbBuilder<P> {
                 "invalid configuration: l0_flush_parallelism must be at least 1".into(),
             ));
         }
+        if self.settings.max_wal_flushes_before_l0_flush < 4096 {
+            return Err(crate::Error::invalid(
+                "invalid configuration: max_wal_flushes_before_l0_flush must be at least 4096"
+                    .into(),
+            ));
+        }
 
         let path = self.path.into();
         // TODO: proper URI generation, for now it works just as a flag
@@ -1749,6 +1755,32 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("l0_flush_parallelism must be at least 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_db_builder_rejects_low_max_wal_flushes_before_l0_flush() {
+        let result = crate::Db::builder(
+            "test_db_builder_rejects_low_max_wal_flushes_before_l0_flush",
+            Arc::new(InMemory::new()),
+        )
+        .with_settings(Settings {
+            max_wal_flushes_before_l0_flush: 4095,
+            ..Settings::default()
+        })
+        .build()
+        .await;
+
+        let err = match result {
+            Ok(_) => panic!("expected invalid max_wal_flushes_before_l0_flush to fail"),
+            Err(err) => err,
+        };
+
+        assert!(matches!(err.kind(), ErrorKind::Invalid));
+        assert!(
+            err.to_string()
+                .contains("max_wal_flushes_before_l0_flush must be at least 4096"),
             "unexpected error: {err}"
         );
     }

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -6,8 +6,6 @@ use crate::error::SlateDBError;
 use crate::oracle::Oracle;
 use crate::wal_replay::ReplayedMemtable;
 
-pub(crate) const MAX_WAL_FLUSHES_BEFORE_L0_FLUSH: u64 = 4096;
-
 impl DbInner {
     pub(crate) fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {
         let wal_id = self.wal_buffer.recent_flushed_wal_id();
@@ -29,7 +27,7 @@ impl DbInner {
             .checked_sub(last_freeze_wal_id)
             .ok_or_else(|| SlateDBError::InvalidDBState)?;
 
-        if wal_id_gap < MAX_WAL_FLUSHES_BEFORE_L0_FLUSH
+        if wal_id_gap < self.settings.max_wal_flushes_before_l0_flush
             && l0_sst_size_est < self.settings.l0_sst_size_bytes
         {
             Ok(())

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -1822,6 +1822,7 @@ mod tests {
             l0_flush_parallelism: 1,
             min_filter_keys,
             l0_sst_size_bytes,
+            max_wal_flushes_before_l0_flush: 4096,
             compactor_options,
             compression_codec: None,
             object_store_cache_options: crate::config::ObjectStoreCacheOptions::default(),


### PR DESCRIPTION
## Summary

Promote the previously hardcoded `MAX_WAL_FLUSHES_BEFORE_L0_FLUSH` constant to a `max_wal_flushes_before_l0_flush` field on `Settings`, keeping the default of 4096. This lets operators tune how aggressively the active memtable is frozen based on WAL flush count, balancing recovery time, L0 SST count, and manifest churn.

Our use case has the WAL use a 1ms flush_interval to a regional disk, and this default creates too many manifest files for us.

Related to https://github.com/slatedb/slatedb/issues/1640

## Changes

- make the setting configurable, with a validation that it is above or equal to 4096

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
