### PR TITLE
Break clone chain by using final checkpoints instead of source checkpoints

### DIFF
--- a/rfcs/0004-checkpoints.md
+++ b/rfcs/0004-checkpoints.md
@@ -88,7 +88,14 @@ table ExternalDb {
     // Path to root of the external database
     path: string (required);
 
-    // Externally owned Checkpoint ID we've used to create an initial state of cloned database.
+    // Checkpoint ID on the external database used to create the initial state of this clone.
+    // For an entry added for the immediate parent, this is the user-supplied (or ephemeral)
+    // checkpoint passed to the clone operation. For entries carried over from the parent's
+    // own `external_dbs` (i.e. nested clones), this is set to the parent's
+    // `final_checkpoint_id` for that grandparent — a slatedb-generated, slatedb-owned id —
+    // rather than the original user-supplied checkpoint. This breaks the chain back to a
+    // user-supplied checkpoint that the user could delete at any time, which would otherwise
+    // invalidate every future clone in the chain.
     source_checkpoint_id: Uuid (required);
 
     // Checkpoint ID this database has placed on the external database that prevents referenced
@@ -529,7 +536,15 @@ To support this, we add the `Db::open_from_checkpoint` method, which accepts a `
 8. Write a new clone manifest `M_c'`. If CAS fails, go to step 1. `M_c'` fields are set to:
   - external_dbs:
     - initial list copied from `M_p'` (this list is non-empty for nested clones)
-      - for each `entry` in the list: set `entry.final_checkpoint_id` to `final_checkpoint_id`
+      - for each `entry` in the list:
+        - set `entry.source_checkpoint_id` to `entry.final_checkpoint_id` (the parent's pinned
+          final checkpoint on that grandparent). This breaks the chain back to the original
+          user-supplied checkpoint on the grandparent: that checkpoint can be deleted by the
+          user at any time, and if a later clone tried to re-pin it the operation would fail.
+          The parent's `final_checkpoint_id` is slatedb-generated and pinned by the parent, so
+          it is safe to depend on for future clones.
+        - assign a fresh `entry.final_checkpoint_id` (a new random v4 UUID) for this clone to
+          own.
     - add an `entry` for `parent_path` with:
       - `entry.path` set to `parent_path`
       - `entry.source_checkpoint_id` set to `source_checkpoint_id`
@@ -739,7 +754,12 @@ The union process works as follows:
      same external_db entry via projection, so their `sst_ids` lists are merged (unioned). Entries with different keys 
      for the same path represent distinct checkpoints and must be kept separate. Without this deduplication, repeated
      cycles of projection and union cause exponential growth of duplicated entries: projecting into N parts
-     and unioning back multiplies the entry count by N each cycle. New `final_checkpoint_id` values are
+     and unioning back multiplies the entry count by N each cycle. Note that for entries carried
+     over from a clone's parents, `source_checkpoint_id` is the parent's `final_checkpoint_id`
+     on that grandparent (a slatedb-owned, pinned id — see [Clones](#clones)), not the original
+     user-supplied checkpoint; this is what makes the dedup key stable across the union, since
+     all sibling projections share the same slatedb-owned id and the user cannot invalidate it
+     by deleting their own checkpoint. New `final_checkpoint_id` values are
      generated for all entries — the old ones belong to the source databases' clone relationships and are
      not valid for the new database.
    - SSTs with the same ID but __originating__ from different source databases are deduplicated by assigning a new ID

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -711,7 +711,11 @@ impl Manifest {
         for parent_external_db in &parent_manifest.external_dbs {
             clone_external_dbs.push(ExternalDb {
                 path: parent_external_db.path.clone(),
-                source_checkpoint_id: parent_external_db.source_checkpoint_id,
+                // don't depend on the original source_checkpoint: it was supplied by the user and
+                // might have been deleted; use slatedb-generated final checkpoint instead
+                source_checkpoint_id: parent_external_db
+                    .final_checkpoint_id
+                    .expect("final_checkpoint_id must be present"),
                 final_checkpoint_id: Some(rand.rng().gen_uuid()),
                 sst_ids: parent_external_db.sst_ids.clone(),
             });
@@ -940,7 +944,11 @@ impl Manifest {
             for parent_external_db in &manifest.external_dbs {
                 external_dbs.push(ExternalDb {
                     path: parent_external_db.path.clone(),
-                    source_checkpoint_id: parent_external_db.source_checkpoint_id,
+                    // don't depend on the original source_checkpoint: it was supplied by the user and
+                    // might have been deleted; use slatedb-generated final checkpoint instead
+                    source_checkpoint_id: parent_external_db
+                        .final_checkpoint_id
+                        .expect("final_checkpoint_id must be present"),
                     final_checkpoint_id: None,
                     sst_ids: parent_external_db.sst_ids.clone(),
                 });
@@ -1220,6 +1228,88 @@ mod tests {
         assert_eq!(
             parent_manifest.manifest().compactor_epoch,
             clone_manifest.compactor_epoch
+        );
+    }
+
+    #[test]
+    fn test_cloned_breaks_chain_via_final_checkpoint() {
+        // When the parent is itself a clone, its external_dbs already carry an entry for
+        // the grandparent. Cloning the parent must NOT propagate the grandparent's
+        // user-supplied source_checkpoint_id forward — the user could delete that
+        // checkpoint at any time, which would invalidate any future clones in the chain.
+        // Instead, the carried-over entry's source_checkpoint_id is set to the parent's
+        // final_checkpoint_id (slatedb-generated and pinned by the parent), breaking the
+        // chain back to the user-supplied checkpoint.
+        let rand = Arc::new(DbRand::default());
+
+        let grandparent_sst = SsTableId::Compacted(Ulid::new());
+        let parent_owned_sst = SsTableId::Compacted(Ulid::new());
+        let grandparent_source_cp = Uuid::new_v4();
+        let grandparent_final_cp = Uuid::new_v4();
+
+        let mut parent = build_manifest(
+            &SimpleManifest {
+                l0: vec![SstEntry::projected("parent_owned", "a", "a"..)],
+                sorted_runs: vec![],
+            },
+            |_| parent_owned_sst,
+        );
+        parent.external_dbs.push(ExternalDb {
+            path: "/tmp/grandparent".to_string(),
+            source_checkpoint_id: grandparent_source_cp,
+            final_checkpoint_id: Some(grandparent_final_cp),
+            sst_ids: vec![grandparent_sst],
+        });
+
+        let parent_cp = Uuid::new_v4();
+        let cloned = Manifest::cloned(&parent, "/tmp/parent".to_string(), parent_cp, rand);
+
+        // Two entries: the new immediate-parent entry, plus the carried-over grandparent.
+        assert_eq!(cloned.external_dbs.len(), 2);
+
+        let grandparent_entry = cloned
+            .external_dbs
+            .iter()
+            .find(|e| e.path == "/tmp/grandparent")
+            .expect("grandparent entry should be carried over");
+
+        // The chain to the user-supplied grandparent_source_cp must be broken:
+        // source_checkpoint_id is now the parent's final_checkpoint_id.
+        assert_eq!(
+            grandparent_entry.source_checkpoint_id, grandparent_final_cp,
+            "carried-over source_checkpoint_id must be the parent's final_checkpoint_id"
+        );
+        assert_ne!(
+            grandparent_entry.source_checkpoint_id, grandparent_source_cp,
+            "carried-over source_checkpoint_id must not depend on the user-supplied checkpoint"
+        );
+        // A fresh final_checkpoint_id is generated for the new clone's entry.
+        assert!(grandparent_entry.final_checkpoint_id.is_some());
+        assert_ne!(
+            grandparent_entry.final_checkpoint_id,
+            Some(grandparent_final_cp),
+            "final_checkpoint_id must be regenerated for the new clone"
+        );
+        assert_eq!(grandparent_entry.sst_ids, vec![grandparent_sst]);
+
+        // The new immediate-parent entry uses the user-supplied checkpoint as expected.
+        let parent_entry = cloned
+            .external_dbs
+            .iter()
+            .find(|e| e.path == "/tmp/parent")
+            .expect("parent entry should be added for the immediate parent");
+        assert_eq!(parent_entry.source_checkpoint_id, parent_cp);
+        assert_eq!(parent_entry.sst_ids, vec![parent_owned_sst]);
+
+        // The chain-break must hold across the whole clone manifest: no entry
+        // anywhere should still reference the user-supplied grandparent checkpoint.
+        assert!(
+            cloned
+                .external_dbs
+                .iter()
+                .all(|e| e.source_checkpoint_id != grandparent_source_cp
+                    && e.final_checkpoint_id != Some(grandparent_source_cp)),
+            "no entry in the clone may reference the user-supplied grandparent_source_cp"
         );
     }
 
@@ -2334,9 +2424,11 @@ mod tests {
             .iter()
             .find(|e| e.path == "/tmp/grandparent")
             .unwrap();
-        // source_checkpoint_id is preserved so the union still depends on the
-        // same checkpoint on grandparent that the parent's clone depends on.
-        assert_eq!(grandparent.source_checkpoint_id, grandparent_source_cp);
+        // The carried-over entry's source_checkpoint_id must be replaced with the
+        // parent's final_checkpoint_id, so the union does not depend on the original
+        // user-supplied grandparent_source_cp (which the user could delete).
+        assert_eq!(grandparent.source_checkpoint_id, grandparent_final_cp);
+        assert_ne!(grandparent.source_checkpoint_id, grandparent_source_cp);
         // final_checkpoint_id must be regenerated — the union clone owns its own
         // checkpoint and must not claim ownership over the parent's.
         assert!(grandparent.final_checkpoint_id.is_some());
@@ -2761,16 +2853,24 @@ mod tests {
 
         let result = Manifest::cloned_from_union(sources, rand).unwrap();
 
+        // After the commit, carried-over external_dbs use the parent's final_checkpoint_id
+        // as their source_checkpoint_id (not the original user-supplied source_cp), so
+        // dedup on the union side keys off original_final_cp.
         let shared_entries: Vec<_> = result
             .external_dbs
             .iter()
-            .filter(|db| db.path == shared_path && db.source_checkpoint_id == shared_source_cp)
+            .filter(|db| db.path == shared_path && db.source_checkpoint_id == original_final_cp)
             .collect();
         assert_eq!(
             shared_entries.len(),
             1,
             "Should have exactly one entry for the shared (path, source_checkpoint_id)"
         );
+        // No entry should still reference the user-supplied shared_source_cp.
+        assert!(result
+            .external_dbs
+            .iter()
+            .all(|db| db.source_checkpoint_id != shared_source_cp));
 
         let merged_ids: HashSet<SsTableId> = shared_entries[0].sst_ids.iter().copied().collect();
         let expected_ids: HashSet<SsTableId> = [sst_a, sst_b, sst_c].iter().copied().collect();


### PR DESCRIPTION
## Summary

```
When SlateDB is cloned, external_dbs of the clone is populated with:
- new entry for the immediate parent
- all the (still relevant) entries from the parents

The user provides source checkpoint ID for the parent database which is recorded as part of external_dbs entry. So after a chain of clone() calls, the latest clone still references all source checkpoint IDs.

These checkpoint IDs are user-supplied and are not meant to be used outside of the original clone().

A removal of such a checkpoint (by the user) invalidates the future cloning because source checkpoints can not be re-pinned anymore.
```

## Notes for Reviewers

--

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
