### PR TITLE
Add slatedb.compactor.expired_entries_purged counter to RetentionIterator

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1027,11 +1027,14 @@ pub mod stats {
         compactor_stat_name!("total_bytes_being_compacted");
     pub const TOTAL_THROUGHPUT_BYTES_PER_SEC: &str =
         compactor_stat_name!("total_throughput_bytes_per_sec");
-    pub const EXPIRED_ENTRIES: &str = compactor_stat_name!("expired_entries");
-    pub const EXPIRED_ENTRIES_DESCRIPTION: &str =
-        "Count of tombstones added by the RetentionIterator when an expired value entry \
-         is rewritten as a tombstone. Does not include expired merge entries, which are \
-         skipped silently.";
+    pub const EXPIRED_ENTRIES_PURGED: &str = compactor_stat_name!("expired_entries_purged");
+    pub const EXPIRED_ENTRIES_PURGED_DESCRIPTION: &str =
+        "Count of expired entries purged by the RetentionIterator. \
+         `entry_type=\"value\"` counts expired value entries rewritten as tombstones; \
+         `entry_type=\"merge\"` counts expired merge entries dropped without a tombstone.";
+    pub const ENTRY_TYPE_LABEL: &str = "entry_type";
+    pub const ENTRY_TYPE_VALUE: &str = "value";
+    pub const ENTRY_TYPE_MERGE: &str = "merge";
 
     pub(crate) struct CompactionStats {
         pub(crate) compactor_epoch: Arc<dyn GaugeFn>,
@@ -1041,7 +1044,8 @@ pub mod stats {
         pub(crate) total_bytes_being_compacted: Arc<dyn GaugeFn>,
         pub(crate) total_throughput: Arc<dyn GaugeFn>,
         pub(crate) merge_operator_compact_operands: Arc<dyn CounterFn>,
-        pub(crate) expired_entries: Arc<dyn CounterFn>,
+        pub(crate) expired_entries_purged_value: Arc<dyn CounterFn>,
+        pub(crate) expired_entries_purged_merge: Arc<dyn CounterFn>,
     }
 
     impl CompactionStats {
@@ -1058,16 +1062,23 @@ pub mod stats {
                     .labels(&[(MERGE_OPERATOR_PATH_LABEL, MERGE_OPERATOR_COMPACT_PATH)])
                     .description(MERGE_OPERATOR_OPERANDS_DESCRIPTION)
                     .register(),
-                expired_entries: recorder
-                    .counter(EXPIRED_ENTRIES)
-                    .description(EXPIRED_ENTRIES_DESCRIPTION)
+                expired_entries_purged_value: recorder
+                    .counter(EXPIRED_ENTRIES_PURGED)
+                    .labels(&[(ENTRY_TYPE_LABEL, ENTRY_TYPE_VALUE)])
+                    .description(EXPIRED_ENTRIES_PURGED_DESCRIPTION)
+                    .register(),
+                expired_entries_purged_merge: recorder
+                    .counter(EXPIRED_ENTRIES_PURGED)
+                    .labels(&[(ENTRY_TYPE_LABEL, ENTRY_TYPE_MERGE)])
+                    .description(EXPIRED_ENTRIES_PURGED_DESCRIPTION)
                     .register(),
             }
         }
 
         pub(crate) fn retention_metrics(&self) -> crate::retention_iterator::RetentionMetrics {
             crate::retention_iterator::RetentionMetrics {
-                expired_entries: self.expired_entries.clone(),
+                expired_entries_purged_value: self.expired_entries_purged_value.clone(),
+                expired_entries_purged_merge: self.expired_entries_purged_merge.clone(),
             }
         }
     }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1027,6 +1027,11 @@ pub mod stats {
         compactor_stat_name!("total_bytes_being_compacted");
     pub const TOTAL_THROUGHPUT_BYTES_PER_SEC: &str =
         compactor_stat_name!("total_throughput_bytes_per_sec");
+    pub const EXPIRED_ENTRIES: &str = compactor_stat_name!("expired_entries");
+    pub const EXPIRED_ENTRIES_DESCRIPTION: &str =
+        "Count of tombstones added by the RetentionIterator when an expired value entry \
+         is rewritten as a tombstone. Does not include expired merge entries, which are \
+         skipped silently.";
 
     pub(crate) struct CompactionStats {
         pub(crate) compactor_epoch: Arc<dyn GaugeFn>,
@@ -1036,6 +1041,7 @@ pub mod stats {
         pub(crate) total_bytes_being_compacted: Arc<dyn GaugeFn>,
         pub(crate) total_throughput: Arc<dyn GaugeFn>,
         pub(crate) merge_operator_compact_operands: Arc<dyn CounterFn>,
+        pub(crate) expired_entries: Arc<dyn CounterFn>,
     }
 
     impl CompactionStats {
@@ -1052,6 +1058,16 @@ pub mod stats {
                     .labels(&[(MERGE_OPERATOR_PATH_LABEL, MERGE_OPERATOR_COMPACT_PATH)])
                     .description(MERGE_OPERATOR_OPERANDS_DESCRIPTION)
                     .register(),
+                expired_entries: recorder
+                    .counter(EXPIRED_ENTRIES)
+                    .description(EXPIRED_ENTRIES_DESCRIPTION)
+                    .register(),
+            }
+        }
+
+        pub(crate) fn retention_metrics(&self) -> crate::retention_iterator::RetentionMetrics {
+            crate::retention_iterator::RetentionMetrics {
+                expired_entries: self.expired_entries.clone(),
             }
         }
     }

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -333,6 +333,7 @@ impl TokioCompactionExecutorInner {
             job_args.compaction_clock_tick,
             self.clock.clone(),
             Arc::new(stored_manifest.db_state().sequence_tracker.clone()),
+            Some(self.stats.retention_metrics()),
         )
         .await?;
         retention_iter.init().await?;

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -220,6 +220,7 @@ impl DbInner {
             imm_table.last_tick(),
             self.system_clock.clone(),
             Arc::new(state.core().sequence_tracker.clone()),
+            None,
         )
         .await?;
         iter.init().await?;

--- a/slatedb/src/retention_iterator.rs
+++ b/slatedb/src/retention_iterator.rs
@@ -12,15 +12,19 @@ use crate::types::{RowEntry, ValueDeletable};
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::CounterFn;
 
-/// Counter for expired value entries rewritten as tombstones by [`RetentionIterator`].
+/// Counters for expired entries purged by [`RetentionIterator`], split by
+/// `entry_type` label.
 ///
-/// A user-written `CompactionFilter` can't observe this rewrite — the tombstone
-/// reaches the filter with `expire_ts: None`, indistinguishable from one the
-/// user wrote — so the counter surfaces it instead. Expired `Merge` entries
-/// are skipped silently and are not counted.
+/// - `entry_type="value"`: expired value entries rewritten as tombstones. A
+///   user-written `CompactionFilter` can't observe the rewrite (the tombstone
+///   reaches the filter with `expire_ts: None`, indistinguishable from one the
+///   user wrote), so the counter surfaces it.
+/// - `entry_type="merge"`: expired merge entries skipped by the iterator
+///   (no tombstone is written).
 #[derive(Clone)]
 pub(crate) struct RetentionMetrics {
-    pub(crate) expired_entries: Arc<dyn CounterFn>,
+    pub(crate) expired_entries_purged_value: Arc<dyn CounterFn>,
+    pub(crate) expired_entries_purged_merge: Arc<dyn CounterFn>,
 }
 
 /// A retention iterator that filters entries based on retention time and handles expired/tombstoned keys.
@@ -106,6 +110,9 @@ impl<T: RowEntryIterator> RetentionIterator<T> {
                     if is_merge {
                         // just skip expired merge entries rather than write a tombstone
                         // as earlier merges may still be un-expired
+                        if let Some(m) = metrics {
+                            m.expired_entries_purged_merge.increment(1);
+                        }
                         continue;
                     }
                     // for values, insert a tombstone instead of just filtering out the
@@ -113,7 +120,7 @@ impl<T: RowEntryIterator> RetentionIterator<T> {
                     // an older version of the KV pair that has a larger TTL in
                     // a lower level of the LSM tree
                     if let Some(m) = metrics {
-                        m.expired_entries.increment(1);
+                        m.expired_entries_purged_value.increment(1);
                     }
                     RowEntry {
                         key: entry.key,
@@ -1169,21 +1176,45 @@ mod tests {
     #[cfg(feature = "test-util")]
     mod expired_entries_metrics {
         use super::*;
-        use crate::compactor::stats::EXPIRED_ENTRIES;
+        use crate::compactor::stats::{
+            ENTRY_TYPE_LABEL, ENTRY_TYPE_MERGE, ENTRY_TYPE_VALUE, EXPIRED_ENTRIES_PURGED,
+        };
         use crate::test_utils::TestIterator;
         use slatedb_common::clock::MockSystemClock;
-        use slatedb_common::metrics::{lookup_metric, test_recorder_helper};
+        use slatedb_common::metrics::{
+            lookup_metric_with_labels, test_recorder_helper, DefaultMetricsRecorder,
+        };
         use std::collections::BTreeMap;
 
-        fn build_metrics() -> (
-            std::sync::Arc<slatedb_common::metrics::DefaultMetricsRecorder>,
-            RetentionMetrics,
-        ) {
+        fn build_metrics() -> (Arc<DefaultMetricsRecorder>, RetentionMetrics) {
             let (recorder, helper) = test_recorder_helper();
             let metrics = RetentionMetrics {
-                expired_entries: helper.counter(EXPIRED_ENTRIES).register(),
+                expired_entries_purged_value: helper
+                    .counter(EXPIRED_ENTRIES_PURGED)
+                    .labels(&[(ENTRY_TYPE_LABEL, ENTRY_TYPE_VALUE)])
+                    .register(),
+                expired_entries_purged_merge: helper
+                    .counter(EXPIRED_ENTRIES_PURGED)
+                    .labels(&[(ENTRY_TYPE_LABEL, ENTRY_TYPE_MERGE)])
+                    .register(),
             };
             (recorder, metrics)
+        }
+
+        fn value_count(recorder: &DefaultMetricsRecorder) -> Option<i64> {
+            lookup_metric_with_labels(
+                recorder,
+                EXPIRED_ENTRIES_PURGED,
+                &[(ENTRY_TYPE_LABEL, ENTRY_TYPE_VALUE)],
+            )
+        }
+
+        fn merge_count(recorder: &DefaultMetricsRecorder) -> Option<i64> {
+            lookup_metric_with_labels(
+                recorder,
+                EXPIRED_ENTRIES_PURGED,
+                &[(ENTRY_TYPE_LABEL, ENTRY_TYPE_MERGE)],
+            )
         }
 
         #[test]
@@ -1215,11 +1246,12 @@ mod tests {
                 only.expire_ts.is_none(),
                 "tombstone should have expire_ts cleared"
             );
-            assert_eq!(lookup_metric(recorder.as_ref(), EXPIRED_ENTRIES), Some(1));
+            assert_eq!(value_count(recorder.as_ref()), Some(1));
+            assert_eq!(merge_count(recorder.as_ref()), Some(0));
         }
 
         #[test]
-        fn apply_retention_filter_no_increment_for_expired_merge() {
+        fn apply_retention_filter_increments_for_expired_merge() {
             let (recorder, metrics) = build_metrics();
             let entry = RowEntry::new_merge(b"k", b"v", 1).with_expire_ts(500);
             let mut versions = BTreeMap::new();
@@ -1237,11 +1269,8 @@ mod tests {
             );
 
             assert!(filtered.is_empty(), "expired merge entry should be dropped");
-            assert_eq!(
-                lookup_metric(recorder.as_ref(), EXPIRED_ENTRIES),
-                Some(0),
-                "merge drops must not increment the counter"
-            );
+            assert_eq!(merge_count(recorder.as_ref()), Some(1));
+            assert_eq!(value_count(recorder.as_ref()), Some(0));
         }
 
         #[test]
@@ -1263,7 +1292,8 @@ mod tests {
             );
 
             assert_eq!(filtered.len(), 1);
-            assert_eq!(lookup_metric(recorder.as_ref(), EXPIRED_ENTRIES), Some(0));
+            assert_eq!(value_count(recorder.as_ref()), Some(0));
+            assert_eq!(merge_count(recorder.as_ref()), Some(0));
         }
 
         #[test]

--- a/slatedb/src/retention_iterator.rs
+++ b/slatedb/src/retention_iterator.rs
@@ -10,6 +10,18 @@ use crate::seq_tracker::{FindOption, SequenceTracker};
 use crate::types::ValueDeletable::Tombstone;
 use crate::types::{RowEntry, ValueDeletable};
 use slatedb_common::clock::SystemClock;
+use slatedb_common::metrics::CounterFn;
+
+/// Counter for expired value entries rewritten as tombstones by [`RetentionIterator`].
+///
+/// A user-written `CompactionFilter` can't observe this rewrite — the tombstone
+/// reaches the filter with `expire_ts: None`, indistinguishable from one the
+/// user wrote — so the counter surfaces it instead. Expired `Merge` entries
+/// are skipped silently and are not counted.
+#[derive(Clone)]
+pub(crate) struct RetentionMetrics {
+    pub(crate) expired_entries: Arc<dyn CounterFn>,
+}
 
 /// A retention iterator that filters entries based on retention time and handles expired/tombstoned keys.
 ///
@@ -36,6 +48,9 @@ pub(crate) struct RetentionIterator<T: RowEntryIterator> {
     system_clock: Arc<dyn SystemClock>,
     /// Historical sequence metadata used to translate sequence numbers into wall-clock timestamps.
     sequence_tracker: Arc<SequenceTracker>,
+    /// Optional counters for observing expire_ts-driven decisions. Populated on
+    /// the compaction path; `None` on the flush path.
+    metrics: Option<RetentionMetrics>,
 }
 
 impl<T: RowEntryIterator> RetentionIterator<T> {
@@ -48,6 +63,7 @@ impl<T: RowEntryIterator> RetentionIterator<T> {
         compaction_start_ts: i64,
         system_clock: Arc<dyn SystemClock>,
         sequence_tracker: Arc<SequenceTracker>,
+        metrics: Option<RetentionMetrics>,
     ) -> Result<Self, SlateDBError> {
         Ok(Self {
             inner,
@@ -57,6 +73,7 @@ impl<T: RowEntryIterator> RetentionIterator<T> {
             compaction_start_ts,
             system_clock,
             sequence_tracker,
+            metrics,
             buffer: RetentionBuffer::new(),
         })
     }
@@ -75,6 +92,7 @@ impl<T: RowEntryIterator> RetentionIterator<T> {
         retention_min_seq: Option<u64>,
         filter_tombstone: bool,
         sequence_tracker: Arc<SequenceTracker>,
+        metrics: Option<&RetentionMetrics>,
     ) -> BTreeMap<Reverse<u64>, RowEntry> {
         let mut filtered_versions = BTreeMap::new();
         let current_system_ts = system_clock.now().timestamp_millis();
@@ -94,6 +112,9 @@ impl<T: RowEntryIterator> RetentionIterator<T> {
                     // value in the iterator because this may otherwise "revive"
                     // an older version of the KV pair that has a larger TTL in
                     // a lower level of the LSM tree
+                    if let Some(m) = metrics {
+                        m.expired_entries.increment(1);
+                    }
                     RowEntry {
                         key: entry.key,
                         value: Tombstone,
@@ -226,6 +247,7 @@ impl<T: RowEntryIterator> RowEntryIterator for RetentionIterator<T> {
                     let retention_timeout = self.retention_timeout;
                     let retention_min_seq = self.retention_min_seq;
                     let system_clock = self.system_clock.clone();
+                    let metrics = self.metrics.clone();
                     self.buffer.process_retention(|versions| {
                         Self::apply_retention_filter(
                             versions,
@@ -235,6 +257,7 @@ impl<T: RowEntryIterator> RowEntryIterator for RetentionIterator<T> {
                             retention_min_seq,
                             self.filter_tombstone,
                             self.sequence_tracker.clone(),
+                            metrics.as_ref(),
                         )
                     })?;
                 }
@@ -1012,6 +1035,7 @@ mod tests {
             test_case.retention_min_seq,
             test_case.filter_tombstone,
             Arc::new(SequenceTracker::new()),
+            None,
         );
 
         // Convert filtered versions back to expected order
@@ -1124,6 +1148,7 @@ mod tests {
             None,
             false,
             tracker,
+            None,
         );
 
         let derived_ts = sorted_points
@@ -1139,5 +1164,131 @@ mod tests {
             "{:?}[{}@{} Now({})]",
             filtered, entry_seq, derived_ts, clock_now
         );
+    }
+
+    #[cfg(feature = "test-util")]
+    mod expired_entries_metrics {
+        use super::*;
+        use crate::compactor::stats::EXPIRED_ENTRIES;
+        use crate::test_utils::TestIterator;
+        use slatedb_common::clock::MockSystemClock;
+        use slatedb_common::metrics::{lookup_metric, test_recorder_helper};
+        use std::collections::BTreeMap;
+
+        fn build_metrics() -> (
+            std::sync::Arc<slatedb_common::metrics::DefaultMetricsRecorder>,
+            RetentionMetrics,
+        ) {
+            let (recorder, helper) = test_recorder_helper();
+            let metrics = RetentionMetrics {
+                expired_entries: helper.counter(EXPIRED_ENTRIES).register(),
+            };
+            (recorder, metrics)
+        }
+
+        #[test]
+        fn apply_retention_filter_increments_for_expired_value() {
+            let (recorder, metrics) = build_metrics();
+            let entry = RowEntry::new_value(b"k", b"v", 1).with_expire_ts(500);
+            let mut versions = BTreeMap::new();
+            versions.insert(Reverse(entry.seq), entry);
+
+            let filtered = RetentionIterator::<TestIterator>::apply_retention_filter(
+                versions,
+                1_000,
+                Arc::new(MockSystemClock::with_time(1_000)),
+                None,
+                None,
+                false,
+                Arc::new(SequenceTracker::new()),
+                Some(&metrics),
+            );
+
+            assert_eq!(filtered.len(), 1);
+            let only = filtered.values().next().unwrap();
+            assert!(
+                matches!(only.value, ValueDeletable::Tombstone),
+                "expired value should become a tombstone, got {:?}",
+                only.value
+            );
+            assert!(
+                only.expire_ts.is_none(),
+                "tombstone should have expire_ts cleared"
+            );
+            assert_eq!(lookup_metric(recorder.as_ref(), EXPIRED_ENTRIES), Some(1));
+        }
+
+        #[test]
+        fn apply_retention_filter_no_increment_for_expired_merge() {
+            let (recorder, metrics) = build_metrics();
+            let entry = RowEntry::new_merge(b"k", b"v", 1).with_expire_ts(500);
+            let mut versions = BTreeMap::new();
+            versions.insert(Reverse(entry.seq), entry);
+
+            let filtered = RetentionIterator::<TestIterator>::apply_retention_filter(
+                versions,
+                1_000,
+                Arc::new(MockSystemClock::with_time(1_000)),
+                None,
+                None,
+                false,
+                Arc::new(SequenceTracker::new()),
+                Some(&metrics),
+            );
+
+            assert!(filtered.is_empty(), "expired merge entry should be dropped");
+            assert_eq!(
+                lookup_metric(recorder.as_ref(), EXPIRED_ENTRIES),
+                Some(0),
+                "merge drops must not increment the counter"
+            );
+        }
+
+        #[test]
+        fn apply_retention_filter_no_increment_when_not_expired() {
+            let (recorder, metrics) = build_metrics();
+            let entry = RowEntry::new_value(b"k", b"v", 1).with_expire_ts(2_000);
+            let mut versions = BTreeMap::new();
+            versions.insert(Reverse(entry.seq), entry);
+
+            let filtered = RetentionIterator::<TestIterator>::apply_retention_filter(
+                versions,
+                1_000,
+                Arc::new(MockSystemClock::with_time(1_000)),
+                None,
+                None,
+                false,
+                Arc::new(SequenceTracker::new()),
+                Some(&metrics),
+            );
+
+            assert_eq!(filtered.len(), 1);
+            assert_eq!(lookup_metric(recorder.as_ref(), EXPIRED_ENTRIES), Some(0));
+        }
+
+        #[test]
+        fn apply_retention_filter_no_panic_when_metrics_none() {
+            let merge_entry = RowEntry::new_merge(b"k1", b"v", 1).with_expire_ts(500);
+            let value_entry = RowEntry::new_value(b"k2", b"v", 2).with_expire_ts(500);
+            let mut versions = BTreeMap::new();
+            versions.insert(Reverse(merge_entry.seq), merge_entry);
+            versions.insert(Reverse(value_entry.seq), value_entry);
+
+            let filtered = RetentionIterator::<TestIterator>::apply_retention_filter(
+                versions,
+                1_000,
+                Arc::new(MockSystemClock::with_time(1_000)),
+                None,
+                None,
+                false,
+                Arc::new(SequenceTracker::new()),
+                None,
+            );
+
+            // merge dropped, value kept as tombstone
+            assert_eq!(filtered.len(), 1);
+            let kept = filtered.values().next().unwrap();
+            assert!(matches!(kept.value, ValueDeletable::Tombstone));
+        }
     }
 }


### PR DESCRIPTION
## Summary

User-written CompactionFilters can't observe expire_ts-driven tombstones: expired value entries arrive at the filter as plain tombstones with expire_ts cleared, indistinguishable from a user-written tombstone. There is currently no way to see how many entries are dropped due to expire_ts in the RetentionIterator.

## Changes

Add an unlabeled counter slatedb.compactor.expired_entries threaded through CompactionStats into RetentionIterator, incremented when an expired value is rewritten as a tombstone. Expired merge entries are skipped silently and not counted. The flush path passes None since the metric is compactor-scoped.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
