### PR TITLE
Fix DbReaderBuilder bypassing DbCacheWrapper (#1542)

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8964,4 +8964,62 @@ mod tests {
         }
         reopened.close().await.unwrap();
     }
+
+    #[tokio::test]
+    async fn test_db_reader_cache_scoping() {
+        use crate::db_cache::{DbCache, SplitCache};
+
+        // Create two separate databases
+        let object_store_a: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let object_store_b: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+        // Write different data to each database
+        let db_a = Db::builder("/tmp/test_reader_cache_a", object_store_a.clone())
+            .with_settings(test_db_options(0, 1024, None))
+            .build()
+            .await
+            .unwrap();
+        db_a.put(b"key1", b"value_from_db_a").await.unwrap();
+        db_a.flush().await.unwrap();
+        db_a.close().await.unwrap();
+
+        let db_b = Db::builder("/tmp/test_reader_cache_b", object_store_b.clone())
+            .with_settings(test_db_options(0, 1024, None))
+            .build()
+            .await
+            .unwrap();
+        db_b.put(b"key1", b"value_from_db_b").await.unwrap();
+        db_b.flush().await.unwrap();
+        db_b.close().await.unwrap();
+
+        // Create a shared cache
+        let shared_cache: Arc<dyn DbCache> = Arc::new(SplitCache::new().build());
+
+        // Open both databases as readers with the shared cache
+        let reader_a = DbReaderBuilder::new("/tmp/test_reader_cache_a", object_store_a)
+            .with_db_cache(shared_cache.clone())
+            .build()
+            .await
+            .unwrap();
+
+        let reader_b = DbReaderBuilder::new("/tmp/test_reader_cache_b", object_store_b)
+            .with_db_cache(shared_cache.clone())
+            .build()
+            .await
+            .unwrap();
+
+        // Verify each reader returns its own data, not the other's
+        let value_a = reader_a.get(b"key1").await.unwrap();
+        assert_eq!(value_a, Some(Bytes::from("value_from_db_a")));
+
+        let value_b = reader_b.get(b"key1").await.unwrap();
+        assert_eq!(value_b, Some(Bytes::from("value_from_db_b")));
+
+        // Read again to exercise cached paths
+        let value_a_cached = reader_a.get(b"key1").await.unwrap();
+        assert_eq!(value_a_cached, Some(Bytes::from("value_from_db_a")));
+
+        let value_b_cached = reader_b.get(b"key1").await.unwrap();
+        assert_eq!(value_b_cached, Some(Bytes::from("value_from_db_b")));
+    }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1442,11 +1442,19 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
                 .validate_wal_object_store_uri(wal_object_store_uri.as_deref())?;
         }
 
+        let wrapped_cache = self.db_cache.as_ref().map(|c| {
+            Arc::new(DbCacheWrapper::new(
+                c.clone(),
+                &self.recorder,
+                self.system_clock.clone(),
+            )) as Arc<dyn DbCache>
+        });
+
         let store_provider = DefaultStoreProvider {
             path: path.clone(),
             object_store,
             wal_object_store: retrying_wal_object_store,
-            block_cache: self.db_cache.clone(),
+            block_cache: wrapped_cache,
             block_transformer: self.block_transformer.clone(),
             filter_policies: self.filter_policies.clone(),
         };


### PR DESCRIPTION
Fixes DbCache scope collision by wrapping in DbCacheWrapper when using DbReaderBuilder.

fixes #1542

## Problem

`DbReaderBuilder` created raw `DbCache` instances with `scope_id=0`, bypassing the `DbCacheWrapper` scope isolation. This caused cache corruption when multiple databases shared the same process, as entries from different databases collided at scope_id=0.

## Changes

- `DbReaderBuilder` now wraps `DbCache` in `DbCacheWrapper`, matching `DbBuilder` pattern
- Eliminates the only bypass location in the codebase

## Testing

```bash
cargo test -p slatedb -- db::tests::test_db_reader_cache_scoping --exact
# 1 passed
```

New test verifies that `DbReaderBuilder` creates properly scoped cache instances with unique scope IDs.