### PR TITLE
Bump object_store to 0.13 (fixes #1140)

### DIFF
--- a/.config/clippy.toml
+++ b/.config/clippy.toml
@@ -1,6 +1,7 @@
 disallowed-types   = [
     # Safety checks to keep SlateDB safe for deterministic simulation testing (DST)
-    { path = "rand::rngs::OsRng", reason = "Use crate::rand::DbRand instead" },
+    # OsRng is allow-invalid because rand 0.10 (transitive via object_store 0.13) no longer re-exports it at this path
+    { path = "rand::rngs::OsRng", reason = "Use crate::rand::DbRand instead", allow-invalid = true },
     { path = "rand::rngs::ThreadRng", reason = "Use crate::rand::DbRand instead" },
     { path = "rand::rngs::StdRng", reason = "Use crate::rand::DbRand instead" },
     { path = "rand::rngs::SmallRng", reason = "Use crate::rand::DbRand instead" },
@@ -46,7 +47,8 @@ disallowed-types   = [
 disallowed-methods = [
     # Safety checks to keep SlateDB safe for deterministic simulation testing (DST)
     { path = "rand::random", reason = "Use crate::rand::DbRand instead" },
-    { path = "rand::thread_rng", reason = "Use crate::rand::DbRand instead" },
+    # thread_rng is allow-invalid because rand 0.10 (transitive via object_store 0.13) no longer re-exports it at this path
+    { path = "rand::thread_rng", reason = "Use crate::rand::DbRand instead", allow-invalid = true },
     # prelude versions are allow-invalid since they may not be in scope
     { path = "rand::prelude::random", reason = "Use crate::rand::DbRand instead", allow-invalid = true  },
     { path = "rand::prelude::thread_rng", reason = "Use crate::rand::DbRand instead", allow-invalid = true  },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,9 +381,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -402,6 +402,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -517,6 +528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +567,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -700,7 +735,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -836,7 +873,7 @@ checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
 dependencies = [
  "log",
  "once_cell",
- "rand",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -876,13 +913,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1054,7 +1090,7 @@ dependencies = [
  "mea",
  "parking_lot",
  "pin-project",
- "rand",
+ "rand 0.9.4",
  "serde",
  "tracing",
  "twox-hash",
@@ -1229,6 +1265,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1270,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1320,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1346,6 +1383,21 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1577,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1592,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1631,16 +1683,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -1684,6 +1726,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "js-sys",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "wasm-bindgen",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1719,21 +1804,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
-]
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1768,7 +1841,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -2008,16 +2081,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "httparse",
@@ -2027,11 +2102,11 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
- "rand",
- "reqwest",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
+ "reqwest 0.12.28",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2046,13 +2121,15 @@ dependencies = [
 
 [[package]]
 name = "object_store_opendal"
-version = "0.54.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b88fc0e0c4890c1d99e2b8c519c5db40f7d9b69a0f562ff1ad4967a4c8bbc6"
+checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
 dependencies = [
  "async-trait",
  "bytes",
+ "chrono",
  "futures",
+ "mea",
  "object_store",
  "opendal",
  "pin-project",
@@ -2079,28 +2156,39 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
-version = "0.54.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42afda58fa2cf50914402d132cc1caacff116a85d10c72ab2082bb7c50021754"
+checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+dependencies = [
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
 dependencies = [
  "anyhow",
- "backon",
  "base64",
  "bytes",
- "chrono",
  "futures",
- "getrandom 0.2.17",
  "http",
  "http-body",
+ "jiff",
  "log",
  "md-5",
+ "mea",
  "percent-encoding",
- "quick-xml",
- "reqwest",
+ "quick-xml 0.38.4",
+ "reqsign-core",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
+ "url",
  "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -2159,7 +2247,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "petgraph",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2211,18 +2299,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2280,6 +2368,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2380,7 +2477,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.1",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -2431,6 +2528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,7 +2566,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2513,7 +2620,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2523,7 +2641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2536,12 +2654,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2550,7 +2674,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2578,15 +2702,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -2627,6 +2742,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
+name = "reqsign-core"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10302cf0a7d7e7352ba211fc92c3c5bebf1286153e49cc5aa87348078a8e102"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures",
+ "hex",
+ "hmac",
+ "http",
+ "jiff",
+ "log",
+ "percent-encoding",
+ "sha1",
+ "sha2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,7 +2801,39 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -2713,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -2757,9 +2926,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "ring",
@@ -2782,19 +2951,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2802,9 +2962,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2999,6 +3159,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,9 +3219,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3086,7 +3268,7 @@ dependencies = [
  "parking_lot",
  "pprof",
  "proptest",
- "rand",
+ "rand 0.9.4",
  "rand_xoshiro",
  "rstest",
  "serde",
@@ -3120,7 +3302,7 @@ dependencies = [
  "clap",
  "futures",
  "object_store",
- "rand",
+ "rand 0.9.4",
  "rand_xorshift",
  "slatedb",
  "sysinfo",
@@ -3171,7 +3353,7 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.9.4",
  "rstest",
  "slatedb",
  "slatedb-common",
@@ -3289,9 +3471,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
-version = "12.18.2"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbc8b4f883265fb2207a0d6ce67095f4bd6cf13e5f9183eb8b3e73fa1b2466a"
+checksum = "332615d90111d8eeaf86a84dc9bbe9f65d0d8c5cf11b4caccedc37754eb0dcfd"
 dependencies = [
  "debugid",
  "memmap2",
@@ -3301,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.18.2"
+version = "12.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eda470a26ea40eb5cafc35487718e23a2f19153d3a589affb9e8f7fa1aa73b3"
+checksum = "912017718eb4d21930546245af9a3475c9dccf15675a5c215664e76621afc471"
 dependencies = [
  "cpp_demangle",
  "rustc-demangle",
@@ -3487,9 +3669,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3636,7 +3818,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3645,7 +3827,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3677,20 +3859,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3779,7 +3961,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3794,7 +3976,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.4",
  "serde",
  "web-time",
 ]
@@ -4060,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4073,9 +4255,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4083,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4093,9 +4275,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4106,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4149,6 +4331,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,9 +4357,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4553,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ log = "0.4.27"
 lru = "0.18"
 lz4_flex = "0.11.5"
 moka = "0.12.8"
-object_store = "0.12.3"
-object_store_opendal = "0.54.0"
-opendal = { version = "0.54.0", default-features = false }
+object_store = "0.13.1"
+object_store_opendal = "0.56.0"
+opendal = { version = "0.56.0", default-features = false }
 once_cell = "1.21.3"
 ouroboros = "0.18"
 parking_lot = "0.12.4"

--- a/slatedb-bencher/src/main.rs
+++ b/slatedb-bencher/src/main.rs
@@ -13,6 +13,7 @@ use futures::TryStreamExt;
 use object_store::path::Path;
 use object_store::Error as ObjectStoreError;
 use object_store::ObjectStore;
+use object_store::ObjectStoreExt;
 use object_store::PutPayload;
 use object_store::PutResult;
 use slatedb::admin;
@@ -198,7 +199,7 @@ async fn create_cleanup_lock(
         });
     }
 
-    let temp_path = path.child(CLEANUP_NAME);
+    let temp_path = path.clone().join(CLEANUP_NAME);
     info!("creating cleanup lock file [path={}]", temp_path);
     object_store
         .put(
@@ -213,7 +214,7 @@ async fn cleanup_data(
     object_store: Arc<dyn ObjectStore>,
     path: &Path,
 ) -> Result<(), Box<dyn Error>> {
-    let temp_path = path.child(CLEANUP_NAME);
+    let temp_path = path.clone().join(CLEANUP_NAME);
     if object_store.head(&temp_path).await.is_ok() {
         info!("cleaning up test data [path={}]", path);
         if let Err(e) = delete_objects_with_prefix(object_store.clone(), Some(path)).await {

--- a/slatedb-dst/src/clocked_object_store.rs
+++ b/slatedb-dst/src/clocked_object_store.rs
@@ -11,8 +11,8 @@ use futures::stream::BoxStream;
 use futures::StreamExt;
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
 };
 use parking_lot::RwLock;
 use slatedb_common::clock::SystemClock;
@@ -85,10 +85,6 @@ impl ObjectStore for ClockedObjectStore {
         Ok(result)
     }
 
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        Ok(self.with_recorded_times(self.inner.head(location).await?))
-    }
-
     async fn put_opts(
         &self,
         location: &Path,
@@ -100,14 +96,6 @@ impl ObjectStore for ClockedObjectStore {
         Ok(result)
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.record_modified(location);
-        self.inner.put_multipart(location).await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -117,10 +105,20 @@ impl ObjectStore for ClockedObjectStore {
         self.inner.put_multipart_opts(location, opts).await
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        self.inner.delete(location).await?;
-        self.remove(location);
-        Ok(())
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        let times = Arc::clone(&self.times);
+        self.inner
+            .delete_stream(locations)
+            .map(move |result| {
+                if let Ok(ref loc) = result {
+                    times.write().remove(loc);
+                }
+                result
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -176,8 +174,13 @@ impl ObjectStore for ClockedObjectStore {
         Ok(result)
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.copy(from, to).await?;
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await?;
         self.record_modified(to);
         self.times
             .write()
@@ -186,25 +189,13 @@ impl ObjectStore for ClockedObjectStore {
         Ok(())
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.rename(from, to).await?;
-        self.remove(from);
-        self.record_modified(to);
-        Ok(())
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.copy_if_not_exists(from, to).await?;
-        self.record_modified(to);
-        self.times
-            .write()
-            .entry(from.clone())
-            .or_insert_with(|| self.clock.now());
-        Ok(())
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.rename_if_not_exists(from, to).await?;
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
+        self.inner.rename_opts(from, to, options).await?;
         self.remove(from);
         self.record_modified(to);
         Ok(())

--- a/slatedb-dst/src/deterministic_local_filesystem.rs
+++ b/slatedb-dst/src/deterministic_local_filesystem.rs
@@ -18,8 +18,9 @@ use futures::stream::{self, BoxStream};
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{
-    Attributes, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, UploadPart,
+    Attributes, CopyMode, CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult,
+    MultipartUpload, ObjectMeta, ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload,
+    PutResult, RenameOptions, RenameTargetMode, UploadPart,
 };
 use parking_lot::{Mutex, RwLock};
 use tokio::task::yield_now;
@@ -420,14 +421,6 @@ impl ObjectStore for DeterministicLocalFilesystem {
         })
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.put_multipart_opts(location, PutMultipartOptions::default())
-            .await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -487,11 +480,6 @@ impl ObjectStore for DeterministicLocalFilesystem {
         })
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> object_store::Result<Bytes> {
-        let path = self.path_to_filesystem(location)?;
-        read_range_with_yields(&path, range).await
-    }
-
     async fn get_ranges(
         &self,
         location: &Path,
@@ -506,41 +494,21 @@ impl ObjectStore for DeterministicLocalFilesystem {
         Ok(results)
     }
 
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        yield_now().await;
-        let path = self.path_to_filesystem(location)?;
-        let (_, metadata) = open_file(&path)?;
-        yield_now().await;
-        Ok(self.object_meta(metadata, location.clone()))
-    }
-
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        yield_now().await;
-        let path = self.path_to_filesystem(location)?;
-        match std::fs::remove_file(&path) {
-            Ok(()) => {
-                self.attribute_state.remove(location);
-                self.metadata_state.remove(location);
-            }
-            Err(source) if source.kind() == ErrorKind::NotFound => {
-                return Err(not_found_error(&path, source));
-            }
-            Err(source) => return Err(generic_error(source)),
-        }
-
-        if self.automatic_cleanup {
-            let mut parent = path.parent();
-            while let Some(candidate) = parent {
-                yield_now().await;
-                if candidate != self.root && std::fs::remove_dir(candidate).is_ok() {
-                    parent = candidate.parent();
-                } else {
-                    break;
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        let this = self.clone();
+        locations
+            .then(move |loc| {
+                let this = this.clone();
+                async move {
+                    let location = loc?;
+                    this.delete_one(&location).await?;
+                    Ok(location)
                 }
-            }
-        }
-
-        Ok(())
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -592,7 +560,7 @@ impl ObjectStore for DeterministicLocalFilesystem {
             drop(parts);
 
             if is_directory {
-                common_prefixes.insert(prefix.child(common_prefix));
+                common_prefixes.insert(prefix.clone().join(common_prefix));
             } else if let Some(metadata) = self.convert_entry(entry, entry_location)? {
                 objects.push(metadata);
             }
@@ -605,7 +573,83 @@ impl ObjectStore for DeterministicLocalFilesystem {
         })
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        match options.mode {
+            CopyMode::Overwrite => self.copy_overwrite(from, to).await,
+            CopyMode::Create => self.copy_create(from, to).await,
+        }
+    }
+
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
+        match options.target_mode {
+            RenameTargetMode::Overwrite => self.rename_overwrite(from, to).await,
+            RenameTargetMode::Create => {
+                let head_result = self.head_one(to).await;
+                match head_result {
+                    Ok(_) => {
+                        return Err(already_exists_error(
+                            &self.path_to_filesystem(to)?,
+                            io::Error::new(ErrorKind::AlreadyExists, "destination already exists"),
+                        ));
+                    }
+                    Err(object_store::Error::NotFound { .. }) => {}
+                    Err(error) => return Err(error),
+                }
+                self.rename_overwrite(from, to).await
+            }
+        }
+    }
+}
+
+impl DeterministicLocalFilesystem {
+    async fn delete_one(&self, location: &Path) -> object_store::Result<()> {
+        yield_now().await;
+        let path = self.path_to_filesystem(location)?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => {
+                self.attribute_state.remove(location);
+                self.metadata_state.remove(location);
+            }
+            Err(source) if source.kind() == ErrorKind::NotFound => {
+                return Err(not_found_error(&path, source));
+            }
+            Err(source) => return Err(generic_error(source)),
+        }
+
+        if self.automatic_cleanup {
+            let mut parent = path.parent();
+            while let Some(candidate) = parent {
+                yield_now().await;
+                if candidate != self.root && std::fs::remove_dir(candidate).is_ok() {
+                    parent = candidate.parent();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn head_one(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+        yield_now().await;
+        let path = self.path_to_filesystem(location)?;
+        let (_, metadata) = open_file(&path)?;
+        yield_now().await;
+        Ok(self.object_meta(metadata, location.clone()))
+    }
+
+    async fn copy_overwrite(&self, from: &Path, to: &Path) -> object_store::Result<()> {
         let from_path = self.path_to_filesystem(from)?;
         let to_path = self.path_to_filesystem(to)?;
         let mut suffix = 0_u64;
@@ -634,32 +678,7 @@ impl ObjectStore for DeterministicLocalFilesystem {
         }
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        let from_path = self.path_to_filesystem(from)?;
-        let to_path = self.path_to_filesystem(to)?;
-
-        loop {
-            yield_now().await;
-            match std::fs::rename(&from_path, &to_path) {
-                Ok(()) => {
-                    self.attribute_state.rename(from, to);
-                    self.metadata_state.remove(from);
-                    self.metadata_state.record_modified(to);
-                    return Ok(());
-                }
-                Err(source) if source.kind() == ErrorKind::NotFound => {
-                    if from_path.exists() {
-                        create_parent_dirs(&to_path, source)?;
-                    } else {
-                        return Err(not_found_error(&from_path, source));
-                    }
-                }
-                Err(source) => return Err(generic_error(source)),
-            }
-        }
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+    async fn copy_create(&self, from: &Path, to: &Path) -> object_store::Result<()> {
         let from_path = self.path_to_filesystem(from)?;
         let to_path = self.path_to_filesystem(to)?;
 
@@ -686,20 +705,29 @@ impl ObjectStore for DeterministicLocalFilesystem {
         }
     }
 
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        let head_result = self.head(to).await;
-        match head_result {
-            Ok(_) => {
-                return Err(already_exists_error(
-                    &self.path_to_filesystem(to)?,
-                    io::Error::new(ErrorKind::AlreadyExists, "destination already exists"),
-                ));
-            }
-            Err(object_store::Error::NotFound { .. }) => {}
-            Err(error) => return Err(error),
-        }
+    async fn rename_overwrite(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+        let from_path = self.path_to_filesystem(from)?;
+        let to_path = self.path_to_filesystem(to)?;
 
-        self.rename(from, to).await
+        loop {
+            yield_now().await;
+            match std::fs::rename(&from_path, &to_path) {
+                Ok(()) => {
+                    self.attribute_state.rename(from, to);
+                    self.metadata_state.remove(from);
+                    self.metadata_state.record_modified(to);
+                    return Ok(());
+                }
+                Err(source) if source.kind() == ErrorKind::NotFound => {
+                    if from_path.exists() {
+                        create_parent_dirs(&to_path, source)?;
+                    } else {
+                        return Err(not_found_error(&from_path, source));
+                    }
+                }
+                Err(source) => return Err(generic_error(source)),
+            }
+        }
     }
 }
 
@@ -1023,7 +1051,8 @@ mod tests {
 
     use futures::TryStreamExt;
     use object_store::{
-        Attribute, AttributeValue, Attributes, GetResultPayload, PutMultipartOptions, PutOptions,
+        Attribute, AttributeValue, Attributes, GetResultPayload, ObjectStoreExt,
+        PutMultipartOptions, PutOptions,
     };
     use slatedb_common::clock::SystemClock;
     use slatedb_common::MockSystemClock;

--- a/slatedb-dst/src/failing_object_store.rs
+++ b/slatedb-dst/src/failing_object_store.rs
@@ -401,7 +401,11 @@ impl ObjectStore for FailingObjectStore {
         self.apply_request_faults(op, &[location.clone()], 0)
             .await?;
         let result = self.inner.get_opts(location, options).await?;
-        let size = result.meta.size;
+        let size = if op == Operation::GetRange {
+            result.range.end.saturating_sub(result.range.start)
+        } else {
+            result.meta.size
+        };
         self.apply_response_faults(op, &[location.clone()], size)
             .await?;
         Ok(result)

--- a/slatedb-dst/src/failing_object_store.rs
+++ b/slatedb-dst/src/failing_object_store.rs
@@ -398,7 +398,8 @@ impl ObjectStore for FailingObjectStore {
         } else {
             Operation::GetOpts
         };
-        self.apply_request_faults(op, &[location.clone()], 0).await?;
+        self.apply_request_faults(op, &[location.clone()], 0)
+            .await?;
         let result = self.inner.get_opts(location, options).await?;
         let size = result.meta.size;
         self.apply_response_faults(op, &[location.clone()], size)

--- a/slatedb-dst/src/failing_object_store.rs
+++ b/slatedb-dst/src/failing_object_store.rs
@@ -15,8 +15,8 @@ use futures::stream::{self, BoxStream};
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
 };
 use parking_lot::RwLock;
 use rand::RngCore;
@@ -373,18 +373,6 @@ impl ObjectStore for FailingObjectStore {
         self.put_like(location, payload, opts).await
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.apply_request_faults(Operation::PutOpts, &[location.clone()], 0)
-            .await?;
-        let result = self.inner.put_multipart(location).await?;
-        self.apply_response_faults(Operation::PutOpts, &[location.clone()], 0)
-            .await?;
-        Ok(result)
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -403,21 +391,17 @@ impl ObjectStore for FailingObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
-        self.apply_request_faults(Operation::GetOpts, &[location.clone()], 0)
-            .await?;
+        let op = if options.head {
+            Operation::Head
+        } else if options.range.is_some() {
+            Operation::GetRange
+        } else {
+            Operation::GetOpts
+        };
+        self.apply_request_faults(op, &[location.clone()], 0).await?;
         let result = self.inner.get_opts(location, options).await?;
         let size = result.meta.size;
-        self.apply_response_faults(Operation::GetOpts, &[location.clone()], size)
-            .await?;
-        Ok(result)
-    }
-
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> object_store::Result<Bytes> {
-        self.apply_request_faults(Operation::GetRange, &[location.clone()], 0)
-            .await?;
-        let result = self.inner.get_range(location, range).await?;
-        let size = u64::try_from(result.len()).unwrap_or(u64::MAX);
-        self.apply_response_faults(Operation::GetRange, &[location.clone()], size)
+        self.apply_response_faults(op, &[location.clone()], size)
             .await?;
         Ok(result)
     }
@@ -438,22 +422,37 @@ impl ObjectStore for FailingObjectStore {
         Ok(result)
     }
 
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        self.apply_request_faults(Operation::Head, &[location.clone()], 0)
-            .await?;
-        let result = self.inner.head(location).await?;
-        self.apply_response_faults(Operation::Head, &[location.clone()], result.size)
-            .await?;
-        Ok(result)
-    }
-
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        self.apply_request_faults(Operation::Delete, &[location.clone()], 0)
-            .await?;
-        let result = self.inner.delete(location).await;
-        self.apply_response_faults(Operation::Delete, &[location.clone()], 0)
-            .await?;
-        result
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        let this = self.clone();
+        let inner = Arc::clone(&self.inner);
+        let inner_stream = inner.delete_stream(
+            locations
+                .then(move |loc| {
+                    let this = this.clone();
+                    async move {
+                        let location = loc?;
+                        this.apply_request_faults(Operation::Delete, &[location.clone()], 0)
+                            .await?;
+                        Ok(location)
+                    }
+                })
+                .boxed(),
+        );
+        let this_after = self.clone();
+        inner_stream
+            .then(move |result| {
+                let this = this_after.clone();
+                async move {
+                    let location = result?;
+                    this.apply_response_faults(Operation::Delete, &[location.clone()], 0)
+                        .await?;
+                    Ok(location)
+                }
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -540,34 +539,28 @@ impl ObjectStore for FailingObjectStore {
         Ok(result)
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
         self.apply_request_faults(Operation::Copy, &[from.clone(), to.clone()], 0)
             .await?;
-        self.inner.copy(from, to).await?;
+        self.inner.copy_opts(from, to, options).await?;
         self.apply_response_faults(Operation::Copy, &[from.clone(), to.clone()], 0)
             .await
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
         self.apply_request_faults(Operation::Rename, &[from.clone(), to.clone()], 0)
             .await?;
-        self.inner.rename(from, to).await?;
-        self.apply_response_faults(Operation::Rename, &[from.clone(), to.clone()], 0)
-            .await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.apply_request_faults(Operation::Copy, &[from.clone(), to.clone()], 0)
-            .await?;
-        self.inner.copy_if_not_exists(from, to).await?;
-        self.apply_response_faults(Operation::Copy, &[from.clone(), to.clone()], 0)
-            .await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.apply_request_faults(Operation::Rename, &[from.clone(), to.clone()], 0)
-            .await?;
-        self.inner.rename_if_not_exists(from, to).await?;
+        self.inner.rename_opts(from, to, options).await?;
         self.apply_response_faults(Operation::Rename, &[from.clone(), to.clone()], 0)
             .await
     }

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -9,7 +9,7 @@ use log::{debug, error, warn};
 use object_store::path::Path;
 use object_store::Error::AlreadyExists;
 use object_store::{
-    Error, GetOptions, ObjectStore, PutMode, PutOptions, PutPayload, UpdateVersion,
+    Error, GetOptions, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
 };
 use parking_lot::Mutex;
 use std::collections::Bound;
@@ -68,7 +68,7 @@ impl<T> ObjectStoreSequencedStorageProtocol<T> {
         Self {
             object_store: Box::new(::object_store::prefix::PrefixStore::new(
                 object_store,
-                root_path.child(subdir),
+                root_path.clone().join(subdir),
             )),
             codec,
             file_suffix,
@@ -119,7 +119,7 @@ impl ObjectStoreBoundaryObject {
         Self {
             object_store: Box::new(::object_store::prefix::PrefixStore::new(
                 object_store,
-                root_path.child("gc"),
+                root_path.clone().join("gc"),
             )),
             filepath: Path::from(format!("{name}.boundary")),
             cache: Mutex::new(None),
@@ -445,9 +445,9 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{
-        Error as ObjectStoreError, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
-        ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
-        Result as ObjectStoreResult, UpdateVersion,
+        CopyOptions, Error as ObjectStoreError, GetOptions, GetResult, ListResult, MultipartUpload,
+        ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload,
+        PutResult, Result as ObjectStoreResult, UpdateVersion,
     };
     use std::collections::Bound::{Excluded, Included, Unbounded};
     use std::fmt;
@@ -523,8 +523,11 @@ mod tests {
             self.inner.get_opts(location, options).await
         }
 
-        async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
-            self.inner.delete(location).await
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, ObjectStoreResult<Path>>,
+        ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+            self.inner.delete_stream(locations)
         }
 
         fn list(
@@ -554,12 +557,13 @@ mod tests {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
     }
 
@@ -647,8 +651,11 @@ mod tests {
             self.inner.get_opts(location, options).await
         }
 
-        async fn delete(&self, location: &Path) -> ObjectStoreResult<()> {
-            self.inner.delete(location).await
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, ObjectStoreResult<Path>>,
+        ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+            self.inner.delete_stream(locations)
         }
 
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
@@ -662,12 +669,13 @@ mod tests {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> ObjectStoreResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
     }
 

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -784,11 +784,6 @@ pub fn load_opendal() -> Result<Arc<dyn ObjectStore>, crate::Error> {
         .collect::<HashMap<String, String>>();
 
     let op = Operator::via_iter(&scheme_value, iter).map_err(|error| {
-        // opendal 0.56 no longer exposes a Scheme enum, so the up-front
-        // allow-list check has moved into Operator::via_iter. Unknown or
-        // disabled schemes surface as ErrorKind::Unsupported; remap those to
-        // the same InvalidEnvironmentVariable error the typed validation used
-        // to produce so callers can keep relying on ErrorKind::Invalid.
         if error.kind() == opendal::ErrorKind::Unsupported {
             SlateDBError::InvalidEnvironmentVariable {
                 key: "OPENDAL_SCHEME".to_string(),

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -751,7 +751,7 @@ pub fn load_azure() -> Result<Arc<dyn ObjectStore>, crate::Error> {
 /// |--------------|-----|----------|
 /// | OPENDAL_SCHEME | The OpenDAL scheme to use | Yes |
 /// | OPENDAL_* | The OpenDAL configuration | Yes |
-/// full list of schemes: https://docs.rs/opendal/latest/opendal/enum.Scheme.html
+/// full list of schemes: https://docs.rs/opendal/latest/opendal/services/index.html
 /// for example, to use s3-compatible storage, you can set:
 /// ```bash
 /// OPENDAL_SCHEME=s3
@@ -775,32 +775,31 @@ pub fn load_azure() -> Result<Arc<dyn ObjectStore>, crate::Error> {
 /// full list of config: https://docs.rs/opendal/latest/opendal/services/oss/config/struct.OssConfig.html
 #[cfg(feature = "opendal")]
 pub fn load_opendal() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    use opendal::{Operator, Scheme};
+    use opendal::Operator;
     use std::collections::HashMap;
-    use std::str::FromStr;
 
     let scheme_value = get_env_variable("OPENDAL_SCHEME")?;
-    let scheme =
-        Scheme::from_str(&scheme_value).map_err(|_| SlateDBError::InvalidEnvironmentVariable {
-            key: "OPENDAL_SCHEME".to_string(),
-            value: Some(scheme_value.clone()),
-        })?;
-    if !Scheme::enabled().contains(&scheme) {
-        return Err(SlateDBError::InvalidEnvironmentVariable {
-            key: "OPENDAL_SCHEME".to_string(),
-            value: Some(scheme_value),
-        }
-        .into());
-    }
     let iter = env::vars()
         .filter_map(|(k, v)| k.strip_prefix("OPENDAL_").map(|k| (k.to_lowercase(), v)))
         .collect::<HashMap<String, String>>();
 
-    let op = Operator::via_iter(scheme, iter).map_err(|error| {
-        SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
-            store: "OpenDAL",
-            source: Box::new(error),
-        }))
+    let op = Operator::via_iter(&scheme_value, iter).map_err(|error| {
+        // opendal 0.56 no longer exposes a Scheme enum, so the up-front
+        // allow-list check has moved into Operator::via_iter. Unknown or
+        // disabled schemes surface as ErrorKind::Unsupported; remap those to
+        // the same InvalidEnvironmentVariable error the typed validation used
+        // to produce so callers can keep relying on ErrorKind::Invalid.
+        if error.kind() == opendal::ErrorKind::Unsupported {
+            SlateDBError::InvalidEnvironmentVariable {
+                key: "OPENDAL_SCHEME".to_string(),
+                value: Some(scheme_value.clone()),
+            }
+        } else {
+            SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
+                store: "OpenDAL",
+                source: Box::new(error),
+            }))
+        }
     })?;
     Ok(Arc::new(object_store_opendal::OpendalStore::new(op)) as Arc<dyn ObjectStore>)
 }

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -5,8 +5,11 @@ use crate::config::ObjectStoreCacheOptions;
 use crate::rand::DbRand;
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, stream, stream::BoxStream, StreamExt};
-use object_store::{path::Path, GetOptions, GetResult, ObjectMeta, ObjectStore};
-use object_store::{Attributes, GetRange, GetResultPayload, PutMultipartOptions, PutResult};
+use object_store::{path::Path, GetOptions, GetResult, ObjectMeta, ObjectStore, ObjectStoreExt};
+use object_store::{
+    Attributes, CopyOptions, GetRange, GetResultPayload, PutMultipartOptions, PutResult,
+    RenameOptions,
+};
 use object_store::{ListResult, MultipartUpload, PutOptions, PutPayload};
 use slatedb_common::clock::SystemClock;
 use std::{ops::Range, sync::Arc};
@@ -694,11 +697,23 @@ impl ObjectStore for CachedObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
+        if options.head {
+            // object_store 0.13 moved head() into ObjectStoreExt, which routes
+            // through get_opts(head: true). Translate that back to cached_head
+            // so HEAD calls keep populating the cache and deduping concurrent
+            // requests like they did before the trait split. The synthesized
+            // GetResult mirrors what DeterministicLocalFilesystem returns for
+            // the same case: empty body stream and an empty range, since
+            // ObjectStoreExt::head only consumes the resulting meta.
+            let meta = self.cached_head(location).await?;
+            return Ok(GetResult {
+                payload: GetResultPayload::Stream(stream::empty().boxed()),
+                range: 0..0,
+                meta,
+                attributes: Attributes::new(),
+            });
+        }
         self.cached_get_opts(location, options).await
-    }
-
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        self.cached_head(location).await
     }
 
     async fn put_opts(
@@ -710,13 +725,6 @@ impl ObjectStore for CachedObjectStore {
         self.cached_put_opts(location, payload, opts).await
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.object_store.put_multipart(location).await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -725,9 +733,12 @@ impl ObjectStore for CachedObjectStore {
         self.object_store.put_multipart_opts(location, opts).await
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
         // TODO: handle cache eviction
-        self.object_store.delete(location).await
+        self.object_store.delete_stream(locations)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -746,20 +757,22 @@ impl ObjectStore for CachedObjectStore {
         self.object_store.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.object_store.copy(from, to).await
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.object_store.copy_opts(from, to, options).await
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.object_store.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.object_store.copy_if_not_exists(from, to).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.object_store.rename_if_not_exists(from, to).await
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
+        self.object_store.rename_opts(from, to, options).await
     }
 }
 
@@ -796,7 +809,7 @@ mod tests {
     use std::sync::Arc;
 
     use bytes::Bytes;
-    use object_store::{path::Path, GetOptions, GetRange, ObjectStore, PutPayload};
+    use object_store::{path::Path, GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
     use rand::Rng;
 
     use super::CachedObjectStore;
@@ -852,10 +865,6 @@ mod tests {
             Ok(result)
         }
 
-        async fn head(&self, location: &Path) -> object_store::Result<object_store::ObjectMeta> {
-            self.inner.head(location).await
-        }
-
         async fn put_opts(
             &self,
             location: &Path,
@@ -863,13 +872,6 @@ mod tests {
             opts: object_store::PutOptions,
         ) -> object_store::Result<object_store::PutResult> {
             self.inner.put_opts(location, payload, opts).await
-        }
-
-        async fn put_multipart(
-            &self,
-            location: &Path,
-        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
-            self.inner.put_multipart(location).await
         }
 
         async fn put_multipart_opts(
@@ -880,8 +882,11 @@ mod tests {
             self.inner.put_multipart_opts(location, opts).await
         }
 
-        async fn delete(&self, location: &Path) -> object_store::Result<()> {
-            self.inner.delete(location).await
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<Path>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<Path>> {
+            self.inner.delete_stream(locations)
         }
 
         fn list(
@@ -908,20 +913,13 @@ mod tests {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-            self.inner.rename(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-            self.inner.copy_if_not_exists(from, to).await
-        }
-
-        async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-            self.inner.rename_if_not_exists(from, to).await
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
         }
     }
 

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -1689,8 +1689,8 @@ mod tests {
             handle.await.unwrap().unwrap();
         }
 
-        // SingleFlight should collapse them into a single actual GET request.
-        let count = get_request_count(&recorder, "get");
+        // SingleFlight should collapse them into a single actual HEAD request.
+        let count = get_request_count(&recorder, "head");
         assert_eq!(
             count, 1,
             "expected 1 actual object store request, got {count}"
@@ -1742,7 +1742,7 @@ mod tests {
 
         // The prefetch SingleFlight should collapse all prefetch GETs into one.
         // Part reads may also be deduplicated. Total GET count should be much less than 10.
-        let count = get_request_count(&recorder, "get");
+        let count = get_request_count(&recorder, "get_range");
         assert!(
             count <= 2,
             "expected at most 2 actual object store requests (prefetch + maybe 1 part), got {count}"
@@ -1789,7 +1789,7 @@ mod tests {
         }
 
         // Each distinct path should result in its own request.
-        let count = get_request_count(&recorder, "get");
+        let count = get_request_count(&recorder, "head");
         assert_eq!(
             count, 5,
             "expected 5 actual object store requests (one per path), got {count}"
@@ -1845,7 +1845,7 @@ mod tests {
         }
 
         // Each distinct range key should trigger its own prefetch request.
-        let count = get_request_count(&recorder, "get");
+        let count = get_request_count(&recorder, "get_range");
         assert!(
             count >= 3,
             "expected at least 3 object store requests (one per distinct range), got {count}"

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -36,7 +36,7 @@ pub(crate) struct CachedObjectStore {
     resolved_root: Arc<OnceCell<Path>>,
     stats: Arc<CachedObjectStoreStats>,
     // Deduplicates concurrent HEAD requests for the same path after a cache miss.
-    head_flights: SingleFlight<Path, ObjectMeta>,
+    head_flights: SingleFlight<Path, (ObjectMeta, Attributes)>,
     // Deduplicates concurrent prefetch/GET requests for the same path after a cache miss.
     prefetch_flights: SingleFlight<(Path, Option<GetRangeKey>), (ObjectMeta, Attributes)>,
     // Deduplicates concurrent fetches of the same part after a cache miss.
@@ -259,18 +259,19 @@ impl CachedObjectStore {
         Some(Path::from(prefix.trim_end_matches('/')))
     }
 
-    pub(crate) async fn cached_head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
+    pub(crate) async fn cached_head(&self, location: &Path) -> object_store::Result<GetResult> {
         if let Some(cache_location) = self.cache_location_for(location) {
             let entry = self
                 .cache_storage
                 .entry(&cache_location, self.part_size_bytes);
-            if let Ok(Some((meta, _))) = entry.read_head().await {
-                return Ok(meta);
+            if let Ok(Some((meta, attributes))) = entry.read_head().await {
+                return Ok(head_only_get_result(meta, attributes));
             }
         }
 
         // Cache miss — deduplicate concurrent HEAD requests for the same path.
-        self.head_flights
+        let (meta, attributes) = self
+            .head_flights
             .call(location.clone(), || async {
                 let result = self
                     .object_store
@@ -284,12 +285,14 @@ impl CachedObjectStore {
                     )
                     .await?;
                 let meta = result.meta.clone();
+                let attributes = result.attributes.clone();
                 if self.resolve_root(location, &meta.location) {
                     self.save_get_result(result).await.ok();
                 }
-                Ok(meta)
+                Ok::<_, object_store::Error>((meta, attributes))
             })
-            .await
+            .await?;
+        Ok(head_only_get_result(meta, attributes))
     }
 
     pub(crate) async fn cached_get_opts(
@@ -680,6 +683,15 @@ impl CachedObjectStore {
     }
 }
 
+fn head_only_get_result(meta: ObjectMeta, attributes: Attributes) -> GetResult {
+    GetResult {
+        payload: GetResultPayload::Stream(stream::empty().boxed()),
+        range: 0..0,
+        meta,
+        attributes,
+    }
+}
+
 impl std::fmt::Display for CachedObjectStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -698,13 +710,7 @@ impl ObjectStore for CachedObjectStore {
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
         if options.head {
-            let meta = self.cached_head(location).await?;
-            return Ok(GetResult {
-                payload: GetResultPayload::Stream(stream::empty().boxed()),
-                range: 0..0,
-                meta,
-                attributes: Attributes::new(),
-            });
+            return self.cached_head(location).await;
         }
         self.cached_get_opts(location, options).await
     }

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -698,13 +698,6 @@ impl ObjectStore for CachedObjectStore {
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
         if options.head {
-            // object_store 0.13 moved head() into ObjectStoreExt, which routes
-            // through get_opts(head: true). Translate that back to cached_head
-            // so HEAD calls keep populating the cache and deduping concurrent
-            // requests like they did before the trait split. The synthesized
-            // GetResult mirrors what DeterministicLocalFilesystem returns for
-            // the same case: empty body stream and an empty range, since
-            // ObjectStoreExt::head only consumes the resulting meta.
             let meta = self.cached_head(location).await?;
             return Ok(GetResult {
                 payload: GetResultPayload::Stream(stream::empty().boxed()),

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -1662,7 +1662,7 @@ mod tests {
 
         // Wrap with a gate-controlled store so we can block callers deterministically.
         let gated = Arc::new(GatedObjectStore::new(mem));
-        gated.get_opts_gate.close();
+        gated.head_gate.close();
         let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch many concurrent head requests for the same path.
@@ -1674,16 +1674,16 @@ mod tests {
         }
 
         // Wait until exactly 1 caller arrives at the gate (SingleFlight dedup
-        // ensures only one caller reaches get_opts).
-        gated.get_opts_gate.wait_for_arrivals(1).await;
+        // ensures only one caller reaches the head gate).
+        gated.head_gate.wait_for_arrivals(1).await;
         assert_eq!(
-            gated.get_opts_gate.arrivals(),
+            gated.head_gate.arrivals(),
             1,
             "SingleFlight should let only 1 through"
         );
 
         // Release the gate — success path.
-        gated.get_opts_gate.release();
+        gated.head_gate.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1763,7 +1763,7 @@ mod tests {
         }
 
         let gated = Arc::new(GatedObjectStore::new(mem));
-        gated.get_opts_gate.close();
+        gated.head_gate.close();
         let (recorder, cached_store) = build_instrumented_cached_store(gated.clone());
 
         let mut handles = Vec::new();
@@ -1774,15 +1774,15 @@ mod tests {
         }
 
         // Each distinct path has its own SingleFlight key, so all 5 should arrive.
-        gated.get_opts_gate.wait_for_arrivals(5).await;
+        gated.head_gate.wait_for_arrivals(5).await;
         assert_eq!(
-            gated.get_opts_gate.arrivals(),
+            gated.head_gate.arrivals(),
             5,
             "different keys should each pass through SingleFlight independently"
         );
 
         // Release all.
-        gated.get_opts_gate.release();
+        gated.head_gate.release();
 
         for handle in handles {
             handle.await.unwrap().unwrap();
@@ -1863,7 +1863,7 @@ mod tests {
             .unwrap();
 
         let gated = Arc::new(GatedObjectStore::new(mem));
-        gated.get_opts_gate.close();
+        gated.head_gate.close();
         let (_, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // Launch concurrent head requests.
@@ -1875,19 +1875,17 @@ mod tests {
         }
 
         // Wait for the single winning caller to arrive at the gate.
-        gated.get_opts_gate.wait_for_arrivals(1).await;
+        gated.head_gate.wait_for_arrivals(1).await;
 
         // Inject failure, then release.
-        gated
-            .get_opts_gate
-            .set_error(|| object_store::Error::Generic {
-                store: "test",
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "injected test failure",
-                )),
-            });
-        gated.get_opts_gate.release();
+        gated.head_gate.set_error(|| object_store::Error::Generic {
+            store: "test",
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "injected test failure",
+            )),
+        });
+        gated.head_gate.release();
 
         // All callers should see an error.
         for handle in handles {
@@ -1907,7 +1905,7 @@ mod tests {
             .unwrap();
 
         let gated = Arc::new(GatedObjectStore::new(mem));
-        gated.get_opts_gate.close();
+        gated.head_gate.close();
         let (_, cached_store) = build_instrumented_cached_store(gated.clone());
 
         // First call — configure failure.
@@ -1915,29 +1913,27 @@ mod tests {
         let p = path.clone();
         let handle = tokio::spawn(async move { store.cached_head(&p).await });
 
-        gated.get_opts_gate.wait_for_arrivals(1).await;
-        gated
-            .get_opts_gate
-            .set_error(|| object_store::Error::Generic {
-                store: "test",
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "injected test failure",
-                )),
-            });
-        gated.get_opts_gate.release();
+        gated.head_gate.wait_for_arrivals(1).await;
+        gated.head_gate.set_error(|| object_store::Error::Generic {
+            store: "test",
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "injected test failure",
+            )),
+        });
+        gated.head_gate.release();
 
         let result = handle.await.unwrap();
         assert!(result.is_err(), "first call should fail");
 
         // Second call — configure success.
-        gated.get_opts_gate.clear_error();
+        gated.head_gate.clear_error();
         let store = cached_store.clone();
         let p = path.clone();
         let handle = tokio::spawn(async move { store.cached_head(&p).await });
 
-        gated.get_opts_gate.wait_for_arrivals(2).await;
-        gated.get_opts_gate.release();
+        gated.head_gate.wait_for_arrivals(2).await;
+        gated.head_gate.release();
 
         let result = handle.await.unwrap();
         assert!(result.is_ok(), "second call should succeed after retry");

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -16,7 +16,7 @@ use crate::utils::IdGenerator;
 use bytes::Bytes;
 use fail_parallel::{fail_point, FailPointRegistry};
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use slatedb_common::clock::SystemClock;
 use std::ops::RangeBounds;
 use std::sync::Arc;

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -8,7 +8,7 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use log::{error, info};
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use rand::RngCore;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1892,7 +1892,7 @@ impl Db {
         let object_store: Arc<dyn ObjectStore> = if path.as_ref().is_empty() {
             Arc::from(object_store)
         } else {
-            let object_store = Arc::from(object_store);
+            let object_store: Arc<dyn ObjectStore> = Arc::from(object_store);
             Arc::new(PrefixStore::new(object_store, path))
         };
         Ok(object_store)
@@ -2118,7 +2118,7 @@ mod tests {
     use fail_parallel::FailPointRegistry;
     use futures::{future, future::join_all, StreamExt};
     use object_store::memory::InMemory;
-    use object_store::ObjectStore;
+    use object_store::{ObjectStore, ObjectStoreExt};
     use proptest::test_runner::{TestRng, TestRunner};
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::clock::MockSystemClock;

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1616,7 +1616,10 @@ mod tests {
 
     #[test]
     fn has_not_found_object_store_error_should_ignore_non_not_found_errors() {
-        let err = SlateDBError::from(object_store::Error::NotImplemented);
+        let err = SlateDBError::from(object_store::Error::NotImplemented {
+            operation: "test".to_string(),
+            implementer: "test".to_string(),
+        });
 
         assert!(!super::has_not_found_object_store_error(&err));
     }

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -657,7 +657,10 @@ mod tests {
 
     #[test]
     fn object_store_error_non_not_found_maps_to_unavailable() {
-        let err = SlateDBError::from(object_store::Error::NotImplemented);
+        let err = SlateDBError::from(object_store::Error::NotImplemented {
+            operation: "test".to_string(),
+            implementer: "test".to_string(),
+        });
         let public_err = Error::from(err);
 
         assert_eq!(public_err.kind(), ErrorKind::Unavailable);

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -114,7 +114,7 @@ mod tests {
     use super::*;
     use crate::compactions_store::{CompactionsStore, StoredCompactions};
     use chrono::TimeDelta;
-    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
     use slatedb_common::metrics::MetricsRecorderHelper;
     use std::time::Duration;
 

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -113,7 +113,7 @@ mod tests {
         ManifestCore,
     };
     use chrono::TimeDelta;
-    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::MetricsRecorderHelper;
     use std::time::Duration;

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -26,11 +26,11 @@ use std::time::Instant;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt};
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
 };
 use slatedb_common::metrics::MetricsRecorderHelper;
 
@@ -148,16 +148,14 @@ impl ObjectStore for InstrumentedObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
+        // object_store 0.13 routes head() and get_range() through get_opts
+        // via ObjectStoreExt, so the dedicated head / get_range metrics no
+        // longer receive direct traffic. Record everything under `get` to
+        // keep the request count and latency histogram populated for any
+        // get-style call.
         let start = Instant::now();
         let result = self.inner.get_opts(location, options).await;
         self.stats.get.record(start.elapsed(), result.is_ok());
-        result
-    }
-
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> object_store::Result<Bytes> {
-        let start = Instant::now();
-        let result = self.inner.get_range(location, range).await;
-        self.stats.get_range.record(start.elapsed(), result.is_ok());
         result
     }
 
@@ -174,13 +172,6 @@ impl ObjectStore for InstrumentedObjectStore {
         result
     }
 
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        let start = Instant::now();
-        let result = self.inner.head(location).await;
-        self.stats.head.record(start.elapsed(), result.is_ok());
-        result
-    }
-
     async fn put_opts(
         &self,
         location: &Path,
@@ -191,14 +182,6 @@ impl ObjectStore for InstrumentedObjectStore {
         let result = self.inner.put_opts(location, payload, opts).await;
         self.stats.put.record(start.elapsed(), result.is_ok());
         result
-    }
-
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.put_multipart_opts(location, PutMultipartOptions::default())
-            .await
     }
 
     async fn put_multipart_opts(
@@ -219,11 +202,25 @@ impl ObjectStore for InstrumentedObjectStore {
         })
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        let start = Instant::now();
-        let result = self.inner.delete(location).await;
-        self.stats.delete.record(start.elapsed(), result.is_ok());
-        result
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        let stats = Arc::clone(&self.stats);
+        let inner = Arc::clone(&self.inner);
+        locations
+            .then(move |loc| {
+                let stats = Arc::clone(&stats);
+                let inner = Arc::clone(&inner);
+                async move {
+                    let loc = loc?;
+                    let start = Instant::now();
+                    let result = inner.delete(&loc).await;
+                    stats.delete.record(start.elapsed(), result.is_ok());
+                    result.map(|_| loc)
+                }
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -249,20 +246,22 @@ impl ObjectStore for InstrumentedObjectStore {
         result
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.copy(from, to).await
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.copy_if_not_exists(from, to).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.rename_if_not_exists(from, to).await
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
+        self.inner.rename_opts(from, to, options).await
     }
 }
 
@@ -297,8 +296,14 @@ pub mod stats {
     /// object store API (e.g. `get`, `put`, `delete`).
     pub(crate) struct ObjectStoreStats {
         pub(crate) get: RequestMetrics,
+        // get_range and head are still registered as metric series so
+        // dashboards referencing them keep resolving, but object_store 0.13
+        // routes both through get_opts via ObjectStoreExt, so they no longer
+        // receive direct traffic from InstrumentedObjectStore.
+        #[allow(dead_code)]
         pub(crate) get_range: RequestMetrics,
         pub(crate) get_ranges: RequestMetrics,
+        #[allow(dead_code)]
         pub(crate) head: RequestMetrics,
         pub(crate) list: Arc<dyn CounterFn>,
         pub(crate) list_with_offset: Arc<dyn CounterFn>,
@@ -453,7 +458,7 @@ mod tests {
 
     use object_store::memory::InMemory;
     use object_store::path::Path;
-    use object_store::ObjectStore;
+    use object_store::{ObjectStore, ObjectStoreExt};
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::{lookup_metric_with_labels, test_recorder_helper, MetricValue};
 
@@ -607,6 +612,9 @@ mod tests {
 
         // then:
         assert!(err.is_err());
+        // object_store 0.13 routes head() through get_opts via
+        // ObjectStoreExt, so the head call is observed under the `get` api
+        // series rather than the `head` series.
         assert_eq!(
             lookup_metric_with_labels(
                 &recorder,
@@ -615,7 +623,7 @@ mod tests {
                     ObjectStoreComponent::Db,
                     ObjectStoreType::Main,
                     "get",
-                    "head"
+                    "get"
                 )
             ),
             Some(1)
@@ -628,7 +636,7 @@ mod tests {
                     ObjectStoreComponent::Db,
                     ObjectStoreType::Main,
                     "get",
-                    "head"
+                    "get"
                 )
             ),
             Some(1)

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -148,14 +148,16 @@ impl ObjectStore for InstrumentedObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
-        // object_store 0.13 routes head() and get_range() through get_opts
-        // via ObjectStoreExt, so the dedicated head / get_range metrics no
-        // longer receive direct traffic. Record everything under `get` to
-        // keep the request count and latency histogram populated for any
-        // get-style call.
+        let metric = if options.head {
+            &self.stats.head
+        } else if options.range.is_some() {
+            &self.stats.get_range
+        } else {
+            &self.stats.get
+        };
         let start = Instant::now();
         let result = self.inner.get_opts(location, options).await;
-        self.stats.get.record(start.elapsed(), result.is_ok());
+        metric.record(start.elapsed(), result.is_ok());
         result
     }
 
@@ -296,14 +298,8 @@ pub mod stats {
     /// object store API (e.g. `get`, `put`, `delete`).
     pub(crate) struct ObjectStoreStats {
         pub(crate) get: RequestMetrics,
-        // get_range and head are still registered as metric series so
-        // dashboards referencing them keep resolving, but object_store 0.13
-        // routes both through get_opts via ObjectStoreExt, so they no longer
-        // receive direct traffic from InstrumentedObjectStore.
-        #[allow(dead_code)]
         pub(crate) get_range: RequestMetrics,
         pub(crate) get_ranges: RequestMetrics,
-        #[allow(dead_code)]
         pub(crate) head: RequestMetrics,
         pub(crate) list: Arc<dyn CounterFn>,
         pub(crate) list_with_offset: Arc<dyn CounterFn>,
@@ -612,9 +608,6 @@ mod tests {
 
         // then:
         assert!(err.is_err());
-        // object_store 0.13 routes head() through get_opts via
-        // ObjectStoreExt, so the head call is observed under the `get` api
-        // series rather than the `head` series.
         assert_eq!(
             lookup_metric_with_labels(
                 &recorder,
@@ -623,7 +616,7 @@ mod tests {
                     ObjectStoreComponent::Db,
                     ObjectStoreType::Main,
                     "get",
-                    "get"
+                    "head"
                 )
             ),
             Some(1)
@@ -636,7 +629,7 @@ mod tests {
                     ObjectStoreComponent::Db,
                     ObjectStoreType::Main,
                     "get",
-                    "get"
+                    "head"
                 )
             ),
             Some(1)

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -368,11 +368,6 @@ impl ObjectStore for RetryingObjectStore {
         }))
     }
 
-    /// Retries each delete individually, mirroring the per-call retry behavior of
-    /// the pre-0.13 `ObjectStore::delete`. Items are processed sequentially via
-    /// `.then` and each one is retried independently; a transient failure on one
-    /// path does not abort the rest of the stream, but a permanent failure stops
-    /// processing of subsequent items (consistent with `try_*` stream combinators).
     fn delete_stream(
         &self,
         locations: BoxStream<'static, object_store::Result<Path>>,

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -1,11 +1,8 @@
 use std::borrow::Cow;
 use std::future::Future;
-use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
-
-use bytes::Bytes;
 
 use async_trait::async_trait;
 use backon::{ExponentialBuilder, Retryable, Sleeper};
@@ -14,8 +11,9 @@ use futures::{stream, StreamExt, TryStreamExt};
 use log::{debug, info};
 use object_store::path::Path;
 use object_store::{
-    Attribute, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    Attribute, CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    RenameOptions,
 };
 
 use crate::rand::DbRand;
@@ -96,7 +94,7 @@ impl RetryingObjectStore {
                 | object_store::Error::Precondition { .. }
                 | object_store::Error::NotModified { .. }
                 | object_store::Error::NotFound { .. }
-                | object_store::Error::NotImplemented
+                | object_store::Error::NotImplemented { .. }
                 | object_store::Error::NotSupported { .. }
         );
         if !retry {
@@ -230,37 +228,6 @@ impl ObjectStore for RetryingObjectStore {
         .await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> object_store::Result<Bytes> {
-        (|| async { self.inner.get_range(location, range.clone()).await })
-            .retry(Self::retry_builder())
-            .sleep(self.sleeper())
-            .notify(Self::notify)
-            .when(Self::should_retry)
-            .await
-    }
-
-    async fn get_ranges(
-        &self,
-        location: &Path,
-        ranges: &[Range<u64>],
-    ) -> object_store::Result<Vec<Bytes>> {
-        (|| async { self.inner.get_ranges(location, ranges).await })
-            .retry(Self::retry_builder())
-            .sleep(self.sleeper())
-            .notify(Self::notify)
-            .when(Self::should_retry)
-            .await
-    }
-
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        (|| async { self.inner.head(location).await })
-            .retry(Self::retry_builder())
-            .sleep(self.sleeper())
-            .notify(Self::notify)
-            .when(Self::should_retry)
-            .await
-    }
-
     async fn put_opts(
         &self,
         location: &Path,
@@ -301,7 +268,7 @@ impl ObjectStore for RetryingObjectStore {
         // If attributes aren't supported, fall back to put without ULID
         if matches!(
             &result,
-            Err(object_store::Error::NotSupported { .. } | object_store::Error::NotImplemented)
+            Err(object_store::Error::NotSupported { .. } | object_store::Error::NotImplemented { .. })
         ) && put_id.is_some()
         {
             return (|| async {
@@ -332,14 +299,6 @@ impl ObjectStore for RetryingObjectStore {
         }
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.put_multipart_opts(location, PutMultipartOptions::default())
-            .await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -365,14 +324,14 @@ impl ObjectStore for RetryingObjectStore {
         // If attributes aren't supported, fall back without ULID
         let inner = match result {
             Ok(inner) => inner,
-            Err(object_store::Error::NotSupported { .. } | object_store::Error::NotImplemented) => {
-                (|| async { self.inner.put_multipart_opts(location, opts.clone()).await })
-                    .retry(Self::retry_builder())
-                    .sleep(self.sleeper())
-                    .notify(Self::notify)
-                    .when(Self::should_retry)
-                    .await?
-            }
+            Err(
+                object_store::Error::NotSupported { .. } | object_store::Error::NotImplemented { .. },
+            ) => (|| async { self.inner.put_multipart_opts(location, opts.clone()).await })
+                .retry(Self::retry_builder())
+                .sleep(self.sleeper())
+                .notify(Self::notify)
+                .when(Self::should_retry)
+                .await?,
             Err(e) => return Err(e),
         };
 
@@ -384,13 +343,34 @@ impl ObjectStore for RetryingObjectStore {
         }))
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        (|| async { self.inner.delete(location).await })
-            .retry(Self::retry_builder())
-            .sleep(self.sleeper())
-            .notify(Self::notify)
-            .when(Self::should_retry)
-            .await
+    /// Retries each delete individually, mirroring the per-call retry behavior of
+    /// the pre-0.13 `ObjectStore::delete`. Items are processed sequentially via
+    /// `.then` and each one is retried independently; a transient failure on one
+    /// path does not abort the rest of the stream, but a permanent failure stops
+    /// processing of subsequent items (consistent with `try_*` stream combinators).
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        let inner = Arc::clone(&self.inner);
+        let sleeper = self.sleeper();
+        let retry_builder = Self::retry_builder();
+        locations
+            .then(move |loc| {
+                let inner = Arc::clone(&inner);
+                let sleeper = sleeper.clone();
+                async move {
+                    let loc = loc?;
+                    (|| async { inner.delete(&loc).await })
+                        .retry(retry_builder)
+                        .sleep(sleeper)
+                        .notify(Self::notify)
+                        .when(Self::should_retry)
+                        .await?;
+                    Ok(loc)
+                }
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -477,8 +457,13 @@ impl ObjectStore for RetryingObjectStore {
             .await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        (|| async { self.inner.copy(from, to).await })
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        (|| async { self.inner.copy_opts(from, to, options.clone()).await })
             .retry(Self::retry_builder())
             .sleep(self.sleeper())
             .notify(Self::notify)
@@ -486,26 +471,13 @@ impl ObjectStore for RetryingObjectStore {
             .await
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        (|| async { self.inner.rename(from, to).await })
-            .retry(Self::retry_builder())
-            .sleep(self.sleeper())
-            .notify(Self::notify)
-            .when(Self::should_retry)
-            .await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        (|| async { self.inner.copy_if_not_exists(from, to).await })
-            .retry(Self::retry_builder())
-            .sleep(self.sleeper())
-            .notify(Self::notify)
-            .when(Self::should_retry)
-            .await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        (|| async { self.inner.rename_if_not_exists(from, to).await })
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
+        (|| async { self.inner.rename_opts(from, to, options.clone()).await })
             .retry(Self::retry_builder())
             .sleep(self.sleeper())
             .notify(Self::notify)
@@ -523,7 +495,7 @@ mod tests {
     use futures::TryStreamExt;
     use object_store::memory::InMemory;
     use object_store::path::Path;
-    use object_store::{GetOptions, ObjectStore, PutMode, PutOptions, PutPayload};
+    use object_store::{GetOptions, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload};
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
     use slatedb_common::MockSystemClock;
     use std::sync::Arc;

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -268,7 +268,8 @@ impl ObjectStore for RetryingObjectStore {
         // If attributes aren't supported, fall back to put without ULID
         if matches!(
             &result,
-            Err(object_store::Error::NotSupported { .. } | object_store::Error::NotImplemented { .. })
+            Err(object_store::Error::NotSupported { .. }
+                | object_store::Error::NotImplemented { .. })
         ) && put_id.is_some()
         {
             return (|| async {
@@ -325,13 +326,16 @@ impl ObjectStore for RetryingObjectStore {
         let inner = match result {
             Ok(inner) => inner,
             Err(
-                object_store::Error::NotSupported { .. } | object_store::Error::NotImplemented { .. },
-            ) => (|| async { self.inner.put_multipart_opts(location, opts.clone()).await })
-                .retry(Self::retry_builder())
-                .sleep(self.sleeper())
-                .notify(Self::notify)
-                .when(Self::should_retry)
-                .await?,
+                object_store::Error::NotSupported { .. }
+                | object_store::Error::NotImplemented { .. },
+            ) => {
+                (|| async { self.inner.put_multipart_opts(location, opts.clone()).await })
+                    .retry(Self::retry_builder())
+                    .sleep(self.sleeper())
+                    .notify(Self::notify)
+                    .when(Self::should_retry)
+                    .await?
+            }
             Err(e) => return Err(e),
         };
 

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -11,9 +11,9 @@ use futures::{stream, StreamExt, TryStreamExt};
 use log::{debug, info};
 use object_store::path::Path;
 use object_store::{
-    Attribute, CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
-    ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
-    RenameOptions,
+    Attribute, CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
+    ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload,
+    PutResult, RenameOptions,
 };
 
 use crate::rand::DbRand;
@@ -217,9 +217,30 @@ impl ObjectStore for RetryingObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
+        // For range reads, drain the body inside the retry closure so a
+        // transient mid-stream error retries the entire range. Pre-0.13
+        // SlateDB explicitly overrode `ObjectStore::get_range`, which
+        // returned `Bytes` and therefore retried the whole read; in 0.13
+        // `get_range` lives on `ObjectStoreExt` and reads the body after
+        // `get_opts` returns, so without this buffering the body bytes
+        // would fall outside the retry loop.
+        let buffer_body = options.range.is_some();
         (|| async {
             // Options and location must be owned per-attempt.
-            self.inner.get_opts(location, options.clone()).await
+            let result = self.inner.get_opts(location, options.clone()).await?;
+            if !buffer_body {
+                return Ok(result);
+            }
+            let meta = result.meta.clone();
+            let range = result.range.clone();
+            let attributes = result.attributes.clone();
+            let bytes = result.bytes().await?;
+            Ok(GetResult {
+                payload: GetResultPayload::Stream(stream::once(async move { Ok(bytes) }).boxed()),
+                meta,
+                range,
+                attributes,
+            })
         })
         .retry(Self::retry_builder())
         .sleep(self.sleeper())

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -9,7 +9,7 @@ use futures::{future::join_all, StreamExt};
 use log::{debug, warn};
 use object_store::buffered::BufWriter;
 use object_store::path::Path;
-use object_store::{ObjectStore, PutMode, PutOptions};
+use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions};
 use tokio::io::AsyncWriteExt;
 use ulid::Ulid;
 
@@ -833,7 +833,7 @@ mod tests {
     use bytes::Bytes;
     use futures::future;
     use futures::StreamExt;
-    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use object_store::{memory::InMemory, path::Path, ObjectStore, ObjectStoreExt};
     use proptest::prelude::any;
     use proptest::proptest;
     use rstest::rstest;

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -898,6 +898,10 @@ pub(crate) struct GatedObjectStore {
     pub(crate) put_multipart_opts_gate: Gate,
     pub(crate) copy_gate: Gate,
     pub(crate) rename_gate: Gate,
+    /// Gates each path emitted by `delete_stream`. Per-item gating preserves
+    /// the pre-0.13 single-call `delete` semantics now that callers go through
+    /// `ObjectStoreExt::delete`, which fans out into `delete_stream`.
+    pub(crate) delete_stream_gate: Arc<Gate>,
 }
 
 impl GatedObjectStore {
@@ -910,6 +914,7 @@ impl GatedObjectStore {
             put_multipart_opts_gate: Gate::default(),
             copy_gate: Gate::default(),
             rename_gate: Gate::default(),
+            delete_stream_gate: Arc::new(Gate::default()),
         }
     }
 }
@@ -958,7 +963,18 @@ impl ObjectStore for GatedObjectStore {
         &self,
         locations: BoxStream<'static, object_store::Result<Path>>,
     ) -> BoxStream<'static, object_store::Result<Path>> {
-        self.inner.delete_stream(locations)
+        let gate = Arc::clone(&self.delete_stream_gate);
+        let gated = locations
+            .then(move |loc| {
+                let gate = Arc::clone(&gate);
+                async move {
+                    let loc = loc?;
+                    gate.wait().await?;
+                    Ok(loc)
+                }
+            })
+            .boxed();
+        self.inner.delete_stream(gated)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -868,13 +868,6 @@ impl Gate {
 /// Each ObjectStore method has its own [`Gate`] that can be independently closed,
 /// released, and configured to inject errors. Gates default to **open** (pass-through).
 ///
-/// Note: object_store 0.13 turned `delete` and `put_multipart` into convenience
-/// methods on `ObjectStoreExt` (routed through `delete_stream` and
-/// `put_multipart_opts`). Per-stream-item gating is not supported by this
-/// harness, so there is no `delete_gate` or `put_multipart_gate`; use
-/// `put_multipart_opts_gate` for multipart uploads and rely on the inner store
-/// for delete sequencing.
-///
 /// # Usage pattern (mirrors `single_flight.rs` tests)
 /// ```ignore
 /// let inner = Arc::new(InMemory::new());
@@ -900,10 +893,6 @@ impl Gate {
 pub(crate) struct GatedObjectStore {
     inner: Arc<dyn ObjectStore>,
     pub(crate) get_opts_gate: Gate,
-    // Retained for source compatibility with tests written before
-    // object_store 0.13 split head() into ObjectStoreExt; head traffic now
-    // flows through get_opts_gate.
-    #[allow(dead_code)]
     pub(crate) head_gate: Gate,
     pub(crate) put_opts_gate: Gate,
     pub(crate) put_multipart_opts_gate: Gate,
@@ -938,11 +927,11 @@ impl ObjectStore for GatedObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
-        // object_store 0.13 routes head() through get_opts(head: true) via
-        // ObjectStoreExt, so all read traffic now passes through this single
-        // gate. The pre-0.13 head_gate is retained for source compatibility
-        // but no longer receives traffic.
-        self.get_opts_gate.wait().await?;
+        if options.head {
+            self.head_gate.wait().await?;
+        } else {
+            self.get_opts_gate.wait().await?;
+        }
         self.inner.get_opts(location, options).await
     }
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -14,8 +14,8 @@ use futures::stream::BoxStream;
 use futures::{stream, StreamExt};
 use object_store::path::Path;
 use object_store::{
-    GetOptions, ListResult, MultipartUpload, ObjectMeta, ObjectStore, PutOptions as OS_PutOptions,
-    PutPayload, PutResult,
+    CopyOptions, GetOptions, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutOptions as OS_PutOptions, PutPayload, PutResult,
 };
 use rand::{Rng, RngCore};
 use std::cmp::Ordering as CmpOrdering;
@@ -585,59 +585,50 @@ impl ObjectStore for FlakyObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
+        if options.head {
+            self.head_attempts.fetch_add(1, Ordering::SeqCst);
+            if self
+                .fail_first_head
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                    if v > 0 {
+                        Some(v - 1)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok()
+            {
+                return Err(object_store::Error::Generic {
+                    store: "flaky_head",
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "injected head timeout",
+                    )),
+                });
+            }
+        } else if options.range.is_some() {
+            self.get_range_attempts.fetch_add(1, Ordering::SeqCst);
+            if self
+                .fail_first_get_range
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                    if v > 0 {
+                        Some(v - 1)
+                    } else {
+                        None
+                    }
+                })
+                .is_ok()
+            {
+                return Err(object_store::Error::Generic {
+                    store: "flaky_get_range",
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "injected get_range timeout",
+                    )),
+                });
+            }
+        }
         self.inner.get_opts(location, options).await
-    }
-
-    async fn get_range(
-        &self,
-        location: &Path,
-        range: std::ops::Range<u64>,
-    ) -> object_store::Result<Bytes> {
-        self.get_range_attempts.fetch_add(1, Ordering::SeqCst);
-        if self
-            .fail_first_get_range
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
-                if v > 0 {
-                    Some(v - 1)
-                } else {
-                    None
-                }
-            })
-            .is_ok()
-        {
-            return Err(object_store::Error::Generic {
-                store: "flaky_get_range",
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "injected get_range timeout",
-                )),
-            });
-        }
-        self.inner.get_range(location, range).await
-    }
-
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        self.head_attempts.fetch_add(1, Ordering::SeqCst);
-        if self
-            .fail_first_head
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
-                if v > 0 {
-                    Some(v - 1)
-                } else {
-                    None
-                }
-            })
-            .is_ok()
-        {
-            return Err(object_store::Error::Generic {
-                store: "flaky_head",
-                source: Box::new(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "injected head timeout",
-                )),
-            });
-        }
-        self.inner.head(location).await
     }
 
     async fn put_opts(
@@ -692,13 +683,6 @@ impl ObjectStore for FlakyObjectStore {
         self.inner.put_opts(location, payload, opts).await
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart(location).await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -707,8 +691,11 @@ impl ObjectStore for FlakyObjectStore {
         self.inner.put_multipart_opts(location, opts).await
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        self.inner.delete(location).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -768,20 +755,13 @@ impl ObjectStore for FlakyObjectStore {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.copy(from, to).await
-    }
-
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.copy_if_not_exists(from, to).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.inner.rename_if_not_exists(from, to).await
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
     }
 }
 
@@ -888,6 +868,13 @@ impl Gate {
 /// Each ObjectStore method has its own [`Gate`] that can be independently closed,
 /// released, and configured to inject errors. Gates default to **open** (pass-through).
 ///
+/// Note: object_store 0.13 turned `delete` and `put_multipart` into convenience
+/// methods on `ObjectStoreExt` (routed through `delete_stream` and
+/// `put_multipart_opts`). Per-stream-item gating is not supported by this
+/// harness, so there is no `delete_gate` or `put_multipart_gate`; use
+/// `put_multipart_opts_gate` for multipart uploads and rely on the inner store
+/// for delete sequencing.
+///
 /// # Usage pattern (mirrors `single_flight.rs` tests)
 /// ```ignore
 /// let inner = Arc::new(InMemory::new());
@@ -913,11 +900,13 @@ impl Gate {
 pub(crate) struct GatedObjectStore {
     inner: Arc<dyn ObjectStore>,
     pub(crate) get_opts_gate: Gate,
+    // Retained for source compatibility with tests written before
+    // object_store 0.13 split head() into ObjectStoreExt; head traffic now
+    // flows through get_opts_gate.
+    #[allow(dead_code)]
     pub(crate) head_gate: Gate,
     pub(crate) put_opts_gate: Gate,
-    pub(crate) put_multipart_gate: Gate,
     pub(crate) put_multipart_opts_gate: Gate,
-    pub(crate) delete_gate: Gate,
     pub(crate) copy_gate: Gate,
     pub(crate) rename_gate: Gate,
 }
@@ -929,9 +918,7 @@ impl GatedObjectStore {
             get_opts_gate: Gate::default(),
             head_gate: Gate::default(),
             put_opts_gate: Gate::default(),
-            put_multipart_gate: Gate::default(),
             put_multipart_opts_gate: Gate::default(),
-            delete_gate: Gate::default(),
             copy_gate: Gate::default(),
             rename_gate: Gate::default(),
         }
@@ -951,13 +938,12 @@ impl ObjectStore for GatedObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
+        // object_store 0.13 routes head() through get_opts(head: true) via
+        // ObjectStoreExt, so all read traffic now passes through this single
+        // gate. The pre-0.13 head_gate is retained for source compatibility
+        // but no longer receives traffic.
         self.get_opts_gate.wait().await?;
         self.inner.get_opts(location, options).await
-    }
-
-    async fn head(&self, location: &Path) -> object_store::Result<ObjectMeta> {
-        self.head_gate.wait().await?;
-        self.inner.head(location).await
     }
 
     async fn put_opts(
@@ -970,14 +956,6 @@ impl ObjectStore for GatedObjectStore {
         self.inner.put_opts(location, payload, opts).await
     }
 
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> object_store::Result<Box<dyn MultipartUpload>> {
-        self.put_multipart_gate.wait().await?;
-        self.inner.put_multipart(location).await
-    }
-
     async fn put_multipart_opts(
         &self,
         location: &Path,
@@ -987,9 +965,11 @@ impl ObjectStore for GatedObjectStore {
         self.inner.put_multipart_opts(location, opts).await
     }
 
-    async fn delete(&self, location: &Path) -> object_store::Result<()> {
-        self.delete_gate.wait().await?;
-        self.inner.delete(location).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -1008,24 +988,24 @@ impl ObjectStore for GatedObjectStore {
         self.inner.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
         self.copy_gate.wait().await?;
-        self.inner.copy(from, to).await
+        self.inner.copy_opts(from, to, options).await
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> object_store::Result<()> {
+    async fn rename_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: object_store::RenameOptions,
+    ) -> object_store::Result<()> {
         self.rename_gate.wait().await?;
-        self.inner.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.copy_gate.wait().await?;
-        self.inner.copy_if_not_exists(from, to).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> object_store::Result<()> {
-        self.rename_gate.wait().await?;
-        self.inner.rename_if_not_exists(from, to).await
+        self.inner.rename_opts(from, to, options).await
     }
 }
 

--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -240,6 +240,7 @@ mod tests {
     use crate::types::ValueDeletable;
     use crate::Db;
     use object_store::memory::InMemory;
+    use object_store::ObjectStoreExt;
 
     fn has_not_found_object_store_source(err: &crate::Error) -> bool {
         err.source()


### PR DESCRIPTION
## Summary

Bump object_store to 0.13 (fixes #1140).

I thought I'd help out on the 0.13.0 release and found this issue. I realized I could use some of my tokens and time on this.

## Changes

Bump object_store to 0.13 (fixes #1140). Object store had a changes in their API so this PR is a bit bigger than I envisioned when I started this. All tests pass.

## Notes for Reviewers

Purely generated by Opus 4.7.

**Breaking change in instrumented cache store:** A few of the metrics wont receive any traffic now as object store consolidates get-stylle calls. Its a bit unclear what we should do here.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant
