### PR TITLE
Fix compaction destination bug

### DIFF
--- a/schemas/compactor.fbs
+++ b/schemas/compactor.fbs
@@ -33,6 +33,12 @@ table TieredCompactionSpec {
     // serialized before this field existed; readers default missing values
     // to empty bytes.
     segment: [ubyte];
+
+    // Destination Sorted Run ID for the compaction output. Appended after
+    // pre-existing fields so vtable offsets for earlier fields remain stable
+    // across schema evolution. Absent in v1 wire files; readers infer the
+    // destination from SR inputs for v1 and trust this field for v2+.
+    destination: uint32;
 }
 
 // Drains a named segment as part of segment retention (RFC-0024). The

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -51,9 +51,10 @@ use crate::utils::clamp_allocated_size_bytes;
 use slatedb_txn_obj::ObjectCodec;
 
 pub(crate) const MANIFEST_FORMAT_VERSION: u16 = 2;
-/// v2 (current) adds the `DrainSegmentSpec` union variant per RFC-0024.
-/// v1 files contain only `TieredCompactionSpec` specs and decode under
-/// the current schema without modification.
+/// v2 (current) adds the `DrainSegmentSpec` union variant per RFC-0024 and
+/// persists the tiered destination explicitly so L0-only compactions round-trip
+/// across restart. v1 files have no destination field and infer it from SR
+/// inputs on decode.
 pub(crate) const COMPACTIONS_FORMAT_VERSION: u16 = 2;
 pub(crate) const SUPPORTED_COMPACTIONS_FORMAT_VERSIONS: &[u16] = &[1, 2];
 pub(crate) const ORIGINAL_SST_FORMAT_VERSION: u16 = SST_FORMAT_VERSION;
@@ -571,23 +572,27 @@ impl FlatBufferCompactionsCodec {
             &verifier_options(),
             unversioned_bytes.as_ref(),
         )?;
-        Self::compactions(&fb)
+        Self::compactions(&fb, version)
     }
 
     pub(crate) fn compactions(
         compactions: &CompactionsV1,
+        version: u16,
     ) -> Result<CompactorCompactions, SlateDBError> {
         let recent_compactions = compactions
             .recent_compactions()
             .iter()
-            .map(|c| Self::compaction(&c))
+            .map(|c| Self::compaction(&c, version))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(CompactorCompactions::new(compactions.compactor_epoch())
             .with_compactions(recent_compactions))
     }
 
-    fn compaction(compaction: &FbCompaction) -> Result<CompactorCompaction, SlateDBError> {
-        let spec = Self::compaction_spec(compaction)?;
+    fn compaction(
+        compaction: &FbCompaction,
+        version: u16,
+    ) -> Result<CompactorCompaction, SlateDBError> {
+        let spec = Self::compaction_spec(compaction, version)?;
         let status = CompactionStatus::from(compaction.status());
         let output_ssts = compaction
             .output_ssts()
@@ -598,7 +603,10 @@ impl FlatBufferCompactionsCodec {
             .with_output_ssts(output_ssts))
     }
 
-    fn compaction_spec(compaction: &FbCompaction) -> Result<CompactorCompactionSpec, SlateDBError> {
+    fn compaction_spec(
+        compaction: &FbCompaction,
+        version: u16,
+    ) -> Result<CompactorCompactionSpec, SlateDBError> {
         match compaction.spec_type() {
             FbCompactionSpec::TieredCompactionSpec => {
                 let Some(spec) = compaction.spec_as_tiered_compaction_spec() else {
@@ -618,8 +626,12 @@ impl FlatBufferCompactionsCodec {
                     .map(|runs| runs.iter().collect())
                     .unwrap_or_default();
                 sources.extend(sorted_runs.iter().copied().map(SourceId::SortedRun));
-                // Destination is not explicitly encoded in the flatbuffer; derive it from SR inputs.
-                let destination = sorted_runs.iter().copied().min().unwrap_or(0);
+                let destination = if version >= 2 {
+                    spec.destination()
+                } else {
+                    // Legacy v1 files do not encode destination explicitly.
+                    sorted_runs.iter().copied().min().unwrap_or(0)
+                };
                 // Pre-segment specs serialized before this field existed have
                 // no segment; treat as the compatibility-encoded `prefix=""`
                 // segment (root tree).
@@ -991,6 +1003,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                     &TieredCompactionSpecArgs {
                         ssts: None,
                         sorted_runs,
+                        destination: spec.destination().expect("tiered spec"),
                         l0_view_ids,
                         segment: Some(segment),
                     },
@@ -1792,7 +1805,7 @@ mod tests {
         let output_ssts = vec![new_output_sst(b"a"), new_output_sst(b"m")];
         let compaction_l0 = Compaction::new(
             ulid::Ulid::new(),
-            CompactionSpec::new(vec![SourceId::SstView(ulid::Ulid::new())], 0),
+            CompactionSpec::new(vec![SourceId::SstView(ulid::Ulid::new())], 11),
         )
         .with_status(CompactionStatus::Running)
         .with_output_ssts(output_ssts);
@@ -2249,6 +2262,7 @@ mod tests {
             &TieredCompactionSpecArgs {
                 ssts: Some(source_ssts),
                 sorted_runs: None,
+                destination: 0,
                 l0_view_ids: None,
                 segment: Some(segment_bytes),
             },
@@ -2322,6 +2336,7 @@ mod tests {
             &TieredCompactionSpecArgs {
                 ssts: Some(source_ssts),
                 sorted_runs: None,
+                destination: 0,
                 l0_view_ids: None,
                 segment: None,
             },
@@ -2366,6 +2381,70 @@ mod tests {
         // segment (root tree).
         let decoded_compaction = decoded.get(&compaction_ulid).expect("missing compaction");
         assert_eq!(decoded_compaction.spec().segment(), &Bytes::new());
+    }
+
+    #[test]
+    fn test_should_decode_v1_tiered_compaction_with_legacy_inferred_destination() {
+        // given: a v1 compactions flatbuffer encoding a tiered compaction with
+        // SR inputs but no explicit destination field. v1 readers must infer
+        // the destination as `min(sorted_runs)` for backward compatibility.
+        use super::root_generated::{
+            Compaction as FbCompaction, CompactionArgs as FbCompactionArgs,
+            CompactionSpec as FbCompactionSpec, CompactionStatus as FbCompactionStatus,
+            CompactionsV1, CompactionsV1Args, TieredCompactionSpec, TieredCompactionSpecArgs,
+        };
+        let mut fbb = flatbuffers::FlatBufferBuilder::new();
+        let sorted_runs = fbb.create_vector(&[5u32, 3u32]);
+        let segment_bytes = fbb.create_vector::<u8>(&[]);
+        let spec = TieredCompactionSpec::create(
+            &mut fbb,
+            &TieredCompactionSpecArgs {
+                ssts: None,
+                sorted_runs: Some(sorted_runs),
+                destination: 0, // absent on v1 wire; default 0 is skipped
+                l0_view_ids: None,
+                segment: Some(segment_bytes),
+            },
+        );
+        let compaction_ulid = ulid::Ulid::new();
+        let compaction_id = super::root_generated::Ulid::create(
+            &mut fbb,
+            &super::root_generated::UlidArgs {
+                high: (compaction_ulid.0 >> 64) as u64,
+                low: ((compaction_ulid.0 << 64) >> 64) as u64,
+            },
+        );
+        let compaction = FbCompaction::create(
+            &mut fbb,
+            &FbCompactionArgs {
+                id: Some(compaction_id),
+                spec_type: FbCompactionSpec::TieredCompactionSpec,
+                spec: Some(spec.as_union_value()),
+                status: FbCompactionStatus::Running,
+                output_ssts: None,
+            },
+        );
+        let compactions_vec = fbb.create_vector(&[compaction]);
+        let compactions = CompactionsV1::create(
+            &mut fbb,
+            &CompactionsV1Args {
+                compactor_epoch: 1,
+                recent_compactions: Some(compactions_vec),
+            },
+        );
+        fbb.finish(compactions, None);
+        let mut bytes = BytesMut::new();
+        bytes.put_u16(1);
+        bytes.put_slice(fbb.finished_data());
+        let bytes = bytes.freeze();
+
+        // when:
+        let codec = FlatBufferCompactionsCodec {};
+        let decoded = codec.decode(&bytes).expect("failed to decode compactions");
+
+        // then: destination is inferred as min(sorted_runs) = 3.
+        let decoded_compaction = decoded.get(&compaction_ulid).expect("missing compaction");
+        assert_eq!(decoded_compaction.spec().destination(), Some(3));
     }
 
     #[test]

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -1875,6 +1875,28 @@ mod tests {
     }
 
     #[test]
+    fn test_should_roundtrip_v2_l0_only_compaction_destination() {
+        // Regression guard for issue #1652: an L0-only tiered compaction has
+        // no SR inputs, so the pre-fix decoder inferred destination=0 and
+        // dropped any real destination N>0 across restart. With the explicit
+        // `destination` field on the v2 wire format, the destination must
+        // round-trip through encode/decode.
+        let compaction = Compaction::new(
+            ulid::Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SstView(ulid::Ulid::new())], 7),
+        );
+        let mut compactions = Compactions::new(1);
+        compactions.insert(compaction.clone());
+
+        let codec = FlatBufferCompactionsCodec {};
+        let bytes = codec.encode(&compactions);
+        let decoded = codec.decode(&bytes).expect("failed to decode compactions");
+
+        let decoded_compaction = decoded.get(&compaction.id()).expect("missing compaction");
+        assert_eq!(decoded_compaction.spec().destination(), Some(7));
+    }
+
+    #[test]
     fn test_should_round_trip_compaction_statuses() {
         let statuses = [
             CompactionStatus::Submitted,

--- a/slatedb/src/generated/root_generated.rs
+++ b/slatedb/src/generated/root_generated.rs
@@ -2561,6 +2561,7 @@ impl<'a> TieredCompactionSpec<'a> {
   pub const VT_SORTED_RUNS: flatbuffers::VOffsetT = 6;
   pub const VT_L0_VIEW_IDS: flatbuffers::VOffsetT = 8;
   pub const VT_SEGMENT: flatbuffers::VOffsetT = 10;
+  pub const VT_DESTINATION: flatbuffers::VOffsetT = 12;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2572,6 +2573,7 @@ impl<'a> TieredCompactionSpec<'a> {
     args: &'args TieredCompactionSpecArgs<'args>
   ) -> flatbuffers::WIPOffset<TieredCompactionSpec<'bldr>> {
     let mut builder = TieredCompactionSpecBuilder::new(_fbb);
+    builder.add_destination(args.destination);
     if let Some(x) = args.segment { builder.add_segment(x); }
     if let Some(x) = args.l0_view_ids { builder.add_l0_view_ids(x); }
     if let Some(x) = args.sorted_runs { builder.add_sorted_runs(x); }
@@ -2608,6 +2610,13 @@ impl<'a> TieredCompactionSpec<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, u8>>>(TieredCompactionSpec::VT_SEGMENT, None)}
   }
+  #[inline]
+  pub fn destination(&self) -> u32 {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<u32>(TieredCompactionSpec::VT_DESTINATION, Some(0)).unwrap()}
+  }
 }
 
 impl flatbuffers::Verifiable for TieredCompactionSpec<'_> {
@@ -2621,6 +2630,7 @@ impl flatbuffers::Verifiable for TieredCompactionSpec<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u32>>>("sorted_runs", Self::VT_SORTED_RUNS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("l0_view_ids", Self::VT_L0_VIEW_IDS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("segment", Self::VT_SEGMENT, false)?
+     .visit_field::<u32>("destination", Self::VT_DESTINATION, false)?
      .finish();
     Ok(())
   }
@@ -2630,6 +2640,7 @@ pub struct TieredCompactionSpecArgs<'a> {
     pub sorted_runs: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u32>>>,
     pub l0_view_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
     pub segment: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    pub destination: u32,
 }
 impl<'a> Default for TieredCompactionSpecArgs<'a> {
   #[inline]
@@ -2639,6 +2650,7 @@ impl<'a> Default for TieredCompactionSpecArgs<'a> {
       sorted_runs: None,
       l0_view_ids: None,
       segment: None,
+      destination: 0,
     }
   }
 }
@@ -2665,6 +2677,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> TieredCompactionSpecBuilder<'a,
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(TieredCompactionSpec::VT_SEGMENT, segment);
   }
   #[inline]
+  pub fn add_destination(&mut self, destination: u32) {
+    self.fbb_.push_slot::<u32>(TieredCompactionSpec::VT_DESTINATION, destination, 0);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> TieredCompactionSpecBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     TieredCompactionSpecBuilder {
@@ -2686,6 +2702,7 @@ impl core::fmt::Debug for TieredCompactionSpec<'_> {
       ds.field("sorted_runs", &self.sorted_runs());
       ds.field("l0_view_ids", &self.l0_view_ids());
       ds.field("segment", &self.segment());
+      ds.field("destination", &self.destination());
       ds.finish()
   }
 }


### PR DESCRIPTION
Fixes #1652, which is a bug in the way that the destination SR Id is reloaded. When there are no SRs present in the compaction, then the SR Id is reset to 0. We fix the issue by explicitly encoding the destination into the spec for v2.

Thank you for the review! 🙏
