### PR TITLE
Render segment prefix with debug escapes in CompactionSpec Display

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -208,19 +208,14 @@ impl Display for CompactionSpec {
                 } else {
                     write!(
                         f,
-                        "[seg={}] {:?} -> SR({})",
-                        String::from_utf8_lossy(segment),
-                        displayed_sources,
-                        spec.destination,
+                        "[seg={:?}] {:?} -> SR({})",
+                        segment, displayed_sources, spec.destination,
                     )
                 }
             }
-            CompactionSpec::DrainSegment(_) => write!(
-                f,
-                "[seg={}] drain {:?}",
-                String::from_utf8_lossy(segment),
-                displayed_sources,
-            ),
+            CompactionSpec::DrainSegment(_) => {
+                write!(f, "[seg={:?}] drain {:?}", segment, displayed_sources)
+            }
         }
     }
 }


### PR DESCRIPTION

## Changes

- Render segment prefix with debug escapes in CompactionSpec Display

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
