### PR TITLE
Fix unsegmented code paths

### DIFF
--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -6,7 +6,7 @@ use log::{debug, warn};
 use tokio::sync::OnceCell;
 
 use crate::bytes_range::BytesRange;
-use crate::db_state::{SsTableHandle, SsTableId, SsTableView};
+use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::manifest::VersionedManifest;
@@ -63,24 +63,24 @@ pub(crate) async fn warm_sst_impl(
 
     // Reuse the handle embedded in the manifest view instead of calling
     // `open_sst`, which would issue an extra object_store GET for info+version.
-    // All matching views share the same physical handle, so grab the first.
-    // RFC-0024: walk every tree (unsegmented + segments) via `core()`.
-    let matching: Vec<&SsTableView> = manifest
+    // RFC-0024: walk every tree (unsegmented + segments) via `core()`. Each
+    // SST id appears in at most one view (segments have disjoint key spaces;
+    // within a tree an SST is in either L0 or one SR), so `find` is enough.
+    let Some(view) = manifest
         .core()
         .all_sst_views()
-        .filter(|view| view.sst.id == sst_id)
-        .collect();
-    let Some(first) = matching.first() else {
+        .find(|view| view.sst.id == sst_id)
+    else {
         debug!(
             "warm_sst: SST {:?} not reachable from current manifest",
             sst_id
         );
         return Ok(());
     };
-    let handle = first.sst.clone();
-    let visible_ranges: Vec<BytesRange> = matching
-        .iter()
-        .filter_map(|v| v.calculate_view_range(BytesRange::unbounded()))
+    let handle = view.sst.clone();
+    let visible_ranges: Vec<BytesRange> = view
+        .calculate_view_range(BytesRange::unbounded())
+        .into_iter()
         .collect();
     // Shared lazy index — populated at most once, so parallel target fanout
     // can share a single object-store read.

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -64,10 +64,10 @@ pub(crate) async fn warm_sst_impl(
     // Reuse the handle embedded in the manifest view instead of calling
     // `open_sst`, which would issue an extra object_store GET for info+version.
     // All matching views share the same physical handle, so grab the first.
+    // RFC-0024: walk every tree (unsegmented + segments) via `core()`.
     let matching: Vec<&SsTableView> = manifest
-        .l0()
-        .iter()
-        .chain(manifest.compacted().iter().flat_map(|run| &run.sst_views))
+        .core()
+        .all_sst_views()
         .filter(|view| view.sst.id == sst_id)
         .collect();
     let Some(first) = matching.first() else {
@@ -511,6 +511,36 @@ mod tests {
         l0.push_front(view.with_visible_range(visible_range));
     }
 
+    /// Open a DB configured with a 3-byte prefix extractor — every flush of
+    /// `key…`-prefixed writes lands entirely in segment `b"key"` rather than
+    /// the root tree.
+    async fn open_segmented_db(object_store: Arc<dyn ObjectStore>) -> Db {
+        Db::builder(PATH, object_store)
+            .with_settings(Settings {
+                flush_interval: None,
+                ..Default::default()
+            })
+            .with_segment_extractor(Arc::new(crate::test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .expect("failed to open segmented db")
+    }
+
+    /// Return the id of the first L0 SST in the manifest, walking root tree
+    /// then named segments. Used by tests that don't care which tree the
+    /// SST lives in.
+    fn first_l0_sst_id_any_tree(db: &Db) -> SsTableId {
+        let manifest = db.manifest();
+        let id = manifest
+            .core()
+            .trees()
+            .flat_map(|t| t.l0.iter())
+            .next()
+            .map(|v| v.sst.id)
+            .expect("expected at least one L0 SST across root + segments");
+        id
+    }
+
     #[tokio::test]
     async fn should_warm_only_within_visible_view_range() {
         // given: a single-SST DB whose cache is empty
@@ -546,6 +576,50 @@ mod tests {
         assert!(
             !is_key_cached(&db.inner.table_store, sst_id, b"key000000").await,
             "block below visible view should not be cached",
+        );
+
+        db.close().await.expect("close");
+    }
+
+    #[tokio::test]
+    async fn should_warm_sst_resident_in_named_segment() {
+        // RFC-0024: a DB configured with a segment extractor routes flushes
+        // into named segments, leaving the root tree empty. `warm_sst_impl`
+        // must reach those segment-resident SSTs. Pre-fix it only walked
+        // `manifest.l0()`/`compacted()` and silently no-op'd here.
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = open_segmented_db(os).await;
+        write_keys(&db, 64).await;
+        flush_to_l0(&db).await;
+
+        let manifest = db.manifest();
+        assert!(
+            manifest.l0().is_empty() && manifest.compacted().is_empty(),
+            "extractor-configured DB should leave root tree empty"
+        );
+        assert!(
+            !manifest.segments().is_empty(),
+            "extractor-configured flush should populate at least one segment"
+        );
+
+        let sst_id = first_l0_sst_id_any_tree(&db);
+        db.evict_cached_sst(sst_id).await.expect("evict");
+
+        warm_sst_impl(
+            &db.inner.table_store,
+            &manifest,
+            sst_id,
+            &[CacheTarget::data::<&[u8], _>(..)],
+        )
+        .await
+        .expect("warm_sst_impl");
+
+        let mask = cached_block_mask(&db.inner.table_store, sst_id).await;
+        assert!(!mask.is_empty(), "expected SST to have data blocks");
+        assert!(
+            mask.iter().all(|&b| b),
+            "expected all blocks cached for segment-resident SST, got {:?}",
+            mask,
         );
 
         db.close().await.expect("close");

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -251,6 +251,11 @@ impl DbReaderInner {
             != current_state.tree.last_compacted_l0_sst_view_id
             || latest.last_l0_seq > current_state.last_l0_seq
             || latest.tree.compacted != current_state.tree.compacted
+            // RFC-0024: segment-only progress (per-segment compactions,
+            // drains, segment-set changes) is invisible to the root-tree
+            // diff above. Structural equality on `Segment` covers each
+            // segment's tree state, so any change retires the snapshot.
+            || latest.segments != current_state.segments
     }
 
     async fn replace_checkpoint(
@@ -2304,20 +2309,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn should_reestablish_checkpoint_when_latest_last_l0_seq_exceeds_last_remote_persisted_seq() {
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = Path::from(format!(
-            "/tmp/test_db_reader_should_reestablish_checkpoint_{}",
-            Uuid::new_v4()
-        ));
-        let test_provider = TestProvider::new(path, Arc::clone(&object_store));
+    fn build_db_reader_inner(
+        test_provider: &TestProvider,
+        current_core: &ManifestCore,
+    ) -> DbReaderInner {
         let manifest_store = test_provider.manifest_store();
         let table_store = test_provider.table_store();
-
-        let mut current_core = ManifestCore::new();
-        current_core.last_l0_seq = 10;
-        current_core.next_wal_sst_id = 2;
 
         let prior_state = CheckpointState {
             checkpoint: test_checkpoint(1, test_provider.system_clock.clone()),
@@ -2342,7 +2339,7 @@ mod tests {
             oracle.clone(),
             None,
         );
-        let inner = DbReaderInner {
+        DbReaderInner {
             manifest_store,
             table_store,
             options: DbReaderOptions::default(),
@@ -2354,7 +2351,23 @@ mod tests {
             status_manager: DbStatusManager::new(0),
             rand: test_provider.rand.clone(),
             recorder,
-        };
+        }
+    }
+
+    #[test]
+    fn should_reestablish_checkpoint_when_latest_last_l0_seq_exceeds_last_remote_persisted_seq() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from(format!(
+            "/tmp/test_db_reader_should_reestablish_checkpoint_{}",
+            Uuid::new_v4()
+        ));
+        let test_provider = TestProvider::new(path, Arc::clone(&object_store));
+
+        let mut current_core = ManifestCore::new();
+        current_core.last_l0_seq = 10;
+        current_core.next_wal_sst_id = 2;
+
+        let inner = build_db_reader_inner(&test_provider, &current_core);
 
         assert!(!inner.should_reestablish_checkpoint(&current_core));
 
@@ -2362,6 +2375,108 @@ mod tests {
         latest.last_l0_seq = 11;
 
         assert!(inner.should_reestablish_checkpoint(&latest));
+    }
+
+    #[test]
+    fn should_reestablish_checkpoint_when_segments_differ() {
+        // RFC-0024: per-segment compactions, drains, and segment-set changes
+        // are invisible to the root-tree diff. Verify the segments comparison
+        // fires on each of those shapes.
+        use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
+        use crate::format::sst::SST_FORMAT_VERSION_LATEST;
+        use crate::manifest::{LsmTreeState, Segment};
+
+        fn view(seq: u64) -> SsTableView {
+            SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(ulid::Ulid::from_parts(seq, 0)),
+                SST_FORMAT_VERSION_LATEST,
+                SsTableInfo::default(),
+            ))
+        }
+        fn segment_with(prefix: &'static [u8], tree: LsmTreeState) -> Segment {
+            Segment {
+                prefix: Bytes::from_static(prefix),
+                tree,
+            }
+        }
+        fn tree_l0(views: Vec<SsTableView>) -> LsmTreeState {
+            LsmTreeState {
+                last_compacted_l0_sst_view_id: None,
+                last_compacted_l0_sst_id: None,
+                l0: VecDeque::from(views),
+                compacted: vec![],
+            }
+        }
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from(format!(
+            "/tmp/test_db_reader_segments_diff_{}",
+            Uuid::new_v4()
+        ));
+        let test_provider = TestProvider::new(path, Arc::clone(&object_store));
+
+        let baseline_segment = segment_with(b"hour=12/", tree_l0(vec![view(1)]));
+        let mut current_core = ManifestCore::new();
+        current_core.segment_extractor_name = Some("hour".into());
+        current_core.segments = vec![baseline_segment.clone()];
+
+        let inner = build_db_reader_inner(&test_provider, &current_core);
+
+        // Identical segments → no refresh.
+        assert!(!inner.should_reestablish_checkpoint(&current_core));
+
+        // New segment appears.
+        let mut latest = current_core.clone();
+        latest
+            .segments
+            .push(segment_with(b"hour=13/", tree_l0(vec![view(2)])));
+        assert!(
+            inner.should_reestablish_checkpoint(&latest),
+            "adding a segment should retire the snapshot"
+        );
+
+        // Segment's L0 changes in place (compaction within a segment).
+        let mut latest = current_core.clone();
+        latest.segments = vec![segment_with(b"hour=12/", tree_l0(vec![view(1), view(3)]))];
+        assert!(
+            inner.should_reestablish_checkpoint(&latest),
+            "segment L0 change should retire the snapshot"
+        );
+
+        // Segment's compacted list changes (sorted-run added).
+        let mut latest = current_core.clone();
+        latest.segments = vec![segment_with(
+            b"hour=12/",
+            LsmTreeState {
+                last_compacted_l0_sst_view_id: None,
+                last_compacted_l0_sst_id: None,
+                l0: VecDeque::from(vec![view(1)]),
+                compacted: vec![SortedRun {
+                    id: 0,
+                    sst_views: vec![view(4)],
+                }],
+            },
+        )];
+        assert!(
+            inner.should_reestablish_checkpoint(&latest),
+            "segment compacted change should retire the snapshot"
+        );
+
+        // Segment drained (watermark advances).
+        let mut latest = current_core.clone();
+        latest.segments = vec![segment_with(
+            b"hour=12/",
+            LsmTreeState {
+                last_compacted_l0_sst_view_id: Some(ulid::Ulid::from_parts(99, 0)),
+                last_compacted_l0_sst_id: None,
+                l0: VecDeque::new(),
+                compacted: vec![],
+            },
+        )];
+        assert!(
+            inner.should_reestablish_checkpoint(&latest),
+            "segment drain marker should retire the snapshot"
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -660,28 +660,10 @@ pub(crate) async fn preload_cache_from_manifest(
 ) -> Result<(), SlateDBError> {
     match preload_level {
         Some(PreloadLevel::AllSst) => {
-            let mut all_sst_paths: Vec<object_store::path::Path> = Vec::with_capacity(
-                core.tree.l0.len()
-                    + core
-                        .tree
-                        .compacted
-                        .iter()
-                        .map(|sr| sr.sst_views.len())
-                        .sum::<usize>(),
-            );
-            all_sst_paths.extend(
-                core.tree
-                    .l0
-                    .iter()
-                    .map(|view| path_resolver.table_path(&view.sst.id)),
-            );
-            all_sst_paths.extend(
-                core.tree
-                    .compacted
-                    .iter()
-                    .flat_map(|sr| &sr.sst_views)
-                    .map(|view| path_resolver.table_path(&view.sst.id)),
-            );
+            let all_sst_paths: Vec<object_store::path::Path> = core
+                .all_sst_views()
+                .map(|view| path_resolver.table_path(&view.sst.id))
+                .collect();
             if !all_sst_paths.is_empty() {
                 if let Err(e) = cached_obj_store
                     .load_files_to_cache(all_sst_paths, max_cache_size)
@@ -693,9 +675,8 @@ pub(crate) async fn preload_cache_from_manifest(
         }
         Some(PreloadLevel::L0Sst) => {
             let l0_sst_paths: Vec<object_store::path::Path> = core
-                .tree
-                .l0
-                .iter()
+                .trees()
+                .flat_map(|tree| tree.l0.iter())
                 .map(|view| path_resolver.table_path(&view.sst.id))
                 .collect();
             if !l0_sst_paths.is_empty() {


### PR DESCRIPTION
Fixes a few of the issues from #1662. 

- Cache warming and preloading should use the segment trees
- DbReader should check segments to see if checkpoint needs to be established

Thank you for the review! 🙏
