### PR TITLE
Update full compaction for segments

### DIFF
--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -176,18 +176,25 @@ pub(crate) enum CliCommands {
         #[arg(long, default_value = "size-tiered")]
         scheduler: String,
 
-        /// Submit a full JSON-encoded compaction request.
+        /// Submit a JSON-encoded compaction request.
         ///
-        /// The `segment` field is a byte array — an empty array `[]` targets
-        /// the compatibility-encoded root tree (the only valid segment on an
-        /// unsegmented DB); a non-empty array names a segment by prefix.
+        /// `"Full"` sweeps every tree in the DB (root + every named segment)
+        /// best-effort, skipping trees that have no compacted sorted runs.
+        ///
+        /// `FullSegment` targets a single tree. Its `segment` field is a byte
+        /// array — an empty array `[]` targets the compatibility-encoded root
+        /// tree (the only valid segment on an unsegmented DB); a non-empty
+        /// array names a segment by prefix.
         ///
         /// ## Examples
         /// ```json
-        /// {"Full":{"segment":[]}}
+        /// "Full"
         /// ```
         /// ```json
-        /// {"Full":{"segment":[104,111,117,114,61,49,50,47]}}
+        /// {"FullSegment":{"segment":[]}}
+        /// ```
+        /// ```json
+        /// {"FullSegment":{"segment":[104,111,117,114,61,49,50,47]}}
         /// ```
         /// ```json
         /// {"Spec":{"sources":[{"SortedRun":3},{"Sst":"01H8FQ5K6K7QK6EJ0E9HNF1J2B"}],"destination":7}}

--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -178,9 +178,16 @@ pub(crate) enum CliCommands {
 
         /// Submit a full JSON-encoded compaction request.
         ///
+        /// The `segment` field is a byte array — an empty array `[]` targets
+        /// the compatibility-encoded root tree (the only valid segment on an
+        /// unsegmented DB); a non-empty array names a segment by prefix.
+        ///
         /// ## Examples
         /// ```json
-        /// "Full"
+        /// {"Full":{"segment":[]}}
+        /// ```
+        /// ```json
+        /// {"Full":{"segment":[104,111,117,114,61,49,50,47]}}
         /// ```
         /// ```json
         /// {"Spec":{"sources":[{"SortedRun":3},{"Sst":"01H8FQ5K6K7QK6EJ0E9HNF1J2B"}],"destination":7}}

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -58,6 +58,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::stream::BoxStream;
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
@@ -152,13 +153,13 @@ pub trait CompactionScheduler: Send + Sync {
     /// Generate a compaction based on a compaction request.
     ///
     /// - If the request is a `CompactionRequest::Spec`, it simply returns the provided spec.
-    /// - If the request is a `CompactionRequest::Full`, it generates a compaction spec that
-    ///   includes all current sorted runs as sources, excluding L0 SSTs, and selects the
-    ///   lowest existing sorted run ID as the destination.
+    /// - If the request is a [`CompactionRequest::Full`], it targets the named
+    ///   tree, taking every sorted run in that tree as sources and the tree's lowest
+    ///   sorted-run id as the destination. L0 SSTs are excluded by design (see below).
     ///
-    /// Full compactions intentionally skip L0 so the size-tiered scheduler can continue
+    /// Full intentionally skips L0 so the size-tiered scheduler can continue
     /// compacting new flush output in parallel. Including L0 would mark those SSTs as
-    /// in-use for the duration of the full compaction, eventually stalling writers once
+    /// in-use for the duration of the compaction, eventually stalling writers once
     /// L0 reaches `l0_max_ssts`.
     ///
     /// ## Arguments
@@ -175,30 +176,38 @@ pub trait CompactionScheduler: Send + Sync {
     ) -> Result<Vec<CompactionSpec>, Error> {
         match request {
             CompactionRequest::Spec(spec) => Ok(vec![spec.clone()]),
-            CompactionRequest::Full => {
+            CompactionRequest::Full { segment } => {
                 let manifest = state.manifest().core();
-                let sources = manifest
-                    .tree
+                let Some(tree) = manifest.tree_for_segment(segment) else {
+                    error!("rejected full compaction: unknown segment {:?}", segment);
+                    return Err(crate::Error::from(SlateDBError::InvalidCompaction));
+                };
+                let sources = tree
                     .compacted
                     .iter()
                     .map(|sr| SourceId::SortedRun(sr.id))
                     .collect::<Vec<_>>();
                 if sources.is_empty() {
-                    if !manifest.tree.l0.is_empty() {
+                    if !tree.l0.is_empty() {
                         error!(
-                            "rejected full compaction: L0-only input is invalid because Full excludes L0 SSTs"
+                            "rejected full compaction: segment {:?} has L0 SSTs but no sorted runs to merge; \
+                             L0 SSTs are not eligible inputs",
+                            segment
                         );
                     }
                     return Err(crate::Error::from(SlateDBError::InvalidCompaction));
                 }
-                let destination = manifest
-                    .tree
+                let destination = tree
                     .compacted
                     .iter()
                     .map(|sr| sr.id)
                     .min()
-                    .expect("full compaction requires at least one sorted run");
-                Ok(vec![CompactionSpec::new(sources, destination)])
+                    .expect("at least one sorted run");
+                Ok(vec![CompactionSpec::for_segment(
+                    segment.clone(),
+                    sources,
+                    destination,
+                )])
             }
         }
     }
@@ -207,13 +216,18 @@ pub trait CompactionScheduler: Send + Sync {
 /// Request to submit a compaction for execution.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum CompactionRequest {
-    /// Compact all current sorted runs, excluding L0 SSTs.
+    /// Compact every sorted run in the named tree into the tree's lowest-id
+    /// sorted run, excluding L0 SSTs. Use `segment: Bytes::new()` to target
+    /// the compatibility-encoded root tree (RFC-0024); on a database without
+    /// a segment extractor this is the only valid form.
     ///
-    /// L0 SSTs are left to regular size-tiered compaction so memtable flushes can continue
-    /// producing new sorted runs while the full compaction is in flight. Pulling L0 into the
-    /// full compaction would block parallel L0 work and can back pressure writes once
-    /// `l0_max_ssts` is reached.
-    Full,
+    /// L0 SSTs are left to regular size-tiered compaction so memtable flushes
+    /// can continue producing new sorted runs while this compaction is in
+    /// flight. Pulling L0 into the merge would mark those SSTs as in-use
+    /// for the duration of the compaction, eventually stalling writers
+    /// once L0 reaches `l0_max_ssts`. To compact every tree in a segmented
+    /// database, the caller issues one `Full` request per segment.
+    Full { segment: Bytes },
     /// Use a caller-provided compaction spec.
     Spec(CompactionSpec),
 }
@@ -1259,7 +1273,7 @@ mod tests {
     use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
     use crate::iter::RowEntryIterator;
     use crate::manifest::store::{ManifestStore, StoredManifest};
-    use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
+    use crate::manifest::{LsmTreeState, Manifest, ManifestCore, Segment, VersionedManifest};
     use crate::merge_operator::{MergeOperator, MergeOperatorError};
     use crate::object_stores::ObjectStores;
     use crate::proptest_util::rng;
@@ -3160,7 +3174,9 @@ mod tests {
                         stored_manifest.manifest().clone(),
                     ),
                 },
-                &CompactionRequest::Full,
+                &CompactionRequest::Full {
+                    segment: Bytes::new(),
+                },
             )
             .unwrap();
         assert_eq!(specs.len(), 1);
@@ -3202,7 +3218,7 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_full_uses_sorted_runs_and_min_destination() {
+    fn test_plan_full_root_uses_sorted_runs_and_min_destination() {
         let scheduler = MockScheduler::new();
         let mut core = ManifestCore::new();
         let l0_info = SsTableInfo {
@@ -3248,7 +3264,12 @@ mod tests {
         };
 
         let planned = scheduler
-            .generate(&state, &CompactionRequest::Full)
+            .generate(
+                &state,
+                &CompactionRequest::Full {
+                    segment: Bytes::new(),
+                },
+            )
             .unwrap();
 
         let expected_sources = vec![SourceId::SortedRun(5), SourceId::SortedRun(2)];
@@ -3258,7 +3279,7 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_full_without_sorted_runs_is_invalid() {
+    fn test_plan_full_root_without_sorted_runs_is_invalid() {
         let scheduler = MockScheduler::new();
         let mut core = ManifestCore::new();
         let l0_info = SsTableInfo {
@@ -3283,13 +3304,154 @@ mod tests {
         };
 
         let err = scheduler
-            .generate(&state, &CompactionRequest::Full)
-            .expect_err(
-            "full compaction should reject empty or L0-only inputs because L0 SSTs are excluded",
-        );
+            .generate(
+                &state,
+                &CompactionRequest::Full {
+                    segment: Bytes::new(),
+                },
+            )
+            .expect_err("full should reject empty or L0-only inputs because L0 SSTs are excluded");
 
         assert_eq!(err.kind(), crate::ErrorKind::Invalid);
         assert_eq!(err.to_string(), "Invalid error: invalid compaction");
+    }
+
+    #[test]
+    fn test_plan_full_targets_named_segment() {
+        // Full against a named segment must pull sources from that
+        // segment's tree, not the root tree. RFC-0024 routes named-segment
+        // SRs through `core.segments[..].tree.compacted`, so a request
+        // against `b"key"` should ignore root-tree SRs entirely.
+        let scheduler = MockScheduler::new();
+        let mut core = ManifestCore::new();
+        core.segment_extractor_name = Some("test".into());
+        let sr_info = SsTableInfo {
+            first_entry: Some(Bytes::from_static(b"key1")),
+            ..SsTableInfo::default()
+        };
+        core.segments = vec![Segment {
+            prefix: Bytes::from_static(b"key"),
+            tree: LsmTreeState {
+                last_compacted_l0_sst_view_id: None,
+                last_compacted_l0_sst_id: None,
+                l0: VecDeque::new(),
+                compacted: vec![
+                    SortedRun {
+                        id: 7,
+                        sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                            SsTableId::Compacted(Ulid::from_parts(70, 0)),
+                            SST_FORMAT_VERSION_LATEST,
+                            sr_info.clone(),
+                        ))],
+                    },
+                    SortedRun {
+                        id: 3,
+                        sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                            SsTableId::Compacted(Ulid::from_parts(30, 0)),
+                            SST_FORMAT_VERSION_LATEST,
+                            sr_info,
+                        ))],
+                    },
+                ],
+            },
+        }];
+        let state = CompactorStateView {
+            compactions: None,
+            manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
+        };
+
+        let planned = scheduler
+            .generate(
+                &state,
+                &CompactionRequest::Full {
+                    segment: Bytes::from_static(b"key"),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].segment().as_ref(), b"key");
+        assert_eq!(
+            planned[0].sources(),
+            &vec![SourceId::SortedRun(7), SourceId::SortedRun(3)]
+        );
+        assert_eq!(planned[0].destination(), Some(3));
+    }
+
+    #[test]
+    fn test_plan_full_unknown_segment_is_invalid() {
+        // Asking to compact a non-empty segment prefix on an unsegmented DB
+        // (root has sorted runs, no segments configured) must be rejected.
+        // A segment-blind implementation that ignored the prefix would
+        // happily return root SRs here — this asserts the routing actually
+        // looks the segment up.
+        let scheduler = MockScheduler::new();
+        let mut core = ManifestCore::new();
+        let sr_info = SsTableInfo {
+            first_entry: Some(Bytes::from_static(b"r")),
+            ..SsTableInfo::default()
+        };
+        core.tree.compacted = vec![SortedRun {
+            id: 9,
+            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(Ulid::from_parts(90, 0)),
+                SST_FORMAT_VERSION_LATEST,
+                sr_info,
+            ))],
+        }];
+        let state = CompactorStateView {
+            compactions: None,
+            manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
+        };
+
+        let err = scheduler
+            .generate(
+                &state,
+                &CompactionRequest::Full {
+                    segment: Bytes::from_static(b"missing"),
+                },
+            )
+            .expect_err("full against unknown segment should fail");
+
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+    }
+
+    #[test]
+    fn test_plan_full_single_sorted_run_is_allowed() {
+        // A tree with exactly one SR is a legitimate target — the merge
+        // pipeline still applies retention, TTL, compaction filters, and
+        // merge-operator collapses. Reject only when there are no SRs at all.
+        let scheduler = MockScheduler::new();
+        let mut core = ManifestCore::new();
+        let sr_info = SsTableInfo {
+            first_entry: Some(Bytes::from_static(b"a")),
+            ..SsTableInfo::default()
+        };
+        core.tree.compacted = vec![SortedRun {
+            id: 4,
+            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(Ulid::from_parts(40, 0)),
+                SST_FORMAT_VERSION_LATEST,
+                sr_info,
+            ))],
+        }];
+        let state = CompactorStateView {
+            compactions: None,
+            manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
+        };
+
+        let planned = scheduler
+            .generate(
+                &state,
+                &CompactionRequest::Full {
+                    segment: Bytes::new(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].sources(), &vec![SourceId::SortedRun(4)]);
+        assert_eq!(planned[0].destination(), Some(4));
     }
 
     struct CompactorEventHandlerTestFixture {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -229,10 +229,9 @@ fn plan_full_tree(prefix: &Bytes, tree: &LsmTreeState) -> Option<CompactionSpec>
         .iter()
         .map(|sr| SourceId::SortedRun(sr.id))
         .collect::<Vec<_>>();
-    let destination = tree
-        .compacted
+    let destination = sources
         .iter()
-        .map(|sr| sr.id)
+        .map(|s| s.unwrap_sorted_run())
         .min()
         .expect("at least one sorted run");
     Some(CompactionSpec::for_segment(

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -81,7 +81,7 @@ use crate::db_status::ClosedResultWriter;
 use crate::dispatcher::{MessageFactory, MessageHandler, MessageHandlerExecutor};
 use crate::error::{Error, SlateDBError};
 use crate::manifest::store::ManifestStore;
-use crate::manifest::{ManifestCore, SsTableHandle};
+use crate::manifest::{LsmTreeState, ManifestCore, SsTableHandle};
 use crate::merge_operator::MergeOperatorType;
 use crate::rand::DbRand;
 use crate::tablestore::TableStore;
@@ -150,17 +150,22 @@ pub trait CompactionScheduler: Send + Sync {
         Ok(())
     }
 
-    /// Generate a compaction based on a compaction request.
+    /// Generate one or more compaction specs from a [`CompactionRequest`].
     ///
-    /// - If the request is a `CompactionRequest::Spec`, it simply returns the provided spec.
-    /// - If the request is a [`CompactionRequest::Full`], it targets the named
-    ///   tree, taking every sorted run in that tree as sources and the tree's lowest
-    ///   sorted-run id as the destination. L0 SSTs are excluded by design (see below).
+    /// - [`CompactionRequest::Spec`] returns the caller-provided spec verbatim.
+    /// - [`CompactionRequest::FullSegment`] targets a single tree (root or a
+    ///   named segment): every sorted run becomes a source, the tree's lowest
+    ///   sorted-run id is the destination. Returns an error if the segment
+    ///   is unknown or the tree has no compacted sorted runs.
+    /// - [`CompactionRequest::Full`] applies the same per-tree rule to every
+    ///   tree in the DB (root + every named segment), best-effort: trees
+    ///   without compacted sorted runs are silently skipped and an empty
+    ///   `Vec` is returned if no tree is eligible.
     ///
-    /// Full intentionally skips L0 so the size-tiered scheduler can continue
-    /// compacting new flush output in parallel. Including L0 would mark those SSTs as
-    /// in-use for the duration of the compaction, eventually stalling writers once
-    /// L0 reaches `l0_max_ssts`.
+    /// L0 SSTs are intentionally excluded so the size-tiered scheduler can
+    /// keep compacting new flush output in parallel. Including L0 would
+    /// mark those SSTs as in-use for the duration of the compaction,
+    /// eventually stalling writers once L0 reaches `l0_max_ssts`.
     ///
     /// ## Arguments
     /// - `state`: Process-local view of the DB's manifest and compactions.
@@ -176,58 +181,88 @@ pub trait CompactionScheduler: Send + Sync {
     ) -> Result<Vec<CompactionSpec>, Error> {
         match request {
             CompactionRequest::Spec(spec) => Ok(vec![spec.clone()]),
-            CompactionRequest::Full { segment } => {
+            CompactionRequest::FullSegment { segment } => {
                 let manifest = state.manifest().core();
                 let Some(tree) = manifest.tree_for_segment(segment) else {
-                    error!("rejected full compaction: unknown segment {:?}", segment);
+                    error!(
+                        "rejected full-segment compaction: unknown segment {:?}",
+                        segment
+                    );
                     return Err(crate::Error::from(SlateDBError::InvalidCompaction));
                 };
-                let sources = tree
-                    .compacted
-                    .iter()
-                    .map(|sr| SourceId::SortedRun(sr.id))
-                    .collect::<Vec<_>>();
-                if sources.is_empty() {
-                    if !tree.l0.is_empty() {
-                        error!(
-                            "rejected full compaction: segment {:?} has L0 SSTs but no sorted runs to merge; \
-                             L0 SSTs are not eligible inputs",
-                            segment
-                        );
+                match plan_full_tree(segment, tree) {
+                    Some(spec) => Ok(vec![spec]),
+                    None => {
+                        if !tree.l0.is_empty() {
+                            error!(
+                                "rejected full-segment compaction: segment {:?} has L0 SSTs but no sorted runs to merge; \
+                                 L0 SSTs are not eligible inputs",
+                                segment
+                            );
+                        }
+                        Err(crate::Error::from(SlateDBError::InvalidCompaction))
                     }
-                    return Err(crate::Error::from(SlateDBError::InvalidCompaction));
                 }
-                let destination = tree
-                    .compacted
-                    .iter()
-                    .map(|sr| sr.id)
-                    .min()
-                    .expect("at least one sorted run");
-                Ok(vec![CompactionSpec::for_segment(
-                    segment.clone(),
-                    sources,
-                    destination,
-                )])
+            }
+            CompactionRequest::Full => {
+                let manifest = state.manifest().core();
+                let specs = manifest
+                    .trees_with_prefix()
+                    .filter_map(|(prefix, tree)| plan_full_tree(&prefix, tree))
+                    .collect();
+                Ok(specs)
             }
         }
     }
 }
 
+/// Build a [`CompactionSpec`] that compacts every sorted run in `tree` into
+/// the tree's lowest-id sorted run. Returns `None` when the tree has no
+/// compacted sorted runs — L0 SSTs are not eligible inputs.
+fn plan_full_tree(prefix: &Bytes, tree: &LsmTreeState) -> Option<CompactionSpec> {
+    if tree.compacted.is_empty() {
+        return None;
+    }
+    let sources = tree
+        .compacted
+        .iter()
+        .map(|sr| SourceId::SortedRun(sr.id))
+        .collect::<Vec<_>>();
+    let destination = tree
+        .compacted
+        .iter()
+        .map(|sr| sr.id)
+        .min()
+        .expect("at least one sorted run");
+    Some(CompactionSpec::for_segment(
+        prefix.clone(),
+        sources,
+        destination,
+    ))
+}
+
 /// Request to submit a compaction for execution.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum CompactionRequest {
-    /// Compact every sorted run in the named tree into the tree's lowest-id
-    /// sorted run, excluding L0 SSTs. Use `segment: Bytes::new()` to target
-    /// the compatibility-encoded root tree (RFC-0024); on a database without
-    /// a segment extractor this is the only valid form.
+    /// Compact every tree in the DB — the root tree plus each named segment
+    /// (RFC-0024) — by merging every sorted run in each tree into that
+    /// tree's lowest-id sorted run. Trees with no compacted sorted runs are
+    /// silently skipped; an empty `Vec` is returned when no tree is eligible.
     ///
     /// L0 SSTs are left to regular size-tiered compaction so memtable flushes
     /// can continue producing new sorted runs while this compaction is in
     /// flight. Pulling L0 into the merge would mark those SSTs as in-use
-    /// for the duration of the compaction, eventually stalling writers
-    /// once L0 reaches `l0_max_ssts`. To compact every tree in a segmented
-    /// database, the caller issues one `Full` request per segment.
-    Full { segment: Bytes },
+    /// for the duration of the compaction, eventually stalling writers once
+    /// L0 reaches `l0_max_ssts`.
+    Full,
+    /// Compact a single tree: every sorted run in the tree at `segment` is
+    /// merged into the tree's lowest-id sorted run. `segment: Bytes::new()`
+    /// targets the compatibility-encoded root tree (the only valid segment
+    /// on a database without a segment extractor); a non-empty prefix names
+    /// a segment. Rejected if the segment is unknown or the tree has no
+    /// compacted sorted runs. L0 SSTs are excluded for the same reason
+    /// documented on `Full`.
+    FullSegment { segment: Bytes },
     /// Use a caller-provided compaction spec.
     Spec(CompactionSpec),
 }
@@ -859,7 +894,7 @@ impl CompactorEventHandler {
     /// and pass through unchecked.
     fn validate_drain_watermark_advance(
         compaction: &CompactionSpec,
-        tree: &crate::manifest::LsmTreeState,
+        tree: &LsmTreeState,
     ) -> Result<(), SlateDBError> {
         if !compaction.is_drain() {
             return Ok(());
@@ -3174,7 +3209,7 @@ mod tests {
                         stored_manifest.manifest().clone(),
                     ),
                 },
-                &CompactionRequest::Full {
+                &CompactionRequest::FullSegment {
                     segment: Bytes::new(),
                 },
             )
@@ -3218,7 +3253,7 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_full_root_uses_sorted_runs_and_min_destination() {
+    fn test_plan_full_segment_root_uses_sorted_runs_and_min_destination() {
         let scheduler = MockScheduler::new();
         let mut core = ManifestCore::new();
         let l0_info = SsTableInfo {
@@ -3266,7 +3301,7 @@ mod tests {
         let planned = scheduler
             .generate(
                 &state,
-                &CompactionRequest::Full {
+                &CompactionRequest::FullSegment {
                     segment: Bytes::new(),
                 },
             )
@@ -3279,7 +3314,7 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_full_root_without_sorted_runs_is_invalid() {
+    fn test_plan_full_segment_root_without_sorted_runs_is_invalid() {
         let scheduler = MockScheduler::new();
         let mut core = ManifestCore::new();
         let l0_info = SsTableInfo {
@@ -3306,19 +3341,21 @@ mod tests {
         let err = scheduler
             .generate(
                 &state,
-                &CompactionRequest::Full {
+                &CompactionRequest::FullSegment {
                     segment: Bytes::new(),
                 },
             )
-            .expect_err("full should reject empty or L0-only inputs because L0 SSTs are excluded");
+            .expect_err(
+                "full-segment should reject empty or L0-only inputs because L0 SSTs are excluded",
+            );
 
         assert_eq!(err.kind(), crate::ErrorKind::Invalid);
         assert_eq!(err.to_string(), "Invalid error: invalid compaction");
     }
 
     #[test]
-    fn test_plan_full_targets_named_segment() {
-        // Full against a named segment must pull sources from that
+    fn test_plan_full_segment_targets_named_segment() {
+        // FullSegment against a named segment must pull sources from that
         // segment's tree, not the root tree. RFC-0024 routes named-segment
         // SRs through `core.segments[..].tree.compacted`, so a request
         // against `b"key"` should ignore root-tree SRs entirely.
@@ -3363,7 +3400,7 @@ mod tests {
         let planned = scheduler
             .generate(
                 &state,
-                &CompactionRequest::Full {
+                &CompactionRequest::FullSegment {
                     segment: Bytes::from_static(b"key"),
                 },
             )
@@ -3379,7 +3416,7 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_full_unknown_segment_is_invalid() {
+    fn test_plan_full_segment_unknown_segment_is_invalid() {
         // Asking to compact a non-empty segment prefix on an unsegmented DB
         // (root has sorted runs, no segments configured) must be rejected.
         // A segment-blind implementation that ignored the prefix would
@@ -3407,17 +3444,17 @@ mod tests {
         let err = scheduler
             .generate(
                 &state,
-                &CompactionRequest::Full {
+                &CompactionRequest::FullSegment {
                     segment: Bytes::from_static(b"missing"),
                 },
             )
-            .expect_err("full against unknown segment should fail");
+            .expect_err("full-segment against unknown segment should fail");
 
         assert_eq!(err.kind(), crate::ErrorKind::Invalid);
     }
 
     #[test]
-    fn test_plan_full_single_sorted_run_is_allowed() {
+    fn test_plan_full_segment_single_sorted_run_is_allowed() {
         // A tree with exactly one SR is a legitimate target — the merge
         // pipeline still applies retention, TTL, compaction filters, and
         // merge-operator collapses. Reject only when there are no SRs at all.
@@ -3443,7 +3480,7 @@ mod tests {
         let planned = scheduler
             .generate(
                 &state,
-                &CompactionRequest::Full {
+                &CompactionRequest::FullSegment {
                     segment: Bytes::new(),
                 },
             )
@@ -3452,6 +3489,184 @@ mod tests {
         assert_eq!(planned.len(), 1);
         assert_eq!(planned[0].sources(), &vec![SourceId::SortedRun(4)]);
         assert_eq!(planned[0].destination(), Some(4));
+    }
+
+    #[test]
+    fn test_plan_full_sweeps_root_and_every_named_segment() {
+        // Full must produce one spec per eligible tree, ordered as
+        // `trees_with_prefix()` yields them: root first, then segments by
+        // ascending prefix.
+        let scheduler = MockScheduler::new();
+        let mut core = ManifestCore::new();
+        let info = SsTableInfo {
+            first_entry: Some(Bytes::from_static(b"x")),
+            ..SsTableInfo::default()
+        };
+        core.tree.compacted = vec![
+            SortedRun {
+                id: 8,
+                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                    SsTableId::Compacted(Ulid::from_parts(80, 0)),
+                    SST_FORMAT_VERSION_LATEST,
+                    info.clone(),
+                ))],
+            },
+            SortedRun {
+                id: 4,
+                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                    SsTableId::Compacted(Ulid::from_parts(40, 0)),
+                    SST_FORMAT_VERSION_LATEST,
+                    info.clone(),
+                ))],
+            },
+        ];
+        core.segment_extractor_name = Some("test".into());
+        core.segments = vec![
+            Segment {
+                prefix: Bytes::from_static(b"a/"),
+                tree: LsmTreeState {
+                    last_compacted_l0_sst_view_id: None,
+                    last_compacted_l0_sst_id: None,
+                    l0: VecDeque::new(),
+                    compacted: vec![SortedRun {
+                        id: 3,
+                        sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                            SsTableId::Compacted(Ulid::from_parts(30, 0)),
+                            SST_FORMAT_VERSION_LATEST,
+                            info.clone(),
+                        ))],
+                    }],
+                },
+            },
+            Segment {
+                prefix: Bytes::from_static(b"b/"),
+                tree: LsmTreeState {
+                    last_compacted_l0_sst_view_id: None,
+                    last_compacted_l0_sst_id: None,
+                    l0: VecDeque::new(),
+                    compacted: vec![
+                        SortedRun {
+                            id: 9,
+                            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                                SsTableId::Compacted(Ulid::from_parts(90, 0)),
+                                SST_FORMAT_VERSION_LATEST,
+                                info.clone(),
+                            ))],
+                        },
+                        SortedRun {
+                            id: 6,
+                            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                                SsTableId::Compacted(Ulid::from_parts(60, 0)),
+                                SST_FORMAT_VERSION_LATEST,
+                                info,
+                            ))],
+                        },
+                    ],
+                },
+            },
+        ];
+        let state = CompactorStateView {
+            compactions: None,
+            manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
+        };
+
+        let planned = scheduler
+            .generate(&state, &CompactionRequest::Full)
+            .unwrap();
+
+        assert_eq!(planned.len(), 3);
+        assert_eq!(planned[0].segment().as_ref(), b"");
+        assert_eq!(
+            planned[0].sources(),
+            &vec![SourceId::SortedRun(8), SourceId::SortedRun(4)]
+        );
+        assert_eq!(planned[0].destination(), Some(4));
+        assert_eq!(planned[1].segment().as_ref(), b"a/");
+        assert_eq!(planned[1].sources(), &vec![SourceId::SortedRun(3)]);
+        assert_eq!(planned[1].destination(), Some(3));
+        assert_eq!(planned[2].segment().as_ref(), b"b/");
+        assert_eq!(
+            planned[2].sources(),
+            &vec![SourceId::SortedRun(9), SourceId::SortedRun(6)]
+        );
+        assert_eq!(planned[2].destination(), Some(6));
+    }
+
+    #[test]
+    fn test_plan_full_skips_trees_without_sorted_runs() {
+        // Best-effort semantics: a tree with no compacted SRs is silently
+        // skipped (even if it has L0 SSTs), but eligible peers still produce
+        // specs. This is the key behavioral difference from FullSegment,
+        // which errors when explicitly asked to compact such a tree.
+        let scheduler = MockScheduler::new();
+        let mut core = ManifestCore::new();
+        let info = SsTableInfo {
+            first_entry: Some(Bytes::from_static(b"x")),
+            ..SsTableInfo::default()
+        };
+        core.tree.compacted = vec![SortedRun {
+            id: 5,
+            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(Ulid::from_parts(50, 0)),
+                SST_FORMAT_VERSION_LATEST,
+                info.clone(),
+            ))],
+        }];
+        core.segment_extractor_name = Some("test".into());
+        core.segments = vec![
+            // L0-only: still skipped because L0 SSTs are ineligible inputs.
+            Segment {
+                prefix: Bytes::from_static(b"l0only/"),
+                tree: LsmTreeState {
+                    last_compacted_l0_sst_view_id: None,
+                    last_compacted_l0_sst_id: None,
+                    l0: VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
+                        SsTableId::Compacted(Ulid::from_parts(1, 0)),
+                        SST_FORMAT_VERSION_LATEST,
+                        info,
+                    ))]),
+                    compacted: vec![],
+                },
+            },
+            // Fully empty tree: also skipped.
+            Segment {
+                prefix: Bytes::from_static(b"none/"),
+                tree: LsmTreeState {
+                    last_compacted_l0_sst_view_id: None,
+                    last_compacted_l0_sst_id: None,
+                    l0: VecDeque::new(),
+                    compacted: vec![],
+                },
+            },
+        ];
+        let state = CompactorStateView {
+            compactions: None,
+            manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
+        };
+
+        let planned = scheduler
+            .generate(&state, &CompactionRequest::Full)
+            .unwrap();
+
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].segment().as_ref(), b"");
+        assert_eq!(planned[0].sources(), &vec![SourceId::SortedRun(5)]);
+    }
+
+    #[test]
+    fn test_plan_full_returns_empty_when_no_tree_is_eligible() {
+        // Empty DB / no compacted SRs anywhere → Ok(vec![]), not an error.
+        let scheduler = MockScheduler::new();
+        let state = CompactorStateView {
+            compactions: None,
+            manifest: VersionedManifest::from_manifest(0, Manifest::initial(ManifestCore::new())),
+        };
+
+        let planned = scheduler
+            .generate(&state, &CompactionRequest::Full)
+            .unwrap();
+
+        assert!(planned.is_empty(), "expected empty plan, got {:?}", planned);
     }
 
     struct CompactorEventHandlerTestFixture {


### PR DESCRIPTION
Addresses 1) from #1662. Currently `CompactionRequest::Full` targets all sorted runs in the default tree. In this patch, I've added `segment` to the `Full` request spec. So `Full("")` is equivalent to the old behavior.

Alternatively, we could leave `Full` unchanged and submit compaction specs across each present segment, but I wasn't sure if there was a real need for it.

Thank you for the review! 🙏
