### PR TITLE
Delete file cache entries on object deletion

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -736,6 +736,19 @@ impl ObjectStore for CachedObjectStore {
         self.object_store.put_multipart_opts(location, opts).await
     }
 
+    /// Deletion of the cache entries associated with the object being
+    /// deleted is not atomic with respect to the object deletion from
+    /// the underlying object store. So for some period of time after
+    /// the deletion, cached object parts are still visible in the cache.
+    /// But assuming each object ever created by SlateDB is immutable and
+    /// has a unique name, this is not a problem.
+    ///
+    /// If eviction is enabled, deletion of the associated cache entries
+    /// happens asynchronously; when the control returns to the caller,
+    /// the entries still might be present in the cache. If eviction is
+    /// off, the deletion happens synchronously; when the control returns
+    /// to the caller, it is guaranteed no entries present in the cache
+    /// (assuming no errors happened during the deletion).
     fn delete_stream(
         &self,
         locations: BoxStream<'static, object_store::Result<Path>>,

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -178,12 +178,7 @@ impl CachedObjectStore {
     /// lazily from observed metadata locations, so this method may return `None`
     /// for early requests until successful GET/HEAD responses are observed.
     fn cache_location_for(&self, location: &Path) -> Option<Path> {
-        self.resolved_root.get().map(|root| {
-            if root.as_ref().is_empty() {
-                return location.clone();
-            }
-            root.parts().chain(location.parts()).collect()
-        })
+        cache_location_for(&self.resolved_root, location)
     }
 
     /// Lazily resolves the root prefix and validates the derived cache key.
@@ -692,6 +687,15 @@ fn head_only_get_result(meta: ObjectMeta, attributes: Attributes) -> GetResult {
     }
 }
 
+fn cache_location_for(resolved_root: &Arc<OnceCell<Path>>, location: &Path) -> Option<Path> {
+    resolved_root.get().map(|root| {
+        if root.as_ref().is_empty() {
+            return location.clone();
+        }
+        root.parts().chain(location.parts()).collect()
+    })
+}
+
 impl std::fmt::Display for CachedObjectStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -736,8 +740,26 @@ impl ObjectStore for CachedObjectStore {
         &self,
         locations: BoxStream<'static, object_store::Result<Path>>,
     ) -> BoxStream<'static, object_store::Result<Path>> {
-        // TODO: handle cache eviction
-        self.object_store.delete_stream(locations)
+        let resolved_root = self.resolved_root.clone();
+        let cache_storage = self.cache_storage.clone();
+        let part_size_bytes = self.part_size_bytes;
+
+        self.object_store
+            .delete_stream(locations)
+            .then(move |result| {
+                let resolved_root = resolved_root.clone();
+                let cache_storage = cache_storage.clone();
+                async move {
+                    if let Ok(ref location) = result {
+                        if let Some(cache_location) = cache_location_for(&resolved_root, location) {
+                            let entry = cache_storage.entry(&cache_location, part_size_bytes);
+                            entry.delete().await;
+                        }
+                    }
+                    result
+                }
+            })
+            .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -806,6 +828,7 @@ impl From<GetRange> for GetRangeKey {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use bytes::Bytes;
     use object_store::{path::Path, GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
@@ -1981,5 +2004,82 @@ mod tests {
         assert!(result.is_ok());
         let bytes = result.unwrap().bytes().await.unwrap();
         assert_eq!(&bytes[..], &payload[..512]);
+    }
+
+    #[rstest::rstest]
+    #[case::no_evictor(false)]
+    #[case::with_evictor(true)]
+    #[tokio::test]
+    async fn test_delete(#[case] evictor: bool) {
+        const PART_SIZE: usize = 1024;
+
+        let location1 = Path::from("/data/testfile1");
+        let location2 = Path::from("/data/testfile2");
+
+        let test_cache_folder = new_test_cache_folder();
+        let payload = gen_rand_bytes(1024 * 3);
+        let object_store = Arc::new(object_store::memory::InMemory::new());
+        let recorder = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
+
+        object_store
+            .put(&location1, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+        object_store
+            .put(&location2, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            test_cache_folder.clone(),
+            evictor.then_some(1024 * 1024),
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            1000,
+        ));
+
+        let cached_store =
+            CachedObjectStore::new(object_store, cache_storage, PART_SIZE, false, stats).unwrap();
+        cached_store.start_evictor().await;
+
+        cached_store.get(&location1).await.unwrap();
+        cached_store.get(&location2).await.unwrap();
+
+        let cache_location1 = cached_store.cache_location_for(&location1).unwrap();
+        let entry1 = cached_store
+            .cache_storage
+            .entry(&cache_location1, PART_SIZE);
+        let parts1 = entry1.cached_parts().await.unwrap();
+        assert_eq!(parts1.len(), 3, "{parts1:?}");
+
+        let cache_location2 = cached_store.cache_location_for(&location2).unwrap();
+        let entry2 = cached_store
+            .cache_storage
+            .entry(&cache_location2, PART_SIZE);
+        let parts2 = entry2.cached_parts().await.unwrap();
+        assert_eq!(parts2.len(), 3, "{parts2:?}");
+
+        cached_store.delete(&location1).await.unwrap();
+        if evictor {
+            // XXX: If evictor is running, deletion is performed asynchronously
+            //      from the evictor "thread".
+            tokio::time::sleep(Duration::from_secs(3)).await;
+        }
+
+        let entry1 = cached_store
+            .cache_storage
+            .entry(&cache_location1, PART_SIZE);
+        let parts1 = entry1.cached_parts().await.unwrap();
+        assert_eq!(parts1.len(), 0, "{parts1:?}");
+
+        let cache_location2 = cached_store.cache_location_for(&location2).unwrap();
+        let entry2 = cached_store
+            .cache_storage
+            .entry(&cache_location2, PART_SIZE);
+        let parts2 = entry2.cached_parts().await.unwrap();
+        assert_eq!(parts2.len(), 3, "{parts2:?}");
     }
 }

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -2056,8 +2056,14 @@ mod tests {
             1000,
         ));
 
-        let cached_store =
-            CachedObjectStore::new(object_store, cache_storage, PART_SIZE, false, stats).unwrap();
+        let cached_store = CachedObjectStore::new(
+            object_store,
+            Arc::clone(&cache_storage) as Arc<dyn LocalCacheStorage>,
+            PART_SIZE,
+            false,
+            stats,
+        )
+        .unwrap();
         cached_store.start_evictor().await;
 
         if cached {
@@ -2084,10 +2090,10 @@ mod tests {
         let parts1 = entry1.cached_parts().await.unwrap();
         if cached {
             assert_eq!(parts1.len(), 3, "{parts1:?}");
-            assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 6);
+            assert_eq!(cache_storage.file_handle_cache_population(), 6);
         } else {
             assert_eq!(parts1.len(), 0, "{parts1:?}");
-            assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 3);
+            assert_eq!(cache_storage.file_handle_cache_population(), 3);
         }
 
         let cache_location2 = cached_store.cache_location_for(&location2).unwrap();
@@ -2109,7 +2115,7 @@ mod tests {
             .entry(&cache_location1, PART_SIZE);
         let parts1 = entry1.cached_parts().await.unwrap();
         assert_eq!(parts1.len(), 0, "{parts1:?}");
-        assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 3);
+        assert_eq!(cache_storage.file_handle_cache_population(), 3);
 
         let cache_location2 = cached_store.cache_location_for(&location2).unwrap();
         let entry2 = cached_store
@@ -2125,6 +2131,6 @@ mod tests {
             .entry(&cache_location1, PART_SIZE);
         let parts1 = entry1.cached_parts().await.unwrap();
         assert_eq!(parts1.len(), 0, "{parts1:?}");
-        assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 3);
+        assert_eq!(cache_storage.file_handle_cache_population(), 3);
     }
 }

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -2020,17 +2020,19 @@ mod tests {
     }
 
     #[rstest::rstest]
-    #[case::no_evictor(false)]
-    #[case::with_evictor(true)]
+    #[case::no_evictor_cached(false, true)]
+    #[case::with_evictor_cached(true, true)]
+    #[case::no_evictor_uncached(false, false)]
+    #[case::with_evictor_uncached(true, false)]
     #[tokio::test]
-    async fn test_delete(#[case] evictor: bool) {
+    async fn test_delete(#[case] evictor: bool, #[case] cached: bool) {
         const PART_SIZE: usize = 1024;
 
         let location1 = Path::from("/data/testfile1");
         let location2 = Path::from("/data/testfile2");
 
         let test_cache_folder = new_test_cache_folder();
-        let payload = gen_rand_bytes(1024 * 3);
+        let payload = gen_rand_bytes(PART_SIZE * 3);
         let object_store = Arc::new(object_store::memory::InMemory::new());
         let recorder = MetricsRecorderHelper::noop();
         let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
@@ -2058,15 +2060,35 @@ mod tests {
             CachedObjectStore::new(object_store, cache_storage, PART_SIZE, false, stats).unwrap();
         cached_store.start_evictor().await;
 
-        cached_store.get(&location1).await.unwrap();
-        cached_store.get(&location2).await.unwrap();
+        if cached {
+            cached_store
+                .get(&location1)
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap();
+        }
+        cached_store
+            .get(&location2)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
 
         let cache_location1 = cached_store.cache_location_for(&location1).unwrap();
         let entry1 = cached_store
             .cache_storage
             .entry(&cache_location1, PART_SIZE);
         let parts1 = entry1.cached_parts().await.unwrap();
-        assert_eq!(parts1.len(), 3, "{parts1:?}");
+        if cached {
+            assert_eq!(parts1.len(), 3, "{parts1:?}");
+            assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 6);
+        } else {
+            assert_eq!(parts1.len(), 0, "{parts1:?}");
+            assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 3);
+        }
 
         let cache_location2 = cached_store.cache_location_for(&location2).unwrap();
         let entry2 = cached_store
@@ -2087,6 +2109,7 @@ mod tests {
             .entry(&cache_location1, PART_SIZE);
         let parts1 = entry1.cached_parts().await.unwrap();
         assert_eq!(parts1.len(), 0, "{parts1:?}");
+        assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 3);
 
         let cache_location2 = cached_store.cache_location_for(&location2).unwrap();
         let entry2 = cached_store
@@ -2094,5 +2117,14 @@ mod tests {
             .entry(&cache_location2, PART_SIZE);
         let parts2 = entry2.cached_parts().await.unwrap();
         assert_eq!(parts2.len(), 3, "{parts2:?}");
+
+        // verify repeated delete is idempotent
+        cached_store.delete(&location1).await.unwrap();
+        let entry1 = cached_store
+            .cache_storage
+            .entry(&cache_location1, PART_SIZE);
+        let parts1 = entry1.cached_parts().await.unwrap();
+        assert_eq!(parts1.len(), 0, "{parts1:?}");
+        assert_eq!(cached_store.cache_storage.file_handle_cache_population(), 3);
     }
 }

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -74,6 +74,9 @@ pub trait LocalCacheStorage: Send + Sync + std::fmt::Debug + Display + 'static {
     fn entry(&self, location: &Path, part_size: usize) -> Box<dyn LocalCacheEntry>;
 
     async fn start_evictor(&self);
+
+    #[cfg(test)]
+    fn file_handle_cache_population(&self) -> usize;
 }
 
 #[async_trait]

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -96,7 +96,7 @@ pub trait LocalCacheEntry: Send + Sync + std::fmt::Debug + 'static {
 
     async fn read_head(&self) -> object_store::Result<Option<(ObjectMeta, Attributes)>>;
 
-    /// Delete this cache entry from the associated cache on the best effort
+    /// Deletes this cache entry from the associated cache on the best effort
     /// basis. If some error happens during the deletion, it's logged instead
     /// of being reported to the caller.
     async fn delete(&self);

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -95,6 +95,11 @@ pub trait LocalCacheEntry: Send + Sync + std::fmt::Debug + 'static {
     async fn save_head(&self, meta: (&ObjectMeta, &Attributes)) -> object_store::Result<()>;
 
     async fn read_head(&self) -> object_store::Result<Option<(ObjectMeta, Attributes)>>;
+
+    /// Delete this cache entry from the associated cache on the best effort
+    /// basis. If some error happens during the deletion, it's logged instead
+    /// of being reported to the caller.
+    async fn delete(&self);
 }
 
 pub type PartID = usize;

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -74,9 +74,6 @@ pub trait LocalCacheStorage: Send + Sync + std::fmt::Debug + Display + 'static {
     fn entry(&self, location: &Path, part_size: usize) -> Box<dyn LocalCacheEntry>;
 
     async fn start_evictor(&self);
-
-    #[cfg(test)]
-    fn file_handle_cache_population(&self) -> usize;
 }
 
 #[async_trait]

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -2,7 +2,7 @@ use crate::cached_object_store::stats::CachedObjectStoreStats;
 use crate::rand::DbRand;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use log::{debug, warn};
+use log::{debug, error, warn};
 use lru::LruCache;
 use object_store::path::Path;
 use object_store::{Attributes, ObjectMeta};
@@ -236,7 +236,7 @@ impl FsCacheEntry {
             // If the evictor is backpressured, skip this cache write to avoid
             // stalling foreground PUTs. Cache writes are best-effort.
             if !evictor
-                .track_entry_accessed(path.clone(), buf.len(), true)
+                .track_entry_accessed(path.clone(), buf.len(), EntryAccess::Write)
                 .await
             {
                 return Ok(());
@@ -369,7 +369,7 @@ impl LocalCacheEntry for FsCacheEntry {
         if result.is_some() {
             if let Some(evictor) = &self.evictor {
                 evictor
-                    .track_entry_accessed(part_path, self.part_size, false)
+                    .track_entry_accessed(part_path, self.part_size, EntryAccess::Read)
                     .await;
             }
         }
@@ -495,7 +495,7 @@ impl LocalCacheEntry for FsCacheEntry {
             if let Some(evictor) = &self.evictor {
                 let head_path = Self::make_head_path(self.root_folder.clone(), &self.location);
                 evictor
-                    .track_entry_accessed(head_path, head_size_bytes, false)
+                    .track_entry_accessed(head_path, head_size_bytes, EntryAccess::Read)
                     .await;
             }
             Ok(Some((meta, attributes)))
@@ -503,9 +503,41 @@ impl LocalCacheEntry for FsCacheEntry {
             Ok(None)
         }
     }
+
+    async fn delete(&self) {
+        let Some(path) = Self::make_head_path(self.root_folder.clone(), &self.location)
+            .parent()
+            .map(std::path::PathBuf::from)
+        else {
+            error!(
+                "failed to obtain cache entry directory for {}",
+                self.location
+            );
+            return;
+        };
+
+        if let Some(evictor) = &self.evictor {
+            evictor
+                .track_entry_accessed(path, 0, EntryAccess::Delete)
+                .await;
+        } else {
+            let result = tokio::fs::remove_dir_all(path).await;
+            if let Err(e) = result {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    error!("failed to delete cache entry {}: {e:?}", self.location);
+                }
+            }
+        }
+    }
 }
 
-type FsCacheEvictorWork = (std::path::PathBuf, usize, bool);
+enum EntryAccess {
+    Read,
+    Write,
+    Delete,
+}
+
+type FsCacheEvictorWork = (std::path::PathBuf, usize, EntryAccess);
 // Minimum time between aggregated "evictor queue is full" warnings.
 const QUEUE_FULL_LOG_INTERVAL_MS: i64 = 30_000;
 
@@ -604,11 +636,21 @@ impl FsCacheEvictor {
     ) {
         loop {
             match rx.recv().await {
-                Some((path, bytes, evict)) => {
-                    inner
-                        .track_entry_accessed(path, bytes, system_clock.now(), evict)
-                        .await;
-                }
+                Some((path, bytes, access)) => match access {
+                    EntryAccess::Read => {
+                        inner
+                            .track_entry_accessed(path, bytes, system_clock.now(), false)
+                            .await;
+                    }
+                    EntryAccess::Write => {
+                        inner
+                            .track_entry_accessed(path, bytes, system_clock.now(), true)
+                            .await;
+                    }
+                    EntryAccess::Delete => {
+                        inner.delete_entry(path).await;
+                    }
+                },
                 None => return,
             }
         }
@@ -637,13 +679,13 @@ impl FsCacheEvictor {
         &self,
         path: std::path::PathBuf,
         bytes: usize,
-        evict: bool,
+        access: EntryAccess,
     ) -> bool {
         if !self.started() {
             return true;
         }
 
-        match self.tx.try_send((path, bytes, evict)) {
+        match self.tx.try_send((path, bytes, access)) {
             Ok(()) => true,
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 self.queue_full_count.fetch_add(1, Ordering::AcqRel);
@@ -679,6 +721,22 @@ struct CacheEntry {
 struct CacheState {
     entries: HashMap<std::path::PathBuf, CacheEntry>,
     keys: Vec<std::path::PathBuf>,
+}
+
+impl CacheState {
+    fn remove_entry(&mut self, path: &std::path::PathBuf) -> Option<CacheEntry> {
+        let removed = self.entries.remove(path);
+        if let Some(removed) = &removed {
+            self.keys.swap_remove(removed.key_index);
+            if removed.key_index < self.keys.len() {
+                let swapped_key = self.keys[removed.key_index].clone();
+                if let Some(swapped) = self.entries.get_mut(&swapped_key) {
+                    swapped.key_index = removed.key_index;
+                }
+            }
+        }
+        removed
+    }
 }
 
 /// FsCacheEvictorInner manages the cache entries in `CacheState`, and evict the cache entries
@@ -884,14 +942,7 @@ impl FsCacheEvictorInner {
             let mut total_bytes: usize = 0;
 
             for (target, target_bytes) in deleted_targets.iter() {
-                if let Some(removed) = cache_state.entries.remove(target) {
-                    cache_state.keys.swap_remove(removed.key_index);
-                    if removed.key_index < cache_state.keys.len() {
-                        let swapped_key = cache_state.keys[removed.key_index].clone();
-                        if let Some(swapped) = cache_state.entries.get_mut(&swapped_key) {
-                            swapped.key_index = removed.key_index;
-                        }
-                    }
+                if cache_state.remove_entry(target).is_some() {
                     self.cache_size_bytes
                         .fetch_sub(*target_bytes as u64, Ordering::SeqCst);
                     total_bytes += target_bytes;
@@ -914,6 +965,90 @@ impl FsCacheEvictorInner {
             .set(self.cache_size_bytes.load(Ordering::Relaxed) as i64);
 
         total_evicted_bytes
+    }
+
+    async fn delete_entry(&self, path: std::path::PathBuf) {
+        let file_handle_cache = self.file_handle_cache.clone();
+        // Run deletion as a single blocking task rather than jumping back and
+        // forth to the same blocking thread pool tokio uses under the hood.
+        #[allow(clippy::disallowed_methods)]
+        let result = tokio::task::spawn_blocking(move || {
+            let result = std::fs::read_dir(&path);
+            match result {
+                Ok(read_dir) => {
+                    let mut deleted_entries = Vec::with_capacity(32);
+
+                    // Delete the head and the parts.
+                    for entry in read_dir {
+                        match entry {
+                            Ok(entry) => {
+                                let entry_path = entry.path();
+                                let result = std::fs::remove_file(&entry_path);
+                                match result {
+                                    Ok(()) => {
+                                        file_handle_cache.invalidate(&entry_path);
+                                        deleted_entries.push(entry_path);
+                                    }
+                                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                        file_handle_cache.invalidate(&entry_path);
+                                        deleted_entries.push(entry_path);
+                                    }
+                                    Err(e) => {
+                                        error!("evictor failed to delete {entry_path:?}: {e:?}");
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error!("evictor failed to iterate read_dir {path:?}: {e:?}");
+                                continue;
+                            }
+                        }
+                    }
+
+                    // Delete the entry directory itself.
+                    let result = std::fs::remove_dir(&path);
+                    if let Err(e) = result {
+                        if e.kind() != std::io::ErrorKind::NotFound {
+                            error!("evictor failed to delete {path:?}: {e:?}");
+                        }
+                    }
+
+                    deleted_entries
+                }
+                Err(e) => {
+                    error!("evictor failed to read_dir {path:?}: {e:?}");
+                    vec![]
+                }
+            }
+        })
+        .await;
+        let deleted_entries = match result {
+            Ok(deleted_entries) => deleted_entries,
+            Err(e) => {
+                error!("evictor failed to join deletion task: {e:?}");
+                return;
+            }
+        };
+
+        let _track_guard = self.track_lock.lock().await;
+
+        // Untrack the deleted entries.
+        let entry_count = {
+            let mut cache_state = self.cache_state.lock().await;
+            for deleted_entry in deleted_entries {
+                if let Some(removed) = cache_state.remove_entry(&deleted_entry) {
+                    self.cache_size_bytes
+                        .fetch_sub(removed.size_bytes as u64, Ordering::SeqCst);
+                }
+            }
+            cache_state.entries.len()
+        };
+
+        // Update the stats.
+        self.stats.object_store_cache_keys.set(entry_count as i64);
+        self.stats
+            .object_store_cache_bytes
+            .set(self.cache_size_bytes.load(Ordering::Relaxed) as i64);
     }
 
     /// Pick multiple eviction targets in a single pass using pick-of-2 strategy, which is an approximation
@@ -1111,13 +1246,17 @@ mod tests {
 
         for idx in 0..100 {
             let accepted = evictor
-                .track_entry_accessed(std::path::PathBuf::from(format!("file{idx}")), 1, true)
+                .track_entry_accessed(
+                    std::path::PathBuf::from(format!("file{idx}")),
+                    1,
+                    EntryAccess::Write,
+                )
                 .await;
             assert!(accepted);
         }
 
         let accepted = evictor
-            .track_entry_accessed(std::path::PathBuf::from("overflow"), 1, true)
+            .track_entry_accessed(std::path::PathBuf::from("overflow"), 1, EntryAccess::Write)
             .await;
         assert!(!accepted);
     }

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -521,12 +521,7 @@ impl LocalCacheEntry for FsCacheEntry {
                 .track_entry_accessed(path, 0, EntryAccess::Delete)
                 .await;
         } else {
-            let result = tokio::fs::remove_dir_all(path).await;
-            if let Err(e) = result {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    error!("failed to delete cache entry {}: {e:?}", self.location);
-                }
-            }
+            delete_cache_entry(path, self.file_handle_cache.clone()).await;
         }
     }
 }
@@ -968,67 +963,10 @@ impl FsCacheEvictorInner {
     }
 
     async fn delete_entry(&self, path: std::path::PathBuf) {
-        let file_handle_cache = self.file_handle_cache.clone();
-        // Run deletion as a single blocking task rather than jumping back and
-        // forth to the same blocking thread pool tokio uses under the hood.
-        #[allow(clippy::disallowed_methods)]
-        let result = tokio::task::spawn_blocking(move || {
-            let result = std::fs::read_dir(&path);
-            match result {
-                Ok(read_dir) => {
-                    let mut deleted_entries = Vec::with_capacity(32);
-
-                    // Delete the head and the parts.
-                    for entry in read_dir {
-                        match entry {
-                            Ok(entry) => {
-                                let entry_path = entry.path();
-                                let result = std::fs::remove_file(&entry_path);
-                                match result {
-                                    Ok(()) => {
-                                        file_handle_cache.invalidate(&entry_path);
-                                        deleted_entries.push(entry_path);
-                                    }
-                                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                                        file_handle_cache.invalidate(&entry_path);
-                                        deleted_entries.push(entry_path);
-                                    }
-                                    Err(e) => {
-                                        error!("evictor failed to delete {entry_path:?}: {e:?}");
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                error!("evictor failed to iterate read_dir {path:?}: {e:?}");
-                                continue;
-                            }
-                        }
-                    }
-
-                    // Delete the entry directory itself.
-                    let result = std::fs::remove_dir(&path);
-                    if let Err(e) = result {
-                        if e.kind() != std::io::ErrorKind::NotFound {
-                            error!("evictor failed to delete {path:?}: {e:?}");
-                        }
-                    }
-
-                    deleted_entries
-                }
-                Err(e) => {
-                    error!("evictor failed to read_dir {path:?}: {e:?}");
-                    vec![]
-                }
-            }
-        })
-        .await;
-        let deleted_entries = match result {
-            Ok(deleted_entries) => deleted_entries,
-            Err(e) => {
-                error!("evictor failed to join deletion task: {e:?}");
-                return;
-            }
-        };
+        let deleted_entries = delete_cache_entry(path, self.file_handle_cache.clone()).await;
+        if deleted_entries.is_empty() {
+            return;
+        }
 
         let _track_guard = self.track_lock.lock().await;
 
@@ -1158,6 +1096,70 @@ fn wrap_io_err(err: impl std::error::Error + Send + Sync + 'static) -> object_st
         store: "cached_object_store",
         source: Box::new(err),
     }
+}
+
+async fn delete_cache_entry(
+    path: std::path::PathBuf,
+    file_handle_cache: FileHandleCache,
+) -> Vec<std::path::PathBuf> {
+    // Run deletion as a single blocking task rather than jumping back and
+    // forth to the same blocking thread pool tokio uses under the hood.
+    #[allow(clippy::disallowed_methods)]
+    let result = tokio::task::spawn_blocking(move || {
+        let result = std::fs::read_dir(&path);
+        match result {
+            Ok(read_dir) => {
+                let mut deleted_entries = Vec::with_capacity(32);
+
+                // Delete the head and the parts.
+                for entry in read_dir {
+                    match entry {
+                        Ok(entry) => {
+                            let entry_path = entry.path();
+                            let result = std::fs::remove_file(&entry_path);
+                            match result {
+                                Ok(()) => {
+                                    file_handle_cache.invalidate(&entry_path);
+                                    deleted_entries.push(entry_path);
+                                }
+                                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                    file_handle_cache.invalidate(&entry_path);
+                                    deleted_entries.push(entry_path);
+                                }
+                                Err(e) => {
+                                    file_handle_cache.invalidate(&entry_path);
+                                    error!("FS cache failed to delete {entry_path:?}: {e:?}");
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            error!("FS cache failed to iterate read_dir {path:?}: {e:?}");
+                            continue;
+                        }
+                    }
+                }
+
+                // Delete the entry directory itself.
+                let result = std::fs::remove_dir(&path);
+                if let Err(e) = result {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        error!("FS cache failed to delete {path:?}: {e:?}");
+                    }
+                }
+
+                deleted_entries
+            }
+            Err(e) => {
+                error!("FS cache failed to read_dir {path:?}: {e:?}");
+                vec![]
+            }
+        }
+    })
+    .await;
+    result.unwrap_or_else(|e| {
+        error!("FS cache failed to join deletion task: {e:?}");
+        vec![]
+    })
 }
 
 #[cfg(test)]

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -185,6 +185,11 @@ impl FsCacheStorage {
             file_handle_cache,
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn file_handle_cache_population(&self) -> usize {
+        self.file_handle_cache.inner.lock().unwrap().len()
+    }
 }
 
 #[async_trait::async_trait]
@@ -208,11 +213,6 @@ impl LocalCacheStorage for FsCacheStorage {
         if let Some(evictor) = &self.evictor {
             evictor.start().await
         }
-    }
-
-    #[cfg(test)]
-    fn file_handle_cache_population(&self) -> usize {
-        self.file_handle_cache.inner.lock().unwrap().len()
     }
 }
 

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -209,6 +209,11 @@ impl LocalCacheStorage for FsCacheStorage {
             evictor.start().await
         }
     }
+
+    #[cfg(test)]
+    fn file_handle_cache_population(&self) -> usize {
+        self.file_handle_cache.inner.lock().unwrap().len()
+    }
 }
 
 impl Display for FsCacheStorage {

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -241,7 +241,7 @@ impl FsCacheEntry {
             // If the evictor is backpressured, skip this cache write to avoid
             // stalling foreground PUTs. Cache writes are best-effort.
             if !evictor
-                .track_entry_accessed(path.clone(), buf.len(), EntryAccess::Write)
+                .track_entry_accessed(path.clone(), EntryAccess::Write(buf.len()))
                 .await
             {
                 return Ok(());
@@ -374,7 +374,7 @@ impl LocalCacheEntry for FsCacheEntry {
         if result.is_some() {
             if let Some(evictor) = &self.evictor {
                 evictor
-                    .track_entry_accessed(part_path, self.part_size, EntryAccess::Read)
+                    .track_entry_accessed(part_path, EntryAccess::Read(self.part_size))
                     .await;
             }
         }
@@ -500,7 +500,7 @@ impl LocalCacheEntry for FsCacheEntry {
             if let Some(evictor) = &self.evictor {
                 let head_path = Self::make_head_path(self.root_folder.clone(), &self.location);
                 evictor
-                    .track_entry_accessed(head_path, head_size_bytes, EntryAccess::Read)
+                    .track_entry_accessed(head_path, EntryAccess::Read(head_size_bytes))
                     .await;
             }
             Ok(Some((meta, attributes)))
@@ -523,7 +523,7 @@ impl LocalCacheEntry for FsCacheEntry {
 
         if let Some(evictor) = &self.evictor {
             evictor
-                .track_entry_accessed(path, 0, EntryAccess::Delete)
+                .track_entry_accessed(path, EntryAccess::Delete)
                 .await;
         } else {
             delete_cache_entry(path, self.file_handle_cache.clone()).await;
@@ -532,12 +532,12 @@ impl LocalCacheEntry for FsCacheEntry {
 }
 
 enum EntryAccess {
-    Read,
-    Write,
+    Read(usize),
+    Write(usize),
     Delete,
 }
 
-type FsCacheEvictorWork = (std::path::PathBuf, usize, EntryAccess);
+type FsCacheEvictorWork = (std::path::PathBuf, EntryAccess);
 // Minimum time between aggregated "evictor queue is full" warnings.
 const QUEUE_FULL_LOG_INTERVAL_MS: i64 = 30_000;
 
@@ -636,13 +636,13 @@ impl FsCacheEvictor {
     ) {
         loop {
             match rx.recv().await {
-                Some((path, bytes, access)) => match access {
-                    EntryAccess::Read => {
+                Some((path, access)) => match access {
+                    EntryAccess::Read(bytes) => {
                         inner
                             .track_entry_accessed(path, bytes, system_clock.now(), false)
                             .await;
                     }
-                    EntryAccess::Write => {
+                    EntryAccess::Write(bytes) => {
                         inner
                             .track_entry_accessed(path, bytes, system_clock.now(), true)
                             .await;
@@ -675,17 +675,12 @@ impl FsCacheEvictor {
     // sender and receiver. It doesn't close the channel, and both sender and receiver are dropped
     // when the evictor is dropped.
     #[allow(clippy::disallowed_methods)]
-    async fn track_entry_accessed(
-        &self,
-        path: std::path::PathBuf,
-        bytes: usize,
-        access: EntryAccess,
-    ) -> bool {
+    async fn track_entry_accessed(&self, path: std::path::PathBuf, access: EntryAccess) -> bool {
         if !self.started() {
             return true;
         }
 
-        match self.tx.try_send((path, bytes, access)) {
+        match self.tx.try_send((path, access)) {
             Ok(()) => true,
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 self.queue_full_count.fetch_add(1, Ordering::AcqRel);
@@ -1255,15 +1250,14 @@ mod tests {
             let accepted = evictor
                 .track_entry_accessed(
                     std::path::PathBuf::from(format!("file{idx}")),
-                    1,
-                    EntryAccess::Write,
+                    EntryAccess::Write(1),
                 )
                 .await;
             assert!(accepted);
         }
 
         let accepted = evictor
-            .track_entry_accessed(std::path::PathBuf::from("overflow"), 1, EntryAccess::Write)
+            .track_entry_accessed(std::path::PathBuf::from("overflow"), EntryAccess::Write(1))
             .await;
         assert!(!accepted);
     }


### PR DESCRIPTION
This PR fixes an old TODO in `CachedObjectStore` by deleting the associated
file cache entries when an object is deleted from the object store. This
reduces the stress on the evictor if it is on. If the evictor is off, this
maintains a healthy file cache free from entries that will never be used
again.