### PR TITLE
Update l0 count metric for segments

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8826,6 +8826,76 @@ mod tests {
             "expected l0_sst_count > 0, got {:?}",
             l0_count
         );
+        // No segment extractor configured → root is the only tree, so the
+        // per-tree max equals the total. Both gauges are updated at the
+        // same call site in `merge_remote_manifest`.
+        let segment_max =
+            lookup_metric(&metrics_recorder, crate::db_stats::SEGMENT_MAX_L0_SST_COUNT);
+        assert_eq!(
+            segment_max, l0_count,
+            "expected segment_max_l0_sst_count == l0_sst_count for an unsegmented DB"
+        );
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_should_record_segment_max_l0_sst_count_with_extractor() {
+        // With a segment extractor configured, `l0_sst_count` sums L0 SSTs
+        // across every tree (root + each named segment) while
+        // `segment_max_l0_sst_count` reports the largest single tree. The
+        // two values diverge whenever segments accumulate L0 SSTs unevenly
+        // — the case the new gauge exists to catch, since `l0_max_ssts`
+        // backpressure is enforced per-tree.
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let extractor = Arc::new(test_utils::FixedThreeBytePrefixExtractor);
+        let db = Db::builder(
+            "/tmp/test_should_record_segment_max_l0_sst_count_with_extractor",
+            object_store,
+        )
+        .with_settings(test_db_options(0, 1024, None))
+        .with_segment_extractor(extractor)
+        .with_metrics_recorder(metrics_recorder.clone())
+        .build()
+        .await
+        .unwrap();
+
+        // Flush 1: two prefixes → each segment tree gets one L0 SST.
+        db.put(b"aaa-1", b"v").await.unwrap();
+        db.put(b"bbb-1", b"v").await.unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // Flush 2: only "aaa" → that tree grows to 2 L0 SSTs while "bbb"
+        // stays at 1. Final state: total = 3, per-tree max = 2.
+        db.put(b"aaa-2", b"v").await.unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // Wait for the manifest poll to refresh both gauges (interval 100ms).
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let total = lookup_metric(&metrics_recorder, crate::db_stats::L0_SST_COUNT);
+        let segment_max =
+            lookup_metric(&metrics_recorder, crate::db_stats::SEGMENT_MAX_L0_SST_COUNT);
+        assert_eq!(
+            total,
+            Some(3),
+            "expected l0_sst_count to sum across trees, got {:?}",
+            total
+        );
+        assert_eq!(
+            segment_max,
+            Some(2),
+            "expected segment_max_l0_sst_count to track the largest tree, got {:?}",
+            segment_max
+        );
         db.close().await.unwrap();
     }
 

--- a/slatedb/src/db_stats.rs
+++ b/slatedb/src/db_stats.rs
@@ -24,6 +24,7 @@ pub const WAL_BUFFER_FLUSH_REQUESTS: &str = db_stat_name!("wal_buffer_flush_requ
 pub const WAL_BUFFER_ESTIMATED_BYTES: &str = db_stat_name!("wal_buffer_estimated_bytes");
 pub const TOTAL_MEM_SIZE_BYTES: &str = db_stat_name!("total_mem_size_bytes");
 pub const L0_SST_COUNT: &str = db_stat_name!("l0_sst_count");
+pub const SEGMENT_MAX_L0_SST_COUNT: &str = db_stat_name!("segment_max_l0_sst_count");
 pub const L0_FLUSH_BYTES: &str = db_stat_name!("l0_flush_bytes");
 pub const SST_FILTER_FALSE_POSITIVE_COUNT: &str = db_stat_name!("sst_filter_false_positive_count");
 pub const SST_FILTER_POSITIVE_COUNT: &str = db_stat_name!("sst_filter_positive_count");
@@ -55,6 +56,7 @@ pub(crate) struct DbStatsInner {
     pub(crate) write_ops: Arc<dyn CounterFn>,
     pub(crate) total_mem_size_bytes: Arc<dyn GaugeFn>,
     pub(crate) l0_sst_count: Arc<dyn GaugeFn>,
+    pub(crate) segment_max_l0_sst_count: Arc<dyn GaugeFn>,
     pub(crate) l0_flush_bytes: Arc<dyn CounterFn>,
     pub(crate) merge_operator_read_operands: Arc<dyn CounterFn>,
     pub(crate) merge_operator_flush_operands: Arc<dyn CounterFn>,
@@ -122,6 +124,7 @@ impl DbStats {
             write_ops: recorder.counter(WRITE_OPS).register(),
             total_mem_size_bytes: recorder.gauge(TOTAL_MEM_SIZE_BYTES).register(),
             l0_sst_count: recorder.gauge(L0_SST_COUNT).register(),
+            segment_max_l0_sst_count: recorder.gauge(SEGMENT_MAX_L0_SST_COUNT).register(),
             l0_flush_bytes: recorder.counter(L0_FLUSH_BYTES).register(),
             merge_operator_read_operands: recorder
                 .counter(MERGE_OPERATOR_OPERANDS)

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -617,10 +617,17 @@ impl ManifestWriterHandler {
             let mut wguard_state = self.db.state.write();
             wguard_state.merge_remote_manifest(remote_dirty);
             let cow = wguard_state.state();
-            self.db
-                .db_stats
-                .l0_sst_count
-                .set(cow.core().tree.l0.len() as i64);
+            // L0 SST counters span every tree (root + each named segment per
+            // RFC-0024). `l0_sst_count` reports the total; `segment_max_*`
+            // reports the largest single tree, which is the right quantity
+            // for backpressure since `l0_max_ssts` is enforced per-tree.
+            let (total, max) = cow
+                .core()
+                .trees()
+                .map(|t| t.l0.len())
+                .fold((0usize, 0usize), |(sum, max), n| (sum + n, max.max(n)));
+            self.db.db_stats.l0_sst_count.set(total as i64);
+            self.db.db_stats.segment_max_l0_sst_count.set(max as i64);
             cow.manifest.clone()
         };
         self.db

--- a/website/src/content/docs/docs/operations/metrics.mdx
+++ b/website/src/content/docs/docs/operations/metrics.mdx
@@ -86,7 +86,8 @@ All metric names use dot-separated notation: `slatedb.<subsystem>.<metric>`.
 | `slatedb.db.wal_buffer_flush_requests` | counter | | WAL buffer flush requests |
 | `slatedb.db.wal_buffer_estimated_bytes` | gauge | | Estimated WAL buffer size |
 | `slatedb.db.total_mem_size_bytes` | gauge | | Total memory usage |
-| `slatedb.db.l0_sst_count` | gauge | | L0 SST count |
+| `slatedb.db.l0_sst_count` | gauge | | L0 SST count summed across all segment trees |
+| `slatedb.db.segment_max_l0_sst_count` | gauge | | Maximum L0 SST count across all segments (useful for detecting backpressure on specific segments) |
 | `slatedb.db.sst_filter_false_positive_count` | counter | | Bloom filter false positives |
 | `slatedb.db.sst_filter_positive_count` | counter | | Bloom filter positives |
 | `slatedb.db.sst_filter_negative_count` | counter | | Bloom filter negatives |


### PR DESCRIPTION
As described in #1662, the `l0_sst_count` currently only considers the default tree. This patch does the following:
- updated `l0_sst_count` to sum l0s across all segments
- added `segment_max_l0_sst_count` to provide the max count across all segments (useful for detecting backpressure)

Thank you for the review! 🙏
