### PR TITLE
Retain WAL fences for a configurable time

### DIFF
--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -1879,14 +1879,12 @@ func TestWalReaderMetadataAndRows(t *testing.T) {
 	}
 
 	var allRows []slatedb.RowEntry
+	nonEmptyFiles := 0
 
 	for i, file := range files {
 		metadata, err := file.Metadata()
 		if err != nil {
 			t.Fatalf("WalFile.Metadata() for file %d: %v", i, err)
-		}
-		if metadata.SizeBytes == 0 {
-			t.Fatalf("WalFile.Metadata() for file %d: SizeBytes = 0", i)
 		}
 		if metadata.Location == "" {
 			t.Fatalf("WalFile.Metadata() for file %d: Location is empty", i)
@@ -1899,12 +1897,24 @@ func TestWalReaderMetadataAndRows(t *testing.T) {
 		t.Cleanup(iter.Destroy)
 
 		rows := drainWalIterator(t, iter)
+		if metadata.SizeBytes == 0 {
+			if len(rows) != 0 {
+				t.Fatalf("zero-byte WAL file %d returned %d rows, want 0", i, len(rows))
+			}
+			continue
+		}
+		nonEmptyFiles++
+
 		for j, row := range rows {
 			if row.Seq == 0 {
 				t.Fatalf("row %d in file %d: Seq = 0", j, i)
 			}
 		}
 		allRows = append(allRows, rows...)
+	}
+
+	if nonEmptyFiles == 0 {
+		t.Fatal("no non-empty WAL files found")
 	}
 
 	if len(allRows) != 4 {

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbWalReaderTest.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbWalReaderTest.java
@@ -82,14 +82,20 @@ class SlateDbWalReaderTest {
                     assertTrue(files.size() >= 3);
 
                     List<RowEntry> allRows = new ArrayList<>();
+                    int nonEmptyFiles = 0;
                     for (WalFile file : files) {
                         WalFileMetadata metadata = TestSupport.await(file.metadata());
                         assertNotNull(metadata);
-                        assertTrue(metadata.sizeBytes() > 0);
                         assertFalse(metadata.location().isEmpty());
 
                         try (WalFileIterator iterator = TestSupport.await(file.iterator())) {
                             List<RowEntry> rows = TestSupport.drainWalIterator(iterator);
+                            if (metadata.sizeBytes() == 0) {
+                                assertTrue(rows.isEmpty());
+                                continue;
+                            }
+
+                            nonEmptyFiles++;
                             for (RowEntry row : rows) {
                                 assertTrue(row.seq() > 0);
                             }
@@ -97,6 +103,7 @@ class SlateDbWalReaderTest {
                         }
                     }
 
+                    assertTrue(nonEmptyFiles > 0);
                     assertEquals(4, allRows.size());
                     TestSupport.assertWalRow(allRows.get(0), RowEntryKind.VALUE, "a", "1");
                     TestSupport.assertWalRow(allRows.get(1), RowEntryKind.VALUE, "b", "2");

--- a/bindings/node/tests/wal-reader.test.mjs
+++ b/bindings/node/tests/wal-reader.test.mjs
@@ -62,19 +62,26 @@ test("wal reader metadata and row decoding", async (t) => {
   assert.ok(files.length >= 3);
 
   const allRows = [];
+  let nonEmptyFiles = 0;
   for (const walFile of files) {
     const metadata = await walFile.metadata();
-    assert.ok(BigInt(metadata.size_bytes) > 0n);
     assert.notEqual(metadata.location, "");
 
     const iterator = cleanup.track(await walFile.iterator());
     const rows = await drainWalIterator(iterator);
+    if (BigInt(metadata.size_bytes) === 0n) {
+      assert.deepEqual(rows, []);
+      continue;
+    }
+
+    nonEmptyFiles += 1;
     for (const row of rows) {
       assert.ok(BigInt(row.seq) > 0n);
     }
     allRows.push(...rows);
   }
 
+  assert.ok(nonEmptyFiles > 0);
   assert.equal(allRows.length, 4);
   requireWalRow(allRows[0], RowEntryKind.Value, "a", "1");
   requireWalRow(allRows[1], RowEntryKind.Value, "b", "2");

--- a/bindings/python/tests/test_wal_reader.py
+++ b/bindings/python/tests/test_wal_reader.py
@@ -53,15 +53,21 @@ async def test_wal_reader_metadata_and_row_decoding() -> None:
     assert len(files) >= 3
 
     all_rows = []
+    non_empty_files = 0
     for wal_file in files:
         metadata = await wal_file.metadata()
-        assert metadata.size_bytes > 0
         assert metadata.location
 
         rows = await drain_wal_iterator(await wal_file.iterator())
+        if metadata.size_bytes == 0:
+            assert rows == []
+            continue
+
+        non_empty_files += 1
         assert all(row.seq > 0 for row in rows)
         all_rows.extend(rows)
 
+    assert non_empty_files > 0
     assert len(all_rows) == 4
     require_wal_row(all_rows[0], RowEntryKind.VALUE, "a", "1")
     require_wal_row(all_rows[1], RowEntryKind.VALUE, "b", "2")

--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -138,7 +138,7 @@ pub(crate) enum CliCommands {
 
     /// Runs a garbage collection for a specific resource type once
     RunGarbageCollection {
-        /// the type of resource to clean up (manifest, wal, compacted, compactions)
+        /// the type of resource to clean up (manifest, wal, wal-fence, compacted, compactions)
         #[arg(short, long)]
         resource: GcResource,
 
@@ -206,7 +206,7 @@ pub(crate) enum CliCommands {
     /// Schedules a period garbage collection job
     #[command(group(
         ArgGroup::new("gc_config")
-            .args(["manifest", "wal", "compacted", "compactions"])
+            .args(["manifest", "wal", "wal_fence", "compacted", "compactions"])
             .multiple(true)
             .required(true)
     ))]
@@ -224,6 +224,13 @@ pub(crate) enum CliCommands {
         /// the period is how often to attempt a GC
         #[arg(long, value_parser = parse_gc_schedule)]
         wal: Option<GcSchedule>,
+
+        /// Configuration for WAL fence garbage collection should be set in the
+        /// format min_age=<duration>,period=<duration> -- the min_age is the
+        /// minimum WAL fence age that should be considered for collection and
+        /// the period is how often to attempt a GC
+        #[arg(long, value_parser = parse_gc_schedule)]
+        wal_fence: Option<GcSchedule>,
 
         /// Configuration for compacted SST garbage collection should be set in the
         /// format min_age=<duration>,period=<duration> -- the min_age is the
@@ -245,6 +252,7 @@ pub(crate) enum CliCommands {
 pub(crate) enum GcResource {
     Manifest,
     Wal,
+    WalFence,
     Compacted,
     Compactions,
 }
@@ -304,7 +312,8 @@ fn parse_find_option(s: &str) -> Result<FindOption, String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::args::parse_gc_schedule;
+    use super::{parse_gc_schedule, CliArgs, CliCommands, GcResource};
+    use clap::Parser;
     use rstest::rstest;
     use std::time::Duration;
 
@@ -360,6 +369,53 @@ mod tests {
             }
             // Any unexpected combination fails the test
             result => panic!("Unexpected test case result. {:?}", result),
+        }
+    }
+
+    #[test]
+    fn parses_wal_fence_gc_resource() {
+        let args = CliArgs::try_parse_from([
+            "slatedb",
+            "--path",
+            "/tmp/slatedb",
+            "run-garbage-collection",
+            "--resource",
+            "wal-fence",
+            "--min-age",
+            "1m",
+        ])
+        .unwrap();
+
+        match args.command {
+            CliCommands::RunGarbageCollection { resource, min_age } => {
+                assert!(matches!(resource, GcResource::WalFence));
+                assert_eq!(min_age, Duration::from_secs(60));
+            }
+            command => panic!("unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_wal_fence_gc_schedule() {
+        let args = CliArgs::try_parse_from([
+            "slatedb",
+            "--path",
+            "/tmp/slatedb",
+            "schedule-garbage-collection",
+            "--wal-fence",
+            "min_age=10m,period=1m",
+        ])
+        .unwrap();
+
+        match args.command {
+            CliCommands::ScheduleGarbageCollection {
+                wal_fence: Some(schedule),
+                ..
+            } => {
+                assert_eq!(schedule.min_age, Duration::from_secs(600));
+                assert_eq!(schedule.period, Duration::from_secs(60));
+            }
+            command => panic!("unexpected command: {command:?}"),
         }
     }
 }

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -72,9 +72,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         CliCommands::ScheduleGarbageCollection {
             manifest,
             wal,
+            wal_fence,
             compacted,
             compactions,
-        } => schedule_gc(&admin, manifest, wal, compacted, compactions).await?,
+        } => schedule_gc(&admin, manifest, wal, wal_fence, compacted, compactions).await?,
         CliCommands::SubmitCompaction { scheduler, request } => {
             exec_submit_compaction(&admin, scheduler, request).await?
         }
@@ -265,6 +266,14 @@ async fn exec_gc_once(
             compactions_options: None,
             detach_options: None,
         },
+        GcResource::WalFence => GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: None,
+            wal_fence_options: create_gc_dir_opts(min_age),
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+        },
         GcResource::Compacted => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: None,
@@ -290,6 +299,7 @@ async fn schedule_gc(
     admin: &Admin,
     manifest_schedule: Option<GcSchedule>,
     wal_schedule: Option<GcSchedule>,
+    wal_fence_schedule: Option<GcSchedule>,
     compacted_schedule: Option<GcSchedule>,
     compactions_schedule: Option<GcSchedule>,
 ) -> Result<(), Box<dyn Error>> {
@@ -302,7 +312,7 @@ async fn schedule_gc(
     let gc_opts = GarbageCollectorOptions {
         manifest_options: manifest_schedule.and_then(create_gc_dir_opts),
         wal_options: wal_schedule.and_then(create_gc_dir_opts),
-        wal_fence_options: None,
+        wal_fence_options: wal_fence_schedule.and_then(create_gc_dir_opts),
         compacted_options: compacted_schedule.and_then(create_gc_dir_opts),
         compactions_options: compactions_schedule.and_then(create_gc_dir_opts),
         detach_options: None,

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -252,6 +252,7 @@ async fn exec_gc_once(
         GcResource::Manifest => GarbageCollectorOptions {
             manifest_options: create_gc_dir_opts(min_age),
             wal_options: None,
+            wal_fence_options: None,
             compacted_options: None,
             compactions_options: None,
             detach_options: None,
@@ -259,6 +260,7 @@ async fn exec_gc_once(
         GcResource::Wal => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: create_gc_dir_opts(min_age),
+            wal_fence_options: None,
             compacted_options: None,
             compactions_options: None,
             detach_options: None,
@@ -266,6 +268,7 @@ async fn exec_gc_once(
         GcResource::Compacted => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: None,
+            wal_fence_options: None,
             compacted_options: create_gc_dir_opts(min_age),
             compactions_options: None,
             detach_options: None,
@@ -273,6 +276,7 @@ async fn exec_gc_once(
         GcResource::Compactions => GarbageCollectorOptions {
             manifest_options: None,
             wal_options: None,
+            wal_fence_options: None,
             compacted_options: None,
             compactions_options: create_gc_dir_opts(min_age),
             detach_options: None,
@@ -298,6 +302,7 @@ async fn schedule_gc(
     let gc_opts = GarbageCollectorOptions {
         manifest_options: manifest_schedule.and_then(create_gc_dir_opts),
         wal_options: wal_schedule.and_then(create_gc_dir_opts),
+        wal_fence_options: None,
         compacted_options: compacted_schedule.and_then(create_gc_dir_opts),
         compactions_options: compactions_schedule.and_then(create_gc_dir_opts),
         detach_options: None,

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -118,6 +118,7 @@ pub fn build_settings_gc(rng: &mut impl Rng) -> GarbageCollectorOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
             min_age: rng.random_range(Duration::from_millis(1)..Duration::from_secs(900)),
         }),
+        wal_fence_options: None,
         compacted_options: Some(GarbageCollectorDirectoryOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
             min_age: rng.random_range(Duration::from_millis(1)..Duration::from_secs(900)),

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1233,6 +1233,26 @@ pub struct GarbageCollectorOptions {
     /// None means garbage collection is disabled for the WAL directory.
     pub wal_options: Option<GarbageCollectorDirectoryOptions>,
 
+    /// Garbage collection options for zero-byte WAL fence objects.
+    ///
+    /// WARNING: Setting this to a non-None value can cause data loss if set
+    /// too aggressively. It's possible for the following scenario to occur:
+    ///
+    /// - t0: A writer W1 calculates position 7 for its next WAL entry
+    /// - t1: A writer W2 writes a fence at position 7
+    /// - t2: `min_age` + 1 passes
+    /// - t3: The garbage collector runs and deletes the fence at position 7
+    /// - t4: W1 writes its WAL entry at position 7 and returns success
+    ///
+    /// Because the fence at position 7 was deleted, W1's write will succeed,
+    /// but the data at position 7 is invalid. The only way to protect against
+    /// this scenario is to ensure fence writes are never deleted. In practice,
+    /// setting `min_age` to a very high number (longer than any writer is
+    /// expected to run) should be sufficient to prevent this scenario.
+    ///
+    /// None means garbage collection is disabled for WAL fence objects.
+    pub wal_fence_options: Option<GarbageCollectorDirectoryOptions>,
+
     /// Garbage collection options for the compacted directory.
     ///
     /// None means garbage collection is disabled for the compacted directory.
@@ -1258,6 +1278,7 @@ impl GarbageCollectorOptions {
     pub fn is_empty(&self) -> bool {
         self.manifest_options.is_none()
             && self.wal_options.is_none()
+            && self.wal_fence_options.is_none()
             && self.compacted_options.is_none()
             && self.compactions_options.is_none()
             && self.detach_options.is_none()
@@ -1322,6 +1343,7 @@ impl Default for GarbageCollectorScheduleOptions {
 /// By default, garbage collection is enabled for all managed directories
 /// (manifest, WAL, compacted SSTs, and compactions) using
 /// [`GarbageCollectorDirectoryOptions::default()`].
+/// WAL fence garbage collection is disabled by default.
 ///
 /// To disable garbage collection for a specific file type, set that
 /// directory option to `None`.
@@ -1330,6 +1352,7 @@ impl Default for GarbageCollectorOptions {
         Self {
             manifest_options: Some(GarbageCollectorDirectoryOptions::default()),
             wal_options: Some(GarbageCollectorDirectoryOptions::default()),
+            wal_fence_options: None,
             compacted_options: Some(GarbageCollectorDirectoryOptions::default()),
             compactions_options: Some(GarbageCollectorDirectoryOptions::default()),
             detach_options: Some(GarbageCollectorScheduleOptions::default()),

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1304,9 +1304,9 @@ pub struct GarbageCollectorDirectoryOptions {
     /// The interval at which the garbage collector will run in the background
     /// thread.
     ///
-    /// If set to None, recurring garbage collection will be disabled for the
-    /// directory, but one-time garbage collection can still be triggered
-    /// [`crate::garbage_collector::GarbageCollector::run_gc_once`].
+    /// If set to None while the parent directory options are enabled, recurring
+    /// garbage collection uses the default interval. To disable garbage
+    /// collection for a directory, set the parent `*_options` field to None.
     #[serde(deserialize_with = "deserialize_option_duration")]
     #[serde(serialize_with = "serialize_option_duration")]
     pub interval: Option<Duration>,
@@ -1322,9 +1322,9 @@ pub struct GarbageCollectorDirectoryOptions {
 pub struct GarbageCollectorScheduleOptions {
     /// The interval at which the task will run in the background thread.
     ///
-    /// If set to None, recurring execution is disabled, but a one-time pass
-    /// can still be triggered via
-    /// [`crate::garbage_collector::GarbageCollector::run_gc_once`].
+    /// If set to None while the parent task options are enabled, recurring
+    /// execution uses the default interval. To disable the task, set the parent
+    /// options field to None.
     #[serde(deserialize_with = "deserialize_option_duration")]
     #[serde(serialize_with = "serialize_option_duration")]
     pub interval: Option<Duration>,
@@ -1352,6 +1352,9 @@ impl Default for GarbageCollectorOptions {
         Self {
             manifest_options: Some(GarbageCollectorDirectoryOptions::default()),
             wal_options: Some(GarbageCollectorDirectoryOptions::default()),
+            // Disable WAL fence garbage collection by default to prevent accidental
+            // data loss. This is a very conservative setting. Users can enable it
+            // with a high `min_age` if they want to clean up old fences.
             wal_fence_options: None,
             compacted_options: Some(GarbageCollectorDirectoryOptions::default()),
             compactions_options: Some(GarbageCollectorDirectoryOptions::default()),

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3554,8 +3554,8 @@ mod tests {
             vec![
             ("tmp/test_kv_store_with_cache_stored_files/manifest/00000000000000000001.manifest", 0),
             ("tmp/test_kv_store_with_cache_stored_files/manifest/00000000000000000002.manifest", 0),
-            // 1 part is cached because of wal_replay after fencing (which reads the SST, thereby caching it)
-            ("tmp/test_kv_store_with_cache_stored_files/wal/00000000000000000001.sst", 1),
+            // The startup fence WAL is zero bytes, so replay does not cache any object parts.
+            ("tmp/test_kv_store_with_cache_stored_files/wal/00000000000000000001.sst", 0),
             ("tmp/test_kv_store_with_cache_stored_files/wal/00000000000000000002.sst", 0),
         ];
 
@@ -3577,8 +3577,8 @@ mod tests {
             // `cache_puts_enabled` starts taking effect.
             ("tmp/test_kv_store_with_put_cache_enabled/manifest/00000000000000000001.manifest", 0),
             ("tmp/test_kv_store_with_put_cache_enabled/manifest/00000000000000000002.manifest", 0),
-            // 1 part is cached because of wal_replay after fencing (which reads the SST, thereby caching it)
-            ("tmp/test_kv_store_with_put_cache_enabled/wal/00000000000000000001.sst", 1),
+            // The startup fence WAL is zero bytes, so replay does not cache any object parts.
+            ("tmp/test_kv_store_with_put_cache_enabled/wal/00000000000000000001.sst", 0),
             // 1 part is cached because the put with cache_puts enabled should cache the test_key put
             ("tmp/test_kv_store_with_put_cache_enabled/wal/00000000000000000002.sst", 1),
         ];
@@ -6091,6 +6091,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(db.inner.state.read().state().core().next_wal_sst_id, 2);
+        let wal_ssts = db.inner.table_store.list_wal_ssts(..).await.unwrap();
+        assert_eq!(wal_ssts.len(), 1);
+        assert_eq!(wal_ssts[0].size, 0);
         db.put(b"1", b"1").await.unwrap();
         // assert that second open writes another empty wal.
         let db = Db::builder(path, object_store.clone())

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3339,6 +3339,7 @@ mod tests {
             object_store.clone(),
         )
         .with_settings(opts)
+        .with_db_cache_disabled()
         .with_metrics_recorder(metrics_recorder.clone())
         .build()
         .await
@@ -3348,7 +3349,12 @@ mod tests {
         let key = b"test_key";
         let value = b"test_value";
         kv_store.put(key, value).await.unwrap();
-        kv_store.flush().await.unwrap();
+        kv_store
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
 
         let got = kv_store.get(key).await.unwrap();
         let access_count1 = lookup_metric(&metrics_recorder, PART_ACCESS_COUNT).unwrap();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -7274,6 +7274,7 @@ mod tests {
                 interval: None,
                 min_age: Duration::from_millis(0),
             }),
+            wal_fence_options: None,
             manifest_options: Some(GarbageCollectorDirectoryOptions {
                 interval: None,
                 min_age: Duration::from_millis(0),

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -161,25 +161,11 @@ impl DbInner {
         Ok(handle)
     }
 
-    /// Write an empty WAL SST at `wal_id` as a fencing barrier. The
+    /// Write a zero-byte WAL object at `wal_id` as a fencing barrier. The
     /// object-storage put-if-absent at this slot is what fences in-flight
     /// WAL writes from older-epoch writers — see [`Self::fence_writers`].
-    ///
-    /// Builds the empty SST blob directly from an empty builder; bypasses
-    /// the L0 build pipeline since there's no memtable to flush. L0 data
-    /// must go through the segment-aware upload pipeline
-    /// ([`Self::build_imm_ssts`]).
     pub(crate) async fn flush_empty_wal(&self, wal_id: u64) -> Result<(), SlateDBError> {
-        let encoded_sst = self.table_store.table_builder().build().await?;
-        let empty = crate::mem_table::WritableKVTable::new();
-        self.upload_sst(
-            &db_state::SsTableId::Wal(wal_id),
-            empty.table().clone(),
-            &encoded_sst,
-            false,
-        )
-        .await?;
-        Ok(())
+        self.table_store.write_wal_fence(wal_id).await
     }
 
     /// Test helper: build L0 SSTs from `imm_table` via the segment-aware

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -37,7 +37,7 @@ use slatedb_txn_obj::{DirtyObject, SimpleTransactionalObject, TransactionalObjec
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::instrument;
-use wal_gc::WalGcTask;
+use wal_gc::{WalGcMode, WalGcTask};
 
 mod compacted_gc;
 mod compactions_gc;
@@ -58,6 +58,7 @@ trait GcTask {
 #[derive(Debug)]
 pub(crate) enum GcMessage {
     Wal,
+    WalFence,
     Compacted,
     Compactions,
     Manifest,
@@ -87,6 +88,7 @@ pub struct GarbageCollector {
     system_clock: Arc<dyn SystemClock>,
     manifest_gc_task: Option<ManifestGcTask>,
     wal_gc_task: Option<WalGcTask>,
+    wal_fence_gc_task: Option<WalGcTask>,
     compacted_gc_task: Option<CompactedGcTask>,
     compactions_gc_task: Option<CompactionsGcTask>,
     detach_gc_task: Option<DetachGcTask>,
@@ -107,6 +109,12 @@ impl MessageHandler<GcMessage> for GarbageCollector {
             tickers.push((
                 opts.interval.unwrap_or(DEFAULT_INTERVAL),
                 Box::new(|| GcMessage::Wal),
+            ));
+        }
+        if let Some(opts) = self.options.wal_fence_options {
+            tickers.push((
+                opts.interval.unwrap_or(DEFAULT_INTERVAL),
+                Box::new(|| GcMessage::WalFence),
             ));
         }
         if let Some(opts) = self.options.compacted_options {
@@ -145,6 +153,13 @@ impl MessageHandler<GcMessage> for GarbageCollector {
                     .wal_gc_task
                     .as_ref()
                     .expect("got wal tick with unconfigured wal task");
+                self.run_gc_task(task).await;
+            }
+            GcMessage::WalFence => {
+                let task = self
+                    .wal_fence_gc_task
+                    .as_ref()
+                    .expect("got wal fence tick with unconfigured wal fence task");
                 self.run_gc_task(task).await;
             }
             GcMessage::Compacted => {
@@ -213,6 +228,16 @@ impl GarbageCollector {
                 table_store.clone(),
                 stats.clone(),
                 wal_options,
+                WalGcMode::Regular,
+            )
+        });
+        let wal_fence_gc_task = options.wal_fence_options.map(|wal_fence_options| {
+            WalGcTask::new(
+                manifest_store.clone(),
+                table_store.clone(),
+                stats.clone(),
+                wal_fence_options,
+                WalGcMode::Fence,
             )
         });
         let compacted_gc_task = options.compacted_options.map(|compacted_options| {
@@ -250,6 +275,7 @@ impl GarbageCollector {
             system_clock,
             manifest_gc_task,
             wal_gc_task,
+            wal_fence_gc_task,
             compacted_gc_task,
             compactions_gc_task,
             detach_gc_task,
@@ -269,6 +295,9 @@ impl GarbageCollector {
             self.run_gc_task(task).await;
         }
         if let Some(task) = &self.wal_gc_task {
+            self.run_gc_task(task).await;
+        }
+        if let Some(task) = &self.wal_fence_gc_task {
             self.run_gc_task(task).await;
         }
         if let Some(task) = &self.compacted_gc_task {
@@ -1003,6 +1032,265 @@ mod tests {
         assert_eq!(wal_ssts[0].id, id2);
     }
 
+    #[tokio::test]
+    async fn test_regular_wal_gc_does_not_delete_wal_fences() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+
+        let fence_id = SsTableId::Wal(1);
+        table_store.write_wal_fence(1).await.unwrap();
+
+        let regular_wal_id = SsTableId::Wal(2);
+        write_sst(table_store.clone(), &regular_wal_id)
+            .await
+            .unwrap();
+
+        for id in [fence_id, regular_wal_id] {
+            set_modified(
+                local_object_store.clone(),
+                &path_resolver.table_path(&id),
+                86400,
+            );
+        }
+
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 3;
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: None,
+            }),
+            wal_fence_options: None,
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+        };
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store,
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &MetricsRecorderHelper::noop(),
+            Arc::new(DefaultSystemClock::default()),
+        );
+
+        gc.run_gc_once().await;
+
+        let wal_ssts = table_store.list_wal_ssts(..).await.unwrap();
+        assert_eq!(wal_ssts.len(), 1);
+        assert_eq!(wal_ssts[0].id, fence_id);
+        assert_eq!(wal_ssts[0].size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_wal_fence_gc_deletes_old_fences() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+
+        let old_fence_id = SsTableId::Wal(1);
+        table_store.write_wal_fence(1).await.unwrap();
+
+        let regular_wal_id = SsTableId::Wal(2);
+        write_sst(table_store.clone(), &regular_wal_id)
+            .await
+            .unwrap();
+
+        let newer_fence_id = SsTableId::Wal(3);
+        table_store.write_wal_fence(3).await.unwrap();
+
+        for id in [old_fence_id, regular_wal_id, newer_fence_id] {
+            set_modified(
+                local_object_store.clone(),
+                &path_resolver.table_path(&id),
+                86400,
+            );
+        }
+
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 4;
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: None,
+            wal_fence_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: None,
+            }),
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+        };
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(recorder.clone(), Default::default());
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store,
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &helper,
+            Arc::new(DefaultSystemClock::default()),
+        );
+
+        gc.run_gc_once().await;
+
+        let wal_ssts = table_store.list_wal_ssts(..).await.unwrap();
+        let wal_ids = wal_ssts.iter().map(|sst| sst.id).collect::<Vec<_>>();
+        assert_eq!(wal_ids, vec![regular_wal_id]);
+        assert!(wal_ssts[0].size > 0);
+        assert_eq!(
+            lookup_metric_with_labels(
+                &recorder,
+                crate::garbage_collector::stats::DELETED_COUNT,
+                &[("resource", "wal_fence")]
+            ),
+            Some(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_wal_fence_gc_deletes_single_old_fence() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+
+        let fence_id = SsTableId::Wal(1);
+        table_store.write_wal_fence(1).await.unwrap();
+        set_modified(
+            local_object_store,
+            &path_resolver.table_path(&fence_id),
+            86400,
+        );
+
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 2;
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: None,
+            wal_fence_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: None,
+            }),
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+        };
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store,
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &MetricsRecorderHelper::noop(),
+            Arc::new(DefaultSystemClock::default()),
+        );
+
+        gc.run_gc_once().await;
+
+        let wal_ssts = table_store.list_wal_ssts(..).await.unwrap();
+        assert!(wal_ssts.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_regular_and_wal_fence_gc_run_independently() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+
+        let old_fence_id = SsTableId::Wal(1);
+        table_store.write_wal_fence(1).await.unwrap();
+
+        let regular_wal_id_1 = SsTableId::Wal(2);
+        write_sst(table_store.clone(), &regular_wal_id_1)
+            .await
+            .unwrap();
+
+        let newer_fence_id = SsTableId::Wal(3);
+        table_store.write_wal_fence(3).await.unwrap();
+
+        let regular_wal_id_2 = SsTableId::Wal(4);
+        write_sst(table_store.clone(), &regular_wal_id_2)
+            .await
+            .unwrap();
+
+        for id in [
+            old_fence_id,
+            regular_wal_id_1,
+            newer_fence_id,
+            regular_wal_id_2,
+        ] {
+            set_modified(
+                local_object_store.clone(),
+                &path_resolver.table_path(&id),
+                86400,
+            );
+        }
+
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 4;
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: None,
+            }),
+            wal_fence_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: None,
+            }),
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+        };
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store,
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &MetricsRecorderHelper::noop(),
+            Arc::new(DefaultSystemClock::default()),
+        );
+
+        gc.run_gc_once().await;
+
+        let wal_ssts = table_store.list_wal_ssts(..).await.unwrap();
+        assert_eq!(wal_ssts.len(), 1);
+        assert_eq!(wal_ssts[0].id, regular_wal_id_2);
+        assert!(wal_ssts[0].size > 0);
+    }
+
     /// This test creates eight compacted SSTs:
     /// - One L0 SST
     /// - One active L0 SST that's a day old
@@ -1420,6 +1708,7 @@ mod tests {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
             }),
+            wal_fence_options: None,
             compacted_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
@@ -1488,6 +1777,7 @@ mod tests {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
             }),
+            wal_fence_options: None,
             compacted_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
@@ -1552,6 +1842,7 @@ mod tests {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
             }),
+            wal_fence_options: None,
             compacted_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
@@ -1595,6 +1886,10 @@ mod tests {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(11)),
             }),
+            wal_fence_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: Some(Duration::from_secs(13)),
+            }),
             compacted_options: None,
             compactions_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
@@ -1620,7 +1915,11 @@ mod tests {
             .collect();
         assert_eq!(
             intervals,
-            vec![Duration::from_secs(11), Duration::from_secs(17),]
+            vec![
+                Duration::from_secs(11),
+                Duration::from_secs(13),
+                Duration::from_secs(17),
+            ]
         );
     }
 
@@ -1638,6 +1937,7 @@ mod tests {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),
             }),
+            wal_fence_options: None,
             compacted_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),

--- a/slatedb/src/garbage_collector/stats.rs
+++ b/slatedb/src/garbage_collector/stats.rs
@@ -14,6 +14,7 @@ pub const GC_COUNT: &str = gc_stat_name!("count");
 pub struct GcStats {
     pub gc_manifest_count: Arc<dyn CounterFn>,
     pub gc_wal_count: Arc<dyn CounterFn>,
+    pub gc_wal_fence_count: Arc<dyn CounterFn>,
     pub gc_compacted_count: Arc<dyn CounterFn>,
     pub gc_compactions_count: Arc<dyn CounterFn>,
     pub gc_detach_count: Arc<dyn CounterFn>,
@@ -30,6 +31,10 @@ impl GcStats {
             gc_wal_count: recorder
                 .counter(DELETED_COUNT)
                 .labels(&[("resource", "wal")])
+                .register(),
+            gc_wal_fence_count: recorder
+                .counter(DELETED_COUNT)
+                .labels(&[("resource", "wal_fence")])
                 .register(),
             gc_compacted_count: recorder
                 .counter(DELETED_COUNT)

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -11,17 +11,37 @@ use std::sync::Arc;
 
 use super::{GcStats, GcTask};
 
+/// Selects which class of WAL object a [`WalGcTask`] collects.
+///
+/// Regular WAL SSTs and zero-byte WAL fence objects share the same WAL
+/// directory and `SsTableId::Wal` identifier space, but they have separate
+/// retention policies. This mode keeps a single task implementation while
+/// allowing regular WAL GC and fence WAL GC to run on independent schedules.
+#[derive(Debug, Clone, Copy)]
+pub(super) enum WalGcMode {
+    /// Collect non-empty WAL SSTs that are older than the compacted WAL
+    /// boundary, old enough for retention, and unreferenced by active
+    /// checkpoint manifests.
+    Regular,
+
+    /// Collect zero-byte WAL fence objects under the same safety checks as
+    /// regular WAL GC.
+    Fence,
+}
+
 pub(crate) struct WalGcTask {
     manifest_store: Arc<ManifestStore>,
     table_store: Arc<TableStore>,
     stats: Arc<GcStats>,
     wal_options: GarbageCollectorDirectoryOptions,
+    mode: WalGcMode,
 }
 
 impl std::fmt::Debug for WalGcTask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WalGcTask")
             .field("wal_options", &self.wal_options)
+            .field("mode", &self.mode)
             .finish()
     }
 }
@@ -32,12 +52,14 @@ impl WalGcTask {
         table_store: Arc<TableStore>,
         stats: Arc<GcStats>,
         wal_options: GarbageCollectorDirectoryOptions,
+        mode: WalGcMode,
     ) -> Self {
         WalGcTask {
             manifest_store,
             table_store,
             stats,
             wal_options,
+            mode,
         }
     }
 
@@ -81,6 +103,13 @@ impl GcTask for WalGcTask {
             .list_wal_ssts(..last_compacted_wal_sst_id)
             .await?
             .into_iter()
+            .filter(|wal_sst| match self.mode {
+                // In regular mode, only consider WAL SSTs with size > 0 for deletion.
+                WalGcMode::Regular => wal_sst.size > 0,
+                // In fence mode, only consider zero-byte WAL SSTs for deletion.
+                WalGcMode::Fence => wal_sst.size == 0,
+            })
+            // Respect min_age and any WAL references held by active checkpoint manifests.
             .filter(|wal_sst| {
                 Self::is_wal_sst_eligible_for_deletion(
                     &utc_now,
@@ -96,7 +125,10 @@ impl GcTask for WalGcTask {
             if let Err(e) = self.table_store.delete_sst(&id).await {
                 error!("error deleting WAL SST [id={:?}, error={}]", id, e);
             } else {
-                self.stats.gc_wal_count.increment(1);
+                match self.mode {
+                    WalGcMode::Regular => self.stats.gc_wal_count.increment(1),
+                    WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(1),
+                }
             }
         }
 
@@ -104,6 +136,9 @@ impl GcTask for WalGcTask {
     }
 
     fn resource(&self) -> &str {
-        "WAL"
+        match self.mode {
+            WalGcMode::Regular => "WAL",
+            WalGcMode::Fence => "WAL fence",
+        }
     }
 }

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -844,6 +844,7 @@ impl RowEntryIterator for FilterIterator<'_> {
 enum SstIteratorDelegate<'a> {
     Direct(InternalSstIterator<'a>),
     Filter(FilterIterator<'a>),
+    Empty(SsTableId),
 }
 
 pub(crate) struct SstIterator<'a> {
@@ -851,6 +852,12 @@ pub(crate) struct SstIterator<'a> {
 }
 
 impl<'a> SstIterator<'a> {
+    pub(crate) fn new_empty(table_id: SsTableId) -> Self {
+        Self {
+            delegate: SstIteratorDelegate::Empty(table_id),
+        }
+    }
+
     fn from_internal(internal: InternalSstIterator<'a>, db_stats: Option<DbStats>) -> Self {
         let point_key = internal.view().point_key().map(Bytes::copy_from_slice);
         let prefix = internal.options.prefix.clone();
@@ -931,6 +938,7 @@ impl<'a> SstIterator<'a> {
                     SstIteratorDelegate::Direct(inner_iter) => {
                         inner_iter.init().await?;
                     }
+                    SstIteratorDelegate::Empty(_) => {}
                 }
                 Ok(Some(iterator))
             }
@@ -980,6 +988,7 @@ impl<'a> SstIterator<'a> {
                     SstIteratorDelegate::Direct(inner_iter) => {
                         inner_iter.init().await?;
                     }
+                    SstIteratorDelegate::Empty(_) => {}
                 }
                 Ok(Some(iterator))
             }
@@ -1021,6 +1030,7 @@ impl<'a> SstIterator<'a> {
                     SstIteratorDelegate::Direct(inner_iter) => {
                         inner_iter.init().await?;
                     }
+                    SstIteratorDelegate::Empty(_) => {}
                 }
                 Ok(Some(iterator))
             }
@@ -1032,6 +1042,7 @@ impl<'a> SstIterator<'a> {
         match &self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.table_id(),
             SstIteratorDelegate::Filter(inner) => inner.table_id(),
+            SstIteratorDelegate::Empty(table_id) => *table_id,
         }
     }
 }
@@ -1042,6 +1053,7 @@ impl RowEntryIterator for SstIterator<'_> {
         match &mut self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.init().await,
             SstIteratorDelegate::Filter(inner) => inner.init().await,
+            SstIteratorDelegate::Empty(_) => Ok(()),
         }
     }
 
@@ -1049,6 +1061,7 @@ impl RowEntryIterator for SstIterator<'_> {
         match &mut self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.next().await,
             SstIteratorDelegate::Filter(inner) => inner.next().await,
+            SstIteratorDelegate::Empty(_) => Ok(None),
         }
     }
 
@@ -1056,6 +1069,7 @@ impl RowEntryIterator for SstIterator<'_> {
         match &mut self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.seek(next_key).await,
             SstIteratorDelegate::Filter(inner) => inner.seek(next_key).await,
+            SstIteratorDelegate::Empty(_) => Ok(()),
         }
     }
 }

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -10,7 +10,7 @@ use tokio::task::JoinHandle;
 
 use crate::block_iterator::DataBlockIterator;
 use crate::bytes_range::BytesRange;
-use crate::db_state::{SsTableId, SsTableView};
+use crate::db_state::SsTableView;
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::filter_policy::{FilterContext, FilterQuery, NamedFilter};
@@ -308,10 +308,6 @@ impl<'a> InternalSstIterator<'a> {
             descending_buffer,
             pending_entry: None,
         })
-    }
-
-    fn table_id(&self) -> SsTableId {
-        self.view.table_as_ref().sst.id
     }
 
     fn view(&self) -> &SstView<'a> {
@@ -779,10 +775,6 @@ impl<'a> FilterIterator<'a> {
         }
     }
 
-    fn table_id(&self) -> SsTableId {
-        self.inner.table_id()
-    }
-
     fn is_filtered_out(&self) -> bool {
         self.filter.is_filtered_out()
     }
@@ -844,7 +836,6 @@ impl RowEntryIterator for FilterIterator<'_> {
 enum SstIteratorDelegate<'a> {
     Direct(InternalSstIterator<'a>),
     Filter(FilterIterator<'a>),
-    Empty(SsTableId),
 }
 
 pub(crate) struct SstIterator<'a> {
@@ -852,12 +843,6 @@ pub(crate) struct SstIterator<'a> {
 }
 
 impl<'a> SstIterator<'a> {
-    pub(crate) fn new_empty(table_id: SsTableId) -> Self {
-        Self {
-            delegate: SstIteratorDelegate::Empty(table_id),
-        }
-    }
-
     fn from_internal(internal: InternalSstIterator<'a>, db_stats: Option<DbStats>) -> Self {
         let point_key = internal.view().point_key().map(Bytes::copy_from_slice);
         let prefix = internal.options.prefix.clone();
@@ -938,7 +923,6 @@ impl<'a> SstIterator<'a> {
                     SstIteratorDelegate::Direct(inner_iter) => {
                         inner_iter.init().await?;
                     }
-                    SstIteratorDelegate::Empty(_) => {}
                 }
                 Ok(Some(iterator))
             }
@@ -988,7 +972,6 @@ impl<'a> SstIterator<'a> {
                     SstIteratorDelegate::Direct(inner_iter) => {
                         inner_iter.init().await?;
                     }
-                    SstIteratorDelegate::Empty(_) => {}
                 }
                 Ok(Some(iterator))
             }
@@ -1030,19 +1013,10 @@ impl<'a> SstIterator<'a> {
                     SstIteratorDelegate::Direct(inner_iter) => {
                         inner_iter.init().await?;
                     }
-                    SstIteratorDelegate::Empty(_) => {}
                 }
                 Ok(Some(iterator))
             }
             None => Ok(None),
-        }
-    }
-
-    pub(crate) fn table_id(&self) -> SsTableId {
-        match &self.delegate {
-            SstIteratorDelegate::Direct(inner) => inner.table_id(),
-            SstIteratorDelegate::Filter(inner) => inner.table_id(),
-            SstIteratorDelegate::Empty(table_id) => *table_id,
         }
     }
 }
@@ -1053,7 +1027,6 @@ impl RowEntryIterator for SstIterator<'_> {
         match &mut self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.init().await,
             SstIteratorDelegate::Filter(inner) => inner.init().await,
-            SstIteratorDelegate::Empty(_) => Ok(()),
         }
     }
 
@@ -1061,7 +1034,6 @@ impl RowEntryIterator for SstIterator<'_> {
         match &mut self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.next().await,
             SstIteratorDelegate::Filter(inner) => inner.next().await,
-            SstIteratorDelegate::Empty(_) => Ok(None),
         }
     }
 
@@ -1069,7 +1041,6 @@ impl RowEntryIterator for SstIterator<'_> {
         match &mut self.delegate {
             SstIteratorDelegate::Direct(inner) => inner.seek(next_key).await,
             SstIteratorDelegate::Filter(inner) => inner.seek(next_key).await,
-            SstIteratorDelegate::Empty(_) => Ok(()),
         }
     }
 }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -249,6 +249,24 @@ impl TableStore {
         ))
     }
 
+    /// Writes a zero-byte WAL object as a fencing marker.
+    ///
+    /// Uses create-if-absent semantics so any existing WAL object at this ID
+    /// fences the writer by returning [`SlateDBError::Fenced`].
+    pub(crate) async fn write_wal_fence(&self, wal_id: u64) -> Result<(), SlateDBError> {
+        let id = SsTableId::Wal(wal_id);
+        fail_point!(self.fp_registry.clone(), "write-wal-sst-io-error", |_| {
+            Result::Err(slatedb_io_error())
+        });
+        write_sst_in_object_store(
+            self.object_stores.store_for(&id),
+            &id,
+            &self.path(&id),
+            &Bytes::new(),
+        )
+        .await
+    }
+
     async fn cache_filters(&self, sst: SsTableId, id: u64, filters: Arc<[NamedFilter]>) {
         let Some(ref cache) = self.cache else {
             return;
@@ -1062,6 +1080,58 @@ mod tests {
 
         // write another wal sst with the same id.
         let result = ts.write_sst(&wal_id, &table2, false).await;
+        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+    }
+
+    #[tokio::test]
+    async fn test_wal_fence_should_write_zero_bytes() {
+        let os = Arc::new(InMemory::new());
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ));
+
+        ts.write_wal_fence(1).await.unwrap();
+
+        let metadata = ts.metadata(&SsTableId::Wal(1)).await.unwrap();
+        assert_eq!(metadata.size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_wal_fence_should_fail_when_fenced() {
+        let os = Arc::new(InMemory::new());
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ));
+
+        ts.write_wal_fence(1).await.unwrap();
+        let result = ts.write_wal_fence(1).await;
+        assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+    }
+
+    #[tokio::test]
+    async fn test_wal_write_should_fail_after_zero_byte_fence() {
+        let os = Arc::new(InMemory::new());
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ));
+
+        ts.write_wal_fence(1).await.unwrap();
+
+        let mut sst = ts.table_builder();
+        sst.add(RowEntry::new_value(b"key", b"value", 0))
+            .await
+            .unwrap();
+        let table = sst.build().await.unwrap();
+        let result = ts.write_sst(&SsTableId::Wal(1), &table, false).await;
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
     }
 

--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -151,7 +151,14 @@ impl WalFile {
     /// [`crate::ErrorKind::Data`] is returned, and its source contains an
     /// `object_store::Error::NotFound`.
     pub async fn iterator(&self) -> Result<WalFileIterator, crate::Error> {
-        let sst = self.table_store.open_sst(&SsTableId::Wal(self.id)).await?;
+        let sst = match self.table_store.open_sst(&SsTableId::Wal(self.id)).await {
+            Ok(sst) => sst,
+            Err(crate::error::SlateDBError::EmptySSTable) => {
+                // Zero-byte WAL files are fencing markers, not corrupt WALs.
+                return Ok(WalFileIterator::new(Box::new(EmptyIterator::new())));
+            }
+            Err(err) => return Err(err.into()),
+        };
         let iter = match SstIterator::new_owned_initialized(
             ..,
             SsTableView::identity(sst),
@@ -375,6 +382,24 @@ mod tests {
             assert_eq!(wal_metadata.size_bytes, object_metadata.size);
             assert_eq!(wal_metadata.location, object_metadata.location);
         }
+    }
+
+    #[tokio::test]
+    async fn test_zero_byte_wal_file_has_empty_iterator() {
+        let main_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/test_wal_reader_zero_byte";
+        let wal_reader = WalReader::new(path, main_store);
+        wal_reader.table_store.write_wal_fence(1).await.unwrap();
+
+        let wal_files = wal_reader.list(..).await.unwrap();
+        assert_eq!(wal_files.len(), 1);
+        assert_eq!(wal_files[0].id, 1);
+
+        let wal_metadata = wal_files[0].metadata().await.unwrap();
+        assert_eq!(wal_metadata.size_bytes, 0);
+
+        let mut iter = wal_files[0].iterator().await.unwrap();
+        assert!(iter.next().await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -1,6 +1,6 @@
 use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
-use crate::iter::RowEntryIterator;
+use crate::iter::{EmptyIterator, RowEntryIterator};
 use crate::manifest::ManifestCore;
 use crate::manifest::SsTableView;
 use crate::mem_table::WritableKVTable;
@@ -49,6 +49,11 @@ pub(crate) struct ReplayedMemtable {
     pub(crate) last_wal_id: u64,
 }
 
+struct WalIdAndIter {
+    wal_id: u64,
+    iter: Box<dyn RowEntryIterator + 'static>,
+}
+
 struct IteratorHolder<T> {
     initialized: bool,
     current_iter: Option<T>,
@@ -77,19 +82,19 @@ impl<T> IteratorHolder<T> {
     }
 }
 
-pub(crate) struct WalReplayIterator<'a> {
+pub(crate) struct WalReplayIterator {
     options: WalReplayOptions,
     wal_id_range: Range<u64>,
     table_store: Arc<TableStore>,
-    current_iter: IteratorHolder<SstIterator<'a>>,
-    next_iters: VecDeque<JoinHandle<Result<Option<SstIterator<'a>>, SlateDBError>>>,
+    current_iter: IteratorHolder<WalIdAndIter>,
+    next_iters: VecDeque<JoinHandle<Result<Option<WalIdAndIter>, SlateDBError>>>,
     last_tick: i64,
     last_seq: u64,
     min_seq: u64,
     next_wal_id: u64,
 }
 
-impl WalReplayIterator<'_> {
+impl WalReplayIterator {
     pub(crate) async fn range(
         wal_id_range: Range<u64>,
         db_state: &ManifestCore,
@@ -152,27 +157,34 @@ impl WalReplayIterator<'_> {
         let next_wal_id = self.next_wal_id;
         self.next_wal_id += 1;
 
-        async fn load_iter<'a>(
+        async fn load_iter(
             wal_id: u64,
             sst_iter_options: SstIteratorOptions,
             table_store: Arc<TableStore>,
-        ) -> Result<Option<SstIterator<'a>>, SlateDBError> {
+        ) -> Result<Option<WalIdAndIter>, SlateDBError> {
             let sst = match table_store.open_sst(&SsTableId::Wal(wal_id)).await {
                 Ok(sst) => sst,
                 Err(SlateDBError::EmptySSTable) => {
                     // Zero-byte WAL files are fence markers; replay them as empty WALs
                     // so the last replayed WAL ID still advances past the marker.
-                    return Ok(Some(SstIterator::new_empty(SsTableId::Wal(wal_id))));
+                    return Ok(Some(WalIdAndIter {
+                        wal_id,
+                        iter: Box::new(EmptyIterator::new()),
+                    }));
                 }
                 Err(err) => return Err(err),
             };
-            SstIterator::new_owned_initialized(
+            let iter = SstIterator::new_owned_initialized(
                 ..,
                 SsTableView::identity(sst),
                 Arc::clone(&table_store),
                 sst_iter_options,
             )
-            .await
+            .await?;
+            Ok(iter.map(|iter| WalIdAndIter {
+                wal_id,
+                iter: Box::new(iter) as Box<dyn RowEntryIterator + 'static>,
+            }))
         }
 
         let handle = task::spawn(load_iter(
@@ -228,9 +240,8 @@ impl WalReplayIterator<'_> {
         let mut last_wal_id = 0;
 
         while !self.current_iter.is_finished() {
-            if let Some(sst_iter) = &mut self.current_iter.current_iter {
-                let wal_id = sst_iter.table_id().unwrap_wal_id();
-                while let Some(row_entry) = sst_iter.next().await? {
+            if let Some(wal_id_and_iter) = &mut self.current_iter.current_iter {
+                while let Some(row_entry) = wal_id_and_iter.iter.next().await? {
                     // skip the entries that are already in the L0 SST.
                     if row_entry.seq <= self.min_seq {
                         continue;
@@ -243,7 +254,7 @@ impl WalReplayIterator<'_> {
                     table.put(row_entry);
                 }
 
-                last_wal_id = wal_id;
+                last_wal_id = wal_id_and_iter.wal_id;
 
                 let meta = table.metadata();
                 let estimated_bytes = self

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -157,7 +157,15 @@ impl WalReplayIterator<'_> {
             sst_iter_options: SstIteratorOptions,
             table_store: Arc<TableStore>,
         ) -> Result<Option<SstIterator<'a>>, SlateDBError> {
-            let sst = table_store.open_sst(&SsTableId::Wal(wal_id)).await?;
+            let sst = match table_store.open_sst(&SsTableId::Wal(wal_id)).await {
+                Ok(sst) => sst,
+                Err(SlateDBError::EmptySSTable) => {
+                    // Zero-byte WAL files are fence markers; replay them as empty WALs
+                    // so the last replayed WAL ID still advances past the marker.
+                    return Ok(Some(SstIterator::new_empty(SsTableId::Wal(wal_id))));
+                }
+                Err(err) => return Err(err),
+            };
             SstIterator::new_owned_initialized(
                 ..,
                 SsTableView::identity(sst),
@@ -309,6 +317,62 @@ mod tests {
         assert_eq!(table.last_seq, 0);
         assert!(table.table.is_empty());
         assert_eq!(table.last_tick, i64::MIN);
+        assert!(replay_iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn should_replay_zero_byte_wal_fence() {
+        let table_store = test_table_store();
+        table_store.write_wal_fence(1).await.unwrap();
+        let mut replay_iter = WalReplayIterator::new(
+            &ManifestCore::new(),
+            WalReplayOptions::default(),
+            Arc::clone(&table_store),
+        )
+        .await
+        .unwrap();
+
+        let Some(table) = replay_iter.next().await.unwrap() else {
+            panic!("Expected empty table to be returned from iterator")
+        };
+
+        assert_eq!(table.last_wal_id, 1);
+        assert_eq!(table.last_seq, 0);
+        assert!(table.table.is_empty());
+        assert_eq!(table.last_tick, i64::MIN);
+        assert!(replay_iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn should_replay_zero_byte_wal_fence_before_real_wal() {
+        let table_store = test_table_store();
+        table_store.write_wal_fence(1).await.unwrap();
+
+        let row = RowEntry::new_value(b"key", b"value", 1);
+        let mut builder = table_store.wal_table_builder();
+        builder.add(row.clone()).await.unwrap();
+        let encoded_sst = builder.build().await.unwrap();
+        table_store
+            .write_sst(&SsTableId::Wal(2), &encoded_sst, false)
+            .await
+            .unwrap();
+
+        let mut replay_iter = WalReplayIterator::new(
+            &ManifestCore::new(),
+            WalReplayOptions::default(),
+            Arc::clone(&table_store),
+        )
+        .await
+        .unwrap();
+
+        let Some(replayed_table) = replay_iter.next().await.unwrap() else {
+            panic!("Expected table to be returned from iterator")
+        };
+        assert_eq!(replayed_table.last_wal_id, 2);
+        assert_eq!(replayed_table.last_seq, 1);
+
+        let mut iter = replayed_table.table.table().iter();
+        test_utils::assert_iterator(&mut iter, vec![row]).await;
         assert!(replay_iter.next().await.unwrap().is_none());
     }
 

--- a/specs/fizzbee/SequencedMetadataBoundary.fizz
+++ b/specs/fizzbee/SequencedMetadataBoundary.fizz
@@ -8,7 +8,7 @@ options:
 # Run with:
 #
 # ```
-# fizz specs/fizzbee/SequencedMetadataBoundary.fizz
+# fizz --experimental_no_graph specs/fizzbee/SequencedMetadataBoundary.fizz
 # ```
 #
 # This spec models the GC boundary protocol for SlateDB's sequenced metadata

--- a/specs/fizzbee/WalProtocol.fizz
+++ b/specs/fizzbee/WalProtocol.fizz
@@ -113,7 +113,7 @@ DATA = "d"
 FENCE = "f"
 
 NUM_WRITERS = 3
-NUM_GCS = 1
+NUM_GCS = 2
 
 action Init:
     # Objects that currently exist in the object store.

--- a/specs/fizzbee/WalProtocol.fizz
+++ b/specs/fizzbee/WalProtocol.fizz
@@ -1,0 +1,329 @@
+---
+deadlock_detection: false
+options:
+    max_actions: 40
+    crash_on_yield: false
+---
+
+# Run with:
+#
+# ```
+# fizz --experimental_no_graph specs/fizzbee/WalProtocol.fizz
+# ```
+#
+# This spec models SlateDB's object-store WAL writer fencing protocol, as
+# described by rfcs/0001-manifest.md. The real system stores WAL files as
+# immutable, monotonically numbered objects such as:
+#
+# - wal/00000000000000000012.sst
+# - wal/00000000000000000013.sst
+#
+# A writer claims a new writer epoch, writes a fence object into the next
+# available WAL slot with create-if-absent, validates that the fence is still
+# useful, and then writes normal WAL data objects. A newer writer can fence an
+# older writer by claiming a higher epoch and occupying later WAL slots.
+#
+# This model abstracts the WAL namespace and the manifest field that makes old
+# WALs eligible for removal:
+#
+# - `objects` is the current object-store contents. The key is the WAL object ID
+#   and the value is either `FENCE` or `DATA`.
+# - `current_epoch` is the highest epoch claimed by any writer. A writer whose
+#   epoch is below this value has been superseded by a newer writer.
+# - `replay_after_wal_id` is the manifest boundary. WALs at or below this ID
+#   have been flushed to L0 and no longer need to be replayed. In this model,
+#   garbage collection may delete `DATA` objects strictly below this boundary.
+# - each `WalWriter` lists the latest WAL object to choose the next ID, claims a
+#   fresh epoch, writes a fence object, validates the fence against the current
+#   epoch and `replay_after_wal_id`, and then appends `DATA` objects until it is
+#   fenced or reaches the model bound.
+# - each `GarbageCollector` deletes old `DATA` objects behind
+#   `replay_after_wal_id`. Fence objects remain as durable evidence that a WAL
+#   slot was occupied by a writer.
+#
+# `WriteFence` and `ValidateFence` are separate actions because the important
+# race is between the fence create and the validation step. During that window,
+# another writer can claim a later epoch or a flush can advance
+# `replay_after_wal_id`, making the just-written fence unusable.
+#
+# `Flush` nondeterministically advances `replay_after_wal_id` to an existing
+# WAL ID after the writer has created at least one object. This is to simulate
+# L0 MemTable flushes that advance replay boundaries.
+#
+# WalWriter state transitions:
+#
+#            ┌───────────────────┐
+#            │       Init        │
+#            └─────────┬─────────┘
+#            ┌─────────▼─────────┐
+#            │    InitNextId     │
+#            └─────────┬─────────┘
+#            ┌─────────▼─────────┐
+#            │    ClaimEpoch     │
+#            └─────────┬─────────┘
+#            ┌─────────▼─────────┐
+# ┌──────────▶    WriteFence     ◀──────────┐
+# │          └─────────┬─────────┘          │
+# │          ┌─────────┴─────────┐          │
+# │┌─────────▼─────────┐┌────────▼────────┐ │
+# └┤   ValidateFence   ││   CheckFenced   ├─┘
+#  └─────────┬─────┬───┘└────────┬────────┘
+#            │     └─────────────┤
+#      ┌─────▼─────┐       ┌─────▼─────┐
+#  ┌───▶ WriteWal  ├───────▶  Fenced   │
+#  │   └─────┬─────┘       └───────────┘
+#  └─────────┤
+#            │
+#      ┌─────▼─────┐
+#      │  Fenced   │
+#      └───────────┘
+#
+# The assertions prove the protocol properties we care about:
+#
+# - no WAL ID is reported successful more than once;
+# - live, replayable WAL IDs remain contiguous above `replay_after_wal_id`;
+# - acknowledged epochs are nondecreasing by WAL ID;
+# - `replay_after_wal_id` is monotonic and never exceeds the latest object;
+# - deletes only remove WAL IDs already covered by `replay_after_wal_id`; and
+# - the latest object is never deleted.
+#
+# GC for WAL fences is disabled in this model. If GC collects WAL fence writes,
+# there will always be a race condition where the writer might successfully writes
+# to a slot behind replay_after_wal_id. This is fixable by refreshing the manifest
+# and checking the replay_after_wal_id after each write, similar to the approach
+# taken in ValidateFence. We've opted to skip this check due to its added latency
+# and API costs. Users that want a full guarantee must leave WAL fence GC
+# disabled. Realistically, users may set a conservative WAL fence GC threshold
+# such as a week. This would guarantee that any stalled writer that attempts to
+# write less than a week after its last successful write/manifest refresh will be
+# fenced correctly.
+
+# Per-writer bound on successful object WAL writes including the fence write. This
+# is not a SlateDB protocol limit; it keeps the state space finite while still
+# allowing each writer to create multiple sequenced metadata objects and exercise
+# GC races between creates and boundary checks.
+MAX_WRITES_PER_WRITER = 3
+
+# Per-writer bound on fence write attempts. This is not a SlateDB protocol limit;
+# it prevents the model from an infinite loop where the writer always fences behind
+# the boundary. In practice, we would retry forever or have a timeout.
+MAX_FENCE_ATTEMPTS_PER_WRITER = 3
+
+DATA = "d"
+FENCE = "f"
+
+NUM_WRITERS = 3
+NUM_GCS = 1
+
+action Init:
+    # Objects that currently exist in the object store.
+    # Contains `id -> f|d`.
+    objects = {}
+
+    # The highest epoch claimed by any writer.
+    current_epoch = 0
+
+    # WALs <= this sequence ID have been written to L0 and are eligible for GC.
+    replay_after_wal_id = 0
+
+    # Ghost state: sequenced IDs that have been written to object storage and
+    # reported as successful.
+    _committed = {}
+    _commit_counts = {}
+
+    writers = bag()
+    for i in range(NUM_WRITERS):
+        writers.add(WalWriter())
+
+    gcs = bag()
+    for i in range(NUM_GCS):
+        gcs.add(GarbageCollector())
+
+atomic func latest_sequence_id():
+    """
+    Returns the most recently written sequence ID, or 0 if no objects exist.
+    """
+    if len(objects) == 0:
+        return 0
+    return max(objects.keys())
+
+atomic func record_commit(id, epoch, _type):
+    """
+    Records that a writer reported success for `id` at `epoch`. This is not
+    part of the real protocol; it's ghost state that lets assertions check that
+    writers only report success for IDs that passed the boundary check and were
+    not already reported by another writer.
+    """
+    _committed[id] = record(epoch=epoch, _type=_type)
+    _commit_counts[id] = _commit_counts.get(id, 0) + 1
+
+
+symmetric role WalWriter:
+    atomic action Init:
+        # Next sequence file ID to write to.
+        self.next_id = 0
+        # Counts successful writes to object storage.
+        self.writes = 0
+        # Counts the number of fence attempts.
+        self.attempts = 0
+        # Epoch claimed by this writer.
+        self.epoch = None
+        self.status = "InitNextId"
+
+    atomic action InitNextId:
+        require self.status == "InitNextId"
+        sid = latest_sequence_id() # builder.rs#L549
+        self.next_id = sid + 1
+        self.status = "ClaimEpoch"
+
+    atomic action ClaimEpoch:
+        require self.status == "ClaimEpoch"
+        current_epoch = current_epoch + 1 # builder.rs#L569
+        self.epoch = current_epoch
+        self.status = "WriteFence"
+
+    atomic action WriteFence:
+        require (
+            self.status == "WriteFence"
+            and self.attempts < MAX_FENCE_ATTEMPTS_PER_WRITER
+        )
+        self.attempts += 1
+        success = self.write(FENCE) # builder.rs#L610
+        if success:
+            self.status = "ValidateFence"
+        else:
+            self.status = "CheckFenced"
+
+    # Not yet implemented in code. We simply return success right now.
+    atomic action ValidateFence:
+        """
+        Fence write succeeded. Make sure we're still the latest epoch and the
+        fence write was > replay_after_wal_id.
+        """
+        require self.status == "ValidateFence"
+        if self.epoch < current_epoch:
+            # We don't technically need to check this, but might as well since
+            # we refresh the manifest to get the latest replay_after_wal_id anyway.
+            self.status = "Fenced"
+        elif self.next_id > replay_after_wal_id:
+            record_commit(self.next_id, self.epoch, FENCE)
+            self.status = "WriteWal"
+            self.next_id += 1
+        else:
+            self.status = "WriteFence"
+            self.next_id = max(self.next_id + 1, replay_after_wal_id + 1)
+
+    atomic action CheckFenced:
+        """
+        Fence write failed. Retry at the next slot unless we no longer own the
+        latest epoch.
+        """
+        require self.status == "CheckFenced"
+        if self.epoch < current_epoch: # db.rs#L313
+            self.status = "Fenced"
+        else:
+            self.next_id += 1 # db.rs#L321
+            self.status = "WriteFence"
+
+    atomic action WriteWal:
+        """
+        Write normal non-fence WAL data after a fence has already been written.
+        """
+        require (
+            self.status == "WriteWal"
+            and self.writes < MAX_WRITES_PER_WRITER
+        )
+        success = self.write(DATA)
+        if success:
+            record_commit(self.next_id, self.epoch, DATA)
+            self.next_id += 1
+        else:
+            # Another writer claimed this ID first, so this writer is fenced.
+            self.status = "Fenced"
+
+    atomic action Flush:
+        """
+        Pretend we've written more L0 data. This updates the manifest with a
+        new replay_after_wal_id. We just pick a random WAL ID to use as the
+        flush point.
+        """
+        if self.writes > 0:
+            candidates = [
+                id
+                for id in objects.keys()
+                if id > replay_after_wal_id
+            ]
+            replay_after_wal_id = oneof candidates
+
+    atomic func write(_type):
+        # If next_id is already in `objects`, this write does not succeed.
+        success = self.next_id not in objects.keys()
+        if success:
+            objects[self.next_id] = _type
+            self.writes += 1
+        return success
+
+
+symmetric role GarbageCollector:
+    atomic action Delete:
+        candidates = [
+            id
+            for id in objects
+            # Not <= because we need to keep the last WAL.
+            if id < replay_after_wal_id and objects[id] == DATA
+        ]
+        id = oneof candidates
+        objects.pop(id)
+
+
+# -----------------------------------------------------------------------------
+# Assertions
+# -----------------------------------------------------------------------------
+
+always assertion NoDuplicateCommit:
+    for id in _commit_counts:
+        if _commit_counts[id] != 1:
+            return False
+    return True
+
+always assertion LiveHistoryIsContiguous:
+    if len(objects) == 0:
+        return True
+    latest = max(objects.keys())
+    for id in range(replay_after_wal_id + 1, latest + 1):
+        if id not in objects.keys():
+            return False
+    return True
+
+always assertion CommittedEpochsAreNonDecreasing:
+    if len(_committed) == 0:
+        return True
+    latest = max(_committed.keys())
+    prev_epoch = 0
+    for id in range(1, latest + 1):
+        if id in _committed.keys():
+            r = _committed[id]
+            if r.epoch < prev_epoch:
+                return False
+            prev_epoch = r.epoch
+    return True
+
+always assertion LatestObjectIsNotBehindBoundary:
+    if len(objects) == 0:
+        return True
+    return max(objects.keys()) >= replay_after_wal_id
+
+transition assertion BoundaryIsMonotonic(before, after):
+    return after.replay_after_wal_id >= before.replay_after_wal_id
+
+transition assertion DeletesOnlyBehindBoundary(before, after):
+    for id in before.objects:
+        if id not in after.objects.keys() and before.replay_after_wal_id <= id:
+            return False
+    return True
+
+transition assertion LatestObjectIsNeverDeleted(before, after):
+    if len(before.objects) == 0:
+        return True
+    latest = max(before.objects.keys())
+    return latest in after.objects.keys()


### PR DESCRIPTION
## Summary

This PR decouples WAL fence GC from regular WAL SST GC. By default, WAL fence writes are kept forever. This is conservative, but guarantees a stale writer will never return a stale write as successful.

Fixes #352
Fixes #1622

## Changes

- Make WAL fence writes 0 byte
- Update WalGcTask to support either "regular" or "fence" GC modes
- Update configs to allow users to config regular/fence min_age/interval separately

## Notes for Reviewers

- Review in commit order.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
