### PR TITLE
Add fast-path memtable get bypassing the iterator pipeline

### DIFF
--- a/slatedb/benches/db_operations.rs
+++ b/slatedb/benches/db_operations.rs
@@ -4,7 +4,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use object_store::memory::InMemory;
 use pprof::criterion::{Output, PProfProfiler};
-use slatedb::config::{PutOptions, WriteOptions};
+use slatedb::config::{PutOptions, ReadOptions, WriteOptions};
 use slatedb::Db;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -33,6 +33,43 @@ fn criterion_benchmark(c: &mut Criterion) {
             .expect("put failed");
         })
     });
+    // Memtable-hit point lookup. Pre-populates the active memtable with
+    // a single key so the get path stays in-memory and never touches SSTs.
+    {
+        let key = b"key";
+        let value = b"value";
+        #[allow(clippy::disallowed_methods)]
+        runtime
+            .block_on(db.put_with_options(
+                key,
+                value,
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            ))
+            .expect("put failed");
+        c.bench_function("get_memtable_hit", |b| {
+            b.to_async(&runtime).iter(|| async {
+                let v = db
+                    .get_with_options(key, &ReadOptions::default())
+                    .await
+                    .expect("get failed");
+                criterion::black_box(v);
+            })
+        });
+        c.bench_function("get_memtable_miss", |b| {
+            b.to_async(&runtime).iter(|| async {
+                let v = db
+                    .get_with_options(b"absent_key", &ReadOptions::default())
+                    .await
+                    .expect("get failed");
+                criterion::black_box(v);
+            })
+        });
+    }
+
     c.bench_function("open_close", |b| {
         b.to_async(&runtime).iter(|| async {
             let db = Db::open("/tmp/test_kv_store", Arc::new(InMemory::new()))

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -482,6 +482,30 @@ impl KVTable {
         self.range_ascending(..)
     }
 
+    /// Point lookup for a single user key, returning the freshest entry with
+    /// `seq <= max_seq` (or unbounded when `max_seq` is `None`). Returns
+    /// `None` if no entry exists for `key`.
+    ///
+    /// This is a fast path for the read flow: it bypasses the merge-iterator
+    /// machinery, dynamic dispatch, and the per-bound `Bytes` clones that
+    /// `KVTable::range` does. The skip list orders entries by user-key
+    /// ascending then by sequence descending (see [`SequencedKey::cmp`]), so a
+    /// `lower_bound` probe at `(key, seq_bound)` lands on the largest-seq
+    /// entry that satisfies the filter.
+    ///
+    /// Callers must handle `Merge` operands themselves, a `Merge` hit here
+    /// only represents one operand and must still be folded with operands
+    /// from older sources. `Value` and `Tombstone` hits are terminal.
+    pub(crate) fn get(&self, key: &[u8], max_seq: Option<u64>) -> Option<RowEntry> {
+        let seq_bound = max_seq.unwrap_or(u64::MAX);
+        let probe = SequencedKey::new(Bytes::copy_from_slice(key), seq_bound);
+        let entry = self.map.lower_bound(Bound::Included(&probe))?;
+        if entry.key().user_key.as_ref() != key {
+            return None;
+        }
+        Some(entry.value().clone())
+    }
+
     pub(crate) fn range_ascending<T: RangeBounds<Bytes>>(&self, range: T) -> MemTableIterator {
         self.range(range, IterationOrder::Ascending)
     }
@@ -567,6 +591,7 @@ mod tests {
     use crate::merge_iterator::MergeIterator;
     use crate::proptest_util::{arbitrary, sample};
     use crate::test_utils::assert_iterator;
+    use crate::types::ValueDeletable;
     use crate::{proptest_util, test_utils};
     use rstest::rstest;
     use tokio::runtime::Runtime;
@@ -950,6 +975,90 @@ mod tests {
         assert!(!table
             .ensure_valid_segment(&Bytes::from_static(b"zzz"))
             .unwrap());
+    }
+
+    #[test]
+    fn test_get_returns_freshest_value_for_key() {
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"k", b"v1", 1));
+        table.put(RowEntry::new_value(b"k", b"v2", 5));
+        table.put(RowEntry::new_value(b"k", b"v3", 3));
+
+        let entry = table.table().get(b"k", None).expect("hit expected");
+        assert_eq!(entry.seq, 5);
+        assert_eq!(
+            entry.value,
+            ValueDeletable::Value(Bytes::from_static(b"v2"))
+        );
+    }
+
+    #[test]
+    fn test_get_returns_none_for_missing_key() {
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"k1", b"v1", 1));
+        table.put(RowEntry::new_value(b"k3", b"v3", 2));
+
+        assert!(table.table().get(b"k2", None).is_none());
+        assert!(table.table().get(b"k0", None).is_none());
+        assert!(table.table().get(b"k4", None).is_none());
+    }
+
+    #[test]
+    fn test_get_returns_tombstone_when_freshest() {
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"k", b"v1", 1));
+        table.put(RowEntry::new_tombstone(b"k", 5));
+        table.put(RowEntry::new_value(b"k", b"v3", 3));
+
+        let entry = table.table().get(b"k", None).expect("hit expected");
+        assert_eq!(entry.seq, 5);
+        assert!(entry.value.is_tombstone());
+    }
+
+    #[test]
+    fn test_get_respects_max_seq() {
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"k", b"v1", 1));
+        table.put(RowEntry::new_value(b"k", b"v3", 3));
+        table.put(RowEntry::new_value(b"k", b"v5", 5));
+
+        // No filter: freshest wins.
+        let entry = table.table().get(b"k", None).unwrap();
+        assert_eq!(entry.seq, 5);
+
+        // max_seq=4: should return seq=3.
+        let entry = table.table().get(b"k", Some(4)).unwrap();
+        assert_eq!(entry.seq, 3);
+
+        // max_seq=2: should return seq=1.
+        let entry = table.table().get(b"k", Some(2)).unwrap();
+        assert_eq!(entry.seq, 1);
+
+        // max_seq=0: no visible entries.
+        assert!(table.table().get(b"k", Some(0)).is_none());
+    }
+
+    #[test]
+    fn test_get_returns_merge_operand() {
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_merge(b"k", b"m1", 1));
+        table.put(RowEntry::new_merge(b"k", b"m2", 2));
+
+        let entry = table.table().get(b"k", None).unwrap();
+        assert_eq!(entry.seq, 2);
+        assert!(matches!(entry.value, ValueDeletable::Merge(_)));
+    }
+
+    #[test]
+    fn test_get_does_not_leak_across_user_keys() {
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"aaa", b"v_a", 1));
+        table.put(RowEntry::new_value(b"aab", b"v_ab", 2));
+
+        // Probing "aa" must not return "aaa" or "aab".
+        assert!(table.table().get(b"aa", None).is_none());
+        // Probing "a" must not return anything either.
+        assert!(table.table().get(b"a", None).is_none());
     }
 
     #[tokio::test]

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -134,6 +134,26 @@ impl Reader {
         max_seq
     }
 
+    /// Walk the memtables (active first, then immutables freshest-first) and
+    /// return the freshest entry visible at `max_seq` for `key`. Returns
+    /// `None` if no memtable contains the key. A `Merge` operand is returned
+    /// as-is, the caller must still fold it with older sources.
+    fn memtable_get(
+        db_state: &(dyn DbStateReader + Sync + Send),
+        key: &[u8],
+        max_seq: Option<u64>,
+    ) -> Option<crate::types::RowEntry> {
+        if let Some(entry) = db_state.memtable().get(key, max_seq) {
+            return Some(entry);
+        }
+        for imm in db_state.imm_memtable() {
+            if let Some(entry) = imm.table().get(key, max_seq) {
+                return Some(entry);
+            }
+        }
+        None
+    }
+
     async fn build_iterator_sources(
         &self,
         range: &BytesRange,
@@ -208,6 +228,25 @@ impl Reader {
         self.db_stats.get_requests.increment(1);
         let max_seq = self.prepare_max_seq(max_seq, options.durability_filter, options.dirty);
         let key_slice = key.as_ref();
+
+        // Fast path: if there's no transaction write batch in play, probe the
+        // memtables directly. A terminal hit (Value or Tombstone) in the
+        // freshest matching memtable masks every deeper source, so we can
+        // skip the merge-iterator / segment-iterator construction entirely.
+        // A `Merge` operand still requires folding with older sources, so we
+        // fall through to the full path in that case.
+        if write_batch_iter.is_none() {
+            if let Some(entry) = Self::memtable_get(db_state, key_slice, max_seq) {
+                match entry.value {
+                    crate::types::ValueDeletable::Value(_) => {
+                        return Ok(Some(KeyValue::from(entry)))
+                    }
+                    crate::types::ValueDeletable::Tombstone => return Ok(None),
+                    crate::types::ValueDeletable::Merge(_) => { /* fall through */ }
+                }
+            }
+        }
+
         let range = BytesRange::from_slice(key_slice..=key_slice);
 
         let sst_iter_options = SstIteratorOptions {


### PR DESCRIPTION
## Summary

Skip the merge-iterator setup when a `get` can be answered directly from a memtable.

## Changes

- `KVTable::get` does a single `SkipMap::lower_bound` for a point lookup.
- `Reader::get_key_value_with_options` probes memtables first; on a `Value` or `Tombstone` hit, returns without building the iterator pipeline. `Merge`, misses, and transactions fall through unchanged.

## Notes for Reviewers

Bench (one key in active memtable, miss is empty SST tree):

```
  |                      | before | after  |
  |----------------------|--------|--------|
  | `get_memtable_hit`   | 822 ns | 135 ns |
  | `get_memtable_miss`  | 835 ns | 914 ns |
```

The miss cost is one wasted `SkipMap::lower_bound` before falling through; in real workloads it's noise next to block fetches.

Correctness rests on `SequencedKey` ordering (user-key asc, seq desc): `lower_bound(Included((key, seq_bound)))` lands on the entry with the largest `seq <= seq_bound` for `key`, which is exactly what the pipeline would have picked.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
