### PR TITLE
Fix Python wheel builds for io-uring cross targets

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -38,6 +38,9 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         env:
+          # Foyer pulls in io-uring on Linux, and io-uring's prebuilt sys.rs
+          # bindings do not cover every cross-compiled wheel target we publish.
+          RUSTFLAGS: "--cfg io_uring_skip_arch_check"
           CC_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-gcc
           AR_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-ar
           RANLIB_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-ranlib
@@ -79,6 +82,10 @@ jobs:
           python-version: 3.x
       - name: Build wheels
         uses: PyO3/maturin-action@v1
+        env:
+          # Foyer pulls in io-uring on Linux, and io-uring's prebuilt sys.rs
+          # bindings do not cover every cross-compiled wheel target we publish.
+          RUSTFLAGS: "--cfg io_uring_skip_arch_check"
         with:
           working-directory: ./bindings/python
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
## Summary

Python release wheels started failing for some Linux cross targets because Foyer pulls in `io-uring`, and `io-uring`'s prebuilt `sys.rs` bindings do not cover every architecture we publish.

https://github.com/slatedb/slatedb/actions/runs/25927431126

## Changes

- Add `RUSTFLAGS="--cfg io_uring_skip_arch_check"` to the Linux and musllinux maturin build jobs

Thank you for the review! 🙏
