### PR TITLE
Fix missed wakeup in dispatcher parallel-handler tests

### DIFF
--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -1592,10 +1592,17 @@ mod test {
             entries,
         );
 
-        // Unblock both and shut down
-        block1.notify_waiters();
-        block2.notify_waiters();
-        task_executor.shutdown_task("parallel").await.ok();
+        // Unblock both and shut down. Use notify_one so a permit is retained
+        // if a handler has logged but has not yet reached notified().await.
+        block1.notify_one();
+        block2.notify_one();
+        let result = timeout(
+            Duration::from_secs(5),
+            task_executor.shutdown_task("parallel"),
+        )
+        .await
+        .expect("timeout waiting for shutdown after unblock");
+        assert!(result.is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1756,9 +1763,10 @@ mod test {
             "join_task should not resolve while members are still blocked"
         );
 
-        // Unblock both — now join should resolve
-        block1.notify_waiters();
-        block2.notify_waiters();
+        // Unblock both. notify_one is safe even if a handler has logged but
+        // has not yet reached notified().await.
+        block1.notify_one();
+        block2.notify_one();
         let result = timeout(Duration::from_secs(5), task_executor.join_task("parallel"))
             .await
             .expect("timeout waiting for join after unblock");


### PR DESCRIPTION
## Summary

Fix a flaky timeout in the dispatcher parallel-handler tests. Detected here:

https://github.com/slatedb/slatedb/actions/runs/25854410417/job/75968552463

The tests used `Notify::notify_waiters()` to unblock handlers after observing that each handler had logged a message. That log entry happens before the handler awaits `notified()`, so the test could signal too early. Since `notify_waiters()` does not retain a permit for future waiters, a handler could miss the notification and block forever during shutdown.

## Changes

- Convert `notify_waiters` to `notify_one` in two tests

## Notes for Reviewers

I could not reproduce the issue locally despite running the test 1000+ times with CPU saturated. Still, this fix seems to make sense.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
