### PR TITLE
Verify fence writes are > replay_after_wal_id

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -332,7 +332,7 @@ impl DbInner {
 
             // If the fence failed or was behind the replay_after_wal_id barrier, we need to
             // try again with a higher empty WAL ID.
-            empty_wal_id += 1;
+            empty_wal_id = (empty_wal_id + 1).max(replay_after_wal_id + 1);
         }
     }
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3562,7 +3562,8 @@ mod tests {
         let expected_cache_parts =
             vec![
             ("tmp/test_kv_store_with_cache_stored_files/manifest/00000000000000000001.manifest", 0),
-            ("tmp/test_kv_store_with_cache_stored_files/manifest/00000000000000000002.manifest", 0),
+            // 1 part is cached because fence_writers refreshes the manifest after writing the fence.
+            ("tmp/test_kv_store_with_cache_stored_files/manifest/00000000000000000002.manifest", 1),
             // 1 part is cached because of wal_replay after fencing (which reads the SST, thereby caching it)
             ("tmp/test_kv_store_with_cache_stored_files/wal/00000000000000000001.sst", 1),
             ("tmp/test_kv_store_with_cache_stored_files/wal/00000000000000000002.sst", 0),
@@ -3582,10 +3583,11 @@ mod tests {
     async fn test_get_with_object_store_cache_put_caching_enabled() {
         let expected_cache_parts =
             vec![
-            // not cached because manifests are put before the root is resolved, which is when
+            // not cached because this manifest is put before the root is resolved, which is when
             // `cache_puts_enabled` starts taking effect.
             ("tmp/test_kv_store_with_put_cache_enabled/manifest/00000000000000000001.manifest", 0),
-            ("tmp/test_kv_store_with_put_cache_enabled/manifest/00000000000000000002.manifest", 0),
+            // 1 part is cached because fence_writers refreshes the manifest after writing the fence.
+            ("tmp/test_kv_store_with_put_cache_enabled/manifest/00000000000000000002.manifest", 1),
             // 1 part is cached because of wal_replay after fencing (which reads the SST, thereby caching it)
             ("tmp/test_kv_store_with_put_cache_enabled/wal/00000000000000000001.sst", 1),
             // 1 part is cached because the put with cache_puts enabled should cache the test_key put

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6143,6 +6143,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fence_writers_retries_successful_fence_behind_replay_boundary() {
+        // Race:
+        // - t0: W2 computes stale next_wal_id=2 while W1 is still active.
+        // - t1: W1 writes WAL 2 and WAL 3, flushes them to L0, and advances
+        //   the replay boundary to 3.
+        // - t2: WAL GC deletes WAL 2, so a future create at stale WAL 2 can
+        //   succeed, but it leaves WAL 3 because replay_after_wal_id is not
+        //   eligible for deletion.
+        // - t3: W2 claims the writer epoch from that manifest.
+        // - t4: W2 builds the DbInner needed to run fence_writers.
+        // - t5: W2 writes a fence at stale WAL 2; current code accepts it.
+        // - t6: W1 can still create live WAL 4 unless W2 retried the fence
+        //   above the replay boundary.
+        // - t7: ValidateFence should make t6 fail with Fenced.
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_fence_writers_retries_successful_fence_behind_replay_boundary";
+        let mut settings = test_db_options(0, 128, None);
+        settings.flush_interval = None;
+
+        // - t0: W2 computes stale next_wal_id=2 while W1 is still active.
+        let stale_next_wal_id = 2;
+        let replay_after_wal_id = stale_next_wal_id + 1; // 3
+        let live_wal_id = replay_after_wal_id + 1; // 4
+
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            SsTableFormat::default(),
+            path,
+            None,
+        ));
+
+        // - t1: W1 writes WAL 2 and WAL 3, flushes them to L0, and advances
+        //   the replay boundary to 3.
+        for wal_id in [stale_next_wal_id, replay_after_wal_id] {
+            let mut w1_wal = table_store.table_builder();
+            w1_wal
+                .add(RowEntry::new_value(b"w1", b"write", wal_id))
+                .await
+                .unwrap();
+            let w1_wal = w1_wal.build().await.unwrap();
+            table_store
+                .write_sst(&SsTableId::Wal(wal_id), &w1_wal, false)
+                .await
+                .unwrap();
+        }
+        let mut core = ManifestCore::new();
+        core.replay_after_wal_id = replay_after_wal_id;
+        core.next_wal_sst_id = live_wal_id;
+
+        // - t2: WAL GC deletes WAL 2, so a future create at stale WAL 2 can
+        //   succeed, but it leaves WAL 3 because replay_after_wal_id is not
+        //   eligible for deletion.
+        table_store
+            .delete_sst(&SsTableId::Wal(stale_next_wal_id))
+            .await
+            .unwrap();
+
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let stored_manifest =
+            StoredManifest::create_new_db(manifest_store, core, system_clock.clone())
+                .await
+                .unwrap();
+
+        // - t3: W2 claims the writer epoch from that manifest.
+        let mut manifest = FenceableManifest::init_writer(
+            stored_manifest,
+            settings.manifest_update_timeout,
+            system_clock.clone(),
+        )
+        .await
+        .unwrap();
+        let manifest_dirty = manifest.prepare_dirty().unwrap();
+
+        // - t4: Build the minimal DbInner needed to run W2's fence_writers.
+        let status_manager = DbStatusManager::new_with_manifest(
+            manifest_dirty.value.core.last_l0_seq,
+            manifest_dirty.clone().into(),
+        );
+        let (write_tx, _write_rx) = SafeSender::unbounded_channel(status_manager.result_reader());
+        let memtable_flusher = Arc::new(MemtableFlusher::new(&status_manager));
+        let inner = DbInner::new(
+            settings,
+            system_clock,
+            Arc::new(DbRand::new(0)),
+            table_store.clone(),
+            manifest_dirty,
+            memtable_flusher,
+            write_tx,
+            MetricsRecorderHelper::noop(),
+            Arc::new(FailPointRegistry::new()),
+            None,
+            status_manager,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // - t5: W2 writes a fence at stale WAL 2; current code accepts it.
+        inner
+            .fence_writers(&mut manifest, stale_next_wal_id)
+            .await
+            .unwrap();
+
+        // - t6: W1 can still create live WAL 4 unless W2 retried the fence
+        //   above the replay boundary.
+        let mut stale_writer_wal = table_store.table_builder();
+        stale_writer_wal
+            .add(RowEntry::new_value(b"stale", b"write", 0))
+            .await
+            .unwrap();
+        let stale_writer_wal = stale_writer_wal.build().await.unwrap();
+        let stale_write_result = table_store
+            .write_sst(&SsTableId::Wal(live_wal_id), &stale_writer_wal, false)
+            .await;
+
+        // - t7: ValidateFence should make t6 fail with Fenced.
+        assert!(
+            matches!(stale_write_result, Err(SlateDBError::Fenced)),
+            "expected fence_writers to retry from stale WAL {stale_next_wal_id} and fence live WAL {live_wal_id}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_invalid_clock_progression() {
         // Given:
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -311,7 +311,7 @@ impl DbInner {
                 Err(err) => return Err(err),
             };
 
-            // Refresh validates tha we own the latest epoch still.
+            // Refresh validates that we own the latest epoch still.
             manifest.refresh().await?;
             let remote_dirty = manifest.prepare_dirty()?;
             let replay_after_wal_id = remote_dirty.value.core.replay_after_wal_id;
@@ -322,17 +322,26 @@ impl DbInner {
             };
             self.status_manager.report_manifest(dirty_manifest.into());
 
-            // Our fence write might be behind replay_after_wal_id since we're racing with
-            // older writers that can advance replay_after_wal_id by flushing data to L0.
-            // We need to make sure the fence write falls above this barrier so it's visible
-            // to all other active writers.
-            if wrote_fence && empty_wal_id > replay_after_wal_id {
-                return Ok(());
+            if wrote_fence {
+                // Our fence write might be behind replay_after_wal_id since we're racing with
+                // older writers that can advance replay_after_wal_id by flushing data to L0.
+                // We need to make sure the fence write falls above this barrier so it's visible
+                // to all other active writers.
+                if empty_wal_id > replay_after_wal_id {
+                    return Ok(());
+                } else {
+                    // If we're behind the barrier, reset to the next WAL slot.
+                    empty_wal_id = self
+                        .table_store
+                        .next_wal_sst_id(replay_after_wal_id)
+                        .await?;
+                }
+            } else {
+                // We're (probably) ahead of the barrier, but we hit a race with another writer.
+                // Instead of paying for the LIST (API cost and latency), just try the next ID.
+                // This is an optimization: we could always advance with next_wal_sst_id.
+                empty_wal_id += 1;
             }
-
-            // If the fence failed or was behind the replay_after_wal_id barrier, we need to
-            // try again with a higher empty WAL ID.
-            empty_wal_id = (empty_wal_id + 1).max(replay_after_wal_id + 1);
         }
     }
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -305,25 +305,34 @@ impl DbInner {
         let mut empty_wal_id = next_wal_id;
 
         loop {
-            match self.flush_empty_wal(empty_wal_id).await {
-                Ok(()) => {
-                    return Ok(());
-                }
-                Err(SlateDBError::Fenced) => {
-                    manifest.refresh().await?;
-                    let remote_dirty = manifest.prepare_dirty()?;
-                    let dirty_manifest = {
-                        let mut state = self.state.write();
-                        state.merge_remote_manifest(remote_dirty);
-                        state.state().manifest.clone()
-                    };
-                    self.status_manager.report_manifest(dirty_manifest.into());
-                    empty_wal_id += 1;
-                }
-                Err(e) => {
-                    return Err(e);
-                }
+            let wrote_fence = match self.flush_empty_wal(empty_wal_id).await {
+                Ok(()) => true,
+                Err(SlateDBError::Fenced) => false,
+                Err(err) => return Err(err),
+            };
+
+            // Refresh validates tha we own the latest epoch still.
+            manifest.refresh().await?;
+            let remote_dirty = manifest.prepare_dirty()?;
+            let replay_after_wal_id = remote_dirty.value.core.replay_after_wal_id;
+            let dirty_manifest = {
+                let mut state = self.state.write();
+                state.merge_remote_manifest(remote_dirty);
+                state.state().manifest.clone()
+            };
+            self.status_manager.report_manifest(dirty_manifest.into());
+
+            // Our fence write might be behind replay_after_wal_id since we're racing with
+            // older writers that can advance replay_after_wal_id by flushing data to L0.
+            // We need to make sure the fence write falls above this barrier so it's visible
+            // to all other active writers.
+            if wrote_fence && empty_wal_id > replay_after_wal_id {
+                return Ok(());
             }
+
+            // If the fence failed or was behind the replay_after_wal_id barrier, we need to
+            // try again with a higher empty WAL ID.
+            empty_wal_id += 1;
         }
     }
 


### PR DESCRIPTION
## Summary

I was modeling our WAL protocol as part of #1672. While doing so, I found an issue with the current design. `Db` does the following on startup:

1. Find the next available slot to write to
2. Bump the `writer_epoch` in the manifest
3. Write a fence (empty SST) to the slot it picked in (1)

If the write is successful in (3), `Ok(())` is returned and the new `Db` considers itself ready.

There is a race in this scenario. It's possible that an older writer could have already written data to that slot and flushed its data to L0. In doing so, it could have advanced the `replay_after_wal_id` value beyond the slot discovered in (1).

- t0: W2 sees next slot 4
- t1: W1 writes to slot 4, slot 5, and slot 6
- t2: W1 flushes to L0, updating manifest.replay_after_wal_id to 6
- t3: GC deletes WALs 4 and 5 since they are > min_age and < replay_after_wal_id
- t4: W2 successfully writes to slot 4 and returns `Ok(())` believing it's fenced all previous writers
- t5+: W1 continues writing at slots 7+

This is wrong. W2 needs to verify that its fence write is within bounds before it returns success. That's what this patch does.

## Changes

- Add a test to replicate the issue
- Verify both `writer_epoch` (via `manifest.refresh().await?`) and `empty_wal_id > replay_after_wal_id`
- Fix two object store cache tests that now see cached parts due to the refresh on successful write during fencing

## Notes for Reviewers

Nope.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
