### PR TITLE
Retry boundary conflicts on compactor startup

### DIFF
--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -166,14 +166,19 @@ impl CompactorStateWriter {
             system_clock.clone(),
         )
         .await?;
-        let stored_compactions =
+        let stored_compactions = loop {
             match StoredCompactions::try_load(compactions_store.clone()).await? {
-                Some(compactions) => compactions,
+                Some(compactions) => break compactions,
                 None => {
                     info!("creating new compactions file [compactor_epoch=0]");
-                    StoredCompactions::create(compactions_store.clone(), 0).await?
+                    match StoredCompactions::create(compactions_store.clone(), 0).await {
+                        Ok(compactions) => break compactions,
+                        Err(err) if err.is_sequenced_write_conflict() => continue,
+                        Err(err) => return Err(err),
+                    }
                 }
-            };
+            }
+        };
         let fenceable_compactions = FenceableCompactions::init_with_epoch(
             stored_compactions,
             options.manifest_update_timeout,
@@ -878,6 +883,108 @@ mod tests {
             .unwrap()
             .id;
         assert_eq!(final_id, start_id + 3);
+    }
+
+    #[tokio::test]
+    async fn test_new_retries_initial_compactions_create_on_boundary_conflict() {
+        // Use a gated store only for compactions so manifest fencing can complete
+        // before the test pauses the initial compactions create.
+        let raw_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated_object_store = Arc::new(GatedObjectStore::new(Arc::clone(&raw_object_store)));
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&raw_object_store),
+        ));
+        let compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from(ROOT),
+            gated_object_store.clone(),
+        ));
+        let external_compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&raw_object_store),
+        ));
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            system_clock.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Pause CompactorStateWriter::new after it observes missing compactions and
+        // attempts to create the initial compactions file.
+        let arrivals = gated_object_store.put_opts_gate.arrivals();
+        gated_object_store.put_opts_gate.close();
+        let writer_task = tokio::spawn({
+            let manifest_store = manifest_store.clone();
+            let compactions_store = compactions_store.clone();
+            let system_clock = system_clock.clone();
+            async move {
+                let options = CompactorOptions::default();
+                CompactorStateWriter::new(
+                    manifest_store,
+                    compactions_store,
+                    system_clock,
+                    &options,
+                    Arc::new(DbRand::new(7)),
+                )
+                .await
+            }
+        });
+        gated_object_store
+            .put_opts_gate
+            .wait_for_arrivals(arrivals + 1)
+            .await;
+
+        // Let an external writer create the ID that the paused writer intended
+        // to create.
+        let mut external = StoredCompactions::create(external_compactions_store.clone(), 0)
+            .await
+            .unwrap();
+        assert_eq!(external.id(), 1);
+
+        // Add a live version above the future boundary that the retried constructor
+        // should load and preserve.
+        let external_id = Ulid::from_parts(2, 0);
+        let mut external_dirty = external.prepare_dirty().unwrap();
+        external_dirty
+            .value
+            .insert(Compaction::new(external_id, CompactionSpec::new(vec![], 0)));
+        external.update(external_dirty).await.unwrap();
+        assert_eq!(external.id(), 2);
+
+        // Fence and delete the stale initial ID so the paused create returns a
+        // boundary conflict rather than a plain version conflict.
+        external_compactions_store
+            .advance_boundary(1)
+            .await
+            .unwrap();
+        external_compactions_store
+            .delete_compactions(1)
+            .await
+            .unwrap();
+
+        // Release the paused create. fence() should retry, load the external live
+        // compactions file, and continue initialization.
+        gated_object_store.put_opts_gate.release();
+        let writer = writer_task.await.unwrap().unwrap();
+
+        let latest = external_compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap();
+        assert_eq!(latest.id, 4);
+        assert_eq!(u64::from(writer.state.compactions().id), latest.id);
+        assert_eq!(
+            latest
+                .compactions
+                .get(&external_id)
+                .expect("missing external submitted compaction")
+                .status(),
+            CompactionStatus::Submitted
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use log::{debug, info};
 
 use crate::compactions_store::{CompactionsStore, FenceableCompactions, StoredCompactions};
-use crate::compactor_state::{CompactionStatus, CompactorState, VersionedCompactions};
+use crate::compactor_state::{CompactionStatus, Compactions, CompactorState, VersionedCompactions};
 use crate::config::{CheckpointOptions, CompactorOptions};
 use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
@@ -23,6 +23,7 @@ use crate::manifest::VersionedManifest;
 use crate::utils::IdGenerator;
 use crate::DbRand;
 use slatedb_common::clock::SystemClock;
+use slatedb_txn_obj::DirtyObject;
 
 /// A read-only view of compactor state suitable for consumers like GC.
 ///
@@ -143,18 +144,7 @@ impl CompactorStateWriter {
         )
         .await?;
         let dirty_manifest = manifest.prepare_dirty()?;
-        let mut dirty_compactions = compactions.prepare_dirty()?;
-        // Move running compactions back to submitted so we can resume them after restart.
-        // Submitted compactions are left intact for future scheduling.
-        // Keep only the most recent finished compaction for GC safety (#1044).
-        dirty_compactions.value.iter_mut().for_each(|c| {
-            if matches!(c.status(), CompactionStatus::Running) {
-                c.set_status(CompactionStatus::Submitted);
-            }
-        });
-        dirty_compactions.value.retain_active_and_last_finished();
-        // Persist recovery state before any refresh() can overwrite it.
-        compactions.update(dirty_compactions.clone()).await?;
+        let dirty_compactions = Self::write_recovered_compactions_safely(&mut compactions).await?;
         let state = CompactorState::new(dirty_manifest, dirty_compactions);
         Ok(Self {
             state,
@@ -192,6 +182,35 @@ impl CompactorStateWriter {
         )
         .await?;
         Ok((fenceable_manifest, fenceable_compactions))
+    }
+
+    async fn write_recovered_compactions_safely(
+        compactions: &mut FenceableCompactions,
+    ) -> Result<DirtyObject<Compactions>, SlateDBError> {
+        // This runs before `CompactorStateWriter` has a `state`, so it can't call
+        // `write_compactions_safely`. Recovery also needs to recompute from the
+        // refreshed compactions value after each boundary/CAS conflict.
+        loop {
+            let mut dirty = compactions.prepare_dirty()?;
+
+            // Move running compactions back to submitted so we can resume them after restart.
+            // Submitted compactions are left intact for future scheduling.
+            // Keep only the most recent finished compaction for GC safety (#1044).
+            dirty.value.iter_mut().for_each(|c| {
+                if matches!(c.status(), CompactionStatus::Running) {
+                    c.set_status(CompactionStatus::Submitted);
+                }
+            });
+            dirty.value.retain_active_and_last_finished();
+
+            match compactions.update(dirty).await {
+                Ok(()) => return compactions.prepare_dirty(),
+                Err(err) if err.is_sequenced_write_conflict() => {
+                    compactions.refresh().await?;
+                }
+                Err(err) => return Err(err),
+            }
+        }
     }
 
     /// Refreshes the manifest and updates the local compactor state with any remote
@@ -332,6 +351,7 @@ mod tests {
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
+    use crate::test_utils::GatedObjectStore;
     use bytes::Bytes;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -858,6 +878,136 @@ mod tests {
             .unwrap()
             .id;
         assert_eq!(final_id, start_id + 3);
+    }
+
+    #[tokio::test]
+    async fn test_write_recovered_compactions_safely_retries_on_boundary_conflict() {
+        // Set up a gated store for the recovering writer and a raw store for the
+        // external writer so only the recovery write is paused.
+        let raw_object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated_object_store = Arc::new(GatedObjectStore::new(Arc::clone(&raw_object_store)));
+        let compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from(ROOT),
+            gated_object_store.clone(),
+        ));
+        let external_compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&raw_object_store),
+        ));
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+
+        // Seed a compactions record with a Running entry that startup recovery must
+        // move back to Submitted.
+        let mut stored_compactions = StoredCompactions::create(compactions_store.clone(), 1)
+            .await
+            .unwrap();
+        let running_id = Ulid::from_parts(1, 0);
+        let mut dirty = stored_compactions.prepare_dirty().unwrap();
+        dirty.value.insert(
+            Compaction::new(running_id, CompactionSpec::new(vec![], 0))
+                .with_status(CompactionStatus::Running),
+        );
+        stored_compactions.update(dirty).await.unwrap();
+
+        // Fence the recovering compactor so the helper writes with the same handle
+        // used by CompactorStateWriter::new.
+        let stored_compactions = StoredCompactions::load(compactions_store.clone())
+            .await
+            .unwrap();
+        let mut compactions = FenceableCompactions::init_with_epoch(
+            stored_compactions,
+            Duration::from_secs(300),
+            system_clock,
+            2,
+        )
+        .await
+        .unwrap();
+        let start_id = compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .id;
+
+        // Pause the recovery write after it has chosen its stale next ID.
+        let arrivals = gated_object_store.put_opts_gate.arrivals();
+        gated_object_store.put_opts_gate.close();
+        let recovery_task = tokio::spawn(async move {
+            CompactorStateWriter::write_recovered_compactions_safely(&mut compactions).await
+        });
+        gated_object_store
+            .put_opts_gate
+            .wait_for_arrivals(arrivals + 1)
+            .await;
+
+        // Let an external writer win the recovering writer's intended ID.
+        let mut external = StoredCompactions::load(external_compactions_store.clone())
+            .await
+            .unwrap();
+        external
+            .update(external.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        assert_eq!(external.id(), start_id + 1);
+
+        // Add a second external version above the future boundary, carrying a
+        // submitted compaction that recovery must preserve after refreshing.
+        let external_id = Ulid::from_parts(2, 0);
+        let mut external_dirty = external.prepare_dirty().unwrap();
+        external_dirty
+            .value
+            .insert(Compaction::new(external_id, CompactionSpec::new(vec![], 0)));
+        external.update(external_dirty).await.unwrap();
+        assert_eq!(external.id(), start_id + 2);
+
+        // Fence and delete the stale ID so the paused recovery write hits a
+        // boundary conflict instead of a plain version conflict.
+        external_compactions_store
+            .advance_boundary(start_id + 1)
+            .await
+            .unwrap();
+        external_compactions_store
+            .delete_compactions(start_id + 1)
+            .await
+            .unwrap();
+
+        // Release the paused write; it should see the boundary conflict, refresh,
+        // recompute recovery, and write the next safe ID.
+        gated_object_store.put_opts_gate.release();
+
+        // Verify the returned recovered state advanced past the fenced ID.
+        let recovered = recovery_task.await.unwrap().unwrap();
+        assert_eq!(u64::from(recovered.id), start_id + 3);
+        // Verify startup recovery converted the original Running compaction.
+        assert_eq!(
+            recovered
+                .value
+                .get(&running_id)
+                .expect("missing recovered running compaction")
+                .status(),
+            CompactionStatus::Submitted
+        );
+        // Verify the recompute-after-refresh preserved the external submitted compaction.
+        assert_eq!(
+            recovered
+                .value
+                .get(&external_id)
+                .expect("missing external submitted compaction")
+                .status(),
+            CompactionStatus::Submitted
+        );
+
+        // Verify the durable latest compactions record matches the recovered state.
+        let latest = compactions_store.read_latest_compactions().await.unwrap();
+        assert_eq!(latest.id, start_id + 3);
+        assert_eq!(
+            latest
+                .compactions
+                .get(&running_id)
+                .expect("missing latest recovered running compaction")
+                .status(),
+            CompactionStatus::Submitted
+        );
+        assert!(latest.compactions.contains(&external_id));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The chaos test failed a couple of nights ago:

- https://github.com/slatedb/slatedb/actions/runs/25958431611/job/76309293353

This test runs with GC min_age=0 so the boundary is very tight. We have a few places on startup where we don't retry boundary conflicts--we just fail. This PR fixes two such cases in the compactor.

## Changes

- Retry on boundary conflict in Compactor::new when resetting running compactions to submitted
- Retry on boundary conflict in Compactor::new when creating new .compactions files for the first time

## Notes for Reviewers

It's a bit annoying to have both `write_recovered_compactions_safely` and `write_compactions_safely`. The former must be an associative function because it's called from `new`. I explored combining the two, but it got a bit messy because we don't yet have `state` in `new()`. Bit of a chicken and egg problem. I opted to just keep them separate.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
