### PR TITLE
Fix boundary file race condition leading to `InvalidObjectState`

### DIFF
--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::StreamExt;
-use log::{debug, warn};
+use log::{debug, error, warn};
 use object_store::path::Path;
 use object_store::Error::AlreadyExists;
 use object_store::{
@@ -188,20 +188,30 @@ impl ObjectStoreBoundaryObject {
                 // NotModified implies we have a cache, since we need the
                 // version's ETag for the conditional GET. If cache is missing,
                 // treat as invalid state.
-                None => Err(TransactionalObjectError::InvalidObjectState),
+                None => {
+                    error!(
+                        "received NotModified without cache [path={}]",
+                        self.filepath
+                    );
+                    Err(TransactionalObjectError::InvalidObjectState)
+                }
             },
             Err(Error::NotFound { .. }) => match (cached, self.cache.lock().clone()) {
                 // This read began before this boundary object had observed a
                 // boundary, and another task advanced/read the boundary while
                 // the GET was in flight. Use the newer local observation rather
                 // than treating the racing GET as a durable disappearance.
-                (None, Some((boundary, version))) => {
-                    Ok((boundary, Some(version)))
-                }
+                (None, Some((boundary, version))) => Ok((boundary, Some(version))),
                 // Once this read starts with an observed boundary, the boundary
                 // file disappearing means durable state regressed; do not treat
                 // it as an initial zero boundary.
-                (Some(_), _) => Err(TransactionalObjectError::InvalidObjectState),
+                (Some(_), _) => {
+                    error!(
+                        "received NotFound after observing boundary [path={}]",
+                        self.filepath
+                    );
+                    Err(TransactionalObjectError::InvalidObjectState)
+                }
                 // Default to zero boundary if file is missing and we've never
                 // observed it before.
                 (None, None) => Ok((MonotonicId::new(0), None)),

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -196,11 +196,6 @@ impl ObjectStoreBoundaryObject {
                 // the GET was in flight. Use the newer local observation rather
                 // than treating the racing GET as a durable disappearance.
                 (None, Some((boundary, version))) => {
-                    debug!(
-                        "boundary was observed while missing boundary read was in flight [path={}, boundary={}]",
-                        self.filepath,
-                        boundary.id()
-                    );
                     Ok((boundary, Some(version)))
                 }
                 // Once this read starts with an observed boundary, the boundary

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -190,13 +190,26 @@ impl ObjectStoreBoundaryObject {
                 // treat as invalid state.
                 None => Err(TransactionalObjectError::InvalidObjectState),
             },
-            Err(Error::NotFound { .. }) => match self.cache.lock().clone() {
-                // Once observed, the boundary file disappearing means durable state
-                // regressed; do not treat it as an initial zero boundary.
-                Some(_) => Err(TransactionalObjectError::InvalidObjectState),
+            Err(Error::NotFound { .. }) => match (cached, self.cache.lock().clone()) {
+                // This read began before this boundary object had observed a
+                // boundary, and another task advanced/read the boundary while
+                // the GET was in flight. Use the newer local observation rather
+                // than treating the racing GET as a durable disappearance.
+                (None, Some((boundary, version))) => {
+                    debug!(
+                        "boundary was observed while missing boundary read was in flight [path={}, boundary={}]",
+                        self.filepath,
+                        boundary.id()
+                    );
+                    Ok((boundary, Some(version)))
+                }
+                // Once this read starts with an observed boundary, the boundary
+                // file disappearing means durable state regressed; do not treat
+                // it as an initial zero boundary.
+                (Some(_), _) => Err(TransactionalObjectError::InvalidObjectState),
                 // Default to zero boundary if file is missing and we've never
                 // observed it before.
-                None => Ok((MonotonicId::new(0), None)),
+                (None, None) => Ok((MonotonicId::new(0), None)),
             },
             Err(e) => Err(TransactionalObjectError::from(e)),
         }
@@ -441,13 +454,15 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{
-        GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-        PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as ObjectStoreResult,
+        Error as ObjectStoreError, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+        ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+        Result as ObjectStoreResult, UpdateVersion,
     };
     use std::collections::Bound::{Excluded, Included, Unbounded};
     use std::fmt;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tokio::sync::Notify;
 
     /// A flaky object store that simulates a missing file on the first list() call.
     /// On the first call to list(), it returns a file with `missing_id`. On subsequent
@@ -558,10 +573,17 @@ mod tests {
     }
 
     #[derive(Debug)]
+    struct BlockingNotFoundGet {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    #[derive(Debug)]
     struct CountingGetStore {
         inner: InMemory,
         get_opts_calls: AtomicUsize,
         if_none_match_gets: AtomicUsize,
+        blocking_not_found: StdMutex<Option<BlockingNotFoundGet>>,
     }
 
     impl CountingGetStore {
@@ -570,7 +592,18 @@ mod tests {
                 inner: InMemory::new(),
                 get_opts_calls: AtomicUsize::new(0),
                 if_none_match_gets: AtomicUsize::new(0),
+                blocking_not_found: StdMutex::new(None),
             }
+        }
+
+        fn block_next_get_opts_with_not_found(&self) -> (Arc<Notify>, Arc<Notify>) {
+            let started = Arc::new(Notify::new());
+            let release = Arc::new(Notify::new());
+            *self.blocking_not_found.lock().unwrap() = Some(BlockingNotFoundGet {
+                started: started.clone(),
+                release: release.clone(),
+            });
+            (started, release)
         }
     }
 
@@ -607,6 +640,18 @@ mod tests {
             self.get_opts_calls.fetch_add(1, Ordering::SeqCst);
             if options.if_none_match.is_some() {
                 self.if_none_match_gets.fetch_add(1, Ordering::SeqCst);
+            }
+            let blocking = self.blocking_not_found.lock().unwrap().take();
+            if let Some(blocking) = blocking {
+                blocking.started.notify_one();
+                blocking.release.notified().await;
+                return Err(ObjectStoreError::NotFound {
+                    path: location.to_string(),
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "injected missing boundary",
+                    )),
+                });
             }
             self.inner.get_opts(location, options).await
         }
@@ -763,6 +808,40 @@ mod tests {
             .await
             .unwrap();
         assert_eq!("4", std::str::from_utf8(&raw_boundary).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_boundary_read_uses_cache_populated_while_initial_missing_read_is_in_flight() {
+        let counting_store = Arc::new(CountingGetStore::new());
+        let (started, release) = counting_store.block_next_get_opts_with_not_found();
+        let object_store: Arc<dyn ObjectStore> = counting_store;
+        let boundary = Arc::new(ObjectStoreBoundaryObject::new(
+            &Path::from("/root"),
+            object_store,
+            "manifest",
+        ));
+
+        let read = tokio::spawn({
+            let boundary = boundary.clone();
+            async move { boundary.read_boundary().await }
+        });
+
+        started.notified().await;
+        *boundary.cache.lock() = Some((
+            MonotonicId::new(2),
+            UpdateVersion {
+                e_tag: Some("\"etag\"".to_string()),
+                version: None,
+            },
+        ));
+        release.notify_one();
+
+        let (observed_boundary, observed_version) = read.await.unwrap().unwrap();
+        assert_eq!(MonotonicId::new(2), observed_boundary);
+        assert_eq!(
+            Some("\"etag\""),
+            observed_version.as_ref().and_then(|v| v.e_tag.as_deref())
+        );
     }
 
     #[tokio::test]

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -100,7 +100,7 @@ impl<T> ObjectStoreSequencedStorageProtocol<T> {
 ///
 /// The boundary is stored as a single ASCII-encoded `u64` at
 /// `<root_path>/gc/<name>.boundary`. A missing boundary file is treated as `0`
-/// until this process has observed the boundary file at least once.
+/// even if this process already has a cached boundary observation.
 ///
 /// Successful reads cache the boundary value along with object-store version
 /// metadata. Later reads pass the cached ETag as `if-none-match`, allowing stores
@@ -196,26 +196,12 @@ impl ObjectStoreBoundaryObject {
                     Err(TransactionalObjectError::InvalidObjectState)
                 }
             },
-            Err(Error::NotFound { .. }) => match (cached, self.cache.lock().clone()) {
-                // This read began before this boundary object had observed a
-                // boundary, and another task advanced/read the boundary while
-                // the GET was in flight. Use the newer local observation rather
-                // than treating the racing GET as a durable disappearance.
-                (None, Some((boundary, version))) => Ok((boundary, Some(version))),
-                // Once this read starts with an observed boundary, the boundary
-                // file disappearing means durable state regressed; do not treat
-                // it as an initial zero boundary.
-                (Some(_), _) => {
-                    error!(
-                        "received NotFound after observing boundary [path={}]",
-                        self.filepath
-                    );
-                    Err(TransactionalObjectError::InvalidObjectState)
-                }
-                // Default to zero boundary if file is missing and we've never
-                // observed it before.
-                (None, None) => Ok((MonotonicId::new(0), None)),
-            },
+            // A missing boundary is treated as zero. Don't use cache because
+            // a write that occurred before a boundary file exists is valid even if
+            // we later have a cached boundary above it. Assume the object store is
+            // infallible here; if the object store loses data, this will return 0
+            // when it should panic. But object stores should never lose data.
+            Err(Error::NotFound { .. }) => Ok((MonotonicId::new(0), None)),
             Err(e) => Err(TransactionalObjectError::from(e)),
         }
     }
@@ -816,7 +802,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_boundary_read_uses_cache_populated_while_initial_missing_read_is_in_flight() {
+    async fn test_boundary_read_returns_zero_when_not_found_get_has_cached_boundary() {
         let counting_store = Arc::new(CountingGetStore::new());
         let (started, release) = counting_store.block_next_get_opts_with_not_found();
         let object_store: Arc<dyn ObjectStore> = counting_store;
@@ -842,28 +828,8 @@ mod tests {
         release.notify_one();
 
         let (observed_boundary, observed_version) = read.await.unwrap().unwrap();
-        assert_eq!(MonotonicId::new(2), observed_boundary);
-        assert_eq!(
-            Some("\"etag\""),
-            observed_version.as_ref().and_then(|v| v.e_tag.as_deref())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_boundary_check_returns_invalid_state_when_observed_boundary_disappears() {
-        let object_store = Arc::new(InMemory::new());
-        let boundary =
-            ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store.clone(), "manifest");
-
-        boundary.advance(MonotonicId::new(2)).await.unwrap();
-        object_store
-            .delete(&Path::from("/root/gc/manifest.boundary"))
-            .await
-            .unwrap();
-
-        let err = boundary.check(MonotonicId::new(3)).await.unwrap_err();
-
-        assert!(matches!(err, TransactionalObjectError::InvalidObjectState));
+        assert_eq!(MonotonicId::new(0), observed_boundary);
+        assert!(observed_version.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The chaos test failed a couple of nights ago:

- https://github.com/slatedb/slatedb/actions/runs/25958431611/job/76309293353

I had Codex replicate the failure using Docker on my local machine. It turns out there is a race condition between two reads for the same boundary object:

1. reader 1 calls check
2. reader 1 sees no cache entry
3. reader 1 calls read_boundary since cache is empty
4. reader 1 receives 404 not found--no boundary has yet been created
5. GC creates boundary file
6. reader 2 calls check, sees no cache entry, calls read_boundary, gets 200 and stores the object in cache 
7. reader 1 checks its cache and sees the cache is now non-empty. it returns an `InvalidObjectState`

This can happen with the manifest file since both `Db`, `Compactor`, and `GarbageCollector` are reading/writing to it from the same manifest store and boundary object.

## Changes

- On 404, check if the cache was populated _before_ the read call. If it was, still panic. If it wasn't, someone else populated the cache during the read, so just use its value.
- Add test to replicate

## Notes for Reviewers

- Codex replicated the issue 3x in 200 runs with saturated CPU. After patch, it works correctly 200 times without issue.
- The added unit test fails before the fix and passes now.
- We could relax the invariant check: if there's a cache, always use it on 404. If object stores are _always_ fully consistent, this should be fine. There are just so many and they are so exotic, I'd like to be extra paranoid. If others feel it's overkill, we can relax the constraint.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
