### PR TITLE
Update DST for RFC 24 and fix dispatch bug

### DIFF
--- a/slatedb-dst/Cargo.toml
+++ b/slatedb-dst/Cargo.toml
@@ -28,6 +28,7 @@ parking_lot = { workspace = true }
 rand = { workspace = true }
 slatedb = { workspace = true, features = ["all"] }
 slatedb-common = { workspace = true, features = ["test-util"] }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }
 tokio-util = { workspace = true, default-features = false, features = ["rt"] }
 tracing = { workspace = true }
@@ -36,7 +37,6 @@ walkdir = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
-tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -22,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 
 use fail_parallel::FailPointRegistry;
 use slatedb::compactor::Compactor;
-use slatedb::{Db, DbRand, Error, MergeOperator};
+use slatedb::{Db, DbRand, Error, MergeOperator, PrefixExtractor};
 use slatedb_common::clock::SystemClock;
 use slatedb_common::MockSystemClock;
 
@@ -181,6 +181,20 @@ impl ActorCtx {
         self.shared.startup_ctx.merge_operator()
     }
 
+    /// Returns the segment extractor configured for this harness run, if any.
+    ///
+    /// Startup factories and reopen flows should pass this handle through to
+    /// `DbBuilder::with_segment_extractor` so that the writer's per-tree
+    /// routing is consistent across the initial open and any subsequent
+    /// reopens.
+    ///
+    /// ## Returns
+    /// - `Option<Arc<dyn PrefixExtractor>>`: The shared segment extractor, or
+    ///   `None` when the harness was not configured with one.
+    pub fn segment_extractor(&self) -> Option<Arc<dyn PrefixExtractor>> {
+        self.shared.startup_ctx.segment_extractor()
+    }
+
     /// Returns the shared shutdown token for the current harness run.
     ///
     /// Actors may call `cancel()` to request harness shutdown, or observe the
@@ -204,6 +218,7 @@ pub struct StartupCtx {
     fp_registry: Arc<FailPointRegistry>,
     failure_controller: FailingObjectStoreController,
     merge_operator: Option<Arc<dyn MergeOperator + Send + Sync>>,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     rand: Arc<DbRand>,
 }
 
@@ -262,6 +277,21 @@ impl StartupCtx {
     ///   merge-operator handle, or `None`.
     pub fn merge_operator(&self) -> Option<Arc<dyn MergeOperator + Send + Sync>> {
         self.merge_operator.clone()
+    }
+
+    /// Returns the segment extractor configured for this harness run, if any.
+    ///
+    /// Startup factories should pass this handle to
+    /// `DbBuilder::with_segment_extractor` when opening a database that
+    /// participates in RFC-0024 segmentation. The same handle should be
+    /// reused on reopens (e.g. through the fencer actor) so the writer's
+    /// persisted extractor name matches across restarts.
+    ///
+    /// ## Returns
+    /// - `Option<Arc<dyn PrefixExtractor>>`: The shared segment extractor, or
+    ///   `None`.
+    pub fn segment_extractor(&self) -> Option<Arc<dyn PrefixExtractor>> {
+        self.segment_extractor.clone()
     }
 
     /// Returns the shared failure controller for the harness object stores.
@@ -361,6 +391,7 @@ pub struct Harness {
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     clock_advance_ms: RangeInclusive<u64>,
     merge_operator: Option<Arc<dyn MergeOperator + Send + Sync>>,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     startup_factory: StartupFactory,
     actors: Vec<ActorRegistration>,
 }
@@ -392,6 +423,7 @@ impl Harness {
             wal_object_store: None,
             clock_advance_ms: 1..=5,
             merge_operator: None,
+            segment_extractor: None,
             startup_factory: Box::new(move |ctx| Box::pin(factory(ctx))),
             actors: Vec::new(),
         }
@@ -507,6 +539,24 @@ impl Harness {
         self
     }
 
+    /// Configures the segment extractor shared by DST components.
+    ///
+    /// The handle is exposed through [`StartupCtx::segment_extractor`] and
+    /// [`ActorCtx::segment_extractor`]. Startup factories pass it through to
+    /// `DbBuilder::with_segment_extractor`, and reopen flows (e.g. the
+    /// fencer actor) reuse the same handle so that the persisted extractor
+    /// name remains consistent across restarts.
+    ///
+    /// ## Arguments
+    /// - `segment_extractor`: The extractor handle to use for this harness run.
+    ///
+    /// ## Returns
+    /// - `Harness`: The updated harness builder.
+    pub fn with_segment_extractor(mut self, segment_extractor: Arc<dyn PrefixExtractor>) -> Self {
+        self.segment_extractor = Some(segment_extractor);
+        self
+    }
+
     /// Registers one actor task under a unique logical name.
     ///
     /// ## Arguments
@@ -569,6 +619,7 @@ impl Harness {
             wal_object_store,
             clock_advance_ms: _,
             merge_operator,
+            segment_extractor,
             startup_factory,
             actors,
         } = self;
@@ -612,6 +663,7 @@ impl Harness {
             fp_registry: Arc::clone(&fp_registry),
             failure_controller,
             merge_operator,
+            segment_extractor,
             rand: Arc::clone(&rand),
         };
 

--- a/slatedb-dst/src/lib.rs
+++ b/slatedb-dst/src/lib.rs
@@ -12,6 +12,8 @@ mod clocked_object_store;
 mod deterministic_local_filesystem;
 pub mod failing_object_store;
 mod harness;
+mod prefix_extractor;
+mod scenarios;
 pub mod utils;
 
 pub use self::deterministic_local_filesystem::DeterministicLocalFilesystem;
@@ -20,3 +22,5 @@ pub use self::failing_object_store::{
     StreamDirection, Toxic, ToxicKind,
 };
 pub use self::harness::*;
+pub use self::prefix_extractor::FirstDelimiterPrefixExtractor;
+pub use self::scenarios::DeterministicScenario;

--- a/slatedb-dst/src/prefix_extractor.rs
+++ b/slatedb-dst/src/prefix_extractor.rs
@@ -1,0 +1,73 @@
+//! Deterministic prefix extractors for DST scenarios.
+
+use slatedb::{PrefixExtractor, PrefixTarget};
+
+/// Deterministic prefix extractor that segments keys at the first `/`
+/// delimiter (inclusive). It matches the actor-namespaced key shape used
+/// by the bundled DST workload and bank actors, where each actor or
+/// account namespace writes under `{name}/...`.
+///
+/// The returned prefix length always points *past* the delimiter, so the
+/// extracted prefix retains the trailing `/` (for example
+/// `b"workload-1/foo"` extracts to prefix `b"workload-1/"`).
+///
+/// For [`PrefixTarget::Prefix`], the extractor returns `Some(n)` only when
+/// the input already contains a `/`; otherwise extensions of the prefix
+/// could place the first delimiter at different positions and probing
+/// would be unsafe. This satisfies the trait's `Prefix` invariant.
+#[derive(Debug)]
+pub struct FirstDelimiterPrefixExtractor;
+
+impl PrefixExtractor for FirstDelimiterPrefixExtractor {
+    fn name(&self) -> &str {
+        "first-delim-/"
+    }
+
+    fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+        let bytes: &[u8] = match target {
+            PrefixTarget::Point(b) | PrefixTarget::Prefix(b) => b.as_ref(),
+        };
+        bytes.iter().position(|&b| b == b'/').map(|idx| idx + 1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    fn point(s: &'static str) -> PrefixTarget {
+        PrefixTarget::Point(Bytes::from_static(s.as_bytes()))
+    }
+
+    fn prefix(s: &'static str) -> PrefixTarget {
+        PrefixTarget::Prefix(Bytes::from_static(s.as_bytes()))
+    }
+
+    #[test]
+    fn point_returns_position_after_first_delimiter() {
+        let extractor = FirstDelimiterPrefixExtractor;
+        assert_eq!(extractor.prefix_len(&point("workload-1/0")), Some(11));
+        assert_eq!(extractor.prefix_len(&point("a/b/c")), Some(2));
+        assert_eq!(extractor.prefix_len(&point("/x")), Some(1));
+    }
+
+    #[test]
+    fn point_returns_none_without_delimiter() {
+        let extractor = FirstDelimiterPrefixExtractor;
+        assert_eq!(extractor.prefix_len(&point("nodelim")), None);
+        assert_eq!(extractor.prefix_len(&point("")), None);
+    }
+
+    #[test]
+    fn prefix_returns_none_until_delimiter_is_present() {
+        let extractor = FirstDelimiterPrefixExtractor;
+        // Without a `/`, an extension could place the first delimiter at
+        // any later position, so we cannot safely return a length.
+        assert_eq!(extractor.prefix_len(&prefix("workload-")), None);
+        // Once the delimiter is in the prefix, every extension keeps it
+        // anchored at the same position.
+        assert_eq!(extractor.prefix_len(&prefix("workload-1/")), Some(11));
+        assert_eq!(extractor.prefix_len(&prefix("workload-1/foo")), Some(11));
+    }
+}

--- a/slatedb-dst/src/scenarios.rs
+++ b/slatedb-dst/src/scenarios.rs
@@ -1,0 +1,276 @@
+//! Reusable shape for "determinism" scenario tests in the DST suite.
+//!
+//! Each simulation run:
+//! - starts from a fresh harness root [`DbRand`] initialized with the same seed
+//! - starts from a fresh shared [`MockSystemClock`]
+//! - opens a real [`Db`] using randomized deterministic settings from
+//!   [`build_settings`]
+//! - runs looping workload, flusher, and compactor actors against
+//!   deterministic local filesystem-backed object stores until a shutdown actor
+//!   cancels the shared token at a fixed mock-clock deadline
+//! - compares the next random `u64` and current clock time after the run
+//!
+//! If either the harness or SlateDB consumes randomness differently, advances
+//! the clock differently, or executes different deterministic branches for the
+//! same seed, one of those post-run checks will diverge.
+//!
+//! Variants are configured by the fields of [`DeterministicScenario`] —
+//! e.g. enabling RFC-0024 segmentation by supplying a
+//! [`slatedb::PrefixExtractor`], in which case each workload actor's
+//! `{name}/N` keys route to a distinct segment.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use log::{error, info};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use rand::RngCore;
+use slatedb::config::{CompactorOptions, DurabilityLevel, SizeTieredCompactionSchedulerOptions};
+use slatedb::{Db, DbRand, PrefixExtractor};
+use slatedb_common::clock::{MockSystemClock, SystemClock};
+use tempfile::TempDir;
+use tracing::instrument;
+
+use crate::actors::{
+    CompactorActor, CompactorActorOptions, FlusherActor, ShutdownActor, WorkloadActor,
+    WorkloadActorOptions, WorkloadMergeOperator,
+};
+use crate::utils::{build_settings, build_toxic};
+use crate::{DeterministicLocalFilesystem, Harness};
+
+type ScenarioError = Box<dyn std::error::Error + Send + Sync>;
+type ScenarioResult<T> = Result<T, ScenarioError>;
+
+/// Configuration for a deterministic SlateDB scenario test.
+///
+/// The scenario fans out one random seed per available CPU core, runs
+/// those seed groups on separate OS threads, and within each thread
+/// replays the seeded scenario `simulations` times in serial. Every
+/// replay must leave the harness in the same observable state (next root
+/// RNG value + current mock-clock time); a divergence indicates a
+/// non-deterministic code path in the harness or SlateDB.
+pub struct DeterministicScenario {
+    /// Logical name used for the harness label and tempdir path prefix.
+    pub name: &'static str,
+    /// Number of times to replay each seed in serial. The first replay
+    /// establishes the expected post-run state; later replays must match.
+    pub simulations: u32,
+    /// Mock-clock deadline (ms since the unix epoch) at which the
+    /// shutdown actor cancels the simulation.
+    pub shutdown_at_ms: i64,
+    /// Optional segment extractor. When `Some`, the scenario configures
+    /// the harness and `DbBuilder` for RFC-0024 segmentation; when
+    /// `None`, the scenario runs the unsegmented configuration.
+    pub segment_extractor: Option<Arc<dyn PrefixExtractor>>,
+}
+
+impl DeterministicScenario {
+    /// Runs the scenario across all available CPU cores in parallel.
+    ///
+    /// Creates one random seed per available CPU core, then runs those seed
+    /// groups concurrently on separate OS threads. Each thread owns one seed
+    /// and executes that seed repeatedly in serial, so the determinism
+    /// assertion is still made by comparing multiple runs of the same seed
+    /// against one another. The seed and core index are logged so a failing
+    /// or panicking worker gives a direct reproduction handle.
+    pub fn run(self) -> ScenarioResult<()> {
+        let DeterministicScenario {
+            name,
+            simulations,
+            shutdown_at_ms,
+            segment_extractor,
+        } = self;
+        let num_cores = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(1);
+        let seeds: Vec<u64> = (0..num_cores).map(|_| rand::random::<u64>()).collect();
+
+        let handles = seeds
+            .into_iter()
+            .enumerate()
+            .map(|(core, seed)| {
+                info!("dst {name} seed [core={core}, seed={seed}]");
+                let extractor = segment_extractor.clone();
+                (
+                    core,
+                    seed,
+                    std::thread::spawn(move || {
+                        run_seed_is_deterministic(
+                            name,
+                            core,
+                            seed,
+                            simulations,
+                            shutdown_at_ms,
+                            extractor,
+                        )
+                    }),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        for (core, seed, handle) in handles {
+            match handle.join() {
+                Ok(result) => result?,
+                Err(payload) => {
+                    error!("dst {name} panicked [core={core}, seed={seed}]");
+                    std::panic::resume_unwind(payload);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Re-runs a single seed and checks that every simulation leaves the
+/// harness in the same post-run position.
+///
+/// The first simulation establishes the expected next root RNG value and
+/// mock-clock time. Later simulations with the same seed must produce the
+/// same values. `core` is diagnostic context only; it identifies which
+/// worker thread owned the seed when reporting assertion failures.
+fn run_seed_is_deterministic(
+    name: &'static str,
+    core: usize,
+    seed: u64,
+    simulations: u32,
+    shutdown_at_ms: i64,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
+) -> ScenarioResult<()> {
+    let mut expected_u64: Option<u64> = None;
+    let mut expected_time: Option<DateTime<Utc>> = None;
+
+    for simulation_count in 0..simulations {
+        let (next_u64, next_time) =
+            run_seed_once(name, seed, shutdown_at_ms, segment_extractor.clone())?;
+
+        if let Some(expected_u64) = expected_u64 {
+            assert_eq!(
+                next_u64, expected_u64,
+                "non-determinism detected [scenario={name}, core={core}, seed={seed}, simulation_count={simulation_count}, next_u64={next_u64}, expected_u64={expected_u64}]",
+            );
+        }
+
+        if let Some(expected_time) = expected_time {
+            assert_eq!(
+                next_time, expected_time,
+                "non-determinism detected [scenario={name}, core={core}, seed={seed}, simulation_count={simulation_count}, next_time={next_time:?}, expected_time={expected_time:?}]",
+            );
+        }
+
+        expected_u64 = Some(next_u64);
+        expected_time = Some(next_time);
+    }
+
+    Ok(())
+}
+
+/// Runs one complete seeded scenario and returns the observable
+/// deterministic state after the harness shuts down.
+///
+/// Each invocation builds a fresh temporary main and WAL object-store root,
+/// fresh root RNG, and fresh mock clock. The harness then owns the
+/// fault-injection controller, opens a real `Db`, starts workload, flusher,
+/// compactor, and shutdown actors, and runs until the shutdown actor cancels
+/// the simulation. Returning the next root RNG value and current mock-clock
+/// time gives callers a compact fingerprint of the deterministic execution
+/// path.
+#[instrument(level = "debug", skip_all, fields(scenario = name, seed = seed))]
+fn run_seed_once(
+    name: &'static str,
+    seed: u64,
+    shutdown_at_ms: i64,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
+) -> ScenarioResult<(u64, DateTime<Utc>)> {
+    let tempdir = TempDir::new()?;
+    let main_dir = tempdir.path().join("main");
+    let wal_dir = tempdir.path().join("wal");
+    std::fs::create_dir_all(&main_dir)?;
+    std::fs::create_dir_all(&wal_dir)?;
+
+    let rand = Arc::new(DbRand::new(seed));
+    let system_clock = Arc::new(MockSystemClock::new());
+    let main_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?);
+    let wal_store: Arc<dyn ObjectStore> =
+        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?);
+    let workload_options = WorkloadActorOptions {
+        read_durability: DurabilityLevel::Remote,
+        ..WorkloadActorOptions::default()
+    };
+    let compactor_options = CompactorOptions {
+        poll_interval: Duration::from_millis(10),
+        scheduler_options: SizeTieredCompactionSchedulerOptions {
+            min_compaction_sources: 2,
+            max_compaction_sources: 999,
+            include_size_threshold: 4.0,
+        }
+        .into(),
+        ..CompactorOptions::default()
+    };
+    let mut harness = Harness::new(name, seed, move |ctx| async move {
+        let failures = ctx.failure_controller();
+        for index in 0..10 {
+            failures.add_toxic(build_toxic(ctx.rand(), ctx.path().as_ref(), index));
+        }
+
+        let db_seed = ctx.rand().rng().next_u64();
+        let mut settings = build_settings(ctx.rand()).await;
+
+        // Keep L0 tiny and compactor polling aggressive so a small number of
+        // explicit memtable flushes will trigger real compaction during the run.
+        settings.l0_sst_size_bytes = 1024;
+        settings.l0_max_ssts = 4;
+        settings.manifest_poll_interval = Duration::from_millis(10);
+        // Disable since we're using the standalone compactor actor.
+        settings.compactor_options = None;
+
+        let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
+            .with_wal_object_store(ctx.wal_object_store().expect("configured"))
+            .with_system_clock(ctx.system_clock())
+            .with_fp_registry(ctx.fp_registry())
+            .with_seed(db_seed)
+            .with_settings(settings);
+        if let Some(merge_operator) = ctx.merge_operator() {
+            builder = builder.with_merge_operator(merge_operator);
+        }
+        if let Some(extractor) = ctx.segment_extractor() {
+            builder = builder.with_segment_extractor(extractor);
+        }
+        let db = builder.build().await?;
+        Ok(Arc::new(db))
+    })
+    .with_rand(Arc::clone(&rand))
+    .with_system_clock(Arc::clone(&system_clock))
+    .with_path(Path::from(name))
+    .with_main_object_store(main_store)
+    .with_wal_object_store(wal_store)
+    .with_merge_operator(Arc::new(WorkloadMergeOperator));
+
+    if let Some(extractor) = segment_extractor {
+        harness = harness.with_segment_extractor(extractor);
+    }
+
+    let harness = harness
+        .actor("workload-1", WorkloadActor::new(workload_options.clone())?)
+        .actor("workload-2", WorkloadActor::new(workload_options.clone())?)
+        .actor("workload-3", WorkloadActor::new(workload_options.clone())?)
+        .actor("workload-4", WorkloadActor::new(workload_options)?)
+        .actor("flusher", FlusherActor::new(1_u64..=5_u64)?)
+        .actor(
+            "compactor",
+            CompactorActor::new(CompactorActorOptions {
+                restart_interval: Duration::from_millis(25),
+                compactor_options,
+            })?,
+        )
+        .actor("shutdown", ShutdownActor::new(shutdown_at_ms)?);
+
+    harness.run()?;
+
+    let next_u64 = rand.rng().next_u64();
+    let next_time = system_clock.now();
+    Ok((next_u64, next_time))
+}

--- a/slatedb-dst/src/scenarios.rs
+++ b/slatedb-dst/src/scenarios.rs
@@ -1,4 +1,4 @@
-//! Reusable shape for "determinism" scenario tests in the DST suite.
+//! Shared structures and execution logic for running DST scenarios.
 //!
 //! Each simulation run:
 //! - starts from a fresh harness root [`DbRand`] initialized with the same seed

--- a/slatedb-dst/tests/determinism.rs
+++ b/slatedb-dst/tests/determinism.rs
@@ -16,41 +16,12 @@
 //! same seed, one of those post-run checks will diverge.
 #![cfg(dst)]
 
-use std::sync::Arc;
-use std::time::Duration;
-
-use chrono::{DateTime, Utc};
-use log::{error, info};
-use object_store::path::Path;
-use object_store::ObjectStore;
-use rand::RngCore;
 use rstest::rstest;
-use slatedb::config::{CompactorOptions, DurabilityLevel, SizeTieredCompactionSchedulerOptions};
-use slatedb::{Db, DbRand};
-use slatedb_common::clock::{MockSystemClock, SystemClock};
-use slatedb_dst::{
-    actors::{
-        CompactorActor, CompactorActorOptions, FlusherActor, ShutdownActor, WorkloadActor,
-        WorkloadActorOptions, WorkloadMergeOperator,
-    },
-    utils::{build_settings, build_toxic},
-    DeterministicLocalFilesystem, Harness,
-};
-use tempfile::TempDir;
-use tracing::instrument;
+use slatedb_dst::DeterministicScenario;
 
 type TestError = Box<dyn std::error::Error + Send + Sync>;
 type TestResult<T> = Result<T, TestError>;
 
-/// Verifies that the DST harness produces repeatable outcomes for independently
-/// chosen seeds.
-///
-/// The test creates one random seed per available CPU core, then runs those
-/// seed groups concurrently on separate OS threads. Each thread owns one seed
-/// and executes that seed repeatedly in serial, so the determinism assertion is
-/// still made by comparing multiple runs of the same seed against one another.
-/// Printing the seed and core gives a direct reproduction handle when a worker
-/// fails or panics.
 #[rstest]
 #[cfg_attr(not(slow), case::regular(4, 200))]
 #[cfg_attr(slow, case::slow(2, 10_000))]
@@ -58,183 +29,11 @@ fn test_dst_is_deterministic(
     #[case] simulations: u32,
     #[case] shutdown_at_ms: i64,
 ) -> TestResult<()> {
-    let num_cores = std::thread::available_parallelism()
-        .map(|parallelism| parallelism.get())
-        .unwrap_or(1);
-    let seeds: Vec<u64> = (0..num_cores).map(|_| rand::random::<u64>()).collect();
-
-    let handles = seeds
-        .into_iter()
-        .enumerate()
-        .map(|(core, seed)| {
-            info!("dst determinism seed [core={core}, seed={seed}]");
-            (
-                core,
-                seed,
-                std::thread::spawn(move || {
-                    run_seed_is_deterministic(core, seed, simulations, shutdown_at_ms)
-                }),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    for (core, seed, handle) in handles {
-        match handle.join() {
-            Ok(result) => result?,
-            Err(payload) => {
-                error!("dst determinism panicked [core={core}, seed={seed}]");
-                std::panic::resume_unwind(payload);
-            }
-        }
+    DeterministicScenario {
+        name: "determinism",
+        simulations,
+        shutdown_at_ms,
+        segment_extractor: None,
     }
-
-    Ok(())
-}
-
-/// Re-runs a single seed and checks that every simulation leaves deterministic
-/// state in the same post-run position.
-///
-/// The first simulation establishes the expected next root RNG value and
-/// mock-clock time. Later simulations with the same seed must produce the same
-/// values. The `core` argument is diagnostic context only; it identifies which
-/// worker thread owned the seed when reporting assertion failures.
-fn run_seed_is_deterministic(
-    core: usize,
-    seed: u64,
-    simulations: u32,
-    shutdown_at_ms: i64,
-) -> TestResult<()> {
-    let mut expected_u64: Option<u64> = None;
-    let mut expected_time: Option<DateTime<Utc>> = None;
-
-    for simulation_count in 0..simulations {
-        let (next_u64, next_time) = run_seed_once(seed, shutdown_at_ms)?;
-
-        if let Some(expected_u64) = expected_u64 {
-            assert_eq!(
-                next_u64,
-                expected_u64,
-                "non-determinism detected [core={}, seed={}, simulation_count={}, next_u64={}, expected_u64={}]",
-                core,
-                seed,
-                simulation_count,
-                next_u64,
-                expected_u64,
-            );
-        }
-
-        if let Some(expected_time) = expected_time {
-            assert_eq!(
-                next_time,
-                expected_time,
-                "non-determinism detected [core={}, seed={}, simulation_count={}, next_time={:?}, expected_time={:?}]",
-                core,
-                seed,
-                simulation_count,
-                next_time,
-                expected_time,
-            );
-        }
-
-        expected_u64 = Some(next_u64);
-        expected_time = Some(next_time);
-    }
-
-    Ok(())
-}
-
-/// Runs one complete seeded scenario and returns the observable deterministic
-/// state after the harness shuts down.
-///
-/// Each invocation builds a fresh temporary main and WAL object-store root,
-/// fresh root RNG, and fresh mock clock. The harness then owns the
-/// fault-injection controller, opens a real `Db`, starts workload, flusher,
-/// compactor, and shutdown actors, and runs until the shutdown actor cancels
-/// the simulation. Returning the next root RNG value and current mock-clock
-/// time gives callers a compact fingerprint of the deterministic execution
-/// path.
-#[instrument(level = "debug", skip_all, fields(seed = seed))]
-fn run_seed_once(seed: u64, shutdown_at_ms: i64) -> TestResult<(u64, DateTime<Utc>)> {
-    let tempdir = TempDir::new()?;
-    let main_dir = tempdir.path().join("main");
-    let wal_dir = tempdir.path().join("wal");
-    std::fs::create_dir_all(&main_dir)?;
-    std::fs::create_dir_all(&wal_dir)?;
-
-    let rand = Arc::new(DbRand::new(seed));
-    let system_clock = Arc::new(MockSystemClock::new());
-    let main_store: Arc<dyn ObjectStore> =
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?);
-    let wal_store: Arc<dyn ObjectStore> =
-        Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?);
-    let workload_options = WorkloadActorOptions {
-        read_durability: DurabilityLevel::Remote,
-        ..WorkloadActorOptions::default()
-    };
-    let compactor_options = CompactorOptions {
-        poll_interval: Duration::from_millis(10),
-        scheduler_options: SizeTieredCompactionSchedulerOptions {
-            min_compaction_sources: 2,
-            max_compaction_sources: 999,
-            include_size_threshold: 4.0,
-        }
-        .into(),
-        ..CompactorOptions::default()
-    };
-    let harness = Harness::new("determinism", seed, move |ctx| async move {
-        let failures = ctx.failure_controller();
-        for index in 0..10 {
-            failures.add_toxic(build_toxic(ctx.rand(), ctx.path().as_ref(), index));
-        }
-
-        let db_seed = ctx.rand().rng().next_u64();
-        let mut settings = build_settings(ctx.rand()).await;
-
-        // Keep L0 tiny and compactor polling aggressive so a small number of
-        // explicit memtable flushes will trigger real compaction during the run.
-        settings.l0_sst_size_bytes = 1024;
-        settings.l0_max_ssts = 4;
-        settings.manifest_poll_interval = Duration::from_millis(10);
-        // Disable since we're using the standalone compactor actor.
-        settings.compactor_options = None;
-
-        let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
-            .with_wal_object_store(ctx.wal_object_store().expect("configured"))
-            .with_system_clock(ctx.system_clock())
-            .with_fp_registry(ctx.fp_registry())
-            .with_seed(db_seed)
-            .with_settings(settings);
-        if let Some(merge_operator) = ctx.merge_operator() {
-            builder = builder.with_merge_operator(merge_operator);
-        }
-        let db = builder.build().await?;
-        Ok(Arc::new(db))
-    })
-    .with_rand(Arc::clone(&rand))
-    .with_system_clock(Arc::clone(&system_clock))
-    .with_path(Path::from("determinism"))
-    .with_main_object_store(main_store)
-    .with_wal_object_store(wal_store)
-    .with_merge_operator(Arc::new(WorkloadMergeOperator));
-
-    let harness = harness
-        .actor("workload-1", WorkloadActor::new(workload_options.clone())?)
-        .actor("workload-2", WorkloadActor::new(workload_options.clone())?)
-        .actor("workload-3", WorkloadActor::new(workload_options.clone())?)
-        .actor("workload-4", WorkloadActor::new(workload_options)?)
-        .actor("flusher", FlusherActor::new(1_u64..=5_u64)?)
-        .actor(
-            "compactor",
-            CompactorActor::new(CompactorActorOptions {
-                restart_interval: Duration::from_millis(25),
-                compactor_options,
-            })?,
-        )
-        .actor("shutdown", ShutdownActor::new(shutdown_at_ms)?);
-
-    harness.run()?;
-
-    let next_u64 = rand.rng().next_u64();
-    let next_time = system_clock.now();
-    Ok((next_u64, next_time))
+    .run()
 }

--- a/slatedb-dst/tests/segments.rs
+++ b/slatedb-dst/tests/segments.rs
@@ -1,0 +1,48 @@
+//! Verifies deterministic scenario-test behavior for RFC-0024 segmented
+//! SlateDB databases under DST configuration.
+//!
+//! Mirrors the unsegmented determinism scenario but configures a
+//! [`FirstDelimiterPrefixExtractor`] so the workload's `{name}/N` keys
+//! route to a distinct segment per actor. The harness shape exercises:
+//!
+//! - per-segment L0 grouping at memtable flush (one L0 per touched
+//!   segment per flush)
+//! - per-segment L0 → SR compaction by the standalone compactor
+//! - per-segment backpressure via the standalone compactor's interaction
+//!   with `l0_max_ssts`
+//! - reopen-time reconciliation of the persisted `segment_extractor_name`
+//!   (the standalone compactor opens its own `Db` view of the same
+//!   manifest)
+//! - prefix scans that target a single segment by the workload's
+//!   `scan_prefix({name}/)`
+//!
+//! Determinism is asserted the same way as the unsegmented scenario: the
+//! next root RNG value and current mock-clock time must match across
+//! independent runs of the same seed.
+#![cfg(dst)]
+
+use std::sync::Arc;
+
+use rstest::rstest;
+use slatedb::PrefixExtractor;
+use slatedb_dst::{DeterministicScenario, FirstDelimiterPrefixExtractor};
+
+type TestError = Box<dyn std::error::Error + Send + Sync>;
+type TestResult<T> = Result<T, TestError>;
+
+#[rstest]
+#[cfg_attr(not(slow), case::regular(4, 200))]
+#[cfg_attr(slow, case::slow(2, 10_000))]
+fn test_dst_segments_is_deterministic(
+    #[case] simulations: u32,
+    #[case] shutdown_at_ms: i64,
+) -> TestResult<()> {
+    let extractor: Arc<dyn PrefixExtractor> = Arc::new(FirstDelimiterPrefixExtractor);
+    DeterministicScenario {
+        name: "segments",
+        simulations,
+        shutdown_at_ms,
+        segment_extractor: Some(extractor),
+    }
+    .run()
+}

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -256,25 +256,20 @@ impl FlushTracker {
 
     fn dispatch_ready_memtables(&mut self) -> Result<(), SlateDBError> {
         loop {
-            // Find the next pending imm whose touched segments all
-            // have room. Skip blocked imms rather than stalling — the
-            // manifest writer commits in seqno order regardless of
-            // upload dispatch order, so an unrelated later imm can
-            // make progress while an older one waits on its
-            // saturated segment.
+            // Strict seq order: skipping a blocked older imm
+            // deadlocks against the manifest writer's FIFO commit
+            // (#1687).
             let next_idx = self
                 .frontier
                 .tracked
                 .iter()
-                .enumerate()
-                .find(|(_, t)| {
-                    matches!(t.state, TrackedImmState::PendingDispatch)
-                        && self.can_dispatch(&t.imm_memtable)
-                })
-                .map(|(idx, _)| idx);
+                .position(|t| matches!(t.state, TrackedImmState::PendingDispatch));
             let Some(idx) = next_idx else {
                 return Ok(());
             };
+            if !self.can_dispatch(&self.frontier.tracked[idx].imm_memtable) {
+                return Ok(());
+            }
             self.frontier.tracked[idx].state = TrackedImmState::Uploading;
             let tracked = &self.frontier.tracked[idx];
             let imm_memtable = Arc::clone(&tracked.imm_memtable);


### PR DESCRIPTION
Adds a basic test case with a segment extractor to the DST. The simulation caught #1687, which I've also fixed here.