### PR TITLE
fixup internal to external error mapping

### DIFF
--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -571,6 +571,10 @@ impl From<SlateDBError> for Error {
             SlateDBError::SeekKeyOutOfRange { .. } => Error::invalid(msg),
             SlateDBError::SeekKeyLessThanLastReturnedKey => Error::invalid(msg),
             SlateDBError::IdenticalClonePaths { .. } => Error::invalid(msg),
+            SlateDBError::DuplicatedCloneSourcePath(_) => Error::invalid(msg),
+            SlateDBError::InvalidUnionSourceWithWal { .. } => Error::invalid(msg),
+            SlateDBError::InvalidUnionSetEmpty() => Error::invalid(msg),
+            SlateDBError::InvalidUnion(_) => Error::invalid(msg),
             SlateDBError::WalDisabled => Error::invalid(msg),
             SlateDBError::InvalidCompaction => Error::invalid(msg),
             SlateDBError::InvalidSegmentPrefix { .. } => Error::invalid(msg),
@@ -583,7 +587,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::MergeOperatorError(err) => Error::invalid(msg).with_source(Box::new(err)),
             SlateDBError::MergeOperatorMissing => Error::invalid(msg),
             SlateDBError::IteratorNotInitialized => Error::invalid(msg),
-            SlateDBError::InvalidSequenceOrder { .. } => Error::data(msg),
+            SlateDBError::InvalidSequenceOrder { .. } => Error::invalid(msg),
             SlateDBError::InvalidEnvironmentVariable { .. } => Error::invalid(msg),
             SlateDBError::InvalidSequenceNumber { .. } => Error::invalid(msg),
             SlateDBError::EmptyBatch => Error::invalid(msg),
@@ -632,10 +636,6 @@ impl From<SlateDBError> for Error {
             SlateDBError::TransactionalObjectError(err) => {
                 Error::internal(msg).with_source(Box::new(err))
             }
-            SlateDBError::DuplicatedCloneSourcePath(_) => Error::invalid(msg),
-            SlateDBError::InvalidUnionSourceWithWal { .. } => Error::invalid(msg),
-            SlateDBError::InvalidUnionSetEmpty() => Error::invalid(msg),
-            SlateDBError::InvalidUnion(_) => Error::invalid(msg),
         }
     }
 }


### PR DESCRIPTION
## Summary

Noticed this a while back. Getting around to fixing it.

## Changes

- Move a couple invalid errors from the internal section to the invalid section
- Update InvalidSequenceOrder to be `invalid` not `data`
