### PR TITLE
Add `dry_run` option to `GarbageCollectorDirectoryOptions`

### DIFF
--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -247,6 +247,7 @@ async fn exec_gc_once(
         Some(GarbageCollectorDirectoryOptions {
             interval: None,
             min_age,
+            dry_run: false,
         })
     }
     let gc_opts = match resource {
@@ -307,6 +308,7 @@ async fn schedule_gc(
         Some(GarbageCollectorDirectoryOptions {
             interval: Some(schedule.period),
             min_age: schedule.min_age,
+            dry_run: false,
         })
     }
     let gc_opts = GarbageCollectorOptions {

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -113,19 +113,23 @@ pub fn build_settings_gc(rng: &mut impl Rng) -> GarbageCollectorOptions {
         manifest_options: Some(GarbageCollectorDirectoryOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
             min_age: rng.random_range(Duration::from_millis(1)..Duration::from_secs(900)),
+            dry_run: false,
         }),
         wal_options: Some(GarbageCollectorDirectoryOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
             min_age: rng.random_range(Duration::from_millis(1)..Duration::from_secs(900)),
+            dry_run: false,
         }),
         wal_fence_options: None,
         compacted_options: Some(GarbageCollectorDirectoryOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
             min_age: rng.random_range(Duration::from_millis(1)..Duration::from_secs(900)),
+            dry_run: false,
         }),
         compactions_options: Some(GarbageCollectorDirectoryOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
             min_age: rng.random_range(Duration::from_millis(1)..Duration::from_secs(900)),
+            dry_run: false,
         }),
         detach_options: Some(GarbageCollectorScheduleOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1294,6 +1294,7 @@ impl Default for GarbageCollectorDirectoryOptions {
         Self {
             interval: Some(DEFAULT_INTERVAL),
             min_age: DEFAULT_MIN_AGE,
+            dry_run: false,
         }
     }
 }
@@ -1315,6 +1316,10 @@ pub struct GarbageCollectorDirectoryOptions {
     #[serde(deserialize_with = "deserialize_duration")]
     #[serde(serialize_with = "serialize_duration")]
     pub min_age: Duration,
+
+    /// If true, log files that would be deleted without deleting them.
+    #[serde(default)]
+    pub dry_run: bool,
 }
 
 /// Schedule options for a GC task that has no file-age threshold.

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1346,9 +1346,16 @@ impl Default for GarbageCollectorScheduleOptions {
 /// Default options for the garbage collector.
 ///
 /// By default, garbage collection is enabled for all managed directories
-/// (manifest, WAL, compacted SSTs, and compactions) using
+/// (manifest, WAL, WAL fence, compacted SSTs, and compactions) using
 /// [`GarbageCollectorDirectoryOptions::default()`].
-/// WAL fence garbage collection is disabled by default.
+/// WAL fence garbage collection runs in dry-run mode by default.
+///
+/// WAL fence GC is visible by default but does not delete until users
+/// explicitly disable `dry_run`. This is a very conservative setting.
+/// Users can enable fence GC with a high `min_age` if they want to
+/// clean up old fences. Alternatively, this log can be silenced entirely
+/// by setting `wal_fence_options` to `None`. See
+/// [`GarbageCollectorOptions::wal_fence_options`] for more details.
 ///
 /// To disable garbage collection for a specific file type, set that
 /// directory option to `None`.
@@ -1357,10 +1364,10 @@ impl Default for GarbageCollectorOptions {
         Self {
             manifest_options: Some(GarbageCollectorDirectoryOptions::default()),
             wal_options: Some(GarbageCollectorDirectoryOptions::default()),
-            // Disable WAL fence garbage collection by default to prevent accidental
-            // data loss. This is a very conservative setting. Users can enable it
-            // with a high `min_age` if they want to clean up old fences.
-            wal_fence_options: None,
+            wal_fence_options: Some(GarbageCollectorDirectoryOptions {
+                dry_run: true,
+                ..GarbageCollectorDirectoryOptions::default()
+            }),
             compacted_options: Some(GarbageCollectorDirectoryOptions::default()),
             compactions_options: Some(GarbageCollectorDirectoryOptions::default()),
             detach_options: Some(GarbageCollectorScheduleOptions::default()),

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -7423,19 +7423,23 @@ mod tests {
             wal_options: Some(GarbageCollectorDirectoryOptions {
                 interval: None,
                 min_age: Duration::from_millis(0),
+                dry_run: false,
             }),
             wal_fence_options: None,
             manifest_options: Some(GarbageCollectorDirectoryOptions {
                 interval: None,
                 min_age: Duration::from_millis(0),
+                dry_run: false,
             }),
             compacted_options: Some(GarbageCollectorDirectoryOptions {
                 interval: None,
                 min_age: Duration::from_millis(0),
+                dry_run: false,
             }),
             compactions_options: Some(GarbageCollectorDirectoryOptions {
                 interval: None,
                 min_age: Duration::from_millis(0),
+                dry_run: false,
             }),
             detach_options: None,
         };

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1068,6 +1068,7 @@ mod tests {
             wal_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_fence_options: None,
             compacted_options: None,
@@ -1132,6 +1133,7 @@ mod tests {
             wal_fence_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             compacted_options: None,
             compactions_options: None,
@@ -1194,6 +1196,7 @@ mod tests {
             wal_fence_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             compacted_options: None,
             compactions_options: None,
@@ -1264,10 +1267,12 @@ mod tests {
             wal_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_fence_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             compacted_options: None,
             compactions_options: None,
@@ -1703,19 +1708,23 @@ mod tests {
             manifest_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_fence_options: None,
             compacted_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             compactions_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             detach_options: None,
         };
@@ -1772,19 +1781,23 @@ mod tests {
             manifest_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_fence_options: None,
             compacted_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             compactions_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             detach_options: None,
         };
@@ -1841,15 +1854,18 @@ mod tests {
             wal_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             wal_fence_options: None,
             compacted_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             compactions_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: std::time::Duration::from_secs(3600),
                 interval: None,
+                dry_run: false,
             }),
             detach_options: None,
         };
@@ -1885,15 +1901,18 @@ mod tests {
             wal_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(11)),
+                dry_run: false,
             }),
             wal_fence_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(13)),
+                dry_run: false,
             }),
             compacted_options: None,
             compactions_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(17)),
+                dry_run: false,
             }),
             detach_options: None,
         };
@@ -1932,19 +1951,23 @@ mod tests {
             manifest_options: Some(GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),
+                dry_run: false,
             }),
             wal_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),
+                dry_run: false,
             }),
             wal_fence_options: None,
             compacted_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),
+                dry_run: false,
             }),
             compactions_options: Some(crate::config::GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(3600),
                 interval: Some(Duration::from_secs(1)),
+                dry_run: false,
             }),
             detach_options: None,
         };
@@ -2191,6 +2214,144 @@ mod tests {
                 &[("resource", "compactions")]
             ),
             Some(2)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_skips_directory_gc_deletes() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+        let now = DefaultSystemClock::default().now();
+        let expired_ms = (now - TimeDelta::seconds(7200)).timestamp_millis() as u64;
+        let unexpired_ms = (now - TimeDelta::seconds(1800)).timestamp_millis() as u64;
+
+        let old_wal_id = SsTableId::Wal(1);
+        write_sst(table_store.clone(), &old_wal_id).await.unwrap();
+        let recent_wal_id = SsTableId::Wal(2);
+        write_sst(table_store.clone(), &recent_wal_id)
+            .await
+            .unwrap();
+        let old_fence_id = SsTableId::Wal(3);
+        table_store.write_wal_fence(3).await.unwrap();
+
+        set_modified(
+            local_object_store.clone(),
+            &path_resolver.table_path(&old_wal_id),
+            86400,
+        );
+        set_modified(
+            local_object_store.clone(),
+            &path_resolver.table_path(&old_fence_id),
+            86400,
+        );
+
+        let inactive_expired_handle = create_sst(table_store.clone(), expired_ms).await;
+        let active_l0_handle = create_sst(table_store.clone(), unexpired_ms).await;
+
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 4;
+        state.next_wal_sst_id = 5;
+        state
+            .tree
+            .l0
+            .push_back(SsTableView::identity(active_l0_handle));
+        let mut stored_manifest = StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        set_modified(
+            local_object_store.clone(),
+            &Path::from(format!("manifest/{:020}.manifest", 1)),
+            86400,
+        );
+
+        let mut stored_compactions = StoredCompactions::create(
+            compactions_store.clone(),
+            stored_manifest.manifest().compactor_epoch,
+        )
+        .await
+        .unwrap();
+        let mut compactions_dirty = stored_compactions.prepare_dirty().unwrap();
+        compactions_dirty.value.insert(Compaction::new(
+            ulid::Ulid::from_parts(now.timestamp_millis() as u64, 0),
+            CompactionSpec::new(vec![SourceId::SortedRun(0)], 0),
+        ));
+        stored_compactions.update(compactions_dirty).await.unwrap();
+
+        let compaction_ids = compactions_store
+            .list_compactions(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<Vec<_>>();
+        for id in &compaction_ids {
+            set_modified(
+                local_object_store.clone(),
+                &Path::from(format!("compactions/{id:020}.compactions")),
+                86400,
+            );
+        }
+
+        let dry_run_options = GarbageCollectorDirectoryOptions {
+            min_age: Duration::from_secs(3600),
+            interval: None,
+            dry_run: true,
+        };
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: Some(dry_run_options),
+            wal_options: Some(dry_run_options),
+            wal_fence_options: Some(dry_run_options),
+            compacted_options: Some(dry_run_options),
+            compactions_options: Some(dry_run_options),
+            detach_options: None,
+        };
+        let recorder = MetricsRecorderHelper::noop();
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store.clone(),
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &recorder,
+            Arc::new(DefaultSystemClock::default()),
+        );
+
+        gc.run_gc_once().await;
+
+        let manifests = manifest_store.list_manifests(..).await.unwrap();
+        assert_eq!(manifests.len(), 2);
+
+        let wal_ids = table_store
+            .list_wal_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<HashSet<_>>();
+        assert!(wal_ids.contains(&old_wal_id));
+        assert!(wal_ids.contains(&recent_wal_id));
+        assert!(wal_ids.contains(&old_fence_id));
+
+        let compacted_ids = table_store
+            .list_compacted_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<HashSet<_>>();
+        assert!(compacted_ids.contains(&inactive_expired_handle.id));
+
+        assert_eq!(
+            compactions_store.list_compactions(..).await.unwrap().len(),
+            compaction_ids.len()
         );
     }
 }

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -219,6 +219,10 @@ impl GcTask for CompactedGcTask {
             .collect::<Vec<_>>();
 
         for id in sst_ids_to_delete {
+            if self.compacted_options.dry_run {
+                log::info!("dry run: would delete SST but skipped [id={:?}]", id);
+                continue;
+            }
             log::info!("deleting SST [id={:?}]", id);
             if let Err(e) = self.table_store.delete_sst(&id).await {
                 error!("error deleting SST [id={:?}, error={}]", id, e);
@@ -333,6 +337,7 @@ mod tests {
         let opts = GarbageCollectorDirectoryOptions {
             interval: None,
             min_age: Duration::from_secs(5),
+            dry_run: false,
         };
         let stats = Arc::new(GcStats::new(&recorder));
         let task = CompactedGcTask::new(
@@ -440,6 +445,7 @@ mod tests {
         let opts = GarbageCollectorDirectoryOptions {
             interval: None,
             min_age: Duration::from_secs(0),
+            dry_run: false,
         };
         let stats = Arc::new(GcStats::new(&recorder));
         let task = CompactedGcTask::new(
@@ -542,6 +548,7 @@ mod tests {
         let opts = GarbageCollectorDirectoryOptions {
             interval: None,
             min_age: Duration::from_secs(0),
+            dry_run: false,
         };
         let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
         let stats = Arc::new(GcStats::new(&recorder));
@@ -637,6 +644,7 @@ mod tests {
         let opts = GarbageCollectorDirectoryOptions {
             interval: None,
             min_age: Duration::from_secs(2),
+            dry_run: false,
         };
         let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
         let stats = Arc::new(GcStats::new(&recorder));

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -218,9 +218,15 @@ impl GcTask for CompactedGcTask {
             .filter(|id| !active_ssts.contains(id))
             .collect::<Vec<_>>();
 
+        if self.compacted_options.dry_run {
+            log::info!(
+                "dry run: skipping SST deletion [count={}]",
+                sst_ids_to_delete.len()
+            );
+        }
         for id in sst_ids_to_delete {
             if self.compacted_options.dry_run {
-                log::info!("dry run: would delete SST but skipped [id={:?}]", id);
+                log::debug!("dry run: would delete SST but skipped [id={:?}]", id);
                 continue;
             }
             log::info!("deleting SST [id={:?}]", id);

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -218,7 +218,7 @@ impl GcTask for CompactedGcTask {
             .filter(|id| !active_ssts.contains(id))
             .collect::<Vec<_>>();
 
-        if self.compacted_options.dry_run {
+        if self.compacted_options.dry_run && !sst_ids_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping SST deletion [count={}]",
                 sst_ids_to_delete.len()

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -90,7 +90,7 @@ impl GcTask for CompactionsGcTask {
                 utc_now.signed_duration_since(compactions_metadata.last_modified) > min_age
             })
             .collect::<Vec<_>>();
-        if self.compactions_options.dry_run {
+        if self.compactions_options.dry_run && !compactions_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping compactions deletion [count={}]",
                 compactions_to_delete.len()

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -86,6 +86,13 @@ impl GcTask for CompactionsGcTask {
         // Delete compactions files older than min_age
         for compactions_metadata in compactions_metadata_list {
             if utc_now.signed_duration_since(compactions_metadata.last_modified) > min_age {
+                if self.compactions_options.dry_run {
+                    log::info!(
+                        "dry run: would delete compactions but skipped [id={:?}]",
+                        compactions_metadata.id
+                    );
+                    continue;
+                }
                 if let Err(e) = self
                     .compactions_store
                     .delete_compactions(compactions_metadata.id)
@@ -144,6 +151,7 @@ mod tests {
             GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(1),
                 interval: None,
+                dry_run: false,
             },
         );
         task.collect(Utc::now() + TimeDelta::hours(1))

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -84,27 +84,37 @@ impl GcTask for CompactionsGcTask {
         }
 
         // Delete compactions files older than min_age
-        for compactions_metadata in compactions_metadata_list {
-            if utc_now.signed_duration_since(compactions_metadata.last_modified) > min_age {
-                if self.compactions_options.dry_run {
-                    log::info!(
-                        "dry run: would delete compactions but skipped [id={:?}]",
-                        compactions_metadata.id
-                    );
-                    continue;
-                }
-                if let Err(e) = self
-                    .compactions_store
-                    .delete_compactions(compactions_metadata.id)
-                    .await
-                {
-                    error!(
-                        "error deleting compactions [id={:?}, error={}]",
-                        compactions_metadata.id, e
-                    );
-                } else {
-                    self.stats.gc_compactions_count.increment(1);
-                }
+        let compactions_to_delete = compactions_metadata_list
+            .into_iter()
+            .filter(|compactions_metadata| {
+                utc_now.signed_duration_since(compactions_metadata.last_modified) > min_age
+            })
+            .collect::<Vec<_>>();
+        if self.compactions_options.dry_run {
+            log::info!(
+                "dry run: skipping compactions deletion [count={}]",
+                compactions_to_delete.len()
+            );
+        }
+        for compactions_metadata in compactions_to_delete {
+            if self.compactions_options.dry_run {
+                log::debug!(
+                    "dry run: would delete compactions but skipped [id={:?}]",
+                    compactions_metadata.id
+                );
+                continue;
+            }
+            if let Err(e) = self
+                .compactions_store
+                .delete_compactions(compactions_metadata.id)
+                .await
+            {
+                error!(
+                    "error deleting compactions [id={:?}, error={}]",
+                    compactions_metadata.id, e
+                );
+            } else {
+                self.stats.gc_compactions_count.increment(1);
             }
         }
 

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -85,7 +85,7 @@ impl GcTask for ManifestGcTask {
                     && utc_now.signed_duration_since(manifest_metadata.last_modified) > min_age
             })
             .collect::<Vec<_>>();
-        if self.manifest_options.dry_run {
+        if self.manifest_options.dry_run && !manifests_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping manifest deletion [count={}]",
                 manifests_to_delete.len()

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -77,30 +77,39 @@ impl GcTask for ManifestGcTask {
         }
 
         // Delete manifests older than min_age
-        for manifest_metadata in manifest_metadata_list {
-            let is_active = active_manifest_ids.contains(&manifest_metadata.id);
-            if !is_active
-                && utc_now.signed_duration_since(manifest_metadata.last_modified) > min_age
+        let manifests_to_delete = manifest_metadata_list
+            .into_iter()
+            .filter(|manifest_metadata| {
+                let is_active = active_manifest_ids.contains(&manifest_metadata.id);
+                !is_active
+                    && utc_now.signed_duration_since(manifest_metadata.last_modified) > min_age
+            })
+            .collect::<Vec<_>>();
+        if self.manifest_options.dry_run {
+            log::info!(
+                "dry run: skipping manifest deletion [count={}]",
+                manifests_to_delete.len()
+            );
+        }
+        for manifest_metadata in manifests_to_delete {
+            if self.manifest_options.dry_run {
+                log::debug!(
+                    "dry run: would delete manifest but skipped [id={:?}]",
+                    manifest_metadata.id
+                );
+                continue;
+            }
+            if let Err(e) = self
+                .manifest_store
+                .delete_manifest(manifest_metadata.id)
+                .await
             {
-                if self.manifest_options.dry_run {
-                    log::info!(
-                        "dry run: would delete manifest but skipped [id={:?}]",
-                        manifest_metadata.id
-                    );
-                    continue;
-                }
-                if let Err(e) = self
-                    .manifest_store
-                    .delete_manifest(manifest_metadata.id)
-                    .await
-                {
-                    error!(
-                        "error deleting manifest [id={:?}, error={}]",
-                        manifest_metadata.id, e
-                    );
-                } else {
-                    self.stats.gc_manifest_count.increment(1);
-                }
+                error!(
+                    "error deleting manifest [id={:?}, error={}]",
+                    manifest_metadata.id, e
+                );
+            } else {
+                self.stats.gc_manifest_count.increment(1);
             }
         }
 

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -82,6 +82,13 @@ impl GcTask for ManifestGcTask {
             if !is_active
                 && utc_now.signed_duration_since(manifest_metadata.last_modified) > min_age
             {
+                if self.manifest_options.dry_run {
+                    log::info!(
+                        "dry run: would delete manifest but skipped [id={:?}]",
+                        manifest_metadata.id
+                    );
+                    continue;
+                }
                 if let Err(e) = self
                     .manifest_store
                     .delete_manifest(manifest_metadata.id)
@@ -148,6 +155,7 @@ mod tests {
             GarbageCollectorDirectoryOptions {
                 min_age: Duration::from_secs(1),
                 interval: None,
+                dry_run: false,
             },
         );
         task.collect(Utc::now() + TimeDelta::hours(1))

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -121,12 +121,19 @@ impl GcTask for WalGcTask {
             .map(|wal_sst| wal_sst.id)
             .collect::<Vec<_>>();
 
-        if self.wal_options.dry_run {
+        if self.wal_options.dry_run && !sst_ids_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping {} deletion [count={}]",
                 self.resource(),
                 sst_ids_to_delete.len()
             );
+            if matches!(self.mode, WalGcMode::Fence) {
+                log::info!(
+                    "WAL fence GC is dry-run by default. This is a conservative setting. \
+                    Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
+                    Silence this log with wal_fence_options=None. See #352 for details."
+                );
+            }
         }
         for id in sst_ids_to_delete {
             if self.wal_options.dry_run {

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -121,9 +121,16 @@ impl GcTask for WalGcTask {
             .map(|wal_sst| wal_sst.id)
             .collect::<Vec<_>>();
 
+        if self.wal_options.dry_run {
+            log::info!(
+                "dry run: skipping {} deletion [count={}]",
+                self.resource(),
+                sst_ids_to_delete.len()
+            );
+        }
         for id in sst_ids_to_delete {
             if self.wal_options.dry_run {
-                log::info!(
+                log::debug!(
                     "dry run: would delete {} but skipped [id={:?}]",
                     self.resource(),
                     id

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -122,6 +122,14 @@ impl GcTask for WalGcTask {
             .collect::<Vec<_>>();
 
         for id in sst_ids_to_delete {
+            if self.wal_options.dry_run {
+                log::info!(
+                    "dry run: would delete {} but skipped [id={:?}]",
+                    self.resource(),
+                    id
+                );
+                continue;
+            }
             if let Err(e) = self.table_store.delete_sst(&id).await {
                 error!("error deleting WAL SST [id={:?}, error={}]", id, e);
             } else {

--- a/website/src/content/docs/docs/design/gc.mdx
+++ b/website/src/content/docs/docs/design/gc.mdx
@@ -5,7 +5,9 @@ description: Learn about SlateDB's garbage collection strategy
 
 SlateDB's garbage collector runs as a background task in the client process, periodically checking for obsolete files in the database storage.
 
-The garbage collector has a configurable minimum age and interval for each file type (WAL SSTs, compacted SSTs, and manifests). Garbage collection for a file type can be disabled by setting its options to `None`. The collector runs every `interval` seconds and will delete files older than `min_age` that are not referenced by any active manifest or checkpoint.
+The garbage collector has a configurable minimum age and interval for each file type (WAL SSTs, WAL fence SSTs, compacted SSTs, manifests, and compactions). Garbage collection for a file type can be disabled by setting its options to `None`. The collector runs every `interval` seconds and will delete files older than `min_age` that are not referenced by any active manifest or checkpoint.
+
+Each garbage collection directory type supports a `dry_run` option. When enabled, the collector logs files that would be deleted without actually deleting them. This is useful for testing or verifying garbage collection behavior before enabling actual deletion.
 
 Below is a diagram illustrating the high-level flow of garbage collection in SlateDB:
 
@@ -31,3 +33,11 @@ flowchart TD
 
     C3 & D3 & E3 --> G[Wait for Next Interval or Shutdown]
 ```
+
+## Default Garbage Collection Behavior
+
+By default, garbage collection is enabled for all managed directories (manifest, WAL, WAL fence, compacted SSTs, and compactions) using standard interval and minimum age settings.
+
+WAL fence garbage collection runs in dry-run mode by default. This means it logs files that would be deleted without actually deleting them. This conservative default prevents accidental data loss while still providing visibility into what would be cleaned up.
+
+To enable actual deletion for WAL fence GC, set `dry_run: false` with a high `min_age` to safely clean up old fences. Alternatively, to silence the dry-run logging entirely, set `wal_fence_options: None`.


### PR DESCRIPTION
## Summary

Adds a `dry_run` option for `GarbageCollectorDirectoryOptions`. Defaults to `false`. `true` is used for WAL fences.

This is a follow-up to https://github.com/slatedb/slatedb/pull/1672/#discussion_r3263610372.

## Changes

- Add `dry_run` defaulted to false
- Updates `wal_fence_options` to use `true`
