### PR TITLE
Use streaming uploads for compacted SSTs

### DIFF
--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -214,9 +214,20 @@ impl TableStore {
         );
 
         let object_store = self.object_stores.store_for(id);
-        let data = encoded_sst.remaining_as_bytes();
         let path = self.path(id);
-        write_sst_in_object_store(object_store.clone(), id, &path, &data).await?;
+        match id {
+            SsTableId::Compacted(_) => {
+                write_sst_streaming_in_object_store(object_store.clone(), &path, encoded_sst)
+                    .await?;
+            }
+            // WAL SSTs rely on PutMode::Create for fencing. The generic
+            // object_store multipart API cannot express that condition, so WALs
+            // stay on the conditional single-PUT path for now.
+            SsTableId::Wal(_) => {
+                let data = encoded_sst.remaining_as_bytes();
+                write_sst_in_object_store(object_store.clone(), id, &path, &data).await?;
+            }
+        }
 
         if let Some(ref cache) = self.cache {
             if write_cache {
@@ -782,6 +793,20 @@ async fn write_sst_in_object_store(
     Ok(())
 }
 
+async fn write_sst_streaming_in_object_store(
+    object_store: Arc<dyn ObjectStore>,
+    path: &Path,
+    encoded_sst: &EncodedSsTable,
+) -> Result<(), SlateDBError> {
+    let mut writer = BufWriter::new(object_store, path.clone());
+    for block in &encoded_sst.unconsumed_blocks {
+        writer.put(block.encoded_bytes.clone()).await?;
+    }
+    writer.put(encoded_sst.footer.clone()).await?;
+    writer.shutdown().await?;
+    Ok(())
+}
+
 pub(crate) struct EncodedSsTableWriter<'a> {
     id: SsTableId,
     builder: EncodedSsTableBuilder<'a>,
@@ -1133,6 +1158,95 @@ mod tests {
         let table = sst.build().await.unwrap();
         let result = ts.write_sst(&SsTableId::Wal(1), &table, false).await;
         assert!(matches!(result, Err(error::SlateDBError::Fenced)));
+    }
+
+    #[tokio::test]
+    async fn should_use_streaming_upload_for_large_compacted_sst() {
+        // given:
+        let value_size = 11 * 1024 * 1024;
+        let os = Arc::new(
+            FlakyObjectStore::new(Arc::new(InMemory::new()), 0)
+                .with_single_put_size_limit(1024 * 1024),
+        );
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            format,
+            Path::from(ROOT),
+            None,
+        ));
+        let id = SsTableId::Compacted(ulid::Ulid::new());
+
+        let mut builder = ts.table_builder();
+        builder
+            .add(RowEntry::new(
+                Bytes::from_static(b"key"),
+                ValueDeletable::Value(Bytes::from(vec![b'x'; value_size])),
+                0,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        let sst = builder.build().await.unwrap();
+
+        // when:
+        ts.write_sst(&id, &sst, false).await.unwrap();
+
+        // then:
+        assert_eq!(os.put_attempts(), 0);
+        assert_eq!(os.multipart_attempts(), 1);
+        ts.open_sst(&id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_keep_conditional_single_put_for_large_wal_sst() {
+        // given:
+        let value_size = 11 * 1024 * 1024;
+        let os = Arc::new(
+            FlakyObjectStore::new(Arc::new(InMemory::new()), 0)
+                .with_single_put_size_limit(1024 * 1024),
+        );
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            format,
+            Path::from(ROOT),
+            None,
+        ));
+        let wal_id = SsTableId::Wal(1);
+
+        let mut builder = ts.table_builder();
+        builder
+            .add(RowEntry::new(
+                Bytes::from_static(b"key"),
+                ValueDeletable::Value(Bytes::from(vec![b'x'; value_size])),
+                0,
+                None,
+                None,
+            ))
+            .await
+            .unwrap();
+        let sst = builder.build().await.unwrap();
+
+        // when:
+        let result = ts.write_sst(&wal_id, &sst, false).await;
+
+        // then:
+        assert!(matches!(
+            result,
+            Err(error::SlateDBError::ObjectStoreError(_))
+        ));
+        assert_eq!(os.put_attempts(), 1);
+        assert_eq!(os.multipart_attempts(), 0);
     }
 
     #[tokio::test]

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -429,6 +429,8 @@ pub(crate) struct FlakyObjectStore {
     fail_first_put_opts: AtomicUsize,
     put_opts_attempts: AtomicUsize,
     put_opts_attempt_notify: Notify,
+    max_single_put_bytes: AtomicUsize,
+    put_multipart_attempts: AtomicUsize,
     // Put options: if set, always return Precondition error (non-retryable)
     put_precondition_always: std::sync::atomic::AtomicBool,
     // Put options: if set, write succeeds but returns AlreadyExists error
@@ -461,6 +463,8 @@ impl FlakyObjectStore {
             fail_first_put_opts: AtomicUsize::new(fail_first_put_opts),
             put_opts_attempts: AtomicUsize::new(0),
             put_opts_attempt_notify: Notify::new(),
+            max_single_put_bytes: AtomicUsize::new(0),
+            put_multipart_attempts: AtomicUsize::new(0),
             put_precondition_always: std::sync::atomic::AtomicBool::new(false),
             put_succeeds_but_returns_already_exists: std::sync::atomic::AtomicBool::new(false),
             fail_first_head: AtomicUsize::new(0),
@@ -478,6 +482,12 @@ impl FlakyObjectStore {
 
     pub(crate) fn with_put_precondition_always(self) -> Self {
         self.put_precondition_always.store(true, Ordering::SeqCst);
+        self
+    }
+
+    pub(crate) fn with_single_put_size_limit(self, max_single_put_bytes: usize) -> Self {
+        self.max_single_put_bytes
+            .store(max_single_put_bytes, Ordering::SeqCst);
         self
     }
 
@@ -514,6 +524,10 @@ impl FlakyObjectStore {
 
     pub(crate) fn put_attempts(&self) -> usize {
         self.put_opts_attempts.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn multipart_attempts(&self) -> usize {
+        self.put_multipart_attempts.load(Ordering::SeqCst)
     }
 
     pub(crate) async fn wait_for_put_attempts(&self, expected: usize) {
@@ -639,6 +653,17 @@ impl ObjectStore for FlakyObjectStore {
     ) -> object_store::Result<PutResult> {
         self.put_opts_attempts.fetch_add(1, Ordering::SeqCst);
         self.put_opts_attempt_notify.notify_waiters();
+        let max_single_put_bytes = self.max_single_put_bytes.load(Ordering::SeqCst);
+        if max_single_put_bytes > 0 && payload.content_length() > max_single_put_bytes {
+            return Err(object_store::Error::Generic {
+                store: "flaky_single_put_limit",
+                source: Box::new(std::io::Error::other(format!(
+                    "single PUT payload of {} bytes exceeds limit of {} bytes",
+                    payload.content_length(),
+                    max_single_put_bytes
+                ))),
+            });
+        }
         if self.put_precondition_always.load(Ordering::SeqCst) {
             return Err(object_store::Error::Precondition {
                 path: location.to_string(),
@@ -688,6 +713,7 @@ impl ObjectStore for FlakyObjectStore {
         location: &Path,
         opts: object_store::PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.put_multipart_attempts.fetch_add(1, Ordering::SeqCst);
         self.inner.put_multipart_opts(location, opts).await
     }
 


### PR DESCRIPTION
## Summary

Fixes #1679. Large compacted SST uploads now go through `object_store::buffered::BufWriter`, so we can switch to multipart upload instead of failing the single PUT size limit.

## Changes

- Route compacted SST writes through `BufWriter`.
- Keep WAL SST writes on conditional single PUTs, since they need create-if-absent semantics (the bug will still exist if you enable WAL).
- Add focused object-store tests for the compacted SST path and the WAL limitation.

## Notes for Reviewers

I considered moving L0 flushes to write through `EncodedSsTableWriter` directly (as Chris suggested) but I kept this change in `TableStore::write_sst` instead because segmented L0 flushes currently build per-segment SSTs and upload those segments in parallel. A direct L0 writer would need significant refactoring to preserve that concurrency and retry behavior.


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant