### PR TITLE
replay the exact range of the wal from `replay_after_wal_id` to the fencing wal

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -27,7 +27,7 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use fail_parallel::FailPointRegistry;
+use fail_parallel::{fail_point, FailPointRegistry};
 use object_store::path::Path;
 use object_store::prefix::PrefixStore;
 use object_store::{parse_url_opts, ObjectStore};
@@ -553,6 +553,17 @@ impl DbInner {
     }
 
     async fn replay_wal(&self) -> Result<(), SlateDBError> {
+        // Tests use this fail point to pause replay so the writer that owns
+        // this epoch can race with a newer writer's fence + replay.
+        let writer_epoch = self.state.read().state().manifest.value.writer_epoch;
+        let _ = writer_epoch;
+        fail_point!(
+            Arc::clone(&self.fp_registry),
+            "replay-wal-pause",
+            writer_epoch == 1,
+            |_| -> Result<(), SlateDBError> { Ok(()) }
+        );
+
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 1,
             blocks_to_fetch: 256,
@@ -6169,6 +6180,105 @@ mod tests {
 
         do_put(&db2, b"2", b"2").await.unwrap();
         assert_eq!(db2.inner.state.read().state().core().next_wal_sst_id, 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_writer_paused_in_replay_wal_should_be_fenced_by_concurrent_open() {
+        // Race we're trying to reproduce:
+        // - W1 starts opening: claims writer_epoch=1, writes its fence WAL, then
+        //   enters replay_wal. We pause it inside replay_wal.
+        // - W2 starts opening: claims writer_epoch=2, writes its own fence WAL
+        //   (above W1's), replays, and finishes init.
+        // - W1 unpauses, finishes replay_wal, and returns its Db handle.
+        // - W1 issues a put. This put should fail
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_writer_paused_in_replay_wal_race";
+        let fp_registry = Arc::new(FailPointRegistry::new());
+
+        // Pause replay_wal for any writer that holds writer_epoch == 1
+        // (the condition is enforced inside the fail point body).
+        fail_parallel::cfg(fp_registry.clone(), "replay-wal-pause", "pause").unwrap();
+
+        // Kick off W1 in the background. It will park inside replay_wal.
+        // Use a long manifest poll interval on W1 so its background poller
+        // doesn't independently observe W2's epoch bump and trip the
+        // closed/fenced check while replay is paused.
+        let w1_settings = {
+            let mut s = test_db_options(0, 128, None);
+            s.manifest_poll_interval = Duration::from_secs(600);
+            s
+        };
+        let w1_handle = {
+            let object_store = object_store.clone();
+            let fp_registry = fp_registry.clone();
+            tokio::spawn(async move {
+                Db::builder(path, object_store)
+                    .with_settings(w1_settings)
+                    .with_fp_registry(fp_registry)
+                    .build()
+                    .await
+            })
+        };
+
+        // Wait for W1 to write its fence WAL — at that point W1 has finished
+        // fence_writers and has either entered or is about to enter the paused
+        // replay_wal call.
+        let probe_table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            SsTableFormat::default(),
+            path,
+            None,
+        ));
+        let mut w1_paused = false;
+        for _ in 0..600 {
+            let wals = probe_table_store.list_wal_ssts(..).await.unwrap();
+            if !wals.is_empty() {
+                w1_paused = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(w1_paused, "W1 did not reach replay_wal pause in time");
+        // Small additional wait for W1 to transition from fence_writers into
+        // the paused replay_wal block.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // While W1 is paused, open W2. W2's epoch is 2, so replay_wal is not
+        // paused for W2. W2 writes its own fence WAL above W1's and finishes
+        // init.
+        let db2 = Db::builder(path, object_store.clone())
+            .with_settings(test_db_options(0, 128, None))
+            .with_fp_registry(fp_registry.clone())
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(
+            db2.inner.state.read().state().manifest.value.writer_epoch,
+            2
+        );
+
+        // Release W1. It finishes replay_wal and returns a Db handle.
+        fail_parallel::cfg(fp_registry.clone(), "replay-wal-pause", "off").unwrap();
+        let db1 = w1_handle.await.unwrap().unwrap();
+        assert_eq!(
+            db1.inner.state.read().state().manifest.value.writer_epoch,
+            1
+        );
+
+        // The race: W1 was fenced by W2 before W1's open returned, but W1's
+        // put currently still succeeds. This assertion documents the bug.
+        let result = db1
+            .put_with_options(
+                b"w1",
+                b"value",
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -583,9 +583,13 @@ impl DbInner {
         };
 
         let db_state = self.state.read().state().core().clone();
-        let mut replay_iter =
-            WalReplayIterator::range(wal_id_range, &db_state, replay_options, Arc::clone(&self.table_store))
-                .await?;
+        let mut replay_iter = WalReplayIterator::range(
+            wal_id_range,
+            &db_state,
+            replay_options,
+            Arc::clone(&self.table_store),
+        )
+        .await?;
 
         while let Some(replayed_table) = replay_iter.next().await? {
             // RFC-0024: re-extract each replayed entry's prefix to

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6279,7 +6279,7 @@ mod tests {
                 },
             )
             .await;
-        assert!(result.is_ok());
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -23,7 +23,7 @@
 pub use crate::db_status::DbStatus;
 
 use crate::db_cache_manager::{self, CacheTarget};
-use std::ops::RangeBounds;
+use std::ops::{Range, RangeBounds};
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -296,12 +296,13 @@ impl DbInner {
 
     /// Fences all writers with an older epoch than the provided `manifest` by flushing
     /// an empty WAL file that acts as a barrier. Any parallel old writers will fail with
-    /// `SlateDBError::Fenced` when trying to "re-write" this file.
+    /// `SlateDBError::Fenced` when trying to "re-write" this file. Returns the range that must
+    /// be replayed to recover up to the current epoch
     async fn fence_writers(
         &self,
         manifest: &mut FenceableManifest,
         next_wal_id: u64,
-    ) -> Result<(), SlateDBError> {
+    ) -> Result<Range<u64>, SlateDBError> {
         let mut empty_wal_id = next_wal_id;
 
         loop {
@@ -328,7 +329,7 @@ impl DbInner {
                 // We need to make sure the fence write falls above this barrier so it's visible
                 // to all other active writers.
                 if empty_wal_id > replay_after_wal_id {
-                    return Ok(());
+                    return Ok(replay_after_wal_id + 1..empty_wal_id + 1);
                 } else {
                     // If we're behind the barrier, reset to the next WAL slot.
                     empty_wal_id = self
@@ -552,7 +553,7 @@ impl DbInner {
         }
     }
 
-    async fn replay_wal(&self) -> Result<(), SlateDBError> {
+    async fn replay_wal(&self, wal_id_range: Range<u64>) -> Result<(), SlateDBError> {
         // Tests use this fail point to pause replay so the writer that owns
         // this epoch can race with a newer writer's fence + replay.
         let writer_epoch = self.state.read().state().manifest.value.writer_epoch;
@@ -583,7 +584,7 @@ impl DbInner {
 
         let db_state = self.state.read().state().core().clone();
         let mut replay_iter =
-            WalReplayIterator::new(&db_state, replay_options, Arc::clone(&self.table_store))
+            WalReplayIterator::range(wal_id_range, &db_state, replay_options, Arc::clone(&self.table_store))
                 .await?;
 
         while let Some(replayed_table) = replay_iter.next().await? {

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -606,9 +606,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         );
 
         // Fence writers if WAL is enabled
-        if inner.wal_enabled {
-            inner.fence_writers(&mut manifest, next_wal_id).await?;
-        }
+        let replay_range = inner.fence_writers(&mut manifest, next_wal_id).await?;
 
         // Setup background tasks
         let tokio_handle = Handle::current();
@@ -710,7 +708,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         task_executor.monitor_on(&tokio_handle)?;
 
         // Replay WAL
-        inner.replay_wal().await?;
+        inner.replay_wal(replay_range).await?;
 
         // Preload cache if enabled
         if let Some(cached_obj_store) = cached_object_store {

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -136,17 +136,6 @@ impl WalReplayIterator {
         Ok(replay_iter)
     }
 
-    pub(crate) async fn new(
-        db_state: &ManifestCore,
-        options: WalReplayOptions,
-        table_store: Arc<TableStore>,
-    ) -> Result<Self, SlateDBError> {
-        let wal_id_start = db_state.replay_after_wal_id + 1;
-        let wal_id_end = table_store.last_seen_wal_id().await?;
-        let wal_id_range = wal_id_start..(wal_id_end + 1);
-        Self::range(wal_id_range, db_state, options, table_store).await
-    }
-
     fn maybe_load_next_iter(&mut self) -> bool {
         if !self.wal_id_range.contains(&self.next_wal_id)
             || self.next_iters.len() >= self.options.sst_batch_size
@@ -308,11 +297,24 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
+    impl WalReplayIterator {
+        async fn all_wal_ids(
+            db_state: &ManifestCore,
+            options: WalReplayOptions,
+            table_store: Arc<TableStore>,
+        ) -> Result<Self, SlateDBError> {
+            let wal_id_start = db_state.replay_after_wal_id + 1;
+            let wal_id_end = table_store.last_seen_wal_id().await?;
+            let wal_id_range = wal_id_start..(wal_id_end + 1);
+            Self::range(wal_id_range, db_state, options, table_store).await
+        }
+    }
+
     #[tokio::test]
     async fn should_replay_empty_wal() {
         let table_store = test_table_store();
         write_empty_wal(1, Arc::clone(&table_store)).await.unwrap();
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions::default(),
             Arc::clone(&table_store),
@@ -335,7 +337,7 @@ mod tests {
     async fn should_replay_zero_byte_wal_fence() {
         let table_store = test_table_store();
         table_store.write_wal_fence(1).await.unwrap();
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions::default(),
             Arc::clone(&table_store),
@@ -368,7 +370,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions::default(),
             Arc::clone(&table_store),
@@ -396,7 +398,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions::default(),
             Arc::clone(&table_store),
@@ -431,7 +433,7 @@ mod tests {
             .unwrap();
 
         let max_memtable_bytes = 1024;
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions {
                 max_memtable_bytes,
@@ -501,7 +503,7 @@ mod tests {
                 .unwrap();
         }
 
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions {
                 max_memtable_bytes,
@@ -569,7 +571,7 @@ mod tests {
 
         // Replay the single WAL SST into in-memory tables. If the replay code
         // can split a single commit sequence, it will do so here.
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions {
                 max_memtable_bytes,
@@ -627,7 +629,7 @@ mod tests {
             .unwrap();
 
         // Replay the single WAL SST into in-memory tables.
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &ManifestCore::new(),
             WalReplayOptions {
                 max_memtable_bytes,
@@ -689,7 +691,7 @@ mod tests {
         db_state.replay_after_wal_id = replay_after_wal_id;
         db_state.next_wal_sst_id = replay_after_wal_id + 1;
 
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &db_state,
             WalReplayOptions::default(),
             Arc::clone(&table_store),
@@ -728,7 +730,7 @@ mod tests {
         db_state.last_l0_seq = min_seq;
         db_state.last_l0_clock_tick = 0;
 
-        let mut replay_iter = WalReplayIterator::new(
+        let mut replay_iter = WalReplayIterator::all_wal_ids(
             &db_state,
             WalReplayOptions::default(),
             Arc::clone(&table_store),


### PR DESCRIPTION
## Summary

Changes wal replay to replay the exact range of the wal from `replay_after_wal_id` to the fencing wal. Previously, `Db` would re-resolve the end of the WAL when replaying. This could allow it to resolve an incorrect ending range (either too many WAL files if another writer has come in and fenced), or too few WAL files (if WAL has been GC'd)

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
