### PR TITLE
protoype of query tracing layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "slatedb-tracing"
+version = "0.12.0"
+dependencies = [
+ "slatedb",
+ "tokio",
+ "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "slatedb-txn-obj"
 version = "0.12.0"
 dependencies = [
@@ -3725,6 +3736,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "slatedb-common",
     "slatedb-bencher",
     "slatedb-cli",
+    "slatedb-tracing",
     "slatedb-txn-obj",
 ]
 

--- a/slatedb-tracing/Cargo.toml
+++ b/slatedb-tracing/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "slatedb-tracing"
+description = "Tracing layers for aggregating SlateDB query spans."
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
+
+[dependencies]
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["registry"] }
+tracing-chrome = "0.7.2"
+
+[dev-dependencies]
+slatedb = { path = "../slatedb" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { workspace = true, features = ["registry"] }

--- a/slatedb-tracing/src/lib.rs
+++ b/slatedb-tracing/src/lib.rs
@@ -1,0 +1,621 @@
+//! Tracing layer that aggregates SlateDB query spans into per-query
+//! atomic counters.
+//!
+//! Install [`QueryTracingLayer`] in any `tracing-subscriber` `Registry`. The
+//! layer accumulates counts and elapsed time across every `slatedb.query.*`
+//! span it observes, bucketing them under the span's `query_id` field. The
+//! application reads the totals for a specific query via the accessors.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::Subscriber;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::Layer;
+
+const MEMTABLE_SPAN: &str = "slatedb.query.memtable";
+const READ_BLOCKS_SPAN: &str = "slatedb.query.read_blocks";
+const READ_INDEX_SPAN: &str = "slatedb.query.read_index";
+const READ_FILTER_SPAN: &str = "slatedb.query.read_filter";
+const BLOOM_FILTER_SPAN: &str = "slatedb.query.bloom_filter";
+const MERGE_SPAN: &str = "slatedb.query.merge";
+const QUERY_ID_FIELD: &str = "query_id";
+const CACHE_HITS_FIELD: &str = "cache_hits";
+const CACHE_MISSES_FIELD: &str = "cache_misses";
+
+/// `tracing-subscriber` layer that accumulates SlateDB query aggregates
+/// into per-query atomic counters. Cheap to clone — the state lives in an
+/// `Arc` so every clone observes the same totals. Hand one clone to the
+/// registry and keep another to read the aggregates back.
+#[derive(Clone, Default)]
+pub struct QueryTracingLayer {
+    inner: Arc<QueryTracingInner>,
+}
+
+#[derive(Default)]
+struct QueryTracingInner {
+    counters: Mutex<HashMap<String, Arc<QueryCounters>>>,
+}
+
+#[derive(Default)]
+struct QueryCounters {
+    memtable_consulted: AtomicU64,
+    memtable_read_duration_micros: AtomicU64,
+    block_read_duration_micros: AtomicU64,
+    index_read_duration_micros: AtomicU64,
+    filter_read_duration_micros: AtomicU64,
+    bloom_filter_check_duration_micros: AtomicU64,
+    merge_duration_micros: AtomicU64,
+    block_cache_hits: AtomicU64,
+    block_cache_misses: AtomicU64,
+}
+
+impl QueryTracingLayer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of memtables consulted for `query_id`. Returns 0 if no spans
+    /// have been observed for that id.
+    pub fn memtable_consulted(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.memtable_consulted)
+    }
+
+    /// Cumulative memtable read time for `query_id`, in microseconds.
+    pub fn memtable_read_duration_micros(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.memtable_read_duration_micros)
+    }
+
+    /// Cumulative SST block read time for `query_id`, in microseconds.
+    pub fn block_read_duration_micros(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.block_read_duration_micros)
+    }
+
+    /// Cumulative SST index read time for `query_id`, in microseconds.
+    pub fn index_read_duration_micros(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.index_read_duration_micros)
+    }
+
+    /// Cumulative SST filter read time for `query_id`, in microseconds.
+    pub fn filter_read_duration_micros(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.filter_read_duration_micros)
+    }
+
+    /// Cumulative bloom-filter `might_contain` check time for `query_id`,
+    /// in microseconds.
+    pub fn bloom_filter_check_duration_micros(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.bloom_filter_check_duration_micros)
+    }
+
+    /// Cumulative merge-operator time for `query_id`, in microseconds.
+    pub fn merge_duration_micros(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.merge_duration_micros)
+    }
+
+    /// Total number of SST data blocks served from the block cache during
+    /// `query_id`. Summed across every `slatedb.query.read_blocks` span
+    /// that fires for the query.
+    pub fn block_cache_hits(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.block_cache_hits)
+    }
+
+    /// Total number of SST data blocks that missed the block cache and had
+    /// to be fetched from object storage during `query_id`. Summed across
+    /// every `slatedb.query.read_blocks` span that fires for the query.
+    pub fn block_cache_misses(&self, query_id: &str) -> u64 {
+        self.read_counter(query_id, |c| &c.block_cache_misses)
+    }
+
+    /// Snapshot of all query ids the layer has observed so far.
+    pub fn query_ids(&self) -> Vec<String> {
+        self.lock_counters().keys().cloned().collect()
+    }
+
+    fn read_counter(
+        &self,
+        query_id: &str,
+        select: impl FnOnce(&QueryCounters) -> &AtomicU64,
+    ) -> u64 {
+        self.lock_counters()
+            .get(query_id)
+            .map(|c| select(c).load(Ordering::Relaxed))
+            .unwrap_or(0)
+    }
+
+    fn counters_for(&self, query_id: &str) -> Arc<QueryCounters> {
+        self.lock_counters()
+            .entry(query_id.to_string())
+            .or_insert_with(|| Arc::new(QueryCounters::default()))
+            .clone()
+    }
+
+    fn lock_counters(&self) -> std::sync::MutexGuard<'_, HashMap<String, Arc<QueryCounters>>> {
+        self.inner
+            .counters
+            .lock()
+            .expect("QueryTracingLayer query map mutex poisoned")
+    }
+}
+
+/// Per-query duration snapshot taken under the queries-map lock so the
+/// `Display` impl can format without holding it.
+struct QueryDurations {
+    memtable: Duration,
+    block: Duration,
+    index: Duration,
+    filter: Duration,
+    bloom_filter: Duration,
+    merge: Duration,
+    block_cache_hits: u64,
+    block_cache_misses: u64,
+}
+
+impl QueryDurations {
+    fn snapshot(c: &QueryCounters) -> Self {
+        let load = |a: &AtomicU64| Duration::from_micros(a.load(Ordering::Relaxed));
+        Self {
+            memtable: load(&c.memtable_read_duration_micros),
+            block: load(&c.block_read_duration_micros),
+            index: load(&c.index_read_duration_micros),
+            filter: load(&c.filter_read_duration_micros),
+            bloom_filter: load(&c.bloom_filter_check_duration_micros),
+            merge: load(&c.merge_duration_micros),
+            block_cache_hits: c.block_cache_hits.load(Ordering::Relaxed),
+            block_cache_misses: c.block_cache_misses.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Pretty-prints aggregated per-query durations. Layout is intended for
+/// human debugging (`println!("{layer}")`) and is not part of the API
+/// contract — callers that need stable values should use the typed
+/// accessors.
+impl fmt::Display for QueryTracingLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut snapshots: Vec<(String, QueryDurations)> = {
+            let map = self.lock_counters();
+            map.iter()
+                .map(|(id, c)| (id.clone(), QueryDurations::snapshot(c)))
+                .collect()
+        };
+        snapshots.sort_by(|a, b| a.0.cmp(&b.0));
+
+        writeln!(f, "QueryTracingLayer {{")?;
+        for (id, d) in &snapshots {
+            writeln!(
+                f,
+                "  {id}: memtable={:?} block={:?} index={:?} filter={:?} bloom_filter={:?} merge={:?} block_cache_hits={} block_cache_misses={}",
+                d.memtable,
+                d.block,
+                d.index,
+                d.filter,
+                d.bloom_filter,
+                d.merge,
+                d.block_cache_hits,
+                d.block_cache_misses,
+            )?;
+        }
+        write!(f, "}}")
+    }
+}
+
+impl<S> Layer<S> for QueryTracingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let name = attrs.metadata().name();
+        if name != MEMTABLE_SPAN
+            && name != READ_BLOCKS_SPAN
+            && name != READ_INDEX_SPAN
+            && name != READ_FILTER_SPAN
+            && name != BLOOM_FILTER_SPAN
+            && name != MERGE_SPAN
+        {
+            return;
+        }
+        let mut visitor = QueryIdVisitor::default();
+        attrs.record(&mut visitor);
+        let Some(query_id) = visitor.query_id else { return };
+        let counters = self.counters_for(&query_id);
+        if name == MEMTABLE_SPAN {
+            counters.memtable_consulted.fetch_add(1, Ordering::Relaxed);
+        }
+        let Some(span) = ctx.span(id) else { return };
+        span.extensions_mut().insert(SpanCounters(counters));
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if span.metadata().name() != READ_BLOCKS_SPAN {
+            return;
+        }
+        let exts = span.extensions();
+        let Some(SpanCounters(counters)) = exts.get::<SpanCounters>() else {
+            return;
+        };
+        let mut visitor = BlockCacheFieldsVisitor::default();
+        values.record(&mut visitor);
+        if let Some(hits) = visitor.cache_hits {
+            counters.block_cache_hits.fetch_add(hits, Ordering::Relaxed);
+        }
+        if let Some(misses) = visitor.cache_misses {
+            counters
+                .block_cache_misses
+                .fetch_add(misses, Ordering::Relaxed);
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if span.extensions().get::<SpanCounters>().is_none() {
+            return;
+        }
+        span.extensions_mut().insert(EnterTime(Instant::now()));
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let entered = span.extensions_mut().remove::<EnterTime>();
+        let Some(EnterTime(start)) = entered else { return };
+        let elapsed = start.elapsed().as_micros() as u64;
+        let exts = span.extensions();
+        let Some(SpanCounters(counters)) = exts.get::<SpanCounters>() else {
+            return;
+        };
+        let counter = match span.metadata().name() {
+            MEMTABLE_SPAN => &counters.memtable_read_duration_micros,
+            READ_BLOCKS_SPAN => &counters.block_read_duration_micros,
+            READ_INDEX_SPAN => &counters.index_read_duration_micros,
+            READ_FILTER_SPAN => &counters.filter_read_duration_micros,
+            BLOOM_FILTER_SPAN => &counters.bloom_filter_check_duration_micros,
+            MERGE_SPAN => &counters.merge_duration_micros,
+            _ => return,
+        };
+        counter.fetch_add(elapsed, Ordering::Relaxed);
+    }
+}
+
+/// Per-span handle to the [`QueryCounters`] for the span's `query_id`,
+/// resolved once at span creation and stashed in the span's extensions so
+/// later `on_enter` / `on_exit` calls don't have to take the query-map lock.
+struct SpanCounters(Arc<QueryCounters>);
+
+/// Span extension recording the most recent `on_enter` timestamp.
+struct EnterTime(Instant);
+
+/// Extracts the `query_id` field from a span's [`Attributes`].
+#[derive(Default)]
+struct QueryIdVisitor {
+    query_id: Option<String>,
+}
+
+/// Captures the `cache_hits` / `cache_misses` u64 fields recorded on a
+/// `slatedb.query.read_blocks` span by `tablestore::read_blocks_using_index`.
+/// Both are set once per span via `tracing::Span::current().record(...)`
+/// after the cache lookups complete, so they surface through `on_record`.
+#[derive(Default)]
+struct BlockCacheFieldsVisitor {
+    cache_hits: Option<u64>,
+    cache_misses: Option<u64>,
+}
+
+impl Visit for BlockCacheFieldsVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        match field.name() {
+            CACHE_HITS_FIELD => self.cache_hits = Some(value),
+            CACHE_MISSES_FIELD => self.cache_misses = Some(value),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {}
+}
+
+impl Visit for QueryIdVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == QUERY_ID_FIELD {
+            self.query_id = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        // SlateDB instruments spans with `query_id = %id`, which routes
+        // through `record_debug` (the `Debug` impl of `fmt::Arguments`
+        // delegates to `Display`, so this yields the same string as the
+        // caller's `Display` formatting).
+        if field.name() == QUERY_ID_FIELD && self.query_id.is_none() {
+            self.query_id = Some(format!("{:?}", value));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+    use std::time::Duration;
+    use tracing::dispatcher;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_subscriber::Registry;
+
+    fn with_layer<F: FnOnce(&QueryTracingLayer)>(f: F) {
+        let layer = QueryTracingLayer::new();
+        let subscriber = Registry::default().with(layer.clone());
+        dispatcher::with_default(&subscriber.into(), || f(&layer));
+    }
+
+    #[test]
+    fn should_count_each_memtable_span_creation() {
+        with_layer(|layer| {
+            let s1 = tracing::debug_span!("slatedb.query.memtable", query_id = "q1");
+            let s2 = tracing::debug_span!("slatedb.query.memtable", query_id = "q1");
+            let _ = (s1, s2);
+            assert_eq!(layer.memtable_consulted("q1"), 2);
+            assert_eq!(layer.memtable_read_duration_micros("q1"), 0);
+        });
+    }
+
+    #[test]
+    fn should_sum_memtable_duration_across_polls() {
+        with_layer(|layer| {
+            let span = tracing::debug_span!("slatedb.query.memtable", query_id = "q2");
+            for _ in 0..3 {
+                let _enter = span.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(span);
+            assert_eq!(layer.memtable_consulted("q2"), 1);
+            let micros = layer.memtable_read_duration_micros("q2");
+            assert!(micros >= 6_000, "micros = {micros}");
+        });
+    }
+
+    #[test]
+    fn should_ignore_unrelated_spans() {
+        with_layer(|layer| {
+            let _ = tracing::debug_span!("unrelated", query_id = "q3");
+            assert_eq!(layer.memtable_consulted("q3"), 0);
+            assert_eq!(layer.memtable_read_duration_micros("q3"), 0);
+            assert_eq!(layer.block_read_duration_micros("q3"), 0);
+            assert!(layer.query_ids().is_empty());
+        });
+    }
+
+    #[test]
+    fn should_sum_block_read_duration_across_polls() {
+        with_layer(|layer| {
+            let span = tracing::debug_span!("slatedb.query.read_blocks", query_id = "q4");
+            for _ in 0..3 {
+                let _enter = span.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(span);
+            // read_blocks does not contribute to memtable_consulted.
+            assert_eq!(layer.memtable_consulted("q4"), 0);
+            assert_eq!(layer.memtable_read_duration_micros("q4"), 0);
+            let micros = layer.block_read_duration_micros("q4");
+            assert!(micros >= 6_000, "micros = {micros}");
+        });
+    }
+
+    #[test]
+    fn should_sum_index_read_duration_across_polls() {
+        with_layer(|layer| {
+            let span = tracing::debug_span!("slatedb.query.read_index", query_id = "qi");
+            for _ in 0..3 {
+                let _enter = span.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(span);
+            // read_index does not contribute to memtable_consulted nor to
+            // block/memtable durations.
+            assert_eq!(layer.memtable_consulted("qi"), 0);
+            assert_eq!(layer.memtable_read_duration_micros("qi"), 0);
+            assert_eq!(layer.block_read_duration_micros("qi"), 0);
+            let micros = layer.index_read_duration_micros("qi");
+            assert!(micros >= 6_000, "micros = {micros}");
+        });
+    }
+
+    #[test]
+    fn should_sum_filter_read_duration_across_polls() {
+        with_layer(|layer| {
+            let span = tracing::debug_span!("slatedb.query.read_filter", query_id = "qf");
+            for _ in 0..3 {
+                let _enter = span.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(span);
+            assert_eq!(layer.memtable_consulted("qf"), 0);
+            assert_eq!(layer.memtable_read_duration_micros("qf"), 0);
+            assert_eq!(layer.block_read_duration_micros("qf"), 0);
+            assert_eq!(layer.index_read_duration_micros("qf"), 0);
+            let micros = layer.filter_read_duration_micros("qf");
+            assert!(micros >= 6_000, "micros = {micros}");
+        });
+    }
+
+    #[test]
+    fn should_sum_bloom_filter_check_duration_across_polls() {
+        with_layer(|layer| {
+            let span = tracing::debug_span!("slatedb.query.bloom_filter", query_id = "qb");
+            for _ in 0..3 {
+                let _enter = span.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(span);
+            assert_eq!(layer.memtable_consulted("qb"), 0);
+            assert_eq!(layer.filter_read_duration_micros("qb"), 0);
+            let micros = layer.bloom_filter_check_duration_micros("qb");
+            assert!(micros >= 6_000, "micros = {micros}");
+        });
+    }
+
+    #[test]
+    fn should_sum_merge_duration_across_polls() {
+        with_layer(|layer| {
+            let span = tracing::debug_span!("slatedb.query.merge", query_id = "qm");
+            for _ in 0..3 {
+                let _enter = span.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(span);
+            assert_eq!(layer.memtable_consulted("qm"), 0);
+            assert_eq!(layer.memtable_read_duration_micros("qm"), 0);
+            assert_eq!(layer.block_read_duration_micros("qm"), 0);
+            assert_eq!(layer.index_read_duration_micros("qm"), 0);
+            assert_eq!(layer.filter_read_duration_micros("qm"), 0);
+            let micros = layer.merge_duration_micros("qm");
+            assert!(micros >= 6_000, "micros = {micros}");
+        });
+    }
+
+    #[test]
+    fn should_accumulate_block_cache_hits_and_misses_across_read_blocks_spans() {
+        with_layer(|layer| {
+            // First read_blocks span: 2 hits, 1 miss.
+            let s1 = tracing::debug_span!(
+                "slatedb.query.read_blocks",
+                query_id = "qbc",
+                cache_hits = tracing::field::Empty,
+                cache_misses = tracing::field::Empty,
+            );
+            s1.record("cache_hits", 2u64);
+            s1.record("cache_misses", 1u64);
+            drop(s1);
+
+            // Second read_blocks span on the same query: 3 hits, 4 misses.
+            let s2 = tracing::debug_span!(
+                "slatedb.query.read_blocks",
+                query_id = "qbc",
+                cache_hits = tracing::field::Empty,
+                cache_misses = tracing::field::Empty,
+            );
+            s2.record("cache_hits", 3u64);
+            s2.record("cache_misses", 4u64);
+            drop(s2);
+
+            assert_eq!(layer.block_cache_hits("qbc"), 5);
+            assert_eq!(layer.block_cache_misses("qbc"), 5);
+        });
+    }
+
+    #[test]
+    fn should_not_count_block_cache_for_non_read_blocks_spans() {
+        with_layer(|layer| {
+            // `cache_hits` / `cache_misses` on a different span name must
+            // not bump the block_cache counters.
+            let span = tracing::debug_span!(
+                "slatedb.query.read_index",
+                query_id = "qbcn",
+                cache_hits = tracing::field::Empty,
+                cache_misses = tracing::field::Empty,
+            );
+            span.record("cache_hits", 7u64);
+            span.record("cache_misses", 9u64);
+            drop(span);
+            assert_eq!(layer.block_cache_hits("qbcn"), 0);
+            assert_eq!(layer.block_cache_misses("qbcn"), 0);
+        });
+    }
+
+    #[test]
+    fn should_isolate_counters_by_query_id() {
+        with_layer(|layer| {
+            let a1 = tracing::debug_span!("slatedb.query.memtable", query_id = "qa");
+            let a2 = tracing::debug_span!("slatedb.query.memtable", query_id = "qa");
+            let b1 = tracing::debug_span!("slatedb.query.memtable", query_id = "qb");
+            let _ = (a1, a2, b1);
+
+            assert_eq!(layer.memtable_consulted("qa"), 2);
+            assert_eq!(layer.memtable_consulted("qb"), 1);
+            assert_eq!(layer.memtable_consulted("unknown"), 0);
+
+            let mut ids = layer.query_ids();
+            ids.sort();
+            assert_eq!(ids, vec!["qa".to_string(), "qb".to_string()]);
+        });
+    }
+
+    #[test]
+    fn should_render_durations_per_query_via_display() {
+        with_layer(|layer| {
+            let m = tracing::debug_span!("slatedb.query.memtable", query_id = "qa");
+            {
+                let _e = m.enter();
+                sleep(Duration::from_millis(2));
+            }
+            drop(m);
+
+            let b = tracing::debug_span!("slatedb.query.read_blocks", query_id = "qb");
+            {
+                let _e = b.enter();
+                sleep(Duration::from_millis(3));
+            }
+            drop(b);
+
+            let rendered = format!("{layer}");
+            // Header + one line per query.
+            assert!(rendered.starts_with("QueryTracingLayer {\n"));
+            assert!(rendered.ends_with("}"));
+            // Queries are listed in sorted order.
+            let qa_pos = rendered.find("qa:").expect("qa line");
+            let qb_pos = rendered.find("qb:").expect("qb line");
+            assert!(qa_pos < qb_pos, "expected qa before qb in:\n{rendered}");
+            // Each duration label appears on every line. Use leading-space
+            // matching so `filter=` doesn't also count `bloom_filter=`.
+            for label in [
+                " memtable=",
+                " block=",
+                " index=",
+                " filter=",
+                " bloom_filter=",
+                " merge=",
+            ] {
+                let count = rendered.matches(label).count();
+                assert_eq!(count, 2, "label {label} should appear twice in:\n{rendered}");
+            }
+            // qa accumulated memtable time; qb did not.
+            let qa_line = rendered
+                .lines()
+                .find(|l| l.contains("qa:"))
+                .expect("qa line");
+            assert!(
+                !qa_line.contains("memtable=0ns"),
+                "qa should have non-zero memtable duration: {qa_line}"
+            );
+            let qb_line = rendered
+                .lines()
+                .find(|l| l.contains("qb:"))
+                .expect("qb line");
+            assert!(
+                qb_line.contains("memtable=0ns"),
+                "qb should have zero memtable duration: {qb_line}"
+            );
+        });
+    }
+
+    #[test]
+    fn should_render_empty_display_when_no_queries_observed() {
+        let layer = QueryTracingLayer::new();
+        let rendered = format!("{layer}");
+        assert_eq!(rendered, "QueryTracingLayer {\n}");
+    }
+
+    #[test]
+    fn should_capture_query_id_from_display_value() {
+        with_layer(|layer| {
+            // SlateDB's instrumentation uses `query_id = %id`, which routes
+            // through `record_debug`. Reproduce that here.
+            let id: &str = "qd";
+            let _ = tracing::debug_span!("slatedb.query.memtable", query_id = %id);
+            assert_eq!(layer.memtable_consulted("qd"), 1);
+        });
+    }
+}

--- a/slatedb-tracing/tests/bloom_filter_span.rs
+++ b/slatedb-tracing/tests/bloom_filter_span.rs
@@ -1,0 +1,180 @@
+//! Verifies that `slatedb.query.bloom_filter` spans fire on the read
+//! path when a query reaches an SST that has a filter, and that each
+//! span records `sst_id`, `key`, and `result`. Drives both a hit
+//! (`result=true`) and a miss (`result=false`) scenario.
+
+use std::sync::{Arc, Mutex};
+
+use slatedb::config::{FlushOptions, FlushType, ReadOptions, Settings};
+use slatedb::object_store::memory::InMemory;
+use slatedb::Db;
+use slatedb_tracing::QueryTracingLayer;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::Subscriber;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
+
+const BLOOM_FILTER_SPAN: &str = "slatedb.query.bloom_filter";
+
+#[derive(Debug, Default, Clone)]
+struct BloomSpanFields {
+    sst_id: Option<String>,
+    key: Option<String>,
+    result: Option<bool>,
+}
+
+#[derive(Clone, Default)]
+struct BloomSpanCapture {
+    spans: Arc<Mutex<Vec<BloomSpanFields>>>,
+}
+
+impl<S> Layer<S> for BloomSpanCapture
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        if attrs.metadata().name() != BLOOM_FILTER_SPAN {
+            return;
+        }
+        let Some(span) = ctx.span(id) else { return };
+        let mut fields = BloomSpanFields::default();
+        let mut v = FieldVisitor { fields: &mut fields };
+        attrs.record(&mut v);
+        span.extensions_mut().insert(Slot {
+            fields: Arc::new(Mutex::new(fields)),
+        });
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if span.metadata().name() != BLOOM_FILTER_SPAN {
+            return;
+        }
+        let exts = span.extensions();
+        let Some(slot) = exts.get::<Slot>() else { return };
+        let mut fields = slot.fields.lock().unwrap();
+        let mut v = FieldVisitor { fields: &mut fields };
+        values.record(&mut v);
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        if span.metadata().name() != BLOOM_FILTER_SPAN {
+            return;
+        }
+        let snapshot = span
+            .extensions()
+            .get::<Slot>()
+            .map(|s| s.fields.lock().unwrap().clone());
+        if let Some(fields) = snapshot {
+            self.spans.lock().unwrap().push(fields);
+        }
+    }
+}
+
+struct Slot {
+    fields: Arc<Mutex<BloomSpanFields>>,
+}
+
+struct FieldVisitor<'a> {
+    fields: &'a mut BloomSpanFields,
+}
+
+impl<'a> Visit for FieldVisitor<'a> {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == "result" {
+            self.fields.result = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        match field.name() {
+            "sst_id" => self.fields.sst_id = Some(format!("{value:?}")),
+            "key" => self.fields.key = Some(format!("{value:?}")),
+            _ => {}
+        }
+    }
+}
+
+#[tokio::test]
+async fn records_bloom_filter_span_fields_for_hit_and_miss() {
+    let layer = QueryTracingLayer::new();
+    let capture = BloomSpanCapture::default();
+    tracing_subscriber::registry()
+        .with(layer.clone())
+        .with(capture.clone())
+        .init();
+
+    let object_store = Arc::new(InMemory::new());
+    // Force filter creation on a small SST.
+    let settings = Settings {
+        min_filter_keys: 1,
+        ..Settings::default()
+    };
+    let db = Db::builder("/tmp/slatedb_bloom_span_test", object_store)
+        .with_settings(settings)
+        .build()
+        .await
+        .expect("open db");
+
+    // Seed the SST with widely-spaced keys so its byte range covers many
+    // potential lookup keys. The bloom filter is consulted only when the
+    // lookup key falls inside the SST's `[first_key, last_key]` range; a
+    // key outside that range is skipped by a cheaper pre-check.
+    db.put(b"aa", b"v").await.expect("put aa");
+    db.put(b"az", b"v").await.expect("put az");
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .expect("flush");
+
+    // hit: key actually stored — filter says "might match".
+    let opts_hit = ReadOptions::new().with_query_id("hit".to_string());
+    let v = db.get_with_options(b"aa", &opts_hit).await.expect("get hit");
+    assert!(v.is_some());
+
+    // miss: key inside the SST's range but not stored — filter says
+    // "definitely absent".
+    let opts_miss = ReadOptions::new().with_query_id("miss".to_string());
+    let v = db
+        .get_with_options(b"am", &opts_miss)
+        .await
+        .expect("get miss");
+    assert!(v.is_none());
+
+    db.close().await.expect("close");
+
+    // Span fields: every span must have sst_id, key, and a recorded result.
+    // Bloom-filter probes are sub-microsecond, so the duration counter can
+    // round to 0 — the capture layer is the reliable proof that a span
+    // fired.
+    let spans = capture.spans.lock().unwrap().clone();
+    assert!(!spans.is_empty(), "expected at least one bloom_filter span");
+    for s in &spans {
+        assert!(s.sst_id.is_some(), "missing sst_id: {s:?}");
+        assert!(s.key.is_some(), "missing key: {s:?}");
+        assert!(s.result.is_some(), "missing result: {s:?}");
+    }
+    assert!(
+        spans.iter().any(|s| s.result == Some(true)),
+        "expected at least one span with result=true, got {spans:?}"
+    );
+    assert!(
+        spans.iter().any(|s| s.result == Some(false)),
+        "expected at least one span with result=false, got {spans:?}"
+    );
+
+    // Sanity: the duration counter accumulates across both queries. Even if
+    // any individual check rounds to 0us, the sum across all spans for at
+    // least one query should be non-zero on a real machine.
+    let total_us = layer.bloom_filter_check_duration_micros("hit")
+        + layer.bloom_filter_check_duration_micros("miss");
+    assert!(
+        total_us > 0,
+        "expected non-zero combined bloom_filter_check_duration across hit+miss"
+    );
+}

--- a/slatedb-tracing/tests/cached_field.rs
+++ b/slatedb-tracing/tests/cached_field.rs
@@ -1,0 +1,200 @@
+//! Verifies that `slatedb::tablestore` records the `cached` field on the
+//! surrounding `slatedb.query.read_index` and `slatedb.query.read_filter`
+//! spans — `false` on the first read (cache miss, fetched from object
+//! store) and `true` on the second read of the same SST (cache hit).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use slatedb::config::{FlushOptions, FlushType, ReadOptions, Settings};
+use slatedb::object_store::memory::InMemory;
+use slatedb::Db;
+use slatedb_tracing::QueryTracingLayer;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::Subscriber;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
+
+const READ_INDEX_SPAN: &str = "slatedb.query.read_index";
+const READ_FILTER_SPAN: &str = "slatedb.query.read_filter";
+
+#[derive(Clone, Default)]
+struct CachedFieldCapture {
+    /// Map of span name → list of `cached` values observed across all spans
+    /// of that name, in close order. `None` means the field was never
+    /// recorded for that span.
+    by_span: Arc<Mutex<HashMap<&'static str, Vec<Option<bool>>>>>,
+}
+
+impl CachedFieldCapture {
+    fn snapshot(&self, span: &'static str) -> Vec<Option<bool>> {
+        self.by_span
+            .lock()
+            .unwrap()
+            .get(span)
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+fn tracked_span_name(name: &str) -> Option<&'static str> {
+    match name {
+        READ_INDEX_SPAN => Some(READ_INDEX_SPAN),
+        READ_FILTER_SPAN => Some(READ_FILTER_SPAN),
+        _ => None,
+    }
+}
+
+impl<S> Layer<S> for CachedFieldCapture
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let Some(name) = tracked_span_name(attrs.metadata().name()) else { return };
+        let Some(span) = ctx.span(id) else { return };
+        let slot = Arc::new(Mutex::new(None::<bool>));
+        span.extensions_mut().insert(CachedSlot {
+            value: slot.clone(),
+        });
+        // Reserve a slot for this span's eventual `cached` value; filled
+        // in on_close in the same order spans were created.
+        self.by_span
+            .lock()
+            .unwrap()
+            .entry(name)
+            .or_default()
+            .push(None);
+        let mut v = SlotVisitor { slot: &slot };
+        attrs.record(&mut v);
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        if tracked_span_name(span.metadata().name()).is_none() {
+            return;
+        }
+        let exts = span.extensions();
+        let Some(slot) = exts.get::<CachedSlot>() else { return };
+        let mut v = SlotVisitor { slot: &slot.value };
+        values.record(&mut v);
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(&id) else { return };
+        let Some(name) = tracked_span_name(span.metadata().name()) else { return };
+        let final_value = span
+            .extensions()
+            .get::<CachedSlot>()
+            .and_then(|s| *s.value.lock().unwrap());
+        let mut by_span = self.by_span.lock().unwrap();
+        let entries = by_span.entry(name).or_default();
+        // Fill the most-recent placeholder reserved in on_new_span. Spans
+        // may close out of creation order, but for this single-threaded
+        // test that's not a concern.
+        if let Some(empty) = entries.iter_mut().rev().find(|v| v.is_none()) {
+            *empty = final_value;
+        }
+    }
+}
+
+struct CachedSlot {
+    value: Arc<Mutex<Option<bool>>>,
+}
+
+struct SlotVisitor<'a> {
+    slot: &'a Arc<Mutex<Option<bool>>>,
+}
+
+impl<'a> Visit for SlotVisitor<'a> {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        if field.name() == "cached" {
+            *self.slot.lock().unwrap() = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+}
+
+#[tokio::test]
+async fn records_cached_field_for_read_index_and_read_filter_spans() {
+    let capture = CachedFieldCapture::default();
+    let layer = QueryTracingLayer::new();
+    tracing_subscriber::registry()
+        .with(layer)
+        .with(capture.clone())
+        .init();
+
+    let object_store = Arc::new(InMemory::new());
+    let path = "/tmp/slatedb_cached_field_test";
+    // Default `min_filter_keys` is 1000 — too high to materialize a filter
+    // for a one-row SST. Lower it so `read_filters` returns a real filter
+    // (and therefore actually caches it).
+    let settings = Settings {
+        min_filter_keys: 1,
+        ..Settings::default()
+    };
+
+    // Phase 1 — populate an SST then close. Writing the SST seeds the block
+    // cache with its index/filter, so we can't observe a miss against this
+    // instance.
+    {
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(settings.clone())
+            .build()
+            .await
+            .expect("open db");
+        db.put(b"k", b"v").await.expect("put");
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("flush");
+        db.close().await.expect("close db");
+    }
+
+    // Phase 2 — reopen with a fresh in-memory cache. The first traced get
+    // must load index + filter from object storage (cache miss → cached=false).
+    // The second get hits the now-warm cache (cached=true).
+    let db = Db::builder(path, object_store)
+        .with_settings(settings)
+        .build()
+        .await
+        .expect("reopen db");
+
+    let opts1 = ReadOptions::new().with_query_id("cold".to_string());
+    db.get_with_options(b"k", &opts1)
+        .await
+        .expect("get cold")
+        .expect("value");
+
+    let opts2 = ReadOptions::new().with_query_id("warm".to_string());
+    db.get_with_options(b"k", &opts2)
+        .await
+        .expect("get warm")
+        .expect("value");
+
+    db.close().await.expect("close db");
+
+    for span in [READ_INDEX_SPAN, READ_FILTER_SPAN] {
+        let observed = capture.snapshot(span);
+        assert!(
+            !observed.is_empty(),
+            "expected at least one {span} span to fire"
+        );
+        assert!(
+            observed.contains(&Some(false)),
+            "expected at least one {span} span with cached=false, got {observed:?}"
+        );
+        assert!(
+            observed.contains(&Some(true)),
+            "expected at least one {span} span with cached=true, got {observed:?}"
+        );
+        assert!(
+            !observed.iter().any(|v| v.is_none()),
+            "every {span} span should have its `cached` field recorded, got {observed:?}"
+        );
+    }
+}

--- a/slatedb-tracing/tests/merge_span.rs
+++ b/slatedb-tracing/tests/merge_span.rs
@@ -1,0 +1,155 @@
+//! Verifies that `slatedb.query.merge` spans fire on the read path when a
+//! merge operator is configured and the value being resolved is built from
+//! one or more merge operands. The `QueryTracingLayer` should accumulate a
+//! non-zero `merge_duration_micros` for the query id, and each span should
+//! carry `key` and `num_operands` fields as described in the RFC.
+
+use std::sync::{Arc, Mutex};
+use std::thread::sleep;
+use std::time::Duration;
+
+use slatedb::bytes::Bytes;
+use slatedb::config::{ReadOptions, Settings};
+use slatedb::object_store::memory::InMemory;
+use slatedb::{Db, MergeOperator, MergeOperatorError};
+use slatedb_tracing::QueryTracingLayer;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id};
+use tracing::Subscriber;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
+
+const MERGE_SPAN: &str = "slatedb.query.merge";
+
+/// Concatenates merge operands with a `+` separator, slow enough to ensure
+/// the merge span captures a measurable duration.
+struct SlowConcatMergeOperator;
+
+impl MergeOperator for SlowConcatMergeOperator {
+    fn merge(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operand: Bytes,
+    ) -> Result<Bytes, MergeOperatorError> {
+        sleep(Duration::from_millis(1));
+        let mut out = existing_value.map(|v| v.to_vec()).unwrap_or_default();
+        if !out.is_empty() {
+            out.push(b'+');
+        }
+        out.extend_from_slice(&operand);
+        Ok(Bytes::from(out))
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct MergeSpanFields {
+    key: Option<String>,
+    num_operands: Option<u64>,
+}
+
+#[derive(Clone, Default)]
+struct MergeSpanCapture {
+    spans: Arc<Mutex<Vec<MergeSpanFields>>>,
+}
+
+impl<S> Layer<S> for MergeSpanCapture
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+        if attrs.metadata().name() != MERGE_SPAN {
+            return;
+        }
+        let mut visitor = FieldVisitor::default();
+        attrs.record(&mut visitor);
+        self.spans.lock().unwrap().push(MergeSpanFields {
+            key: visitor.key,
+            num_operands: visitor.num_operands,
+        });
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    key: Option<String>,
+    num_operands: Option<u64>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == "num_operands" {
+            self.num_operands = Some(value);
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        if field.name() == "num_operands" && value >= 0 {
+            self.num_operands = Some(value as u64);
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "key" {
+            self.key = Some(format!("{value:?}"));
+        }
+    }
+}
+
+#[tokio::test]
+async fn records_merge_duration_and_fields_for_traced_get() {
+    let layer = QueryTracingLayer::new();
+    let capture = MergeSpanCapture::default();
+    tracing_subscriber::registry()
+        .with(layer.clone())
+        .with(capture.clone())
+        .init();
+
+    let object_store = Arc::new(InMemory::new());
+    let db = Db::builder("/tmp/slatedb_merge_span_test", object_store)
+        .with_settings(Settings::default())
+        .with_merge_operator(Arc::new(SlowConcatMergeOperator))
+        .build()
+        .await
+        .expect("open db");
+
+    // Three merge operands and no base value → read path must call the
+    // merge operator to fold them.
+    db.merge(b"k", b"a").await.expect("merge a");
+    db.merge(b"k", b"b").await.expect("merge b");
+    db.merge(b"k", b"c").await.expect("merge c");
+
+    let opts = ReadOptions::new().with_query_id("qmerge".to_string());
+    let value = db
+        .get_with_options(b"k", &opts)
+        .await
+        .expect("get")
+        .expect("value");
+    assert_eq!(value.as_ref(), b"a+b+c");
+
+    db.close().await.expect("close db");
+
+    let micros = layer.merge_duration_micros("qmerge");
+    assert!(
+        micros > 0,
+        "expected non-zero merge_duration_micros for 'qmerge', got {micros}"
+    );
+    assert!(layer.memtable_consulted("qmerge") > 0);
+
+    let spans = capture.spans.lock().unwrap().clone();
+    assert!(!spans.is_empty(), "expected at least one merge span");
+    for s in &spans {
+        assert!(s.key.is_some(), "every merge span must record `key`: {s:?}");
+        assert!(
+            s.num_operands.is_some(),
+            "every merge span must record `num_operands`: {s:?}"
+        );
+    }
+    // At least one span should have observed all three operands folded together.
+    assert!(
+        spans.iter().any(|s| s.num_operands == Some(3)),
+        "expected one merge span with num_operands=3, got {spans:?}"
+    );
+}

--- a/slatedb-tracing/tests/point_lookup_sources.rs
+++ b/slatedb-tracing/tests/point_lookup_sources.rs
@@ -1,0 +1,416 @@
+//! Per-source point-lookup tracing tests.
+//!
+//! Each test arranges the database so a known key lives in exactly one
+//! source — active memtable, immutable memtable, an L0 SST, or a
+//! sorted run — then performs a traced `get_with_options` and asserts
+//! that the `QueryTracingLayer`'s per-query duration counters reflect
+//! the work the read path actually had to do.
+//!
+//! Conventions used by every test in this file:
+//! - Each test creates its own `QueryTracingLayer` and `Dispatch`, and
+//!   scopes the traced call with `.with_subscriber(dispatch)` so tests
+//!   don't share global subscriber state.
+//! - SST tests use `min_filter_keys = 1` so a single-entry SST still
+//!   gets a bloom filter (otherwise the read-path skips both
+//!   `read_filter` and `bloom_filter`).
+//! - Background flushing is effectively disabled via a long
+//!   `flush_interval`; tests trigger flushes explicitly so memtable vs.
+//!   SST placement is deterministic.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use slatedb::bytes::Bytes;
+use slatedb::config::{
+    CompactorOptions, FlushOptions, FlushType, ReadOptions, Settings,
+};
+use slatedb::fail_parallel::{self, FailPointRegistry};
+use slatedb::object_store::memory::InMemory;
+use slatedb::Db;
+use slatedb_tracing::QueryTracingLayer;
+use tracing::instrument::WithSubscriber;
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+// ---------------------------------------------------------------------------
+// Shared harness
+// ---------------------------------------------------------------------------
+
+/// Bundles a `Db`, the `QueryTracingLayer` attached to its subscriber, and
+/// the `Dispatch` carrying that subscriber. Traced operations call
+/// `traced_get` so each test's spans land on its own dedicated layer.
+struct TracedDb {
+    db: Db,
+    layer: QueryTracingLayer,
+    dispatch: tracing::Dispatch,
+    _guard: FlushGuard,
+}
+
+impl TracedDb {
+    async fn open(
+        path: &str,
+        settings: Settings,
+        fp_registry: Option<Arc<FailPointRegistry>>,
+    ) -> Self {
+        let store = Arc::new(InMemory::new());
+        let layer = QueryTracingLayer::new();
+        let (chrome_layer, guard) = ChromeLayerBuilder::new()
+            .include_args(true)
+            // .trace_style(tracing_chrome::TraceStyle::Async)
+            .build();
+        let subscriber = tracing_subscriber::Registry::default()
+            .with(layer.clone())
+            .with(chrome_layer);
+        let dispatch: tracing::Dispatch = subscriber.into();
+
+        let mut builder = Db::builder(path, store).with_settings(settings);
+        if let Some(fp) = fp_registry {
+            builder = builder.with_fp_registry(fp);
+        }
+        let db = builder.build().await.expect("open db");
+        Self { db, layer, dispatch, _guard: guard }
+    }
+
+    async fn traced_get(&self, key: &[u8], query_id: &str) -> Option<Bytes> {
+        let opts = ReadOptions::new().with_query_id(query_id.to_string());
+        self.db
+            .get_with_options(key, &opts)
+            .with_subscriber(self.dispatch.clone())
+            .await
+            .expect("get")
+    }
+}
+
+/// Baseline settings used by every test. Keeps the default 100ms
+/// `flush_interval` (writes use `await_durable=true`, so disabling the
+/// WAL-flush timer would make every put block on a never-arriving WAL
+/// flush). Memtable→L0 promotion is driven by `l0_sst_size_bytes` which
+/// stays at its 64MiB default — far above anything these tests write, so
+/// the background flusher never auto-flushes our memtables. The tests
+/// drive that transition explicitly via `flush_with_options`.
+///
+/// `min_filter_keys = 1` ensures even one-row SSTs carry a bloom filter
+/// so SST tests can assert filter/bloom spans fire.
+fn base_settings() -> Settings {
+    Settings {
+        min_filter_keys: 1,
+        ..Settings::default()
+    }
+}
+
+/// Settings that additionally enable the size-tiered compactor with a fast
+/// poll and a lowered `min_compaction_sources` so a handful of L0 SSTs is
+/// enough to trigger a compaction into a sorted run.
+fn settings_with_eager_compactor() -> Settings {
+    use std::collections::HashMap;
+    let mut scheduler_options = HashMap::new();
+    scheduler_options.insert("min_compaction_sources".to_string(), "2".to_string());
+    let compactor_options = CompactorOptions {
+        poll_interval: Duration::from_millis(50),
+        scheduler_options,
+        ..CompactorOptions::default()
+    };
+    Settings {
+        compactor_options: Some(compactor_options),
+        ..base_settings()
+    }
+}
+
+/// Poll the manifest until at least one sorted run is recorded or the
+/// timeout expires. Returns whether a sorted run was observed.
+async fn wait_for_sorted_run(db: &Db, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        let _ = db.refresh_manifest().await;
+        if !db.manifest().compacted().is_empty() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    false
+}
+
+/// Asserts that none of the SST-side duration counters fired for
+/// `query_id`. Used by the memtable-only tests.
+fn assert_no_sst_work(layer: &QueryTracingLayer, query_id: &str) {
+    assert_eq!(
+        layer.block_read_duration_micros(query_id),
+        0,
+        "block_read_duration should be 0 for {query_id}"
+    );
+    assert_eq!(
+        layer.index_read_duration_micros(query_id),
+        0,
+        "index_read_duration should be 0 for {query_id}"
+    );
+    assert_eq!(
+        layer.filter_read_duration_micros(query_id),
+        0,
+        "filter_read_duration should be 0 for {query_id}"
+    );
+    assert_eq!(
+        layer.bloom_filter_check_duration_micros(query_id),
+        0,
+        "bloom_filter_check_duration should be 0 for {query_id}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn result_in_active_memtable() {
+    let h = TracedDb::open("/tmp/pl_active", base_settings(), None).await;
+
+    // The put goes straight to the active memtable; with the long
+    // flush_interval and no explicit flush, it stays there.
+    h.db.put(b"k", b"v").await.expect("put");
+
+    let value = h.traced_get(b"k", "q").await;
+    assert_eq!(value.as_deref(), Some(b"v".as_ref()));
+
+    // The active memtable was consulted at least once; the SST path was
+    // never entered, so all SST-side timers are zero.
+    assert!(
+        h.layer.memtable_consulted("q") >= 1,
+        "expected memtable_consulted >= 1, got {}",
+        h.layer.memtable_consulted("q"),
+    );
+    assert_no_sst_work(&h.layer, "q");
+
+    println!("{}", h.layer);
+    h.db.close().await.expect("close");
+}
+
+// TODO(query-tracing): the immutable-memtable case requires a slatedb hook
+// that lets the test pause the L0 write while still letting the active
+// memtable be frozen.
+//
+// The existing `flush-memtable-to-l0` fail point sits inside
+// `FlushTracker::handle_flush_request`, but L0 upload is also driven from
+// the `MemtableFrozen` path fired synchronously by `freeze_current_memtable`
+// — so by the time `handle_flush_request` runs (and could be paused), the
+// L0 SST has typically already been built. We confirmed this experimentally:
+// pausing `flush-memtable-to-l0` still left `manifest().l0().len() == 1`
+// before the read, and the read consequently exercised the SST path.
+//
+// From the layer's perspective the spans for active and immutable
+// memtables are identical (`slatedb.query.memtable` with `memtable_consulted`
+// incremented), so this test would only meaningfully differ from
+// `result_in_active_memtable` if we could *prove* the row was served from
+// an immutable memtable rather than the active one. That proof needs a
+// fail point on the L0 upload path (e.g. inside `Uploader` or
+// `reconcile_and_dispatch`) which doesn't exist today.
+#[tokio::test]
+#[ignore = "needs a slatedb fail point that halts L0 upload but not freeze; see comment above"]
+async fn result_in_immutable_memtable() {
+    // Halt the memtable→L0 flush so the active memtable can be frozen
+    // (becoming immutable) without being written to L0.
+    let fp_registry = Arc::new(FailPointRegistry::new());
+    fail_parallel::cfg(
+        fp_registry.clone(),
+        "flush-memtable-to-l0",
+        "pause",
+    )
+    .expect("cfg pause");
+
+    let h = TracedDb::open(
+        "/tmp/pl_immutable",
+        base_settings(),
+        Some(fp_registry.clone()),
+    )
+    .await;
+
+    h.db.put(b"k", b"v").await.expect("put");
+
+    let flusher = h.db.clone();
+    let flush_task = tokio::spawn(async move {
+        flusher
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let value = h.traced_get(b"k", "q").await;
+    assert_eq!(value.as_deref(), Some(b"v".as_ref()));
+
+    fail_parallel::cfg(fp_registry, "flush-memtable-to-l0", "off").expect("cfg off");
+    let _ = flush_task.await.expect("flush task panicked");
+
+    assert!(
+        h.layer.memtable_consulted("q") >= 1,
+        "expected memtable_consulted >= 1, got {}",
+        h.layer.memtable_consulted("q"),
+    );
+    assert_no_sst_work(&h.layer, "q");
+
+    h.db.close().await.expect("close");
+}
+
+#[tokio::test]
+async fn result_in_l0_sst() {
+    let h = TracedDb::open("/tmp/pl_l0", base_settings(), None).await;
+
+    h.db.put(b"k", b"v").await.expect("put");
+    h.db
+        .flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("flush");
+
+    // The active memtable is now empty; the row lives only in an L0 SST.
+    // Verify via the manifest that there's exactly one L0 SST and no
+    // compacted runs yet.
+    let m = h.db.manifest();
+    assert_eq!(m.l0().len(), 1, "expected 1 L0 SST, manifest = {m:?}");
+    assert!(
+        m.compacted().is_empty(),
+        "no compactor configured; sorted runs should be empty, manifest = {m:?}",
+    );
+
+    let value = h.traced_get(b"k", "q").await;
+    assert_eq!(value.as_deref(), Some(b"v".as_ref()));
+
+    // Reading the L0 SST must have loaded its index, filter section, and
+    // the data block holding the row, and exercised the bloom filter.
+    assert!(
+        h.layer.index_read_duration_micros("q") > 0,
+        "expected index_read_duration > 0 for L0 read"
+    );
+    assert!(
+        h.layer.filter_read_duration_micros("q") > 0,
+        "expected filter_read_duration > 0 for L0 read"
+    );
+    assert!(
+        h.layer.block_read_duration_micros("q") > 0,
+        "expected block_read_duration > 0 for L0 read"
+    );
+    // The bloom check itself can round to 0us; the read_filter span above
+    // is the load-time proof. Assert only that work happened cumulatively.
+    let total = h.layer.filter_read_duration_micros("q")
+        + h.layer.bloom_filter_check_duration_micros("q");
+    assert!(
+        total > 0,
+        "expected non-zero filter+bloom time for L0 read, got {total}"
+    );
+
+    println!("{}", h.layer);
+    h.db.close().await.expect("close");
+}
+
+#[tokio::test]
+async fn result_in_sorted_run() {
+    let h = TracedDb::open(
+        "/tmp/pl_sorted_run",
+        settings_with_eager_compactor(),
+        None,
+    )
+    .await;
+
+    // Write several keys across distinct L0 SSTs. With the size-tiered
+    // scheduler's `min_compaction_sources = 2` and a 50ms poll interval,
+    // the compactor will fold these L0s into a sorted run shortly.
+    for (i, key) in [b"k1", b"k2", b"k3", b"k4"].iter().enumerate() {
+        h.db.put(*key, format!("v{i}").as_bytes())
+            .await
+            .expect("put");
+        h.db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .expect("flush");
+    }
+
+    assert!(
+        wait_for_sorted_run(&h.db, Duration::from_secs(5)).await,
+        "compactor did not produce a sorted run within 5s; manifest = {:?}",
+        h.db.manifest()
+    );
+
+    let value = h.traced_get(b"k2", "q").await;
+    assert_eq!(value.as_deref(), Some(b"v1".as_ref()));
+
+    // The read path opened at least one SST (whether that SST now lives
+    // in a sorted run or remains in L0 doesn't change the spans fired —
+    // both routes go through the same SST iterator) and consulted the
+    // index, filter, and at least one data block.
+    assert!(
+        h.layer.index_read_duration_micros("q") > 0,
+        "expected index_read_duration > 0 for sorted-run read"
+    );
+    assert!(
+        h.layer.filter_read_duration_micros("q") > 0,
+        "expected filter_read_duration > 0 for sorted-run read"
+    );
+    assert!(
+        h.layer.block_read_duration_micros("q") > 0,
+        "expected block_read_duration > 0 for sorted-run read"
+    );
+
+    println!("{}", h.layer);
+    h.db.close().await.expect("close");
+}
+
+#[tokio::test]
+async fn result_in_sorted_run_global_subscriber() {
+    let store = Arc::new(InMemory::new());
+    let builder = Db::builder("/tmp/pl_immutable", store).with_settings(base_settings());
+    let db = builder.build().await.expect("open db");
+
+    let layer = QueryTracingLayer::new();
+
+    tracing_subscriber::registry()
+        .with(layer.clone())
+        .init();
+
+    // Write several keys across distinct L0 SSTs. With the size-tiered
+    // scheduler's `min_compaction_sources = 2` and a 50ms poll interval,
+    // the compactor will fold these L0s into a sorted run shortly.
+    for (i, key) in [b"k1", b"k2", b"k3", b"k4"].iter().enumerate() {
+        db.put(*key, format!("v{i}").as_bytes())
+            .await
+            .expect("put");
+        db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .expect("flush");
+    }
+
+    assert!(
+        wait_for_sorted_run(&db, Duration::from_secs(5)).await,
+        "compactor did not produce a sorted run within 5s; manifest = {:?}",
+        db.manifest()
+    );
+
+    let opts = ReadOptions::new().with_query_id("id1".to_string());
+    let value = db.get_with_options(b"k2", &opts).await.expect("get value");
+    assert_eq!(value.as_deref(), Some(b"v1".as_ref()));
+
+    // The read path opened at least one SST (whether that SST now lives
+    // in a sorted run or remains in L0 doesn't change the spans fired —
+    // both routes go through the same SST iterator) and consulted the
+    // index, filter, and at least one data block.
+    // assert!(
+    //     h.layer.index_read_duration_micros("q") > 0,
+    //     "expected index_read_duration > 0 for sorted-run read"
+    // );
+    // assert!(
+    //     h.layer.filter_read_duration_micros("q") > 0,
+    //     "expected filter_read_duration > 0 for sorted-run read"
+    // );
+    // assert!(
+    //     h.layer.block_read_duration_micros("q") > 0,
+    //     "expected block_read_duration > 0 for sorted-run read"
+    // );
+
+    println!("{}", layer);
+    db.close().await.expect("close");
+}

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -351,6 +351,7 @@ impl WriteBatch {
                 it,
                 false,
                 None,
+                None,
             ));
         }
 

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -284,6 +284,7 @@ impl TokioCompactionExecutorInner {
             order: IterationOrder::Ascending,
             prefix: None,
             filter_context: None,
+            query_id: None,
         };
 
         let max_parallel = compute_max_parallel(job_args.sst_views.len(), &job_args.sorted_runs, 4);
@@ -318,6 +319,7 @@ impl TokioCompactionExecutorInner {
                     merge_iter,
                     false,
                     job_args.retention_min_seq,
+                    None,
                 ))
             } else {
                 Box::new(MergeOperatorRequiredIterator::new(merge_iter))

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -277,6 +277,10 @@ pub struct ReadOptions {
     /// Optional context forwarded to custom filter policies; ignored by
     /// built-in filters. See [`FilterContext`].
     pub filter_context: Option<FilterContext>,
+    /// Optional caller-supplied identifier attached to the `slatedb.query`
+    /// span as a `query_id` field. Subscribers (e.g. `tracing-chrome`) can
+    /// filter on this to capture spans for a specific query.
+    pub query_id: Option<String>,
 }
 
 impl Default for ReadOptions {
@@ -286,6 +290,7 @@ impl Default for ReadOptions {
             dirty: false,
             cache_blocks: true,
             filter_context: None,
+            query_id: None,
         }
     }
 }
@@ -319,6 +324,13 @@ impl ReadOptions {
             ..self
         }
     }
+
+    pub fn with_query_id(self, query_id: impl Into<String>) -> Self {
+        Self {
+            query_id: Some(query_id.into()),
+            ..self
+        }
+    }
 }
 #[derive(Clone, Debug)]
 pub struct ScanOptions {
@@ -346,6 +358,10 @@ pub struct ScanOptions {
     /// Only consulted for `scan_prefix` today. Plain range scans do not
     /// evaluate SST filters, so this field has no effect on `scan`.
     pub filter_context: Option<FilterContext>,
+    /// Optional caller-supplied identifier attached to the `slatedb.query`
+    /// span as a `query_id` field. Subscribers (e.g. `tracing-chrome`) can
+    /// filter on this to capture spans for a specific query.
+    pub query_id: Option<String>,
 }
 
 impl Default for ScanOptions {
@@ -359,6 +375,7 @@ impl Default for ScanOptions {
             max_fetch_tasks: 1,
             order: IterationOrder::Ascending,
             filter_context: None,
+            query_id: None,
         }
     }
 }
@@ -407,6 +424,13 @@ impl ScanOptions {
     pub fn with_filter_context(self, filter_context: Option<FilterContext>) -> Self {
         Self {
             filter_context,
+            ..self
+        }
+    }
+
+    pub fn with_query_id(self, query_id: impl Into<String>) -> Self {
+        Self {
+            query_id: Some(query_id.into()),
             ..self
         }
     }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -532,6 +532,7 @@ impl DbInner {
             order: IterationOrder::Ascending,
             prefix: None,
             filter_context: None,
+            query_id: None,
         };
 
         let replay_options = WalReplayOptions {
@@ -2341,6 +2342,7 @@ mod tests {
                                         dirty: false,
                                         cache_blocks: true,
                                         filter_context: None,
+                                        query_id: None,
                                     }
                                 )
                                 .await

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -242,6 +242,7 @@ impl DbIterator {
         range_tracker: Option<Arc<DbIteratorRangeTracker>>,
         merge_operator: Option<MergeOperatorType>,
         order: IterationOrder,
+        query_id: Option<String>,
     ) -> Result<Self, SlateDBError> {
         // The write_batch iterator is provided only when operating within a Transaction. It represents the uncommitted
         // writes made during the transaction. We do not need to apply the max_seq filter to them, because they do
@@ -288,6 +289,7 @@ impl DbIterator {
                 // The entries in the write batch iterator have seq num u64::MAX and any merges
                 // there need to be merged with the entries from the other iterators.
                 None,
+                query_id,
             ));
         } else {
             // When no merge operator is configured, wrap with iterator that errors on merge operands
@@ -440,6 +442,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();
@@ -481,6 +484,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();
@@ -512,6 +516,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();
@@ -561,6 +566,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -460,6 +460,7 @@ impl DbReaderInner {
             order: IterationOrder::Ascending,
             prefix: None,
             filter_context: None,
+            query_id: None,
         };
 
         let (mut replay_after_wal_id, mut last_committed_seq) =

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -86,6 +86,7 @@ impl DbInner {
                 imm_table.iter(),
                 false,
                 min_retention_seq,
+                None,
             ))
         } else {
             Box::new(MergeOperatorRequiredIterator::new(imm_table.iter()))

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -182,6 +182,10 @@ pub(crate) struct MemTableIteratorInner<T: RangeBounds<SequencedKey>> {
     /// in seq-ascending order. Pushing them onto this stack and popping gives
     /// seq-descending order, which is what the merge iterator needs for dedup.
     descending_stack: Vec<RowEntry>,
+    /// Optional `slatedb.query.memtable` span. When `Some`, it is re-entered
+    /// around every poll so the span's busy time reflects cumulative memtable
+    /// lookup cost across all rows yielded for the query.
+    span: Option<tracing::Span>,
 }
 pub(crate) type MemTableIterator = MemTableIteratorInner<KVTableInternalKeyRange>;
 
@@ -192,10 +196,14 @@ impl RowEntryIterator for MemTableIterator {
     }
 
     async fn next(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
+        let span = self.borrow_span().clone();
+        let _enter = span.as_ref().map(|s| s.enter());
         Ok(self.next_sync())
     }
 
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+        let span = self.borrow_span().clone();
+        let _enter = span.as_ref().map(|s| s.enter());
         loop {
             let front = self.borrow_item().clone();
             if front.is_some_and(|record| record.key < next_key) {
@@ -381,23 +389,33 @@ impl KVTable {
     }
 
     pub(crate) fn range_ascending<T: RangeBounds<Bytes>>(&self, range: T) -> MemTableIterator {
-        self.range(range, IterationOrder::Ascending)
+        self.range(range, IterationOrder::Ascending, None)
     }
 
     pub(crate) fn range<T: RangeBounds<Bytes>>(
         &self,
         range: T,
         ordering: IterationOrder,
+        query_id: Option<&str>,
     ) -> MemTableIterator {
         let internal_range = KVTableInternalKeyRange::from(range);
+        let span = query_id.map(|id| {
+            tracing::debug_span!(
+                "slatedb.query.memtable",
+                query_id = %id,
+                key = ?internal_range,
+            )
+        });
         let mut iterator = MemTableIteratorInnerBuilder {
             map: self.map.clone(),
             inner_builder: |map| map.range(internal_range),
             ordering,
             item: None,
             descending_stack: Vec::new(),
+            span: span.clone(),
         }
         .build();
+        let _enter = span.as_ref().map(|s| s.enter());
         iterator.next_sync();
         iterator
     }
@@ -741,7 +759,7 @@ mod tests {
             .run(
                 &(arbitrary::nonempty_range(10), arbitrary::iteration_order()),
                 |(range, ordering)| {
-                    let mut kv_iter = kv_table.table.range(range.clone(), ordering);
+                    let mut kv_iter = kv_table.table.range(range.clone(), ordering, None);
 
                     runtime.block_on(test_utils::assert_ranged_kv_scan(
                         &sample_table,
@@ -763,7 +781,7 @@ mod tests {
         table.put(RowEntry::new_value(b"bbbb", b"new", 2));
         table.put(RowEntry::new_value(b"cccc", b"v3", 3));
 
-        let mut iter = table.table().range(.., IterationOrder::Descending);
+        let mut iter = table.table().range(.., IterationOrder::Descending, None);
 
         // In descending order, for key "bbbb" the newest version (seq 2) must
         // come before the older version (seq 1) so that dedup works correctly.

--- a/slatedb/src/merge_operator.rs
+++ b/slatedb/src/merge_operator.rs
@@ -249,6 +249,9 @@ pub(crate) struct MergeOperatorIterator<T: RowEntryIterator> {
     /// A barrier sequence number that supports snapshot reads using this iterator. If not None,
     /// the iterator will not merge entries with sequence number greater than this value.
     snapshot_barrier_seq: Option<u64>,
+    /// Optional caller-supplied identifier; when `Some`, each `merge_batch`
+    /// call is wrapped in a `slatedb.query.merge` span tagged with this id.
+    query_id: Option<String>,
 }
 
 /// Tracks metadata across multiple entries during merge operations.
@@ -310,6 +313,7 @@ impl<T: RowEntryIterator> MergeOperatorIterator<T> {
         delegate: T,
         merge_different_expire_ts: bool,
         snapshot_barrier_seq: Option<u64>,
+        query_id: Option<String>,
     ) -> Self {
         Self {
             merge_operator,
@@ -317,6 +321,7 @@ impl<T: RowEntryIterator> MergeOperatorIterator<T> {
             buffered_entry: None,
             merge_different_expire_ts,
             snapshot_barrier_seq,
+            query_id,
         }
     }
 }
@@ -353,7 +358,17 @@ impl<T: RowEntryIterator> MergeOperatorIterator<T> {
             }
         }
 
+        let span = self.query_id.as_ref().map(|id| {
+            tracing::debug_span!(
+                "slatedb.query.merge",
+                query_id = %id,
+                key = ?key,
+                num_operands = operands.len(),
+            )
+        });
+        let _enter = span.as_ref().map(|s| s.enter());
         let batch_result = self.merge_operator.merge_batch(key, None, &operands)?;
+        drop(_enter);
         batch.clear();
         Ok(batch_result)
     }
@@ -428,9 +443,19 @@ impl<T: RowEntryIterator> MergeOperatorIterator<T> {
         }
 
         results.reverse();
+        let span = self.query_id.as_ref().map(|id| {
+            tracing::debug_span!(
+                "slatedb.query.merge",
+                query_id = %id,
+                key = ?key,
+                num_operands = results.len(),
+            )
+        });
+        let _enter = span.as_ref().map(|s| s.enter());
         let final_result = self
             .merge_operator
             .merge_batch(&key, base_value, &results)?;
+        drop(_enter);
 
         Ok(Some(RowEntry {
             key: key.clone(),
@@ -660,6 +685,7 @@ mod tests {
             data.into(),
             true,
             None,
+            None,
         );
         assert_iterator(
             &mut iterator,
@@ -684,6 +710,7 @@ mod tests {
             merge_operator,
             data.into(),
             true,
+            None,
             None,
         );
 
@@ -810,6 +837,7 @@ mod tests {
             test_case.unsorted_data.into(),
             test_case.merge_different_expire_ts,
             test_case.snapshot_barrier_seq,
+            None,
         );
         assert_iterator(&mut iterator, test_case.expected).await;
     }
@@ -952,6 +980,7 @@ mod tests {
             data.into(),
             true,
             None,
+            None,
         );
 
         // Expected: max should return 10, sum should return 15
@@ -982,6 +1011,7 @@ mod tests {
             data.into(),
             true,
             None,
+            None,
         );
 
         let expected_bytes: Vec<u8> = (1..=250).map(|i| i as u8).collect();
@@ -1004,6 +1034,7 @@ mod tests {
             merge_operator,
             data.into(),
             true,
+            None,
             None,
         );
 
@@ -1028,6 +1059,7 @@ mod tests {
             merge_operator,
             data.into(),
             true,
+            None,
             None,
         );
 
@@ -1059,6 +1091,7 @@ mod tests {
             merge_operator,
             data.into(),
             true,
+            None,
             None,
         );
 
@@ -1093,6 +1126,7 @@ mod tests {
             data.into(),
             true,
             None,
+            None,
         );
 
         // Entries sorted by reverse seq: seq=5, 4, 3, 2, 1
@@ -1123,6 +1157,7 @@ mod tests {
             data.into(),
             true,
             None,
+            None,
         );
 
         // Sorted by reverse seq: seq=4, 3, 2, 1, 0(BASE)
@@ -1151,6 +1186,7 @@ mod tests {
             data.into(),
             true,
             None,
+            None,
         );
 
         // Sorted by reverse seq: seq=3, 2, 1
@@ -1177,6 +1213,7 @@ mod tests {
             merge_operator,
             data.into(),
             true,
+            None,
             None,
         );
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -149,8 +149,12 @@ impl Reader {
         let mem_iters = memtables
             .iter()
             .map(|table| {
-                Box::new(table.range(range.clone(), sst_iter_options.order))
-                    as Box<dyn RowEntryIterator + 'static>
+                let inner = table.range(
+                    range.clone(),
+                    sst_iter_options.order,
+                    sst_iter_options.query_id.as_deref(),
+                );
+                Box::new(inner) as Box<dyn RowEntryIterator + 'static>
             })
             .collect::<Vec<_>>();
 
@@ -212,6 +216,7 @@ impl Reader {
             cache_blocks: options.cache_blocks,
             eager_spawn: true,
             filter_context: options.filter_context.clone(),
+            query_id: options.query_id.clone(),
             ..SstIteratorOptions::default()
         };
 
@@ -239,6 +244,7 @@ impl Reader {
             None,
             self.read_merge_operator.clone(),
             sst_iter_options.order,
+            options.query_id.clone(),
         )
         .await?;
 
@@ -286,6 +292,7 @@ impl Reader {
             order: options.order,
             prefix: ctx.prefix,
             filter_context: options.filter_context.clone(),
+            query_id: options.query_id.clone(),
         };
 
         let IteratorSources {
@@ -312,6 +319,7 @@ impl Reader {
             ctx.range_tracker,
             self.read_merge_operator.clone(),
             options.order,
+            options.query_id.clone(),
         )
         .await
     }

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -7,7 +7,8 @@ use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, Range, RangeBounds};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
-
+use tracing::Instrument;
+use tracing::instrument::WithSubscriber;
 use crate::block_iterator::DataBlockIterator;
 use crate::bytes_range::BytesRange;
 use crate::db_state::{SsTableId, SsTableView};
@@ -38,6 +39,7 @@ pub(crate) struct SstIteratorOptions {
     pub(crate) order: IterationOrder,
     pub(crate) prefix: Option<Bytes>,
     pub(crate) filter_context: Option<FilterContext>,
+    pub(crate) query_id: Option<String>,
 }
 
 impl Default for SstIteratorOptions {
@@ -50,6 +52,7 @@ impl Default for SstIteratorOptions {
             order: IterationOrder::Ascending,
             prefix: None,
             filter_context: None,
+            query_id: None,
         }
     }
 }
@@ -248,6 +251,13 @@ impl FilterEvaluator {
         self.state == FilterState::Negative
     }
 
+    /// Target of the underlying filter query (point key or prefix).
+    /// Exposed so the surrounding `slatedb.query.bloom_filter` span can
+    /// record `key`.
+    fn query_target(&self) -> &PrefixTarget {
+        &self.query.target
+    }
+
     fn notify_key_found(&mut self, key: &[u8]) {
         match &self.query.target {
             PrefixTarget::Point(k) if key == k.as_ref() => self.found_key = true,
@@ -391,17 +401,30 @@ impl<'a> InternalSstIterator<'a> {
                     let blocks_end = self.next_block_idx_to_fetch + blocks_to_fetch;
                     let index = index.clone();
                     let cache_blocks = self.options.cache_blocks;
-                    self.fetch_tasks
-                        .push_back(FetchTask::InFlight(tokio::spawn(async move {
-                            table_store
-                                .read_blocks_using_index(
-                                    &table,
-                                    index,
-                                    blocks_start..blocks_end,
-                                    cache_blocks,
-                                )
-                                .await
-                        })));
+                    let span = self.options.query_id.as_ref().map(|id| {
+                        tracing::debug_span!(
+                            "slatedb.query.read_blocks",
+                            query_id = %id,
+                            sst_id = ?table.id,
+                            cache_hits = tracing::field::Empty,
+                            cache_misses = tracing::field::Empty,
+                        )
+                    });
+                    let fut = async move {
+                        table_store
+                            .read_blocks_using_index(
+                                &table,
+                                index,
+                                blocks_start..blocks_end,
+                                cache_blocks,
+                            )
+                            .await
+                    }.with_current_subscriber();
+                    let handle = match span {
+                        Some(span) => tokio::spawn(fut.instrument(span)),
+                        None => tokio::spawn(fut),
+                    };
+                    self.fetch_tasks.push_back(FetchTask::InFlight(handle));
                     self.next_block_idx_to_fetch = blocks_end;
                 }
             }
@@ -420,17 +443,30 @@ impl<'a> InternalSstIterator<'a> {
                     let blocks_start = blocks_end - blocks_to_fetch;
                     let index = index.clone();
                     let cache_blocks = self.options.cache_blocks;
-                    self.fetch_tasks
-                        .push_back(FetchTask::InFlight(tokio::spawn(async move {
-                            table_store
-                                .read_blocks_using_index(
-                                    &table,
-                                    index,
-                                    blocks_start..blocks_end,
-                                    cache_blocks,
-                                )
-                                .await
-                        })));
+                    let span = self.options.query_id.as_ref().map(|id| {
+                        tracing::debug_span!(
+                            "slatedb.query.read_blocks",
+                            query_id = %id,
+                            sst_id = ?table.id,
+                            cache_hits = tracing::field::Empty,
+                            cache_misses = tracing::field::Empty,
+                        )
+                    });
+                    let fut = async move {
+                        table_store
+                            .read_blocks_using_index(
+                                &table,
+                                index,
+                                blocks_start..blocks_end,
+                                cache_blocks,
+                            )
+                            .await
+                    }.with_current_subscriber();
+                    let handle = match span {
+                        Some(span) => tokio::spawn(fut.instrument(span)),
+                        None => tokio::spawn(fut),
+                    };
+                    self.fetch_tasks.push_back(FetchTask::InFlight(handle));
                     self.next_block_idx_to_fetch = blocks_start;
                 }
             }
@@ -543,10 +579,21 @@ impl<'a> InternalSstIterator<'a> {
 
     async fn ensure_metadata_loaded(&mut self) -> Result<(), SlateDBError> {
         if self.index.is_none() {
-            let index = self
+            let span = self.options.query_id.as_ref().map(|id| {
+                tracing::debug_span!(
+                    "slatedb.query.read_index",
+                    query_id = %id,
+                    sst_id = ?self.view.table_as_ref().sst.id,
+                    cached = tracing::field::Empty,
+                )
+            });
+            let fut = self
                 .table_store
-                .read_index(&self.view.table_as_ref().sst, self.options.cache_blocks)
-                .await?;
+                .read_index(&self.view.table_as_ref().sst, self.options.cache_blocks);
+            let index = match span {
+                Some(span) => fut.instrument(span).await?,
+                None => fut.await?,
+            };
             let block_idx_range = partitioned_keyspace::partitions_covering_range(
                 &index.borrow(),
                 self.view.start_key(),
@@ -792,15 +839,47 @@ impl<'a> FilterIterator<'a> {
 impl RowEntryIterator for FilterIterator<'_> {
     async fn init(&mut self) -> Result<(), SlateDBError> {
         if !self.initialized {
-            let filters = self
-                .inner
-                .table_store()
-                .read_filters(
-                    &self.inner.view().table_as_ref().sst,
-                    self.inner.options.cache_blocks,
+            let span = self.inner.options.query_id.as_ref().map(|id| {
+                tracing::debug_span!(
+                    "slatedb.query.read_filter",
+                    query_id = %id,
+                    sst_id = ?self.inner.view().table_as_ref().sst.id,
+                    cached = tracing::field::Empty,
                 )
-                .await?;
+            });
+            let fut = self.inner.table_store().read_filters(
+                &self.inner.view().table_as_ref().sst,
+                self.inner.options.cache_blocks,
+            );
+            let filters = match span {
+                Some(span) => fut.instrument(span).await?,
+                None => fut.await?,
+            };
+
+            // `slatedb.query.bloom_filter` covers the `might_contain` check
+            // itself. Only emit when there are filters to evaluate — an SST
+            // with no filter section is not a "check".
+            let bf_span = self
+                .inner
+                .options
+                .query_id
+                .as_ref()
+                .filter(|_| !filters.is_empty())
+                .map(|id| {
+                    tracing::debug_span!(
+                        "slatedb.query.bloom_filter",
+                        query_id = %id,
+                        sst_id = ?self.inner.view().table_as_ref().sst.id,
+                        key = ?self.filter.query_target(),
+                        result = tracing::field::Empty,
+                    )
+                });
+            let bf_enter = bf_span.as_ref().map(|s| s.enter());
             self.filter.evaluate(&filters).await;
+            if let Some(ref s) = bf_span {
+                s.record("result", !self.filter.is_filtered_out());
+            }
+            drop(bf_enter);
 
             if self.is_filtered_out() {
                 return Ok(());
@@ -1782,6 +1861,7 @@ mod tests {
                 order: IterationOrder::Ascending,
                 prefix: None,
                 filter_context: None,
+                query_id: None,
             },
         )
         .await
@@ -1800,6 +1880,7 @@ mod tests {
                 order: IterationOrder::Ascending,
                 prefix: None,
                 filter_context: None,
+                query_id: None,
             },
         )
         .await
@@ -2373,6 +2454,7 @@ mod tests {
             order,
             prefix: None,
             filter_context: None,
+            query_id: None,
         };
         let mut iter = SstIterator::new_owned_initialized(
             BytesRange::from_slice(start_key.as_ref()..=end_key.as_ref()),
@@ -2659,6 +2741,7 @@ mod tests {
                 order: IterationOrder::Ascending,
                 prefix: None,
                 filter_context: None,
+                query_id: None,
             },
         )
         .await

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -419,12 +419,14 @@ impl TableStore {
             if let Some(entry) = entry {
                 // Already decoded.
                 if let Some(filters) = entry.filters() {
+                    tracing::Span::current().record("cached", true);
                     return Ok(filters);
                 }
 
                 // Encoded form from disk-cache deserialize. Decode
                 // and overwrite the cache entry with the decoded form.
                 if let Some(encoded) = entry.encoded_filters() {
+                    tracing::Span::current().record("cached", true);
                     return Ok(self.decode_and_refresh(cache, cache_key, &encoded).await);
                 }
             }
@@ -437,6 +439,7 @@ impl TableStore {
             .read_filters(&handle.info, &obj)
             .await
             .map_err(|e| e.with_path(&obj.path))?;
+        tracing::Span::current().record("cached", false);
         if cache_blocks && !named_filters.is_empty() {
             if let Some(ref cache) = self.cache {
                 cache
@@ -506,6 +509,7 @@ impl TableStore {
                 .unwrap_or(None)
                 .and_then(|e| e.sst_index())
             {
+                tracing::Span::current().record("cached", true);
                 return Ok(index);
             }
         }
@@ -518,6 +522,7 @@ impl TableStore {
                 .await
                 .map_err(|e| e.with_path(&obj.path))?,
         );
+        tracing::Span::current().record("cached", false);
         if cache_blocks {
             if let Some(ref cache) = self.cache {
                 cache
@@ -571,6 +576,8 @@ impl TableStore {
         // Initialize the result vector and a vector to track uncached ranges
         let mut blocks_read = VecDeque::with_capacity(blocks.end - blocks.start);
         let mut uncached_ranges = Vec::new();
+        let mut cache_hits: u64 = 0;
+        let mut cache_misses: u64 = 0;
 
         // If block cache is available, try to retrieve cached blocks
         if let Some(ref cache) = self.cache {
@@ -593,6 +600,7 @@ impl TableStore {
             for (index, block_result) in cached_blocks.into_iter().enumerate() {
                 match block_result {
                     Some(cached_block) => {
+                        cache_hits += 1;
                         // If a cached block is found, add it to blocks_read
                         if let Some(start) = last_uncached_start.take() {
                             uncached_ranges.push((blocks.start + start)..(blocks.start + index));
@@ -600,6 +608,7 @@ impl TableStore {
                         blocks_read.push_back(cached_block);
                     }
                     None => {
+                        cache_misses += 1;
                         // If a block is not in cache, mark the start of an uncached range
                         last_uncached_start.get_or_insert(index);
                     }
@@ -611,8 +620,12 @@ impl TableStore {
             }
         } else {
             // If no cache is available, treat all blocks as uncached
+            cache_misses += (blocks.end - blocks.start) as u64;
             uncached_ranges.push(blocks.clone());
         }
+        let current_span = tracing::Span::current();
+        current_span.record("cache_hits", cache_hits);
+        current_span.record("cache_misses", cache_misses);
         // Read uncached blocks concurrently
         let uncached_blocks = join_all(uncached_ranges.iter().map(|range| {
             let obj_ref = &obj;


### PR DESCRIPTION
## Summary

Prototypes the RFC about a query tracing layer proposed https://github.com/slatedb/slatedb/pull/1612.

## Changes

- adds instrumentation to slateDB code
- adds tracing layer to process events from instrumentation

## Notes for Reviewers

This is just a prototype to demonstrate how the RFC could be implemented. 
No production-grade reviews needed at this point.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
