### PR TITLE
docs: note Foyer disk cache upgrade behavior

### DIFF
--- a/website/src/content/docs/docs/operations/foyer-cache.mdx
+++ b/website/src/content/docs/docs/operations/foyer-cache.mdx
@@ -7,6 +7,19 @@ description: Configuration and tuning guide for SlateDB's FoyerHybridCache block
 block cache: a fast in-memory tier backed by a persistent disk tier. For background on how
 it fits into SlateDB's cache layers, see the [Caching](/docs/design/caching) design doc.
 
+## Upgrade note for existing disk caches
+
+SlateDB versions that used Foyer 0.18 wrote the disk tier with Foyer's older large-engine
+layout. Foyer 0.22 uses the block engine, and that engine cannot read all entries from the
+old on-disk layout. After upgrading, startup may log `foyer_storage` `coding error` messages
+while recovering the old cache directory.
+
+These errors are cache misses from SlateDB's point of view. SlateDB falls back to the object
+store, records the cache error in metrics, and reinserts accessed blocks into the new Foyer
+layout. A warm-up pass over the working set should therefore repopulate the cache, but expect
+extra object-store reads and recovery noise during that first pass. To avoid the startup
+noise, clear the Foyer disk cache directory as part of the upgrade and let SlateDB rebuild it.
+
 ## Disk write pipeline
 
 Two mechanisms control whether an in-memory entry reaches disk. Both need configuration for

--- a/website/src/content/docs/docs/operations/foyer-cache.mdx
+++ b/website/src/content/docs/docs/operations/foyer-cache.mdx
@@ -9,10 +9,12 @@ it fits into SlateDB's cache layers, see the [Caching](/docs/design/caching) des
 
 ## Upgrade note for existing disk caches
 
-SlateDB versions that used Foyer 0.18 wrote the disk tier with Foyer's older large-engine
-layout. Foyer 0.22 uses the block engine, and that engine cannot read all entries from the
-old on-disk layout. After upgrading, startup may log `foyer_storage` `coding error` messages
-while recovering the old cache directory.
+When upgrading from SlateDB 0.12.x to SlateDB 0.13.0 or later, existing Foyer disk cache
+directories may need attention. SlateDB 0.8.x through 0.12.x used Foyer 0.18 and wrote the
+disk tier with Foyer's older large-engine layout. SlateDB 0.13.0 uses Foyer 0.22's block
+engine, and that engine cannot read all entries from the old on-disk layout. After upgrading,
+startup may log `foyer_storage` `coding error` messages while recovering the old cache
+directory.
 
 These errors are cache misses from SlateDB's point of view. SlateDB falls back to the object
 store, records the cache error in metrics, and reinserts accessed blocks into the new Foyer


### PR DESCRIPTION

## Summary

Adds an upgrade note to the Foyer cache operations docs for the Foyer 0.18 to 0.22 disk layout change discussed in #1584.

## Changes

- Documented that existing Foyer disk cache directories can produce `foyer_storage` `coding error` logs after the upgrade.
- Clarified that SlateDB treats those cache read failures as misses, falls back to object storage, records cache error metrics, and repopulates accessed entries in the new layout.
- Called out clearing the Foyer disk cache directory during upgrade as the clean path for avoiding first-run recovery noise.

## Notes for Reviewers

This is docs-only. The note is based on the #1584 follow-up and the current `tablestore` cache call sites that convert cache get errors into misses before reading from object storage.

AI usage: Tool/model was OpenAI GPT-5 via the OpenAI coding assistant. It assisted with issue triage, wording, and local review; I reviewed the diff and validation output before submitting.

Validation:

- `npm --prefix website ci`
- `npm --prefix website run build`
- `cargo fmt -- --check`
- `git diff --check`
- local `/review` CLI check

Rust clippy and nextest were not run because this only changes MDX documentation.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant
