### PR TITLE
chore: Replace Lazy with LazyLock for EMPTY_TABLE

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -31,12 +31,12 @@ use futures::stream::BoxStream;
 use log::{info, warn};
 use object_store::path::Path;
 use object_store::ObjectStore;
-use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use slatedb_common::clock::SystemClock;
 use std::collections::VecDeque;
 use std::ops::{RangeBounds, Sub};
 use std::sync::Arc;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use uuid::Uuid;
@@ -82,7 +82,7 @@ struct CheckpointState {
     last_remote_persisted_seq: u64,
 }
 
-static EMPTY_TABLE: Lazy<Arc<KVTable>> = Lazy::new(|| Arc::new(KVTable::new()));
+static EMPTY_TABLE: LazyLock<Arc<KVTable>> = LazyLock::new(|| Arc::new(KVTable::new()));
 
 impl DbStateReader for CheckpointState {
     fn memtable(&self) -> Arc<KVTable> {


### PR DESCRIPTION
## Summary

What is being changed and why?

## Changes

AS IS. We have an MSRV >= 1.91, so it's always available.

Later we can drop once_cell direct dependency.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
