### PR TITLE
Distributed compaction (RFC-0025) Phase 2: Manifest commit protocol

### DIFF
--- a/rfcs/0025-distributed-compaction.md
+++ b/rfcs/0025-distributed-compaction.md
@@ -510,8 +510,9 @@ Worker lifecycle events (claimed, reclaimed, heartbeat timeout) are logged at IN
 
 Phases:
 1. **Schema extension:** add `WorkerSpec` containing `worker_id` and `last_heartbeat_ms` to `Compaction` in `compactor.fbs`.
-2. **Worker implementation:** implement `CompactionWorkerBuilder`, `CompactionWorker`, and `RemoteCompactionExecutor`; coordinator always uses `RemoteCompactionExecutor`. Move `max_concurrent_compactions` from `CompactorOptions` to `CompactionWorkerOptions` (breaking change; see Compatibility).
-3. **Failure detection:** heartbeat timeout and reclamation on the coordinator; resume via `ResumingIterator`.
+2. **Manifest Commit Protocol:** coordinator merges compactions with `Compacted` status from remote workers, transitions them to either `Failed` or `Completed`, and commits their output to the manifest.
+3. **Worker implementation:** implement `CompactionWorkerBuilder`, `CompactionWorker`, and `RemoteCompactionExecutor`; coordinator always uses `RemoteCompactionExecutor`. Move `max_concurrent_compactions` from `CompactorOptions` to `CompactionWorkerOptions` (breaking change; see Compatibility).
+4. **Failure detection:** heartbeat timeout and reclamation on the coordinator; resume via `ResumingIterator`.
 
 ### Docs Updates
 

--- a/rfcs/0025-distributed-compaction.md
+++ b/rfcs/0025-distributed-compaction.md
@@ -294,7 +294,7 @@ Only the coordinator commits manifest updates (preserves single-writer invariant
 On coordinator restart, the recovery logic is:
 
 1. Leave `Running` jobs alone. If the owning worker survived the coordinator restart it continues executing and emitting heartbeats; if it died, the failure detection protocol reclaims it once `worker_heartbeat_timeout_ms` elapses past `coordinator_start_time_ms` (see step 2 of the failure detection protocol).
-2. For each `Compacted` job, retry steps 2–3 of the normal flow above. `validate_compaction()` is called before the manifest write and will fail if the job's sources are already absent from the manifest (i.e. step 2 already completed before the crash). In that case the job is marked `Failed` in `.compactions`. This is safe: the manifest was already updated, the output SSTs are already referenced and protected from GC, and the scheduler has no dependency on whether the entry reads `Completed` or `Failed`.
+2. For each `Compacted` job, retry steps 2–3 of the normal flow above. `validate_compaction()` is called before the manifest write and will fail if the job's sources are already absent from the manifest (i.e. step 2 already completed before the crash). In that case the coordinator verifies the output SR is present in the manifest and marks the job `Completed` without re-writing the manifest.
 3. Retain active (`Submitted`, `Running`, `Compacted`) and last finished (`Completed`, `Failed`) entries.
 
 ### Deployment Shapes

--- a/rfcs/0025-distributed-compaction.md
+++ b/rfcs/0025-distributed-compaction.md
@@ -294,7 +294,7 @@ Only the coordinator commits manifest updates (preserves single-writer invariant
 On coordinator restart, the recovery logic is:
 
 1. Leave `Running` jobs alone. If the owning worker survived the coordinator restart it continues executing and emitting heartbeats; if it died, the failure detection protocol reclaims it once `worker_heartbeat_timeout_ms` elapses past `coordinator_start_time_ms` (see step 2 of the failure detection protocol).
-2. For each `Compacted` job, retry steps 2–3 of the normal flow above. `validate_compaction()` is called before the manifest write and will fail if the job's sources are already absent from the manifest (i.e. step 2 already completed before the crash). In that case the coordinator verifies the output SR is present in the manifest and marks the job `Completed` without re-writing the manifest.
+2. For each `Compacted` job, retry steps 2–3 of the normal flow above. `validate_compaction()` is called before the manifest write and will fail if the job's sources are already absent from the manifest (i.e. step 2 already completed before the crash). In that case the job is marked `Failed` in `.compactions`. This is safe: the manifest was already updated, the output SSTs are already referenced and protected from GC, and the scheduler has no dependency on whether the entry reads `Completed` or `Failed`.
 3. Retain active (`Submitted`, `Running`, `Compacted`) and last finished (`Completed`, `Failed`) entries.
 
 ### Deployment Shapes

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -694,9 +694,79 @@ impl CompactorEventHandler {
     async fn handle_ticker(&mut self) -> Result<(), SlateDBError> {
         if !self.is_executor_stopped() {
             self.state_writer.refresh().await?;
+            self.commit_compacted_entries().await?;
             self.maybe_schedule_compactions().await?;
             self.maybe_start_compactions().await?;
         }
+        Ok(())
+    }
+
+    /// Commits any compactions in the `Compacted` state to the manifest.
+    ///
+    /// `Compacted` is the distributed intermediate state written by a worker after it
+    /// finishes execution. The coordinator is solely responsible for transitioning
+    /// `Compacted → Completed` (or `Compacted → Failed`) by writing the manifest first
+    /// and then updating `.compactions`. See RFC-0025 §Manifest Commit Protocol.
+    ///
+    /// Recovery: on coordinator restart, `Compacted` entries are left intact in
+    /// `.compactions`. The first call to this method after startup retries the manifest
+    /// write. `validate_compaction` will fail if the sources are already absent (meaning
+    /// the manifest was written before the crash), in which case the entry is safely
+    /// marked `Failed`.
+    async fn commit_compacted_entries(&mut self) -> Result<(), SlateDBError> {
+        let compacted = self
+            .state()
+            .compactions_with_status(CompactionStatus::Compacted)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if compacted.is_empty() {
+            return Ok(());
+        }
+
+        let mut any_failed = false;
+        for compaction in compacted {
+            let id = compaction.id();
+            match self.validate_compaction(compaction.spec()) {
+                Ok(()) => {
+                    let destination = compaction
+                        .spec()
+                        .destination()
+                        .expect("Compacted tiered compaction must have a destination SR id");
+                    let output_sr = SortedRun {
+                        id: destination,
+                        sst_views: compaction
+                            .output_ssts()
+                            .iter()
+                            .map(|sst| SsTableView::identity(sst.clone()))
+                            .collect(),
+                    };
+                    self.state_mut().finish_compaction(id, output_sr);
+                    self.log_compaction_state();
+                    self.state_writer.write_state_safely().await?;
+                    self.stats
+                        .last_compaction_ts
+                        .set(self.system_clock.now().timestamp());
+                }
+                Err(_) => {
+                    // Sources are already absent from the manifest: the manifest write
+                    // completed before the last coordinator crash. Mark Failed so the
+                    // entry doesn't get retried on the next tick.
+                    info!(
+                        "compaction sources already absent from manifest, marking Failed [id={}]",
+                        id
+                    );
+                    self.state_mut()
+                        .update_compaction(&id, |c| c.set_status(CompactionStatus::Failed));
+                    any_failed = true;
+                }
+            }
+        }
+
+        if any_failed {
+            self.state_writer.write_compactions_safely().await?;
+        }
+
         Ok(())
     }
 
@@ -5853,5 +5923,134 @@ mod tests {
         fn is_stopped(&self) -> bool {
             false
         }
+    }
+
+    // Builds a fake output SsTableHandle with first_entry set so that
+    // SsTableView::identity can derive a non-empty effective range.
+    fn fake_output_sst() -> SsTableHandle {
+        SsTableHandle::new(
+            SsTableId::Compacted(Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                first_entry: Some(Bytes::from_static(b"a")),
+                ..SsTableInfo::default()
+            },
+        )
+    }
+
+    #[tokio::test]
+    async fn test_commit_compacted_entries_writes_manifest() {
+        // given: a handler with one L0 in the manifest
+        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        fixture.write_l0().await;
+        fixture.handler.state_writer.refresh().await.unwrap();
+
+        let db_state = fixture.handler.state().db_state().clone();
+        let sources: Vec<SourceId> = db_state
+            .tree
+            .l0
+            .iter()
+            .map(|view| SourceId::SstView(view.id))
+            .collect();
+        let destination = 0u32;
+        let spec = CompactionSpec::new(sources, destination);
+        let compaction_id = Ulid::new();
+        let output_sst = fake_output_sst();
+        let compaction = Compaction::new(compaction_id, spec)
+            .with_status(CompactionStatus::Compacted)
+            .with_output_ssts(vec![output_sst.clone()]);
+
+        // inject the Compacted compaction into state (bypassing the executor)
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(compaction);
+
+        // when: the coordinator observes and commits the Compacted entry
+        fixture
+            .handler
+            .commit_compacted_entries()
+            .await
+            .expect("commit_compacted_entries failed");
+
+        // then: the compaction is Completed in the stored compactions file
+        let stored = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        assert_eq!(
+            stored
+                .get(&compaction_id)
+                .expect("missing compaction")
+                .status(),
+            CompactionStatus::Completed,
+        );
+
+        // and: the manifest now contains the output SR
+        let manifest = fixture
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap();
+        let core = manifest.core();
+        let sr = core.tree.compacted.iter().find(|sr| sr.id == destination);
+        assert!(sr.is_some(), "output SR {destination} not found in manifest");
+        assert_eq!(
+            sr.unwrap().sst_views.first().unwrap().sst.id,
+            output_sst.id,
+            "output SR does not contain expected SST"
+        );
+
+        // and: the L0 sources have been removed from the manifest
+        assert!(
+            core.tree.l0.is_empty(),
+            "L0 sources should have been removed after commit"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_compacted_entries_marks_failed_when_sources_absent() {
+        // given: a handler where the Compacted compaction references a source
+        // that no longer exists in the manifest (simulates a post-crash recovery
+        // where the manifest was already written before the coordinator crashed)
+        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        fixture.handler.state_writer.refresh().await.unwrap();
+
+        // Use a fake view ID that is not present in any L0
+        let ghost_view_id = Ulid::from_parts(u64::MAX, 0);
+        let spec = CompactionSpec::new(vec![SourceId::SstView(ghost_view_id)], 0);
+        let compaction_id = Ulid::new();
+        let compaction = Compaction::new(compaction_id, spec)
+            .with_status(CompactionStatus::Compacted)
+            .with_output_ssts(vec![fake_output_sst()]);
+
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(compaction);
+
+        // when:
+        fixture
+            .handler
+            .commit_compacted_entries()
+            .await
+            .expect("commit_compacted_entries failed");
+
+        // then: the compaction is marked Failed (not retried)
+        let stored = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        assert_eq!(
+            stored
+                .get(&compaction_id)
+                .expect("missing compaction")
+                .status(),
+            CompactionStatus::Failed,
+        );
     }
 }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -749,11 +749,10 @@ impl CompactorEventHandler {
                         .set(self.system_clock.now().timestamp());
                 }
                 Err(_) => {
-                    // Sources are already absent from the manifest: the manifest write
-                    // completed before the last coordinator crash. Mark Failed so the
-                    // entry doesn't get retried on the next tick.
+                    // Validation failed against the current manifest. Mark Failed so the
+                    // entry isn't retried on the next tick.
                     info!(
-                        "compaction sources already absent from manifest, marking Failed [id={}]",
+                        "compacted entry failed validation, marking Failed [id={}]",
                         id
                     );
                     self.state_mut()

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -5966,6 +5966,8 @@ mod tests {
             .state_mut()
             .insert_compaction_for_test(compaction);
 
+        fixture.handler.state_writer.refresh().await.unwrap();
+
         // when: the coordinator observes and commits the Compacted entry
         fixture
             .handler

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -711,9 +711,8 @@ impl CompactorEventHandler {
     /// Recovery: on coordinator restart, `Compacted` entries are left intact in
     /// `.compactions`. The first call to this method after startup retries the manifest
     /// write. `validate_compaction` will fail if the sources are already absent (meaning
-    /// the manifest was written before the crash). In that case we verify the output is
-    /// present in the manifest: if so the compaction succeeded and is marked `Completed`;
-    /// if not something unexpected happened and it is marked `Failed`.
+    /// the manifest was written before the crash), in which case the entry is safely
+    /// marked `Failed`.
     async fn commit_compacted_entries(&mut self) -> Result<(), SlateDBError> {
         let compacted = self
             .state()
@@ -725,7 +724,7 @@ impl CompactorEventHandler {
             return Ok(());
         }
 
-        let mut any_terminal = false;
+        let mut any_failed = false;
         for compaction in compacted {
             let id = compaction.id();
             match self.validate_compaction(compaction.spec()) {
@@ -750,55 +749,25 @@ impl CompactorEventHandler {
                         .set(self.system_clock.now().timestamp());
                 }
                 Err(_) => {
-                    // Sources are absent: validate_compaction failed because the manifest
-                    // was already written before the last coordinator crash. Check whether
-                    // the output is present in the manifest to distinguish a successful
-                    // pre-crash write (Completed) from an unexpected state (Failed).
-                    if self.is_compaction_output_committed(compaction.spec()) {
-                        info!(
-                            "compaction output already in manifest, marking Completed [id={}]",
-                            id
-                        );
-                        self.state_mut()
-                            .update_compaction(&id, |c| c.set_status(CompactionStatus::Completed));
-                    } else {
-                        info!(
-                            "compaction sources absent but output not in manifest, marking Failed [id={}]",
-                            id
-                        );
-                        self.state_mut()
-                            .update_compaction(&id, |c| c.set_status(CompactionStatus::Failed));
-                    }
-                    any_terminal = true;
+                    // Sources are already absent from the manifest: the manifest write
+                    // completed before the last coordinator crash. Mark Failed so the
+                    // entry doesn't get retried on the next tick.
+                    info!(
+                        "compaction sources already absent from manifest, marking Failed [id={}]",
+                        id
+                    );
+                    self.state_mut()
+                        .update_compaction(&id, |c| c.set_status(CompactionStatus::Failed));
+                    any_failed = true;
                 }
             }
         }
 
-        if any_terminal {
+        if any_failed {
             self.state_writer.write_compactions_safely().await?;
         }
 
         Ok(())
-    }
-
-    /// Returns true if the output of `spec` is already reflected in the current manifest.
-    ///
-    /// For tiered compactions the destination SR must be present in the target segment's
-    /// `compacted` list. For drain compactions the sources must all be
-    /// absent from the tree.
-    fn is_compaction_output_committed(&self, spec: &CompactionSpec) -> bool {
-        let db_state = self.state().db_state();
-        let Some(tree) = db_state.tree_for_segment(spec.segment()) else {
-            return false;
-        };
-        let Some(dst) = spec.destination() else {
-            // Drain compaction: no output SR, so sources being absent is the confirmation.
-            return spec.sources().iter().all(|src| match src {
-                SourceId::SstView(id) => !tree.l0.iter().any(|v| v.id == *id),
-                SourceId::SortedRun(id) => !tree.compacted.iter().any(|sr| sr.id == *id),
-            });
-        };
-        tree.compacted.iter().any(|sr| sr.id == dst)
     }
 
     /// Stops the underlying compaction executor, aborting the executor and waiting for any
@@ -6080,76 +6049,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_compacted_entries_marks_completed_when_output_in_manifest() {
-        // Simulates a coordinator crash after the manifest write but before the
-        // compaction status was updated. On recovery the Compacted entry is still
-        // present; the L0 source is gone and the output SR is already in the manifest.
-        // The coordinator should detect this and mark the compaction Completed.
-        let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.write_l0().await;
-        fixture.handler.state_writer.refresh().await.unwrap();
-
-        let db_state = fixture.handler.state().db_state().clone();
-        let l0_view_id = db_state.tree.l0.front().unwrap().id;
-        let destination = 0u32;
-        let output_sst = fake_output_sst();
-        let spec = CompactionSpec::new(vec![SourceId::SstView(l0_view_id)], destination);
-        let compaction_id = Ulid::new();
-        let compaction = Compaction::new(compaction_id, spec.clone())
-            .with_status(CompactionStatus::Compacted)
-            .with_output_ssts(vec![output_sst.clone()]);
-        fixture
-            .handler
-            .state_mut()
-            .insert_compaction_for_test(compaction);
-
-        // First pass: sources present — writes the manifest normally (SR 0 is added,
-        // L0 is removed). This simulates the coordinator that crashed after the write.
-        fixture
-            .handler
-            .commit_compacted_entries()
-            .await
-            .expect("first pass failed");
-
-        // Re-inject the same compaction as Compacted to simulate the crash: the status
-        // file was not updated before the crash.
-        fixture.handler.state_mut().insert_compaction_for_test(
-            Compaction::new(compaction_id, spec)
-                .with_status(CompactionStatus::Compacted)
-                .with_output_ssts(vec![output_sst]),
-        );
-
-        // when: recovery pass
-        fixture
-            .handler
-            .commit_compacted_entries()
-            .await
-            .expect("recovery pass failed");
-
-        // then: marked Completed because the output SR is already in the manifest
-        let stored = fixture
-            .compactions_store
-            .read_latest_compactions()
-            .await
-            .unwrap()
-            .compactions;
-        assert_eq!(
-            stored
-                .get(&compaction_id)
-                .expect("missing compaction")
-                .status(),
-            CompactionStatus::Completed,
-        );
-    }
-
-    #[tokio::test]
-    async fn test_commit_compacted_entries_marks_failed_when_sources_and_output_absent() {
-        // given: a Compacted compaction whose source AND destination are both absent
-        // from the manifest — an unexpected state that should be marked Failed.
+    async fn test_commit_compacted_entries_marks_failed_when_sources_absent() {
+        // given: a handler where the Compacted compaction references a source
+        // that no longer exists in the manifest (simulates a post-crash recovery
+        // where the manifest was already written before the coordinator crashed)
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
         fixture.handler.state_writer.refresh().await.unwrap();
 
-        // Ghost view ID and destination SR 0 are not present in the manifest.
+        // Use a fake view ID that is not present in any L0
         let ghost_view_id = Ulid::from_parts(u64::MAX, 0);
         let spec = CompactionSpec::new(vec![SourceId::SstView(ghost_view_id)], 0);
         let compaction_id = Ulid::new();
@@ -6169,7 +6076,7 @@ mod tests {
             .await
             .expect("commit_compacted_entries failed");
 
-        // then: marked Failed because neither source nor output is traceable in the manifest
+        // then: the compaction is marked Failed (not retried)
         let stored = fixture
             .compactions_store
             .read_latest_compactions()

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -5973,7 +5973,7 @@ mod tests {
             .await
             .expect("commit_compacted_entries failed");
 
-        // then: the compaction is Completed in the stored compactions file
+        // then: compaction is Completed, L0 sources removed, output SR added
         let stored = fixture
             .compactions_store
             .read_latest_compactions()
@@ -5987,25 +5987,62 @@ mod tests {
                 .status(),
             CompactionStatus::Completed,
         );
-
-        // and: the manifest now contains the output SR
         let manifest = fixture.manifest_store.read_latest_manifest().await.unwrap();
         let core = manifest.core();
+        assert!(core.tree.l0.is_empty(), "L0 sources should be removed");
         let sr = core.tree.compacted.iter().find(|sr| sr.id == destination);
         assert!(
             sr.is_some(),
             "output SR {destination} not found in manifest"
         );
-        assert_eq!(
-            sr.unwrap().sst_views.first().unwrap().sst.id,
-            output_sst.id,
-            "output SR does not contain expected SST"
-        );
+        assert_eq!(sr.unwrap().sst_views.first().unwrap().sst.id, output_sst.id);
 
-        // and: the L0 sources have been removed from the manifest
+        // given: a Compacted SR0→SR1 compaction to validate the SR source path removed when not in L0
+        let sr1_output_sst = fake_output_sst();
+        let sr_compaction_id = Ulid::new();
+        let sr_compaction = Compaction::new(
+            sr_compaction_id,
+            CompactionSpec::new(vec![SourceId::SortedRun(0)], 1),
+        )
+        .with_status(CompactionStatus::Compacted)
+        .with_output_ssts(vec![sr1_output_sst.clone()]);
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(sr_compaction);
+
+        // when:
+        fixture
+            .handler
+            .commit_compacted_entries()
+            .await
+            .expect("SR commit failed");
+
+        // then: SR 0 removed, SR 1 added with the correct SST
+        let manifest2 = fixture.manifest_store.read_latest_manifest().await.unwrap();
+        let core2 = manifest2.core();
         assert!(
-            core.tree.l0.is_empty(),
-            "L0 sources should have been removed after commit"
+            core2.tree.compacted.iter().all(|sr| sr.id != 0),
+            "SR 0 should be removed after SR compaction"
+        );
+        let sr1 = core2.tree.compacted.iter().find(|sr| sr.id == 1);
+        assert!(sr1.is_some(), "SR 1 should exist");
+        assert_eq!(
+            sr1.unwrap().sst_views.first().unwrap().sst.id,
+            sr1_output_sst.id
+        );
+        let stored2 = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        assert_eq!(
+            stored2
+                .get(&sr_compaction_id)
+                .expect("missing SR compaction")
+                .status(),
+            CompactionStatus::Completed,
         );
     }
 

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -735,7 +735,6 @@ impl CompactorEventHandler {
             return Ok(());
         }
 
-        let mut any_failed = false;
         for compaction in compacted {
             let id = compaction.id();
             match self.validate_compaction(compaction.spec()) {
@@ -753,8 +752,6 @@ impl CompactorEventHandler {
                             .collect(),
                     };
                     self.state_mut().finish_compaction(id, output_sr);
-                    self.log_compaction_state();
-                    self.state_writer.write_state_safely().await?;
                     self.stats
                         .last_compaction_ts
                         .set(self.system_clock.now().timestamp());
@@ -768,14 +765,12 @@ impl CompactorEventHandler {
                     );
                     self.state_mut()
                         .update_compaction(&id, |c| c.set_status(CompactionStatus::Failed));
-                    any_failed = true;
                 }
             }
         }
 
-        if any_failed {
-            self.state_writer.write_compactions_safely().await?;
-        }
+        self.log_compaction_state();
+        self.state_writer.write_state_safely().await?;
 
         Ok(())
     }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -711,8 +711,19 @@ impl CompactorEventHandler {
     /// Recovery: on coordinator restart, `Compacted` entries are left intact in
     /// `.compactions`. The first call to this method after startup retries the manifest
     /// write. `validate_compaction` will fail if the sources are already absent (meaning
-    /// the manifest was written before the crash), in which case the entry is safely
-    /// marked `Failed`.
+    /// the manifest was written before the crash), in which case the entry is marked
+    /// `Failed` even though the compaction may have actually succeeded. This is preferred
+    /// over trying to detect success after the fact because any heuristic (e.g. checking
+    /// whether the destination SR is present in the manifest) is fragile: the destination
+    /// SR id may coincide with a source SR id (e.g. `[L0:1, SR:1] -> SR:1`), so the
+    /// destination SR can exist both before and after the compaction runs and its presence
+    /// alone does not confirm the compaction's output was committed. Marking `Failed` is
+    /// safe in both crash scenarios:
+    /// - Crash before manifest write: sources are still present, so the scheduler
+    ///   re-compacts them on the next tick.
+    /// - Crash after manifest write: sources are already absent and the manifest is
+    ///   already in the correct post-compaction state, so marking `Failed` has no
+    ///   effect on correctness.
     async fn commit_compacted_entries(&mut self) -> Result<(), SlateDBError> {
         let compacted = self
             .state()

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -5989,14 +5989,13 @@ mod tests {
         );
 
         // and: the manifest now contains the output SR
-        let manifest = fixture
-            .manifest_store
-            .read_latest_manifest()
-            .await
-            .unwrap();
+        let manifest = fixture.manifest_store.read_latest_manifest().await.unwrap();
         let core = manifest.core();
         let sr = core.tree.compacted.iter().find(|sr| sr.id == destination);
-        assert!(sr.is_some(), "output SR {destination} not found in manifest");
+        assert!(
+            sr.is_some(),
+            "output SR {destination} not found in manifest"
+        );
         assert_eq!(
             sr.unwrap().sst_views.first().unwrap().sst.id,
             output_sst.id,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -711,8 +711,9 @@ impl CompactorEventHandler {
     /// Recovery: on coordinator restart, `Compacted` entries are left intact in
     /// `.compactions`. The first call to this method after startup retries the manifest
     /// write. `validate_compaction` will fail if the sources are already absent (meaning
-    /// the manifest was written before the crash), in which case the entry is safely
-    /// marked `Failed`.
+    /// the manifest was written before the crash). In that case we verify the output is
+    /// present in the manifest: if so the compaction succeeded and is marked `Completed`;
+    /// if not something unexpected happened and it is marked `Failed`.
     async fn commit_compacted_entries(&mut self) -> Result<(), SlateDBError> {
         let compacted = self
             .state()
@@ -724,7 +725,7 @@ impl CompactorEventHandler {
             return Ok(());
         }
 
-        let mut any_failed = false;
+        let mut any_terminal = false;
         for compaction in compacted {
             let id = compaction.id();
             match self.validate_compaction(compaction.spec()) {
@@ -749,25 +750,55 @@ impl CompactorEventHandler {
                         .set(self.system_clock.now().timestamp());
                 }
                 Err(_) => {
-                    // Sources are already absent from the manifest: the manifest write
-                    // completed before the last coordinator crash. Mark Failed so the
-                    // entry doesn't get retried on the next tick.
-                    info!(
-                        "compaction sources already absent from manifest, marking Failed [id={}]",
-                        id
-                    );
-                    self.state_mut()
-                        .update_compaction(&id, |c| c.set_status(CompactionStatus::Failed));
-                    any_failed = true;
+                    // Sources are absent: validate_compaction failed because the manifest
+                    // was already written before the last coordinator crash. Check whether
+                    // the output is present in the manifest to distinguish a successful
+                    // pre-crash write (Completed) from an unexpected state (Failed).
+                    if self.is_compaction_output_committed(compaction.spec()) {
+                        info!(
+                            "compaction output already in manifest, marking Completed [id={}]",
+                            id
+                        );
+                        self.state_mut()
+                            .update_compaction(&id, |c| c.set_status(CompactionStatus::Completed));
+                    } else {
+                        info!(
+                            "compaction sources absent but output not in manifest, marking Failed [id={}]",
+                            id
+                        );
+                        self.state_mut()
+                            .update_compaction(&id, |c| c.set_status(CompactionStatus::Failed));
+                    }
+                    any_terminal = true;
                 }
             }
         }
 
-        if any_failed {
+        if any_terminal {
             self.state_writer.write_compactions_safely().await?;
         }
 
         Ok(())
+    }
+
+    /// Returns true if the output of `spec` is already reflected in the current manifest.
+    ///
+    /// For tiered compactions the destination SR must be present in the target segment's
+    /// `compacted` list. For drain compactions the sources must all be
+    /// absent from the tree.
+    fn is_compaction_output_committed(&self, spec: &CompactionSpec) -> bool {
+        let db_state = self.state().db_state();
+        let Some(tree) = db_state.tree_for_segment(spec.segment()) else {
+            return false;
+        };
+        let Some(dst) = spec.destination() else {
+            // Drain compaction: no output SR, so sources being absent is the confirmation.
+            return spec.sources().iter().all(|src| match src {
+                SourceId::SstView(id) => !tree.l0.iter().any(|v| v.id == *id),
+                SourceId::SortedRun(id) => !tree.compacted.iter().any(|sr| sr.id == *id),
+            });
+        };
+        tree.compacted.iter().any(|sr| sr.id == dst)
     }
 
     /// Stops the underlying compaction executor, aborting the executor and waiting for any
@@ -6049,14 +6080,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_commit_compacted_entries_marks_failed_when_sources_absent() {
-        // given: a handler where the Compacted compaction references a source
-        // that no longer exists in the manifest (simulates a post-crash recovery
-        // where the manifest was already written before the coordinator crashed)
+    async fn test_commit_compacted_entries_marks_completed_when_output_in_manifest() {
+        // Simulates a coordinator crash after the manifest write but before the
+        // compaction status was updated. On recovery the Compacted entry is still
+        // present; the L0 source is gone and the output SR is already in the manifest.
+        // The coordinator should detect this and mark the compaction Completed.
+        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        fixture.write_l0().await;
+        fixture.handler.state_writer.refresh().await.unwrap();
+
+        let db_state = fixture.handler.state().db_state().clone();
+        let l0_view_id = db_state.tree.l0.front().unwrap().id;
+        let destination = 0u32;
+        let output_sst = fake_output_sst();
+        let spec = CompactionSpec::new(vec![SourceId::SstView(l0_view_id)], destination);
+        let compaction_id = Ulid::new();
+        let compaction = Compaction::new(compaction_id, spec.clone())
+            .with_status(CompactionStatus::Compacted)
+            .with_output_ssts(vec![output_sst.clone()]);
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(compaction);
+
+        // First pass: sources present — writes the manifest normally (SR 0 is added,
+        // L0 is removed). This simulates the coordinator that crashed after the write.
+        fixture
+            .handler
+            .commit_compacted_entries()
+            .await
+            .expect("first pass failed");
+
+        // Re-inject the same compaction as Compacted to simulate the crash: the status
+        // file was not updated before the crash.
+        fixture.handler.state_mut().insert_compaction_for_test(
+            Compaction::new(compaction_id, spec)
+                .with_status(CompactionStatus::Compacted)
+                .with_output_ssts(vec![output_sst]),
+        );
+
+        // when: recovery pass
+        fixture
+            .handler
+            .commit_compacted_entries()
+            .await
+            .expect("recovery pass failed");
+
+        // then: marked Completed because the output SR is already in the manifest
+        let stored = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        assert_eq!(
+            stored
+                .get(&compaction_id)
+                .expect("missing compaction")
+                .status(),
+            CompactionStatus::Completed,
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_compacted_entries_marks_failed_when_sources_and_output_absent() {
+        // given: a Compacted compaction whose source AND destination are both absent
+        // from the manifest — an unexpected state that should be marked Failed.
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
         fixture.handler.state_writer.refresh().await.unwrap();
 
-        // Use a fake view ID that is not present in any L0
+        // Ghost view ID and destination SR 0 are not present in the manifest.
         let ghost_view_id = Ulid::from_parts(u64::MAX, 0);
         let spec = CompactionSpec::new(vec![SourceId::SstView(ghost_view_id)], 0);
         let compaction_id = Ulid::new();
@@ -6076,7 +6169,7 @@ mod tests {
             .await
             .expect("commit_compacted_entries failed");
 
-        // then: the compaction is marked Failed (not retried)
+        // then: marked Failed because neither source nor output is traceable in the manifest
         let stored = fixture
             .compactions_store
             .read_latest_compactions()

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt::{Display, Formatter};
 
 use bytes::Bytes;
-use log::{error, info};
+use log::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use ulid::Ulid;
 
@@ -721,6 +721,11 @@ impl CompactorState {
                 Entry::Occupied(mut o) => {
                     if matches!(compaction.status(), CompactionStatus::Compacted) {
                         o.insert(compaction.clone());
+                    } else {
+                        debug!(
+                            "ignoring remote compaction update with non-Compacted status [compaction={:?}]",
+                            compaction,
+                        );
                     }
                 }
             }

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -703,18 +703,29 @@ impl CompactorState {
         }
 
         for compaction in remote_compactions.value.iter() {
-            if let Entry::Vacant(v) = merged.entry(compaction.id()) {
-                // The compactor should control all compaction state transitions. If the
-                // compactor finds a new remote compaction (a compaction that the compactor
-                // didn't create), it must be in `Submitted` status (the beginning status).
-                if !matches!(compaction.status(), CompactionStatus::Submitted) {
-                    error!(
-                        "skipping remote commpaction with unexpected (non-Submitted) status [compaction={:?}]",
-                        compaction,
-                    );
-                    continue;
+            match merged.entry(compaction.id()) {
+                Entry::Vacant(v) => {
+                    // The compactor should control all compaction state transitions. If the
+                    // compactor finds a new remote compaction (a compaction that the compactor
+                    // didn't create), it must be in `Submitted` status (the beginning status).
+                    if !matches!(compaction.status(), CompactionStatus::Submitted) {
+                        error!(
+                            "skipping remote compaction with unexpected (non-Submitted) status [compaction={:?}]",
+                            compaction,
+                        );
+                        continue;
+                    }
+                    v.insert(compaction.clone());
                 }
-                v.insert(compaction.clone());
+                Entry::Occupied(mut o) => {
+                    // Accept `Compacted` status written by a remote worker. This is the
+                    // signal that execution finished and the coordinator should commit the
+                    // manifest. All other remote status updates are ignored; the coordinator
+                    // owns every other transition.
+                    if matches!(compaction.status(), CompactionStatus::Compacted) {
+                        o.insert(compaction.clone());
+                    }
+                }
             }
         }
 
@@ -1152,6 +1163,32 @@ mod tests {
         assert_eq!(
             merged.get(&remote_submitted).expect("not found").status(),
             CompactionStatus::Submitted
+        );
+    }
+
+    #[test]
+    fn test_merge_remote_compactions_accepts_compacted_from_worker() {
+        let manifest = new_dirty_manifest();
+        let compactor_epoch = manifest.value.compactor_epoch;
+        let id = Ulid::from_parts(1, 0);
+
+        let mut local_compactions = new_dirty_compactions(compactor_epoch);
+        local_compactions
+            .value
+            .insert(compaction_with_status(id, CompactionStatus::Running));
+        let mut state = CompactorState::new(manifest, local_compactions);
+
+        let mut remote_compactions = new_dirty_compactions(compactor_epoch);
+        remote_compactions
+            .value
+            .insert(compaction_with_status(id, CompactionStatus::Compacted));
+
+        state.merge_remote_compactions(remote_compactions);
+
+        let merged = &state.compactions.value;
+        assert_eq!(
+            merged.get(&id).expect("not found").status(),
+            CompactionStatus::Compacted
         );
     }
 

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -702,12 +702,13 @@ impl CompactorState {
             merged.insert(compaction.id(), compaction.clone());
         }
 
+        // For compactions not in local state (Vacant), only accept `Submitted` since
+        // execution hasn't started so it's safe to adopt. For known compactions (Occupied),
+        // only accept `Compacted`, the worker's signal that execution finished and the
+        // coordinator should commit the manifest.
         for compaction in remote_compactions.value.iter() {
             match merged.entry(compaction.id()) {
                 Entry::Vacant(v) => {
-                    // The compactor should control all compaction state transitions. If the
-                    // compactor finds a new remote compaction (a compaction that the compactor
-                    // didn't create), it must be in `Submitted` status (the beginning status).
                     if !matches!(compaction.status(), CompactionStatus::Submitted) {
                         error!(
                             "skipping remote compaction with unexpected (non-Submitted) status [compaction={:?}]",
@@ -718,10 +719,6 @@ impl CompactorState {
                     v.insert(compaction.clone());
                 }
                 Entry::Occupied(mut o) => {
-                    // Accept `Compacted` status written by a remote worker. This is the
-                    // signal that execution finished and the coordinator should commit the
-                    // manifest. All other remote status updates are ignored; the coordinator
-                    // owns every other transition.
                     if matches!(compaction.status(), CompactionStatus::Compacted) {
                         o.insert(compaction.clone());
                     }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1156,7 +1156,7 @@ impl Default for CompactionWorkerOptions {
             max_concurrent_compactions: 4,
             compactions_poll_interval: Duration::from_secs(5),
             heartbeat_bytes: 5_242_880,
-            heartbeat_min_interval: Duration::from_secs(1),
+            heartbeat_min_interval: Duration::from_secs(5),
         }
     }
 }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1155,7 +1155,7 @@ impl Default for CompactionWorkerOptions {
         Self {
             max_concurrent_compactions: 4,
             compactions_poll_interval: Duration::from_secs(5),
-            heartbeat_bytes: 64000,
+            heartbeat_bytes: 5_242_880,
             heartbeat_min_interval: Duration::from_secs(1),
         }
     }


### PR DESCRIPTION
## Summary

Coordinator-side manifest commit protocol from [RFC-0025](https://github.com/slatedb/slatedb/blob/main/rfcs/0025-distributed-compaction.md)

## Changes

Adds `commit_compacted_entries()` to `CompactorEventHandler`, called on each poll tick after refreshing state:

1. If validate_compaction() passes: calls finish_compaction() to remove source L0s/SRs and insert the output SR in the manifest, then write_state_safely() to persist the manifest update and transition Compacted → Completed.
  - `test_commit_compacted_entries_writes_manifest`: covers L0 and SR source compactions (chains L0→SR0 then SR0→SR1).

3. If validate_compaction() fails (sources already absent): the manifest was already committed before a coordinator crash. Mark `Failed` and persist to stop retries.
  - `test_commit_compacted_entries_marks_failed_when_sources_absent`: test recovery path where sources are gone and the entry is marked `Failed`.

## Notes for Reviewers

[Phase 1. Schema & Types](https://github.com/slatedb/slatedb/pull/1680)
[Phase 3. Compaction Worker](https://github.com/slatedb/slatedb/pull/1730)
## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏