### PR TITLE
tighten up resolution of fencing wal id and isolate fencing logic

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -57,7 +57,7 @@ use crate::db_state::{DbState, SsTableId};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
-use crate::manifest::store::FenceableManifest;
+use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::manifest::{Manifest, VersionedManifest};
 use crate::memtable_flusher::{FlushResult, FlushTarget, MemtableFlusher};
 use crate::merge_operator::{instrument_merge_operator, MergeOperatorType};
@@ -292,50 +292,6 @@ impl DbInner {
         self.reader
             .scan_prefix_by_recency_with_options(prefix, options, &db_state)
             .await
-    }
-
-    /// Fences all writers with an older epoch than the provided `manifest` by flushing
-    /// an empty WAL file that acts as a barrier. Any parallel old writers will fail with
-    /// `SlateDBError::Fenced` when trying to "re-write" this file. Returns the range that must
-    /// be replayed to recover up to the current epoch
-    async fn fence_writers(
-        &self,
-        manifest: &mut FenceableManifest,
-        next_wal_id: u64,
-    ) -> Result<Range<u64>, SlateDBError> {
-        let mut empty_wal_id = next_wal_id;
-
-        loop {
-            let wrote_fence = match self.flush_empty_wal(empty_wal_id).await {
-                Ok(()) => true,
-                Err(SlateDBError::Fenced) => false,
-                Err(err) => return Err(err),
-            };
-
-            // Refresh validates that we own the latest epoch still.
-            manifest.refresh().await?;
-            let remote_dirty = manifest.prepare_dirty()?;
-            let replay_after_wal_id = remote_dirty.value.core.replay_after_wal_id;
-            let dirty_manifest = {
-                let mut state = self.state.write();
-                state.merge_remote_manifest(remote_dirty);
-                state.state().manifest.clone()
-            };
-            self.status_manager.report_manifest(dirty_manifest.into());
-
-            if wrote_fence {
-                // this writer is the only writer that could have written replay_after_wal_id,
-                // so it should not be possible for it to have advanced past the fencing wal.
-                // older writers would have failed with a stale epoch
-                assert!(empty_wal_id > replay_after_wal_id);
-                return Ok(replay_after_wal_id + 1..empty_wal_id + 1);
-            } else {
-                // We're (probably) ahead of the barrier, but we hit a race with another writer.
-                // Instead of paying for the LIST (API cost and latency), just try the next ID.
-                // This is an optimization: we could always advance with next_wal_sst_id.
-                empty_wal_id += 1;
-            }
-        }
     }
 
     #[allow(unused_variables)]
@@ -6275,130 +6231,6 @@ mod tests {
             )
             .await;
         assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn test_fence_writers_retries_successful_fence_behind_replay_boundary() {
-        // Race:
-        // - t0: W2 computes stale next_wal_id=2 while W1 is still active.
-        // - t1: W1 writes WAL 2 and WAL 3, flushes them to L0, and advances
-        //   the replay boundary to 3.
-        // - t2: WAL GC deletes WAL 2, so a future create at stale WAL 2 can
-        //   succeed, but it leaves WAL 3 because replay_after_wal_id is not
-        //   eligible for deletion.
-        // - t3: W2 claims the writer epoch from that manifest.
-        // - t4: W2 builds the DbInner needed to run fence_writers.
-        // - t5: W2 writes a fence at stale WAL 2; current code accepts it.
-        // - t6: W1 can still create live WAL 4 unless W2 retried the fence
-        //   above the replay boundary.
-        // - t7: ValidateFence should make t6 fail with Fenced.
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = "/tmp/test_fence_writers_retries_successful_fence_behind_replay_boundary";
-        let mut settings = test_db_options(0, 128, None);
-        settings.flush_interval = None;
-
-        // - t0: W2 computes stale next_wal_id=2 while W1 is still active.
-        let stale_next_wal_id = 2;
-        let replay_after_wal_id = stale_next_wal_id + 1; // 3
-        let live_wal_id = replay_after_wal_id + 1; // 4
-
-        let table_store = Arc::new(TableStore::new(
-            ObjectStores::new(object_store.clone(), None),
-            SsTableFormat::default(),
-            path,
-            None,
-        ));
-
-        // - t1: W1 writes WAL 2 and WAL 3, flushes them to L0, and advances
-        //   the replay boundary to 3.
-        for wal_id in [stale_next_wal_id, replay_after_wal_id] {
-            let mut w1_wal = table_store.table_builder();
-            w1_wal
-                .add(RowEntry::new_value(b"w1", b"write", wal_id))
-                .await
-                .unwrap();
-            let w1_wal = w1_wal.build().await.unwrap();
-            table_store
-                .write_sst(&SsTableId::Wal(wal_id), &w1_wal, false)
-                .await
-                .unwrap();
-        }
-        let mut core = ManifestCore::new();
-        core.replay_after_wal_id = replay_after_wal_id;
-        core.next_wal_sst_id = live_wal_id;
-
-        // - t2: WAL GC deletes WAL 2, so a future create at stale WAL 2 can
-        //   succeed, but it leaves WAL 3 because replay_after_wal_id is not
-        //   eligible for deletion.
-        table_store
-            .delete_sst(&SsTableId::Wal(stale_next_wal_id))
-            .await
-            .unwrap();
-
-        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
-        let stored_manifest =
-            StoredManifest::create_new_db(manifest_store, core, system_clock.clone())
-                .await
-                .unwrap();
-
-        // - t3: W2 claims the writer epoch from that manifest.
-        let mut manifest = FenceableManifest::init_writer(
-            stored_manifest,
-            settings.manifest_update_timeout,
-            system_clock.clone(),
-        )
-        .await
-        .unwrap();
-        let manifest_dirty = manifest.prepare_dirty().unwrap();
-
-        // - t4: Build the minimal DbInner needed to run W2's fence_writers.
-        let status_manager = DbStatusManager::new_with_manifest(
-            manifest_dirty.value.core.last_l0_seq,
-            manifest_dirty.clone().into(),
-        );
-        let (write_tx, _write_rx) = SafeSender::unbounded_channel(status_manager.result_reader());
-        let memtable_flusher = Arc::new(MemtableFlusher::new(&status_manager));
-        let inner = DbInner::new(
-            settings,
-            system_clock,
-            Arc::new(DbRand::new(0)),
-            table_store.clone(),
-            manifest_dirty,
-            memtable_flusher,
-            write_tx,
-            MetricsRecorderHelper::noop(),
-            Arc::new(FailPointRegistry::new()),
-            None,
-            status_manager,
-            None,
-        )
-        .await
-        .unwrap();
-
-        // - t5: W2 writes a fence at stale WAL 2; current code accepts it.
-        inner
-            .fence_writers(&mut manifest, stale_next_wal_id)
-            .await
-            .unwrap();
-
-        // - t6: W1 can still create live WAL 4 unless W2 retried the fence
-        //   above the replay boundary.
-        let mut stale_writer_wal = table_store.table_builder();
-        stale_writer_wal
-            .add(RowEntry::new_value(b"stale", b"write", 0))
-            .await
-            .unwrap();
-        let stale_writer_wal = stale_writer_wal.build().await.unwrap();
-        let stale_write_result = table_store
-            .write_sst(&SsTableId::Wal(live_wal_id), &stale_writer_wal, false)
-            .await;
-
-        // - t7: ValidateFence should make t6 fail with Fenced.
-        assert!(
-            matches!(stale_write_result, Err(SlateDBError::Fenced)),
-            "expected fence_writers to retry from stale WAL {stale_next_wal_id} and fence live WAL {live_wal_id}"
-        );
     }
 
     #[tokio::test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -324,19 +324,11 @@ impl DbInner {
             self.status_manager.report_manifest(dirty_manifest.into());
 
             if wrote_fence {
-                // Our fence write might be behind replay_after_wal_id since we're racing with
-                // older writers that can advance replay_after_wal_id by flushing data to L0.
-                // We need to make sure the fence write falls above this barrier so it's visible
-                // to all other active writers.
-                if empty_wal_id > replay_after_wal_id {
-                    return Ok(replay_after_wal_id + 1..empty_wal_id + 1);
-                } else {
-                    // If we're behind the barrier, reset to the next WAL slot.
-                    empty_wal_id = self
-                        .table_store
-                        .next_wal_sst_id(replay_after_wal_id)
-                        .await?;
-                }
+                // this writer is the only writer that could have written replay_after_wal_id,
+                // so it should not be possible for it to have advanced past the fencing wal.
+                // older writers would have failed with a stale epoch
+                assert!(empty_wal_id > replay_after_wal_id);
+                return Ok(replay_after_wal_id + 1..empty_wal_id + 1);
             } else {
                 // We're (probably) ahead of the barrier, but we hit a race with another writer.
                 // Instead of paying for the LIST (API cost and latency), just try the next ID.

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -57,7 +57,6 @@ use crate::db_state::{DbState, SsTableId};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
-use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::manifest::{Manifest, VersionedManifest};
 use crate::memtable_flusher::{FlushResult, FlushTarget, MemtableFlusher};
 use crate::merge_operator::{instrument_merge_operator, MergeOperatorType};

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -146,7 +146,7 @@ use crate::format::sst::{BlockTransformer, SsTableFormat};
 use crate::garbage_collector::GarbageCollector;
 use crate::garbage_collector::GC_TASK_NAME;
 use crate::instrumented_object_store::{InstrumentedObjectStore, ObjectStoreComponent};
-use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
+use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::ManifestCore;
 use crate::memtable_flusher::MemtableFlusher;
 use crate::merge_operator::MergeOperatorType;

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -546,7 +546,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             Some(latest_stored_manifest) => latest_stored_manifest.db_state().replay_after_wal_id,
             None => 0,
         };
-        let next_wal_id = table_store.next_wal_sst_id(replay_after_wal_id).await?;
+        let mut next_wal_id = table_store.next_wal_sst_id(replay_after_wal_id).await?;
 
         // Initialize the database
         let stored_manifest = match latest_manifest {
@@ -573,9 +573,21 @@ impl<P: Into<Path>> DbBuilder<P> {
         )
         .await?;
 
+        let mut manifest_dirty = manifest.prepare_dirty()?;
+        // verify that the next_wal_id we computed is still valid
+        if next_wal_id <= manifest_dirty.value.core.replay_after_wal_id {
+            // the wal gc boundary advanced because the old writer finished a flush - recompute
+            // the next wal id
+            next_wal_id = table_store.next_wal_sst_id(manifest_dirty.value.core.replay_after_wal_id).await?;
+            manifest.refresh().await?;
+            manifest_dirty = manifest.prepare_dirty()?;
+            // at this point we still hold the epoch, so it should not be possible for the barrier
+            // to have advanced past the computed next_wal_id
+            assert!(next_wal_id > manifest_dirty.value.core.replay_after_wal_id);
+        }
+
         // Shared lifecycle state — created before DbInner so it can be shared
         // with the executor and future channel construction.
-        let manifest_dirty = manifest.prepare_dirty()?;
         let status_manager = DbStatusManager::new_with_manifest(
             manifest_dirty.value.core.last_l0_seq,
             manifest_dirty.clone().into(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -140,6 +140,7 @@ use crate::db_reader::DbReader;
 use crate::db_status::{ClosedResultWriter, DbStatusManager};
 use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
+use crate::fence::{WriterFenceResult, WriterFencer};
 use crate::filter_policy::{BloomFilterPolicy, FilterPolicy};
 use crate::format::sst::{BlockTransformer, SsTableFormat};
 use crate::garbage_collector::GarbageCollector;
@@ -541,13 +542,6 @@ impl<P: Into<Path>> DbBuilder<P> {
             }),
         ));
 
-        // Get next WAL ID before writing manifest
-        let replay_after_wal_id = match &latest_manifest {
-            Some(latest_stored_manifest) => latest_stored_manifest.db_state().replay_after_wal_id,
-            None => 0,
-        };
-        let mut next_wal_id = table_store.next_wal_sst_id(replay_after_wal_id).await?;
-
         // Initialize the database
         let stored_manifest = match latest_manifest {
             Some(manifest) => manifest,
@@ -566,25 +560,13 @@ impl<P: Into<Path>> DbBuilder<P> {
             }
         };
 
-        let mut manifest = FenceableManifest::init_writer(
-            stored_manifest,
-            self.settings.manifest_update_timeout,
-            system_clock.clone(),
-        )
-        .await?;
+        let fencer = WriterFencer::new(table_store.clone(), &self.settings, system_clock.clone());
+        let WriterFenceResult {
+            manifest,
+            replay_range,
+        } = fencer.fence(stored_manifest).await?;
 
-        let mut manifest_dirty = manifest.prepare_dirty()?;
-        // verify that the next_wal_id we computed is still valid
-        if next_wal_id <= manifest_dirty.value.core.replay_after_wal_id {
-            // the wal gc boundary advanced because the old writer finished a flush - recompute
-            // the next wal id
-            next_wal_id = table_store.next_wal_sst_id(manifest_dirty.value.core.replay_after_wal_id).await?;
-            manifest.refresh().await?;
-            manifest_dirty = manifest.prepare_dirty()?;
-            // at this point we still hold the epoch, so it should not be possible for the barrier
-            // to have advanced past the computed next_wal_id
-            assert!(next_wal_id > manifest_dirty.value.core.replay_after_wal_id);
-        }
+        let manifest_dirty = manifest.prepare_dirty()?;
 
         // Shared lifecycle state — created before DbInner so it can be shared
         // with the executor and future channel construction.
@@ -616,9 +598,6 @@ impl<P: Into<Path>> DbBuilder<P> {
             )
             .await?,
         );
-
-        // Fence writers if WAL is enabled
-        let replay_range = inner.fence_writers(&mut manifest, next_wal_id).await?;
 
         // Setup background tasks
         let tokio_handle = Handle::current();

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -1,0 +1,305 @@
+use crate::error::SlateDBError;
+use crate::manifest::store::{FenceableManifest, StoredManifest};
+use crate::tablestore::TableStore;
+use crate::Settings;
+use fail_parallel::{fail_point, FailPointRegistry};
+use slatedb_common::SystemClock;
+use std::ops::Range;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+pub(crate) struct WriterFencer {
+    table_store: Arc<TableStore>,
+    manifest_update_timeout: Duration,
+    system_clock: Arc<dyn SystemClock>,
+    fp_ctl: Arc<FailPointCtl>,
+}
+
+pub(crate) struct WriterFenceResult {
+    pub(crate) manifest: FenceableManifest,
+    pub(crate) replay_range: Range<u64>,
+}
+
+struct FailPointCtl {
+    fp_registry: Arc<FailPointRegistry>,
+    event_tx: tokio::sync::mpsc::UnboundedSender<String>,
+    event_toggle: Mutex<String>,
+}
+
+impl FailPointCtl {
+    fn new(
+        fp_registry: Arc<FailPointRegistry>,
+        event_tx: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> Self {
+        Self {
+            fp_registry,
+            event_tx,
+            event_toggle: Mutex::new("".to_string()),
+        }
+    }
+
+    #[cfg(test)]
+    fn enable_fp(&self, event: impl ToString) {
+        *self.event_toggle.lock().unwrap() = event.to_string();
+    }
+}
+
+impl WriterFencer {
+    pub(crate) fn new(
+        table_store: Arc<TableStore>,
+        settings: &Settings,
+        system_clock: Arc<dyn SystemClock>,
+    ) -> Self {
+        let (event_tx, _) = tokio::sync::mpsc::unbounded_channel();
+        Self::new_with_fp_ctl(
+            table_store,
+            settings,
+            system_clock,
+            Arc::new(FailPointCtl::new(
+                Arc::new(FailPointRegistry::new()),
+                event_tx,
+            )),
+        )
+    }
+
+    fn new_with_fp_ctl(
+        table_store: Arc<TableStore>,
+        settings: &Settings,
+        system_clock: Arc<dyn SystemClock>,
+        fp_ctl: Arc<FailPointCtl>,
+    ) -> Self {
+        Self {
+            table_store,
+            manifest_update_timeout: settings.manifest_update_timeout,
+            system_clock,
+            fp_ctl,
+        }
+    }
+
+    #[cfg(test)]
+    fn fp_notify(&self, event: impl ToString) {
+        let event = event.to_string();
+        let _ = self.fp_ctl.event_tx.send(event.clone());
+        let event_toggle = String::clone(&*self.fp_ctl.event_toggle.lock().unwrap());
+        fail_point!(
+            Arc::clone(&self.fp_ctl.fp_registry),
+            "fence_event",
+            event == event_toggle,
+            |_| {}
+        );
+    }
+
+    #[cfg(not(test))]
+    fn fp_notify(&self, _event: impl ToString) {}
+
+    /// Fences all writers with an older epoch than the provided `stored_manifest` by (1) writing
+    /// a new `FenceableManifest` with a bumped epoch, and (2) writing an empty WAL file that acts
+    /// as a barrier. Any parallel old writers will fail with `SlateDBError::Fenced` when trying
+    /// to "re-write" this file. Returns a `WriterFence` with the `FenceableManifest` and range
+    /// that must be replayed to recover up to the current epoch
+    pub(crate) async fn fence(
+        self,
+        stored_manifest: StoredManifest,
+    ) -> Result<WriterFenceResult, SlateDBError> {
+        let mut empty_wal_id = self
+            .table_store
+            .next_wal_sst_id(stored_manifest.manifest().core.replay_after_wal_id)
+            .await?;
+        self.fp_notify("LoadEmptyWalId");
+
+        let mut manifest = FenceableManifest::init_writer(
+            stored_manifest,
+            self.manifest_update_timeout,
+            self.system_clock.clone(),
+        )
+        .await?;
+        self.fp_notify("FenceManifest");
+
+        let mut manifest_dirty = manifest.prepare_dirty()?;
+        // verify that the empty_wal_id we computed is still valid. Its possible that between
+        // computing empty_wal_id and fencing the manifest, the fenced writer advanced the gc
+        // boundary (replay_after_wal_id)
+        if empty_wal_id <= manifest_dirty.value.core.replay_after_wal_id {
+            // the wal gc boundary advanced because the old writer finished a flush - recompute
+            // the next wal id
+            empty_wal_id = self
+                .table_store
+                .next_wal_sst_id(manifest_dirty.value.core.replay_after_wal_id)
+                .await?;
+            manifest.refresh().await?;
+            manifest_dirty = manifest.prepare_dirty()?;
+            self.fp_notify("ReloadEmptyWalId");
+            // at this point we still hold the epoch, so it should not be possible for the barrier
+            // to have advanced past the computed empty_wal_id
+            assert!(empty_wal_id > manifest_dirty.value.core.replay_after_wal_id);
+        }
+
+        loop {
+            let wrote_fence = match self.table_store.write_wal_fence(empty_wal_id).await {
+                Ok(()) => true,
+                Err(SlateDBError::Fenced) => false,
+                Err(err) => return Err(err),
+            };
+            self.fp_notify(format!("{}:{}", "WriteWalFence", empty_wal_id));
+
+            // Refresh validates that we own the latest epoch still.
+            manifest.refresh().await?;
+            let dirty_manifest = manifest.prepare_dirty()?;
+            let replay_after_wal_id = dirty_manifest.value.core.replay_after_wal_id;
+            self.fp_notify(format!("{}:{}", "RefreshManifest", empty_wal_id));
+
+            if wrote_fence {
+                // this writer is the only writer that could have written replay_after_wal_id,
+                // so it should not be possible for it to have advanced past the fencing wal.
+                // older writers would have failed with a stale epoch
+                assert!(empty_wal_id > replay_after_wal_id);
+                return Ok(WriterFenceResult {
+                    manifest,
+                    replay_range: replay_after_wal_id + 1..empty_wal_id + 1,
+                });
+            } else {
+                // The old writer managed to write a WAL before we could write the fencing wal.
+                // Try the next wal ID
+                empty_wal_id += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::ObjectStoreCacheOptions;
+    use crate::db_state::{SsTableHandle, SsTableId};
+    use crate::error::SlateDBError;
+    use crate::fence::{FailPointCtl, WriterFencer};
+    use crate::format::sst::SsTableFormat;
+    use crate::manifest::store::{ManifestStore, StoredManifest};
+    use crate::manifest::ManifestCore;
+    use crate::object_stores::ObjectStores;
+    use crate::tablestore::TableStore;
+    use crate::{RowEntry, Settings};
+    use fail_parallel::FailPointRegistry;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use slatedb_common::{DefaultSystemClock, SystemClock};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_fence_retries_next_wal_id_when_behind_replay_boundary() {
+        // Race:
+        // - t0: W2 computes stale next_wal_id=1 while W1 is still active.
+        // - t1: W1 writes WAL 1 and WAL 2, flushes them to L0, and advances
+        //   the replay boundary to 2.
+        // - t2: WAL GC deletes WAL 2, so a future create at stale WAL 2 can
+        //   succeed, but it leaves WAL 3 because replay_after_wal_id is not
+        //   eligible for deletion.
+        // - t3: W2 claims the writer epoch from that manifest.
+        // - t4: W2 builds the DbInner needed to run fence_writers.
+        // - t5: W2 writes a fence at stale WAL 2; current code accepts it.
+        // - t6: W1 can still create live WAL 4 unless W2 retried the fence
+        //   above the replay boundary.
+        // - t7: ValidateFence should make t6 fail with Fenced.
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_fence_retries_next_wal_id_when_behind_replay_boundary";
+        let settings = test_db_options();
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            SsTableFormat::default(),
+            path,
+            None,
+        ));
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+        let core = ManifestCore::new();
+        let stored_manifest =
+            StoredManifest::create_new_db(manifest_store.clone(), core, system_clock.clone())
+                .await
+                .unwrap();
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
+        let fp_ctl = Arc::new(FailPointCtl::new(fp_registry.clone(), event_tx));
+        let fencer = WriterFencer::new_with_fp_ctl(
+            table_store.clone(),
+            &settings,
+            system_clock.clone(),
+            fp_ctl.clone(),
+        );
+
+        // - t0: W2 computes stale next_wal_id=1 while W1 is still active.
+        fp_ctl.enable_fp("LoadEmptyWalId");
+        fail_parallel::cfg(fp_registry.clone(), "fence_event", "pause").unwrap();
+        let jh = tokio::task::spawn(async move { fencer.fence(stored_manifest).await });
+        // wait for w2 to load empty wal id
+        event_rx.recv().await.unwrap();
+
+        // - t1: W1 writes WAL 1 and 2
+        write_wal(1, table_store.as_ref()).await.unwrap();
+        write_wal(2, table_store.as_ref()).await.unwrap();
+
+        // - t2: WAL GC deletes WAL 1
+        let mut stored_manifest =
+            StoredManifest::load(manifest_store.clone(), system_clock.clone())
+                .await
+                .unwrap();
+        let mut dirty = stored_manifest.prepare_dirty().unwrap();
+        dirty.value.core.replay_after_wal_id = 2;
+        stored_manifest.update(dirty).await.unwrap();
+        delete_wal(1, table_store.as_ref()).await;
+
+        // - t3-t5: W2 reloads last wal id and writes fence wal
+        fail_parallel::cfg(fp_registry.clone(), "fence_event", "off").unwrap();
+        let result = jh.await.unwrap().unwrap();
+        assert_eq!(result.replay_range, 3u64..4u64);
+
+        // - t6 - t7 - writing wal at 3 should fail
+        let err = write_wal(3, table_store.as_ref()).await.unwrap_err();
+        assert!(matches!(err, SlateDBError::Fenced));
+    }
+
+    async fn delete_wal(wal_id: u64, table_store: &TableStore) {
+        table_store
+            .delete_sst(&SsTableId::Wal(wal_id))
+            .await
+            .unwrap();
+    }
+
+    async fn write_wal(
+        wal_id: u64,
+        table_store: &TableStore,
+    ) -> Result<SsTableHandle, SlateDBError> {
+        let mut w1_wal = table_store.table_builder();
+        w1_wal
+            .add(RowEntry::new_value(b"w1", b"write", wal_id))
+            .await
+            .unwrap();
+        let w1_wal = w1_wal.build().await.unwrap();
+        table_store
+            .write_sst(&SsTableId::Wal(wal_id), &w1_wal, false)
+            .await
+    }
+
+    fn test_db_options() -> Settings {
+        Settings {
+            flush_interval: Some(Duration::from_millis(100)),
+            #[cfg(feature = "wal_disable")]
+            wal_enabled: true,
+            manifest_poll_interval: Duration::from_millis(100),
+            manifest_update_timeout: Duration::from_secs(300),
+            max_unflushed_bytes: 134_217_728,
+            l0_max_ssts: 8,
+            l0_max_ssts_per_key: 8,
+            l0_flush_parallelism: 1,
+            min_filter_keys: 0,
+            l0_sst_size_bytes: 128,
+            max_wal_flushes_before_l0_flush: 4096,
+            compression_codec: None,
+            object_store_cache_options: ObjectStoreCacheOptions::default(),
+            garbage_collector_options: None,
+            default_ttl: None,
+            block_format: None,
+            ..Settings::default()
+        }
+    }
+}

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -2,7 +2,9 @@ use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
 use crate::Settings;
-use fail_parallel::{fail_point, FailPointRegistry};
+#[cfg(test)]
+use fail_parallel::fail_point;
+use fail_parallel::FailPointRegistry;
 use slatedb_common::SystemClock;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
@@ -12,6 +14,7 @@ pub(crate) struct WriterFencer {
     table_store: Arc<TableStore>,
     manifest_update_timeout: Duration,
     system_clock: Arc<dyn SystemClock>,
+    #[cfg_attr(not(test), allow(dead_code))]
     fp_ctl: Arc<FailPointCtl>,
 }
 
@@ -20,6 +23,7 @@ pub(crate) struct WriterFenceResult {
     pub(crate) replay_range: Range<u64>,
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 struct FailPointCtl {
     fp_registry: Arc<FailPointRegistry>,
     event_tx: tokio::sync::mpsc::UnboundedSender<String>,
@@ -134,19 +138,21 @@ impl WriterFencer {
             assert!(empty_wal_id > manifest_dirty.value.core.replay_after_wal_id);
         }
 
+        let mut attempt = 0;
         loop {
+            attempt += 1;
             let wrote_fence = match self.table_store.write_wal_fence(empty_wal_id).await {
                 Ok(()) => true,
                 Err(SlateDBError::Fenced) => false,
                 Err(err) => return Err(err),
             };
-            self.fp_notify(format!("{}:{}", "WriteWalFence", empty_wal_id));
+            self.fp_notify(format!("{}:{}", "WriteWalFence", attempt));
 
             // Refresh validates that we own the latest epoch still.
             manifest.refresh().await?;
             let dirty_manifest = manifest.prepare_dirty()?;
             let replay_after_wal_id = dirty_manifest.value.core.replay_after_wal_id;
-            self.fp_notify(format!("{}:{}", "RefreshManifest", empty_wal_id));
+            self.fp_notify(format!("{}:{}", "RefreshManifest", attempt));
 
             if wrote_fence {
                 // this writer is the only writer that could have written replay_after_wal_id,
@@ -168,137 +174,342 @@ impl WriterFencer {
 
 #[cfg(test)]
 mod tests {
-    use crate::config::ObjectStoreCacheOptions;
-    use crate::db_state::{SsTableHandle, SsTableId};
-    use crate::error::SlateDBError;
+    use crate::compactions_store::CompactionsStore;
+    use crate::config::{
+        FlushOptions, FlushType, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
+    };
     use crate::fence::{FailPointCtl, WriterFencer};
     use crate::format::sst::SsTableFormat;
+    use crate::garbage_collector::GarbageCollector;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
+    use crate::memtable_flusher::MANIFEST_REFRESH_COUNT;
     use crate::object_stores::ObjectStores;
     use crate::tablestore::TableStore;
-    use crate::{RowEntry, Settings};
+    use crate::{CloseReason, Db, ErrorKind, Settings};
+    use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
+    use rstest::rstest;
+    use slatedb_common::metrics::{lookup_metric, DefaultMetricsRecorder, MetricsRecorderHelper};
     use slatedb_common::{DefaultSystemClock, SystemClock};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
+    struct WriterFencerTestHarness {
+        object_store: Arc<dyn ObjectStore>,
+        path: String,
+        manifest_store: Arc<ManifestStore>,
+        table_store: Arc<TableStore>,
+        fp_registry: Arc<FailPointRegistry>,
+        fp_ctl: Arc<FailPointCtl>,
+        event_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
+        fencer: Option<WriterFencer>,
+        stored_manifest: Option<StoredManifest>,
+        data: HashMap<Bytes, Bytes>,
+    }
+
+    impl WriterFencerTestHarness {
+        async fn new(path: &str) -> Self {
+            let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+            let settings = test_db_options();
+            let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+            let manifest_store =
+                Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
+            let table_store = Arc::new(TableStore::new(
+                ObjectStores::new(object_store.clone(), None),
+                SsTableFormat::default(),
+                path,
+                None,
+            ));
+            let stored_manifest = StoredManifest::create_new_db(
+                manifest_store.clone(),
+                ManifestCore::new(),
+                system_clock.clone(),
+            )
+            .await
+            .unwrap();
+            let fp_registry = Arc::new(FailPointRegistry::new());
+            let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+            let fp_ctl = Arc::new(FailPointCtl::new(fp_registry.clone(), event_tx));
+            let fencer = WriterFencer::new_with_fp_ctl(
+                table_store.clone(),
+                &settings,
+                system_clock.clone(),
+                fp_ctl.clone(),
+            );
+            Self {
+                object_store,
+                path: path.to_string(),
+                manifest_store,
+                table_store,
+                fp_registry,
+                fp_ctl,
+                event_rx,
+                fencer: Some(fencer),
+                stored_manifest: Some(stored_manifest),
+                data: HashMap::new(),
+            }
+        }
+
+        async fn fenced_db(&self) -> Db {
+            // initialize a db with manifest poll interval set to 1hr — long enough
+            // that the db won't independently observe the fencer's epoch bump
+            // through its background poller while the fencer is paused.
+            let recorder = Arc::new(DefaultMetricsRecorder::new());
+            let mut settings = test_db_options();
+            settings.manifest_poll_interval = Duration::from_secs(3600);
+            let db = Db::builder(self.path.clone(), self.object_store.clone())
+                .with_settings(settings)
+                .with_metrics_recorder(recorder.clone())
+                .build()
+                .await
+                .unwrap();
+            // wait for initial manifest poll using "manifest_refresh_count" stat
+            // so the db has settled before the test starts fencing it.
+            for _ in 0..600 {
+                if lookup_metric(&recorder, MANIFEST_REFRESH_COUNT).unwrap_or(0) > 0 {
+                    return db;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            panic!("manifest writer did not perform initial poll");
+        }
+
+        async fn db(&self) -> Db {
+            let recorder = Arc::new(DefaultMetricsRecorder::new());
+            Db::builder(self.path.clone(), self.object_store.clone())
+                .with_settings(test_db_options())
+                .with_metrics_recorder(recorder)
+                .build()
+                .await
+                .unwrap()
+        }
+
+        async fn run_gc(&self, wal_id: u64) {
+            let compactions_store = Arc::new(CompactionsStore::new(
+                &Path::from(self.path.clone()),
+                self.object_store.clone(),
+            ));
+            let gc_opts = GarbageCollectorOptions {
+                manifest_options: None,
+                wal_options: Some(GarbageCollectorDirectoryOptions {
+                    min_age: Duration::ZERO,
+                    interval: None,
+                    dry_run: false,
+                }),
+                wal_fence_options: None,
+                compacted_options: None,
+                compactions_options: None,
+                detach_options: None,
+            };
+            let gc = GarbageCollector::new(
+                self.manifest_store.clone(),
+                compactions_store,
+                self.table_store.clone(),
+                self.object_store.clone(),
+                gc_opts,
+                &MetricsRecorderHelper::noop(),
+                Arc::new(DefaultSystemClock::new()),
+            );
+            gc.run_gc_once().await;
+            // verify all regular (size > 0) wals up to wal_id are deleted (the wal
+            // at replay_after_wal_id is retained as the boundary; old fence wals
+            // stay because we don't enable wal_fence_options).
+            let remaining: Vec<_> = self
+                .table_store
+                .list_wal_ssts(..wal_id)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter(|w| w.size > 0)
+                .collect();
+            assert!(
+                remaining.is_empty(),
+                "expected no regular wals below {wal_id}, got {} wals",
+                remaining.len()
+            );
+        }
+
+        async fn put(&mut self, db: &Db, v: u32, expect_fenced: bool) {
+            let k = Bytes::from(format!("k{}", v));
+            let v = Bytes::from(format!("v{}", v));
+            let result = db.put(k.as_ref(), v.as_ref()).await;
+            if expect_fenced {
+                assert_eq!(
+                    result.unwrap_err().kind(),
+                    ErrorKind::Closed(CloseReason::Fenced)
+                );
+            } else {
+                self.data.insert(k, v);
+                assert!(result.is_ok());
+            }
+        }
+
+        async fn assert_fencing_wal(&self) {
+            let wals = self.table_store.list_wal_ssts(..).await.unwrap();
+            let last = wals.last().expect("wal list is empty");
+            assert_eq!(last.size, 0, "last wal is not a fence wal");
+        }
+
+        async fn assert_wals_contiguous(&self) {
+            let replay_after_wal_id = self
+                .manifest_store
+                .read_latest_manifest()
+                .await
+                .unwrap()
+                .manifest
+                .core
+                .replay_after_wal_id;
+            let wal_ids: Vec<u64> = self
+                .table_store
+                .list_wal_ssts(replay_after_wal_id + 1..)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|w| w.id.unwrap_wal_id())
+                .collect();
+            for (i, id) in wal_ids.iter().enumerate() {
+                let expected = replay_after_wal_id + 1 + i as u64;
+                assert_eq!(
+                    *id, expected,
+                    "wal ids above replay_after_wal_id={replay_after_wal_id} are not contiguous: {wal_ids:?}"
+                );
+            }
+        }
+
+        async fn assert_data(&self) {
+            let db = self.db().await;
+            for (k, v) in &self.data {
+                let actual = db.get(k.as_ref()).await.unwrap();
+                assert_eq!(
+                    actual.as_ref(),
+                    Some(v),
+                    "key {:?} expected {:?}, got {:?}",
+                    k,
+                    v,
+                    actual
+                );
+            }
+            db.close().await.unwrap();
+        }
+    }
+
+    struct FencedWriterFlushTestCase {
+        event: &'static str,
+        write_fenced: bool,
+        flush_fenced: bool,
+    }
+
+    impl FencedWriterFlushTestCase {
+        fn new(event: &'static str, write_fenced: bool, flush_fenced: bool) -> Self {
+            Self {
+                event,
+                write_fenced,
+                flush_fenced,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_fence() {
+        let mut h =
+            WriterFencerTestHarness::new("/tmp/test_fence_handles_fenced_writer_flush").await;
+        let db = h.db().await;
+        h.put(&db, 1, false).await;
+        let fencer = h.fencer.take().unwrap();
+
+        let result = fencer.fence(h.stored_manifest.take().unwrap()).await;
+
+        assert!(result.is_ok());
+        h.put(&db, 2, true).await;
+        h.assert_fencing_wal().await;
+        h.assert_wals_contiguous().await;
+        h.assert_data().await;
+    }
+
+    #[rstest]
+    #[case::load_empty_wal_id(FencedWriterFlushTestCase::new("LoadEmptyWalId", false, false))]
+    #[case::fence_manifest(FencedWriterFlushTestCase::new("FenceManifest", false, true))]
+    #[case::write_wal_fence(FencedWriterFlushTestCase::new("WriteWalFence:1", true, true))]
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn test_fence_retries_next_wal_id_when_behind_replay_boundary() {
-        // Race:
-        // - t0: W2 computes stale next_wal_id=1 while W1 is still active.
-        // - t1: W1 writes WAL 1 and WAL 2, flushes them to L0, and advances
-        //   the replay boundary to 2.
-        // - t2: WAL GC deletes WAL 2, so a future create at stale WAL 2 can
-        //   succeed, but it leaves WAL 3 because replay_after_wal_id is not
-        //   eligible for deletion.
-        // - t3: W2 claims the writer epoch from that manifest.
-        // - t4: W2 builds the DbInner needed to run fence_writers.
-        // - t5: W2 writes a fence at stale WAL 2; current code accepts it.
-        // - t6: W1 can still create live WAL 4 unless W2 retried the fence
-        //   above the replay boundary.
-        // - t7: ValidateFence should make t6 fail with Fenced.
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = "/tmp/test_fence_retries_next_wal_id_when_behind_replay_boundary";
-        let settings = test_db_options();
-        let fp_registry = Arc::new(FailPointRegistry::new());
-        let table_store = Arc::new(TableStore::new(
-            ObjectStores::new(object_store.clone(), None),
-            SsTableFormat::default(),
-            path,
-            None,
-        ));
-        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
-        let manifest_store = Arc::new(ManifestStore::new(&Path::from(path), object_store.clone()));
-        let core = ManifestCore::new();
-        let stored_manifest =
-            StoredManifest::create_new_db(manifest_store.clone(), core, system_clock.clone())
-                .await
-                .unwrap();
-        let (event_tx, mut event_rx) = tokio::sync::mpsc::unbounded_channel();
-        let fp_ctl = Arc::new(FailPointCtl::new(fp_registry.clone(), event_tx));
-        let fencer = WriterFencer::new_with_fp_ctl(
-            table_store.clone(),
-            &settings,
-            system_clock.clone(),
-            fp_ctl.clone(),
-        );
+    async fn test_fence_handles_fenced_writer_flush(#[case] case: FencedWriterFlushTestCase) {
+        let mut h =
+            WriterFencerTestHarness::new("/tmp/test_fence_handles_fenced_writer_flush").await;
+        let db = h.fenced_db().await;
 
-        // - t0: W2 computes stale next_wal_id=1 while W1 is still active.
-        fp_ctl.enable_fp("LoadEmptyWalId");
-        fail_parallel::cfg(fp_registry.clone(), "fence_event", "pause").unwrap();
+        // write a wal file
+        h.put(&db, 0, false).await;
+
+        // configure the fencer to pause
+        h.fp_ctl.enable_fp(case.event);
+        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "pause").unwrap();
+
+        // spawn WriterFencer on another task
+        let fencer = h.fencer.take().unwrap();
+        let stored_manifest = h.stored_manifest.take().unwrap();
         let jh = tokio::task::spawn(async move { fencer.fence(stored_manifest).await });
-        // wait for w2 to load empty wal id
-        event_rx.recv().await.unwrap();
+        // wait for fencer to load empty wal id and pause
+        h.event_rx.recv().await.unwrap();
 
-        // - t1: W1 writes WAL 1 and 2
-        write_wal(1, table_store.as_ref()).await.unwrap();
-        write_wal(2, table_store.as_ref()).await.unwrap();
+        // write 2 new wal files to fenced db (write with await durable twice)
+        h.put(&db, 1, case.write_fenced).await;
+        h.put(&db, 2, case.write_fenced).await;
+        // force l0 flush — advances replay_after_wal_id past the fencer's
+        // stale empty_wal_id.
+        let result = db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await;
+        let replay_after_wal_id = h
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core
+            .replay_after_wal_id;
+        if case.flush_fenced {
+            assert_eq!(
+                result.unwrap_err().kind(),
+                ErrorKind::Closed(CloseReason::Fenced)
+            );
+        } else {
+            assert!(result.is_ok());
+            assert!(replay_after_wal_id > 0);
+            // force gc to run
+            h.run_gc(replay_after_wal_id).await;
+        }
 
-        // - t2: WAL GC deletes WAL 1
-        let mut stored_manifest =
-            StoredManifest::load(manifest_store.clone(), system_clock.clone())
-                .await
-                .unwrap();
-        let mut dirty = stored_manifest.prepare_dirty().unwrap();
-        dirty.value.core.replay_after_wal_id = 2;
-        stored_manifest.update(dirty).await.unwrap();
-        delete_wal(1, table_store.as_ref()).await;
-
-        // - t3-t5: W2 reloads last wal id and writes fence wal
-        fail_parallel::cfg(fp_registry.clone(), "fence_event", "off").unwrap();
+        // unpause WriterFencer
+        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "off").unwrap();
+        // verify it returns successfully
         let result = jh.await.unwrap().unwrap();
-        assert_eq!(result.replay_range, 3u64..4u64);
+        // The fencer's stale empty_wal_id was retried above the fenced writer's possibly
+        // advanced replay_after_wal_id.
+        assert_eq!(result.replay_range.start, replay_after_wal_id + 1);
 
-        // - t6 - t7 - writing wal at 3 should fail
-        let err = write_wal(3, table_store.as_ref()).await.unwrap_err();
-        assert!(matches!(err, SlateDBError::Fenced));
-    }
-
-    async fn delete_wal(wal_id: u64, table_store: &TableStore) {
-        table_store
-            .delete_sst(&SsTableId::Wal(wal_id))
-            .await
-            .unwrap();
-    }
-
-    async fn write_wal(
-        wal_id: u64,
-        table_store: &TableStore,
-    ) -> Result<SsTableHandle, SlateDBError> {
-        let mut w1_wal = table_store.table_builder();
-        w1_wal
-            .add(RowEntry::new_value(b"w1", b"write", wal_id))
-            .await
-            .unwrap();
-        let w1_wal = w1_wal.build().await.unwrap();
-        table_store
-            .write_sst(&SsTableId::Wal(wal_id), &w1_wal, false)
-            .await
+        // verify that fenced db is fenced (new write fails)
+        use crate::error::{CloseReason, ErrorKind};
+        let err = db.put(b"k4", b"v4").await.unwrap_err();
+        assert!(
+            matches!(err.kind(), ErrorKind::Closed(CloseReason::Fenced)),
+            "expected Fenced, got {err}"
+        );
+        h.assert_fencing_wal().await;
+        h.assert_wals_contiguous().await;
+        h.assert_data().await;
     }
 
     fn test_db_options() -> Settings {
         Settings {
-            flush_interval: Some(Duration::from_millis(100)),
             #[cfg(feature = "wal_disable")]
             wal_enabled: true,
-            manifest_poll_interval: Duration::from_millis(100),
-            manifest_update_timeout: Duration::from_secs(300),
-            max_unflushed_bytes: 134_217_728,
-            l0_max_ssts: 8,
-            l0_max_ssts_per_key: 8,
-            l0_flush_parallelism: 1,
-            min_filter_keys: 0,
-            l0_sst_size_bytes: 128,
-            max_wal_flushes_before_l0_flush: 4096,
-            compression_codec: None,
-            object_store_cache_options: ObjectStoreCacheOptions::default(),
             garbage_collector_options: None,
-            default_ttl: None,
-            block_format: None,
             ..Settings::default()
         }
     }

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -6,6 +6,7 @@ use crate::Settings;
 use fail_parallel::fail_point;
 use fail_parallel::FailPointRegistry;
 use slatedb_common::SystemClock;
+use std::collections::HashSet;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -27,7 +28,7 @@ pub(crate) struct WriterFenceResult {
 struct FailPointCtl {
     fp_registry: Arc<FailPointRegistry>,
     event_tx: tokio::sync::mpsc::UnboundedSender<String>,
-    event_toggle: Mutex<String>,
+    event_toggles: Mutex<HashSet<String>>,
 }
 
 impl FailPointCtl {
@@ -38,13 +39,13 @@ impl FailPointCtl {
         Self {
             fp_registry,
             event_tx,
-            event_toggle: Mutex::new("".to_string()),
+            event_toggles: Mutex::new(HashSet::new()),
         }
     }
 
     #[cfg(test)]
     fn enable_fp(&self, event: impl ToString) {
-        *self.event_toggle.lock().unwrap() = event.to_string();
+        self.event_toggles.lock().unwrap().insert(event.to_string());
     }
 }
 
@@ -84,11 +85,11 @@ impl WriterFencer {
     fn fp_notify(&self, event: impl ToString) {
         let event = event.to_string();
         let _ = self.fp_ctl.event_tx.send(event.clone());
-        let event_toggle = String::clone(&*self.fp_ctl.event_toggle.lock().unwrap());
+        let event_toggle = HashSet::clone(&*self.fp_ctl.event_toggles.lock().unwrap());
         fail_point!(
             Arc::clone(&self.fp_ctl.fp_registry),
             "fence_event",
-            event == event_toggle,
+            event_toggle.contains(&event),
             |_| {}
         );
     }
@@ -178,6 +179,7 @@ mod tests {
     use crate::config::{
         FlushOptions, FlushType, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
     };
+    use crate::error::SlateDBError;
     use crate::fence::{FailPointCtl, WriterFencer};
     use crate::format::sst::SsTableFormat;
     use crate::garbage_collector::GarbageCollector;
@@ -427,6 +429,126 @@ mod tests {
         assert!(result.is_ok());
         h.put(&db, 2, true).await;
         h.assert_fencing_wal().await;
+        h.assert_wals_contiguous().await;
+        h.assert_data().await;
+    }
+
+    struct FencerFencedTestCase {
+        pause_event: &'static str,
+        new_db_writes: bool,
+    }
+
+    impl FencerFencedTestCase {
+        const fn new(pause_event: &'static str, new_db_writes: bool) -> Self {
+            Self {
+                pause_event,
+                new_db_writes,
+            }
+        }
+    }
+
+    #[rstest]
+    #[case::fence_manifest(FencerFencedTestCase::new("FenceManifest", false))]
+    #[case::fence_manifest_with_new_db_writes(FencerFencedTestCase::new("FenceManifest", true))]
+    #[case::reload_empty_wal_id(FencerFencedTestCase::new("ReloadEmptyWalId", false))]
+    #[case::reload_empty_wal_id_with_new_db_writes(FencerFencedTestCase::new(
+        "ReloadEmptyWalId",
+        true
+    ))]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_fencer_fenced_after_claiming_epoch(#[case] case: FencerFencedTestCase) {
+        // initialize a fenced db
+        let mut h =
+            WriterFencerTestHarness::new("/tmp/test_fencer_fenced_after_claiming_epoch").await;
+        let db = h.fenced_db().await;
+        h.put(&db, 0, false).await;
+
+        // initialize a fencer. configure it to pause at LoadEmptyWalId (so the
+        // fenced writer can race ahead) and at the case's event (so a new
+        // writer can claim the epoch out from under the fencer).
+        h.fp_ctl.enable_fp("LoadEmptyWalId");
+        h.fp_ctl.enable_fp(case.pause_event);
+        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "pause").unwrap();
+
+        let fencer = h.fencer.take().unwrap();
+        let stored_manifest = h.stored_manifest.take().unwrap();
+        let jh = tokio::task::spawn(async move { fencer.fence(stored_manifest).await });
+        // wait for LoadEmptyWalId pause
+        assert_eq!(h.event_rx.recv().await.unwrap(), "LoadEmptyWalId");
+
+        // after LoadEmptyWalId pause, have the fenced db write some wals and flush and gc.
+        // This advances replay_after_wal_id past the fencer's stale empty_wal_id, so the
+        // recompute branch (and ReloadEmptyWalId fp_notify) fires when the fencer resumes.
+        h.put(&db, 1, false).await;
+        h.put(&db, 2, false).await;
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        let replay_after_wal_id = h
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core
+            .replay_after_wal_id;
+        h.run_gc(replay_after_wal_id).await;
+
+        // resume the fencer. re-issuing "pause" wakes the current pause and
+        // keeps the action set to "pause" so the next toggled event also
+        // pauses.
+        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "pause").unwrap();
+
+        // wait for the case's pause event. fp_notify sends an event for every
+        // failpoint regardless of whether it pauses, so drain intermediate
+        // events (e.g. FenceManifest fires before ReloadEmptyWalId).
+        loop {
+            let event = h.event_rx.recv().await.unwrap();
+            if event == case.pause_event {
+                break;
+            }
+        }
+
+        // init the new db; this bumps the writer epoch, fencing our paused fencer
+        let db2 = h.db().await;
+        if case.new_db_writes {
+            // optionally let the new db write wals, flush, and gc — exercises the
+            // case where wals below the fencer's stale empty_wal_id get cleaned up
+            // while it is paused.
+            h.put(&db2, 3, false).await;
+            h.put(&db2, 4, false).await;
+            db2.flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+            let replay_after_wal_id = h
+                .manifest_store
+                .read_latest_manifest()
+                .await
+                .unwrap()
+                .manifest
+                .core
+                .replay_after_wal_id;
+            h.run_gc(replay_after_wal_id).await;
+        }
+
+        // resume the fencer
+        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "off").unwrap();
+
+        // validate that its fenced — the fencer's manifest.refresh sees the new db's
+        // bumped epoch and returns Fenced.
+        let result = jh.await.unwrap();
+        assert!(
+            matches!(result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            result.map(|_| ())
+        );
+        db2.close().await.unwrap();
+
+        // validate that the wal is contiguous and db has all data
         h.assert_wals_contiguous().await;
         h.assert_data().await;
     }

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -161,13 +161,6 @@ impl DbInner {
         Ok(handle)
     }
 
-    /// Write a zero-byte WAL object at `wal_id` as a fencing barrier. The
-    /// object-storage put-if-absent at this slot is what fences in-flight
-    /// WAL writes from older-epoch writers — see [`Self::fence_writers`].
-    pub(crate) async fn flush_empty_wal(&self, wal_id: u64) -> Result<(), SlateDBError> {
-        self.table_store.write_wal_fence(wal_id).await
-    }
-
     /// Test helper: build L0 SSTs from `imm_table` via the segment-aware
     /// path ([`Self::build_imm_ssts`]) and upload each one with a freshly
     /// allocated [`db_state::SsTableId::Compacted`]. Returns the resulting

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -163,6 +163,7 @@ mod transaction_manager;
 mod types;
 mod utils;
 
+mod fence;
 mod wal;
 mod wal_buffer;
 mod wal_id;

--- a/slatedb/src/memtable_flusher/mod.rs
+++ b/slatedb/src/memtable_flusher/mod.rs
@@ -11,6 +11,8 @@ mod tracker;
 mod uploader;
 
 pub(crate) use manifest_writer::FlushResult;
+#[cfg(test)]
+pub(crate) use tracker::MANIFEST_REFRESH_COUNT;
 
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use log::debug;
+use slatedb_common::metrics::{CounterFn, MetricsRecorderHelper};
 
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
@@ -29,6 +30,42 @@ use fail_parallel::fail_point;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use tokio::sync::oneshot;
+
+macro_rules! memtable_flush_stat_name {
+    ($suffix:expr) => {
+        concat!("slatedb.memtable_flush.", $suffix)
+    };
+}
+
+pub(crate) const MEMTABLE_FREEZE_COUNT: &str = memtable_flush_stat_name!("memtable_freeze_count");
+pub(crate) const CHECKPOINT_REQUEST_COUNT: &str =
+    memtable_flush_stat_name!("checkpoint_request_count");
+pub(crate) const FLUSH_REQUEST_COUNT: &str = memtable_flush_stat_name!("flush_request_count");
+pub(crate) const L0_UPLOAD_COUNT: &str = memtable_flush_stat_name!("l0_upload_count");
+pub(crate) const L0_FLUSH_COUNT: &str = memtable_flush_stat_name!("l0_flush_count");
+pub(crate) const MANIFEST_REFRESH_COUNT: &str = memtable_flush_stat_name!("manifest_refresh_count");
+
+pub(crate) struct FlushTrackerStats {
+    pub(crate) memtable_freeze_count: Arc<dyn CounterFn>,
+    pub(crate) checkpoint_request_count: Arc<dyn CounterFn>,
+    pub(crate) flush_request_count: Arc<dyn CounterFn>,
+    pub(crate) l0_upload_count: Arc<dyn CounterFn>,
+    pub(crate) l0_flush_count: Arc<dyn CounterFn>,
+    pub(crate) manifest_refresh_count: Arc<dyn CounterFn>,
+}
+
+impl FlushTrackerStats {
+    pub(crate) fn new(recorder: &MetricsRecorderHelper) -> Self {
+        Self {
+            memtable_freeze_count: recorder.counter(MEMTABLE_FREEZE_COUNT).register(),
+            checkpoint_request_count: recorder.counter(CHECKPOINT_REQUEST_COUNT).register(),
+            flush_request_count: recorder.counter(FLUSH_REQUEST_COUNT).register(),
+            l0_upload_count: recorder.counter(L0_UPLOAD_COUNT).register(),
+            l0_flush_count: recorder.counter(L0_FLUSH_COUNT).register(),
+            manifest_refresh_count: recorder.counter(MANIFEST_REFRESH_COUNT).register(),
+        }
+    }
+}
 
 /// Unified message type for the flush tracker's event loop.
 pub(crate) enum TrackerMessage {
@@ -84,6 +121,7 @@ pub(super) struct FlushTracker {
     uploader: Uploader,
     manifest_writer: ManifestWriter,
     frontier: TrackedImmFrontier,
+    stats: FlushTrackerStats,
 }
 
 impl FlushTracker {
@@ -92,11 +130,13 @@ impl FlushTracker {
         uploader: Uploader,
         manifest_writer: ManifestWriter,
     ) -> Self {
+        let stats = FlushTrackerStats::new(&inner.recorder);
         Self {
             inner,
             uploader,
             manifest_writer,
             frontier: TrackedImmFrontier::new(),
+            stats,
         }
     }
 }
@@ -105,8 +145,12 @@ impl FlushTracker {
 impl MessageHandler<TrackerMessage> for FlushTracker {
     async fn handle(&mut self, message: TrackerMessage) -> Result<(), SlateDBError> {
         match message {
-            TrackerMessage::MemtableFrozen => self.reconcile_and_dispatch().await,
+            TrackerMessage::MemtableFrozen => {
+                self.stats.memtable_freeze_count.increment(1);
+                self.reconcile_and_dispatch().await
+            }
             TrackerMessage::FlushRequest { target, sender } => {
+                self.stats.flush_request_count.increment(1);
                 self.handle_flush_request(target, sender).await
             }
             TrackerMessage::CheckpointRequest {
@@ -114,15 +158,23 @@ impl MessageHandler<TrackerMessage> for FlushTracker {
                 options,
                 sender,
             } => {
+                self.stats.checkpoint_request_count.increment(1);
                 self.handle_checkpoint_request(target, options, sender)
                     .await
             }
-            TrackerMessage::UploadComplete(uploaded) => self.handle_uploaded(uploaded).await,
+            TrackerMessage::UploadComplete(uploaded) => {
+                self.stats.l0_upload_count.increment(1);
+                self.handle_uploaded(uploaded).await
+            }
             TrackerMessage::FlushComplete { through_seq } => {
+                self.stats.l0_flush_count.increment(1);
                 self.frontier.retire_through(through_seq);
                 self.reconcile_and_dispatch().await
             }
-            TrackerMessage::ManifestRefreshed => self.reconcile_and_dispatch().await,
+            TrackerMessage::ManifestRefreshed => {
+                self.stats.manifest_refresh_count.increment(1);
+                self.reconcile_and_dispatch().await
+            }
             TrackerMessage::PollManifest { sender } => self.manifest_writer.send_poll(sender),
         }
     }

--- a/website/src/content/docs/docs/operations/metrics.mdx
+++ b/website/src/content/docs/docs/operations/metrics.mdx
@@ -117,6 +117,17 @@ All metric names use dot-separated notation: `slatedb.<subsystem>.<metric>`.
 | `slatedb.gc.deleted_count` | counter | `resource`: manifest, wal, compacted, compactions | Deleted resources |
 | `slatedb.gc.count` | counter | | GC runs |
 
+### Memtable flush (`slatedb.memtable_flush.*`)
+
+| Name | Type | Labels | Description |
+|------|------|--------|-------------|
+| `slatedb.memtable_flush.memtable_freeze_count` | counter | | Frozen memtables |
+| `slatedb.memtable_flush.checkpoint_request_count` | counter | | Checkpoint requests |
+| `slatedb.memtable_flush.flush_request_count` | counter | | Flush requests |
+| `slatedb.memtable_flush.l0_upload_count` | counter | | Completed L0 uploads |
+| `slatedb.memtable_flush.l0_flush_count` | counter | | Completed L0 flushes |
+| `slatedb.memtable_flush.manifest_refresh_count` | counter | | Manifest refreshes |
+
 ### Object store (`slatedb.object_store.*`)
 
 All object store metrics carry four labels:


### PR DESCRIPTION
## Summary

This patch makes 2 changes:

First, it changes the fencing logic to only probe for the fencing wal id once when initially fencing the
manifest. This check works by first probing, then fencing the manifest. Then, if the fenced manifest
indicates the GC boundary was moved by the old writer, the fencing logic re-probes the fencing wal id.

Second, it moves the whole fencing protocol to a new module called fence:
    - Adds `WriterFencer` which actually executes the fencing logic. This includes both writing the new epoch to the manifest and writing the fencing wal.
    - `WriterFencer` returns a result that includes both the fenced manifest and the replay range.
    - `WriterFencer` emits events and executes fail points as it moves through the protocol. These can be used by tests to inject pauses to help testing.

## Notes for Reviewers

This PR has 2 commits. The first commit fixes the bug in the fencing protocol caused by re-resolving the next_wal_id if the writer detects the boundary moved. The second commit moves the fencing logic to its own module.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
