### PR TITLE
Track the entire scanned range in `DbIteratorRangeTracker` to fix some phantom reads and write skew

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -251,7 +251,6 @@ impl DbInner {
                     db_state: &db_state,
                     write_batch_iter: None,
                     max_seq: None,
-                    range_tracker: None,
                     prefix: None,
                 },
             )
@@ -274,7 +273,6 @@ impl DbInner {
                     db_state: &db_state,
                     write_batch_iter: None,
                     max_seq: None,
-                    range_tracker: None,
                     prefix: Some(prefix),
                 },
             )

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -13,82 +13,35 @@ use crate::types::{KeyValue, RowEntry, ValueDeletable};
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::ops::RangeBounds;
-use std::sync::Arc;
 
-/// [`DbIteratorRangeTracker'] is used to track the range of keys accessed by a [`DbIterator`].  For
-/// Serializable Snapshot Isolation, we need to track the read keys during the transaction to detect
-/// read-write conflicts with recent committed transactions.
+/// [`DbIteratorRangeTracker`] records the *requested* scan range of a
+/// [`DbIterator`] so that the transaction manager can detect read-write
+/// conflicts under Serializable Snapshot Isolation.
 ///
-/// A naive implementation is to maintain a set of read keys, but this may suffers phantom read conflicts.
-/// For example, if transaction A reads a range `["key01", "key10"]` and transaction B writes to `"key05"`
-/// which falls within that range, we cannot detect this conflict and abort one of the transactions to
-/// maintain serializability.
+/// The tracker holds the range the caller asked to scan — not the bounding
+/// box of keys the iterator happened to yield. Tracking the requested range
+/// is required for correctness: an empty scan still establishes a read
+/// dependency on every key in that range (and a concurrent insert anywhere
+/// inside it is a phantom), and a partial scan or a scan whose tombstones
+/// were skipped likewise depends on the whole requested range.
 ///
-/// To mitigate this, we could use a range tracker to track the range of keys accessed by the iterator,
-/// and check if the write key falls within the range.
-///
-/// A [`DbIteratorRangeTracker`] can be passed to [`DbIterator`] optionally. If it's passed, you can retrieve
-/// the range of keys scanned by [`DbIterator`] from it.
+/// Early termination via [`DbIterator::seek`] does not narrow the registered
+/// range: the transaction has already taken a logical read dependency on the
+/// whole requested range when the scan was issued.
 #[derive(Debug)]
 pub(crate) struct DbIteratorRangeTracker {
-    inner: Mutex<DbIteratorRangeTrackerInner>,
-}
-
-#[derive(Debug)]
-struct DbIteratorRangeTrackerInner {
-    first_key: Option<Bytes>,
-    last_key: Option<Bytes>,
-    has_data: bool,
+    requested_range: BytesRange,
 }
 
 impl DbIteratorRangeTracker {
-    pub(crate) fn new() -> Self {
-        Self {
-            inner: Mutex::new(DbIteratorRangeTrackerInner {
-                first_key: None,
-                last_key: None,
-                has_data: false,
-            }),
-        }
+    pub(crate) fn new(requested_range: BytesRange) -> Self {
+        Self { requested_range }
     }
 
-    fn track_key(&self, key: &Bytes) {
-        let mut inner = self.inner.lock();
-
-        inner.first_key = Some(match &inner.first_key {
-            Some(first) if key < first => key.clone(),
-            Some(first) => first.clone(),
-            None => key.clone(),
-        });
-
-        inner.last_key = Some(match &inner.last_key {
-            Some(last) if key > last => key.clone(),
-            Some(last) => last.clone(),
-            None => key.clone(),
-        });
-
-        inner.has_data = true;
-    }
-
-    pub(crate) fn get_range(&self) -> Option<BytesRange> {
-        let inner = self.inner.lock();
-        match (&inner.first_key, &inner.last_key) {
-            (Some(first), Some(last)) => {
-                use std::ops::Bound;
-                Some(BytesRange::from((
-                    Bound::Included(first.clone()),
-                    Bound::Included(last.clone()),
-                )))
-            }
-            _ => None,
-        }
-    }
-
-    pub(crate) fn has_data(&self) -> bool {
-        self.inner.lock().has_data
+    pub(crate) fn get_range(&self) -> BytesRange {
+        self.requested_range.clone()
     }
 }
 
@@ -230,7 +183,6 @@ pub struct DbIterator {
     iter: Box<dyn RowEntryIterator + 'static>,
     invalidated_error: Option<SlateDBError>,
     last_key: Option<Bytes>,
-    range_tracker: Option<Arc<DbIteratorRangeTracker>>,
 }
 
 impl DbIterator {
@@ -240,7 +192,6 @@ impl DbIterator {
         mem_iters: impl IntoIterator<Item = Box<dyn RowEntryIterator + 'static>>,
         segment_iter: Box<dyn RowEntryIterator + 'static>,
         max_seq: Option<u64>,
-        range_tracker: Option<Arc<DbIteratorRangeTracker>>,
         merge_operator: Option<MergeOperatorType>,
         order: IterationOrder,
     ) -> Result<Self, SlateDBError> {
@@ -302,7 +253,6 @@ impl DbIterator {
             iter,
             invalidated_error: None,
             last_key: None,
-            range_tracker,
         })
     }
 
@@ -346,10 +296,6 @@ impl DbIterator {
             let result = self.maybe_invalidate(result);
             if let Ok(Some(ref entry)) = result {
                 self.last_key = Some(entry.key.clone());
-                // Track the key in range tracker if present
-                if let Some(tracker) = &self.range_tracker {
-                    tracker.track_key(&entry.key);
-                }
             }
             result
         }
@@ -512,7 +458,6 @@ mod tests {
             Box::new(EmptyIterator::new()),
             None,
             None,
-            None,
             IterationOrder::Ascending,
         )
         .await
@@ -553,7 +498,6 @@ mod tests {
             Box::new(EmptyIterator::new()),
             Some(100),
             None,
-            None,
             IterationOrder::Ascending,
         )
         .await
@@ -582,7 +526,6 @@ mod tests {
             None,
             vec![Box::new(mem_iter) as Box<dyn RowEntryIterator + 'static>],
             Box::new(EmptyIterator::new()),
-            None,
             None,
             None,
             IterationOrder::Ascending,
@@ -631,7 +574,6 @@ mod tests {
             Some(wb_iter),
             mem_iters,
             Box::new(EmptyIterator::new()),
-            None,
             None,
             None,
             IterationOrder::Ascending,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -237,7 +237,6 @@ impl DbReaderInner {
                     db_state: db_state.as_ref(),
                     write_batch_iter: None,
                     max_seq: None,
-                    range_tracker: None,
                     prefix,
                 },
             )

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -187,7 +187,6 @@ impl DbSnapshot {
                     db_state: &db_state,
                     write_batch_iter: None,
                     max_seq: Some(self.started_seq),
-                    range_tracker: None,
                     prefix,
                 },
             )

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -68,7 +68,7 @@ pub struct DbTransaction {
     /// Isolation level for this transaction
     isolation_level: IsolationLevel,
     /// Range trackers for scanned ranges (used for SSI conflict detection)
-    range_trackers: Mutex<Vec<Arc<DbIteratorRangeTracker>>>,
+    range_trackers: Mutex<Vec<DbIteratorRangeTracker>>,
     /// Keys that should be excluded from write conflict detection when committing.
     untracked_write_keys: RwLock<HashSet<Bytes>>,
 }
@@ -272,14 +272,16 @@ impl DbTransaction {
         options: &ScanOptions,
         prefix: Option<Bytes>,
     ) -> Result<DbIterator, crate::Error> {
-        // Track read range for SSI conflict detection if needed
-        let range_tracker = if self.isolation_level == IsolationLevel::SerializableSnapshot {
-            let tracker = Arc::new(DbIteratorRangeTracker::new());
-            self.range_trackers.lock().push(tracker.clone());
-            Some(tracker)
-        } else {
-            None
-        };
+        // Under SSI, register the *requested* scan range with the transaction
+        // so that any concurrent write inside it is detected as an
+        // rw-anti-dependency at commit time — including writes to portions of
+        // the range that the iterator never yielded (empty scans, partial
+        // scans, scans whose tombstones were skipped). See
+        // `DbIteratorRangeTracker` for the rationale.
+        if self.isolation_level == IsolationLevel::SerializableSnapshot {
+            let tracker = DbIteratorRangeTracker::new(range.clone());
+            self.range_trackers.lock().push(tracker);
+        }
 
         self.db_inner.check_closed()?;
         let db_state = self.db_inner.state.read().view();
@@ -305,7 +307,6 @@ impl DbTransaction {
                     db_state: &db_state,
                     write_batch_iter,
                     max_seq: Some(self.started_seq),
-                    range_tracker,
                     prefix,
                 },
             )
@@ -543,14 +544,14 @@ impl DbTransaction {
         // Take the write_batch for submission to the database.
         let write_batch = self.write_batch.read().clone();
 
-        // Extract actual scanned ranges from trackers for SSI conflict detection
+        // Materialize the SSI read-range dependencies the transaction
+        // accumulated during scans. Each tracker carries the requested scan
+        // range; the conflict check in `TransactionManager` will then catch
+        // any committed write whose key falls inside it.
         if self.isolation_level == IsolationLevel::SerializableSnapshot {
             for tracker in self.range_trackers.lock().iter() {
-                if tracker.has_data() {
-                    if let Some(range) = tracker.get_range() {
-                        self.txn_manager.track_read_range(&self.txn_id, range);
-                    }
-                }
+                self.txn_manager
+                    .track_read_range(&self.txn_id, tracker.get_range());
             }
         }
 

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -946,6 +946,159 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Two SSI transactions each scan a disjoint range that is empty at the
+    /// snapshot, then each writes a key inside the *other* transaction's
+    /// scanned range. Under a correct SSI implementation exactly one of the
+    /// two must abort: the requested-but-empty scan ranges create
+    /// rw-anti-dependencies in both directions, and no serial order is
+    /// consistent with both reads. Regression: previously the range tracker
+    /// only recorded yielded keys, so an empty scan registered no range and
+    /// both txns committed (write skew).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_txn_ssi_write_skew_via_empty_scans() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::open("test_db", object_store).await.unwrap();
+
+        // Seed a key well outside both scan ranges so neither scan sees it.
+        db.put(b"~outside_both_ranges", b"v").await.unwrap();
+        db.flush().await.unwrap();
+
+        let txn1 = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+        let txn2 = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+
+        // T1 scans [a..m); empty.
+        {
+            let mut iter = txn1.scan(&b"a"[..]..&b"m"[..]).await.unwrap();
+            assert!(iter.next().await.unwrap().is_none(), "[a..m) is empty");
+        }
+        // T2 scans [n..z); empty.
+        {
+            let mut iter = txn2.scan(&b"n"[..]..&b"z"[..]).await.unwrap();
+            assert!(iter.next().await.unwrap().is_none(), "[n..z) is empty");
+        }
+
+        // Each writes into the other's scan range.
+        txn1.put(b"x_from_t1", b"v1").unwrap();
+        txn2.put(b"b_from_t2", b"v2").unwrap();
+
+        let r1 = txn1.commit().await;
+        let r2 = txn2.commit().await;
+
+        // Exactly one of the two must be rejected as a TransactionConflict.
+        assert!(
+            r1.is_ok() ^ r2.is_ok(),
+            "expected exactly one commit to abort, got r1={r1:?}, r2={r2:?}",
+        );
+    }
+
+    /// A scan over a wide range that yields a single key in the middle still
+    /// observes the entire requested range, so a concurrent write into the
+    /// unobserved portion is a phantom. Regression: previously the tracker
+    /// only recorded `[yielded_first, yielded_last]`, so a write outside that
+    /// bounding box but inside the requested range was missed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_txn_ssi_phantom_outside_yielded_bbox() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::open("test_db", object_store).await.unwrap();
+
+        db.put(b"k_mid", b"seed").await.unwrap();
+        db.flush().await.unwrap();
+
+        let txn1 = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+
+        // Scan [k_aaa..k_zzz); only k_mid is in range, so the yielded bbox
+        // collapses to (k_mid, k_mid) under the old tracker.
+        {
+            let mut iter = txn1.scan(&b"k_aaa"[..]..&b"k_zzz"[..]).await.unwrap();
+            let kv = iter.next().await.unwrap().expect("k_mid present");
+            assert_eq!(kv.key.as_ref(), b"k_mid");
+            assert!(iter.next().await.unwrap().is_none(), "only k_mid in range");
+        }
+
+        // Concurrent non-txn writer inserts a key inside T1's requested range
+        // but outside the yielded bbox.
+        db.put(b"k_aaa_inserted", b"phantom").await.unwrap();
+
+        // T1 makes a write so commit triggers SSI conflict checks.
+        txn1.put(b"t1_marker", b"x").unwrap();
+        assert!(txn1.commit().await.is_err());
+    }
+
+    /// A tombstone that sits inside a scan's requested range causes
+    /// `DbIterator::next_entry` to skip the key, so the caller sees an
+    /// "absent" observation. A concurrent resurrect of that key is therefore
+    /// a phantom. Regression: the old tracker only saw yielded keys, so
+    /// tombstone-only ranges registered no read dependency at all.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_txn_ssi_tombstone_resurrection_in_scan_range() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::open("test_db", object_store).await.unwrap();
+
+        db.put(b"k_deleted", b"v_orig").await.unwrap();
+        db.flush().await.unwrap();
+        db.delete(b"k_deleted").await.unwrap();
+        db.flush().await.unwrap();
+
+        let txn1 = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+
+        {
+            let mut iter = txn1.scan(&b"k_a"[..]..&b"k_z"[..]).await.unwrap();
+            assert!(
+                iter.next().await.unwrap().is_none(),
+                "tombstone in range should make scan appear empty to caller",
+            );
+        }
+
+        // Concurrent (non-txn) writer resurrects the exact key T1 observed
+        // as absent.
+        db.put(b"k_deleted", b"resurrected").await.unwrap();
+
+        txn1.put(b"t1_marker", b"x").unwrap();
+        assert!(txn1.commit().await.is_err());
+    }
+
+    /// `scan_prefix` shares the same range-tracking machinery as `scan`, so
+    /// the empty-prefix-scan blind spot is the same anomaly: a "first
+    /// writer" gate based on an empty prefix scan must abort when another
+    /// writer races in. Regression: previously an empty prefix scan tracked
+    /// no range and both writers committed.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_txn_ssi_empty_scan_prefix_detects_concurrent_insert() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::open("test_db", object_store).await.unwrap();
+
+        db.put(b"sentinel", b"x").await.unwrap();
+        db.flush().await.unwrap();
+
+        let txn1 = db
+            .begin(IsolationLevel::SerializableSnapshot)
+            .await
+            .unwrap();
+
+        {
+            let mut iter = txn1.scan_prefix(b"users/").await.unwrap();
+            assert!(iter.next().await.unwrap().is_none(), "no users yet");
+        }
+
+        // Concurrent writer races T1 and creates the first user.
+        db.put(b"users/alice", b"first").await.unwrap();
+
+        txn1.put(b"users/bob", b"second").unwrap();
+        assert!(txn1.commit().await.is_err());
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn test_txn_commit_await_durable_false() {
         use crate::config::{DurabilityLevel::*, ReadOptions, WriteOptions};

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -14,7 +14,7 @@ use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::types::KeyValue;
-use crate::{db_iter::DbIteratorRangeTracker, error::SlateDBError, DbIterator};
+use crate::{error::SlateDBError, DbIterator};
 
 use bytes::Bytes;
 use std::collections::VecDeque;
@@ -51,10 +51,6 @@ pub(crate) struct ScanContext<'a> {
     /// with a greater sequence number are filtered out by the iterator
     /// construction. Used by snapshots and transactions.
     pub(crate) max_seq: Option<u64>,
-    /// Optional tracker that records the scanned range for SSI conflict
-    /// detection. Populated only for transactions running at the
-    /// serializable-snapshot isolation level.
-    pub(crate) range_tracker: Option<Arc<DbIteratorRangeTracker>>,
     /// Optional scan prefix forwarded to per-SST filter evaluation. When set,
     /// filters are probed with a prefix query so SSTs that do not contain the
     /// prefix can be skipped.
@@ -238,7 +234,6 @@ impl Reader {
             mem_iters,
             segment_iter,
             max_seq,
-            None,
             self.read_merge_operator.clone(),
             sst_iter_options.order,
         )
@@ -311,7 +306,6 @@ impl Reader {
             mem_iters,
             segment_iter,
             max_seq,
-            ctx.range_tracker,
             self.read_merge_operator.clone(),
             options.order,
         )
@@ -1733,7 +1727,6 @@ mod tests {
                     db_state: &test_db_state,
                     write_batch_iter: wb_iter,
                     max_seq: test_case.max_seq,
-                    range_tracker: None,
                     prefix: None,
                 },
             )
@@ -1863,7 +1856,6 @@ mod tests {
                     db_state: &test_db_state,
                     write_batch_iter: wb_iter,
                     max_seq: None,
-                    range_tracker: None,
                     prefix: None,
                 },
             )
@@ -2036,7 +2028,6 @@ mod tests {
                     db_state: &test_db_state,
                     write_batch_iter: wb_iter,
                     max_seq: None,
-                    range_tracker: None,
                     prefix: None,
                 },
             )


### PR DESCRIPTION
## Summary

In serializable snapshot isolation mode, ranges of scans need to be tracked so that conflicts in the ranges can be detected, and transactions can be aborted. However, with the current implementation, only yielded rows are checked, and not the entire scanned range.

This means that ranges without data, or ranges containing tombstones may be vulnerable to write skew or phantom reads - as the range tracker won't consider those entries.

The easiest way to conceptualize this will also go in a bug report, but in `test_txn_ssi_write_skew_via_empty_scans` we see that two transactions can write to each other's ranges (which are empty) and both can succeed. But that means that a read showed up later in one of the transactions and it was allowed to commit.

Another risk is for tombstones, as tombstones aren't yielded to the range tracker. In `test_txn_ssi_tombstone_resurrection_in_scan_range` we see that a tombstone can be resurrected during a transaction, and it is allowed to commit.

Fixes https://github.com/slatedb/slatedb/issues/1711

## Changes

To fix this, I think the `DbIteratorRangeTracker` should be simplified to track the requested range, and not the yielded rows. Since it is being dropped from other callers, I also dropped the `Arc<>`.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
