### PR TITLE
chore: bump object_store and remove `S3ConditionalPut`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ log = "0.4.27"
 lru = "0.18"
 lz4_flex = "0.11.5"
 moka = "0.12.8"
-object_store = "0.13.1"
+object_store = "0.13.2"
 object_store_opendal = "0.56.0"
 opendal = { version = "0.56.0", default-features = false }
 ouroboros = "0.18"

--- a/examples/src/s3_compatible.rs
+++ b/examples/src/s3_compatible.rs
@@ -1,4 +1,3 @@
-use object_store::aws::S3ConditionalPut;
 use slatedb::Db;
 use std::sync::Arc;
 
@@ -13,7 +12,6 @@ async fn main() -> anyhow::Result<()> {
             .with_secret_access_key("test")
             .with_bucket_name("slatedb")
             .with_region("us-east-1")
-            .with_conditional_put(S3ConditionalPut::ETagMatch)
             .build()?,
     );
 

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -717,10 +717,7 @@ pub fn load_memory() -> Result<Arc<dyn ObjectStore>, crate::Error> {
 /// <https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.with_config>
 #[cfg(feature = "aws")]
 pub fn load_aws() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    use object_store::aws::S3ConditionalPut;
-
-    let builder = object_store::aws::AmazonS3Builder::from_env()
-        .with_conditional_put(S3ConditionalPut::ETagMatch);
+    let builder = object_store::aws::AmazonS3Builder::from_env();
 
     Ok(Arc::new(builder.build().map_err(|error| {
         SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {


### PR DESCRIPTION
## Summary

Bump `object_store` from 0.13.1 to 0.13.2 and drop the now-redundant `.with_conditional_put(S3ConditionalPut::ETagMatch)` call from `AmazonS3Builder` configuration. Starting in `object_store` 0.13.x, `S3ConditionalPut::ETagMatch` is the default value of the `conditional_put` setting on `AmazonS3Builder`, so the explicit opt-in we carried since the days when the default was `Disabled` is now dead code.

Upstream references:

- [`AmazonS3Builder::with_conditional_put`](https://docs.rs/object_store/0.13.2/object_store/aws/struct.AmazonS3Builder.html#method.with_conditional_put):
  > Configure how to provide conditional put operations.
  > if not set, the default value will be `S3ConditionalPut::ETagMatch`
- [`S3ConditionalPut`](https://docs.rs/object_store/0.13.2/object_store/aws/enum.S3ConditionalPut.html):
  the `ETagMatch` variant is annotated `#[default]` in the source
  (`object_store-0.13.2/src/aws/precondition.rs:117-128`).

## Changes

- `Cargo.toml`: pin `object_store = "0.13.2"`.
- `slatedb/src/admin.rs::load_aws`: remove the `use object_store::aws::S3ConditionalPut;` import and the `.with_conditional_put(S3ConditionalPut::ETagMatch)` call (4 LOC).
- `examples/src/s3_compatible.rs`: same cleanup applied to the LocalStack example.

## Notes for Reviewers
None

## Checklist
- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally (`cargo check --all-features --all-targets` and `cargo test --all-features --all-targets` both clean; 1759 unit tests pass)
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes (none — behavior preserved)
- [x] Considered performance impact; added notes or benchmarks if relevant (no perf change; pure dead-code removal)

Thank you for the review! 🙏
