### PR TITLE
Use `debug!` for compactor capacity exceeded logs

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1015,7 +1015,7 @@ impl CompactorEventHandler {
             if !compaction.spec().is_drain() {
                 let running_compaction_count = self.running_compaction_count();
                 if running_compaction_count >= self.options.max_concurrent_compactions {
-                    info!(
+                    debug!(
                         "skipping compaction since capacity is exceeded [running_compactions={}, max_concurrent_compactions={}, compaction={:?}]",
                         running_compaction_count,
                         self.options.max_concurrent_compactions,


### PR DESCRIPTION
## Summary

If users adjust `max_concurrent_compactions` downward (say, from 4 to 2), and restart, they will see a flood of:

```
skipping compaction since capacity is exceeded...
```

Messages. This is because the existing .compactions file might already contain > 2 submitted compactions (including those that were `Running`, but got reset on restart). This eventually quiets down as the compactor works its way through the backlog, but it's a little distracting/confusing to users.

## Changes

- Drop `info` to `debug` logging

## Notes for Reviewers

https://discord.com/channels/1232385660460204122/1508157793050558677
