### PR TITLE
Decode blocks concurrently in read_blocks

### DIFF
--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -13,6 +13,7 @@ use crate::sst_stats::{BlockStats, SstStats};
 use async_trait::async_trait;
 use bytes::{Buf, BufMut, Bytes};
 use flatbuffers::DefaultAllocator;
+use futures::future::try_join_all;
 use log::warn;
 use std::collections::VecDeque;
 #[cfg(feature = "zlib")]
@@ -929,28 +930,30 @@ impl SsTableFormat {
         let range = self.block_range(blocks.clone(), info, &index);
         let start_range = range.start;
         let bytes: Bytes = obj.read_range(range).await?;
-        let mut decoded_blocks = VecDeque::new();
         let compression_codec = info.compression_codec;
-        for block in blocks {
-            let block_meta = index.block_meta().get(block);
-            let block_bytes_start = usize::try_from(block_meta.offset() - start_range).expect(
-                "attempted to read byte data with size \
-                larger than 32 bits on a 32-bit system",
-            );
-            let block_bytes = if block == index.block_meta().len() - 1 {
-                bytes.slice(block_bytes_start..)
-            } else {
-                let next_block_meta = index.block_meta().get(block + 1);
-                let block_bytes_end = usize::try_from(next_block_meta.offset() - start_range)
-                    .expect(
-                        "attempted to read byte data with size \
+        let decode_futures: Vec<_> = blocks
+            .map(|block| {
+                let block_meta = index.block_meta().get(block);
+                let block_bytes_start = usize::try_from(block_meta.offset() - start_range).expect(
+                    "attempted to read byte data with size \
                         larger than 32 bits on a 32-bit system",
-                    );
-                bytes.slice(block_bytes_start..block_bytes_end)
-            };
-            decoded_blocks.push_back(self.decode_block(block_bytes, compression_codec).await?);
-        }
-        Ok(decoded_blocks)
+                );
+                let block_bytes = if block == index.block_meta().len() - 1 {
+                    bytes.slice(block_bytes_start..)
+                } else {
+                    let next_block_meta = index.block_meta().get(block + 1);
+                    let block_bytes_end = usize::try_from(next_block_meta.offset() - start_range)
+                        .expect(
+                            "attempted to read byte data with size \
+                            larger than 32 bits on a 32-bit system",
+                        );
+                    bytes.slice(block_bytes_start..block_bytes_end)
+                };
+                self.decode_block(block_bytes, compression_codec)
+            })
+            .collect();
+        let decoded_blocks = try_join_all(decode_futures).await?;
+        Ok(VecDeque::from(decoded_blocks))
     }
 
     async fn decode_block(


### PR DESCRIPTION
## Summary

`BlockTransformer::decode` is async to allow implementations that offload CPU-heavy work (encryption, compression) via spawn_blocking. However, read_blocks was awaiting each decode sequentially in a loop, serializing up to 256 decode calls per batch.

Use `try_join_all` so all decode futures in a batch run concurrently. This lets spawn_blocking-based transformers saturate the blocking thread pool and significantly improves compaction throughput when a `BlockTransformer` is configured.

## Changes

- Use `try_join_all` so all decode futures in a batch run concurrently.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
