### PR TITLE
Fix Go callback crash on empty metric descriptions

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -1321,7 +1321,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_counter()
 		})
-		if checksum != 51600 {
+		if checksum != 33496 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_counter: UniFFI API checksum mismatch")
 		}
@@ -1330,7 +1330,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_gauge()
 		})
-		if checksum != 34281 {
+		if checksum != 11200 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_gauge: UniFFI API checksum mismatch")
 		}
@@ -1339,7 +1339,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_histogram()
 		})
-		if checksum != 4383 {
+		if checksum != 43433 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_histogram: UniFFI API checksum mismatch")
 		}
@@ -1348,7 +1348,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_up_down_counter()
 		})
-		if checksum != 19270 {
+		if checksum != 23894 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_defaultmetricsrecorder_register_up_down_counter: UniFFI API checksum mismatch")
 		}
@@ -1384,7 +1384,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_counter()
 		})
-		if checksum != 40366 {
+		if checksum != 39547 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_counter: UniFFI API checksum mismatch")
 		}
@@ -1393,7 +1393,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_gauge()
 		})
-		if checksum != 30425 {
+		if checksum != 50645 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_gauge: UniFFI API checksum mismatch")
 		}
@@ -1402,7 +1402,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_up_down_counter()
 		})
-		if checksum != 64639 {
+		if checksum != 5890 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_up_down_counter: UniFFI API checksum mismatch")
 		}
@@ -1411,7 +1411,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_histogram()
 		})
-		if checksum != 26503 {
+		if checksum != 20670 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_metricsrecorder_register_histogram: UniFFI API checksum mismatch")
 		}
@@ -5975,10 +5975,10 @@ type DefaultMetricsRecorderInterface interface {
 	MetricByNameAndLabels(name string, labels []MetricLabel) *Metric
 	// Returns every metric with the requested name.
 	MetricsByName(name string) []Metric
-	RegisterCounter(name string, description string, labels []MetricLabel) Counter
-	RegisterGauge(name string, description string, labels []MetricLabel) Gauge
-	RegisterHistogram(name string, description string, labels []MetricLabel, boundaries []float64) Histogram
-	RegisterUpDownCounter(name string, description string, labels []MetricLabel) UpDownCounter
+	RegisterCounter(name string, description *string, labels []MetricLabel) Counter
+	RegisterGauge(name string, description *string, labels []MetricLabel) Gauge
+	RegisterHistogram(name string, description *string, labels []MetricLabel, boundaries []float64) Histogram
+	RegisterUpDownCounter(name string, description *string, labels []MetricLabel) UpDownCounter
 	// Returns a point-in-time snapshot of every registered metric.
 	Snapshot() []Metric
 }
@@ -6019,39 +6019,39 @@ func (_self *DefaultMetricsRecorder) MetricsByName(name string) []Metric {
 	}))
 }
 
-func (_self *DefaultMetricsRecorder) RegisterCounter(name string, description string, labels []MetricLabel) Counter {
+func (_self *DefaultMetricsRecorder) RegisterCounter(name string, description *string, labels []MetricLabel) Counter {
 	_pointer := _self.ffiObject.incrementPointer("*DefaultMetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterCounterINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_defaultmetricsrecorder_register_counter(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
 	}))
 }
 
-func (_self *DefaultMetricsRecorder) RegisterGauge(name string, description string, labels []MetricLabel) Gauge {
+func (_self *DefaultMetricsRecorder) RegisterGauge(name string, description *string, labels []MetricLabel) Gauge {
 	_pointer := _self.ffiObject.incrementPointer("*DefaultMetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterGaugeINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_defaultmetricsrecorder_register_gauge(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
 	}))
 }
 
-func (_self *DefaultMetricsRecorder) RegisterHistogram(name string, description string, labels []MetricLabel, boundaries []float64) Histogram {
+func (_self *DefaultMetricsRecorder) RegisterHistogram(name string, description *string, labels []MetricLabel, boundaries []float64) Histogram {
 	_pointer := _self.ffiObject.incrementPointer("*DefaultMetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterHistogramINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_defaultmetricsrecorder_register_histogram(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), FfiConverterSequenceFloat64INSTANCE.Lower(boundaries), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), FfiConverterSequenceFloat64INSTANCE.Lower(boundaries), _uniffiStatus)
 	}))
 }
 
-func (_self *DefaultMetricsRecorder) RegisterUpDownCounter(name string, description string, labels []MetricLabel) UpDownCounter {
+func (_self *DefaultMetricsRecorder) RegisterUpDownCounter(name string, description *string, labels []MetricLabel) UpDownCounter {
 	_pointer := _self.ffiObject.incrementPointer("*DefaultMetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterUpDownCounterINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_defaultmetricsrecorder_register_up_down_counter(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
 	}))
 }
 
@@ -6815,13 +6815,13 @@ func (c FfiConverterMergeOperator) register() {
 // Application-defined metrics recorder used to publish SlateDB metrics.
 type MetricsRecorder interface {
 	// Registers a monotonically increasing counter.
-	RegisterCounter(name string, description string, labels []MetricLabel) Counter
+	RegisterCounter(name string, description *string, labels []MetricLabel) Counter
 	// Registers a gauge.
-	RegisterGauge(name string, description string, labels []MetricLabel) Gauge
+	RegisterGauge(name string, description *string, labels []MetricLabel) Gauge
 	// Registers an up/down counter.
-	RegisterUpDownCounter(name string, description string, labels []MetricLabel) UpDownCounter
+	RegisterUpDownCounter(name string, description *string, labels []MetricLabel) UpDownCounter
 	// Registers a histogram with explicit bucket boundaries.
-	RegisterHistogram(name string, description string, labels []MetricLabel, boundaries []float64) Histogram
+	RegisterHistogram(name string, description *string, labels []MetricLabel, boundaries []float64) Histogram
 }
 
 // Application-defined metrics recorder used to publish SlateDB metrics.
@@ -6830,42 +6830,42 @@ type MetricsRecorderImpl struct {
 }
 
 // Registers a monotonically increasing counter.
-func (_self *MetricsRecorderImpl) RegisterCounter(name string, description string, labels []MetricLabel) Counter {
+func (_self *MetricsRecorderImpl) RegisterCounter(name string, description *string, labels []MetricLabel) Counter {
 	_pointer := _self.ffiObject.incrementPointer("MetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterCounterINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_metricsrecorder_register_counter(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
 	}))
 }
 
 // Registers a gauge.
-func (_self *MetricsRecorderImpl) RegisterGauge(name string, description string, labels []MetricLabel) Gauge {
+func (_self *MetricsRecorderImpl) RegisterGauge(name string, description *string, labels []MetricLabel) Gauge {
 	_pointer := _self.ffiObject.incrementPointer("MetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterGaugeINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_metricsrecorder_register_gauge(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
 	}))
 }
 
 // Registers an up/down counter.
-func (_self *MetricsRecorderImpl) RegisterUpDownCounter(name string, description string, labels []MetricLabel) UpDownCounter {
+func (_self *MetricsRecorderImpl) RegisterUpDownCounter(name string, description *string, labels []MetricLabel) UpDownCounter {
 	_pointer := _self.ffiObject.incrementPointer("MetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterUpDownCounterINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_metricsrecorder_register_up_down_counter(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), _uniffiStatus)
 	}))
 }
 
 // Registers a histogram with explicit bucket boundaries.
-func (_self *MetricsRecorderImpl) RegisterHistogram(name string, description string, labels []MetricLabel, boundaries []float64) Histogram {
+func (_self *MetricsRecorderImpl) RegisterHistogram(name string, description *string, labels []MetricLabel, boundaries []float64) Histogram {
 	_pointer := _self.ffiObject.incrementPointer("MetricsRecorder")
 	defer _self.ffiObject.decrementPointer()
 	return FfiConverterHistogramINSTANCE.Lift(rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint64_t {
 		return C.uniffi_slatedb_uniffi_fn_method_metricsrecorder_register_histogram(
-			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), FfiConverterSequenceFloat64INSTANCE.Lower(boundaries), _uniffiStatus)
+			_pointer, FfiConverterStringINSTANCE.Lower(name), FfiConverterOptionalStringINSTANCE.Lower(description), FfiConverterSequenceMetricLabelINSTANCE.Lower(labels), FfiConverterSequenceFloat64INSTANCE.Lower(boundaries), _uniffiStatus)
 	}))
 }
 func (object *MetricsRecorderImpl) Destroy() {
@@ -6960,7 +6960,7 @@ func slatedb_uniffi_metrics_cgo_dispatchCallbackInterfaceMetricsRecorderMethod0(
 			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
 				inner: name,
 			}),
-			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
+			FfiConverterOptionalStringINSTANCE.Lift(GoRustBuffer{
 				inner: description,
 			}),
 			FfiConverterSequenceMetricLabelINSTANCE.Lift(GoRustBuffer{
@@ -6984,7 +6984,7 @@ func slatedb_uniffi_metrics_cgo_dispatchCallbackInterfaceMetricsRecorderMethod1(
 			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
 				inner: name,
 			}),
-			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
+			FfiConverterOptionalStringINSTANCE.Lift(GoRustBuffer{
 				inner: description,
 			}),
 			FfiConverterSequenceMetricLabelINSTANCE.Lift(GoRustBuffer{
@@ -7008,7 +7008,7 @@ func slatedb_uniffi_metrics_cgo_dispatchCallbackInterfaceMetricsRecorderMethod2(
 			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
 				inner: name,
 			}),
-			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
+			FfiConverterOptionalStringINSTANCE.Lift(GoRustBuffer{
 				inner: description,
 			}),
 			FfiConverterSequenceMetricLabelINSTANCE.Lift(GoRustBuffer{
@@ -7032,7 +7032,7 @@ func slatedb_uniffi_metrics_cgo_dispatchCallbackInterfaceMetricsRecorderMethod3(
 			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
 				inner: name,
 			}),
-			FfiConverterStringINSTANCE.Lift(GoRustBuffer{
+			FfiConverterOptionalStringINSTANCE.Lift(GoRustBuffer{
 				inner: description,
 			}),
 			FfiConverterSequenceMetricLabelINSTANCE.Lift(GoRustBuffer{

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -287,7 +287,7 @@ func newTestMetricsRecorder() *testMetricsRecorder {
 	}
 }
 
-func (r *testMetricsRecorder) RegisterCounter(name string, _ string, labels []slatedb.MetricLabel) slatedb.Counter {
+func (r *testMetricsRecorder) RegisterCounter(name string, _ *string, labels []slatedb.MetricLabel) slatedb.Counter {
 	key := metricKey(name, labels)
 
 	r.mu.Lock()
@@ -301,7 +301,7 @@ func (r *testMetricsRecorder) RegisterCounter(name string, _ string, labels []sl
 	})
 }
 
-func (r *testMetricsRecorder) RegisterGauge(name string, _ string, labels []slatedb.MetricLabel) slatedb.Gauge {
+func (r *testMetricsRecorder) RegisterGauge(name string, _ *string, labels []slatedb.MetricLabel) slatedb.Gauge {
 	key := metricKey(name, labels)
 
 	r.mu.Lock()
@@ -315,7 +315,7 @@ func (r *testMetricsRecorder) RegisterGauge(name string, _ string, labels []slat
 	})
 }
 
-func (r *testMetricsRecorder) RegisterUpDownCounter(name string, _ string, labels []slatedb.MetricLabel) slatedb.UpDownCounter {
+func (r *testMetricsRecorder) RegisterUpDownCounter(name string, _ *string, labels []slatedb.MetricLabel) slatedb.UpDownCounter {
 	key := metricKey(name, labels)
 
 	r.mu.Lock()
@@ -329,7 +329,7 @@ func (r *testMetricsRecorder) RegisterUpDownCounter(name string, _ string, label
 	})
 }
 
-func (r *testMetricsRecorder) RegisterHistogram(name string, _ string, labels []slatedb.MetricLabel, _ []float64) slatedb.Histogram {
+func (r *testMetricsRecorder) RegisterHistogram(name string, _ *string, labels []slatedb.MetricLabel, _ []float64) slatedb.Histogram {
 	key := metricKey(name, labels)
 
 	r.mu.Lock()
@@ -2063,10 +2063,12 @@ func TestDefaultMetricsRecorderSnapshot(t *testing.T) {
 	recorder := slatedb.NewDefaultMetricsRecorder()
 	t.Cleanup(recorder.Destroy)
 
-	counter := recorder.RegisterCounter("test.counter", "counter", nil)
-	gauge := recorder.RegisterGauge("test.gauge", "gauge", nil)
-	upDownCounter := recorder.RegisterUpDownCounter("test.up_down_counter", "up/down counter", nil)
-	histogram := recorder.RegisterHistogram("test.histogram", "histogram", nil, []float64{1.0, 2.0})
+	counterDesc, gaugeDesc := "counter", "gauge"
+	upDownDesc, histogramDesc := "up/down counter", "histogram"
+	counter := recorder.RegisterCounter("test.counter", &counterDesc, nil)
+	gauge := recorder.RegisterGauge("test.gauge", &gaugeDesc, nil)
+	upDownCounter := recorder.RegisterUpDownCounter("test.up_down_counter", &upDownDesc, nil)
+	histogram := recorder.RegisterHistogram("test.histogram", &histogramDesc, nil, []float64{1.0, 2.0})
 
 	counter.Increment(3)
 	gauge.Set(-7)

--- a/bindings/uniffi/src/metrics.rs
+++ b/bindings/uniffi/src/metrics.rs
@@ -84,6 +84,22 @@ pub trait Histogram: Send + Sync {
 }
 
 /// Application-defined metrics recorder used to publish SlateDB metrics.
+//
+// `description` is `Option<String>` rather than `String` to dodge a
+// uniffi-bindgen-go callback crash (NordSecurity/uniffi-bindgen-go#83). Most
+// SlateDB metrics register with an empty description, and a top-level `String`
+// lowers across the FFI to a raw, length-prefix-free buffer: an empty string
+// becomes a capacity-0 `RustBuffer` whose `data` is Rust's dangling allocation
+// sentinel `0x1`. uniffi-bindgen-go passes that buffer by value into the
+// generated Go callback frame, where `data` is pointer-typed; when the Go GC
+// scans (or the runtime grows/copies) that goroutine stack mid-callback, it
+// rejects the `0x1` and aborts with "invalid pointer found on stack".
+//
+// An `Option` always lowers with a leading discriminant byte, so it never
+// produces a capacity-0 buffer and never carries the sentinel pointer. Empty
+// descriptions map to `None`; the recorder treats `None` as no description.
+// (`name` stays `String` because metric names are always non-empty constants,
+// so they never hit the empty-buffer path.)
 #[uniffi::export(with_foreign)]
 pub trait MetricsRecorder: Send + Sync {
     /// Registers a monotonically increasing counter.

--- a/bindings/uniffi/src/metrics.rs
+++ b/bindings/uniffi/src/metrics.rs
@@ -90,7 +90,7 @@ pub trait MetricsRecorder: Send + Sync {
     fn register_counter(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
     ) -> Arc<dyn Counter>;
 
@@ -98,7 +98,7 @@ pub trait MetricsRecorder: Send + Sync {
     fn register_gauge(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
     ) -> Arc<dyn Gauge>;
 
@@ -106,7 +106,7 @@ pub trait MetricsRecorder: Send + Sync {
     fn register_up_down_counter(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
     ) -> Arc<dyn UpDownCounter>;
 
@@ -114,7 +114,7 @@ pub trait MetricsRecorder: Send + Sync {
     fn register_histogram(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
         boundaries: Vec<f64>,
     ) -> Arc<dyn Histogram>;
@@ -181,55 +181,66 @@ impl MetricsRecorder for DefaultMetricsRecorder {
     fn register_counter(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
     ) -> Arc<dyn Counter> {
         let label_refs = to_label_refs(&labels);
         Arc::new(CoreCounterHandle {
-            inner: self
-                .inner
-                .register_counter(&name, &description, &label_refs),
+            inner: self.inner.register_counter(
+                &name,
+                description.as_deref().unwrap_or(""),
+                &label_refs,
+            ),
         })
     }
 
     fn register_gauge(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
     ) -> Arc<dyn Gauge> {
         let label_refs = to_label_refs(&labels);
         Arc::new(CoreGaugeHandle {
-            inner: self.inner.register_gauge(&name, &description, &label_refs),
+            inner: self.inner.register_gauge(
+                &name,
+                description.as_deref().unwrap_or(""),
+                &label_refs,
+            ),
         })
     }
 
     fn register_up_down_counter(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
     ) -> Arc<dyn UpDownCounter> {
         let label_refs = to_label_refs(&labels);
         Arc::new(CoreUpDownCounterHandle {
-            inner: self
-                .inner
-                .register_up_down_counter(&name, &description, &label_refs),
+            inner: self.inner.register_up_down_counter(
+                &name,
+                description.as_deref().unwrap_or(""),
+                &label_refs,
+            ),
         })
     }
 
     fn register_histogram(
         &self,
         name: String,
-        description: String,
+        description: Option<String>,
         labels: Vec<MetricLabel>,
         boundaries: Vec<f64>,
     ) -> Arc<dyn Histogram> {
         let label_refs = to_label_refs(&labels);
         Arc::new(CoreHistogramHandle {
-            inner: self
-                .inner
-                .register_histogram(&name, &description, &label_refs, &boundaries),
+            inner: self.inner.register_histogram(
+                &name,
+                description.as_deref().unwrap_or(""),
+                &label_refs,
+                &boundaries,
+            ),
         })
     }
 }
@@ -256,7 +267,7 @@ impl core_metrics::MetricsRecorder for MetricsRecorderAdapter {
         Arc::new(CounterAdapter {
             inner: self.inner.register_counter(
                 name.to_owned(),
-                description.to_owned(),
+                (!description.is_empty()).then(|| description.to_owned()),
                 to_metric_labels(labels),
             ),
         })
@@ -271,7 +282,7 @@ impl core_metrics::MetricsRecorder for MetricsRecorderAdapter {
         Arc::new(GaugeAdapter {
             inner: self.inner.register_gauge(
                 name.to_owned(),
-                description.to_owned(),
+                (!description.is_empty()).then(|| description.to_owned()),
                 to_metric_labels(labels),
             ),
         })
@@ -286,7 +297,7 @@ impl core_metrics::MetricsRecorder for MetricsRecorderAdapter {
         Arc::new(UpDownCounterAdapter {
             inner: self.inner.register_up_down_counter(
                 name.to_owned(),
-                description.to_owned(),
+                (!description.is_empty()).then(|| description.to_owned()),
                 to_metric_labels(labels),
             ),
         })
@@ -302,7 +313,7 @@ impl core_metrics::MetricsRecorder for MetricsRecorderAdapter {
         Arc::new(HistogramAdapter {
             inner: self.inner.register_histogram(
                 name.to_owned(),
-                description.to_owned(),
+                (!description.is_empty()).then(|| description.to_owned()),
                 to_metric_labels(labels),
                 boundaries.to_vec(),
             ),
@@ -489,7 +500,7 @@ mod tests {
         fn register_counter(
             &self,
             name: String,
-            _description: String,
+            _description: Option<String>,
             labels: Vec<MetricLabel>,
         ) -> Arc<dyn Counter> {
             let key = metric_key(&name, &labels);
@@ -508,7 +519,7 @@ mod tests {
         fn register_gauge(
             &self,
             name: String,
-            _description: String,
+            _description: Option<String>,
             labels: Vec<MetricLabel>,
         ) -> Arc<dyn Gauge> {
             let key = metric_key(&name, &labels);
@@ -527,7 +538,7 @@ mod tests {
         fn register_up_down_counter(
             &self,
             name: String,
-            _description: String,
+            _description: Option<String>,
             labels: Vec<MetricLabel>,
         ) -> Arc<dyn UpDownCounter> {
             let key = metric_key(&name, &labels);
@@ -546,7 +557,7 @@ mod tests {
         fn register_histogram(
             &self,
             name: String,
-            _description: String,
+            _description: Option<String>,
             labels: Vec<MetricLabel>,
             _boundaries: Vec<f64>,
         ) -> Arc<dyn Histogram> {


### PR DESCRIPTION
## Summary

OK, I admit a lot of this is some Claude investigation that goes over my head, but I had a consistent repro and this fixes it. Basically it seems that the go uniffi binding craps its pants if it passes it a 0-byte string because Rust converts that to a sentinel byte and in some scenarios bad things happen. See https://github.com/NordSecurity/uniffi-bindgen-go/issues/83 for the full repro.

The fix is to make the bindings take in `Option<String>` for descriptions that are empty, making it so that we never pass in empty strings and instead have a prefix for the nullability of it.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
