### PR TITLE
Add Italic variants of Source Serif 4

### DIFF
--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -20,7 +20,7 @@ const starsLabel = await getStarsLabel();
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
             rel="stylesheet"
-            href="https://fonts.googleapis.com/css2?family=Marcellus&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Marcellus&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;0,8..60,700;1,8..60,400;1,8..60,500;1,8..60,600;1,8..60,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
         />
     </head>
     <body>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -132,7 +132,7 @@ const features = [
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
             rel="stylesheet"
-            href="https://fonts.googleapis.com/css2?family=Marcellus&family=Source+Serif+4:opsz,wght@8..60,400;8..60,500;8..60,600;8..60,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Marcellus&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;0,8..60,700;1,8..60,400;1,8..60,500;1,8..60,600;1,8..60,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap"
         />
     </head>
     <body>


### PR DESCRIPTION
## Summary

The website downloads fonts from Google Fonts, but does not explicitly download the italic version of the fonts. This causes the browser to make a "fake" italic font by skewing the letters. This explicitly downloads the italic fonts for more beautiful typography.

Before:

<img width="1047" height="207" alt="image" src="https://github.com/user-attachments/assets/365d1458-9f51-4fb2-8064-18dc30e4b07c" />

After:

<img width="1049" height="201" alt="image" src="https://github.com/user-attachments/assets/37acb49d-4c28-41dc-a029-1bbb27fc2e4f" />


## Changes

- adds italic fonts to the download package for Source Serif 4.

## Notes for Reviewers

Google font URLs are described in [these docs](https://developers.google.com/fonts/docs/getting_started).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts

Not applicable
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant