### PR TITLE
Notify memtable writer channels on close

### DIFF
--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -137,19 +137,17 @@ impl ManifestWriter {
         through_seq: Option<u64>,
         sender: oneshot::Sender<Result<FlushResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        match self
-            .commands_tx
-            .send_recovering(ManifestWriterCommand::AwaitFlush {
+        self.commands_tx.send_with_failure_callback(
+            ManifestWriterCommand::AwaitFlush {
                 through_seq,
                 sender,
-            }) {
-            Ok(()) => Ok(()),
-            Err((ManifestWriterCommand::AwaitFlush { sender, .. }, err)) => {
-                let _ = sender.send(Err(err.clone()));
-                Err(err)
-            }
-            Err((_, err)) => Err(err),
-        }
+            },
+            |message, err| {
+                if let ManifestWriterCommand::AwaitFlush { sender, .. } = message {
+                    let _ = sender.send(Err(err.clone()));
+                }
+            },
+        )
     }
 
     /// Sends a checkpoint request to the manifest_writer. The manifest_writer will write
@@ -161,20 +159,18 @@ impl ManifestWriter {
         options: CheckpointOptions,
         sender: oneshot::Sender<Result<CheckpointCreateResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        match self
-            .commands_tx
-            .send_recovering(ManifestWriterCommand::CreateCheckpoint {
+        self.commands_tx.send_with_failure_callback(
+            ManifestWriterCommand::CreateCheckpoint {
                 through_seq,
                 options,
                 sender,
-            }) {
-            Ok(()) => Ok(()),
-            Err((ManifestWriterCommand::CreateCheckpoint { sender, .. }, err)) => {
-                let _ = sender.send(Err(err.clone()));
-                Err(err)
-            }
-            Err((_, err)) => Err(err),
-        }
+            },
+            |message, err| {
+                if let ManifestWriterCommand::CreateCheckpoint { sender, .. } = message {
+                    let _ = sender.send(Err(err.clone()));
+                }
+            },
+        )
     }
 
     /// Enqueues a manifest poll; the result is delivered to `sender` on completion.
@@ -182,17 +178,14 @@ impl ManifestWriter {
         &self,
         sender: oneshot::Sender<Result<(), SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        match self
-            .commands_tx
-            .send_recovering(ManifestWriterCommand::PollManifest { done: Some(sender) })
-        {
-            Ok(()) => Ok(()),
-            Err((ManifestWriterCommand::PollManifest { done: Some(sender) }, err)) => {
-                let _ = sender.send(Err(err.clone()));
-                Err(err)
-            }
-            Err((_, err)) => Err(err),
-        }
+        self.commands_tx.send_with_failure_callback(
+            ManifestWriterCommand::PollManifest { done: Some(sender) },
+            |message, err| {
+                if let ManifestWriterCommand::PollManifest { done: Some(sender) } = message {
+                    let _ = sender.send(Err(err.clone()));
+                }
+            },
+        )
     }
 
     pub(crate) async fn shutdown(executor: &crate::dispatcher::MessageHandlerExecutor) {

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -137,10 +137,19 @@ impl ManifestWriter {
         through_seq: Option<u64>,
         sender: oneshot::Sender<Result<FlushResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.commands_tx.send(ManifestWriterCommand::AwaitFlush {
-            through_seq,
-            sender,
-        })
+        match self
+            .commands_tx
+            .send_recovering(ManifestWriterCommand::AwaitFlush {
+                through_seq,
+                sender,
+            }) {
+            Ok(()) => Ok(()),
+            Err((ManifestWriterCommand::AwaitFlush { sender, .. }, err)) => {
+                let _ = sender.send(Err(err.clone()));
+                Err(err)
+            }
+            Err((_, err)) => Err(err),
+        }
     }
 
     /// Sends a checkpoint request to the manifest_writer. The manifest_writer will write
@@ -152,12 +161,20 @@ impl ManifestWriter {
         options: CheckpointOptions,
         sender: oneshot::Sender<Result<CheckpointCreateResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.commands_tx
-            .send(ManifestWriterCommand::CreateCheckpoint {
+        match self
+            .commands_tx
+            .send_recovering(ManifestWriterCommand::CreateCheckpoint {
                 through_seq,
                 options,
                 sender,
-            })
+            }) {
+            Ok(()) => Ok(()),
+            Err((ManifestWriterCommand::CreateCheckpoint { sender, .. }, err)) => {
+                let _ = sender.send(Err(err.clone()));
+                Err(err)
+            }
+            Err((_, err)) => Err(err),
+        }
     }
 
     /// Enqueues a manifest poll; the result is delivered to `sender` on completion.
@@ -165,8 +182,17 @@ impl ManifestWriter {
         &self,
         sender: oneshot::Sender<Result<(), SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.commands_tx
-            .send(ManifestWriterCommand::PollManifest { done: Some(sender) })
+        match self
+            .commands_tx
+            .send_recovering(ManifestWriterCommand::PollManifest { done: Some(sender) })
+        {
+            Ok(()) => Ok(()),
+            Err((ManifestWriterCommand::PollManifest { done: Some(sender) }, err)) => {
+                let _ = sender.send(Err(err.clone()));
+                Err(err)
+            }
+            Err((_, err)) => Err(err),
+        }
     }
 
     pub(crate) async fn shutdown(executor: &crate::dispatcher::MessageHandlerExecutor) {
@@ -190,6 +216,7 @@ struct ManifestWriterHandler {
     db_status_rx: watch::Receiver<crate::db_status::DbStatus>,
     pending_flushes: Vec<PendingFlush>,
     pending_checkpoints: Vec<PendingCheckpoint>,
+    pending_manifest_refreshes: Vec<oneshot::Sender<Result<(), SlateDBError>>>,
 }
 
 #[async_trait]
@@ -247,7 +274,7 @@ impl MessageHandler<ManifestWriterCommand> for ManifestWriterHandler {
         let mut commands = commands.fuse();
         let close_result = self.try_graceful_cleanup(&mut commands, &result).await;
         // Drain any commands not consumed by graceful cleanup, collecting
-        // flush/checkpoint waiters so they receive a proper error.
+        // waiters so they receive a proper error.
         while let Some(command) = commands.next().await {
             self.collect_pending_waiter(command);
         }
@@ -258,6 +285,7 @@ impl MessageHandler<ManifestWriterCommand> for ManifestWriterHandler {
             .unwrap_or(SlateDBError::Closed);
         self.fail_pending_flushes(&error);
         self.fail_pending_checkpoints(&error);
+        self.fail_pending_manifest_refreshes(&error);
         close_result
     }
 }
@@ -281,6 +309,7 @@ impl ManifestWriterHandler {
             durable_seq,
             db_status_rx,
             pending_checkpoints: Vec::new(),
+            pending_manifest_refreshes: Vec::new(),
         }
     }
 
@@ -730,8 +759,16 @@ impl ManifestWriterHandler {
         }
     }
 
-    /// Extract flush/checkpoint waiters from a command without processing
-    /// uploads. Used during error shutdown to ensure waiters get a proper error.
+    /// Fail remaining manifest refresh waiters on exit. If a poll request was
+    /// queued but never processed, callers still need the terminal DB error.
+    fn fail_pending_manifest_refreshes(&mut self, err: &SlateDBError) {
+        for sender in self.pending_manifest_refreshes.drain(..) {
+            let _ = sender.send(Err(err.clone()));
+        }
+    }
+
+    /// Extract waiters from a command without processing uploads. Used during
+    /// error shutdown to ensure waiters get a proper error.
     fn collect_pending_waiter(&mut self, command: ManifestWriterCommand) {
         match command {
             ManifestWriterCommand::AwaitFlush {
@@ -753,6 +790,9 @@ impl ManifestWriterHandler {
                     options,
                     sender,
                 });
+            }
+            ManifestWriterCommand::PollManifest { done: Some(sender) } => {
+                self.pending_manifest_refreshes.push(sender);
             }
             _ => {}
         }
@@ -813,7 +853,7 @@ impl crate::dispatcher::Notifier<ManifestWriterCommand> for DurableSeqNotifier {
 
 #[cfg(test)]
 mod tests {
-    use super::{ManifestWriter, ManifestWriterHandler, TrackerMessage};
+    use super::{ManifestWriter, ManifestWriterCommand, ManifestWriterHandler, TrackerMessage};
     use crate::config::{CheckpointOptions, Settings};
     use crate::db::DbInner;
     use crate::db_status::{ClosedResultWriter, DbStatusManager};
@@ -1460,6 +1500,153 @@ mod tests {
         );
 
         started.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn pending_manifest_refresh_waiter_receives_error_on_fenced_shutdown() {
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_manifest_writer_pending_poll_fenced",
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let mut handler = new_handler_from_harness(harness);
+
+        let (tx, rx) = oneshot::channel();
+        let messages =
+            futures::stream::iter(vec![ManifestWriterCommand::PollManifest { done: Some(tx) }]);
+        crate::dispatcher::MessageHandler::cleanup(
+            &mut handler,
+            Box::pin(messages),
+            Err(SlateDBError::Fenced),
+        )
+        .await
+        .unwrap();
+
+        let result = timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("timed out")
+            .expect("channel dropped");
+        assert!(
+            matches!(result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_refresh_waiter_receives_error_when_manifest_writer_channel_closed() {
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_manifest_writer_closed_poll_fenced",
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let inner = Arc::clone(&harness.inner);
+        let started = start_manifest_writer(
+            Arc::clone(&inner),
+            harness.manifest,
+            Duration::from_secs(3600),
+        );
+
+        started
+            .closed_result
+            .write_result(Err(SlateDBError::Fenced));
+        started.shutdown().await;
+
+        let (tx, rx) = oneshot::channel();
+        let err = started.send_poll(tx).unwrap_err();
+        assert!(
+            matches!(err, SlateDBError::Fenced),
+            "expected Fenced, got {:?}",
+            err
+        );
+
+        let result = timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("timed out")
+            .expect("channel dropped");
+        assert!(
+            matches!(result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn flush_waiter_receives_error_when_manifest_writer_channel_closed() {
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_manifest_writer_closed_flush_fenced",
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let inner = Arc::clone(&harness.inner);
+        let started = start_manifest_writer(
+            Arc::clone(&inner),
+            harness.manifest,
+            Duration::from_secs(3600),
+        );
+
+        started
+            .closed_result
+            .write_result(Err(SlateDBError::Fenced));
+        started.shutdown().await;
+
+        let (tx, rx) = oneshot::channel();
+        let err = started.send_flush(Some(1), tx).unwrap_err();
+        assert!(
+            matches!(err, SlateDBError::Fenced),
+            "expected Fenced, got {:?}",
+            err
+        );
+
+        let result = timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("timed out")
+            .expect("channel dropped");
+        assert!(
+            matches!(result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoint_waiter_receives_error_when_manifest_writer_channel_closed() {
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_manifest_writer_closed_checkpoint_fenced",
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let inner = Arc::clone(&harness.inner);
+        let started = start_manifest_writer(
+            Arc::clone(&inner),
+            harness.manifest,
+            Duration::from_secs(3600),
+        );
+
+        started
+            .closed_result
+            .write_result(Err(SlateDBError::Fenced));
+        started.shutdown().await;
+
+        let (tx, rx) = oneshot::channel();
+        let err = started
+            .send_checkpoint(Some(1), CheckpointOptions::default(), tx)
+            .unwrap_err();
+        assert!(
+            matches!(err, SlateDBError::Fenced),
+            "expected Fenced, got {:?}",
+            err
+        );
+
+        let result = timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("timed out")
+            .expect("channel dropped");
+        assert!(
+            matches!(result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            result
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -137,7 +137,7 @@ impl ManifestWriter {
         through_seq: Option<u64>,
         sender: oneshot::Sender<Result<FlushResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.commands_tx.send_with_failure_callback(
+        self.commands_tx.send_or_handle_closed(
             ManifestWriterCommand::AwaitFlush {
                 through_seq,
                 sender,
@@ -159,7 +159,7 @@ impl ManifestWriter {
         options: CheckpointOptions,
         sender: oneshot::Sender<Result<CheckpointCreateResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.commands_tx.send_with_failure_callback(
+        self.commands_tx.send_or_handle_closed(
             ManifestWriterCommand::CreateCheckpoint {
                 through_seq,
                 options,
@@ -178,7 +178,7 @@ impl ManifestWriter {
         &self,
         sender: oneshot::Sender<Result<(), SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.commands_tx.send_with_failure_callback(
+        self.commands_tx.send_or_handle_closed(
             ManifestWriterCommand::PollManifest { done: Some(sender) },
             |message, err| {
                 if let ManifestWriterCommand::PollManifest { done: Some(sender) } = message {

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -203,7 +203,10 @@ impl FlushTracker {
             "flush-memtable-to-l0",
             |_| { Ok(()) }
         );
-        self.reconcile_and_dispatch().await?;
+        if let Err(err) = self.reconcile_and_dispatch().await {
+            let _ = sender.send(Err(err.clone()));
+            return Err(err);
+        }
         let through_seq = self.frontier.resolve_target(target);
         self.manifest_writer.send_flush(through_seq, sender)?;
         Ok(())
@@ -215,7 +218,10 @@ impl FlushTracker {
         options: CheckpointOptions,
         sender: oneshot::Sender<Result<CheckpointCreateResult, SlateDBError>>,
     ) -> Result<(), SlateDBError> {
-        self.reconcile_and_dispatch().await?;
+        if let Err(err) = self.reconcile_and_dispatch().await {
+            let _ = sender.send(Err(err.clone()));
+            return Err(err);
+        }
         let through_seq = self.frontier.resolve_target(target);
         self.manifest_writer
             .send_checkpoint(through_seq, options, sender)?;
@@ -508,6 +514,7 @@ mod tests {
     use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
     use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
+    use crate::memtable_flusher::uploader::Uploader;
     use crate::memtable_flusher::{FlushTarget, MemtableFlusher};
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
@@ -763,11 +770,17 @@ mod tests {
         inner: Arc<DbInner>,
         flusher: MemtableFlusher,
         executor: crate::dispatcher::MessageHandlerExecutor,
+        closed_result: WatchableOnceCell<Result<(), SlateDBError>>,
     }
 
     impl StartedFlusher {
         async fn shutdown(&self) {
             MemtableFlusher::shutdown(&self.executor).await;
+        }
+
+        async fn shutdown_uploader_with_error(&self, err: SlateDBError) {
+            self.closed_result.write_result(Err(err));
+            Uploader::shutdown(&self.executor).await;
         }
     }
 
@@ -801,6 +814,7 @@ mod tests {
             inner,
             flusher,
             executor,
+            closed_result,
         }
     }
 
@@ -1009,6 +1023,61 @@ mod tests {
             matches!(flush_result, Err(SlateDBError::Fenced)),
             "expected Fenced, got {:?}",
             flush_result
+        );
+
+        flusher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn flush_waiter_receives_error_when_reconcile_fails_before_manifest_writer() {
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_flusher_reconcile_flush_error",
+            Settings::default(),
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let flusher = start_flusher(harness);
+        freeze_value_imm(&flusher.inner, b"k1", b"v1", 11);
+        flusher
+            .shutdown_uploader_with_error(SlateDBError::Fenced)
+            .await;
+
+        let flush_result = timeout(Duration::from_secs(5), flusher.flush(FlushTarget::All))
+            .await
+            .unwrap();
+        assert!(
+            matches!(flush_result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            flush_result
+        );
+
+        flusher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn checkpoint_waiter_receives_error_when_reconcile_fails_before_manifest_writer() {
+        let harness = setup_harness(
+            "/tmp/test_parallel_l0_flush_flusher_reconcile_checkpoint_error",
+            Settings::default(),
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let flusher = start_flusher(harness);
+        freeze_value_imm(&flusher.inner, b"k1", b"v1", 11);
+        flusher
+            .shutdown_uploader_with_error(SlateDBError::Fenced)
+            .await;
+
+        let checkpoint_result = timeout(
+            Duration::from_secs(5),
+            flusher.create_checkpoint(FlushTarget::All, CheckpointOptions::default()),
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(checkpoint_result, Err(SlateDBError::Fenced)),
+            "expected Fenced, got {:?}",
+            checkpoint_result
         );
 
         flusher.shutdown().await;

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -752,16 +752,26 @@ impl<T> SafeSender<T> {
         }
     }
 
-    /// Like [`Self::send`], but returns the rejected message with the closed
-    /// result so callers can fail embedded response channels explicitly.
+    /// Like [`Self::send`], but invokes `on_failure` with the rejected message
+    /// and closed result so callers can fail embedded response channels
+    /// explicitly.
     #[inline]
-    pub(crate) fn send_recovering(&self, message: T) -> Result<(), (T, SlateDBError)> {
+    pub(crate) fn send_with_failure_callback<F>(
+        &self,
+        message: T,
+        on_failure: F,
+    ) -> Result<(), SlateDBError>
+    where
+        F: FnOnce(T, &SlateDBError),
+    {
         match self.tx.try_send(message) {
             Ok(_) => Ok(()),
             Err(e) => {
                 let channel_error = e.to_string();
                 let message = e.into_inner();
-                Err((message, self.closed_send_error(channel_error)))
+                let err = self.closed_send_error(channel_error);
+                on_failure(message, &err);
+                Err(err)
             }
         }
     }

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -721,24 +721,47 @@ impl<T> SafeSender<T> {
         (Self::new(tx, closed), rx)
     }
 
+    /// Returns the DB's terminal error for a failed channel send.
+    ///
+    /// Panics if the channel is closed before the DB close result is recorded,
+    /// which indicates a lifecycle ordering bug.
+    #[allow(clippy::panic)]
+    fn closed_send_error(&self, channel_error: String) -> SlateDBError {
+        if let Some(result) = self.closed.read() {
+            match result {
+                Ok(()) => SlateDBError::Closed,
+                Err(err) => err,
+            }
+        } else {
+            panic!(
+                "Failed to send message to unbounded channel: {}",
+                channel_error
+            );
+        }
+    }
+
     /// Attempts to send a message. If the channel is closed, returns the
     /// DB's closed result error, or [`SlateDBError::Closed`] if it was a
     /// clean shutdown. Panics if the channel is closed but no closed result
     /// has been set (indicates a bug).
     #[inline]
-    #[allow(clippy::panic, clippy::disallowed_methods)]
     pub(crate) fn send(&self, message: T) -> Result<(), SlateDBError> {
         match self.tx.try_send(message) {
             Ok(_) => Ok(()),
+            Err(e) => Err(self.closed_send_error(e.to_string())),
+        }
+    }
+
+    /// Like [`Self::send`], but returns the rejected message with the closed
+    /// result so callers can fail embedded response channels explicitly.
+    #[inline]
+    pub(crate) fn send_recovering(&self, message: T) -> Result<(), (T, SlateDBError)> {
+        match self.tx.try_send(message) {
+            Ok(_) => Ok(()),
             Err(e) => {
-                if let Some(result) = self.closed.read() {
-                    match result {
-                        Ok(()) => Err(SlateDBError::Closed),
-                        Err(err) => Err(err),
-                    }
-                } else {
-                    panic!("Failed to send message to unbounded channel: {}", e);
-                }
+                let channel_error = e.to_string();
+                let message = e.into_inner();
+                Err((message, self.closed_send_error(channel_error)))
             }
         }
     }

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -752,14 +752,14 @@ impl<T> SafeSender<T> {
         }
     }
 
-    /// Like [`Self::send`], but invokes `on_failure` with the rejected message
+    /// Like [`Self::send`], but invokes `on_closed` with the rejected message
     /// and closed result so callers can fail embedded response channels
     /// explicitly.
     #[inline]
-    pub(crate) fn send_with_failure_callback<F>(
+    pub(crate) fn send_or_handle_closed<F>(
         &self,
         message: T,
-        on_failure: F,
+        on_closed: F,
     ) -> Result<(), SlateDBError>
     where
         F: FnOnce(T, &SlateDBError),
@@ -770,7 +770,7 @@ impl<T> SafeSender<T> {
                 let channel_error = e.to_string();
                 let message = e.into_inner();
                 let err = self.closed_send_error(channel_error);
-                on_failure(message, &err);
+                on_closed(message, &err);
                 Err(err)
             }
         }


### PR DESCRIPTION
## Summary

#1685 failed with a spurious test issue:

- https://github.com/slatedb/slatedb/actions/runs/26488615605/job/78002861521

`test_writer_paused_in_replay_wal_should_be_fenced_by_concurrent_open` was failing with an internal error instead of `Fenced`, as expected. This test was added in #1718. Upon investigation, there appear to be several places in the MemTable writer/tracker that don't properly notify channels when the `Db` is closed.

## Changes

- Added`SafeSender::send_or_handle_closed` so closed channel sends return the DB terminal `SlateDBError`
- Updated manifest writer flush, checkpoint, and poll sends to fail embedded oneshot responders when the command channel is closed.
- Tracked and failed pending manifest refresh waiters during manifest writer cleanup.
- Failed flush/checkpoint waiters when tracker reconcile/dispatch fails before reaching the manifest writer.
- Added tests covering fenced/closed manifest writer channels, pending poll cleanup, and tracker reconcile error propagation.

## Notes for Reviewers

Codex wrote this. I reviewed it and had it tweak a few things. Seems right. I also reviewed other `send` usage and didn't find any other such cases.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
