### PR TITLE
Bounds validation

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -356,10 +356,18 @@ impl CachedObjectStore {
             let payload_len = payload.content_length() as u64;
             let stream = stream::iter(payload.into_iter()).map(Ok::<Bytes, object_store::Error>);
 
-            // Save parts only, ignoring errors (cache failures shouldn't fail the PUT operation)
-            self.save_parts_stream(entry.as_ref(), stream, 0, 0..payload_len)
+            // Save parts only; on error, clean up any partially-written parts.
+            if let Err(_e) = self
+                .save_parts_stream(entry.as_ref(), stream, 0, 0..payload_len)
                 .await
-                .ok();
+            {
+                let part_size_bytes_u64 = self.part_size_bytes as u64;
+                let end_part_number =
+                    usize::try_from(payload_len.div_ceil(part_size_bytes_u64)).unwrap_or(0);
+                for part_number in 0..end_part_number {
+                    let _ = entry.delete_part(part_number).await;
+                }
+            }
         }
 
         Ok(result)

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -25,6 +25,15 @@ use log::warn;
 use crate::utils::build_concurrent;
 use slatedb_common::metrics::MetricsRecorderHelper;
 
+/// Specifies how `verify_size` should compare actual vs expected bytes.
+#[derive(Debug, Clone, Copy)]
+enum SizeCheck {
+    /// Actual must be ≤ expected (used while a stream is still producing chunks).
+    AtMost,
+    /// Actual must be exactly equal to expected (used after a stream is fully consumed).
+    Exact,
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct CachedObjectStore {
     object_store: Arc<dyn ObjectStore>,
@@ -489,17 +498,7 @@ impl CachedObjectStore {
             let chunk = chunk?;
             total_bytes += chunk.len();
 
-            if total_bytes > range_len {
-                let msg = format!(
-                    "Stream exceeded range bounds: {} bytes read, but range is {}..{} ({} bytes)",
-                    total_bytes, range.start, range.end, range_len
-                );
-                warn!("{}", msg);
-                return Err(object_store::Error::Generic {
-                    store: "cached_object_store",
-                    source: msg.into(),
-                });
-            }
+            Self::verify_size(total_bytes, range_len, SizeCheck::AtMost)?;
 
             buffer.extend_from_slice(&chunk);
 
@@ -511,17 +510,7 @@ impl CachedObjectStore {
         }
 
         // No point in saving an invalid file so return early.
-        if total_bytes != range_len {
-            let msg = format!(
-                "Stream range bounds not met: {} bytes read, but range is {}..{} ({} bytes)",
-                total_bytes, range.start, range.end, range_len
-            );
-            warn!("{}", msg);
-            return Err(object_store::Error::Generic {
-                store: "cached_object_store",
-                source: msg.into(),
-            });
-        }
+        Self::verify_size(total_bytes, range_len, SizeCheck::Exact)?;
 
         // Save any remaining bytes as the last part
         if !buffer.is_empty() {
@@ -628,20 +617,7 @@ impl CachedObjectStore {
                     let meta = get_result.meta.clone();
                     let attrs = get_result.attributes.clone();
                     let bytes = get_result.bytes().await?;
-                    if bytes.len() < range_in_part.len() {
-                        let msg = format!(
-                            "Fetched part bytes do not cover the requested range: \
-                             part has {} bytes, but range_in_part is {}..{}",
-                            bytes.len(),
-                            range_in_part.start,
-                            range_in_part.end
-                        );
-                        warn!("{}", msg);
-                        return Err(object_store::Error::Generic {
-                            store: "cached_object_store",
-                            source: msg.into(),
-                        });
-                    }
+                    Self::verify_size(bytes.len(), range_in_part.len(), SizeCheck::Exact)?;
 
                     // Save the head and the part to cache for future accesses.
                     // Skip if we can't derive a canonical cache key.
@@ -725,6 +701,29 @@ impl CachedObjectStore {
                 GetRange::Offset(offset_aligned)
             }
         }
+    }
+
+    fn verify_size(
+        total_bytes: usize,
+        range_len: usize,
+        check: SizeCheck,
+    ) -> object_store::Result<()> {
+        let failed = match check {
+            SizeCheck::AtMost => total_bytes > range_len,
+            SizeCheck::Exact => total_bytes != range_len,
+        };
+        if failed {
+            let msg = format!(
+                "Size check ({:?}) failed: {} bytes read, but range is {} bytes",
+                check, total_bytes, range_len
+            );
+            warn!("{}", msg);
+            return Err(object_store::Error::Generic {
+                store: "cached_object_store",
+                source: msg.into(),
+            });
+        }
+        Ok(())
     }
 
     fn align_range(&self, range: &Range<u64>, alignment: usize) -> Range<u64> {
@@ -2243,7 +2242,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("Stream exceeded range bounds"),
+            err.contains("Size check (AtMost) failed"),
             "unexpected error: {}",
             err
         );
@@ -2296,7 +2295,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("Stream range bounds not met"),
+            err.contains("Size check (Exact) failed"),
             "unexpected error: {}",
             err
         );
@@ -2503,7 +2502,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("Fetched part bytes do not cover the requested range"),
+            err.contains("Size check (Exact) failed"),
             "unexpected error: {}",
             err
         );

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -4,7 +4,7 @@ use crate::cached_object_store::LocalCacheEntry;
 use crate::config::ObjectStoreCacheOptions;
 use crate::rand::DbRand;
 use bytes::{Bytes, BytesMut};
-use futures::{stream, stream::BoxStream, StreamExt};
+use futures::{future::BoxFuture, stream, stream::BoxStream, StreamExt};
 use object_store::{path::Path, GetOptions, GetResult, ObjectMeta, ObjectStore, ObjectStoreExt};
 use object_store::{
     Attributes, CopyOptions, GetRange, GetResultPayload, PutMultipartOptions, PutResult,
@@ -483,13 +483,14 @@ impl CachedObjectStore {
             total_bytes += chunk.len();
 
             if total_bytes > range_len {
+                let msg = format!(
+                    "Stream exceeded range bounds: {} bytes read, but range is {}..{} ({} bytes)",
+                    total_bytes, range.start, range.end, range_len
+                );
+                warn!("{}", msg);
                 return Err(object_store::Error::Generic {
                     store: "cached_object_store",
-                    source: format!(
-                        "Stream exceeded range bounds: {} bytes read, but range is {}..{} ({} bytes)",
-                        total_bytes, range.start, range.end, range_len
-                    )
-                    .into(),
+                    source: msg.into(),
                 });
             }
 
@@ -500,6 +501,19 @@ impl CachedObjectStore {
                 entry.save_part(part_number, to_write.into()).await?;
                 part_number += 1;
             }
+        }
+
+        // No point in saving an invalid file so return early.
+        if total_bytes != range_len {
+            let msg = format!(
+                "Stream range bounds not met: {} bytes read, but range is {}..{} ({} bytes)",
+                total_bytes, range.start, range.end, range_len
+            );
+            warn!("{}", msg);
+            return Err(object_store::Error::Generic {
+                store: "cached_object_store",
+                source: msg.into(),
+            });
         }
 
         // Save any remaining bytes as the last part
@@ -603,19 +617,31 @@ impl CachedObjectStore {
                         None
                     };
 
-                    // Save the head and the part to cache for future accesses. Just read the bytes
-                    // if we still can't derive a canonical cache key.
-                    let bytes = if let Some(entry) = cache_entry {
-                        // Save the head and the part to cache for future accesses.
-                        let meta = get_result.meta.clone();
-                        let attrs = get_result.attributes.clone();
-                        let bytes = get_result.bytes().await?;
+                    // Read bytes and validate the range before caching.
+                    let meta = get_result.meta.clone();
+                    let attrs = get_result.attributes.clone();
+                    let bytes = get_result.bytes().await?;
+                    if bytes.len() < range_in_part.len() {
+                        let msg = format!(
+                            "Fetched part bytes do not cover the requested range: \
+                             part has {} bytes, but range_in_part is {}..{}",
+                            bytes.len(),
+                            range_in_part.start,
+                            range_in_part.end
+                        );
+                        warn!("{}", msg);
+                        return Err(object_store::Error::Generic {
+                            store: "cached_object_store",
+                            source: msg.into(),
+                        });
+                    }
+
+                    // Save the head and the part to cache for future accesses.
+                    // Skip if we can't derive a canonical cache key.
+                    if let Some(entry) = cache_entry {
                         entry.save_head((&meta, &attrs)).await.ok();
                         entry.save_part(part_id, bytes.clone()).await.ok();
-                        bytes
-                    } else {
-                        get_result.bytes().await?
-                    };
+                    }
 
                     Ok::<_, object_store::Error>(bytes)
                 })

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -366,17 +366,9 @@ impl CachedObjectStore {
             let stream = stream::iter(payload.into_iter()).map(Ok::<Bytes, object_store::Error>);
 
             // Save parts only; on error, clean up any partially-written parts.
-            if let Err(_e) = self
-                .save_parts_stream(entry.as_ref(), stream, 0, 0..payload_len)
-                .await
-            {
-                let part_size_bytes_u64 = self.part_size_bytes as u64;
-                let end_part_number =
-                    usize::try_from(payload_len.div_ceil(part_size_bytes_u64)).unwrap_or(0);
-                for part_number in 0..end_part_number {
-                    let _ = entry.delete_part(part_number).await;
-                }
-            }
+            let _ = self
+                .save_parts_stream_with_cleanup(entry.as_ref(), stream, 0, 0..payload_len)
+                .await;
         }
 
         Ok(result)
@@ -458,21 +450,44 @@ impl CachedObjectStore {
 
             let stream = result.into_stream();
 
-            if let Err(e) = self
-                .save_parts_stream(entry.as_ref(), stream, start_part_number, range.clone())
-                .await
-            {
-                // Clean up any parts that were written before the error
-                let end_part_number = usize::try_from(range.end.div_ceil(part_size_bytes_u64))
-                    .unwrap_or(start_part_number);
-                for part_number in start_part_number..end_part_number {
-                    let _ = entry.delete_part(part_number).await;
-                }
-                return Err(e);
-            }
+            self.save_parts_stream_with_cleanup(
+                entry.as_ref(),
+                stream,
+                start_part_number,
+                range.clone(),
+            )
+            .await?;
         }
 
         Ok(object_size)
+    }
+
+    /// Calls `save_parts_stream` and, on error, deletes any partially-written parts
+    /// before returning the error.
+    async fn save_parts_stream_with_cleanup<S>(
+        &self,
+        entry: &dyn LocalCacheEntry,
+        stream: S,
+        start_part_number: usize,
+        range: Range<u64>,
+    ) -> object_store::Result<usize>
+    where
+        S: stream::Stream<Item = Result<Bytes, object_store::Error>> + Unpin,
+    {
+        let result = self
+            .save_parts_stream(entry, stream, start_part_number, range.clone())
+            .await;
+
+        if result.is_err() {
+            let part_size_bytes_u64 = self.part_size_bytes as u64;
+            let end_part_number = usize::try_from(range.end.div_ceil(part_size_bytes_u64))
+                .unwrap_or(start_part_number);
+            for part_number in start_part_number..end_part_number {
+                let _ = entry.delete_part(part_number).await;
+            }
+        }
+
+        result
     }
 
     /// Save a stream of bytes to cache as parts, starting from the specified part number.

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -4,7 +4,7 @@ use crate::cached_object_store::LocalCacheEntry;
 use crate::config::ObjectStoreCacheOptions;
 use crate::rand::DbRand;
 use bytes::{Bytes, BytesMut};
-use futures::{future::BoxFuture, stream, stream::BoxStream, StreamExt};
+use futures::{stream, stream::BoxStream, StreamExt};
 use object_store::{path::Path, GetOptions, GetResult, ObjectMeta, ObjectStore, ObjectStoreExt};
 use object_store::{
     Attributes, CopyOptions, GetRange, GetResultPayload, PutMultipartOptions, PutResult,
@@ -353,10 +353,13 @@ impl CachedObjectStore {
         if self.admission_picker.pick(entry.as_ref()).admitted() {
             // Convert PutPayload to stream and save parts to cache.
             // Note: cached_head() already saved the head, so we only need to save parts
+            let payload_len = payload.content_length() as u64;
             let stream = stream::iter(payload.into_iter()).map(Ok::<Bytes, object_store::Error>);
 
             // Save parts only, ignoring errors (cache failures shouldn't fail the PUT operation)
-            self.save_parts_stream(entry, stream, 0).await.ok();
+            self.save_parts_stream(entry.as_ref(), stream, 0, 0..payload_len)
+                .await
+                .ok();
         }
 
         Ok(result)
@@ -421,11 +424,9 @@ impl CachedObjectStore {
     /// aligned with the part size.
     async fn save_get_result(&self, result: GetResult) -> object_store::Result<u64> {
         let part_size_bytes_u64 = self.part_size_bytes as u64;
-        assert!(result.range.start.is_multiple_of(part_size_bytes_u64));
-        assert!(
-            result.range.end.is_multiple_of(part_size_bytes_u64)
-                || result.range.end == result.meta.size
-        );
+        let range = result.range.clone();
+        assert!(range.start.is_multiple_of(part_size_bytes_u64));
+        assert!(range.end.is_multiple_of(part_size_bytes_u64) || range.end == result.meta.size);
 
         let entry = self
             .cache_storage
@@ -435,13 +436,24 @@ impl CachedObjectStore {
         if self.admission_picker.pick(entry.as_ref()).admitted() {
             entry.save_head((&result.meta, &result.attributes)).await?;
 
-            let start_part_number = usize::try_from(result.range.start / part_size_bytes_u64)
-                .expect("Part number exceeds u32 on a 32-bit system. Try increasing part size.");
+            let start_part_number = usize::try_from(range.start / part_size_bytes_u64)
+                .expect("Part number exceeds usize on this system. Try increasing part size.");
 
             let stream = result.into_stream();
 
-            self.save_parts_stream(entry, stream, start_part_number)
-                .await?;
+            if let Err(e) = self
+                .save_parts_stream(entry.as_ref(), stream, start_part_number, range.clone())
+                .await
+            {
+                // Clean up any parts that were written before the error
+                let end_part_number =
+                    usize::try_from((range.end + part_size_bytes_u64 - 1) / part_size_bytes_u64)
+                        .unwrap_or(start_part_number);
+                for part_number in start_part_number..end_part_number {
+                    let _ = entry.delete_part(part_number).await;
+                }
+                return Err(e);
+            }
         }
 
         Ok(object_size)
@@ -452,9 +464,10 @@ impl CachedObjectStore {
     /// This method only saves the data parts - the head should be saved separately.
     async fn save_parts_stream<S>(
         &self,
-        entry: Box<dyn LocalCacheEntry>,
+        entry: &dyn LocalCacheEntry,
         mut stream: S,
         start_part_number: usize,
+        range: Range<u64>,
     ) -> object_store::Result<usize>
     where
         S: stream::Stream<Item = Result<Bytes, object_store::Error>> + Unpin,
@@ -463,9 +476,23 @@ impl CachedObjectStore {
         let mut part_number = start_part_number;
         let mut total_bytes: usize = 0;
 
+        let range_len = (range.end - range.start) as usize;
+
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;
             total_bytes += chunk.len();
+
+            if total_bytes > range_len {
+                return Err(object_store::Error::Generic {
+                    store: "cached_object_store",
+                    source: format!(
+                        "Stream exceeded range bounds: {} bytes read, but range is {}..{} ({} bytes)",
+                        total_bytes, range.start, range.end, range_len
+                    )
+                    .into(),
+                });
+            }
+
             buffer.extend_from_slice(&chunk);
 
             while buffer.len() >= self.part_size_bytes {

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -366,9 +366,9 @@ impl CachedObjectStore {
             let stream = stream::iter(payload.into_iter()).map(Ok::<Bytes, object_store::Error>);
 
             // Save parts only; on error, clean up any partially-written parts.
-            let _ = self
-                .save_parts_stream_with_cleanup(entry.as_ref(), stream, 0, 0..payload_len)
-                .await;
+            self.save_parts_stream_with_cleanup(entry.as_ref(), stream, 0, 0..payload_len)
+                .await
+                .ok();
         }
 
         Ok(result)

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -446,9 +446,8 @@ impl CachedObjectStore {
                 .await
             {
                 // Clean up any parts that were written before the error
-                let end_part_number =
-                    usize::try_from((range.end + part_size_bytes_u64 - 1) / part_size_bytes_u64)
-                        .unwrap_or(start_part_number);
+                let end_part_number = usize::try_from(range.end.div_ceil(part_size_bytes_u64))
+                    .unwrap_or(start_part_number);
                 for part_number in start_part_number..end_part_number {
                     let _ = entry.delete_part(part_number).await;
                 }
@@ -897,7 +896,11 @@ mod tests {
     use std::time::Duration;
 
     use bytes::Bytes;
-    use object_store::{path::Path, GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
+    use futures::StreamExt;
+    use object_store::{
+        path::Path, GetOptions, GetRange, GetResult, GetResultPayload, ObjectStore, ObjectStoreExt,
+        PutPayload,
+    };
     use rand::Rng;
 
     use super::CachedObjectStore;
@@ -2185,5 +2188,321 @@ mod tests {
         let parts1 = entry1.cached_parts().await.unwrap();
         assert_eq!(parts1.len(), 0, "{parts1:?}");
         assert_eq!(cache_storage.file_handle_cache_population(), 3);
+    }
+
+    // --- Range bounds validation tests ---
+
+    #[tokio::test]
+    async fn test_save_parts_stream_exceeds_range() {
+        // Create a stream that produces more bytes than the range allows.
+        let part_size = 1024;
+        let object_store = Arc::new(object_store::memory::InMemory::new());
+        let test_cache_folder = new_test_cache_folder();
+        let recorder = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            test_cache_folder,
+            None,
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            1000,
+        ));
+        let cached_store = CachedObjectStore::new(
+            object_store.clone(),
+            cache_storage.clone(),
+            part_size,
+            false,
+            stats,
+        )
+        .unwrap();
+
+        let location = Path::from("/data/range_exceed_test");
+        let entry = cached_store.cache_storage.entry(&location, part_size);
+
+        // Range says 100 bytes, but stream produces 200 bytes.
+        let range = 0u64..100u64;
+        let stream = futures::stream::iter(vec![
+            Ok(Bytes::from(vec![0u8; 80])),
+            Ok(Bytes::from(vec![0u8; 120])), // total 200 > 100
+        ]);
+
+        let result = cached_store
+            .save_parts_stream(entry.as_ref(), stream, 0, range)
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Stream exceeded range bounds"),
+            "unexpected error: {}",
+            err
+        );
+
+        // Verify nothing was persisted to cache (no bad file written).
+        let cached_parts = entry.cached_parts().await.unwrap();
+        assert_eq!(cached_parts.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_save_parts_stream_under_range() {
+        // Create a stream that produces fewer bytes than the range requires.
+        let part_size = 1024;
+        let object_store = Arc::new(object_store::memory::InMemory::new());
+        let test_cache_folder = new_test_cache_folder();
+        let recorder = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            test_cache_folder,
+            None,
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            1000,
+        ));
+        let cached_store = CachedObjectStore::new(
+            object_store.clone(),
+            cache_storage.clone(),
+            part_size,
+            false,
+            stats,
+        )
+        .unwrap();
+
+        let location = Path::from("/data/range_under_test");
+        let entry = cached_store.cache_storage.entry(&location, part_size);
+
+        // Range says 200 bytes, but stream produces only 100 bytes.
+        let range = 0u64..200u64;
+        let stream = futures::stream::iter(vec![
+            Ok(Bytes::from(vec![0u8; 50])),
+            Ok(Bytes::from(vec![0u8; 50])), // total 100 < 200
+        ]);
+
+        let result = cached_store
+            .save_parts_stream(entry.as_ref(), stream, 0, range)
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Stream range bounds not met"),
+            "unexpected error: {}",
+            err
+        );
+
+        // Verify nothing was persisted to cache (no bad file written).
+        let cached_parts = entry.cached_parts().await.unwrap();
+        assert_eq!(cached_parts.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_save_parts_stream_exact_range() {
+        // Stream produces exactly the right number of bytes - should succeed.
+        let part_size = 1024;
+        let object_store = Arc::new(object_store::memory::InMemory::new());
+        let test_cache_folder = new_test_cache_folder();
+        let recorder = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            test_cache_folder,
+            None,
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            1000,
+        ));
+        let cached_store = CachedObjectStore::new(
+            object_store.clone(),
+            cache_storage.clone(),
+            part_size,
+            false,
+            stats,
+        )
+        .unwrap();
+
+        let location = Path::from("/data/range_exact_test");
+        let entry = cached_store.cache_storage.entry(&location, part_size);
+
+        // Range says 150 bytes, stream produces exactly 150 bytes.
+        let range = 10u64..160u64;
+        let stream = futures::stream::iter(vec![
+            Ok(Bytes::from(vec![1u8; 75])),
+            Ok(Bytes::from(vec![2u8; 75])), // total 150 == 150
+        ]);
+
+        let result = cached_store
+            .save_parts_stream(entry.as_ref(), stream, 0, range)
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 150);
+    }
+
+    /// An ObjectStore wrapper that truncates the bytes returned by `get_opts`
+    /// to simulate a corrupted or short response.
+    #[derive(Debug)]
+    struct TruncatingObjectStore {
+        inner: Arc<dyn ObjectStore>,
+        /// Maximum number of bytes to return from get_opts, regardless of the
+        /// requested range.
+        max_bytes: usize,
+    }
+
+    impl TruncatingObjectStore {
+        fn new(inner: Arc<dyn ObjectStore>, max_bytes: usize) -> Self {
+            Self { inner, max_bytes }
+        }
+    }
+
+    impl std::fmt::Display for TruncatingObjectStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "TruncatingObjectStore({})", self.inner)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for TruncatingObjectStore {
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            let result = self.inner.get_opts(location, options).await?;
+            let meta = result.meta.clone();
+            let attrs = result.attributes.clone();
+            let range = result.range.clone();
+            let bytes = result.bytes().await?;
+
+            // Truncate the bytes.
+            let truncated = bytes.slice(..self.max_bytes.min(bytes.len()));
+
+            Ok(GetResult {
+                payload: GetResultPayload::Stream(
+                    futures::stream::once(async move { Ok(truncated) }).boxed(),
+                ),
+                meta,
+                attributes: attrs,
+                range,
+            })
+        }
+
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<Path>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_part_bytes_too_short_for_range() {
+        // Simulate an object store returning fewer bytes than requested,
+        // which should trigger the range validation error in read_part.
+        let part_size = 1024;
+        let inner_store = Arc::new(object_store::memory::InMemory::new());
+
+        // Write a file large enough for at least one full part.
+        let location = Path::from("data/truncated_test");
+        let payload = gen_rand_bytes(part_size * 2);
+        inner_store
+            .put(&location, PutPayload::from_bytes(payload.clone()))
+            .await
+            .unwrap();
+
+        // Wrap with a truncating store that only returns 500 bytes max.
+        let truncating_store: Arc<dyn ObjectStore> =
+            Arc::new(TruncatingObjectStore::new(inner_store, 500));
+
+        let test_cache_folder = new_test_cache_folder();
+        let recorder = MetricsRecorderHelper::noop();
+        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
+        let cache_storage = Arc::new(FsCacheStorage::new(
+            test_cache_folder,
+            None,
+            None,
+            stats.clone(),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            1000,
+        ));
+        let cached_store = CachedObjectStore::new(
+            truncating_store,
+            cache_storage.clone(),
+            part_size,
+            false,
+            stats,
+        )
+        .unwrap();
+
+        // Request a full part (range 0..1024) but the store only returns 500 bytes.
+        // read_part requests range_in_part = 0..1024, so bytes.len() (500) < range_in_part.len() (1024).
+        let result = cached_store.read_part(&location, 0, 0..part_size).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Fetched part bytes do not cover the requested range"),
+            "unexpected error: {}",
+            err
+        );
+
+        // Verify that the truncated data was NOT written to cache.
+        let entry = cached_store.cache_storage.entry(&location, part_size);
+        let cached_parts = entry.cached_parts().await.unwrap();
+        assert_eq!(cached_parts.len(), 0);
     }
 }

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -80,6 +80,8 @@ pub trait LocalCacheStorage: Send + Sync + std::fmt::Debug + Display + 'static {
 pub trait LocalCacheEntry: Send + Sync + std::fmt::Debug + 'static {
     async fn save_part(&self, part_number: PartID, buf: Bytes) -> object_store::Result<()>;
 
+    async fn delete_part(&self, part_number: PartID) -> object_store::Result<()>;
+
     async fn read_part(
         &self,
         part_number: PartID,

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -332,6 +332,29 @@ impl LocalCacheEntry for FsCacheEntry {
         self.atomic_write(part_path, buf).await
     }
 
+    async fn delete_part(&self, part_number: usize) -> object_store::Result<()> {
+        let part_path = Self::make_part_path(
+            self.root_folder.clone(),
+            &self.location,
+            part_number,
+            self.part_size,
+        );
+
+        let file_cache = self.file_handle_cache.clone();
+        #[allow(clippy::disallowed_methods)]
+        tokio::task::spawn_blocking(move || {
+            let result = match std::fs::remove_file(&part_path) {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(err) => Err(wrap_io_err(err)),
+            };
+            file_cache.invalidate(&part_path);
+            result
+        })
+        .await
+        .map_err(wrap_io_err)?
+    }
+
     async fn read_part(
         &self,
         part_number: usize,

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -351,8 +351,7 @@ impl LocalCacheEntry for FsCacheEntry {
             file_cache.invalidate(&part_path);
             result
         })
-        .await
-        .map_err(wrap_io_err)?
+        .await?
     }
 
     async fn read_part(


### PR DESCRIPTION
## Summary

This is to fix the issue discussed here:
https://discord.com/channels/1232385660460204122/1506328708426760384/1507040423309217952

```
Hmm.. Codex:

• My read: this is very likely cache poisoning from an object_store range retry bug, not disk corruption, LZ4, or SlateDB compaction logic.

  The smoking gun is the local cache state: _head says the SST is 4,301,409,156 bytes, so with 4 MiB parts the highest valid zero-based part is 1025. Seeing files like _part4mb-
  000002329 means SlateDB’s cache writer wrote bytes as if the object extended to ~9.77 GB. That can’t be explained by “SST exceeded the 4 GB target”; it is past the actual
  object metadata size.

  The likely path is:

  1. SlateDB asks object_store for an aligned range.
  2. The HTTP/GCS stream fails mid-body.
  3. object_store retries the remaining range.
  4. In released object_store 0.13.2, the retry stream swaps in the retry body after checking ETag, but does not validate the retry response Content-Range.
  5. If the retry response is a superset or replay from an earlier offset, object_store emits extra/replayed bytes.
  6. CachedObjectStore::save_parts_stream trusts the stream length and keeps incrementing part numbers, so it writes out-of-bounds _part4mb-* files.

  That lines up almost exactly with apache/arrow-rs-object-store#654 and the merged-but-not-yet-released fix in #690: “respect range header on retry.” It also explains why
  Zach’s defensive patch feels right. The cache should treat “stream produced more bytes than GetResult.range” as upstream corruption and discard the parts.
```

## Changes

- Adds bounds check to the bytes returned by cached_object_store get requests.

## Notes for Reviewers



## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
