### PR TITLE
Distributed Compaction (RFC-0025) Phase 3: Compaction Worker

### DIFF
--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -1,0 +1,962 @@
+//! Distributed-compaction worker (RFC-0025).
+//!
+//! A [`CompactionWorker`] polls `.compactions` for `Submitted` entries, claims
+//! them via the optimistic CAS protocol described in RFC-0025, executes the
+//! compaction with the same code path the in-process executor uses, and writes
+//! `Compacted` (with the produced `output_ssts`) back to `.compactions`. The
+//! coordinator separately observes those `Compacted` entries and commits the
+//! manifest update (see [`crate::compactor::CompactorEventHandler::commit_compacted_entries`]).
+//!
+//! This implements the claim / execute / complete portion of the worker. The
+//! heartbeat emission and coordinator-side failure-detection / reclamation
+//! protocol are added in a follow-up.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use log::{debug, error, info, warn};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use tokio::runtime::Handle;
+use ulid::Ulid;
+
+#[cfg(feature = "compaction_filters")]
+use crate::compaction_filter::CompactionFilterSupplier;
+use crate::compactions_store::{CompactionsStore, StoredCompactions};
+use crate::compactor::stats::CompactionStats;
+use crate::compactor::CompactorMessage;
+use crate::compactor_executor::{
+    CompactionExecutor, StartCompactionJobArgs, TokioCompactionExecutor,
+    TokioCompactionExecutorOptions,
+};
+use crate::compactor_state::{Compaction, CompactionStatus, SourceId, WorkerSpec};
+use crate::config::{CompactionWorkerOptions, CompactorOptions};
+use crate::db_status::ClosedResultWriter;
+use crate::dispatcher::{MessageFactory, MessageHandler, MessageHandlerExecutor};
+use crate::error::SlateDBError;
+use crate::format::sst::SsTableFormat;
+use crate::manifest::store::ManifestStore;
+use crate::manifest::ManifestCore;
+use crate::merge_operator::MergeOperatorType;
+use crate::object_stores::ObjectStores;
+use crate::rand::DbRand;
+use crate::tablestore::TableStore;
+use crate::utils::{IdGenerator, WatchableOnceCell};
+use slatedb_common::clock::{DefaultSystemClock, SystemClock};
+use slatedb_common::metrics::{MetricLevel, MetricsRecorder, MetricsRecorderHelper};
+
+pub(crate) const COMPACTION_WORKER_TASK_NAME: &str = "compaction_worker";
+
+/// Stateless executor of compaction jobs claimed from `.compactions`.
+///
+/// Build one with [`CompactionWorkerBuilder`] and drive its event loop with
+/// [`CompactionWorker::run`]. Call [`CompactionWorker::stop`] to gracefully
+/// release any in-flight claims.
+#[derive(Clone)]
+pub struct CompactionWorker {
+    manifest_store: Arc<ManifestStore>,
+    compactions_store: Arc<CompactionsStore>,
+    table_store: Arc<TableStore>,
+    options: Arc<CompactionWorkerOptions>,
+    task_executor: Arc<MessageHandlerExecutor>,
+    worker_runtime: Handle,
+    rand: Arc<DbRand>,
+    stats: Arc<CompactionStats>,
+    system_clock: Arc<dyn SystemClock>,
+    merge_operator: Option<MergeOperatorType>,
+    #[cfg(feature = "compaction_filters")]
+    compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
+}
+
+impl CompactionWorker {
+    /// Runs the worker until cancellation or fatal error. The worker polls
+    /// `.compactions` every [`CompactionWorkerOptions::compactions_poll_interval`],
+    /// claims up to [`CompactionWorkerOptions::max_concurrent_compactions`] jobs,
+    /// executes them, and writes `Compacted` back to `.compactions`.
+    pub async fn run(&self) -> Result<(), crate::Error> {
+        let (handler, rx) = self.build_handler();
+        self.task_executor
+            .add_handler(
+                COMPACTION_WORKER_TASK_NAME.to_string(),
+                Box::new(handler),
+                rx,
+                &Handle::current(),
+            )
+            .expect("failed to spawn compaction worker task");
+        self.task_executor.monitor_on(&Handle::current())?;
+        self.task_executor
+            .join_task(COMPACTION_WORKER_TASK_NAME)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Gracefully stops the worker, resetting any compactions it claimed back
+    /// to `Submitted` so other workers can pick them up immediately.
+    pub async fn stop(&self) -> Result<(), crate::Error> {
+        self.task_executor
+            .shutdown_task(COMPACTION_WORKER_TASK_NAME)
+            .await
+            .map_err(|e| e.into())
+    }
+
+    /// Builds the worker's [`CompactionWorkerHandler`] and the receiver that
+    /// the handler reads completion messages from. Shared between the
+    /// standalone `run()` path and the embedded-worker path in `Compactor::run`.
+    pub(crate) fn build_handler(
+        &self,
+    ) -> (
+        CompactionWorkerHandler,
+        async_channel::Receiver<CompactorMessage>,
+    ) {
+        let (tx, rx) = async_channel::unbounded();
+        let executor_compactor_options = Arc::new(CompactorOptions {
+            max_sst_size: self.options.max_sst_size,
+            max_fetch_tasks: self.options.max_fetch_tasks,
+            ..CompactorOptions::default()
+        });
+        let executor = Arc::new(TokioCompactionExecutor::new(
+            TokioCompactionExecutorOptions {
+                handle: self.worker_runtime.clone(),
+                options: executor_compactor_options,
+                worker_tx: tx,
+                table_store: self.table_store.clone(),
+                rand: self.rand.clone(),
+                stats: self.stats.clone(),
+                clock: self.system_clock.clone(),
+                manifest_store: self.manifest_store.clone(),
+                merge_operator: self.merge_operator.clone(),
+                #[cfg(feature = "compaction_filters")]
+                compaction_filter_supplier: self.compaction_filter_supplier.clone(),
+            },
+        ));
+
+        let worker_id = self
+            .rand
+            .rng()
+            .gen_ulid(self.system_clock.as_ref())
+            .to_string();
+        info!("starting compaction worker [worker_id={}]", worker_id);
+
+        let handler = CompactionWorkerHandler::new(
+            worker_id,
+            self.options.clone(),
+            self.compactions_store.clone(),
+            self.manifest_store.clone(),
+            executor,
+            self.system_clock.clone(),
+        );
+        (handler, rx)
+    }
+}
+
+/// Builder for [`CompactionWorker`].
+///
+/// Mirrors `CompactorBuilder`: the user supplies a DB path and object store,
+/// optionally overrides options/clock/seed/merge operator, then calls
+/// [`CompactionWorkerBuilder::build`].
+pub struct CompactionWorkerBuilder<P: Into<Path>> {
+    path: P,
+    main_object_store: Arc<dyn ObjectStore>,
+    worker_runtime: Handle,
+    options: CompactionWorkerOptions,
+    rand: Arc<DbRand>,
+    recorder: MetricsRecorderHelper,
+    system_clock: Arc<dyn SystemClock>,
+    merge_operator: Option<MergeOperatorType>,
+    #[cfg(feature = "compaction_filters")]
+    compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
+}
+
+impl<P: Into<Path>> CompactionWorkerBuilder<P> {
+    pub fn new(path: P, main_object_store: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            path,
+            main_object_store,
+            worker_runtime: Handle::current(),
+            options: CompactionWorkerOptions::default(),
+            rand: Arc::new(DbRand::default()),
+            recorder: MetricsRecorderHelper::noop(),
+            system_clock: Arc::new(DefaultSystemClock::default()),
+            merge_operator: None,
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: None,
+        }
+    }
+
+    pub fn with_options(mut self, options: CompactionWorkerOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    pub fn with_runtime(mut self, runtime: Handle) -> Self {
+        self.worker_runtime = runtime;
+        self
+    }
+
+    pub fn with_system_clock(mut self, system_clock: Arc<dyn SystemClock>) -> Self {
+        self.system_clock = system_clock;
+        self
+    }
+
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.rand = Arc::new(DbRand::new(seed));
+        self
+    }
+
+    pub fn with_metrics_recorder(mut self, recorder: Arc<dyn MetricsRecorder>) -> Self {
+        self.recorder = MetricsRecorderHelper::new(recorder, MetricLevel::default());
+        self
+    }
+
+    pub fn with_merge_operator(mut self, merge_operator: MergeOperatorType) -> Self {
+        self.merge_operator = Some(merge_operator);
+        self
+    }
+
+    #[cfg(feature = "compaction_filters")]
+    pub fn with_compaction_filter_supplier(
+        mut self,
+        supplier: Arc<dyn CompactionFilterSupplier>,
+    ) -> Self {
+        self.compaction_filter_supplier = Some(supplier);
+        self
+    }
+
+    pub async fn build(self) -> Result<CompactionWorker, crate::Error> {
+        let path: Path = self.path.into();
+        let manifest_store = Arc::new(ManifestStore::new(&path, self.main_object_store.clone()));
+        let compactions_store =
+            Arc::new(CompactionsStore::new(&path, self.main_object_store.clone()));
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(self.main_object_store, None),
+            SsTableFormat::default(),
+            path,
+            None,
+        ));
+        let stats = Arc::new(CompactionStats::new(&self.recorder));
+        let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
+        let task_executor = Arc::new(MessageHandlerExecutor::new(
+            closed_result,
+            self.system_clock.clone(),
+        ));
+        Ok(CompactionWorker {
+            manifest_store,
+            compactions_store,
+            table_store,
+            options: Arc::new(self.options),
+            task_executor,
+            worker_runtime: self.worker_runtime,
+            rand: self.rand,
+            stats,
+            system_clock: self.system_clock,
+            merge_operator: self.merge_operator,
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: self.compaction_filter_supplier,
+        })
+    }
+}
+
+/// Internal `MessageHandler` for the worker's event loop.
+///
+/// Reuses [`CompactorMessage`] so the embedded [`TokioCompactionExecutor`] can
+/// report `CompactionJobFinished` on the same channel the dispatcher polls.
+pub(crate) struct CompactionWorkerHandler {
+    worker_id: String,
+    options: Arc<CompactionWorkerOptions>,
+    compactions_store: Arc<CompactionsStore>,
+    manifest_store: Arc<ManifestStore>,
+    executor: Arc<dyn CompactionExecutor + Send + Sync>,
+    clock: Arc<dyn SystemClock>,
+    /// Compactions currently being executed by this worker (claimed but not
+    /// yet `Compacted`). Used to gate capacity and to know what to reset on
+    /// graceful shutdown.
+    active_jobs: HashSet<Ulid>,
+    /// Lazily-initialized handle for CAS reads/writes on `.compactions`. The
+    /// coordinator creates the file on first run; the worker tolerates its
+    /// absence on early ticks.
+    stored: Option<StoredCompactions>,
+}
+
+impl CompactionWorkerHandler {
+    pub(crate) fn new(
+        worker_id: String,
+        options: Arc<CompactionWorkerOptions>,
+        compactions_store: Arc<CompactionsStore>,
+        manifest_store: Arc<ManifestStore>,
+        executor: Arc<dyn CompactionExecutor + Send + Sync>,
+        clock: Arc<dyn SystemClock>,
+    ) -> Self {
+        Self {
+            worker_id,
+            options,
+            compactions_store,
+            manifest_store,
+            executor,
+            clock,
+            active_jobs: HashSet::new(),
+            stored: None,
+        }
+    }
+
+    /// Loads `.compactions` on first use; subsequent calls reuse the cached
+    /// handle. Returns `Ok(false)` if the file does not yet exist (worker
+    /// started before the coordinator).
+    async fn ensure_loaded(&mut self) -> Result<bool, SlateDBError> {
+        if self.stored.is_some() {
+            return Ok(true);
+        }
+        match StoredCompactions::try_load(self.compactions_store.clone()).await? {
+            Some(s) => {
+                self.stored = Some(s);
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn capacity(&self) -> usize {
+        self.options
+            .max_concurrent_compactions
+            .saturating_sub(self.active_jobs.len())
+    }
+
+    /// Scans `.compactions` for `Submitted` entries without a worker, claims up
+    /// to remaining capacity via CAS, and dispatches each to the executor.
+    async fn poll_and_claim(&mut self) -> Result<(), SlateDBError> {
+        if !self.ensure_loaded().await? {
+            return Ok(());
+        }
+        let capacity = self.capacity();
+        if capacity == 0 {
+            return Ok(());
+        }
+
+        // CAS loop: read latest, identify candidates, attempt write.
+        let claimed = loop {
+            let stored = self
+                .stored
+                .as_mut()
+                .expect("ensure_loaded set stored to Some");
+            stored.refresh().await?;
+            let to_claim: Vec<Compaction> = stored
+                .compactions()
+                .iter_with_status(CompactionStatus::Submitted)
+                .filter(|c| c.worker().is_none())
+                .take(capacity)
+                .cloned()
+                .collect();
+            if to_claim.is_empty() {
+                return Ok(());
+            }
+
+            let heartbeat_ms = self.clock.now().timestamp_millis() as u64;
+            let worker_spec = WorkerSpec::new(self.worker_id.clone(), heartbeat_ms);
+
+            let mut dirty = stored.prepare_dirty()?;
+            for c in &to_claim {
+                dirty.value.insert(
+                    c.clone()
+                        .with_status(CompactionStatus::Running)
+                        .with_worker(Some(worker_spec.clone())),
+                );
+            }
+            match stored.update(dirty).await {
+                Ok(()) => break to_claim,
+                Err(e) if e.is_sequenced_write_conflict() => {
+                    debug!("claim conflict on .compactions; refreshing and retrying");
+                    continue;
+                }
+                Err(e) => return Err(e),
+            }
+        };
+
+        let manifest = self.manifest_store.read_latest_manifest().await?;
+        let db_state = manifest.core();
+        for compaction in claimed {
+            match Self::build_job_args(&compaction, db_state, &self.worker_id) {
+                Ok(args) => {
+                    info!(
+                        "claimed compaction [worker_id={}, id={}]",
+                        self.worker_id,
+                        compaction.id()
+                    );
+                    self.active_jobs.insert(compaction.id());
+                    Self::dispatch_to_executor(&self.executor, args).await?;
+                }
+                Err(e) => {
+                    warn!(
+                        "invalid compaction; releasing claim [id={}, error={:?}]",
+                        compaction.id(),
+                        e
+                    );
+                    self.release_claim(compaction.id()).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn build_job_args(
+        compaction: &Compaction,
+        db_state: &ManifestCore,
+        _worker_id: &str,
+    ) -> Result<StartCompactionJobArgs, SlateDBError> {
+        let destination = compaction
+            .spec()
+            .destination()
+            .ok_or(SlateDBError::InvalidCompaction)?;
+        let sst_views = compaction.get_l0_sst_views(db_state);
+        let sorted_runs = compaction.get_sorted_runs(db_state);
+
+        // Reject drain specs (workers only execute tiered compactions; drain
+        // is coordinator-local).
+        if compaction.spec().is_drain() {
+            return Err(SlateDBError::InvalidCompaction);
+        }
+
+        // Validate the spec's sources actually exist in the manifest. If they
+        // don't, the spec was racing with a manifest write — release the
+        // claim and let the coordinator reschedule.
+        let expected_l0 = compaction
+            .spec()
+            .sources()
+            .iter()
+            .filter(|s| matches!(s, SourceId::SstView(_)))
+            .count();
+        let expected_srs = compaction
+            .spec()
+            .sources()
+            .iter()
+            .filter(|s| matches!(s, SourceId::SortedRun(_)))
+            .count();
+        if sst_views.len() != expected_l0 || sorted_runs.len() != expected_srs {
+            return Err(SlateDBError::InvalidCompaction);
+        }
+
+        let is_dest_last_run = match db_state.tree_for_segment(compaction.spec().segment()) {
+            Some(tree) => {
+                tree.compacted.is_empty()
+                    || tree.compacted.last().is_some_and(|sr| destination == sr.id)
+            }
+            None => false,
+        };
+
+        Ok(StartCompactionJobArgs {
+            // Use compaction_id as job id so completion messages line up with
+            // the entry in `.compactions`. (One-job-per-Compaction in phase 2.)
+            id: compaction.id(),
+            compaction_id: compaction.id(),
+            destination,
+            sst_views,
+            sorted_runs,
+            output_ssts: compaction.output_ssts().clone(),
+            compaction_clock_tick: db_state.last_l0_clock_tick,
+            retention_min_seq: Some(db_state.recent_snapshot_min_seq),
+            is_dest_last_run,
+        })
+    }
+
+    async fn dispatch_to_executor(
+        executor: &Arc<dyn CompactionExecutor + Send + Sync>,
+        args: StartCompactionJobArgs,
+    ) -> Result<(), SlateDBError> {
+        let executor = executor.clone();
+        #[cfg(not(dst))]
+        #[allow(clippy::disallowed_methods)]
+        let result = tokio::task::spawn_blocking(move || {
+            executor.start_compaction_job(args);
+        })
+        .await
+        .map_err(|_| SlateDBError::CompactionExecutorFailed);
+        #[cfg(dst)]
+        let result = tokio::spawn(async move {
+            executor.start_compaction_job(args);
+        })
+        .await
+        .map_err(|_| SlateDBError::CompactionExecutorFailed);
+        result
+    }
+
+    /// Writes `Compacted` (with the produced `output_ssts`) for a successfully
+    /// executed job. Only writes if the worker still owns the entry; otherwise
+    /// it has been reclaimed and the produced SSTs become orphans (collected
+    /// by GC).
+    async fn write_compacted(
+        &mut self,
+        compaction_id: Ulid,
+        output_ssts: Vec<crate::db_state::SsTableHandle>,
+    ) -> Result<(), SlateDBError> {
+        if !self.ensure_loaded().await? {
+            return Ok(());
+        }
+        loop {
+            let stored = self.stored.as_mut().expect("ensure_loaded set stored");
+            stored.refresh().await?;
+            let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+                info!(
+                    "compaction entry missing on completion; dropping [id={}]",
+                    compaction_id
+                );
+                return Ok(());
+            };
+            if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
+                info!(
+                    "lost ownership before completion; dropping [id={}]",
+                    compaction_id
+                );
+                return Ok(());
+            }
+            let heartbeat_ms = self.clock.now().timestamp_millis() as u64;
+            let updated = existing
+                .with_status(CompactionStatus::Compacted)
+                .with_output_ssts(output_ssts.clone())
+                .with_worker(Some(WorkerSpec::new(self.worker_id.clone(), heartbeat_ms)));
+            let mut dirty = stored.prepare_dirty()?;
+            dirty.value.insert(updated);
+            match stored.update(dirty).await {
+                Ok(()) => return Ok(()),
+                Err(e) if e.is_sequenced_write_conflict() => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Returns a claim to `Submitted` so it can be re-attempted by any worker
+    /// (used when execution fails or when the worker shuts down gracefully).
+    async fn release_claim(&mut self, compaction_id: Ulid) -> Result<(), SlateDBError> {
+        if !self.ensure_loaded().await? {
+            return Ok(());
+        }
+        loop {
+            let stored = self.stored.as_mut().expect("ensure_loaded set stored");
+            stored.refresh().await?;
+            let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+                return Ok(());
+            };
+            if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
+                return Ok(());
+            }
+            let updated = existing
+                .with_status(CompactionStatus::Submitted)
+                .with_worker(None);
+            let mut dirty = stored.prepare_dirty()?;
+            dirty.value.insert(updated);
+            match stored.update(dirty).await {
+                Ok(()) => return Ok(()),
+                Err(e) if e.is_sequenced_write_conflict() => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    async fn handle_finished(
+        &mut self,
+        id: Ulid,
+        result: Result<crate::db_state::SortedRun, SlateDBError>,
+    ) -> Result<(), SlateDBError> {
+        self.active_jobs.remove(&id);
+        match result {
+            Ok(sr) => {
+                let output_ssts: Vec<crate::db_state::SsTableHandle> =
+                    sr.sst_views.into_iter().map(|v| v.sst).collect();
+                self.write_compacted(id, output_ssts).await?;
+            }
+            Err(e) => {
+                error!("compaction job failed [id={}, error={:?}]", id, e);
+                self.release_claim(id).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl MessageHandler<CompactorMessage> for CompactionWorkerHandler {
+    fn tickers(&mut self) -> Vec<(Duration, Box<MessageFactory<CompactorMessage>>)> {
+        vec![(
+            self.options.compactions_poll_interval,
+            Box::new(|| CompactorMessage::PollCompactions),
+        )]
+    }
+
+    async fn handle(&mut self, message: CompactorMessage) -> Result<(), SlateDBError> {
+        match message {
+            CompactorMessage::PollCompactions => self.poll_and_claim().await?,
+            CompactorMessage::CompactionJobFinished { id, result } => {
+                self.handle_finished(id, result).await?;
+                // Opportunistically claim more after freeing capacity.
+                self.poll_and_claim().await?;
+            }
+            // Heartbeat emission is added in the failure-detection follow-up;
+            // for now progress messages are ignored. The executor still
+            // produces them; we just drop them.
+            CompactorMessage::CompactionJobProgress { .. } => {}
+            CompactorMessage::LogStats | CompactorMessage::PollManifest => {}
+        }
+        Ok(())
+    }
+
+    async fn cleanup(
+        &mut self,
+        _messages: BoxStream<'async_trait, CompactorMessage>,
+        _result: Result<(), SlateDBError>,
+    ) -> Result<(), SlateDBError> {
+        // Stop accepting new work, then release any active claims so other
+        // workers can pick them up immediately rather than waiting for the
+        // heartbeat-timeout reclamation path.
+        //
+        // `TokioCompactionExecutor::stop` internally uses `handle.block_on`,
+        // which panics when called from within an async runtime. Mirror the
+        // coordinator's `stop_executor` pattern (see compactor.rs) and run it
+        // off-runtime.
+        let executor = self.executor.clone();
+        #[cfg(not(dst))]
+        #[allow(clippy::disallowed_methods)]
+        let _ = tokio::task::spawn_blocking(move || executor.stop()).await;
+        #[cfg(dst)]
+        let _ = tokio::spawn(async move { executor.stop() }).await;
+        let claimed: Vec<Ulid> = self.active_jobs.drain().collect();
+        for id in claimed {
+            if let Err(e) = self.release_claim(id).await {
+                error!(
+                    "failed to release claim on shutdown [worker_id={}, id={}, error={:?}]",
+                    self.worker_id, id, e
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---- internal helpers for the embedded-worker path used by `Compactor::run` ----
+
+/// Construct a worker with pre-built stores and stats, used by the
+/// embedded-worker path inside [`crate::compactor::Compactor::run`] to avoid
+/// double-instantiating the manifest / compactions / table stores or building
+/// a second [`MessageHandlerExecutor`]. The worker shares the coordinator's
+/// stats so per-worker metrics are observable through the same recorder.
+// Wired into `Compactor::run` by a later commit; kept here so the worker
+// module compiles standalone on this branch.
+#[allow(dead_code)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_embedded_worker(
+    manifest_store: Arc<ManifestStore>,
+    compactions_store: Arc<CompactionsStore>,
+    table_store: Arc<TableStore>,
+    options: CompactionWorkerOptions,
+    worker_runtime: Handle,
+    rand: Arc<DbRand>,
+    stats: Arc<CompactionStats>,
+    system_clock: Arc<dyn SystemClock>,
+    merge_operator: Option<MergeOperatorType>,
+    #[cfg(feature = "compaction_filters")] compaction_filter_supplier: Option<
+        Arc<dyn CompactionFilterSupplier>,
+    >,
+) -> CompactionWorker {
+    // The embedded worker shares the coordinator's `MessageHandlerExecutor`,
+    // so the local one constructed here is unused — kept only so the
+    // `CompactionWorker` struct shape is identical to the standalone path.
+    let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
+    let task_executor = Arc::new(MessageHandlerExecutor::new(
+        closed_result,
+        system_clock.clone(),
+    ));
+    CompactionWorker {
+        manifest_store,
+        compactions_store,
+        table_store,
+        options: Arc::new(options),
+        task_executor,
+        worker_runtime,
+        rand,
+        stats,
+        system_clock,
+        merge_operator,
+        #[cfg(feature = "compaction_filters")]
+        compaction_filter_supplier,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compactor_state::{Compaction, CompactionSpec, SourceId};
+    use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
+    use crate::format::sst::SST_FORMAT_VERSION_LATEST;
+    use crate::manifest::store::StoredManifest;
+    use crate::manifest::ManifestCore;
+    use bytes::Bytes;
+    use futures::stream::StreamExt;
+    use object_store::memory::InMemory;
+    use parking_lot::Mutex;
+    use slatedb_common::clock::DefaultSystemClock;
+
+    const ROOT: &str = "/worker-test";
+
+    /// Captures `start_compaction_job` calls without executing them, so the
+    /// worker handler can be exercised without spinning up actual SST writers.
+    struct NoopExecutor {
+        jobs: Mutex<Vec<StartCompactionJobArgs>>,
+    }
+
+    impl NoopExecutor {
+        fn new() -> Self {
+            Self {
+                jobs: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn jobs(&self) -> Vec<StartCompactionJobArgs> {
+            self.jobs.lock().clone()
+        }
+    }
+
+    impl CompactionExecutor for NoopExecutor {
+        fn start_compaction_job(&self, args: StartCompactionJobArgs) {
+            self.jobs.lock().push(args);
+        }
+        fn stop(&self) {}
+        fn is_stopped(&self) -> bool {
+            false
+        }
+    }
+
+    struct WorkerFixture {
+        compactions_store: Arc<CompactionsStore>,
+        executor: Arc<NoopExecutor>,
+        handler: CompactionWorkerHandler,
+        worker_id: String,
+        // Holds an SsTableView so the test scope keeps it alive; reused as a
+        // source for claimed compactions.
+        l0_view: SsTableView,
+    }
+
+    impl WorkerFixture {
+        async fn new(worker_id: &str) -> Self {
+            let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+            let path = Path::from(ROOT);
+            let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
+            let compactions_store = Arc::new(CompactionsStore::new(&path, object_store.clone()));
+            let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+
+            // Seed manifest with one L0 view so the worker can validate spec
+            // sources during the claim flow. The unsegmented V1 manifest
+            // wire format only persists the SST ULID for L0 entries (view
+            // id == sst id on round-trip), so use `identity` here.
+            let mut core = ManifestCore::new();
+            let sst_ulid = Ulid::from_parts(1000, 0);
+            let sst_info = SsTableInfo {
+                first_entry: Some(Bytes::from_static(b"a")),
+                ..SsTableInfo::default()
+            };
+            let l0_view = SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(sst_ulid),
+                SST_FORMAT_VERSION_LATEST,
+                sst_info,
+            ));
+            Arc::make_mut(&mut core.tree).l0.push_back(l0_view.clone());
+            StoredManifest::create_new_db(manifest_store.clone(), core, clock.clone())
+                .await
+                .unwrap();
+
+            // Coordinator normally creates `.compactions` on startup. Seed it
+            // here for the worker.
+            StoredCompactions::create(compactions_store.clone(), 0)
+                .await
+                .unwrap();
+
+            let executor = Arc::new(NoopExecutor::new());
+            let handler = CompactionWorkerHandler::new(
+                worker_id.to_string(),
+                Arc::new(CompactionWorkerOptions::default()),
+                compactions_store.clone(),
+                manifest_store.clone(),
+                executor.clone(),
+                clock,
+            );
+
+            Self {
+                compactions_store,
+                executor,
+                handler,
+                worker_id: worker_id.to_string(),
+                l0_view,
+            }
+        }
+
+        /// Writes a single Submitted compaction directly to `.compactions`,
+        /// simulating one a coordinator would emit.
+        async fn seed_submitted_compaction(&self, id: Ulid, sources: Vec<SourceId>) {
+            let spec = CompactionSpec::new(sources, 0);
+            let compaction = Compaction::new(id, spec); // defaults to Submitted, no worker
+            let mut stored = StoredCompactions::try_load(self.compactions_store.clone())
+                .await
+                .unwrap()
+                .expect("compactions file must exist");
+            let mut dirty = stored.prepare_dirty().unwrap();
+            dirty.value.insert(compaction);
+            stored.update(dirty).await.unwrap();
+        }
+
+        async fn read_compaction(&self, id: Ulid) -> Option<Compaction> {
+            let v = self
+                .compactions_store
+                .read_latest_compactions()
+                .await
+                .unwrap();
+            v.compactions.get(&id).cloned()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_worker_claims_submitted_compaction() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_submitted_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        // The compaction should now be Running with this worker's id.
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Running);
+        let worker = c.worker().expect("worker spec missing");
+        assert_eq!(worker.worker_id, fx.worker_id);
+        assert!(worker.last_heartbeat_ms > 0);
+
+        // The worker should have dispatched the job to its executor.
+        let jobs = fx.executor.jobs();
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].compaction_id, id);
+
+        // And the worker tracks the job locally.
+        assert!(fx.handler.active_jobs.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_skips_compactions_owned_by_other_workers() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        // Pre-claim a compaction as "worker-B".
+        let id = Ulid::from_parts(1, 0);
+        let spec = CompactionSpec::new(vec![SourceId::SstView(fx.l0_view.id)], 0);
+        let other = Compaction::new(id, spec)
+            .with_status(CompactionStatus::Running)
+            .with_worker(Some(WorkerSpec::new("worker-B".to_string(), 12345)));
+        let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut dirty = stored.prepare_dirty().unwrap();
+        dirty.value.insert(other);
+        stored.update(dirty).await.unwrap();
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        // No claim should have been made; worker-B's entry is untouched.
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Running);
+        assert_eq!(c.worker().unwrap().worker_id, "worker-B");
+        assert!(fx.executor.jobs().is_empty());
+        assert!(fx.handler.active_jobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_worker_writes_compacted_on_finish() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_submitted_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        // Build a synthetic SortedRun the executor would have returned.
+        let output_handle = SsTableHandle::new(
+            SsTableId::Compacted(Ulid::from_parts(9000, 0)),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                first_entry: Some(Bytes::from_static(b"a")),
+                ..SsTableInfo::default()
+            },
+        );
+        let output_sr = SortedRun {
+            id: 0,
+            sst_views: vec![SsTableView::new(
+                Ulid::from_parts(9001, 0),
+                output_handle.clone(),
+            )],
+        };
+
+        fx.handler.handle_finished(id, Ok(output_sr)).await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Compacted);
+        assert_eq!(c.output_ssts().len(), 1);
+        assert_eq!(c.output_ssts()[0].id, output_handle.id);
+        // worker_id is still attached (the coordinator clears it on commit).
+        assert_eq!(c.worker().unwrap().worker_id, fx.worker_id);
+        // Active set is drained on finish.
+        assert!(!fx.handler.active_jobs.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_releases_claim_on_execution_failure() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_submitted_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        fx.handler
+            .handle_finished(id, Err(SlateDBError::InvalidDBState))
+            .await
+            .unwrap();
+
+        // On error the worker releases the claim so another worker can retry.
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Submitted);
+        assert!(c.worker().is_none());
+        assert!(!fx.handler.active_jobs.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_cleanup_releases_active_claims() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_submitted_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert_eq!(fx.handler.active_jobs.len(), 1);
+
+        // cleanup mirrors graceful shutdown.
+        let empty: BoxStream<'_, CompactorMessage> = futures::stream::empty().boxed();
+        fx.handler.cleanup(empty, Ok(())).await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Submitted);
+        assert!(c.worker().is_none());
+        assert!(fx.handler.active_jobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_worker_invalid_spec_releases_claim() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        // Source view ID that does not exist in the manifest — build_job_args
+        // should reject this and the claim should be released.
+        let ghost = Ulid::from_parts(u64::MAX, 0);
+        fx.seed_submitted_compaction(id, vec![SourceId::SstView(ghost)])
+            .await;
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Submitted);
+        assert!(c.worker().is_none());
+        // No active job retained.
+        assert!(fx.handler.active_jobs.is_empty());
+        // No job was dispatched to the executor either.
+        assert!(fx.executor.jobs().is_empty());
+    }
+}

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -77,7 +77,18 @@ impl CompactionWorker {
     /// claims up to [`CompactionWorkerOptions::max_concurrent_compactions`] jobs,
     /// executes them, and writes `Compacted` back to `.compactions`.
     pub async fn run(&self) -> Result<(), crate::Error> {
-        let (handler, rx) = self.build_handler();
+        let (handler, rx) = build_handler(
+            self.manifest_store.clone(),
+            self.compactions_store.clone(),
+            self.table_store.clone(),
+            self.options.clone(),
+            self.worker_runtime.clone(),
+            self.rand.clone(),
+            self.stats.clone(),
+            self.system_clock.clone(),
+            self.merge_operator.clone(),
+            self.compaction_filter_supplier.clone(),
+        );
         self.task_executor
             .add_handler(
                 COMPACTION_WORKER_TASK_NAME.to_string(),
@@ -100,55 +111,6 @@ impl CompactionWorker {
             .shutdown_task(COMPACTION_WORKER_TASK_NAME)
             .await
             .map_err(|e| e.into())
-    }
-
-    /// Builds the worker's [`CompactionWorkerHandler`] and the receiver that
-    /// the handler reads completion messages from. Shared between the
-    /// standalone `run()` path and the embedded-worker path in `Compactor::run`.
-    pub(crate) fn build_handler(
-        &self,
-    ) -> (
-        CompactionWorkerHandler,
-        async_channel::Receiver<CompactorMessage>,
-    ) {
-        let (tx, rx) = async_channel::unbounded();
-        let executor_compactor_options = Arc::new(CompactorOptions {
-            max_sst_size: self.options.max_sst_size,
-            max_fetch_tasks: self.options.max_fetch_tasks,
-            ..CompactorOptions::default()
-        });
-        let executor = Arc::new(TokioCompactionExecutor::new(
-            TokioCompactionExecutorOptions {
-                handle: self.worker_runtime.clone(),
-                options: executor_compactor_options,
-                worker_tx: tx,
-                table_store: self.table_store.clone(),
-                rand: self.rand.clone(),
-                stats: self.stats.clone(),
-                clock: self.system_clock.clone(),
-                manifest_store: self.manifest_store.clone(),
-                merge_operator: self.merge_operator.clone(),
-                #[cfg(feature = "compaction_filters")]
-                compaction_filter_supplier: self.compaction_filter_supplier.clone(),
-            },
-        ));
-
-        let worker_id = self
-            .rand
-            .rng()
-            .gen_ulid(self.system_clock.as_ref())
-            .to_string();
-        info!("starting compaction worker [worker_id={}]", worker_id);
-
-        let handler = CompactionWorkerHandler::new(
-            worker_id,
-            self.options.clone(),
-            self.compactions_store.clone(),
-            self.manifest_store.clone(),
-            executor,
-            self.system_clock.clone(),
-        );
-        (handler, rx)
     }
 }
 
@@ -631,22 +593,14 @@ impl MessageHandler<CompactorMessage> for CompactionWorkerHandler {
     }
 }
 
-// ---- internal helpers for the embedded-worker path used by `Compactor::run` ----
-
-/// Construct a worker with pre-built stores and stats, used by the
-/// embedded-worker path inside [`crate::compactor::Compactor::run`] to avoid
-/// double-instantiating the manifest / compactions / table stores or building
-/// a second [`MessageHandlerExecutor`]. The worker shares the coordinator's
-/// stats so per-worker metrics are observable through the same recorder.
-// Wired into `Compactor::run` by a later commit; kept here so the worker
-// module compiles standalone on this branch.
-#[allow(dead_code)]
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn build_embedded_worker(
+/// Builds the worker's [`CompactionWorkerHandler`] and the receiver that
+/// the handler reads completion messages from. Shared between the
+/// standalone `run()` path and the embedded-worker path in `Compactor::run`.
+pub(crate) fn build_handler(
     manifest_store: Arc<ManifestStore>,
     compactions_store: Arc<CompactionsStore>,
     table_store: Arc<TableStore>,
-    options: CompactionWorkerOptions,
+    options: Arc<CompactionWorkerOptions>,
     worker_runtime: Handle,
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
@@ -655,29 +609,44 @@ pub(crate) fn build_embedded_worker(
     #[cfg(feature = "compaction_filters")] compaction_filter_supplier: Option<
         Arc<dyn CompactionFilterSupplier>,
     >,
-) -> CompactionWorker {
-    // The embedded worker shares the coordinator's `MessageHandlerExecutor`,
-    // so the local one constructed here is unused — kept only so the
-    // `CompactionWorker` struct shape is identical to the standalone path.
-    let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
-    let task_executor = Arc::new(MessageHandlerExecutor::new(
-        closed_result,
-        system_clock.clone(),
+) -> (
+    CompactionWorkerHandler,
+    async_channel::Receiver<CompactorMessage>,
+) {
+    let (tx, rx) = async_channel::unbounded();
+    let executor_compactor_options = Arc::new(CompactorOptions {
+        max_sst_size: options.max_sst_size,
+        max_fetch_tasks: options.max_fetch_tasks,
+        ..CompactorOptions::default()
+    });
+    let executor = Arc::new(TokioCompactionExecutor::new(
+        TokioCompactionExecutorOptions {
+            handle: worker_runtime.clone(),
+            options: executor_compactor_options,
+            worker_tx: tx,
+            table_store: table_store.clone(),
+            rand: rand.clone(),
+            stats: stats.clone(),
+            clock: system_clock.clone(),
+            manifest_store: manifest_store.clone(),
+            merge_operator: merge_operator.clone(),
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: compaction_filter_supplier.clone(),
+        },
     ));
-    CompactionWorker {
-        manifest_store,
-        compactions_store,
-        table_store,
-        options: Arc::new(options),
-        task_executor,
-        worker_runtime,
-        rand,
-        stats,
-        system_clock,
-        merge_operator,
-        #[cfg(feature = "compaction_filters")]
-        compaction_filter_supplier,
-    }
+
+    let worker_id = rand.rng().gen_ulid(system_clock.as_ref()).to_string();
+    info!("starting compaction worker [worker_id={}]", worker_id);
+
+    let handler = CompactionWorkerHandler::new(
+        worker_id,
+        options.clone(),
+        compactions_store.clone(),
+        manifest_store.clone(),
+        executor,
+        system_clock.clone(),
+    );
+    (handler, rx)
 }
 
 #[cfg(test)]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -27,9 +27,8 @@ use ulid::Ulid;
 use crate::compaction_filter::CompactionFilterSupplier;
 use crate::compactions_store::{CompactionsStore, StoredCompactions};
 use crate::compactor::stats::CompactionStats;
-use crate::compactor::CompactorMessage;
 use crate::compactor_executor::{
-    CompactionExecutor, StartCompactionJobArgs, TokioCompactionExecutor,
+    CompactionExecutor, ExecutorMessage, StartCompactionJobArgs, TokioCompactionExecutor,
     TokioCompactionExecutorOptions,
 };
 use crate::compactor_state::{Compaction, CompactionStatus, SourceId, WorkerSpec};
@@ -49,6 +48,48 @@ use slatedb_common::clock::{DefaultSystemClock, SystemClock};
 use slatedb_common::metrics::{MetricLevel, MetricsRecorder, MetricsRecorderHelper};
 
 pub(crate) const COMPACTION_WORKER_TASK_NAME: &str = "compaction_worker";
+
+#[derive(Debug)]
+pub(crate) enum WorkerMessage {
+    /// Signals that a compaction job has finished execution.
+    CompactionJobFinished {
+        /// Job id (distinct from the canonical compaction id).
+        id: Ulid,
+        /// Output SR on success, or the compaction error.
+        result: Result<crate::db_state::SortedRun, SlateDBError>,
+    },
+    /// Periodic progress update from the [`CompactionExecutor`].
+    // Fields are unused until heartbeat emission is wired in the failure-detection follow-up.
+    #[allow(dead_code)]
+    CompactionJobProgress {
+        /// The job id associated with this progress report.
+        id: Ulid,
+        /// The total number of bytes processed so far (estimate).
+        bytes_processed: u64,
+        /// The output SSTs produced so far (including previous runs).
+        output_ssts: Vec<crate::db_state::SsTableHandle>,
+    },
+    /// Ticker-triggered message to poll `.compactions` for claimable jobs.
+    PollCompactions,
+}
+
+impl ExecutorMessage for WorkerMessage {
+    fn job_finished(id: Ulid, result: Result<crate::db_state::SortedRun, SlateDBError>) -> Self {
+        WorkerMessage::CompactionJobFinished { id, result }
+    }
+
+    fn job_progress(
+        id: Ulid,
+        bytes_processed: u64,
+        output_ssts: Vec<crate::db_state::SsTableHandle>,
+    ) -> Self {
+        WorkerMessage::CompactionJobProgress {
+            id,
+            bytes_processed,
+            output_ssts,
+        }
+    }
+}
 
 /// Stateless executor of compaction jobs claimed from `.compactions`.
 ///
@@ -513,18 +554,18 @@ impl CompactionWorkerHandler {
 }
 
 #[async_trait]
-impl MessageHandler<CompactorMessage> for CompactionWorkerHandler {
-    fn tickers(&mut self) -> Vec<(Duration, Box<MessageFactory<CompactorMessage>>)> {
+impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
+    fn tickers(&mut self) -> Vec<(Duration, Box<MessageFactory<WorkerMessage>>)> {
         vec![(
             self.options.compactions_poll_interval,
-            Box::new(|| CompactorMessage::PollCompactions),
+            Box::new(|| WorkerMessage::PollCompactions),
         )]
     }
 
-    async fn handle(&mut self, message: CompactorMessage) -> Result<(), SlateDBError> {
+    async fn handle(&mut self, message: WorkerMessage) -> Result<(), SlateDBError> {
         match message {
-            CompactorMessage::PollCompactions => self.poll_and_claim().await?,
-            CompactorMessage::CompactionJobFinished { id, result } => {
+            WorkerMessage::PollCompactions => self.poll_and_claim().await?,
+            WorkerMessage::CompactionJobFinished { id, result } => {
                 self.handle_finished(id, result).await?;
                 // Opportunistically claim more after freeing capacity.
                 self.poll_and_claim().await?;
@@ -532,15 +573,14 @@ impl MessageHandler<CompactorMessage> for CompactionWorkerHandler {
             // Heartbeat emission is added in the failure-detection follow-up;
             // for now progress messages are ignored. The executor still
             // produces them; we just drop them.
-            CompactorMessage::CompactionJobProgress { .. } => {}
-            CompactorMessage::LogStats | CompactorMessage::PollManifest => {}
+            WorkerMessage::CompactionJobProgress { .. } => {}
         }
         Ok(())
     }
 
     async fn cleanup(
         &mut self,
-        _messages: BoxStream<'async_trait, CompactorMessage>,
+        _messages: BoxStream<'async_trait, WorkerMessage>,
         _result: Result<(), SlateDBError>,
     ) -> Result<(), SlateDBError> {
         // Stop accepting new work, then release any active claims so other
@@ -588,15 +628,15 @@ pub(crate) fn build_handler(
     >,
 ) -> (
     CompactionWorkerHandler,
-    async_channel::Receiver<CompactorMessage>,
+    async_channel::Receiver<WorkerMessage>,
 ) {
-    let (tx, rx) = async_channel::unbounded();
+    let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
     let executor_compactor_options = Arc::new(CompactorOptions {
         max_sst_size: options.max_sst_size,
         max_fetch_tasks: options.max_fetch_tasks,
         ..CompactorOptions::default()
     });
-    let executor = Arc::new(TokioCompactionExecutor::new(
+    let executor = Arc::new(TokioCompactionExecutor::<WorkerMessage>::new(
         TokioCompactionExecutorOptions {
             handle: worker_runtime.clone(),
             options: executor_compactor_options,
@@ -876,7 +916,7 @@ mod tests {
         assert_eq!(fx.handler.active_jobs.len(), 1);
 
         // cleanup mirrors graceful shutdown.
-        let empty: BoxStream<'_, CompactorMessage> = futures::stream::empty().boxed();
+        let empty: BoxStream<'_, WorkerMessage> = futures::stream::empty().boxed();
         fx.handler.cleanup(empty, Ok(())).await.unwrap();
 
         let c = fx.read_compaction(id).await.expect("compaction missing");

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -55,20 +55,8 @@ pub(crate) const COMPACTION_WORKER_TASK_NAME: &str = "compaction_worker";
 /// Build one with [`CompactionWorkerBuilder`] and drive its event loop with
 /// [`CompactionWorker::run`]. Call [`CompactionWorker::stop`] to gracefully
 /// release any in-flight claims.
-#[derive(Clone)]
 pub struct CompactionWorker {
-    manifest_store: Arc<ManifestStore>,
-    compactions_store: Arc<CompactionsStore>,
-    table_store: Arc<TableStore>,
-    options: Arc<CompactionWorkerOptions>,
     task_executor: Arc<MessageHandlerExecutor>,
-    worker_runtime: Handle,
-    rand: Arc<DbRand>,
-    stats: Arc<CompactionStats>,
-    system_clock: Arc<dyn SystemClock>,
-    merge_operator: Option<MergeOperatorType>,
-    #[cfg(feature = "compaction_filters")]
-    compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
 }
 
 impl CompactionWorker {
@@ -76,27 +64,7 @@ impl CompactionWorker {
     /// `.compactions` every [`CompactionWorkerOptions::compactions_poll_interval`],
     /// claims up to [`CompactionWorkerOptions::max_concurrent_compactions`] jobs,
     /// executes them, and writes `Compacted` back to `.compactions`.
-    pub async fn run(&self) -> Result<(), crate::Error> {
-        let (handler, rx) = build_handler(
-            self.manifest_store.clone(),
-            self.compactions_store.clone(),
-            self.table_store.clone(),
-            self.options.clone(),
-            self.worker_runtime.clone(),
-            self.rand.clone(),
-            self.stats.clone(),
-            self.system_clock.clone(),
-            self.merge_operator.clone(),
-            self.compaction_filter_supplier.clone(),
-        );
-        self.task_executor
-            .add_handler(
-                COMPACTION_WORKER_TASK_NAME.to_string(),
-                Box::new(handler),
-                rx,
-                &Handle::current(),
-            )
-            .expect("failed to spawn compaction worker task");
+    pub async fn run(&mut self) -> Result<(), crate::Error> {
         self.task_executor.monitor_on(&Handle::current())?;
         self.task_executor
             .join_task(COMPACTION_WORKER_TASK_NAME)
@@ -199,25 +167,34 @@ impl<P: Into<Path>> CompactionWorkerBuilder<P> {
             None,
         ));
         let stats = Arc::new(CompactionStats::new(&self.recorder));
+        let options = Arc::new(self.options);
         let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
         let task_executor = Arc::new(MessageHandlerExecutor::new(
             closed_result,
             self.system_clock.clone(),
         ));
-        Ok(CompactionWorker {
+        let (handler, rx) = build_handler(
             manifest_store,
             compactions_store,
             table_store,
-            options: Arc::new(self.options),
-            task_executor,
-            worker_runtime: self.worker_runtime,
-            rand: self.rand,
+            options,
+            self.worker_runtime,
+            self.rand,
             stats,
-            system_clock: self.system_clock,
-            merge_operator: self.merge_operator,
+            self.system_clock,
+            self.merge_operator,
             #[cfg(feature = "compaction_filters")]
-            compaction_filter_supplier: self.compaction_filter_supplier,
-        })
+            self.compaction_filter_supplier,
+        );
+        task_executor
+            .add_handler(
+                COMPACTION_WORKER_TASK_NAME.to_string(),
+                Box::new(handler),
+                rx,
+                &Handle::current(),
+            )
+            .expect("failed to spawn compaction worker task");
+        Ok(CompactionWorker { task_executor })
     }
 }
 

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -131,7 +131,7 @@ impl CompactionWorker {
 pub struct CompactionWorkerBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,
-    worker_runtime: Handle,
+    worker_runtime: Option<Handle>,
     options: CompactionWorkerOptions,
     rand: Arc<DbRand>,
     recorder: MetricsRecorderHelper,
@@ -146,7 +146,7 @@ impl<P: Into<Path>> CompactionWorkerBuilder<P> {
         Self {
             path,
             main_object_store,
-            worker_runtime: Handle::current(),
+            worker_runtime: None,
             options: CompactionWorkerOptions::default(),
             rand: Arc::new(DbRand::default()),
             recorder: MetricsRecorderHelper::noop(),
@@ -163,7 +163,7 @@ impl<P: Into<Path>> CompactionWorkerBuilder<P> {
     }
 
     pub fn with_runtime(mut self, runtime: Handle) -> Self {
-        self.worker_runtime = runtime;
+        self.worker_runtime = Some(runtime);
         self
     }
 
@@ -208,6 +208,7 @@ impl<P: Into<Path>> CompactionWorkerBuilder<P> {
             None,
         ));
         let stats = Arc::new(CompactionStats::new(&self.recorder));
+        let worker_runtime = self.worker_runtime.unwrap_or_else(Handle::current);
         let options = Arc::new(self.options);
         let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
         let task_executor = Arc::new(MessageHandlerExecutor::new(
@@ -219,7 +220,7 @@ impl<P: Into<Path>> CompactionWorkerBuilder<P> {
             compactions_store,
             table_store,
             options,
-            self.worker_runtime,
+            worker_runtime,
             self.rand,
             stats,
             self.system_clock,
@@ -317,8 +318,9 @@ impl CompactionWorkerHandler {
         let claimed = loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
-            let to_claim: Vec<Compaction> = stored
-                .compactions()
+            let mut dirty_compactions = stored.prepare_dirty()?;
+            let to_claim: Vec<Compaction> = dirty_compactions
+                .value
                 .iter_with_status(CompactionStatus::Submitted)
                 .filter(|c| c.worker().is_none())
                 .take(capacity)
@@ -331,15 +333,14 @@ impl CompactionWorkerHandler {
             let heartbeat_ms = self.clock.now().timestamp_millis() as u64;
             let worker_spec = WorkerSpec::new(self.worker_id.clone(), heartbeat_ms);
 
-            let mut dirty = stored.prepare_dirty()?;
             for c in &to_claim {
-                dirty.value.insert(
+                dirty_compactions.value.insert(
                     c.clone()
                         .with_status(CompactionStatus::Running)
                         .with_worker(Some(worker_spec.clone())),
                 );
             }
-            match stored.update(dirty).await {
+            match stored.update(dirty_compactions).await {
                 Ok(()) => break to_claim,
                 Err(e) if e.is_sequenced_write_conflict() => {
                     debug!("claim conflict on .compactions; refreshing and retrying");

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -474,7 +474,8 @@ impl CompactionWorkerHandler {
         loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
-            let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+            let mut dirty = stored.prepare_dirty()?;
+            let Some(existing) = dirty.value.get(&compaction_id).cloned() else {
                 info!(
                     "compaction entry missing on completion; dropping [id={}]",
                     compaction_id
@@ -493,7 +494,6 @@ impl CompactionWorkerHandler {
                 .with_status(CompactionStatus::Compacted)
                 .with_output_ssts(output_ssts.clone())
                 .with_worker(Some(WorkerSpec::new(self.worker_id.clone(), heartbeat_ms)));
-            let mut dirty = stored.prepare_dirty()?;
             dirty.value.insert(updated);
             match stored.update(dirty).await {
                 Ok(()) => return Ok(()),
@@ -510,7 +510,8 @@ impl CompactionWorkerHandler {
         loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
-            let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+            let mut dirty = stored.prepare_dirty()?;
+            let Some(existing) = dirty.value.get(&compaction_id).cloned() else {
                 info!(
                     "compaction no longer exists, no claim to release [worker_id]={} [compaction_id]={}",
                     worker_id,
@@ -531,7 +532,6 @@ impl CompactionWorkerHandler {
             let updated = existing
                 .with_status(CompactionStatus::Submitted)
                 .with_worker(None);
-            let mut dirty = stored.prepare_dirty()?;
             dirty.value.insert(updated);
             match stored.update(dirty).await {
                 Ok(()) => return Ok(()),

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -20,6 +20,7 @@ use futures::stream::BoxStream;
 use log::{debug, error, info, warn};
 use object_store::path::Path;
 use object_store::ObjectStore;
+use rand::Rng;
 use tokio::runtime::Handle;
 use ulid::Ulid;
 
@@ -255,6 +256,7 @@ pub(crate) struct CompactionWorkerHandler {
     /// yet `Compacted`). Used to gate capacity and to know what to reset on
     /// graceful shutdown.
     active_jobs: HashSet<Ulid>,
+    rand: Arc<DbRand>,
     /// Lazily-initialized handle for CAS reads/writes on `.compactions`. The
     /// coordinator creates the file on first run; the worker tolerates its
     /// absence on early ticks.
@@ -269,6 +271,7 @@ impl CompactionWorkerHandler {
         manifest_store: Arc<ManifestStore>,
         executor: Arc<dyn CompactionExecutor + Send + Sync>,
         clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
     ) -> Self {
         Self {
             worker_id,
@@ -278,6 +281,7 @@ impl CompactionWorkerHandler {
             executor,
             clock,
             active_jobs: HashSet::new(),
+            rand,
             stored: None,
         }
     }
@@ -576,7 +580,19 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
             return Ok(());
         }
         match message {
-            WorkerMessage::PollCompactions => self.poll_and_claim().await?,
+            WorkerMessage::PollCompactions => {
+                // RFC-0025: sleep for random(0, interval * 0.1) before each
+                // ticker-driven poll to prevent workers from synchronizing on
+                // `.compactions` reads
+                let max_jitter = (self.options.compactions_poll_interval.as_millis() / 10) as u64;
+                let jitter_ms = if max_jitter > 0 {
+                    self.rand.rng().random_range(0..=max_jitter)
+                } else {
+                    0
+                };
+                self.clock.sleep(Duration::from_millis(jitter_ms)).await;
+                self.poll_and_claim().await?;
+            }
             WorkerMessage::CompactionJobFinished { id, result } => {
                 self.handle_finished(id, result).await?;
                 // Opportunistically claim more after freeing capacity.
@@ -674,6 +690,7 @@ pub(crate) fn build_handler(
         manifest_store.clone(),
         executor,
         system_clock.clone(),
+        rand.clone(),
     );
     (handler, rx)
 }
@@ -774,6 +791,7 @@ mod tests {
                 manifest_store.clone(),
                 executor.clone(),
                 clock,
+                Arc::new(DbRand::default()),
             );
             // `handle()` lazily loads `.compactions` on the first message; the
             // tests below drive the child fns (poll_and_claim, handle_finished,

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -281,6 +281,8 @@ impl CompactionWorkerHandler {
         }
     }
 
+    const EXPECT_LOADED: &str = "ensure_loaded should have set stored compactions";
+
     /// Loads `.compactions` on first use; subsequent calls reuse the cached
     /// handle. Returns `Ok(false)` if the file does not yet exist (worker
     /// started before the coordinator).
@@ -306,9 +308,6 @@ impl CompactionWorkerHandler {
     /// Scans `.compactions` for `Submitted` entries without a worker, claims up
     /// to remaining capacity via CAS, and dispatches each to the executor.
     async fn poll_and_claim(&mut self) -> Result<(), SlateDBError> {
-        if !self.ensure_loaded().await? {
-            return Ok(());
-        }
         let capacity = self.capacity();
         if capacity == 0 {
             return Ok(());
@@ -316,10 +315,7 @@ impl CompactionWorkerHandler {
 
         // CAS loop: read latest, identify candidates, attempt write.
         let claimed = loop {
-            let stored = self
-                .stored
-                .as_mut()
-                .expect("ensure_loaded set stored to Some");
+            let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
             let to_claim: Vec<Compaction> = stored
                 .compactions()
@@ -469,11 +465,8 @@ impl CompactionWorkerHandler {
         compaction_id: Ulid,
         output_ssts: Vec<crate::db_state::SsTableHandle>,
     ) -> Result<(), SlateDBError> {
-        if !self.ensure_loaded().await? {
-            return Ok(());
-        }
         loop {
-            let stored = self.stored.as_mut().expect("ensure_loaded set stored");
+            let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
             let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
                 info!(
@@ -507,16 +500,26 @@ impl CompactionWorkerHandler {
     /// Returns a claim to `Submitted` so it can be re-attempted by any worker
     /// (used when execution fails or when the worker shuts down gracefully).
     async fn release_claim(&mut self, compaction_id: Ulid) -> Result<(), SlateDBError> {
-        if !self.ensure_loaded().await? {
-            return Ok(());
-        }
+        let worker_id = self.worker_id.as_str();
         loop {
-            let stored = self.stored.as_mut().expect("ensure_loaded set stored");
+            let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
             let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+                info!(
+                    "compaction no longer exists, no claim to release [worker_id]={} [compaction_id]={}",
+                    worker_id,
+                    compaction_id
+                );
                 return Ok(());
             };
-            if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
+            let compaction_owner = existing.worker().map(|w| w.worker_id.as_str());
+            if compaction_owner != Some(worker_id) {
+                info!(
+                    "compaction is not owned by this worker, no claim to release [worker_id]={} [compaction_id]={} [owner]={:?}",
+                    worker_id,
+                    compaction_id,
+                    compaction_owner
+                );
                 return Ok(());
             }
             let updated = existing
@@ -563,6 +566,9 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
     }
 
     async fn handle(&mut self, message: WorkerMessage) -> Result<(), SlateDBError> {
+        if !self.ensure_loaded().await? {
+            return Ok(());
+        }
         match message {
             WorkerMessage::PollCompactions => self.poll_and_claim().await?,
             WorkerMessage::CompactionJobFinished { id, result } => {
@@ -755,7 +761,7 @@ mod tests {
                 .unwrap();
 
             let executor = Arc::new(NoopExecutor::new());
-            let handler = CompactionWorkerHandler::new(
+            let mut handler = CompactionWorkerHandler::new(
                 worker_id.to_string(),
                 Arc::new(CompactionWorkerOptions::default()),
                 compactions_store.clone(),
@@ -763,6 +769,13 @@ mod tests {
                 executor.clone(),
                 clock,
             );
+            // `handle()` lazily loads `.compactions` on the first message; the
+            // tests below drive the child fns (poll_and_claim, handle_finished,
+            // cleanup) directly, so load it here to match that entry path.
+            handler
+                .ensure_loaded()
+                .await
+                .expect("compactions file seeded above");
 
             Self {
                 compactions_store,

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -314,18 +314,37 @@ impl CompactionWorkerHandler {
             return Ok(());
         }
 
+        let manifest = self.manifest_store.read_latest_manifest().await?;
+        let db_state = manifest.core();
+
         // CAS loop: read latest, identify candidates, attempt write.
         let claimed = loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
             let mut dirty_compactions = stored.prepare_dirty()?;
-            let to_claim: Vec<Compaction> = dirty_compactions
+
+            // Build the job args while selecting candidates so we only ever
+            // claim compactions we can actually run. Invalid specs (drain
+            // specs, or sources missing from the manifest) are skipped here
+            // rather than claimed and then released.
+            let mut to_claim: Vec<(Compaction, StartCompactionJobArgs)> = Vec::new();
+            for c in dirty_compactions
                 .value
                 .iter_with_status(CompactionStatus::Submitted)
                 .filter(|c| c.worker().is_none())
-                .take(capacity)
-                .cloned()
-                .collect();
+            {
+                if to_claim.len() >= capacity {
+                    break;
+                }
+                match Self::build_job_args(c, db_state, &self.worker_id) {
+                    Ok(args) => to_claim.push((c.clone(), args)),
+                    Err(e) => warn!(
+                        "skipping unrunnable compaction [id={}, error={:?}]",
+                        c.id(),
+                        e
+                    ),
+                }
+            }
             if to_claim.is_empty() {
                 return Ok(());
             }
@@ -333,7 +352,7 @@ impl CompactionWorkerHandler {
             let heartbeat_ms = self.clock.now().timestamp_millis() as u64;
             let worker_spec = WorkerSpec::new(self.worker_id.clone(), heartbeat_ms);
 
-            for c in &to_claim {
+            for (c, _) in &to_claim {
                 dirty_compactions.value.insert(
                     c.clone()
                         .with_status(CompactionStatus::Running)
@@ -350,28 +369,14 @@ impl CompactionWorkerHandler {
             }
         };
 
-        let manifest = self.manifest_store.read_latest_manifest().await?;
-        let db_state = manifest.core();
-        for compaction in claimed {
-            match Self::build_job_args(&compaction, db_state, &self.worker_id) {
-                Ok(args) => {
-                    info!(
-                        "claimed compaction [worker_id={}, id={}]",
-                        self.worker_id,
-                        compaction.id()
-                    );
-                    self.active_jobs.insert(compaction.id());
-                    Self::dispatch_to_executor(&self.executor, args).await?;
-                }
-                Err(e) => {
-                    warn!(
-                        "invalid compaction; releasing claim [id={}, error={:?}]",
-                        compaction.id(),
-                        e
-                    );
-                    self.release_claim(compaction.id()).await?;
-                }
-            }
+        for (compaction, args) in claimed {
+            info!(
+                "claimed compaction [worker_id={}, id={}]",
+                self.worker_id,
+                compaction.id()
+            );
+            self.active_jobs.insert(compaction.id());
+            Self::dispatch_to_executor(&self.executor, args).await?;
         }
         Ok(())
     }
@@ -940,11 +945,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_worker_invalid_spec_releases_claim() {
+    async fn test_worker_skips_unrunnable_spec() {
         let mut fx = WorkerFixture::new("worker-A").await;
         let id = Ulid::from_parts(1, 0);
         // Source view ID that does not exist in the manifest — build_job_args
-        // should reject this and the claim should be released.
+        // should reject this so the worker never claims it, leaving it
+        // Submitted for the coordinator to reschedule.
         let ghost = Ulid::from_parts(u64::MAX, 0);
         fx.seed_submitted_compaction(id, vec![SourceId::SstView(ghost)])
             .await;

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -105,7 +105,7 @@ impl CompactionWorker {
     /// `.compactions` every [`CompactionWorkerOptions::compactions_poll_interval`],
     /// claims up to [`CompactionWorkerOptions::max_concurrent_compactions`] jobs,
     /// executes them, and writes `Compacted` back to `.compactions`.
-    pub async fn run(&mut self) -> Result<(), crate::Error> {
+    pub async fn run(&self) -> Result<(), crate::Error> {
         self.task_executor.monitor_on(&Handle::current())?;
         self.task_executor
             .join_task(COMPACTION_WORKER_TASK_NAME)

--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -80,6 +80,7 @@ impl StoredCompactions {
         self.inner.id().into()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn compactions(&self) -> &Compactions {
         self.inner.object()
     }

--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -80,7 +80,6 @@ impl StoredCompactions {
         self.inner.id().into()
     }
 
-    #[cfg(test)]
     pub(crate) fn compactions(&self) -> &Compactions {
         self.inner.object()
     }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -290,6 +290,8 @@ pub(crate) enum CompactorMessage {
     LogStats,
     /// Ticker-triggered message to refresh the manifest and schedule compactions.
     PollManifest,
+    /// Ticker-triggered message to poll `.compactions` for claimable jobs.
+    PollCompactions,
 }
 
 /// The compactor is responsible for taking groups of sorted runs (this doc uses the term
@@ -506,6 +508,7 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
         match message {
             CompactorMessage::LogStats => self.handle_log_ticker(),
             CompactorMessage::PollManifest => self.handle_ticker().await?,
+            CompactorMessage::PollCompactions => {}
             CompactorMessage::CompactionJobFinished { id, result } => {
                 match result {
                     Ok(sr) => self.finish_compaction(id, sr).await?,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -290,8 +290,6 @@ pub(crate) enum CompactorMessage {
     LogStats,
     /// Ticker-triggered message to refresh the manifest and schedule compactions.
     PollManifest,
-    /// Ticker-triggered message to poll `.compactions` for claimable jobs.
-    PollCompactions,
 }
 
 /// The compactor is responsible for taking groups of sorted runs (this doc uses the term
@@ -508,7 +506,6 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
         match message {
             CompactorMessage::LogStats => self.handle_log_ticker(),
             CompactorMessage::PollManifest => self.handle_ticker().await?,
-            CompactorMessage::PollCompactions => {}
             CompactorMessage::CompactionJobFinished { id, result } => {
                 match result {
                     Ok(sr) => self.finish_compaction(id, sr).await?,

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -14,7 +14,6 @@ use crate::compaction_filter::CompactionFilterSupplier;
 #[cfg(feature = "compaction_filters")]
 use crate::compaction_filter_iterator::CompactionFilterIterator;
 use crate::compactor::CompactorMessage;
-use crate::compactor::CompactorMessage::CompactionJobFinished;
 use crate::config::CompactorOptions;
 use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableView};
 use crate::error::SlateDBError;
@@ -180,11 +179,31 @@ pub(crate) trait CompactionExecutor {
     fn is_stopped(&self) -> bool;
 }
 
+/// Implemented by message types that the executor sends on job completion and progress.
+pub(crate) trait ExecutorMessage: Send + 'static {
+    fn job_finished(id: Ulid, result: Result<SortedRun, SlateDBError>) -> Self;
+    fn job_progress(id: Ulid, bytes_processed: u64, output_ssts: Vec<SsTableHandle>) -> Self;
+}
+
+impl ExecutorMessage for CompactorMessage {
+    fn job_finished(id: Ulid, result: Result<SortedRun, SlateDBError>) -> Self {
+        CompactorMessage::CompactionJobFinished { id, result }
+    }
+
+    fn job_progress(id: Ulid, bytes_processed: u64, output_ssts: Vec<SsTableHandle>) -> Self {
+        CompactorMessage::CompactionJobProgress {
+            id,
+            bytes_processed,
+            output_ssts,
+        }
+    }
+}
+
 /// Options for creating a [`TokioCompactionExecutor`].
-pub(crate) struct TokioCompactionExecutorOptions {
+pub(crate) struct TokioCompactionExecutorOptions<M = CompactorMessage> {
     pub handle: tokio::runtime::Handle,
     pub options: Arc<CompactorOptions>,
-    pub worker_tx: async_channel::Sender<CompactorMessage>,
+    pub worker_tx: async_channel::Sender<M>,
     pub table_store: Arc<TableStore>,
     pub rand: Arc<DbRand>,
     pub stats: Arc<CompactionStats>,
@@ -195,12 +214,12 @@ pub(crate) struct TokioCompactionExecutorOptions {
     pub compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
 }
 
-pub(crate) struct TokioCompactionExecutor {
-    inner: Arc<TokioCompactionExecutorInner>,
+pub(crate) struct TokioCompactionExecutor<M = CompactorMessage> {
+    inner: Arc<TokioCompactionExecutorInner<M>>,
 }
 
-impl TokioCompactionExecutor {
-    pub(crate) fn new(opts: TokioCompactionExecutorOptions) -> Self {
+impl<M: ExecutorMessage> TokioCompactionExecutor<M> {
+    pub(crate) fn new(opts: TokioCompactionExecutorOptions<M>) -> Self {
         let stats = opts.stats;
         let merge_operator = opts.merge_operator.map(|merge_operator| {
             instrument_merge_operator(
@@ -229,7 +248,7 @@ impl TokioCompactionExecutor {
     }
 }
 
-impl CompactionExecutor for TokioCompactionExecutor {
+impl<M: ExecutorMessage> CompactionExecutor for TokioCompactionExecutor<M> {
     fn start_compaction_job(&self, compaction: StartCompactionJobArgs) {
         self.inner.start_compaction_job(compaction);
     }
@@ -247,10 +266,10 @@ struct TokioCompactionTask {
     task: JoinHandle<Result<SortedRun, SlateDBError>>,
 }
 
-pub(crate) struct TokioCompactionExecutorInner {
+pub(crate) struct TokioCompactionExecutorInner<M = CompactorMessage> {
     options: Arc<CompactorOptions>,
     handle: tokio::runtime::Handle,
-    worker_tx: async_channel::Sender<CompactorMessage>,
+    worker_tx: async_channel::Sender<M>,
     table_store: Arc<TableStore>,
     tasks: Arc<Mutex<HashMap<u32, TokioCompactionTask>>>,
     rand: Arc<DbRand>,
@@ -263,7 +282,7 @@ pub(crate) struct TokioCompactionExecutorInner {
     compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
 }
 
-impl TokioCompactionExecutorInner {
+impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
     /// Builds input iterators for all sources (L0 and SR) and wraps them with optional
     /// merge, retention, and compaction filter logic.
     async fn load_iterators<'a>(
@@ -372,11 +391,7 @@ impl TokioCompactionExecutorInner {
         #[allow(clippy::disallowed_methods)]
         if let Err(e) = self
             .worker_tx
-            .try_send(CompactorMessage::CompactionJobProgress {
-                id,
-                bytes_processed,
-                output_ssts: output_ssts.to_vec(),
-            })
+            .try_send(M::job_progress(id, bytes_processed, output_ssts.to_vec()))
         {
             debug!(
                 "failed to send compaction progress (likely DB shutdown) [error={:?}]",
@@ -493,7 +508,7 @@ impl TokioCompactionExecutorInner {
                 #[allow(clippy::disallowed_methods)]
                 if let Err(e) = this_cleanup
                     .worker_tx
-                    .try_send(CompactionJobFinished { id, result })
+                    .try_send(M::job_finished(id, result))
                 {
                     debug!(
                         "failed to send compaction finished msg (likely DB shutdown) [error={:?}]",
@@ -994,7 +1009,7 @@ mod tests {
     ) {
         let handle = tokio::runtime::Handle::current();
         let options = Arc::new(CompactorOptions::default());
-        let (tx, _rx) = async_channel::unbounded();
+        let (tx, _rx) = async_channel::unbounded::<CompactorMessage>();
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let root_path = Path::from("testdb-load-iterators");
         let clock = Arc::new(DefaultSystemClock::new());
@@ -1202,7 +1217,7 @@ mod tests {
                     ..Default::default()
                 };
                 let options = Arc::new(options);
-                let (tx, _rx) = async_channel::unbounded();
+                let (tx, _rx) = async_channel::unbounded::<CompactorMessage>();
                 let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
                 let root_path = Path::from("testdb-exec-resume");
                 let clock = Arc::new(DefaultSystemClock::new());

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -389,9 +389,9 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
         // component. They can do what they want. If the send fails (e.g., during
         // DB shutdown), we log it and continue with the compaction work.
         #[allow(clippy::disallowed_methods)]
-        if let Err(e) = self
-            .worker_tx
-            .try_send(M::job_progress(id, bytes_processed, output_ssts.to_vec()))
+        if let Err(e) =
+            self.worker_tx
+                .try_send(M::job_progress(id, bytes_processed, output_ssts.to_vec()))
         {
             debug!(
                 "failed to send compaction progress (likely DB shutdown) [error={:?}]",
@@ -506,10 +506,7 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
                 // component. They can do what they want. If the send fails (e.g., during
                 // DB shutdown), we log it and continue with cleanup.
                 #[allow(clippy::disallowed_methods)]
-                if let Err(e) = this_cleanup
-                    .worker_tx
-                    .try_send(M::job_finished(id, result))
-                {
+                if let Err(e) = this_cleanup.worker_tx.try_send(M::job_finished(id, result)) {
                     debug!(
                         "failed to send compaction finished msg (likely DB shutdown) [error={:?}]",
                         e

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1146,6 +1146,13 @@ pub struct CompactionWorkerOptions {
     #[serde(deserialize_with = "deserialize_duration")]
     #[serde(serialize_with = "serialize_duration")]
     pub heartbeat_min_interval: Duration,
+
+    /// Maximum size of an output SST before a new one is rolled.
+    pub max_sst_size: usize,
+
+    /// Maximum number of concurrent tasks for fetching SST blocks during
+    /// compaction. Higher values can improve throughput but use more resources.
+    pub max_fetch_tasks: usize,
 }
 
 /// Default options for the compaction worker.
@@ -1157,6 +1164,8 @@ impl Default for CompactionWorkerOptions {
             compactions_poll_interval: Duration::from_secs(5),
             heartbeat_bytes: 5_242_880,
             heartbeat_min_interval: Duration::from_secs(5),
+            max_sst_size: 256 * 1024 * 1024,
+            max_fetch_tasks: 4,
         }
     }
 }

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -80,6 +80,7 @@ pub mod cached_object_store;
 pub mod clock;
 #[cfg(feature = "bencher")]
 pub mod compaction_execute_bench;
+pub mod compaction_worker;
 pub mod compactor;
 pub mod config;
 pub mod db_cache;


### PR DESCRIPTION
## Summary

Adds the worker half of the distributed-compaction protocol from RFC-0025.

## Changes

Adds the Compaction Worker for distributed compaction see [3.1](https://github.com/slatedb/slatedb/pull/1753) for the follow on to wire it into the coordinator

## Notes for Reviewers

Just adds the compaction worker, see 3.1 for the follow on to wire it in.

[Phase 2: Manifest Commit Protocol](https://github.com/slatedb/slatedb/pull/1701)

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏