### PR TITLE
Move ownership of transaction into WriteBatchMessage to prevent cancellation race

### DIFF
--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -16,7 +16,6 @@ use smallvec::{smallvec, SmallVec};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::iter::Peekable;
 use std::ops::RangeBounds;
-use uuid::Uuid;
 
 /// A batch of write operations (puts, deletes, and merges). All operations in
 /// the batch are applied atomically to the database. Put and delete operations
@@ -52,7 +51,6 @@ use uuid::Uuid;
 pub struct WriteBatch {
     pub(crate) ops: BTreeMap<Bytes, SmallVec<[WriteOp; 1]>>,
     pub(crate) op_count: usize,
-    pub(crate) txn_id: Option<Uuid>,
     pub(crate) has_merge_ops: bool,
 }
 
@@ -139,17 +137,7 @@ impl WriteBatch {
         WriteBatch {
             ops: BTreeMap::new(),
             op_count: 0,
-            txn_id: None,
             has_merge_ops: false,
-        }
-    }
-
-    pub(crate) fn with_txn_id(self, txn_id: Uuid) -> Self {
-        Self {
-            ops: self.ops,
-            op_count: self.op_count,
-            txn_id: Some(txn_id),
-            has_merge_ops: self.has_merge_ops,
         }
     }
 

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -39,13 +39,13 @@ use std::collections::BTreeSet;
 use bytes::Bytes;
 
 use crate::config::WriteOptions;
+use crate::db_transaction::DbTransaction;
 use crate::dispatcher::MessageHandler;
 use crate::mem_table::KVTable;
 use crate::types::RowEntry;
 use crate::utils::WatchableOnceCellReader;
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
 use slatedb_common::clock::SystemClock;
-use uuid::Uuid;
 
 pub(crate) const WRITE_BATCH_TASK_NAME: &str = "writer";
 
@@ -64,7 +64,7 @@ pub(crate) struct WriteBatchMessage {
     /// Holds the committing transaction once it is enqueued, ownership
     /// transfers from the caller to the writer. `None` for
     /// non-transactional writes. Fix for #1732.
-    pub(crate) txn: Option<crate::db_transaction::DbTransaction>,
+    pub(crate) txn: Option<DbTransaction>,
 }
 
 impl std::fmt::Debug for WriteBatchMessage {
@@ -100,8 +100,10 @@ impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
             done,
             txn,
         } = message;
-        let txn_id = txn.as_ref().map(|t| t.id());
-        let result = self.db_inner.write_batch(batch, &options, txn_id).await;
+        let result = self
+            .db_inner
+            .write_batch(batch, &options, txn.as_ref())
+            .await;
         // if this is the first write and the WAL is disabled, make sure users are flushing
         // their memtables in a timely manner.
         if self.is_first_write && !self.db_inner.wal_enabled && options.await_durable {
@@ -138,7 +140,7 @@ impl DbInner {
         &self,
         batch: WriteBatch,
         options: &WriteOptions,
-        txn_id: Option<Uuid>,
+        txn: Option<&DbTransaction>,
     ) -> WriteBatchResult {
         let _options = options;
         #[cfg(not(dst))]
@@ -165,8 +167,8 @@ impl DbInner {
 
         // Check for transaction conflicts before proceeding with the write batch
         // if this batch is part of a transaction.
-        if let Some(txn_id) = txn_id.as_ref() {
-            if self.txn_manager.check_has_conflict(txn_id) {
+        if let Some(txn) = txn {
+            if self.txn_manager.check_has_conflict(&txn.id()) {
                 return Err(SlateDBError::TransactionConflict);
             }
         }
@@ -222,11 +224,11 @@ impl DbInner {
             |_| { Err(SlateDBError::from(std::io::Error::other("oops"))) }
         );
 
-        // track the recent committed txn for conflict check. if txn_id is not supplied,
+        // track the recent committed txn for conflict check. if a txn is not supplied,
         // we still consider this as an transaction commit.
-        if let Some(txn_id) = &txn_id {
+        if let Some(txn) = txn {
             self.txn_manager
-                .track_recent_committed_txn(txn_id, commit_seq);
+                .track_recent_committed_txn(&txn.id(), commit_seq);
         } else {
             let write_keys = batch.keys();
             self.txn_manager

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -45,6 +45,7 @@ use crate::types::RowEntry;
 use crate::utils::WatchableOnceCellReader;
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
 use slatedb_common::clock::SystemClock;
+use uuid::Uuid;
 
 pub(crate) const WRITE_BATCH_TASK_NAME: &str = "writer";
 
@@ -60,6 +61,10 @@ pub(crate) struct WriteBatchMessage {
     pub(crate) batch: WriteBatch,
     pub(crate) options: WriteOptions,
     pub(crate) done: tokio::sync::oneshot::Sender<WriteBatchResult>,
+    /// Holds the committing transaction once it is enqueued, ownership
+    /// transfers from the caller to the writer. `None` for
+    /// non-transactional writes. Fix for #1732.
+    pub(crate) txn: Option<crate::db_transaction::DbTransaction>,
 }
 
 impl std::fmt::Debug for WriteBatchMessage {
@@ -93,8 +98,10 @@ impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
             batch,
             options,
             done,
+            txn,
         } = message;
-        let result = self.db_inner.write_batch(batch, &options).await;
+        let txn_id = txn.as_ref().map(|t| t.id());
+        let result = self.db_inner.write_batch(batch, &options, txn_id).await;
         // if this is the first write and the WAL is disabled, make sure users are flushing
         // their memtables in a timely manner.
         if self.is_first_write && !self.db_inner.wal_enabled && options.await_durable {
@@ -127,7 +134,12 @@ impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
 impl DbInner {
     #[allow(clippy::panic)]
     #[instrument(level = "trace", skip_all, fields(batch_size = batch.op_count()))]
-    async fn write_batch(&self, batch: WriteBatch, options: &WriteOptions) -> WriteBatchResult {
+    async fn write_batch(
+        &self,
+        batch: WriteBatch,
+        options: &WriteOptions,
+        txn_id: Option<Uuid>,
+    ) -> WriteBatchResult {
         let _options = options;
         #[cfg(not(dst))]
         let now = self.mono_clock.now().await?;
@@ -153,7 +165,7 @@ impl DbInner {
 
         // Check for transaction conflicts before proceeding with the write batch
         // if this batch is part of a transaction.
-        if let Some(txn_id) = batch.txn_id.as_ref() {
+        if let Some(txn_id) = txn_id.as_ref() {
             if self.txn_manager.check_has_conflict(txn_id) {
                 return Err(SlateDBError::TransactionConflict);
             }
@@ -212,7 +224,7 @@ impl DbInner {
 
         // track the recent committed txn for conflict check. if txn_id is not supplied,
         // we still consider this as an transaction commit.
-        if let Some(txn_id) = &batch.txn_id {
+        if let Some(txn_id) = &txn_id {
             self.txn_manager
                 .track_recent_committed_txn(txn_id, commit_seq);
         } else {
@@ -368,6 +380,27 @@ mod tests {
     use crate::object_store::memory::InMemory;
     use crate::Db;
 
+    /// Build a transaction-less `WriteBatchMessage` and its result receiver,
+    /// keeping the `txn: None` and channel boilerplate out of individual tests.
+    fn test_message(
+        batch: WriteBatch,
+        options: WriteOptions,
+    ) -> (
+        WriteBatchMessage,
+        tokio::sync::oneshot::Receiver<WriteBatchResult>,
+    ) {
+        let (done, rx) = tokio::sync::oneshot::channel();
+        (
+            WriteBatchMessage {
+                batch,
+                options,
+                done,
+                txn: None,
+            },
+            rx,
+        )
+    }
+
     #[tokio::test]
     async fn test_is_first_write_set_false_after_first_write() {
         let object_store = Arc::new(InMemory::new());
@@ -384,15 +417,8 @@ mod tests {
         let mut batch = WriteBatch::new();
         batch.put(b"key", b"value");
 
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        handler
-            .handle(WriteBatchMessage {
-                batch,
-                options: WriteOptions::default(),
-                done: done_tx,
-            })
-            .await
-            .unwrap();
+        let (msg, done_rx) = test_message(batch, WriteOptions::default());
+        handler.handle(msg).await.unwrap();
 
         let result = done_rx.await.unwrap();
         assert!(result.is_ok());
@@ -411,33 +437,22 @@ mod tests {
         // Write with a user-defined seqnum
         let mut batch = WriteBatch::new();
         batch.put(b"key1", b"value1");
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        handler
-            .handle(WriteBatchMessage {
-                batch,
-                options: WriteOptions {
-                    seqnum: 42,
-                    ..Default::default()
-                },
-                done: done_tx,
-            })
-            .await
-            .unwrap();
+        let (msg, done_rx) = test_message(
+            batch,
+            WriteOptions {
+                seqnum: 42,
+                ..Default::default()
+            },
+        );
+        handler.handle(msg).await.unwrap();
         let (write_handle, _) = done_rx.await.unwrap().unwrap();
         assert_eq!(write_handle.seqnum(), 42);
 
         // Write without a seqnum and verify auto-assigned is > 42
         let mut batch = WriteBatch::new();
         batch.put(b"key2", b"value2");
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        handler
-            .handle(WriteBatchMessage {
-                batch,
-                options: WriteOptions::default(),
-                done: done_tx,
-            })
-            .await
-            .unwrap();
+        let (msg, done_rx) = test_message(batch, WriteOptions::default());
+        handler.handle(msg).await.unwrap();
         let (write_handle, _) = done_rx.await.unwrap().unwrap();
         assert!(write_handle.seqnum() > 42);
     }
@@ -457,33 +472,22 @@ mod tests {
         // First, do a normal write to advance the oracle
         let mut batch = WriteBatch::new();
         batch.put(b"key1", b"value1");
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        handler
-            .handle(WriteBatchMessage {
-                batch,
-                options: WriteOptions::default(),
-                done: done_tx,
-            })
-            .await
-            .unwrap();
+        let (msg, done_rx) = test_message(batch, WriteOptions::default());
+        handler.handle(msg).await.unwrap();
         let (write_handle, _) = done_rx.await.unwrap().unwrap();
         let first_seq = write_handle.seqnum();
 
         // Try to write with a seqnum <= the current max
         let mut batch = WriteBatch::new();
         batch.put(b"key2", b"value2");
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
-        handler
-            .handle(WriteBatchMessage {
-                batch,
-                options: WriteOptions {
-                    seqnum: 1,
-                    ..Default::default()
-                },
-                done: done_tx,
-            })
-            .await
-            .unwrap();
+        let (msg, done_rx) = test_message(
+            batch,
+            WriteOptions {
+                seqnum: 1,
+                ..Default::default()
+            },
+        );
+        handler.handle(msg).await.unwrap();
         let result = done_rx.await.unwrap();
         assert!(matches!(
             result,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -8032,6 +8032,106 @@ mod tests {
         db.close().await.unwrap();
     }
 
+    /// Regression test: cancelling a commit future after the write batch has been
+    /// sent to the writer (but before it is processed) drops the DbTransaction,
+    /// which removes it from active_txns. The writer then:
+    ///   1. Skips conflict detection (check_has_conflict returns false for
+    ///      missing txn_ids)
+    ///   2. Skips tracking the committed state (track_recent_committed_txn
+    ///      silently no-ops)
+    ///
+    /// This allows a second transaction writing the same key to commit without
+    /// detecting a write-write conflict — a lost update anomaly.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_commit_future_cancel_bypasses_conflict_detection() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder(
+            "/tmp/test_commit_future_cancel_bypasses_conflict_detection",
+            object_store,
+        )
+        .with_fp_registry(fp_registry.clone())
+        .build()
+        .await
+        .unwrap();
+
+        // Write initial data.
+        db.put(b"x", b"v0").await.unwrap();
+        let initial_last_seq = db.inner.oracle.last_seq();
+
+        // Start txn1 and buffer a write to key "x".
+        let txn1 = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        let txn1_started_seq = txn1.seqnum();
+        txn1.put(b"x", b"txn1_value").unwrap();
+
+        // Pause the writer *before* it tracks the committed transaction state.
+        // At the pause point the WAL + memtable writes have already happened,
+        // but track_recent_committed_txn has not been called yet.
+        fail_parallel::cfg(fp_registry.clone(), "write-batch-pre-commit", "pause").unwrap();
+
+        // Commit txn1 in a background task. It will send the batch to the
+        // writer, which will process it up to the pause point and block.
+        let txn1_commit = tokio::spawn(async move { txn1.commit().await });
+
+        // Wait until the writer has started processing txn1's batch.
+        // oracle.last_seq() advances at the very start of write_batch.
+        let reached = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if db.inner.oracle.last_seq() > initial_last_seq {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(reached.is_ok(), "writer did not start processing txn1");
+        // Give the writer a moment to reach the actual pause point.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Cancel txn1's commit future. This drops the DbTransaction,
+        // which calls drop_txn and removes txn1 from active_txns.
+        txn1_commit.abort();
+        let _ = txn1_commit.await;
+
+        // BUG: txn1 was removed from active_txns by Drop, even though the
+        // writer hasn't finished processing it yet. This should be is_some().
+        assert!(
+            db.inner.txn_manager.min_active_seq().is_none(),
+            "txn1 was removed from active_txns by Drop"
+        );
+
+        // Start txn2 while the writer is still paused (committed_seq has not
+        // been advanced yet), so txn2 starts at the same snapshot as txn1.
+        let txn2 = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        assert_eq!(
+            txn2.seqnum(),
+            txn1_started_seq,
+            "txn2 should start at the same seq as txn1 (committed_seq not yet advanced)"
+        );
+        txn2.put(b"x", b"txn2_value").unwrap();
+
+        // Un-pause the writer. It will try to track txn1's committed state but
+        // will not find txn1 in active_txns (already removed by Drop), so the
+        // committed state is silently lost.
+        fail_parallel::cfg(fp_registry.clone(), "write-batch-pre-commit", "off").unwrap();
+
+        // Wait for the writer to finish processing txn1's batch.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Commit txn2. Both txn1 and txn2 wrote key "x" from the same snapshot.
+        // A correct implementation would detect a write-write conflict here.
+        let result = txn2.commit().await;
+        // BUG: txn2 should detect a WW conflict with txn1, but the commit
+        // succeeds because txn1's committed state was lost when its commit
+        // future was cancelled before the writer tracked it.
+        assert!(
+            result.is_ok(),
+            "demonstrates the bug: txn2 commits without detecting WW conflict"
+        );
+
+        db.close().await.unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_txn_conflict_commit_seq_gap_does_not_block_l0_retirement() {
         const REPRO_SEED: u64 = 2_985_011_763_506_195_159;

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -303,7 +303,7 @@ impl DbInner {
         &self,
         batch: WriteBatch,
         options: &WriteOptions,
-        txn: Option<crate::db_transaction::DbTransaction>,
+        txn: Option<DbTransaction>,
     ) -> Result<WriteHandle, SlateDBError> {
         self.db_stats.write_batch_count.increment(1);
         self.db_stats.write_ops.increment(batch.op_count() as u64);
@@ -2093,7 +2093,7 @@ mod tests {
     use async_trait::async_trait;
     use chrono::{TimeZone, Utc};
     use fail_parallel::FailPointRegistry;
-    use futures::{future, future::join_all, StreamExt};
+    use futures::{future, future::join_all, FutureExt, StreamExt};
     use object_store::memory::InMemory;
     use object_store::{ObjectStore, ObjectStoreExt};
     use proptest::test_runner::{TestRng, TestRunner};
@@ -8077,19 +8077,16 @@ mod tests {
         let txn1_commit = tokio::spawn(async move { txn1.commit().await });
 
         // Wait until the writer has started processing txn1's batch.
-        // oracle.last_seq() advances at the very start of write_batch.
-        let reached = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                if db.inner.oracle.last_seq() > initial_last_seq {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+        // oracle.last_seq() advances at the very start of write_batch. No
+        // further synchronization is needed: the failpoint guarantees the
+        // writer cannot advance past pre-commit before we cancel below.
+        let reached = tokio::time::timeout(Duration::from_secs(30), async {
+            while db.inner.oracle.last_seq() <= initial_last_seq {
+                tokio::task::yield_now().await;
             }
         })
         .await;
         assert!(reached.is_ok(), "writer did not start processing txn1");
-        // Give the writer a moment to reach the actual pause point.
-        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Cancel txn1's commit future. The DbTransaction was moved into the
         // writer's queue message at commit time, so cancelling the future does
@@ -8117,10 +8114,10 @@ mod tests {
         // because txn1 is still in active_txns.
         fail_parallel::cfg(fp_registry.clone(), "write-batch-pre-commit", "off").unwrap();
 
-        // Wait for the writer to finish processing txn1's batch.
-        tokio::time::sleep(Duration::from_millis(100)).await;
-
-        // Commit txn2. Both txn1 and txn2 wrote key "x" from the same snapshot.
+        // Commit txn2. Its batch is enqueued behind txn1's, so the writer
+        // finishes tracking txn1's committed state before it runs conflict
+        // detection for txn2.
+        // Both txn1 and txn2 wrote key "x" from the same snapshot.
         // A correct implementation detects a write-write conflict here.
         let result = txn2.commit().await;
         assert!(
@@ -8151,66 +8148,89 @@ mod tests {
         .await
         .unwrap();
 
-        let initial_seq = db.inner.oracle.last_seq();
-
-        // Start txn_a and txn_b at the same snapshot.
+        // Start txn_a and txn_b at the same snapshot. Both write the same key,
+        // so txn_b will hit a WW conflict once txn_a's commit is tracked.
         let txn_a = db.begin(IsolationLevel::Snapshot).await.unwrap();
         let txn_b = db.begin(IsolationLevel::Snapshot).await.unwrap();
-
-        // Both write the same key — txn_b will conflict with txn_a.
         txn_a.put(b"y", b"txn_a_value").unwrap();
         txn_b.put(b"y", b"txn_b_value").unwrap();
 
-        // Pause the writer AFTER txn_a's commit is tracked (post-commit).
-        // This ensures txn_a's state is in recent_committed_txns, so when
-        // the writer later processes txn_b it will detect a WW conflict.
+        // Commit txn_a fully so its committed state is tracked. From here on,
+        // txn_b is the only active transaction.
+        txn_a.commit().await.expect("txn_a commit should succeed");
+        let seq_after_a = db.inner.oracle.last_seq();
+
+        // Park the writer on a filler write: pause at post-commit and wait for
+        // the filler's processing to start (oracle.last_seq() advances at the
+        // very start of write_batch). With the writer held, txn_b's commit
+        // below cannot complete before we cancel it.
         fail_parallel::cfg(fp_registry.clone(), "write-batch-post-commit", "pause").unwrap();
-
-        // Commit txn_a — writer processes it, tracks it, pauses at post-commit.
-        let txn_a_commit = tokio::spawn(async move { txn_a.commit().await });
-
-        // Wait for the writer to start processing txn_a.
-        let reached = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                if db.inner.oracle.last_seq() > initial_seq {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(10)).await;
+        let filler_db = db.clone();
+        let filler = tokio::spawn(async move { filler_db.put(b"z", b"filler_value").await });
+        let reached = tokio::time::timeout(Duration::from_secs(30), async {
+            while db.inner.oracle.last_seq() <= seq_after_a {
+                tokio::task::yield_now().await;
             }
         })
         .await;
-        assert!(reached.is_ok(), "writer did not start processing txn_a");
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            reached.is_ok(),
+            "writer did not start processing the filler"
+        );
+        let seq_after_filler = db.inner.oracle.last_seq();
 
-        // Now the writer is paused mid-txn_a. Spawn txn_b's commit — the batch
-        // is enqueued behind the paused txn_a.
-        let txn_b_commit = tokio::spawn(async move { txn_b.commit().await });
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        // Start committing txn_b, then cancel the commit. The first poll of the
+        // commit future enqueues the batch — moving the DbTransaction into the
+        // queued message — and then parks waiting on the (paused) writer, so
+        // now_or_never() drops the future exactly like a cancelled in-flight
+        // commit.
+        assert!(
+            txn_b.commit().now_or_never().is_none(),
+            "commit should be pending while the writer is paused"
+        );
 
-        // Cancel txn_b's commit. The enqueue succeeded, so the writer owns txn_b
-        // (it was moved into the queued message); cancelling the future does not
-        // drop it caller-side — the writer cleans it up when it processes it.
-        txn_b_commit.abort();
-        let _ = txn_b_commit.await;
-
-        // txn_b should still be in active_txns.
+        // txn_b should still be in active_txns: ownership moved to the writer
+        // at enqueue, so cancelling the future must not run drop_txn.
         assert!(
             db.inner.txn_manager.min_active_seq().is_some(),
             "txn_b should still be in active_txns (writer owns the in-flight txn)"
         );
 
-        // Un-pause the writer. It finishes txn_a, then processes txn_b.
-        // txn_b hits a WW conflict; the writer drops the queued message, whose
-        // owned DbTransaction runs drop_txn to clean it up.
+        // Un-pause the writer. It finishes the filler, then processes txn_b's
+        // batch, which is rejected with a WW conflict; dropping the rejected
+        // message drops the owned DbTransaction, which runs drop_txn.
         fail_parallel::cfg(fp_registry.clone(), "write-batch-post-commit", "off").unwrap();
-        let _ = txn_a_commit.await;
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        filler
+            .await
+            .expect("failed to join filler task")
+            .expect("filler write should succeed");
 
-        // After the writer processes (and rejects) txn_b, dropping the queued
-        // message ran drop_txn, removing txn_b from active_txns.
+        // The writer picks up txn_b's batch (last_seq advances at the start of
+        // write_batch, before conflict detection rejects it)...
+        let processed = tokio::time::timeout(Duration::from_secs(30), async {
+            while db.inner.oracle.last_seq() <= seq_after_filler {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+        assert!(processed.is_ok(), "writer did not start processing txn_b");
+
+        // ...and cleans it up from active_txns.
+        let cleaned = tokio::time::timeout(Duration::from_secs(30), async {
+            while db.inner.txn_manager.min_active_seq().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
         assert!(
-            db.inner.txn_manager.min_active_seq().is_none(),
+            cleaned.is_ok(),
             "txn_b should have been cleaned up from active_txns by the writer"
+        );
+
+        // txn_b was rejected, so its write must not be visible.
+        assert_eq!(
+            db.get(b"y").await.unwrap(),
+            Some(Bytes::from_static(b"txn_a_value"))
         );
 
         db.close().await.unwrap();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -303,6 +303,7 @@ impl DbInner {
         &self,
         batch: WriteBatch,
         options: &WriteOptions,
+        txn: Option<crate::db_transaction::DbTransaction>,
     ) -> Result<WriteHandle, SlateDBError> {
         self.db_stats.write_batch_count.increment(1);
         self.db_stats.write_ops.increment(batch.op_count() as u64);
@@ -316,6 +317,7 @@ impl DbInner {
             batch,
             options: options.clone(),
             done: tx,
+            txn,
         };
 
         self.maybe_apply_backpressure().await?;
@@ -1707,7 +1709,7 @@ impl Db {
         options: &WriteOptions,
     ) -> Result<WriteHandle, crate::Error> {
         self.inner
-            .write_with_options(batch, options)
+            .write_with_options(batch, options, None)
             .await
             .map_err(Into::into)
     }
@@ -7927,6 +7929,7 @@ mod tests {
                     await_durable: false,
                     ..Default::default()
                 },
+                None,
             )
             .await
             .unwrap_err();
@@ -8088,16 +8091,16 @@ mod tests {
         // Give the writer a moment to reach the actual pause point.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
-        // Cancel txn1's commit future. This drops the DbTransaction,
-        // which calls drop_txn and removes txn1 from active_txns.
+        // Cancel txn1's commit future. The DbTransaction was moved into the
+        // writer's queue message at commit time, so cancelling the future does
+        // NOT drop it on the caller side and therefore cannot call drop_txn.
         txn1_commit.abort();
         let _ = txn1_commit.await;
 
-        // BUG: txn1 was removed from active_txns by Drop, even though the
-        // writer hasn't finished processing it yet. This should be is_some().
+        // txn1 stays in active_txns (the writer now owns it, not the caller).
         assert!(
-            db.inner.txn_manager.min_active_seq().is_none(),
-            "txn1 was removed from active_txns by Drop"
+            db.inner.txn_manager.min_active_seq().is_some(),
+            "txn1 should still be in active_txns (writer owns the in-flight txn)"
         );
 
         // Start txn2 while the writer is still paused (committed_seq has not
@@ -8110,26 +8113,151 @@ mod tests {
         );
         txn2.put(b"x", b"txn2_value").unwrap();
 
-        // Un-pause the writer. It will try to track txn1's committed state but
-        // will not find txn1 in active_txns (already removed by Drop), so the
-        // committed state is silently lost.
+        // Un-pause the writer. It will track txn1's committed state properly
+        // because txn1 is still in active_txns.
         fail_parallel::cfg(fp_registry.clone(), "write-batch-pre-commit", "off").unwrap();
 
         // Wait for the writer to finish processing txn1's batch.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Commit txn2. Both txn1 and txn2 wrote key "x" from the same snapshot.
-        // A correct implementation would detect a write-write conflict here.
+        // A correct implementation detects a write-write conflict here.
         let result = txn2.commit().await;
-        // BUG: txn2 should detect a WW conflict with txn1, but the commit
-        // succeeds because txn1's committed state was lost when its commit
-        // future was cancelled before the writer tracked it.
         assert!(
-            result.is_ok(),
-            "demonstrates the bug: txn2 commits without detecting WW conflict"
+            result.is_err(),
+            "txn2 should detect a WW conflict with txn1"
         );
 
         db.close().await.unwrap();
+    }
+
+    /// Verify that the writer cleans up active_txns when a cancelled commit's
+    /// batch fails (e.g., TransactionConflict). Because commit moves the
+    /// DbTransaction into the writer's queue message, cancelling the future does
+    /// not drop it caller-side; the writer owns it and drops it (running drop_txn)
+    /// when it finishes processing the message. Without that ownership transfer
+    /// the txn would leak in active_txns, pinning min_active_seq and blocking
+    /// compaction.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_cancelled_commit_writer_error_cleans_up_active_txn() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder(
+            "/tmp/test_cancelled_commit_writer_error_cleans_up_active_txn",
+            object_store,
+        )
+        .with_fp_registry(fp_registry.clone())
+        .build()
+        .await
+        .unwrap();
+
+        let initial_seq = db.inner.oracle.last_seq();
+
+        // Start txn_a and txn_b at the same snapshot.
+        let txn_a = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        let txn_b = db.begin(IsolationLevel::Snapshot).await.unwrap();
+
+        // Both write the same key — txn_b will conflict with txn_a.
+        txn_a.put(b"y", b"txn_a_value").unwrap();
+        txn_b.put(b"y", b"txn_b_value").unwrap();
+
+        // Pause the writer AFTER txn_a's commit is tracked (post-commit).
+        // This ensures txn_a's state is in recent_committed_txns, so when
+        // the writer later processes txn_b it will detect a WW conflict.
+        fail_parallel::cfg(fp_registry.clone(), "write-batch-post-commit", "pause").unwrap();
+
+        // Commit txn_a — writer processes it, tracks it, pauses at post-commit.
+        let txn_a_commit = tokio::spawn(async move { txn_a.commit().await });
+
+        // Wait for the writer to start processing txn_a.
+        let reached = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if db.inner.oracle.last_seq() > initial_seq {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        assert!(reached.is_ok(), "writer did not start processing txn_a");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Now the writer is paused mid-txn_a. Spawn txn_b's commit — the batch
+        // is enqueued behind the paused txn_a.
+        let txn_b_commit = tokio::spawn(async move { txn_b.commit().await });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Cancel txn_b's commit. The enqueue succeeded, so the writer owns txn_b
+        // (it was moved into the queued message); cancelling the future does not
+        // drop it caller-side — the writer cleans it up when it processes it.
+        txn_b_commit.abort();
+        let _ = txn_b_commit.await;
+
+        // txn_b should still be in active_txns.
+        assert!(
+            db.inner.txn_manager.min_active_seq().is_some(),
+            "txn_b should still be in active_txns (writer owns the in-flight txn)"
+        );
+
+        // Un-pause the writer. It finishes txn_a, then processes txn_b.
+        // txn_b hits a WW conflict; the writer drops the queued message, whose
+        // owned DbTransaction runs drop_txn to clean it up.
+        fail_parallel::cfg(fp_registry.clone(), "write-batch-post-commit", "off").unwrap();
+        let _ = txn_a_commit.await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // After the writer processes (and rejects) txn_b, dropping the queued
+        // message ran drop_txn, removing txn_b from active_txns.
+        assert!(
+            db.inner.txn_manager.min_active_seq().is_none(),
+            "txn_b should have been cleaned up from active_txns by the writer"
+        );
+
+        db.close().await.unwrap();
+    }
+
+    /// When the commit's enqueue fails (e.g. the writer channel is closed), the
+    /// DbTransaction was moved into `enqueue_write_batch` but never made it onto
+    /// the queue. Ownership therefore stays on the caller side: the moved-in txn
+    /// drops inside the failing enqueue and runs drop_txn, so the txn must not
+    /// leak in active_txns and commit must surface the error.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_commit_enqueue_failure_cleans_up_active_txn() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder(
+            "/tmp/test_commit_enqueue_failure_cleans_up_active_txn",
+            object_store,
+        )
+        .build()
+        .await
+        .unwrap();
+
+        // Capture a handle to the txn manager before closing the db so we can
+        // assert on active_txns afterwards.
+        let txn_manager = db.inner.txn_manager.clone();
+
+        let txn = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        txn.put(b"k", b"v").unwrap();
+        assert!(
+            txn_manager.min_active_seq().is_some(),
+            "txn should be registered in active_txns before commit"
+        );
+
+        // Close the db, shutting down the writer and its channel. The txn keeps
+        // its own Arc<DbInner>, so it remains usable for the commit attempt.
+        db.close().await.unwrap();
+
+        // Commit now fails to enqueue. The moved-in DbTransaction drops on the
+        // caller side and cleans itself up.
+        let result = txn.commit().await;
+        assert!(
+            result.is_err(),
+            "commit should fail once the writer is closed"
+        );
+        assert!(
+            txn_manager.min_active_seq().is_none(),
+            "txn must be cleaned up on the caller side when enqueue fails"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -86,7 +86,7 @@ impl DbTransaction {
             txn_id,
             started_seq: seq,
             txn_manager,
-            write_batch: RwLock::new(WriteBatch::new().with_txn_id(txn_id)),
+            write_batch: RwLock::new(WriteBatch::new()),
             db_inner,
             isolation_level,
             range_trackers: Mutex::new(Vec::new()),
@@ -564,10 +564,8 @@ impl DbTransaction {
         // If the WriteBatch is empty, it's a no-op or read-only batch.
         if write_batch.is_empty() {
             // Check for read conflicts before returning Ok(None).
-            if let Some(txn_id) = write_batch.txn_id.as_ref() {
-                if self.txn_manager.check_has_conflict(txn_id) {
-                    return Err(SlateDBError::TransactionConflict.into());
-                }
+            if self.txn_manager.check_has_conflict(&self.txn_id) {
+                return Err(SlateDBError::TransactionConflict.into());
             }
             return Ok(None);
         }
@@ -588,8 +586,9 @@ impl DbTransaction {
         // dedicated background task (in batch_write.rs) that processes all WriteBatches
         // sequentially, ensuring no concurrent writes. Both conflict checking & persisting
         // are handled there.
-        self.db_inner
-            .write_with_options(write_batch, options)
+        let db_inner = Arc::clone(&self.db_inner);
+        db_inner
+            .write_with_options(write_batch, options, Some(self))
             .await
             .map(Some)
             .map_err(Into::into)


### PR DESCRIPTION
## Summary

This is an attempt to fix https://github.com/slatedb/slatedb/issues/1732. There exists a race where a dropped `txn.commit()`  can bypass conflict detection if it has been enqueued in the writer task, but before it is applied. This can happen when a txn.commit is in a cancelled tokio task:

```rust
let handle = tokio::spawn(async move { tokio::time::timeout(std::time::Duration::from_secs(5), txn.commit()).await });
```

The `drop` removes the txn_id from the transaction manager, but in this race the txn_id shouldn't be removed until after the writebatch is processed, or when cleanup runs.

Instead of updating the transaction_manager to reject an entire batch when a txn_id is missing: https://github.com/slatedb/slatedb/blob/main/slatedb/src/transaction_manager.rs#L198  I think that we need a small refactor to track enqueued vs committed writes. 


## Changes

~I added `commit_in_flight` to `DbTransaction` to prevent a `drop` from removing it from conflict checking when the transaction manager is responsible for it.~

~If it is past the point of no return (already enqueued, commit_in_flight = true), then it does nothing, and it will be cleaned up at one of the two added sites in batch_write.rs~

Move the `DbTransaction` once it is enqueued so that it can't be removed by the caller. After that, only handle, cleanup, or a successful apply will drop it, when the WriteBatchMessage gets applied.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
