### PR TITLE
enable `staticlib` for slatedb-uniffi

### DIFF
--- a/bindings/uniffi/Cargo.toml
+++ b/bindings/uniffi/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 
 [lib]
 name = "slatedb_uniffi"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "staticlib"]
 doc = false
 bench = false
 


### PR DESCRIPTION
## Summary

This will make it easier to integrate these bindings in golang codebase.

## Changes

n/a

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
