### PR TITLE
Fix flaky `test_commit_compacted_entries_writes_manifest`

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -5960,7 +5960,7 @@ mod tests {
             .collect();
         let destination = 0u32;
         let spec = CompactionSpec::new(sources, destination);
-        let compaction_id = Ulid::new();
+        let compaction_id = Ulid::from_parts(1, 0);
         let output_sst = fake_output_sst();
         let compaction = Compaction::new(compaction_id, spec)
             .with_status(CompactionStatus::Compacted)
@@ -6007,7 +6007,7 @@ mod tests {
 
         // given: a Compacted SR0→SR1 compaction to validate the SR source path removed when not in L0
         let sr1_output_sst = fake_output_sst();
-        let sr_compaction_id = Ulid::new();
+        let sr_compaction_id = Ulid::from_parts(2, 0);
         let sr_compaction = Compaction::new(
             sr_compaction_id,
             CompactionSpec::new(vec![SourceId::SortedRun(0)], 1),


### PR DESCRIPTION
## Summary

Found a flaky test in:

https://github.com/slatedb/slatedb/actions/runs/26611371666/job/78418832027

`loop cargo test test_commit_compacted_entries_writes_manifest -p slatedb --lib` fails every 0-20 runs or so.

The issue is SR ULIDs generated in the same millisecond can end up out of order. The second can be smaller than the first, which exposes it to removal in the .compactions file. After this fix, it passed > 300 times.

The broader issue will be addressed in:

- https://github.com/slatedb/slatedb/issues/1707

After GC enforcement is implemented, we won't allow out-of-order SRs to be added.

## Changes

- Use deterministically ordered ULIDs in test
