### PR TITLE
Add Taquba to Adopters list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ See who's using SlateDB.
 - [s2-lite](https://github.com/s2-streamstore/s2)
 - [SQLync](https://sqlync.com)
 - [Storrito](https://storrito.com)
+- [Taquba](https://github.com/micllam/taquba)
 - [Tensorlake](https://www.tensorlake.ai)
 - [Volga](https://github.com/volga-project/volga)
 - [WombatKV](https://github.com/Venkat2811/wombatkv)


### PR DESCRIPTION
## Summary

Adds Taquba to the adopters list.

Taquba is a durable, single-process task queue for Rust built directly on SlateDB. The ecosystem also includes a workflow runtime, cron scheduler, typed job runner and webhook deliverer.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
