### PR TITLE
Error on same key with different TTL in batch

### DIFF
--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -369,9 +369,24 @@ impl WriteBatch {
             ));
         }
 
-        let mut entries = Vec::new();
+        let mut entries: Vec<RowEntry> = Vec::new();
         let mut touched_segments: BTreeSet<Bytes> = BTreeSet::new();
         while let Some(entry) = it.next().await? {
+            // Verify that user has not supplied merge entries with different TTLs.
+            // This is not allowed. See #1581 for details.
+            match entries.last() {
+                Some(previous) if previous.key == entry.key => {
+                    if previous.expire_ts == entry.expire_ts {
+                        panic!("iterator emitted duplicate keys [key={:?}]", entry.key);
+                    }
+                    return Err(SlateDBError::IncompatibleMergeTtls {
+                        key: entry.key.clone(),
+                        previous_expire_ts: previous.expire_ts,
+                        current_expire_ts: entry.expire_ts,
+                    });
+                }
+                _ => {}
+            }
             if let Some(ext) = extractor {
                 match ext.prefix_len(&PrefixTarget::Point(entry.key.clone())) {
                     Some(0) | None => {
@@ -1360,6 +1375,155 @@ mod tests {
             result[0].value,
             ValueDeletable::Merge(Bytes::from_static(b"merge1merge2merge3"))
         );
+    }
+
+    #[tokio::test]
+    async fn should_extract_same_key_merges_with_same_effective_ttl() {
+        let mut batch = WriteBatch::new();
+        batch.merge_with_options(
+            b"key1",
+            b"a",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(3600),
+            },
+        );
+        batch.merge_with_options(
+            b"key1",
+            b"b",
+            &MergeOptions {
+                ttl: Ttl::ExpireAt(4600),
+            },
+        );
+
+        let merge_operator = Some(std::sync::Arc::new(StringConcatMergeOperator)
+            as crate::merge_operator::MergeOperatorType);
+        let (result, _, _) = batch
+            .extract_entries(100, 1000, None, merge_operator, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].key, Bytes::from_static(b"key1"));
+        assert_eq!(
+            result[0].value,
+            ValueDeletable::Merge(Bytes::from_static(b"ab"))
+        );
+        assert_eq!(result[0].expire_ts, Some(4600));
+    }
+
+    #[tokio::test]
+    async fn should_error_extracting_same_key_merges_with_different_ttls() {
+        let mut batch = WriteBatch::new();
+        batch.merge_with_options(
+            b"key1",
+            b"a",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(3600),
+            },
+        );
+        batch.merge_with_options(
+            b"key1",
+            b"b",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(7200),
+            },
+        );
+
+        let merge_operator = Some(std::sync::Arc::new(StringConcatMergeOperator)
+            as crate::merge_operator::MergeOperatorType);
+        let err = batch
+            .extract_entries(100, 1000, None, merge_operator, None)
+            .await
+            .unwrap_err();
+
+        match err {
+            SlateDBError::IncompatibleMergeTtls {
+                key,
+                previous_expire_ts,
+                current_expire_ts,
+            } => {
+                assert_eq!(key, Bytes::from_static(b"key1"));
+                assert_eq!(previous_expire_ts, Some(8200));
+                assert_eq!(current_expire_ts, Some(4600));
+            }
+            other => panic!("expected IncompatibleMergeTtls, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_allow_different_keys_with_different_merge_ttls() {
+        let mut batch = WriteBatch::new();
+        batch.merge_with_options(
+            b"key1",
+            b"a",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(3600),
+            },
+        );
+        batch.merge_with_options(
+            b"key2",
+            b"b",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(7200),
+            },
+        );
+
+        let merge_operator = Some(std::sync::Arc::new(StringConcatMergeOperator)
+            as crate::merge_operator::MergeOperatorType);
+        let (result, _, _) = batch
+            .extract_entries(100, 1000, None, merge_operator, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].key, Bytes::from_static(b"key1"));
+        assert_eq!(result[0].expire_ts, Some(4600));
+        assert_eq!(result[1].key, Bytes::from_static(b"key2"));
+        assert_eq!(result[1].expire_ts, Some(8200));
+    }
+
+    #[tokio::test]
+    async fn should_error_extracting_put_then_merge_with_different_ttls() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"key1", b"base");
+        batch.merge_with_options(
+            b"key1",
+            b"a",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(7200),
+            },
+        );
+
+        let merge_operator = Some(std::sync::Arc::new(StringConcatMergeOperator)
+            as crate::merge_operator::MergeOperatorType);
+        let err = batch
+            .extract_entries(100, 1000, None, merge_operator, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SlateDBError::IncompatibleMergeTtls { .. }));
+    }
+
+    #[tokio::test]
+    async fn should_error_extracting_delete_then_merge_with_different_ttls() {
+        let mut batch = WriteBatch::new();
+        batch.delete(b"key1");
+        batch.merge_with_options(
+            b"key1",
+            b"a",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(7200),
+            },
+        );
+
+        let merge_operator = Some(std::sync::Arc::new(StringConcatMergeOperator)
+            as crate::merge_operator::MergeOperatorType);
+        let err = batch
+            .extract_entries(100, 1000, None, merge_operator, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SlateDBError::IncompatibleMergeTtls { .. }));
     }
 
     #[tokio::test]

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -339,6 +339,7 @@ impl WriteBatch {
     /// or absent prefix for any key.
     ///
     /// When `extractor` is `None`, the returned prefix set is empty.
+    #[allow(clippy::panic)]
     pub(crate) async fn extract_entries(
         &self,
         seq: u64,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -9099,6 +9099,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_reject_batch_local_merges_across_differing_ttls() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = Db::builder(
+            "/tmp/test_reject_batch_local_merges_across_differing_ttls",
+            object_store,
+        )
+        .with_settings(test_db_options(0, 1024, None))
+        .with_merge_operator(Arc::new(StringConcatMergeOperator))
+        .build()
+        .await
+        .unwrap();
+
+        let mut batch = WriteBatch::new();
+        batch.merge_with_options(
+            b"key1",
+            b"a",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(3600),
+            },
+        );
+        batch.merge_with_options(
+            b"key1",
+            b"b",
+            &MergeOptions {
+                ttl: Ttl::ExpireAfter(7200),
+            },
+        );
+
+        let err = db.write(batch).await.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        assert!(
+            err.to_string()
+                .contains("only one merge TTL per-key allowed"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(db.get(b"key1").await.unwrap(), None);
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_should_record_total_mem_size_bytes() {
         // given:
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -1959,6 +1959,49 @@ mod tests {
         assert_eq!(db.get(b"counter").await.unwrap(), None);
     }
 
+    #[tokio::test]
+    async fn test_txn_commit_rejects_same_key_merge_different_ttls() {
+        let object_store: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::builder(
+            "test_txn_commit_rejects_same_key_merge_different_ttls",
+            object_store,
+        )
+        .with_settings(test_db_options(0, 1024, None))
+        .with_merge_operator(Arc::new(CounterMergeOperator))
+        .build()
+        .await
+        .unwrap();
+
+        let txn = db.begin(IsolationLevel::Snapshot).await.unwrap();
+        txn.merge_with_options(
+            b"counter",
+            1u64.to_le_bytes(),
+            &MergeOptions {
+                ttl: crate::config::Ttl::ExpireAfter(3600),
+            },
+        )
+        .unwrap();
+        txn.merge_with_options(
+            b"counter",
+            2u64.to_le_bytes(),
+            &MergeOptions {
+                ttl: crate::config::Ttl::ExpireAfter(7200),
+            },
+        )
+        .unwrap();
+
+        let err = txn.commit().await.unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        assert!(
+            err.to_string()
+                .contains("only one merge TTL per-key allowed"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(db.get(b"counter").await.unwrap(), None);
+
+        db.close().await.unwrap();
+    }
+
     fn test_db_options(
         min_filter_keys: u32,
         l0_sst_size_bytes: usize,

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -166,6 +166,15 @@ pub(crate) enum SlateDBError {
     #[error("merge operator missing. A merge operator is required to read merge operands")]
     MergeOperatorMissing,
 
+    #[error(
+        "only one merge TTL per-key allowed in a batch. key={key:?}, previous=`{previous_expire_ts:?}`, current=`{current_expire_ts:?}`"
+    )]
+    IncompatibleMergeTtls {
+        key: Bytes,
+        previous_expire_ts: Option<i64>,
+        current_expire_ts: Option<i64>,
+    },
+
     #[error("checkpoint missing. checkpoint_id=`{0}`")]
     CheckpointMissing(Uuid),
 
@@ -610,6 +619,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::InvalidDeletion => Error::invalid(msg),
             SlateDBError::MergeOperatorError(err) => Error::invalid(msg).with_source(Box::new(err)),
             SlateDBError::MergeOperatorMissing => Error::invalid(msg),
+            SlateDBError::IncompatibleMergeTtls { .. } => Error::invalid(msg),
             SlateDBError::IteratorNotInitialized => Error::invalid(msg),
             SlateDBError::InvalidSequenceOrder { .. } => Error::invalid(msg),
             SlateDBError::InvalidEnvironmentVariable { .. } => Error::invalid(msg),

--- a/website/src/content/docs/docs/design/merge-operators.mdx
+++ b/website/src/content/docs/docs/design/merge-operators.mdx
@@ -80,7 +80,11 @@ If no merge operator is configured and a read encounters a `Merge` row, SlateDB 
 
 ### Rewrites
 
-Inside a committed [`WriteBatch`](https://docs.rs/slatedb/latest/slatedb/struct.WriteBatch.html), SlateDB reduces consecutive merge operations for the same key when the writer has a merge operator configured. If the batch also contains a value or tombstone base for that key, the reduced row becomes a plain value. If it has only operands, the reduced row stays a `Merge`.
+Before a [`WriteBatch`](https://docs.rs/slatedb/latest/slatedb/struct.WriteBatch.html) is committed, SlateDB reduces consecutive merge operations for the same key when the writer has a merge operator configured. If the batch also contains a value or tombstone base for that key, the reduced row becomes a plain value. If it has only operands, the reduced row stays a `Merge`.
+
+:::caution
+`Db::write(...)` and transaction commits reject batch-local merges for the same key when the rows being reduced have different effective `expire_ts` values. This includes multiple `merge_with_options(...)` calls with different TTLs, a `put_with_options(...)` followed by a merge with a different TTL, or a `delete(...)` followed by a merge that expires. Use one effective TTL for each key in a batch, or split the operations across separate batchces or commits.
+:::
 
 Memtable flush and compaction use the same merge logic before they write new SSTs. Those rewrite paths are stricter than reads. They keep rows with different `expire_ts` values in separate groups so they can expire independently, and they stop at snapshot and durability retention boundaries so active snapshots or remote readers can still see the version chain they need.
 

--- a/website/src/content/docs/docs/design/time.mdx
+++ b/website/src/content/docs/docs/design/time.mdx
@@ -43,6 +43,10 @@ TTL is stored as an absolute expiration timestamp, not a relative duration. On c
 
 Deletes write tombstones and do not carry TTL.
 
+:::caution
+Batch-local merges requires one effective `expire_ts` per key. `Db::write(...)` and transaction commit return `ErrorKind::Invalid` if a single batch tries to merge the same key across different expiration timestamps. Effective timestamps are computed after applying `Settings::default_ttl`, so `Ttl::Default` can still differ from `Ttl::NoExpiry` or from another explicit TTL.
+:::
+
 :::note
 When SlateDB materializes a value from merge operands, the resulting row reports the earliest `expire_ts` across the merged operands and any base value. A later merge with a longer TTL does not extend the lifetime of older merged data.
 :::


### PR DESCRIPTION
## Summary

Return error when a user writes multiple values for the same key with more than one TTL. Panic if we see multiple keys in the same batch with the same TTL after applying merge logic.

Fixes #1581

## Changes

- Add `SlateDBError::IncompatibleMergeTtls`
- Return error in `WriteBatch::extract_entries` if we see multiple rows with same key and different TTLs
- Panic in `WriteBatch::extract_entries` if we see multiple rows with same key and the same TTL. This should never happen since `MemTable` is keyed by `SequencedKey` (`(bytes, seqnum)`) and a single `WriteBatch` has only one `seqnum`. Allowing multiple rows with the same key+seqnum during row extraction would result in data loss.

## Notes for Reviewers

This does have some subtle side-effects. In particular, you can't do:

```
batch.put("foo");
batch.merge("foo", "bar", ttl=123).
```

Nor can you do:

```
batch.delete("foo");
batch.merge("foo", "bar", ttl=123).
```

This is correct according to our semantics, but seems a little unintuitive. I think we'll need to live with it.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
