### PR TITLE
feat(txn-obj): add Invariant<T> predicates run implicitly in update()

### DIFF
--- a/slatedb-txn-obj/src/lib.rs
+++ b/slatedb-txn-obj/src/lib.rs
@@ -203,6 +203,13 @@ pub struct DirtyObject<T, Id = MonotonicId> {
     pub value: T,
 }
 
+/// A predicate over a dirty value and the current committed value that must hold before the dirty
+/// value is committed. The closure receives `(dirty, current)` and returns `Err` to abort the
+/// pending update; the error is surfaced wrapped in [`TransactionalObjectError::CallbackError`].
+/// Registered via [`SimpleTransactionalObject::with_invariants`] and checked in `update`.
+pub type Invariant<T> =
+    Arc<dyn Fn(&T, &T) -> Result<(), Box<dyn std::error::Error + Send + Sync>> + Send + Sync>;
+
 /// An in-memory datum that is backed by durable storage and can be
 /// transactionally updated.
 #[async_trait::async_trait]
@@ -455,9 +462,18 @@ pub struct SimpleTransactionalObject<T, Id = MonotonicId> {
     id: Id,
     object: T,
     ops: Arc<dyn TransactionalStorageProtocol<T, Id>>,
+    /// Predicates evaluated against a dirty value before each `update`. Empty by default.
+    invariants: Vec<Invariant<T>>,
 }
 
 impl<T: Clone, Id> SimpleTransactionalObject<T, Id> {
+    /// Register invariants that are checked against the dirty value before every `update`. The
+    /// first failing invariant aborts the write with its error wrapped in `CallbackError`.
+    pub fn with_invariants(mut self, invariants: Vec<Invariant<T>>) -> Self {
+        self.invariants = invariants;
+        self
+    }
+
     pub async fn init(
         store: Arc<dyn TransactionalStorageProtocol<T, Id>>,
         value: T,
@@ -467,6 +483,7 @@ impl<T: Clone, Id> SimpleTransactionalObject<T, Id> {
             id,
             object: value,
             ops: store,
+            invariants: Vec::new(),
         })
     }
 
@@ -489,6 +506,7 @@ impl<T: Clone, Id> SimpleTransactionalObject<T, Id> {
             id,
             object: val,
             ops: store,
+            invariants: Vec::new(),
         }))
     }
 
@@ -536,6 +554,9 @@ impl<T: Clone + Send + Sync, Id: Clone + PartialEq + Send + Sync> TransactionalO
     async fn update(&mut self, dirty: DirtyObject<T, Id>) -> Result<(), TransactionalObjectError> {
         if dirty.id != self.id {
             return Err(TransactionalObjectError::ObjectVersionExists);
+        }
+        for invariant in &self.invariants {
+            invariant(&dirty.value, &self.object).map_err(CallbackError)?;
         }
         self.id = self.ops.write(Some(dirty.id), &dirty.value).await?;
         self.object = dirty.value;
@@ -716,9 +737,9 @@ mod tests {
     use crate::object_store::ObjectStoreSequencedStorageProtocol;
     use crate::TransactionalObjectError;
     use crate::{
-        BoundaryObject, FenceableTransactionalObject, GenericObjectMetadata, MonotonicId,
-        ObjectCodec, SequencedStorageProtocol, SimpleTransactionalObject, TransactionalObject,
-        TransactionalStorageProtocol,
+        BoundaryObject, FenceableTransactionalObject, GenericObjectMetadata, Invariant,
+        MonotonicId, ObjectCodec, SequencedStorageProtocol, SimpleTransactionalObject,
+        TransactionalObject, TransactionalStorageProtocol,
     };
     use bytes::Bytes;
     use object_store::memory::InMemory;
@@ -1131,6 +1152,7 @@ mod tests {
             id: stale_base_id,
             object,
             ops,
+            invariants: Vec::new(),
         };
         let attempts = AtomicU64::new(0);
 
@@ -1209,6 +1231,7 @@ mod tests {
             id: stale_base_id,
             object,
             ops,
+            invariants: Vec::new(),
         };
 
         let fenceable = FenceableTransactionalObject::init(
@@ -1246,6 +1269,7 @@ mod tests {
             id: id_b,
             object: val_b,
             ops: Arc::clone(&store) as Arc<dyn TransactionalStorageProtocol<TestVal, MonotonicId>>,
+            invariants: Vec::new(),
         };
 
         // A updates first
@@ -1338,6 +1362,7 @@ mod tests {
             id: id_b,
             object: val_b,
             ops: Arc::clone(&store) as Arc<dyn TransactionalStorageProtocol<TestVal, MonotonicId>>,
+            invariants: Vec::new(),
         };
         let mut fb = FenceableTransactionalObject::init(
             sb,
@@ -1413,5 +1438,90 @@ mod tests {
         .await;
 
         assert!(matches!(result, Err(TransactionalObjectError::Fenced)));
+    }
+
+    /// Test invariant: fails when the dirty value's `payload` exceeds `ceiling`, and records every
+    /// invocation so tests can assert short-circuit behavior. Demonstrates carrying per-invariant
+    /// state (`ceiling`, `label`, `calls`) by closure capture rather than a struct.
+    fn ceiling_invariant(
+        ceiling: u64,
+        label: &'static str,
+        calls: Arc<AtomicU64>,
+    ) -> Invariant<TestVal> {
+        Arc::new(move |dirty: &TestVal, _current: &TestVal| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            if dirty.payload > ceiling {
+                return Err(format!(
+                    "{label}: payload {} exceeds ceiling {ceiling}",
+                    dirty.payload
+                )
+                .into());
+            }
+            Ok(())
+        })
+    }
+
+    #[tokio::test]
+    async fn test_update_runs_invariants_and_allows_passing_write() {
+        let store = new_store();
+        let calls = Arc::new(AtomicU64::new(0));
+        let mut sr = SimpleTransactionalObject::<TestVal>::init(
+            Arc::clone(&store) as Arc<dyn TransactionalStorageProtocol<TestVal, MonotonicId>>,
+            TestVal {
+                epoch: 0,
+                payload: 1,
+            },
+        )
+        .await
+        .unwrap()
+        .with_invariants(vec![ceiling_invariant(100, "only", Arc::clone(&calls))]);
+
+        let mut dirty = sr.prepare_dirty().unwrap();
+        dirty.value.payload = 42;
+        sr.update(dirty).await.unwrap();
+
+        assert_eq!(1, calls.load(Ordering::SeqCst));
+        assert_eq!(
+            42,
+            store.try_read_latest().await.unwrap().unwrap().1.payload
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_invariant_failure_aborts_write_and_short_circuits() {
+        let store = new_store();
+        let first_calls = Arc::new(AtomicU64::new(0));
+        let second_calls = Arc::new(AtomicU64::new(0));
+        let mut sr = SimpleTransactionalObject::<TestVal>::init(
+            Arc::clone(&store) as Arc<dyn TransactionalStorageProtocol<TestVal, MonotonicId>>,
+            TestVal {
+                epoch: 0,
+                payload: 1,
+            },
+        )
+        .await
+        .unwrap()
+        .with_invariants(vec![
+            // Fails first, so the second invariant must never run.
+            ceiling_invariant(5, "first", Arc::clone(&first_calls)),
+            ceiling_invariant(1000, "second", Arc::clone(&second_calls)),
+        ]);
+
+        let mut dirty = sr.prepare_dirty().unwrap();
+        dirty.value.payload = 10;
+        let err = sr.update(dirty).await.unwrap_err();
+
+        match err {
+            TransactionalObjectError::CallbackError(e) => {
+                assert!(e.to_string().contains("first"), "unexpected error: {e}");
+            }
+            other => panic!("expected CallbackError, got {other:?}"),
+        }
+        // first invariant ran and failed; second short-circuited.
+        assert_eq!(1, first_calls.load(Ordering::SeqCst));
+        assert_eq!(0, second_calls.load(Ordering::SeqCst));
+        // write was aborted: id unchanged and stored value still the original.
+        assert_eq!(1, sr.id());
+        assert_eq!(1, store.try_read_latest().await.unwrap().unwrap().1.payload);
     }
 }


### PR DESCRIPTION
## Summary

Implements https://github.com/slatedb/slatedb/issues/1707

[RFC-0025 GC cutoff rule enforcement](https://github.com/slatedb/slatedb/blob/741b9a10bfef6f347e47ec00ef7fc4d792bda405/rfcs/0025-garbage-collector-boundary.md#gc-cutoff-rule-enforcement) fixes a data-corruption bug. SlateDB's garbage collector decides what's safe to delete using timestamps embedded in ULIDs (the IDs on SST files and compaction jobs). Those ULIDs are stamped from the machine's wall clock. If a writer's clock is skewed backwards, it can publish a manifest that references an SST whose timestamp is already below the GC's deletion cutoff, so GC deletes live data.

The fix is three write-side invariants checked before every manifest/compactions commit. **This PR defines the generic mechanism for those invariants**. No domain rules shipped with this to get sign off on the high level structure first.

## Changes

- Add an `Invariant<T>` closure type alias to `slatedb-txn-obj`: `Arc<dyn Fn(&T, &T) -> Result<(), Box<dyn Error + Send + Sync>> + Send + Sync>` -> a predicate over `(dirty, current)` that aborts a commit by returning `Err`.
- `SimpleTransactionalObject<T>` now holds `Vec<Invariant<T>>`, attached once via a `with_invariants()` builder (default empty).
- `update()` runs the registered invariants before the CAS write, short-circuiting on the first failure and wrapping the error in the existing `CallbackError` (callers downcast to their own error type). No new error variants.
- Unit tests: a passing invariant writes through; a failing invariant aborts the write and short-circuits subsequent invariants.

## Notes for Reviewers

- **Scope:** mechanism only. The three RFC-0025 cutoff invariants (L0 / sorted-run / compaction-job-id) and the `MemtableFlusher`/compactor retry-on-`InvalidClockTick` paths will come in follow-up PRs. Default (empty invariants) mean **zero behavior change** for existing code.
- **Closure, not a trait:** (because YAGNI) the predicate has a single method, so a closure is lighter and matches the crate's existing convention for caller-supplied behavior (`maybe_apply_update`'s mutator, `FenceableTransactionalObject::init`'s `fn` pointers).
- **Implicit in `update()`, not a separate `validate()` call:** this diverges slightly from the RFC "add `TransactionalObject::validate()`", but it can't be forgotten across the many scattered manifest `update` sites and it composes with `maybe_apply_update`. Invariants are attached at object construction, so callers never pass them per-call. 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); opened as Draft (mechanism only; enforcement invariants + retries are planned follow-ups)
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally (`cargo test -p slatedb-txn-obj`, 27 passing; `cargo clippy -p slatedb-txn-obj --all-targets` clean)
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] No breaking changes -> purely additive; default-empty invariants leave existing implementors unaffected
- [x] Considered performance impact -> invariants are in-memory comparisons run only when registered; none in this PR

Thank you for the review! 🙏