### PR TITLE
feat: use batch delete for GC

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6453,7 +6453,9 @@ mod tests {
             2
         );
 
-        probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
+        let result = probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
+        assert_eq!(result.deleted, 1);
+        assert_eq!(result.failed, 0);
         gated_store.head_gate.release();
 
         let err = match w1_handle.await.unwrap() {
@@ -6516,7 +6518,9 @@ mod tests {
             .wait_for_arrivals(head_arrivals_before + 1)
             .await;
 
-        probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
+        let result = probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
+        assert_eq!(result.deleted, 1);
+        assert_eq!(result.failed, 0);
         gated_store.head_gate.release();
 
         let err = match w1_handle.await.unwrap() {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6454,7 +6454,7 @@ mod tests {
         );
 
         probe_table_store
-            .delete_sst(&SsTableId::Wal(1))
+            .delete_ssts(&[SsTableId::Wal(1)])
             .await
             .unwrap();
         gated_store.head_gate.release();
@@ -6520,7 +6520,7 @@ mod tests {
             .await;
 
         probe_table_store
-            .delete_sst(&SsTableId::Wal(1))
+            .delete_ssts(&[SsTableId::Wal(1)])
             .await
             .unwrap();
         gated_store.head_gate.release();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6453,9 +6453,7 @@ mod tests {
             2
         );
 
-        probe_table_store
-            .delete_ssts(&[SsTableId::Wal(1)])
-            .await;
+        probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
         gated_store.head_gate.release();
 
         let err = match w1_handle.await.unwrap() {
@@ -6518,9 +6516,7 @@ mod tests {
             .wait_for_arrivals(head_arrivals_before + 1)
             .await;
 
-        probe_table_store
-            .delete_ssts(&[SsTableId::Wal(1)])
-            .await;
+        probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
         gated_store.head_gate.release();
 
         let err = match w1_handle.await.unwrap() {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6455,8 +6455,7 @@ mod tests {
 
         probe_table_store
             .delete_ssts(&[SsTableId::Wal(1)])
-            .await
-            .unwrap();
+            .await;
         gated_store.head_gate.release();
 
         let err = match w1_handle.await.unwrap() {
@@ -6521,8 +6520,7 @@ mod tests {
 
         probe_table_store
             .delete_ssts(&[SsTableId::Wal(1)])
-            .await
-            .unwrap();
+            .await;
         gated_store.head_gate.release();
 
         let err = match w1_handle.await.unwrap() {

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -655,7 +655,9 @@ mod tests {
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
         db.evict_cached_sst(sst_id).await.expect("evict");
-        db.inner.table_store.delete_ssts(&[sst_id]).await;
+        let result = db.inner.table_store.delete_ssts(&[sst_id]).await;
+        assert_eq!(result.deleted, 1);
+        assert_eq!(result.failed, 0);
 
         // when: we warm a target whose underlying IO will fail
         let result = db

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -655,11 +655,7 @@ mod tests {
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
         db.evict_cached_sst(sst_id).await.expect("evict");
-        db.inner
-            .table_store
-            .delete_ssts(&[sst_id])
-            .await
-            .expect("delete_ssts");
+        db.inner.table_store.delete_ssts(&[sst_id]).await;
 
         // when: we warm a target whose underlying IO will fail
         let result = db

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -657,9 +657,9 @@ mod tests {
         db.evict_cached_sst(sst_id).await.expect("evict");
         db.inner
             .table_store
-            .delete_sst(&sst_id)
+            .delete_ssts(&[sst_id])
             .await
-            .expect("delete_sst");
+            .expect("delete_ssts");
 
         // when: we warm a target whose underlying IO will fail
         let result = db

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -6,10 +6,9 @@ use crate::{
     db_state::SsTableId,
     error::SlateDBError,
     manifest::{store::ManifestStore, Manifest, VersionedManifest},
-    tablestore::TableStore,
+    tablestore::{DeleteResult, TableStore},
 };
 use chrono::{DateTime, Utc};
-use log::error;
 use std::collections::HashSet;
 use std::sync::Arc;
 
@@ -233,16 +232,17 @@ impl GcTask for CompactedGcTask {
                 "deleting compacted SSTs [count={}]",
                 sst_ids_to_delete.len()
             );
-            match self.table_store.delete_ssts(&sst_ids_to_delete).await {
-                Ok(()) => self
-                    .stats
-                    .gc_compacted_count
-                    .increment(sst_ids_to_delete.len() as u64),
-                Err(e) => error!(
-                    "error deleting compacted SSTs [count={}, error={}]",
-                    sst_ids_to_delete.len(),
-                    e
-                ),
+            let DeleteResult { deleted, failed } =
+                self.table_store.delete_ssts(&sst_ids_to_delete).await;
+            self.stats.gc_compacted_count.increment(deleted as u64);
+            if failed > 0 {
+                log::warn!(
+                    "deleted compacted SSTs with failures [deleted={}, failed={}]",
+                    deleted,
+                    failed
+                );
+            } else {
+                log::info!("deleted compacted SSTs [count={}]", deleted);
             }
         }
 

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -224,16 +224,25 @@ impl GcTask for CompactedGcTask {
                 sst_ids_to_delete.len()
             );
         }
-        for id in sst_ids_to_delete {
-            if self.compacted_options.dry_run {
+        if self.compacted_options.dry_run {
+            for id in &sst_ids_to_delete {
                 log::debug!("dry run: would delete SST but skipped [id={:?}]", id);
-                continue;
             }
-            log::info!("deleting SST [id={:?}]", id);
-            if let Err(e) = self.table_store.delete_sst(&id).await {
-                error!("error deleting SST [id={:?}, error={}]", id, e);
-            } else {
-                self.stats.gc_compacted_count.increment(1);
+        } else {
+            log::info!(
+                "deleting compacted SSTs [count={}]",
+                sst_ids_to_delete.len()
+            );
+            match self.table_store.delete_ssts(&sst_ids_to_delete).await {
+                Ok(()) => self
+                    .stats
+                    .gc_compacted_count
+                    .increment(sst_ids_to_delete.len() as u64),
+                Err(e) => error!(
+                    "error deleting compacted SSTs [count={}, error={}]",
+                    sst_ids_to_delete.len(),
+                    e
+                ),
             }
         }
 

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -217,20 +217,19 @@ impl GcTask for CompactedGcTask {
             .filter(|id| !active_ssts.contains(id))
             .collect::<Vec<_>>();
 
-        if self.compacted_options.dry_run && !sst_ids_to_delete.is_empty() {
-            log::info!(
-                "dry run: skipping SST deletion [count={}]",
-                sst_ids_to_delete.len()
-            );
-        }
         if self.compacted_options.dry_run {
-            for id in &sst_ids_to_delete {
-                log::debug!("dry run: would delete SST but skipped [id={:?}]", id);
+            if !sst_ids_to_delete.is_empty() {
+                log::info!(
+                    "dry run: skipping compacted SST deletion [count={}, ids={:?}]",
+                    sst_ids_to_delete.len(),
+                    sst_ids_to_delete,
+                );
             }
         } else {
             log::info!(
-                "deleting compacted SSTs [count={}]",
-                sst_ids_to_delete.len()
+                "deleting compacted SSTs [count={}, ids={:?}]",
+                sst_ids_to_delete.len(),
+                sst_ids_to_delete,
             );
             let DeleteResult { deleted, failed } =
                 self.table_store.delete_ssts(&sst_ids_to_delete).await;

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -135,22 +135,29 @@ impl GcTask for WalGcTask {
                 );
             }
         }
-        for id in sst_ids_to_delete {
-            if self.wal_options.dry_run {
+        if self.wal_options.dry_run {
+            for id in &sst_ids_to_delete {
                 log::debug!(
                     "dry run: would delete {} but skipped [id={:?}]",
                     self.resource(),
                     id
                 );
-                continue;
             }
-            if let Err(e) = self.table_store.delete_sst(&id).await {
-                error!("error deleting WAL SST [id={:?}, error={}]", id, e);
-            } else {
-                match self.mode {
-                    WalGcMode::Regular => self.stats.gc_wal_count.increment(1),
-                    WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(1),
+        } else {
+            match self.table_store.delete_ssts(&sst_ids_to_delete).await {
+                Ok(()) => {
+                    let n = sst_ids_to_delete.len() as u64;
+                    match self.mode {
+                        WalGcMode::Regular => self.stats.gc_wal_count.increment(n),
+                        WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(n),
+                    }
                 }
+                Err(e) => error!(
+                    "error deleting {} [count={}, error={}]",
+                    self.resource(),
+                    sst_ids_to_delete.len(),
+                    e
+                ),
             }
         }
 

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -118,29 +118,29 @@ impl GcTask for WalGcTask {
             .map(|wal_sst| wal_sst.id)
             .collect::<Vec<_>>();
 
-        if self.wal_options.dry_run && !sst_ids_to_delete.is_empty() {
-            log::info!(
-                "dry run: skipping {} deletion [count={}]",
-                self.resource(),
-                sst_ids_to_delete.len()
-            );
-            if matches!(self.mode, WalGcMode::Fence) {
-                log::info!(
-                    "WAL fence GC is dry-run by default. This is a conservative setting. \
-                    Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
-                    Silence this log with wal_fence_options=None. See #352 for details."
-                );
-            }
-        }
         if self.wal_options.dry_run {
-            for id in &sst_ids_to_delete {
-                log::debug!(
-                    "dry run: would delete {} but skipped [id={:?}]",
+            if !sst_ids_to_delete.is_empty() {
+                log::info!(
+                    "dry run: skipping {} deletion [count={}, ids={:?}]",
                     self.resource(),
-                    id
+                    sst_ids_to_delete.len(),
+                    sst_ids_to_delete,
                 );
+                if matches!(self.mode, WalGcMode::Fence) {
+                    log::info!(
+                        "WAL fence GC is dry-run by default. This is a conservative setting. \
+                        Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
+                        Silence this log with wal_fence_options=None. See #352 for details."
+                    );
+                }
             }
         } else {
+            log::info!(
+                "deleting {} [count={}, ids={:?}]",
+                self.resource(),
+                sst_ids_to_delete.len(),
+                sst_ids_to_delete,
+            );
             let DeleteResult { deleted, failed } =
                 self.table_store.delete_ssts(&sst_ids_to_delete).await;
             match self.mode {

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -2,10 +2,9 @@ use crate::manifest::Manifest;
 use crate::tablestore::SstFileMetadata;
 use crate::{
     config::GarbageCollectorDirectoryOptions, error::SlateDBError, manifest::store::ManifestStore,
-    tablestore::TableStore,
+    tablestore::{DeleteResult, TableStore},
 };
 use chrono::{DateTime, Utc};
-use log::error;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -144,20 +143,19 @@ impl GcTask for WalGcTask {
                 );
             }
         } else {
-            match self.table_store.delete_ssts(&sst_ids_to_delete).await {
-                Ok(()) => {
-                    let n = sst_ids_to_delete.len() as u64;
-                    match self.mode {
-                        WalGcMode::Regular => self.stats.gc_wal_count.increment(n),
-                        WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(n),
-                    }
-                }
-                Err(e) => error!(
-                    "error deleting {} [count={}, error={}]",
+            let DeleteResult { deleted, failed } =
+                self.table_store.delete_ssts(&sst_ids_to_delete).await;
+            match self.mode {
+                WalGcMode::Regular => self.stats.gc_wal_count.increment(deleted as u64),
+                WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(deleted as u64),
+            }
+            if failed > 0 {
+                log::warn!(
+                    "deleted {} with failures [deleted={}, failed={}]",
                     self.resource(),
-                    sst_ids_to_delete.len(),
-                    e
-                ),
+                    deleted,
+                    failed
+                );
             }
         }
 

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -1,9 +1,7 @@
-use crate::manifest::Manifest;
-use crate::tablestore::SstFileMetadata;
-use crate::{
-    config::GarbageCollectorDirectoryOptions, error::SlateDBError, manifest::store::ManifestStore,
-    tablestore::{DeleteResult, TableStore},
-};
+use crate::config::GarbageCollectorDirectoryOptions;
+use crate::error::SlateDBError;
+use crate::manifest::{store::ManifestStore, Manifest};
+use crate::tablestore::{DeleteResult, SstFileMetadata, TableStore};
 use chrono::{DateTime, Utc};
 use std::collections::BTreeMap;
 use std::sync::Arc;

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -204,6 +204,12 @@ impl ObjectStore for InstrumentedObjectStore {
         })
     }
 
+    // Records a single `delete` observation for the whole batch (the time to
+    // drain the entire stream), not one per object. The number of underlying
+    // HTTP requests is backend-specific — S3 bulk-deletes in chunks of up to
+    // 1,000, Azure in chunks of up to 256, while GCS deletes one object per
+    // request — so this duration is "how long the batch took", not a per-object
+    // or per-request latency. See the metrics docs for details.
     fn delete_stream(
         &self,
         locations: BoxStream<'static, object_store::Result<Path>>,

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -30,7 +30,7 @@ use futures::{FutureExt, StreamExt};
 use object_store::path::Path;
 use object_store::{
     CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
 };
 use slatedb_common::metrics::MetricsRecorderHelper;
 
@@ -209,20 +209,16 @@ impl ObjectStore for InstrumentedObjectStore {
         locations: BoxStream<'static, object_store::Result<Path>>,
     ) -> BoxStream<'static, object_store::Result<Path>> {
         let stats = Arc::clone(&self.stats);
-        let inner = Arc::clone(&self.inner);
-        locations
-            .then(move |loc| {
-                let stats = Arc::clone(&stats);
-                let inner = Arc::clone(&inner);
-                async move {
-                    let loc = loc?;
-                    let start = Instant::now();
-                    let result = inner.delete(&loc).await;
-                    stats.delete.record(start.elapsed(), result.is_ok());
-                    result.map(|_| loc)
-                }
-            })
-            .boxed()
+        let stream = self.inner.delete_stream(locations);
+        futures::stream::once(async move {
+            let start = Instant::now();
+            let results: Vec<object_store::Result<Path>> = stream.collect().await;
+            let ok = results.iter().all(|r| r.is_ok());
+            stats.delete.record(start.elapsed(), ok);
+            futures::stream::iter(results)
+        })
+        .flatten()
+        .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -795,6 +791,41 @@ mod tests {
                 &recorder,
                 ERROR_COUNT,
                 &get_labels(ObjectStoreComponent::Gc, ObjectStoreType::Wal, "put", "put")
+            ),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_instrumented_delete_stream_records_one_per_batch() {
+        use futures::StreamExt;
+
+        // given: an instrumented store over a 100-path delete batch.
+        let (recorder, helper) = test_recorder_helper();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let store = InstrumentedObjectStore::new(
+            inner,
+            &helper,
+            ObjectStoreComponent::Db,
+            ObjectStoreType::Main,
+        );
+        let paths: Vec<Path> = (0..100).map(|i| Path::from(format!("d/{i}"))).collect();
+        let input =
+            futures::stream::iter(paths.into_iter().map(Ok::<Path, object_store::Error>)).boxed();
+
+        let _: Vec<_> = store.delete_stream(input).collect().await;
+
+        // one record for the whole batch, not one per path.
+        assert_eq!(
+            lookup_metric_with_labels(
+                &recorder,
+                REQUEST_COUNT,
+                &get_labels(
+                    ObjectStoreComponent::Db,
+                    ObjectStoreType::Main,
+                    "delete",
+                    "delete"
+                ),
             ),
             Some(1)
         );

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -12,8 +12,7 @@ use log::{debug, info};
 use object_store::path::Path;
 use object_store::{
     Attribute, CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
-    ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload,
-    PutResult, RenameOptions,
+    ObjectMeta, ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
 };
 
 use crate::rand::DbRand;
@@ -375,22 +374,32 @@ impl ObjectStore for RetryingObjectStore {
         let inner = Arc::clone(&self.inner);
         let sleeper = self.sleeper();
         let retry_builder = Self::retry_builder();
-        locations
-            .then(move |loc| {
-                let inner = Arc::clone(&inner);
-                let sleeper = sleeper.clone();
-                async move {
-                    let loc = loc?;
-                    (|| async { inner.delete(&loc).await })
-                        .retry(retry_builder)
-                        .sleep(sleeper)
-                        .notify(Self::notify)
-                        .when(Self::should_retry)
-                        .await?;
-                    Ok(loc)
+
+        stream::once(async move {
+            let paths: Vec<Path> = locations.try_collect().await?;
+
+            (|| async {
+                let locs = stream::iter(paths.clone().into_iter().map(Ok)).boxed();
+                let results: Vec<object_store::Result<Path>> =
+                    inner.delete_stream(locs).collect().await;
+                let mut res = Vec::with_capacity(results.len());
+                for r in results {
+                    match r {
+                        Err(e) if Self::should_retry(&e) => return Err(e),
+                        other => res.push(other),
+                    }
                 }
+                Ok::<Vec<object_store::Result<Path>>, object_store::Error>(res)
             })
-            .boxed()
+            .retry(retry_builder)
+            .sleep(sleeper)
+            .notify(Self::notify)
+            .when(Self::should_retry)
+            .await
+        })
+        .map_ok(stream::iter)
+        .try_flatten()
+        .boxed()
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
@@ -512,7 +521,7 @@ mod tests {
     use crate::rand::DbRand;
     use crate::test_utils::FlakyObjectStore;
     use bytes::Bytes;
-    use futures::TryStreamExt;
+    use futures::{StreamExt, TryStreamExt};
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{GetOptions, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload};
@@ -943,5 +952,55 @@ mod tests {
             .attributes
             .get(&Attribute::Metadata(Cow::Borrowed(super::PUT_ID_ATTRIBUTE)))
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn test_delete_stream_batch_level_retry() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let paths = vec![Path::from("/d/a"), Path::from("/d/b"), Path::from("/d/c")];
+        for p in &paths {
+            inner
+                .put(p, PutPayload::from_bytes(Bytes::from_static(b"x")))
+                .await
+                .unwrap();
+        }
+        let count = paths.len();
+
+        // Fail the first 2 delete batches with a retryable error, then succeed.
+        let flaky = Arc::new(FlakyObjectStore::new(inner.clone(), 0).with_delete_failures(2));
+        let retrying = RetryingObjectStore::new(flaky.clone(), test_rand(), test_clock());
+
+        let input =
+            futures::stream::iter(paths.into_iter().map(Ok::<Path, object_store::Error>)).boxed();
+        let results: Vec<_> = retrying.delete_stream(input).collect().await;
+
+        // Every path ultimately deletes successfully.
+        assert_eq!(results.len(), count);
+        assert!(results.iter().all(|r| r.is_ok()));
+        // 2 failed batches + 1 successful batch — the retry is at batch granularity.
+        assert_eq!(flaky.delete_stream_attempts(), 3);
+        // The objects are actually gone from the backing store.
+        assert_eq!(inner.list(None).count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_stream_not_found_is_not_retried() {
+        // Azure/GCP return NotFound (not Ok) when deleting an already-gone object.
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_delete_not_found());
+        let retrying = RetryingObjectStore::new(flaky.clone(), test_rand(), test_clock());
+
+        let paths = vec![Path::from("/d/a"), Path::from("/d/b"), Path::from("/d/c")];
+        let count = paths.len();
+        let input =
+            futures::stream::iter(paths.into_iter().map(Ok::<Path, object_store::Error>)).boxed();
+        let results: Vec<_> = retrying.delete_stream(input).collect().await;
+
+        assert_eq!(results.len(), count);
+        assert!(results
+            .iter()
+            .all(|r| matches!(r, Err(object_store::Error::NotFound { .. }))));
+        // and NotFound is on the should_retry exclusion list → exactly one attempt.
+        assert_eq!(flaky.delete_stream_attempts(), 1);
     }
 }

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -456,6 +456,12 @@ impl TableStore {
             return DeleteResult::default();
         }
         // ids in a single call are all the same kind, so they route to one store.
+        debug_assert!(
+            ids.iter()
+                .all(|id| std::mem::discriminant(id) == std::mem::discriminant(&ids[0])),
+            "all SSTs in a `delete_ssts` batch must be the same kind (all Wal or all \
+             Compacted)"
+        );
         let object_store = self.object_stores.store_for(&ids[0]);
         let paths: Vec<Path> = ids.iter().map(|id| self.path(id)).collect();
         debug!("deleting {} SSTs", paths.len());
@@ -2279,7 +2285,9 @@ mod tests {
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        ts.delete_ssts(&[id1]).await;
+        let result = ts.delete_ssts(&[id1]).await;
+        assert_eq!(result.deleted, 1);
+        assert_eq!(result.failed, 0);
 
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 1);
@@ -2392,7 +2400,9 @@ mod tests {
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        ts.delete_ssts(&[id1]).await;
+        let result = ts.delete_ssts(&[id1]).await;
+        assert_eq!(result.deleted, 1);
+        assert_eq!(result.failed, 0);
 
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 1);

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -2324,6 +2324,34 @@ mod tests {
         assert_eq!(result, DeleteResult::default());
     }
 
+    #[tokio::test]
+    async fn test_delete_ssts_not_found() {
+        // Azure/GCP return NotFound (not Ok) when deleting an already-gone
+        // object. `delete_ssts` must treat those as deleted, not as 
+        // failures, and the batch must not short-circuit on them.
+        let store: Arc<dyn ObjectStore> =
+            Arc::new(FlakyObjectStore::new(Arc::new(InMemory::new()), 0).with_delete_not_found());
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(store, None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ));
+
+        let ids: Vec<SsTableId> = (0..3)
+            .map(|_| SsTableId::Compacted(ulid::Ulid::new()))
+            .collect();
+
+        let result = ts.delete_ssts(&ids).await;
+        assert_eq!(
+            result,
+            DeleteResult {
+                deleted: 3,
+                failed: 0
+            }
+        );
+    }
+
     #[rstest]
     #[case::main_only(make_store(), None)]
     #[case::main_and_wal(make_store(), Some(make_store()))]

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1,12 +1,11 @@
 use std::collections::VecDeque;
-use std::future::ready;
 use std::ops::{Range, RangeBounds};
 use std::sync::Arc;
 
 use bytes::Bytes;
 use chrono::Utc;
 use fail_parallel::{fail_point, FailPointRegistry};
-use futures::{future::join_all, StreamExt, TryStreamExt};
+use futures::{future::join_all, StreamExt};
 use log::{debug, warn};
 use object_store::buffered::BufWriter;
 use object_store::path::Path;
@@ -29,6 +28,15 @@ use crate::sst_builder::EncodedSsTableBuilder;
 use crate::sst_stats::SstStats;
 use crate::types::RowEntry;
 use crate::wal::wal_sst_builder::EncodedWalSsTableBuilder;
+
+/// Counts from a [`TableStore::delete_ssts`] batch.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DeleteResult {
+    /// Objects confirmed gone (successful deletes plus `NotFound`, already gone).
+    pub(crate) deleted: usize,
+    /// Objects whose delete still failed after retries.
+    pub(crate) failed: usize,
+}
 
 pub(crate) struct TableStore {
     object_stores: ObjectStores,
@@ -439,9 +447,13 @@ impl TableStore {
     /// `NotFound` is treated as success — the object is already gone, so the
     /// deletion goal is met (idempotent across S3/Azure/GCP, where deleting a
     /// missing object yields `NotFound` rather than `Ok`).
-    pub(crate) async fn delete_ssts(&self, ids: &[SsTableId]) -> Result<(), SlateDBError> {
+    ///
+    /// The whole stream is drained even when some deletes fail, so a per-path
+    /// failure is recorded in [`DeleteResult::failed`] rather than aborting the
+    /// batch.
+    pub(crate) async fn delete_ssts(&self, ids: &[SsTableId]) -> DeleteResult {
         if ids.is_empty() {
-            return Ok(());
+            return DeleteResult::default();
         }
         // ids in a single call are all the same kind, so they route to one store.
         let object_store = self.object_stores.store_for(&ids[0]);
@@ -449,16 +461,21 @@ impl TableStore {
         debug!("deleting {} SSTs", paths.len());
         let path_stream =
             futures::stream::iter(paths.into_iter().map(Ok::<Path, object_store::Error>)).boxed();
-        object_store
-            .delete_stream(path_stream)
-            // NotFound = object already gone = deletion goal met (idempotent across
-            // S3/Azure/GCP) -> filter it out so it doesn't short-circuit the stream.
-            .filter(|r| ready(!matches!(r, Err(object_store::Error::NotFound { .. }))))
-            // delete_stream yields Ok(path) per deleted location; we don't need the
-            // receipts, only whether any delete failed, so drop them here.
-            .try_for_each(|_path| ready(Ok(())))
-            .await?;
-        Ok(())
+
+        let mut stream = object_store.delete_stream(path_stream);
+        let mut result = DeleteResult::default();
+        while let Some(outcome) = stream.next().await {
+            match outcome {
+                // NotFound = object already gone = deletion goal met (idempotent
+                // across S3/Azure/GCP)
+                Ok(_) | Err(object_store::Error::NotFound { .. }) => result.deleted += 1,
+                Err(e) => {
+                    result.failed += 1;
+                    warn!("error deleting SST [error={}]", e);
+                }
+            }
+        }
+        result
     }
 
     /// Reads metadata for a specific SST object (WAL or compacted).
@@ -1131,7 +1148,7 @@ mod tests {
     use crate::rand::DbRand;
     use crate::retrying_object_store::RetryingObjectStore;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
-    use crate::tablestore::TableStore;
+    use crate::tablestore::{DeleteResult, TableStore};
     use crate::test_utils::FlakyObjectStore;
     use crate::test_utils::{assert_iterator, build_test_sst};
     use crate::types::{RowEntry, ValueDeletable};
@@ -2262,7 +2279,7 @@ mod tests {
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        ts.delete_ssts(&[id1]).await.unwrap();
+        ts.delete_ssts(&[id1]).await;
 
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 1);
@@ -2274,6 +2291,34 @@ mod tests {
         } else {
             assert_eq!(count_ssts_in(&main_store).await, 1);
         }
+    }
+
+    #[tokio::test]
+    async fn test_delete_ssts_reports_counts() {
+        let main_store = make_store();
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(main_store.clone(), None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ));
+
+        let ids: Vec<SsTableId> = (0..3)
+            .map(|_| SsTableId::Compacted(ulid::Ulid::new()))
+            .collect();
+        for id in &ids {
+            main_store.put(&ts.path(id), Bytes::new().into()).await.unwrap();
+        }
+
+        // All three exist -> all counted as deleted, none failed.
+        let result = ts.delete_ssts(&ids).await;
+        assert_eq!(result.deleted, 3);
+        assert_eq!(result.failed, 0);
+        assert_eq!(count_ssts_in(&main_store).await, 0);
+
+        // Empty batch is a no-op with zeroed counts.
+        let result = ts.delete_ssts(&[]).await;
+        assert_eq!(result, DeleteResult::default());
     }
 
     #[rstest]
@@ -2316,7 +2361,7 @@ mod tests {
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        ts.delete_ssts(&[id1]).await.unwrap();
+        ts.delete_ssts(&[id1]).await;
 
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 1);

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -2307,7 +2307,10 @@ mod tests {
             .map(|_| SsTableId::Compacted(ulid::Ulid::new()))
             .collect();
         for id in &ids {
-            main_store.put(&ts.path(id), Bytes::new().into()).await.unwrap();
+            main_store
+                .put(&ts.path(id), Bytes::new().into())
+                .await
+                .unwrap();
         }
 
         // All three exist -> all counted as deleted, none failed.

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1,11 +1,12 @@
 use std::collections::VecDeque;
+use std::future::ready;
 use std::ops::{Range, RangeBounds};
 use std::sync::Arc;
 
 use bytes::Bytes;
 use chrono::Utc;
 use fail_parallel::{fail_point, FailPointRegistry};
-use futures::{future::join_all, StreamExt};
+use futures::{future::join_all, StreamExt, TryStreamExt};
 use log::{debug, warn};
 use object_store::buffered::BufWriter;
 use object_store::path::Path;
@@ -426,12 +427,38 @@ impl TableStore {
         decoded
     }
 
-    /// Delete an SSTable from the object store.
-    pub(crate) async fn delete_sst(&self, id: &SsTableId) -> Result<(), SlateDBError> {
-        let object_store = self.object_stores.store_for(id);
-        let path = self.path(id);
-        debug!("deleting SST [path={}]", path);
-        object_store.delete(&path).await.map_err(SlateDBError::from)
+    /// Delete a batch of SSTables from the object store in a single
+    /// `delete_stream` call.
+    ///
+    /// All `ids` in one call must be of the same kind (all
+    /// [`SsTableId::Compacted`] or all [`SsTableId::Wal`]) so they route to the
+    /// same store; the GC `collect` functions that call this always satisfy
+    /// that. Forwarding the whole batch lets backends that support bulk delete
+    /// (S3, Azure) collapse thousands of deletes into a handful of API calls.
+    ///
+    /// `NotFound` is treated as success — the object is already gone, so the
+    /// deletion goal is met (idempotent across S3/Azure/GCP, where deleting a
+    /// missing object yields `NotFound` rather than `Ok`).
+    pub(crate) async fn delete_ssts(&self, ids: &[SsTableId]) -> Result<(), SlateDBError> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        // ids in a single call are all the same kind, so they route to one store.
+        let object_store = self.object_stores.store_for(&ids[0]);
+        let paths: Vec<Path> = ids.iter().map(|id| self.path(id)).collect();
+        debug!("deleting {} SSTs", paths.len());
+        let path_stream =
+            futures::stream::iter(paths.into_iter().map(Ok::<Path, object_store::Error>)).boxed();
+        object_store
+            .delete_stream(path_stream)
+            // NotFound = object already gone = deletion goal met (idempotent across
+            // S3/Azure/GCP) -> filter it out so it doesn't short-circuit the stream.
+            .filter(|r| ready(!matches!(r, Err(object_store::Error::NotFound { .. }))))
+            // delete_stream yields Ok(path) per deleted location; we don't need the
+            // receipts, only whether any delete failed, so drop them here.
+            .try_for_each(|_path| ready(Ok(())))
+            .await?;
+        Ok(())
     }
 
     /// Reads metadata for a specific SST object (WAL or compacted).
@@ -2235,7 +2262,7 @@ mod tests {
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        ts.delete_sst(&id1).await.unwrap();
+        ts.delete_ssts(&[id1]).await.unwrap();
 
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 1);
@@ -2289,7 +2316,7 @@ mod tests {
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        ts.delete_sst(&id1).await.unwrap();
+        ts.delete_ssts(&[id1]).await.unwrap();
 
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 1);

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -2327,7 +2327,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_ssts_not_found() {
         // Azure/GCP return NotFound (not Ok) when deleting an already-gone
-        // object. `delete_ssts` must treat those as deleted, not as 
+        // object. `delete_ssts` must treat those as deleted, not as
         // failures, and the batch must not short-circuit on them.
         let store: Arc<dyn ObjectStore> =
             Arc::new(FlakyObjectStore::new(Arc::new(InMemory::new()), 0).with_delete_not_found());

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -454,6 +454,13 @@ pub(crate) struct FlakyObjectStore {
     // get_range: transient failures on first N attempts
     fail_first_get_range: AtomicUsize,
     get_range_attempts: AtomicUsize,
+    // Delete: total number of `delete_stream` invocations (one per batch)
+    delete_stream_attempts: AtomicUsize,
+    // Delete: fail the first N `delete_stream` calls with a retryable batch-level error
+    fail_first_delete: AtomicUsize,
+    // Delete: if set, every input path yields a per-path NotFound. Simulates
+    // Azure/GCP, which return NotFound (not Ok) when deleting an already-gone object.
+    delete_not_found: std::sync::atomic::AtomicBool,
 }
 
 impl FlakyObjectStore {
@@ -477,6 +484,9 @@ impl FlakyObjectStore {
             list_with_offset_attempts: AtomicUsize::new(0),
             fail_first_get_range: AtomicUsize::new(0),
             get_range_attempts: AtomicUsize::new(0),
+            delete_stream_attempts: AtomicUsize::new(0),
+            fail_first_delete: AtomicUsize::new(0),
+            delete_not_found: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -559,6 +569,24 @@ impl FlakyObjectStore {
 
     pub(crate) fn get_range_attempts(&self) -> usize {
         self.get_range_attempts.load(Ordering::SeqCst)
+    }
+
+    /// Fail the first `n` `delete_stream` calls with a retryable batch-level error.
+    pub(crate) fn with_delete_failures(self, n: usize) -> Self {
+        self.fail_first_delete.store(n, Ordering::SeqCst);
+        self
+    }
+
+    /// Make every input path yield a per-path `NotFound` (Azure/GCP semantics for
+    /// deleting an already-removed object).
+    pub(crate) fn with_delete_not_found(self) -> Self {
+        self.delete_not_found.store(true, Ordering::SeqCst);
+        self
+    }
+
+    /// Number of `delete_stream` invocations so far (one per batch / retry attempt).
+    pub(crate) fn delete_stream_attempts(&self) -> usize {
+        self.delete_stream_attempts.load(Ordering::SeqCst)
     }
 
     /// Inject a failure after `fail_after` successful items in the stream.
@@ -721,6 +749,46 @@ impl ObjectStore for FlakyObjectStore {
         &self,
         locations: BoxStream<'static, object_store::Result<Path>>,
     ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.delete_stream_attempts.fetch_add(1, Ordering::SeqCst);
+        // Fail the whole batch with a retryable (Generic) error on the first N calls.
+        if self
+            .fail_first_delete
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                if v > 0 {
+                    Some(v - 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok()
+        {
+            return stream::once(async move {
+                Err(object_store::Error::Generic {
+                    store: "flaky_delete",
+                    source: Box::new(std::io::Error::new(
+                        std::io::ErrorKind::TimedOut,
+                        "injected delete timeout",
+                    )),
+                })
+            })
+            .boxed();
+        }
+        // Simulate Azure/GCP: deleting an already-gone object yields per-path NotFound.
+        if self.delete_not_found.load(Ordering::SeqCst) {
+            return locations
+                .map(|r| {
+                    r.and_then(|path| {
+                        Err(object_store::Error::NotFound {
+                            path: path.to_string(),
+                            source: Box::new(std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "injected not found",
+                            )),
+                        })
+                    })
+                })
+                .boxed();
+        }
         self.inner.delete_stream(locations)
     }
 

--- a/website/src/content/docs/docs/operations/metrics.mdx
+++ b/website/src/content/docs/docs/operations/metrics.mdx
@@ -149,6 +149,17 @@ The instrumented store sits beneath the retrying layer, so each retry attempt
 is counted separately. Cache hits that never reach the remote store are not
 counted.
 
+The `delete` API is special: SlateDB deletes SSTs in batches via the object
+store's `delete_stream`, and the instrumented store records a single
+`request_count` and `request_duration_seconds` observation for the whole batch
+(the time to drain the entire stream), not one per object. How that batch maps
+to underlying HTTP requests is backend-specific: S3 collapses deletes into bulk
+calls of up to 1,000 objects, Azure into batches of up to 256, while GCS issues
+one request per object. The number of objects per batch and the backend's
+internal concurrency therefore both move this metric. Treat the `delete`
+duration as "how long a delete batch took" rather than a per-object or
+per-request latency.
+
 ### Object store cache (`slatedb.object_store_cache.*`)
 
 | Name | Type | Labels | Description |


### PR DESCRIPTION
## Summary

GC deleted SSTs one object at a time. `RetryingObjectStore::delete_stream` and `InstrumentedObjectStore::delete_stream` both unpacked the input with `locations.then(|loc| inner.delete(&loc))`, which silently disabled the S3 backend's bulk `DeleteObjects` batching. This forwards the stream through both wrappers and batches the GC delete path, cutting a 5000-SST GC cycle from ~5000 `DeleteObject` calls to ~5 `DeleteObjects` calls.

Close #1714.

## Changes

- **`RetryingObjectStore::delete_stream`** — forward the whole batch to `inner.delete_stream`; retry at batch level instead of per path. `NotFound` stays on the retry-exclusion list, so re-deleting an already-gone object is idempotent across S3/Azure/GCP and never loops.
- **`InstrumentedObjectStore::delete_stream`** — record one metric per batch instead of per path; metric names/labels unchanged.
- **`TableStore::delete_sst` → `delete_ssts(&[SsTableId])`** — batch interface that filters `NotFound` and returns an aggregate `Result`.
- **`CompactedGcTask` / `WalGcTask`** — issue one batched `delete_ssts` per cycle.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
