### PR TITLE
Retry bounds

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -25,15 +25,6 @@ use log::warn;
 use crate::utils::build_concurrent;
 use slatedb_common::metrics::MetricsRecorderHelper;
 
-/// Specifies how `verify_size` should compare actual vs expected bytes.
-#[derive(Debug, Clone, Copy)]
-enum SizeCheck {
-    /// Actual must be ≤ expected (used while a stream is still producing chunks).
-    AtMost,
-    /// Actual must be exactly equal to expected (used after a stream is fully consumed).
-    Exact,
-}
-
 #[derive(Debug, Clone)]
 pub(crate) struct CachedObjectStore {
     object_store: Arc<dyn ObjectStore>,
@@ -362,13 +353,10 @@ impl CachedObjectStore {
         if self.admission_picker.pick(entry.as_ref()).admitted() {
             // Convert PutPayload to stream and save parts to cache.
             // Note: cached_head() already saved the head, so we only need to save parts
-            let payload_len = payload.content_length() as u64;
             let stream = stream::iter(payload.into_iter()).map(Ok::<Bytes, object_store::Error>);
 
-            // Save parts only; on error, clean up any partially-written parts.
-            self.save_parts_stream_with_cleanup(entry.as_ref(), stream, 0, 0..payload_len)
-                .await
-                .ok();
+            // Save parts only, ignoring errors (cache failures shouldn't fail the PUT operation)
+            self.save_parts_stream(entry, stream, 0).await.ok();
         }
 
         Ok(result)
@@ -433,9 +421,11 @@ impl CachedObjectStore {
     /// aligned with the part size.
     async fn save_get_result(&self, result: GetResult) -> object_store::Result<u64> {
         let part_size_bytes_u64 = self.part_size_bytes as u64;
-        let range = result.range.clone();
-        assert!(range.start.is_multiple_of(part_size_bytes_u64));
-        assert!(range.end.is_multiple_of(part_size_bytes_u64) || range.end == result.meta.size);
+        assert!(result.range.start.is_multiple_of(part_size_bytes_u64));
+        assert!(
+            result.range.end.is_multiple_of(part_size_bytes_u64)
+                || result.range.end == result.meta.size
+        );
 
         let entry = self
             .cache_storage
@@ -445,49 +435,16 @@ impl CachedObjectStore {
         if self.admission_picker.pick(entry.as_ref()).admitted() {
             entry.save_head((&result.meta, &result.attributes)).await?;
 
-            let start_part_number = usize::try_from(range.start / part_size_bytes_u64)
-                .expect("Part number exceeds usize on this system. Try increasing part size.");
+            let start_part_number = usize::try_from(result.range.start / part_size_bytes_u64)
+                .expect("Part number exceeds u32 on a 32-bit system. Try increasing part size.");
 
             let stream = result.into_stream();
 
-            self.save_parts_stream_with_cleanup(
-                entry.as_ref(),
-                stream,
-                start_part_number,
-                range.clone(),
-            )
-            .await?;
+            self.save_parts_stream(entry, stream, start_part_number)
+                .await?;
         }
 
         Ok(object_size)
-    }
-
-    /// Calls `save_parts_stream` and, on error, deletes any partially-written parts
-    /// before returning the error.
-    async fn save_parts_stream_with_cleanup<S>(
-        &self,
-        entry: &dyn LocalCacheEntry,
-        stream: S,
-        start_part_number: usize,
-        range: Range<u64>,
-    ) -> object_store::Result<usize>
-    where
-        S: stream::Stream<Item = Result<Bytes, object_store::Error>> + Unpin,
-    {
-        let result = self
-            .save_parts_stream(entry, stream, start_part_number, range.clone())
-            .await;
-
-        if result.is_err() {
-            let part_size_bytes_u64 = self.part_size_bytes as u64;
-            let end_part_number = usize::try_from(range.end.div_ceil(part_size_bytes_u64))
-                .unwrap_or(start_part_number);
-            for part_number in start_part_number..end_part_number {
-                let _ = entry.delete_part(part_number).await;
-            }
-        }
-
-        result
     }
 
     /// Save a stream of bytes to cache as parts, starting from the specified part number.
@@ -495,10 +452,9 @@ impl CachedObjectStore {
     /// This method only saves the data parts - the head should be saved separately.
     async fn save_parts_stream<S>(
         &self,
-        entry: &dyn LocalCacheEntry,
+        entry: Box<dyn LocalCacheEntry>,
         mut stream: S,
         start_part_number: usize,
-        range: Range<u64>,
     ) -> object_store::Result<usize>
     where
         S: stream::Stream<Item = Result<Bytes, object_store::Error>> + Unpin,
@@ -507,14 +463,9 @@ impl CachedObjectStore {
         let mut part_number = start_part_number;
         let mut total_bytes: usize = 0;
 
-        let range_len = (range.end - range.start) as usize;
-
         while let Some(chunk) = stream.next().await {
             let chunk = chunk?;
             total_bytes += chunk.len();
-
-            Self::verify_size(total_bytes, range_len, SizeCheck::AtMost)?;
-
             buffer.extend_from_slice(&chunk);
 
             while buffer.len() >= self.part_size_bytes {
@@ -523,9 +474,6 @@ impl CachedObjectStore {
                 part_number += 1;
             }
         }
-
-        // No point in saving an invalid file so return early.
-        Self::verify_size(total_bytes, range_len, SizeCheck::Exact)?;
 
         // Save any remaining bytes as the last part
         if !buffer.is_empty() {
@@ -628,18 +576,19 @@ impl CachedObjectStore {
                         None
                     };
 
-                    // Read bytes and validate the range before caching.
-                    let meta = get_result.meta.clone();
-                    let attrs = get_result.attributes.clone();
-                    let bytes = get_result.bytes().await?;
-                    Self::verify_size(bytes.len(), range_in_part.len(), SizeCheck::Exact)?;
-
-                    // Save the head and the part to cache for future accesses.
-                    // Skip if we can't derive a canonical cache key.
-                    if let Some(entry) = cache_entry {
+                    // Save the head and the part to cache for future accesses. Just read the bytes
+                    // if we still can't derive a canonical cache key.
+                    let bytes = if let Some(entry) = cache_entry {
+                        // Save the head and the part to cache for future accesses.
+                        let meta = get_result.meta.clone();
+                        let attrs = get_result.attributes.clone();
+                        let bytes = get_result.bytes().await?;
                         entry.save_head((&meta, &attrs)).await.ok();
                         entry.save_part(part_id, bytes.clone()).await.ok();
-                    }
+                        bytes
+                    } else {
+                        get_result.bytes().await?
+                    };
 
                     Ok::<_, object_store::Error>(bytes)
                 })
@@ -716,29 +665,6 @@ impl CachedObjectStore {
                 GetRange::Offset(offset_aligned)
             }
         }
-    }
-
-    fn verify_size(
-        total_bytes: usize,
-        range_len: usize,
-        check: SizeCheck,
-    ) -> object_store::Result<()> {
-        let failed = match check {
-            SizeCheck::AtMost => total_bytes > range_len,
-            SizeCheck::Exact => total_bytes != range_len,
-        };
-        if failed {
-            let msg = format!(
-                "Size check ({:?}) failed: {} bytes read, but range is {} bytes",
-                check, total_bytes, range_len
-            );
-            warn!("{}", msg);
-            return Err(object_store::Error::Generic {
-                store: "cached_object_store",
-                source: msg.into(),
-            });
-        }
-        Ok(())
     }
 
     fn align_range(&self, range: &Range<u64>, alignment: usize) -> Range<u64> {
@@ -918,11 +844,7 @@ mod tests {
     use std::time::Duration;
 
     use bytes::Bytes;
-    use futures::StreamExt;
-    use object_store::{
-        path::Path, GetOptions, GetRange, GetResult, GetResultPayload, ObjectStore, ObjectStoreExt,
-        PutPayload,
-    };
+    use object_store::{path::Path, GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutPayload};
     use rand::Rng;
 
     use super::CachedObjectStore;
@@ -2210,321 +2132,5 @@ mod tests {
         let parts1 = entry1.cached_parts().await.unwrap();
         assert_eq!(parts1.len(), 0, "{parts1:?}");
         assert_eq!(cache_storage.file_handle_cache_population(), 3);
-    }
-
-    // --- Range bounds validation tests ---
-
-    #[tokio::test]
-    async fn test_save_parts_stream_exceeds_range() {
-        // Create a stream that produces more bytes than the range allows.
-        let part_size = 1024;
-        let object_store = Arc::new(object_store::memory::InMemory::new());
-        let test_cache_folder = new_test_cache_folder();
-        let recorder = MetricsRecorderHelper::noop();
-        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
-        let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder,
-            None,
-            None,
-            stats.clone(),
-            Arc::new(DefaultSystemClock::new()),
-            Arc::new(DbRand::default()),
-            1000,
-        ));
-        let cached_store = CachedObjectStore::new(
-            object_store.clone(),
-            cache_storage.clone(),
-            part_size,
-            false,
-            stats,
-        )
-        .unwrap();
-
-        let location = Path::from("/data/range_exceed_test");
-        let entry = cached_store.cache_storage.entry(&location, part_size);
-
-        // Range says 100 bytes, but stream produces 200 bytes.
-        let range = 0u64..100u64;
-        let stream = futures::stream::iter(vec![
-            Ok(Bytes::from(vec![0u8; 80])),
-            Ok(Bytes::from(vec![0u8; 120])), // total 200 > 100
-        ]);
-
-        let result = cached_store
-            .save_parts_stream(entry.as_ref(), stream, 0, range)
-            .await;
-
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("Size check (AtMost) failed"),
-            "unexpected error: {}",
-            err
-        );
-
-        // Verify nothing was persisted to cache (no bad file written).
-        let cached_parts = entry.cached_parts().await.unwrap();
-        assert_eq!(cached_parts.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_save_parts_stream_under_range() {
-        // Create a stream that produces fewer bytes than the range requires.
-        let part_size = 1024;
-        let object_store = Arc::new(object_store::memory::InMemory::new());
-        let test_cache_folder = new_test_cache_folder();
-        let recorder = MetricsRecorderHelper::noop();
-        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
-        let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder,
-            None,
-            None,
-            stats.clone(),
-            Arc::new(DefaultSystemClock::new()),
-            Arc::new(DbRand::default()),
-            1000,
-        ));
-        let cached_store = CachedObjectStore::new(
-            object_store.clone(),
-            cache_storage.clone(),
-            part_size,
-            false,
-            stats,
-        )
-        .unwrap();
-
-        let location = Path::from("/data/range_under_test");
-        let entry = cached_store.cache_storage.entry(&location, part_size);
-
-        // Range says 200 bytes, but stream produces only 100 bytes.
-        let range = 0u64..200u64;
-        let stream = futures::stream::iter(vec![
-            Ok(Bytes::from(vec![0u8; 50])),
-            Ok(Bytes::from(vec![0u8; 50])), // total 100 < 200
-        ]);
-
-        let result = cached_store
-            .save_parts_stream(entry.as_ref(), stream, 0, range)
-            .await;
-
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("Size check (Exact) failed"),
-            "unexpected error: {}",
-            err
-        );
-
-        // Verify nothing was persisted to cache (no bad file written).
-        let cached_parts = entry.cached_parts().await.unwrap();
-        assert_eq!(cached_parts.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_save_parts_stream_exact_range() {
-        // Stream produces exactly the right number of bytes - should succeed.
-        let part_size = 1024;
-        let object_store = Arc::new(object_store::memory::InMemory::new());
-        let test_cache_folder = new_test_cache_folder();
-        let recorder = MetricsRecorderHelper::noop();
-        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
-        let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder,
-            None,
-            None,
-            stats.clone(),
-            Arc::new(DefaultSystemClock::new()),
-            Arc::new(DbRand::default()),
-            1000,
-        ));
-        let cached_store = CachedObjectStore::new(
-            object_store.clone(),
-            cache_storage.clone(),
-            part_size,
-            false,
-            stats,
-        )
-        .unwrap();
-
-        let location = Path::from("/data/range_exact_test");
-        let entry = cached_store.cache_storage.entry(&location, part_size);
-
-        // Range says 150 bytes, stream produces exactly 150 bytes.
-        let range = 10u64..160u64;
-        let stream = futures::stream::iter(vec![
-            Ok(Bytes::from(vec![1u8; 75])),
-            Ok(Bytes::from(vec![2u8; 75])), // total 150 == 150
-        ]);
-
-        let result = cached_store
-            .save_parts_stream(entry.as_ref(), stream, 0, range)
-            .await;
-
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), 150);
-    }
-
-    /// An ObjectStore wrapper that truncates the bytes returned by `get_opts`
-    /// to simulate a corrupted or short response.
-    #[derive(Debug)]
-    struct TruncatingObjectStore {
-        inner: Arc<dyn ObjectStore>,
-        /// Maximum number of bytes to return from get_opts, regardless of the
-        /// requested range.
-        max_bytes: usize,
-    }
-
-    impl TruncatingObjectStore {
-        fn new(inner: Arc<dyn ObjectStore>, max_bytes: usize) -> Self {
-            Self { inner, max_bytes }
-        }
-    }
-
-    impl std::fmt::Display for TruncatingObjectStore {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "TruncatingObjectStore({})", self.inner)
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl ObjectStore for TruncatingObjectStore {
-        async fn get_opts(
-            &self,
-            location: &Path,
-            options: GetOptions,
-        ) -> object_store::Result<object_store::GetResult> {
-            let result = self.inner.get_opts(location, options).await?;
-            let meta = result.meta.clone();
-            let attrs = result.attributes.clone();
-            let range = result.range.clone();
-            let bytes = result.bytes().await?;
-
-            // Truncate the bytes.
-            let truncated = bytes.slice(..self.max_bytes.min(bytes.len()));
-
-            Ok(GetResult {
-                payload: GetResultPayload::Stream(
-                    futures::stream::once(async move { Ok(truncated) }).boxed(),
-                ),
-                meta,
-                attributes: attrs,
-                range,
-            })
-        }
-
-        async fn put_opts(
-            &self,
-            location: &Path,
-            payload: PutPayload,
-            opts: object_store::PutOptions,
-        ) -> object_store::Result<object_store::PutResult> {
-            self.inner.put_opts(location, payload, opts).await
-        }
-
-        async fn put_multipart_opts(
-            &self,
-            location: &Path,
-            opts: object_store::PutMultipartOptions,
-        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
-            self.inner.put_multipart_opts(location, opts).await
-        }
-
-        fn delete_stream(
-            &self,
-            locations: futures::stream::BoxStream<'static, object_store::Result<Path>>,
-        ) -> futures::stream::BoxStream<'static, object_store::Result<Path>> {
-            self.inner.delete_stream(locations)
-        }
-
-        fn list(
-            &self,
-            prefix: Option<&Path>,
-        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
-        {
-            self.inner.list(prefix)
-        }
-
-        fn list_with_offset(
-            &self,
-            prefix: Option<&Path>,
-            offset: &Path,
-        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
-        {
-            self.inner.list_with_offset(prefix, offset)
-        }
-
-        async fn list_with_delimiter(
-            &self,
-            prefix: Option<&Path>,
-        ) -> object_store::Result<object_store::ListResult> {
-            self.inner.list_with_delimiter(prefix).await
-        }
-
-        async fn copy_opts(
-            &self,
-            from: &Path,
-            to: &Path,
-            options: object_store::CopyOptions,
-        ) -> object_store::Result<()> {
-            self.inner.copy_opts(from, to, options).await
-        }
-    }
-
-    #[tokio::test]
-    async fn test_read_part_bytes_too_short_for_range() {
-        // Simulate an object store returning fewer bytes than requested,
-        // which should trigger the range validation error in read_part.
-        let part_size = 1024;
-        let inner_store = Arc::new(object_store::memory::InMemory::new());
-
-        // Write a file large enough for at least one full part.
-        let location = Path::from("data/truncated_test");
-        let payload = gen_rand_bytes(part_size * 2);
-        inner_store
-            .put(&location, PutPayload::from_bytes(payload.clone()))
-            .await
-            .unwrap();
-
-        // Wrap with a truncating store that only returns 500 bytes max.
-        let truncating_store: Arc<dyn ObjectStore> =
-            Arc::new(TruncatingObjectStore::new(inner_store, 500));
-
-        let test_cache_folder = new_test_cache_folder();
-        let recorder = MetricsRecorderHelper::noop();
-        let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
-        let cache_storage = Arc::new(FsCacheStorage::new(
-            test_cache_folder,
-            None,
-            None,
-            stats.clone(),
-            Arc::new(DefaultSystemClock::new()),
-            Arc::new(DbRand::default()),
-            1000,
-        ));
-        let cached_store = CachedObjectStore::new(
-            truncating_store,
-            cache_storage.clone(),
-            part_size,
-            false,
-            stats,
-        )
-        .unwrap();
-
-        // Request a full part (range 0..1024) but the store only returns 500 bytes.
-        // read_part requests range_in_part = 0..1024, so bytes.len() (500) < range_in_part.len() (1024).
-        let result = cached_store.read_part(&location, 0, 0..part_size).await;
-
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("Size check (Exact) failed"),
-            "unexpected error: {}",
-            err
-        );
-
-        // Verify that the truncated data was NOT written to cache.
-        let entry = cached_store.cache_storage.entry(&location, part_size);
-        let cached_parts = entry.cached_parts().await.unwrap();
-        assert_eq!(cached_parts.len(), 0);
     }
 }

--- a/slatedb/src/cached_object_store/storage.rs
+++ b/slatedb/src/cached_object_store/storage.rs
@@ -80,8 +80,6 @@ pub trait LocalCacheStorage: Send + Sync + std::fmt::Debug + Display + 'static {
 pub trait LocalCacheEntry: Send + Sync + std::fmt::Debug + 'static {
     async fn save_part(&self, part_number: PartID, buf: Bytes) -> object_store::Result<()>;
 
-    async fn delete_part(&self, part_number: PartID) -> object_store::Result<()>;
-
     async fn read_part(
         &self,
         part_number: PartID,

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -332,28 +332,6 @@ impl LocalCacheEntry for FsCacheEntry {
         self.atomic_write(part_path, buf).await
     }
 
-    async fn delete_part(&self, part_number: usize) -> object_store::Result<()> {
-        let part_path = Self::make_part_path(
-            self.root_folder.clone(),
-            &self.location,
-            part_number,
-            self.part_size,
-        );
-
-        let file_cache = self.file_handle_cache.clone();
-        #[allow(clippy::disallowed_methods)]
-        tokio::task::spawn_blocking(move || {
-            let result = match std::fs::remove_file(&part_path) {
-                Ok(()) => Ok(()),
-                Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                Err(err) => Err(wrap_io_err(err)),
-            };
-            file_cache.invalidate(&part_path);
-            result
-        })
-        .await?
-    }
-
     async fn read_part(
         &self,
         part_number: usize,

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -233,8 +233,21 @@ impl ObjectStore for RetryingObjectStore {
             }
             let meta = result.meta.clone();
             let range = result.range.clone();
+            let range_len = (range.end - range.start) as usize;
             let attributes = result.attributes.clone();
             let bytes = result.bytes().await?;
+            let bytes_len = bytes.len();
+
+            if bytes_len != range_len {
+                return Err(object_store::Error::Generic {
+                    store: "cached_object_store",
+                    source: format!(
+                        "Size check failed: {bytes_len} bytes read, but range is {range_len} bytes"
+                    )
+                    .into(),
+                });
+            }
+
             Ok(GetResult {
                 payload: GetResultPayload::Stream(stream::once(async move { Ok(bytes) }).boxed()),
                 meta,

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -233,7 +233,7 @@ impl ObjectStore for RetryingObjectStore {
             }
             let meta = result.meta.clone();
             let range = result.range.clone();
-            let range_len = (range.end - range.start) as usize;
+            let range_len = range.end.saturating_sub(range.start) as usize;
             let attributes = result.attributes.clone();
             let bytes = result.bytes().await?;
             let bytes_len = bytes.len();

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -11,9 +11,9 @@ use futures::{stream, StreamExt, TryStreamExt};
 use log::{debug, info};
 use object_store::path::Path;
 use object_store::{
-    Attribute, CopyOptions, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
-    ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload,
-    PutResult, RenameOptions,
+    Attribute, CopyOptions, GetOptions, GetRange, GetResult, GetResultPayload, ListResult,
+    MultipartUpload, ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions,
+    PutPayload, PutResult, RenameOptions,
 };
 
 use crate::rand::DbRand;
@@ -152,6 +152,20 @@ impl RetryingObjectStore {
         );
         new_attrs
     }
+
+    /// Compute the expected byte length of a range read, truncating at the
+    /// actual file size. This handles the case where a `GetRange::Bounded`
+    /// end exceeds the file length.
+    fn expected_range_len(range: &GetRange, file_size: u64) -> u64 {
+        match range {
+            GetRange::Bounded(r) => {
+                let end = r.end.min(file_size);
+                end.saturating_sub(r.start)
+            }
+            GetRange::Offset(offset) => file_size.saturating_sub(*offset),
+            GetRange::Suffix(suffix) => (*suffix).min(file_size),
+        }
+    }
 }
 
 impl std::fmt::Display for RetryingObjectStore {
@@ -224,25 +238,35 @@ impl ObjectStore for RetryingObjectStore {
         // `get_range` lives on `ObjectStoreExt` and reads the body after
         // `get_opts` returns, so without this buffering the body bytes
         // would fall outside the retry loop.
-        let buffer_body = options.range.is_some();
         (|| async {
             // Options and location must be owned per-attempt.
-            let result = self.inner.get_opts(location, options.clone()).await?;
-            if !buffer_body {
+            let options = options.clone();
+            let options_range = options.range.clone();
+            let result = self.inner.get_opts(location, options).await?;
+            let meta = result.meta.clone();
+            let file_size = meta.size;
+
+            if options_range.is_none() {
+                // No range requested — don't buffer the body. The buffer size
+                // can't be validated wihtout buffering.
                 return Ok(result);
             }
-            let meta = result.meta.clone();
+
+            // Range read: buffer the body and validate against the expected
+            // size (requested range truncated at file size).
+            let expected_len = Self::expected_range_len(&options_range.unwrap(), file_size);
             let range = result.range.clone();
-            let range_len = range.end.saturating_sub(range.start) as usize;
             let attributes = result.attributes.clone();
             let bytes = result.bytes().await?;
-            let bytes_len = bytes.len();
+            let bytes_len = bytes.len() as u64;
 
-            if bytes_len != range_len {
+            if bytes_len != expected_len {
                 return Err(object_store::Error::Generic {
-                    store: "cached_object_store",
+                    store: "retrying_object_store",
                     source: format!(
-                        "Size check failed: {bytes_len} bytes read, but range is {range_len} bytes"
+                        "Size check failed: {bytes_len} bytes read, but expected \
+                         {expected_len} bytes (requested range truncated at file \
+                         size {file_size})"
                     )
                     .into(),
                 });

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -957,4 +957,67 @@ mod tests {
             .get(&Attribute::Metadata(Cow::Borrowed(super::PUT_ID_ATTRIBUTE)))
             .is_some());
     }
+
+    #[tokio::test]
+    async fn test_get_opts_range_read_size_check_passes() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let retrying = RetryingObjectStore::new(inner.clone(), test_rand(), test_clock());
+        let path = Path::from("/data/obj");
+
+        inner
+            .put(
+                &path,
+                PutPayload::from_bytes(Bytes::from_static(b"hello world")),
+            )
+            .await
+            .unwrap();
+
+        let result = retrying
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some((0..5).into()),
+                    ..GetOptions::default()
+                },
+            )
+            .await
+            .expect("range read should pass size check");
+
+        let bytes = result.bytes().await.unwrap();
+        assert_eq!(bytes, Bytes::from_static(b"hello"));
+    }
+
+    #[tokio::test]
+    async fn test_get_opts_range_read_size_mismatch_returns_error() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/data/obj");
+        inner
+            .put(
+                &path,
+                PutPayload::from_bytes(Bytes::from_static(b"hello world")),
+            )
+            .await
+            .unwrap();
+
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_truncate_get_range_bytes(1, 1));
+        let retrying = RetryingObjectStore::new(flaky.clone(), test_rand(), test_clock());
+
+        // First attempt returns truncated body (1 byte vs 5 expected),
+        // triggering the size check error. The retry succeeds normally.
+        let result = retrying
+            .get_opts(
+                &path,
+                GetOptions {
+                    range: Some((0..5).into()),
+                    ..GetOptions::default()
+                },
+            )
+            .await
+            .expect("should succeed after retrying past truncated response");
+
+        let bytes = result.bytes().await.unwrap();
+        assert_eq!(bytes, Bytes::from_static(b"hello"));
+        // 1 truncated attempt + 1 successful retry
+        assert_eq!(flaky.get_range_attempts(), 2);
+    }
 }

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -254,7 +254,8 @@ impl ObjectStore for RetryingObjectStore {
 
             // Range read: buffer the body and validate against the expected
             // size (requested range truncated at file size).
-            let expected_len = Self::expected_range_len(&options_range.unwrap(), file_size);
+            let expected_len =
+                Self::expected_range_len(&options_range.expect("range is set"), file_size);
             let range = result.range.clone();
             let attributes = result.attributes.clone();
             let bytes = result.bytes().await?;

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -454,6 +454,9 @@ pub(crate) struct FlakyObjectStore {
     // get_range: transient failures on first N attempts
     fail_first_get_range: AtomicUsize,
     get_range_attempts: AtomicUsize,
+    // get_range: truncate response body to this many bytes on first N attempts (0 = no truncation)
+    truncate_get_range_bytes: AtomicUsize,
+    truncate_get_range_count: AtomicUsize,
 }
 
 impl FlakyObjectStore {
@@ -477,6 +480,8 @@ impl FlakyObjectStore {
             list_with_offset_attempts: AtomicUsize::new(0),
             fail_first_get_range: AtomicUsize::new(0),
             get_range_attempts: AtomicUsize::new(0),
+            truncate_get_range_bytes: AtomicUsize::new(0),
+            truncate_get_range_count: AtomicUsize::new(0),
         }
     }
 
@@ -557,6 +562,12 @@ impl FlakyObjectStore {
         self
     }
 
+    pub(crate) fn with_truncate_get_range_bytes(self, bytes: usize, count: usize) -> Self {
+        self.truncate_get_range_bytes.store(bytes, Ordering::SeqCst);
+        self.truncate_get_range_count.store(count, Ordering::SeqCst);
+        self
+    }
+
     pub(crate) fn get_range_attempts(&self) -> usize {
         self.get_range_attempts.load(Ordering::SeqCst)
     }
@@ -622,7 +633,7 @@ impl ObjectStore for FlakyObjectStore {
             }
         } else if options.range.is_some() {
             self.get_range_attempts.fetch_add(1, Ordering::SeqCst);
-            if self
+            let should_fail = self
                 .fail_first_get_range
                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
                     if v > 0 {
@@ -631,14 +642,42 @@ impl ObjectStore for FlakyObjectStore {
                         None
                     }
                 })
-                .is_ok()
-            {
+                .is_ok();
+            if should_fail {
                 return Err(object_store::Error::Generic {
                     store: "flaky_get_range",
                     source: Box::new(std::io::Error::new(
                         std::io::ErrorKind::TimedOut,
                         "injected get_range timeout",
                     )),
+                });
+            }
+            let truncate_bytes = self.truncate_get_range_bytes.load(Ordering::SeqCst);
+            let should_truncate = truncate_bytes > 0
+                && self
+                    .truncate_get_range_count
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                        if v > 0 {
+                            Some(v - 1)
+                        } else {
+                            None
+                        }
+                    })
+                    .is_ok();
+            if should_truncate {
+                let result = self.inner.get_opts(location, options).await?;
+                let meta = result.meta.clone();
+                let range = result.range.clone();
+                let attributes = result.attributes.clone();
+                let body = result.bytes().await?;
+                let truncated = body.slice(..truncate_bytes.min(body.len()));
+                return Ok(object_store::GetResult {
+                    payload: object_store::GetResultPayload::Stream(
+                        futures::stream::once(async { Ok(truncated) }).boxed(),
+                    ),
+                    meta,
+                    range,
+                    attributes,
                 });
             }
         }


### PR DESCRIPTION
## Summary

[This](https://github.com/slatedb/slatedb/pull/1729) PR Implemented range bounds checking the CachedObjectStore which was not the correct place to add the validation. Adding it as a part of RetryingObjectStore is much cleaner.  

## Changes

- Remove bounds checking from CachedObjectStore and add it to RetryingObjectStore. It reverts PR 1729.

## Notes for Reviewers



## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
