### PR TITLE
feat: add L0 flush stall metric

### DIFF
--- a/slatedb/src/db_stats.rs
+++ b/slatedb/src/db_stats.rs
@@ -18,6 +18,7 @@ pub const REQUEST_COUNT: &str = db_stat_name!("request_count");
 pub const WRITE_OPS: &str = db_stat_name!("write_ops");
 pub const WRITE_BATCH_COUNT: &str = db_stat_name!("write_batch_count");
 pub const BACKPRESSURE_COUNT: &str = db_stat_name!("backpressure_count");
+pub const L0_STALL_COUNT: &str = db_stat_name!("l0_stall_count");
 pub const IMMUTABLE_MEMTABLE_FLUSHES: &str = db_stat_name!("immutable_memtable_flushes");
 pub const WAL_BUFFER_FLUSHES: &str = db_stat_name!("wal_buffer_flushes");
 pub const WAL_BUFFER_FLUSH_REQUESTS: &str = db_stat_name!("wal_buffer_flush_requests");
@@ -56,6 +57,7 @@ pub(crate) struct DbStatsInner {
     pub(crate) sst_filter_prefix_positives: Arc<dyn CounterFn>,
     pub(crate) sst_filter_prefix_negatives: Arc<dyn CounterFn>,
     pub(crate) backpressure_count: Arc<dyn CounterFn>,
+    pub(crate) l0_stall_count: Arc<dyn CounterFn>,
     pub(crate) get_requests: Arc<dyn CounterFn>,
     pub(crate) scan_requests: Arc<dyn CounterFn>,
     pub(crate) flush_requests: Arc<dyn CounterFn>,
@@ -117,6 +119,7 @@ impl DbStats {
                 .labels(&[(FILTER_KIND_LABEL, FILTER_KIND_PREFIX)])
                 .register(),
             backpressure_count: recorder.counter(BACKPRESSURE_COUNT).register(),
+            l0_stall_count: recorder.counter(L0_STALL_COUNT).register(),
             get_requests: recorder
                 .counter(REQUEST_COUNT)
                 .labels(&[("op", "get")])

--- a/slatedb/src/db_stats.rs
+++ b/slatedb/src/db_stats.rs
@@ -19,6 +19,9 @@ pub const WRITE_OPS: &str = db_stat_name!("write_ops");
 pub const WRITE_BATCH_COUNT: &str = db_stat_name!("write_batch_count");
 pub const BACKPRESSURE_COUNT: &str = db_stat_name!("backpressure_count");
 pub const L0_STALL_COUNT: &str = db_stat_name!("l0_stall_count");
+pub const L0_STALL_TYPE_LABEL: &str = "type";
+pub const L0_STALL_TYPE_NUM_SSTS: &str = "num_ssts";
+pub const L0_STALL_TYPE_NUM_SSTS_PER_KEY: &str = "num_ssts_per_key";
 pub const IMMUTABLE_MEMTABLE_FLUSHES: &str = db_stat_name!("immutable_memtable_flushes");
 pub const WAL_BUFFER_FLUSHES: &str = db_stat_name!("wal_buffer_flushes");
 pub const WAL_BUFFER_FLUSH_REQUESTS: &str = db_stat_name!("wal_buffer_flush_requests");
@@ -57,7 +60,8 @@ pub(crate) struct DbStatsInner {
     pub(crate) sst_filter_prefix_positives: Arc<dyn CounterFn>,
     pub(crate) sst_filter_prefix_negatives: Arc<dyn CounterFn>,
     pub(crate) backpressure_count: Arc<dyn CounterFn>,
-    pub(crate) l0_stall_count: Arc<dyn CounterFn>,
+    pub(crate) l0_stall_count_num_ssts: Arc<dyn CounterFn>,
+    pub(crate) l0_stall_count_num_ssts_per_key: Arc<dyn CounterFn>,
     pub(crate) get_requests: Arc<dyn CounterFn>,
     pub(crate) scan_requests: Arc<dyn CounterFn>,
     pub(crate) flush_requests: Arc<dyn CounterFn>,
@@ -119,7 +123,14 @@ impl DbStats {
                 .labels(&[(FILTER_KIND_LABEL, FILTER_KIND_PREFIX)])
                 .register(),
             backpressure_count: recorder.counter(BACKPRESSURE_COUNT).register(),
-            l0_stall_count: recorder.counter(L0_STALL_COUNT).register(),
+            l0_stall_count_num_ssts: recorder
+                .counter(L0_STALL_COUNT)
+                .labels(&[(L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS)])
+                .register(),
+            l0_stall_count_num_ssts_per_key: recorder
+                .counter(L0_STALL_COUNT)
+                .labels(&[(L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS_PER_KEY)])
+                .register(),
             get_requests: recorder
                 .counter(REQUEST_COUNT)
                 .labels(&[("op", "get")])

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -286,10 +286,17 @@ impl FlushTracker {
                 });
             let reserved = self.frontier.reserved_l0_slots();
             if max_l0_len + reserved >= settings.l0_max_ssts {
-                self.inner.db_stats.l0_stall_count.increment(1);
+                self.inner.db_stats.l0_stall_count_num_ssts.increment(1);
                 return false;
             }
-            return max_peak + reserved < settings.l0_max_ssts_per_key;
+            if max_peak + reserved >= settings.l0_max_ssts_per_key {
+                self.inner
+                    .db_stats
+                    .l0_stall_count_num_ssts_per_key
+                    .increment(1);
+                return false;
+            }
+            return true;
         }
         // Per-segment check: every touched segment must have room
         // accounting for in-flight reservations against that segment.
@@ -306,10 +313,14 @@ impl FlushTracker {
                 };
             let reserved = self.frontier.reserved_l0_slots_for(prefix);
             if tree_l0_len + reserved >= settings.l0_max_ssts {
-                self.inner.db_stats.l0_stall_count.increment(1);
+                self.inner.db_stats.l0_stall_count_num_ssts.increment(1);
                 return false;
             }
             if tree_peak + reserved >= settings.l0_max_ssts_per_key {
+                self.inner
+                    .db_stats
+                    .l0_stall_count_num_ssts_per_key
+                    .increment(1);
                 return false;
             }
         }
@@ -513,7 +524,9 @@ mod tests {
     use crate::db_state::{
         FilterFormat, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType,
     };
-    use crate::db_stats::L0_STALL_COUNT;
+    use crate::db_stats::{
+        L0_STALL_COUNT, L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS, L0_STALL_TYPE_NUM_SSTS_PER_KEY,
+    };
     use crate::db_status::{ClosedResultWriter, DbStatusManager};
     use crate::error::SlateDBError;
     use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
@@ -534,7 +547,8 @@ mod tests {
     use object_store::ObjectStore;
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
     use slatedb_common::metrics::{
-        lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorder, MetricsRecorderHelper,
+        lookup_metric_with_labels, DefaultMetricsRecorder, MetricLevel, MetricsRecorder,
+        MetricsRecorderHelper,
     };
     use std::sync::Arc;
     use std::time::Duration;
@@ -1176,7 +1190,23 @@ mod tests {
         assert!(timeout(Duration::from_millis(100), &mut flush)
             .await
             .is_err());
-        assert!(lookup_metric(&metrics_recorder, L0_STALL_COUNT).unwrap_or(0) > 0);
+        assert!(
+            lookup_metric_with_labels(
+                &metrics_recorder,
+                L0_STALL_COUNT,
+                &[(L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS)],
+            )
+            .unwrap_or(0)
+                > 0
+        );
+        assert_eq!(
+            lookup_metric_with_labels(
+                &metrics_recorder,
+                L0_STALL_COUNT,
+                &[(L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS_PER_KEY)],
+            ),
+            Some(0)
+        );
 
         {
             let mut guard = flusher.inner.state.write();
@@ -1427,7 +1457,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn l0_stall_count_does_not_increment_for_per_key_cap() {
+    async fn l0_stall_count_increments_for_per_key_cap() {
         let settings = Settings {
             l0_max_ssts: 100,
             l0_max_ssts_per_key: 1,
@@ -1459,7 +1489,23 @@ mod tests {
         assert!(timeout(Duration::from_millis(100), &mut flush)
             .await
             .is_err());
-        assert_eq!(lookup_metric(&metrics_recorder, L0_STALL_COUNT), Some(0));
+        assert_eq!(
+            lookup_metric_with_labels(
+                &metrics_recorder,
+                L0_STALL_COUNT,
+                &[(L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS)],
+            ),
+            Some(0)
+        );
+        assert!(
+            lookup_metric_with_labels(
+                &metrics_recorder,
+                L0_STALL_COUNT,
+                &[(L0_STALL_TYPE_LABEL, L0_STALL_TYPE_NUM_SSTS_PER_KEY)],
+            )
+            .unwrap_or(0)
+                > 0
+        );
 
         {
             let mut guard = flusher.inner.state.write();

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -285,8 +285,11 @@ impl FlushTracker {
                     )
                 });
             let reserved = self.frontier.reserved_l0_slots();
-            return max_l0_len + reserved < settings.l0_max_ssts
-                && max_peak + reserved < settings.l0_max_ssts_per_key;
+            if max_l0_len + reserved >= settings.l0_max_ssts {
+                self.inner.db_stats.l0_stall_count.increment(1);
+                return false;
+            }
+            return max_peak + reserved < settings.l0_max_ssts_per_key;
         }
         // Per-segment check: every touched segment must have room
         // accounting for in-flight reservations against that segment.
@@ -303,6 +306,7 @@ impl FlushTracker {
                 };
             let reserved = self.frontier.reserved_l0_slots_for(prefix);
             if tree_l0_len + reserved >= settings.l0_max_ssts {
+                self.inner.db_stats.l0_stall_count.increment(1);
                 return false;
             }
             if tree_peak + reserved >= settings.l0_max_ssts_per_key {
@@ -509,6 +513,7 @@ mod tests {
     use crate::db_state::{
         FilterFormat, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType,
     };
+    use crate::db_stats::L0_STALL_COUNT;
     use crate::db_status::{ClosedResultWriter, DbStatusManager};
     use crate::error::SlateDBError;
     use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
@@ -528,7 +533,9 @@ mod tests {
     use object_store::path::Path;
     use object_store::ObjectStore;
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
-    use slatedb_common::metrics::MetricsRecorderHelper;
+    use slatedb_common::metrics::{
+        lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorder, MetricsRecorderHelper,
+    };
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::runtime::Handle;
@@ -546,11 +553,20 @@ mod tests {
         settings: Settings,
         fp_registry: Arc<FailPointRegistry>,
     ) -> TestHarness {
+        setup_harness_with_recorder(path, settings, fp_registry, MetricsRecorderHelper::noop())
+            .await
+    }
+
+    async fn setup_harness_with_recorder(
+        path: &str,
+        settings: Settings,
+        fp_registry: Arc<FailPointRegistry>,
+        db_metrics: MetricsRecorderHelper,
+    ) -> TestHarness {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = path.to_string();
         let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
         let rand = Arc::new(DbRand::new(42));
-        let db_metrics = MetricsRecorderHelper::noop();
         let manifest_store = Arc::new(ManifestStore::new(
             &Path::from(path.clone()),
             Arc::clone(&object_store),
@@ -1130,6 +1146,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn l0_stall_count_increments_when_l0_is_full() {
+        let settings = Settings {
+            l0_max_ssts: 1,
+            manifest_poll_interval: Duration::from_millis(10),
+            ..Settings::default()
+        };
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(
+            metrics_recorder.clone() as Arc<dyn MetricsRecorder>,
+            MetricLevel::default(),
+        );
+        let harness = setup_harness_with_recorder(
+            "/tmp/test_parallel_l0_flush_flusher_l0_stall_count",
+            settings,
+            Arc::new(FailPointRegistry::new()),
+            helper,
+        )
+        .await;
+        set_local_l0_len(&harness, 1);
+        set_remote_l0_len(&harness.path, Arc::clone(&harness.object_store), 1).await;
+        let path = harness.path.clone();
+        let object_store = Arc::clone(&harness.object_store);
+        let flusher = start_flusher(harness);
+        freeze_value_imm(&flusher.inner, b"k1", b"v1", 41);
+
+        let flush = flusher.flush(FlushTarget::All);
+        tokio::pin!(flush);
+        assert!(timeout(Duration::from_millis(100), &mut flush)
+            .await
+            .is_err());
+        assert!(lookup_metric(&metrics_recorder, L0_STALL_COUNT).unwrap_or(0) > 0);
+
+        {
+            let mut guard = flusher.inner.state.write();
+            guard.modify(|modifier| {
+                Arc::make_mut(&mut modifier.state.manifest.value.core.tree)
+                    .l0
+                    .clear()
+            });
+        }
+        set_remote_l0_len(&path, object_store, 0).await;
+
+        let result = timeout(Duration::from_secs(5), &mut flush)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.durable_seq, 1);
+
+        flusher.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn flush_proceeds_when_l0_total_high_but_disjoint_ranges() {
         // Mirrors a post-rescaling (union) manifest: L0 total exceeds the
         // single-source `l0_max_ssts`, but each L0 covers a disjoint key
@@ -1339,6 +1407,60 @@ mod tests {
             .is_err());
 
         // Drain L0 locally and remotely; flush should now progress.
+        {
+            let mut guard = flusher.inner.state.write();
+            guard.modify(|modifier| {
+                Arc::make_mut(&mut modifier.state.manifest.value.core.tree)
+                    .l0
+                    .clear()
+            });
+        }
+        set_remote_l0_disjoint(&path, object_store, &[]).await;
+
+        let result = timeout(Duration::from_secs(5), &mut flush)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.durable_seq, 1);
+
+        flusher.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn l0_stall_count_does_not_increment_for_per_key_cap() {
+        let settings = Settings {
+            l0_max_ssts: 100,
+            l0_max_ssts_per_key: 1,
+            manifest_poll_interval: Duration::from_millis(10),
+            ..Settings::default()
+        };
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(
+            metrics_recorder.clone() as Arc<dyn MetricsRecorder>,
+            MetricLevel::default(),
+        );
+        let harness = setup_harness_with_recorder(
+            "/tmp/test_parallel_l0_flush_flusher_l0_stall_count_per_key",
+            settings,
+            Arc::new(FailPointRegistry::new()),
+            helper,
+        )
+        .await;
+        let ranges: &[(&[u8], &[u8])] = &[(b"aaa", b"zzz")];
+        set_local_l0_disjoint(&harness, ranges);
+        set_remote_l0_disjoint(&harness.path, Arc::clone(&harness.object_store), ranges).await;
+        let path = harness.path.clone();
+        let object_store = Arc::clone(&harness.object_store);
+        let flusher = start_flusher(harness);
+        freeze_value_imm(&flusher.inner, b"k1", b"v1", 42);
+
+        let flush = flusher.flush(FlushTarget::All);
+        tokio::pin!(flush);
+        assert!(timeout(Duration::from_millis(100), &mut flush)
+            .await
+            .is_err());
+        assert_eq!(lookup_metric(&metrics_recorder, L0_STALL_COUNT), Some(0));
+
         {
             let mut guard = flusher.inner.state.write();
             guard.modify(|modifier| {

--- a/website/src/content/docs/docs/operations/metrics.mdx
+++ b/website/src/content/docs/docs/operations/metrics.mdx
@@ -81,6 +81,7 @@ All metric names use dot-separated notation: `slatedb.<subsystem>.<metric>`.
 | `slatedb.db.write_ops` | counter | | Write operations |
 | `slatedb.db.write_batch_count` | counter | | Write batches |
 | `slatedb.db.backpressure_count` | counter | | Backpressure events |
+| `slatedb.db.l0_stall_count` | counter | `type`: num_ssts, num_ssts_per_key | L0 flush dispatch stalls by cause |
 | `slatedb.db.immutable_memtable_flushes` | counter | | Immutable memtable flushes |
 | `slatedb.db.wal_buffer_flushes` | counter | | WAL buffer flushes |
 | `slatedb.db.wal_buffer_flush_requests` | counter | | WAL buffer flush requests |


### PR DESCRIPTION
## Summary

Adds a `slatedb.db.l0_stall_count` metric that increments when the memtable flusher cannot dispatch a pending immutable memtable because L0 is at `l0_max_ssts`. Fixes #1499. 

## Changes

- Registers `slatedb.db.l0_stall_count` in `DbStats`
- Increments it when `FlushTracker::can_dispatch` rejects dispatch due to `l0_max_ssts`
- Extends the flush tracker test harness to optionally use a real metrics recorder instead of always using noop metrics
- Adds regression tests for L0-full stalls and verifies per-key-cap stalls do not increment `l0_stall_count`

## Notes for Reviewers

Hi @agavra! Saw this issue lying around. I like the ideas behind slatedb, would love to chime in. 

I also wrote [this test program](https://github.com/viveknathani/slatedb-play/blob/a4875e0eeda9034be31a0c431a16cd54455e9575/src/main.rs) that uses the code over here to show the stall count being tracked.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
