### PR TITLE
Improve `WriteBatch` performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,6 +3275,7 @@ dependencies = [
  "siphasher",
  "slatedb-common",
  "slatedb-txn-obj",
+ "smallvec",
  "snap",
  "sysinfo",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ rand_xoshiro = "0.7.0"
 serde = "1.0"
 serde_json = "1.0.142"
 siphasher = "1"
+smallvec = "1.15.1"
 slatedb = { path = "slatedb", version = "0.13.0" }
 slatedb-common = { path = "slatedb-common", version = "0.13.0" }
 slatedb-txn-obj = { path = "slatedb-txn-obj", version = "0.13.0" }

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -155,5 +155,10 @@ name = "block_iterator_v2"
 harness = false
 required-features = ["bench-internal"]
 
+[[bench]]
+name = "write_batch"
+harness = false
+required-features = ["bench-internal"]
+
 [lints]
 workspace = true

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -160,5 +160,9 @@ name = "write_batch"
 harness = false
 required-features = ["bench-internal"]
 
+[[bench]]
+name = "db_transaction"
+harness = false
+
 [lints]
 workspace = true

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -44,6 +44,7 @@ rand_xoshiro = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 siphasher = { workspace = true }
+smallvec = { workspace = true }
 slatedb-common = { workspace = true, features = ["serde"] }
 slatedb-txn-obj = { workspace = true }
 snap = { workspace = true, optional = true }

--- a/slatedb/benches/db_transaction.rs
+++ b/slatedb/benches/db_transaction.rs
@@ -1,0 +1,490 @@
+// our microbenchmarks use pprof, but it doesn't work on windows
+#![cfg(not(windows))]
+
+// Run with: cargo bench -p slatedb --features bench-internal --bench db_transaction
+
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+#[allow(clippy::disallowed_types)]
+use std::time::Instant;
+
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use object_store::memory::InMemory;
+use pprof::criterion::{Output, PProfProfiler};
+use slatedb::config::{
+    MergeOptions, PutOptions, ReadOptions, ScanOptions, Settings, Ttl, WriteOptions,
+};
+use slatedb::{Db, DbTransaction, IsolationLevel, MergeOperator, MergeOperatorError};
+use tokio::runtime::Runtime;
+
+const VALUE_SIZE: usize = 128;
+const DB_ENTRY_COUNT: usize = 1_024;
+const TXN_ENTRY_COUNT: usize = 1_024;
+const TXN_MERGE_KEY_COUNT: usize = 256;
+const MERGES_PER_KEY: usize = 3;
+
+struct ConcatMergeOperator;
+
+impl MergeOperator for ConcatMergeOperator {
+    fn merge(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operand: Bytes,
+    ) -> Result<Bytes, MergeOperatorError> {
+        let Some(base) = existing_value else {
+            return Ok(operand);
+        };
+        let mut merged = Vec::with_capacity(base.len() + operand.len());
+        merged.extend_from_slice(&base);
+        merged.extend_from_slice(&operand);
+        Ok(Bytes::from(merged))
+    }
+}
+
+fn concat_merge_operator() -> Arc<dyn MergeOperator + Send + Sync> {
+    static MERGE_OPERATOR: OnceLock<Arc<dyn MergeOperator + Send + Sync>> = OnceLock::new();
+    MERGE_OPERATOR
+        .get_or_init(|| Arc::new(ConcatMergeOperator))
+        .clone()
+}
+
+fn put_options() -> PutOptions {
+    PutOptions {
+        ttl: Ttl::ExpireAfter(3_600),
+    }
+}
+
+fn merge_options() -> MergeOptions {
+    MergeOptions {
+        ttl: Ttl::ExpireAfter(3_600),
+    }
+}
+
+fn write_options() -> WriteOptions {
+    WriteOptions {
+        await_durable: false,
+        ..WriteOptions::default()
+    }
+}
+
+fn key(index: usize) -> Bytes {
+    Bytes::from(format!("txn-key-{index:08}"))
+}
+
+fn value(index: usize) -> Bytes {
+    let mut value = vec![0; VALUE_SIZE];
+    value[..std::mem::size_of::<usize>()].copy_from_slice(&index.to_le_bytes());
+    Bytes::from(value)
+}
+
+fn bench_settings() -> Settings {
+    Settings {
+        flush_interval: None,
+        compactor_options: None,
+        ..Settings::default()
+    }
+}
+
+async fn build_empty_db() -> Db {
+    Db::builder("/bench/db_transaction", Arc::new(InMemory::new()))
+        .with_settings(bench_settings())
+        .with_merge_operator(concat_merge_operator())
+        .build()
+        .await
+        .expect("failed to build db")
+}
+
+async fn build_db() -> Db {
+    let db = build_empty_db().await;
+
+    let put_options = put_options();
+    let write_options = write_options();
+    for index in 0..DB_ENTRY_COUNT {
+        db.put_with_options(key(index), value(index), &put_options, &write_options)
+            .await
+            .expect("populate put failed");
+    }
+
+    db
+}
+
+fn begin_txn(runtime: &Runtime, db: &Db) -> DbTransaction {
+    runtime
+        .block_on(db.begin(IsolationLevel::Snapshot))
+        .expect("begin transaction failed")
+}
+
+fn txn_without_merges(runtime: &Runtime, db: &Db) -> DbTransaction {
+    let txn = begin_txn(runtime, db);
+    let options = put_options();
+    for index in 0..TXN_ENTRY_COUNT {
+        let key = key(index);
+        if index % 4 == 0 {
+            txn.delete(key).expect("delete failed");
+        } else {
+            txn.put_with_options(key, value(index), &options)
+                .expect("put_with_options failed");
+        }
+    }
+    txn
+}
+
+fn txn_with_merges(runtime: &Runtime, db: &Db) -> DbTransaction {
+    let txn = begin_txn(runtime, db);
+    let put_options = put_options();
+    let merge_options = merge_options();
+    for index in 0..TXN_MERGE_KEY_COUNT {
+        let key = key(index);
+        txn.put_with_options(key.clone(), value(index), &put_options)
+            .expect("put_with_options failed");
+        for merge_index in 0..MERGES_PER_KEY {
+            txn.merge_with_options(
+                &key,
+                value(index * MERGES_PER_KEY + merge_index),
+                &merge_options,
+            )
+            .expect("merge_with_options failed");
+        }
+    }
+    txn
+}
+
+fn txn_with_repeated_overwrites(runtime: &Runtime, db: &Db) -> DbTransaction {
+    let txn = begin_txn(runtime, db);
+    let options = put_options();
+    let key = Bytes::from_static(b"txn-repeated-overwrite-key");
+    for index in 0..TXN_ENTRY_COUNT {
+        txn.put_with_options(&key, value(index), &options)
+            .expect("put_with_options failed");
+    }
+    txn
+}
+
+fn bench_db_transaction(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to create runtime");
+    let db = runtime.block_on(build_db());
+    let put_options = put_options();
+    let merge_options = merge_options();
+    let read_options = ReadOptions::default();
+    let scan_options = ScanOptions::default();
+    let write_options = write_options();
+    let read_txn = begin_txn(&runtime, &db);
+    let get_key = key(0);
+    let scan_start = key(100);
+    let scan_end = key(900);
+    let scan_prefix = Bytes::from_static(b"txn-key-00000");
+
+    let mut group = c.benchmark_group("db_transaction");
+    group.sample_size(100);
+
+    group.bench_function("get_key_value_with_options", |b| {
+        b.to_async(&runtime).iter(|| async {
+            let result = read_txn
+                .get_key_value_with_options(get_key.clone(), &read_options)
+                .await
+                .expect("get_key_value_with_options failed");
+            assert!(result.is_some());
+            black_box(result);
+        });
+    });
+
+    group.bench_function("scan_with_options", |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut iter = read_txn
+                .scan_with_options(scan_start.clone()..scan_end.clone(), &scan_options)
+                .await
+                .expect("scan_with_options failed");
+            let mut count = 0usize;
+            while let Some(kv) = iter.next().await.expect("iterator next failed") {
+                count += 1;
+                black_box(kv);
+            }
+            assert!(count > 0);
+            black_box(count);
+        });
+    });
+
+    group.bench_function("scan_prefix_with_options", |b| {
+        b.to_async(&runtime).iter(|| async {
+            let mut iter = read_txn
+                .scan_prefix_with_options(scan_prefix.clone(), &scan_options)
+                .await
+                .expect("scan_prefix_with_options failed");
+            let mut count = 0usize;
+            while let Some(kv) = iter.next().await.expect("iterator next failed") {
+                count += 1;
+                black_box(kv);
+            }
+            assert!(count > 0);
+            black_box(count);
+        });
+    });
+
+    group.bench_function("put_with_options/empty_transaction", |b| {
+        b.iter_batched(
+            || {
+                (
+                    begin_txn(&runtime, &db),
+                    Bytes::from_static(b"txn_bench_key"),
+                    Bytes::from_static(b"txn_bench_value"),
+                )
+            },
+            |(txn, key, value)| {
+                txn.put_with_options(key, value, &put_options)
+                    .expect("put_with_options failed");
+                black_box(txn)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("put_with_options/new_key_populated", |b| {
+        b.iter_batched(
+            || {
+                (
+                    txn_without_merges(&runtime, &db),
+                    key(TXN_ENTRY_COUNT + 1),
+                    value(TXN_ENTRY_COUNT + 1),
+                )
+            },
+            |(txn, key, value)| {
+                txn.put_with_options(key, value, &put_options)
+                    .expect("put_with_options failed");
+                black_box(txn)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("put_with_options/overwrite_existing_key", |b| {
+        b.iter_batched(
+            || {
+                (
+                    txn_with_merges(&runtime, &db),
+                    key(0),
+                    value(TXN_MERGE_KEY_COUNT + 1),
+                )
+            },
+            |(txn, key, value)| {
+                txn.put_with_options(key, value, &put_options)
+                    .expect("put_with_options failed");
+                black_box(txn)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("mark_read", |b| {
+        b.iter_batched(
+            || {
+                (
+                    begin_txn(&runtime, &db),
+                    Bytes::from_static(b"txn_bench_key"),
+                )
+            },
+            |(txn, key)| {
+                txn.mark_read([key]).expect("mark_read failed");
+                black_box(txn)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("unmark_write", |b| {
+        b.iter_batched(
+            || {
+                (
+                    begin_txn(&runtime, &db),
+                    Bytes::from_static(b"txn_bench_key"),
+                )
+            },
+            |(txn, key)| {
+                txn.unmark_write([key]).expect("unmark_write failed");
+                black_box(txn)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("merge_with_options/empty_transaction", |b| {
+        b.iter_batched(
+            || {
+                (
+                    begin_txn(&runtime, &db),
+                    Bytes::from_static(b"txn_bench_key"),
+                    Bytes::from_static(b"txn_bench_value"),
+                )
+            },
+            |(txn, key, value)| {
+                txn.merge_with_options(key, value, &merge_options)
+                    .expect("merge_with_options failed");
+                black_box(txn)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("merge_with_options/new_key_populated", |b| {
+        b.iter_batched(
+            || {
+                (
+                    txn_without_merges(&runtime, &db),
+                    key(TXN_ENTRY_COUNT + 1),
+                    value(TXN_ENTRY_COUNT + 1),
+                )
+            },
+            |(txn, key, value)| {
+                txn.merge_with_options(key, value, &merge_options)
+                    .expect("merge_with_options failed");
+                black_box(txn)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("merge_with_options/existing_key_with_merges", |b| {
+        b.iter_batched(
+            || {
+                (
+                    txn_with_merges(&runtime, &db),
+                    key(0),
+                    value(TXN_MERGE_KEY_COUNT + 1),
+                )
+            },
+            |(txn, key, value)| {
+                txn.merge_with_options(key, value, &merge_options)
+                    .expect("merge_with_options failed");
+                black_box(txn)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("delete/empty_transaction", |b| {
+        b.iter_batched(
+            || {
+                (
+                    begin_txn(&runtime, &db),
+                    Bytes::from_static(b"txn_bench_key"),
+                )
+            },
+            |(txn, key)| {
+                txn.delete(key).expect("delete failed");
+                black_box(txn)
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("delete/new_key_populated", |b| {
+        b.iter_batched(
+            || (txn_without_merges(&runtime, &db), key(TXN_ENTRY_COUNT + 1)),
+            |(txn, key)| {
+                txn.delete(key).expect("delete failed");
+                black_box(txn)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("delete/existing_key", |b| {
+        b.iter_batched(
+            || (txn_with_merges(&runtime, &db), key(0)),
+            |(txn, key)| {
+                txn.delete(key).expect("delete failed");
+                black_box(txn)
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("commit_with_options/empty_transaction", |b| {
+        b.to_async(&runtime).iter_custom(|iters| {
+            let write_options = write_options.clone();
+            async move {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iters {
+                    let db = build_empty_db().await;
+                    let txn = db
+                        .begin(IsolationLevel::Snapshot)
+                        .await
+                        .expect("begin transaction failed");
+                    #[allow(clippy::disallowed_types)]
+                    let start = Instant::now();
+                    let result = txn.commit_with_options(&write_options).await;
+                    elapsed += start.elapsed();
+                    black_box(result.expect("commit failed"));
+                    db.close().await.expect("close failed");
+                }
+                elapsed
+            }
+        });
+    });
+
+    group.bench_function("commit_with_options/one_put", |b| {
+        b.to_async(&runtime).iter_custom(|iters| {
+            let put_options = put_options.clone();
+            let write_options = write_options.clone();
+            async move {
+                let mut elapsed = Duration::ZERO;
+                for _ in 0..iters {
+                    let db = build_empty_db().await;
+                    let txn = db
+                        .begin(IsolationLevel::Snapshot)
+                        .await
+                        .expect("begin transaction failed");
+                    txn.put_with_options(key(0), value(0), &put_options)
+                        .expect("put_with_options failed");
+                    #[allow(clippy::disallowed_types)]
+                    let start = Instant::now();
+                    let result = txn.commit_with_options(&write_options).await;
+                    elapsed += start.elapsed();
+                    black_box(result.expect("commit failed"));
+                    db.close().await.expect("close failed");
+                }
+                elapsed
+            }
+        });
+    });
+
+    group.bench_function("drop/no_merges", |b| {
+        b.iter_batched(
+            || txn_without_merges(&runtime, &db),
+            |txn| drop(black_box(txn)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("drop/with_merges", |b| {
+        b.iter_batched(
+            || txn_with_merges(&runtime, &db),
+            |txn| drop(black_box(txn)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("drop/repeated_overwrites", |b| {
+        b.iter_batched(
+            || txn_with_repeated_overwrites(&runtime, &db),
+            |txn| drop(black_box(txn)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.finish();
+
+    drop(read_txn);
+    runtime.block_on(db.close()).expect("close failed");
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    targets = bench_db_transaction
+}
+
+criterion_main!(benches);

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -1,0 +1,297 @@
+// our microbenchmarks use pprof, but it doesn't work on windows
+#![cfg(not(windows))]
+
+// Run with: cargo bench -p slatedb --features bench-internal --bench write_batch
+
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use pprof::criterion::{Output, PProfProfiler};
+use slatedb::config::{MergeOptions, PutOptions, Ttl};
+use slatedb::{write_batch_benches, MergeOperator, MergeOperatorError, WriteBatch};
+use std::sync::{Arc, OnceLock};
+use tokio::runtime::Runtime;
+
+const VALUE_SIZE: usize = 128;
+const EXTRACT_ENTRY_COUNT: usize = 1_024;
+const EXTRACT_MERGE_KEY_COUNT: usize = 256;
+const MERGES_PER_KEY: usize = 3;
+
+struct ConcatMergeOperator;
+
+impl MergeOperator for ConcatMergeOperator {
+    fn merge(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operand: Bytes,
+    ) -> Result<Bytes, MergeOperatorError> {
+        let Some(base) = existing_value else {
+            return Ok(operand);
+        };
+        let mut merged = Vec::with_capacity(base.len() + operand.len());
+        merged.extend_from_slice(&base);
+        merged.extend_from_slice(&operand);
+        Ok(Bytes::from(merged))
+    }
+}
+
+fn concat_merge_operator() -> Arc<dyn MergeOperator + Send + Sync> {
+    static MERGE_OPERATOR: OnceLock<Arc<dyn MergeOperator + Send + Sync>> = OnceLock::new();
+    MERGE_OPERATOR
+        .get_or_init(|| Arc::new(ConcatMergeOperator))
+        .clone()
+}
+
+fn put_options() -> PutOptions {
+    PutOptions {
+        ttl: Ttl::ExpireAfter(3_600),
+    }
+}
+
+fn merge_options() -> MergeOptions {
+    MergeOptions {
+        ttl: Ttl::ExpireAfter(3_600),
+    }
+}
+
+fn key(index: usize) -> Bytes {
+    Bytes::from(format!("key-{index:08}"))
+}
+
+fn value(index: usize) -> Bytes {
+    let mut value = vec![0; VALUE_SIZE];
+    value[..std::mem::size_of::<usize>()].copy_from_slice(&index.to_le_bytes());
+    Bytes::from(value)
+}
+
+fn make_batch_without_merges() -> WriteBatch {
+    let mut batch = WriteBatch::new();
+    let options = put_options();
+    for index in 0..EXTRACT_ENTRY_COUNT {
+        let key = key(index);
+        if index % 4 == 0 {
+            batch.delete(key);
+        } else {
+            batch.put_bytes_with_options(key, value(index), &options);
+        }
+    }
+    batch
+}
+
+fn make_batch_with_merges() -> WriteBatch {
+    let mut batch = WriteBatch::new();
+    let put_options = put_options();
+    let merge_options = merge_options();
+    for index in 0..EXTRACT_MERGE_KEY_COUNT {
+        let key = key(index);
+        batch.put_bytes_with_options(key.clone(), value(index), &put_options);
+        for merge_index in 0..MERGES_PER_KEY {
+            batch.merge_with_options(
+                &key,
+                value(index * MERGES_PER_KEY + merge_index),
+                &merge_options,
+            );
+        }
+    }
+    batch
+}
+
+fn bench_write_batch(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to create runtime");
+    let put_options = put_options();
+    let merge_options = merge_options();
+    let batch_without_merges = make_batch_without_merges();
+    let batch_with_merges = make_batch_with_merges();
+
+    let mut group = c.benchmark_group("write_batch");
+    group.sample_size(1_000);
+
+    group.bench_function("put_bytes_with_options/empty_batch", |b| {
+        b.iter_batched(
+            || {
+                (
+                    WriteBatch::new(),
+                    Bytes::from_static(b"write_batch_key"),
+                    Bytes::from_static(b"write_batch_value"),
+                )
+            },
+            |(mut batch, key, value)| {
+                batch.put_bytes_with_options(key, value, &put_options);
+                black_box(batch);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("put_bytes_with_options/new_key_populated", |b| {
+        b.iter_batched(
+            || {
+                (
+                    batch_without_merges.clone(),
+                    key(EXTRACT_ENTRY_COUNT + 1),
+                    value(EXTRACT_ENTRY_COUNT + 1),
+                )
+            },
+            |(mut batch, key, value)| {
+                batch.put_bytes_with_options(key, value, &put_options);
+                black_box(batch);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("put_bytes_with_options/overwrite_existing_key", |b| {
+        b.iter_batched(
+            || {
+                (
+                    batch_with_merges.clone(),
+                    key(0),
+                    value(EXTRACT_MERGE_KEY_COUNT + 1),
+                )
+            },
+            |(mut batch, key, value)| {
+                batch.put_bytes_with_options(key, value, &put_options);
+                black_box(batch);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("merge_with_options/empty_batch", |b| {
+        b.iter_batched(
+            || {
+                (
+                    WriteBatch::new(),
+                    Bytes::from_static(b"write_batch_key"),
+                    Bytes::from_static(b"write_batch_value"),
+                )
+            },
+            |(mut batch, key, value)| {
+                batch.merge_with_options(key, value, &merge_options);
+                black_box(batch);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("merge_with_options/new_key_populated", |b| {
+        b.iter_batched(
+            || {
+                (
+                    batch_without_merges.clone(),
+                    key(EXTRACT_ENTRY_COUNT + 1),
+                    value(EXTRACT_ENTRY_COUNT + 1),
+                )
+            },
+            |(mut batch, key, value)| {
+                batch.merge_with_options(key, value, &merge_options);
+                black_box(batch);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("merge_with_options/existing_key_with_merges", |b| {
+        b.iter_batched(
+            || {
+                (
+                    batch_with_merges.clone(),
+                    key(0),
+                    value(EXTRACT_MERGE_KEY_COUNT + 1),
+                )
+            },
+            |(mut batch, key, value)| {
+                batch.merge_with_options(key, value, &merge_options);
+                black_box(batch);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("delete/empty_batch", |b| {
+        b.iter_batched(
+            || (WriteBatch::new(), Bytes::from_static(b"write_batch_key")),
+            |(mut batch, key)| {
+                batch.delete(key);
+                black_box(batch);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("delete/new_key_populated", |b| {
+        b.iter_batched(
+            || (batch_without_merges.clone(), key(EXTRACT_ENTRY_COUNT + 1)),
+            |(mut batch, key)| {
+                batch.delete(key);
+                black_box(batch);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("delete/existing_key", |b| {
+        b.iter_batched(
+            || (batch_with_merges.clone(), key(0)),
+            |(mut batch, key)| {
+                batch.delete(key);
+                black_box(batch);
+            },
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("keys", |b| {
+        b.iter_batched(
+            || batch_without_merges.clone(),
+            |batch| black_box(write_batch_benches::keys(&batch)),
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("extract_entries/no_merges", |b| {
+        b.to_async(&runtime).iter_batched(
+            || batch_without_merges.clone(),
+            |batch| async move {
+                black_box(
+                    write_batch_benches::extract_entries(&batch, 100, 1_000, None, None, None)
+                        .await
+                        .expect("extract_entries failed"),
+                );
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("extract_entries/with_merges", |b| {
+        b.to_async(&runtime).iter_batched(
+            || batch_with_merges.clone(),
+            |batch| async move {
+                black_box(
+                    write_batch_benches::extract_entries(
+                        &batch,
+                        100,
+                        1_000,
+                        None,
+                        Some(concat_merge_operator()),
+                        None,
+                    )
+                    .await
+                    .expect("extract_entries failed"),
+                );
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    targets = bench_write_batch
+}
+
+criterion_main!(benches);

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -16,29 +16,35 @@ const EXTRACT_ENTRY_COUNT: usize = 1_024;
 const EXTRACT_MERGE_KEY_COUNT: usize = 256;
 const MERGES_PER_KEY: usize = 3;
 
-struct ConcatMergeOperator;
+struct SizeSumMergeOperator;
 
-impl MergeOperator for ConcatMergeOperator {
+impl MergeOperator for SizeSumMergeOperator {
     fn merge(
         &self,
         _key: &Bytes,
         existing_value: Option<Bytes>,
         operand: Bytes,
     ) -> Result<Bytes, MergeOperatorError> {
-        let Some(base) = existing_value else {
-            return Ok(operand);
-        };
-        let mut merged = Vec::with_capacity(base.len() + operand.len());
-        merged.extend_from_slice(&base);
-        merged.extend_from_slice(&operand);
-        Ok(Bytes::from(merged))
+        let size = existing_value.as_ref().map_or(0, Bytes::len) + operand.len();
+        Ok(Bytes::copy_from_slice(&(size as u64).to_le_bytes()))
+    }
+
+    fn merge_batch(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operands: &[Bytes],
+    ) -> Result<Bytes, MergeOperatorError> {
+        let size = existing_value.as_ref().map_or(0, Bytes::len)
+            + operands.iter().map(Bytes::len).sum::<usize>();
+        Ok(Bytes::copy_from_slice(&(size as u64).to_le_bytes()))
     }
 }
 
-fn concat_merge_operator() -> Arc<dyn MergeOperator + Send + Sync> {
+fn size_sum_merge_operator() -> Arc<dyn MergeOperator + Send + Sync> {
     static MERGE_OPERATOR: OnceLock<Arc<dyn MergeOperator + Send + Sync>> = OnceLock::new();
     MERGE_OPERATOR
-        .get_or_init(|| Arc::new(ConcatMergeOperator))
+        .get_or_init(|| Arc::new(SizeSumMergeOperator))
         .clone()
 }
 
@@ -284,7 +290,7 @@ fn bench_write_batch(c: &mut Criterion) {
                         100,
                         1_000,
                         None,
-                        Some(concat_merge_operator()),
+                        Some(size_sum_merge_operator()),
                         None,
                     )
                     .await

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -4,7 +4,7 @@
 // Run with: cargo bench -p slatedb --features bench-internal --bench write_batch
 
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 use slatedb::config::{MergeOptions, PutOptions, Ttl};
 use slatedb::{write_batch_benches, MergeOperator, MergeOperatorError, WriteBatch};
@@ -13,8 +13,14 @@ use tokio::runtime::Runtime;
 
 const VALUE_SIZE: usize = 128;
 const EXTRACT_ENTRY_COUNT: usize = 1_024;
-const EXTRACT_MERGE_KEY_COUNT: usize = 256;
-const MERGES_PER_KEY: usize = 3;
+const MERGE_BATCH_SCENARIOS: &[(usize, usize)] = &[
+    // Each scenario is (key_count, merges_per_key).
+    (256, 3),
+    (256, 100),
+    (16, 1_000),
+    (1, 1_000),
+    (1, 10_000),
+];
 
 struct SizeSumMergeOperator;
 
@@ -84,17 +90,21 @@ fn make_batch_without_merges() -> WriteBatch {
     batch
 }
 
-fn make_batch_with_merges() -> WriteBatch {
+fn merge_batch_scenario_id(key_count: usize, merges_per_key: usize) -> String {
+    format!("{key_count}_keys/{merges_per_key}_merges_per_key")
+}
+
+fn make_batch_with_merges(key_count: usize, merges_per_key: usize) -> WriteBatch {
     let mut batch = WriteBatch::new();
     let put_options = put_options();
     let merge_options = merge_options();
-    for index in 0..EXTRACT_MERGE_KEY_COUNT {
+    for index in 0..key_count {
         let key = key(index);
         batch.put_bytes_with_options(key.clone(), value(index), &put_options);
-        for merge_index in 0..MERGES_PER_KEY {
+        for merge_index in 0..merges_per_key {
             batch.merge_with_options(
                 &key,
-                value(index * MERGES_PER_KEY + merge_index),
+                value(index * merges_per_key + merge_index),
                 &merge_options,
             );
         }
@@ -117,7 +127,17 @@ fn bench_write_batch(c: &mut Criterion) {
     let put_options = put_options();
     let merge_options = merge_options();
     let batch_without_merges = make_batch_without_merges();
-    let batch_with_merges = make_batch_with_merges();
+    let batches_with_merges: Vec<_> = MERGE_BATCH_SCENARIOS
+        .iter()
+        .copied()
+        .map(|(key_count, merges_per_key)| {
+            (
+                key_count,
+                merges_per_key,
+                make_batch_with_merges(key_count, merges_per_key),
+            )
+        })
+        .collect();
     let batch_with_repeated_overwrites = make_batch_with_repeated_overwrites();
 
     let mut group = c.benchmark_group("write_batch");
@@ -157,22 +177,35 @@ fn bench_write_batch(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("put_bytes_with_options/overwrite_existing_key", |b| {
-        b.iter_batched(
-            || {
-                (
-                    batch_with_merges.clone(),
-                    key(0),
-                    value(EXTRACT_MERGE_KEY_COUNT + 1),
-                )
+    for (key_count, merges_per_key, batch_with_merges) in &batches_with_merges {
+        let key_count = *key_count;
+        let merges_per_key = *merges_per_key;
+        let scenario_id = merge_batch_scenario_id(key_count, merges_per_key);
+
+        group.bench_with_input(
+            BenchmarkId::new(
+                "put_bytes_with_options/overwrite_existing_key",
+                scenario_id.clone(),
+            ),
+            batch_with_merges,
+            |b, batch_with_merges| {
+                b.iter_batched(
+                    || {
+                        (
+                            batch_with_merges.clone(),
+                            key(0),
+                            value(key_count * merges_per_key + 1),
+                        )
+                    },
+                    |(mut batch, key, value)| {
+                        batch.put_bytes_with_options(key, value, &put_options);
+                        black_box(batch)
+                    },
+                    BatchSize::LargeInput,
+                );
             },
-            |(mut batch, key, value)| {
-                batch.put_bytes_with_options(key, value, &put_options);
-                black_box(batch)
-            },
-            BatchSize::LargeInput,
         );
-    });
+    }
 
     group.bench_function("merge_with_options/empty_batch", |b| {
         b.iter_batched(
@@ -208,22 +241,35 @@ fn bench_write_batch(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("merge_with_options/existing_key_with_merges", |b| {
-        b.iter_batched(
-            || {
-                (
-                    batch_with_merges.clone(),
-                    key(0),
-                    value(EXTRACT_MERGE_KEY_COUNT + 1),
-                )
+    for (key_count, merges_per_key, batch_with_merges) in &batches_with_merges {
+        let key_count = *key_count;
+        let merges_per_key = *merges_per_key;
+        let scenario_id = merge_batch_scenario_id(key_count, merges_per_key);
+
+        group.bench_with_input(
+            BenchmarkId::new(
+                "merge_with_options/existing_key_with_merges",
+                scenario_id.clone(),
+            ),
+            batch_with_merges,
+            |b, batch_with_merges| {
+                b.iter_batched(
+                    || {
+                        (
+                            batch_with_merges.clone(),
+                            key(0),
+                            value(key_count * merges_per_key + 1),
+                        )
+                    },
+                    |(mut batch, key, value)| {
+                        batch.merge_with_options(key, value, &merge_options);
+                        black_box(batch)
+                    },
+                    BatchSize::LargeInput,
+                );
             },
-            |(mut batch, key, value)| {
-                batch.merge_with_options(key, value, &merge_options);
-                black_box(batch)
-            },
-            BatchSize::LargeInput,
         );
-    });
+    }
 
     group.bench_function("delete/empty_batch", |b| {
         b.iter_batched(
@@ -247,16 +293,26 @@ fn bench_write_batch(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("delete/existing_key", |b| {
-        b.iter_batched(
-            || (batch_with_merges.clone(), key(0)),
-            |(mut batch, key)| {
-                batch.delete(key);
-                black_box(batch)
+    for (key_count, merges_per_key, batch_with_merges) in &batches_with_merges {
+        let key_count = *key_count;
+        let merges_per_key = *merges_per_key;
+        let scenario_id = merge_batch_scenario_id(key_count, merges_per_key);
+
+        group.bench_with_input(
+            BenchmarkId::new("delete/existing_key", scenario_id),
+            batch_with_merges,
+            |b, batch_with_merges| {
+                b.iter_batched(
+                    || (batch_with_merges.clone(), key(0)),
+                    |(mut batch, key)| {
+                        batch.delete(key);
+                        black_box(batch)
+                    },
+                    BatchSize::LargeInput,
+                );
             },
-            BatchSize::LargeInput,
         );
-    });
+    }
 
     group.bench_function("keys", |b| {
         b.iter_batched(
@@ -280,26 +336,36 @@ fn bench_write_batch(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("extract_entries/with_merges", |b| {
-        b.to_async(&runtime).iter_batched(
-            || batch_with_merges.clone(),
-            |batch| async move {
-                black_box(
-                    write_batch_benches::extract_entries(
-                        &batch,
-                        100,
-                        1_000,
-                        None,
-                        Some(size_sum_merge_operator()),
-                        None,
-                    )
-                    .await
-                    .expect("extract_entries failed"),
-                )
+    for (key_count, merges_per_key, batch_with_merges) in &batches_with_merges {
+        let key_count = *key_count;
+        let merges_per_key = *merges_per_key;
+        let scenario_id = merge_batch_scenario_id(key_count, merges_per_key);
+
+        group.bench_with_input(
+            BenchmarkId::new("extract_entries/with_merges", scenario_id.clone()),
+            batch_with_merges,
+            |b, batch_with_merges| {
+                b.to_async(&runtime).iter_batched(
+                    || batch_with_merges.clone(),
+                    |batch| async move {
+                        black_box(
+                            write_batch_benches::extract_entries(
+                                &batch,
+                                100,
+                                1_000,
+                                None,
+                                Some(size_sum_merge_operator()),
+                                None,
+                            )
+                            .await
+                            .expect("extract_entries failed"),
+                        )
+                    },
+                    BatchSize::LargeInput,
+                );
             },
-            BatchSize::SmallInput,
         );
-    });
+    }
 
     group.bench_function("drop/no_merges", |b| {
         b.iter_batched(
@@ -309,13 +375,23 @@ fn bench_write_batch(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("drop/with_merges", |b| {
-        b.iter_batched(
-            || batch_with_merges.clone(),
-            |batch| drop(black_box(batch)),
-            BatchSize::LargeInput,
+    for (key_count, merges_per_key, batch_with_merges) in &batches_with_merges {
+        let key_count = *key_count;
+        let merges_per_key = *merges_per_key;
+        let scenario_id = merge_batch_scenario_id(key_count, merges_per_key);
+
+        group.bench_with_input(
+            BenchmarkId::new("drop/with_merges", scenario_id.clone()),
+            batch_with_merges,
+            |b, batch_with_merges| {
+                b.iter_batched(
+                    || batch_with_merges.clone(),
+                    |batch| drop(black_box(batch)),
+                    BatchSize::LargeInput,
+                );
+            },
         );
-    });
+    }
 
     group.bench_function("drop/repeated_overwrites", |b| {
         b.iter_batched(

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -96,12 +96,23 @@ fn make_batch_with_merges() -> WriteBatch {
     batch
 }
 
+fn make_batch_with_repeated_overwrites() -> WriteBatch {
+    let mut batch = WriteBatch::new();
+    let options = put_options();
+    let key = Bytes::from_static(b"repeated-overwrite-key");
+    for index in 0..EXTRACT_ENTRY_COUNT {
+        batch.put_bytes_with_options(key.clone(), value(index), &options);
+    }
+    batch
+}
+
 fn bench_write_batch(c: &mut Criterion) {
     let runtime = Runtime::new().expect("failed to create runtime");
     let put_options = put_options();
     let merge_options = merge_options();
     let batch_without_merges = make_batch_without_merges();
     let batch_with_merges = make_batch_with_merges();
+    let batch_with_repeated_overwrites = make_batch_with_repeated_overwrites();
 
     let mut group = c.benchmark_group("write_batch");
     group.sample_size(1_000);
@@ -117,7 +128,7 @@ fn bench_write_batch(c: &mut Criterion) {
             },
             |(mut batch, key, value)| {
                 batch.put_bytes_with_options(key, value, &put_options);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::SmallInput,
         );
@@ -134,7 +145,7 @@ fn bench_write_batch(c: &mut Criterion) {
             },
             |(mut batch, key, value)| {
                 batch.put_bytes_with_options(key, value, &put_options);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::LargeInput,
         );
@@ -151,7 +162,7 @@ fn bench_write_batch(c: &mut Criterion) {
             },
             |(mut batch, key, value)| {
                 batch.put_bytes_with_options(key, value, &put_options);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::LargeInput,
         );
@@ -168,7 +179,7 @@ fn bench_write_batch(c: &mut Criterion) {
             },
             |(mut batch, key, value)| {
                 batch.merge_with_options(key, value, &merge_options);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::SmallInput,
         );
@@ -185,7 +196,7 @@ fn bench_write_batch(c: &mut Criterion) {
             },
             |(mut batch, key, value)| {
                 batch.merge_with_options(key, value, &merge_options);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::LargeInput,
         );
@@ -202,7 +213,7 @@ fn bench_write_batch(c: &mut Criterion) {
             },
             |(mut batch, key, value)| {
                 batch.merge_with_options(key, value, &merge_options);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::LargeInput,
         );
@@ -213,7 +224,7 @@ fn bench_write_batch(c: &mut Criterion) {
             || (WriteBatch::new(), Bytes::from_static(b"write_batch_key")),
             |(mut batch, key)| {
                 batch.delete(key);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::SmallInput,
         );
@@ -224,7 +235,7 @@ fn bench_write_batch(c: &mut Criterion) {
             || (batch_without_merges.clone(), key(EXTRACT_ENTRY_COUNT + 1)),
             |(mut batch, key)| {
                 batch.delete(key);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::LargeInput,
         );
@@ -235,7 +246,7 @@ fn bench_write_batch(c: &mut Criterion) {
             || (batch_with_merges.clone(), key(0)),
             |(mut batch, key)| {
                 batch.delete(key);
-                black_box(batch);
+                black_box(batch)
             },
             BatchSize::LargeInput,
         );
@@ -257,7 +268,7 @@ fn bench_write_batch(c: &mut Criterion) {
                     write_batch_benches::extract_entries(&batch, 100, 1_000, None, None, None)
                         .await
                         .expect("extract_entries failed"),
-                );
+                )
             },
             BatchSize::SmallInput,
         );
@@ -278,9 +289,33 @@ fn bench_write_batch(c: &mut Criterion) {
                     )
                     .await
                     .expect("extract_entries failed"),
-                );
+                )
             },
             BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("drop/no_merges", |b| {
+        b.iter_batched(
+            || batch_without_merges.clone(),
+            |batch| drop(black_box(batch)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("drop/with_merges", |b| {
+        b.iter_batched(
+            || batch_with_merges.clone(),
+            |batch| drop(black_box(batch)),
+            BatchSize::LargeInput,
+        );
+    });
+
+    group.bench_function("drop/repeated_overwrites", |b| {
+        b.iter_batched(
+            || batch_with_repeated_overwrites.clone(),
+            |batch| drop(black_box(batch)),
+            BatchSize::LargeInput,
         );
     });
 

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -322,10 +322,6 @@ impl WriteBatch {
         extractor: Option<&dyn PrefixExtractor>,
     ) -> Result<(Vec<RowEntry>, BTreeSet<Bytes>, u64), SlateDBError> {
         let mut entries_bytes: u64 = 0;
-        if merger.is_none() && self.has_merge_ops() {
-            return Err(SlateDBError::MergeOperatorMissing);
-        }
-
         let mut it: Box<dyn RowEntryIterator> = Box::new(WriteBatchIterator::new(
             self,
             ..,
@@ -334,13 +330,17 @@ impl WriteBatch {
             Some(now),
             default_ttl,
         ));
-        if let Some(ref merge_operator) = merger {
-            it = Box::new(MergeOperatorIterator::new(
-                merge_operator.clone(),
-                it,
-                false,
-                None,
-            ));
+        if self.has_merge_ops() {
+            if let Some(ref merge_operator) = merger {
+                it = Box::new(MergeOperatorIterator::new(
+                    merge_operator.clone(),
+                    it,
+                    false,
+                    None,
+                ));
+            } else {
+                return Err(SlateDBError::MergeOperatorMissing);
+            }
         }
 
         let mut entries: Vec<RowEntry> = Vec::new();

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -51,6 +51,7 @@ use uuid::Uuid;
 #[derive(Clone, Debug)]
 pub struct WriteBatch {
     pub(crate) ops: BTreeMap<Bytes, SmallVec<[WriteOp; 1]>>,
+    pub(crate) op_count: usize,
     pub(crate) txn_id: Option<Uuid>,
     pub(crate) has_merge_ops: bool,
 }
@@ -141,6 +142,7 @@ impl WriteBatch {
     pub fn new() -> Self {
         WriteBatch {
             ops: BTreeMap::new(),
+            op_count: 0,
             txn_id: None,
             has_merge_ops: false,
         }
@@ -149,6 +151,7 @@ impl WriteBatch {
     pub(crate) fn with_txn_id(self, txn_id: Uuid) -> Self {
         Self {
             ops: self.ops,
+            op_count: self.op_count,
             txn_id: Some(txn_id),
             has_merge_ops: self.has_merge_ops,
         }
@@ -232,11 +235,14 @@ impl WriteBatch {
 
         // put will overwrite the existing key so we can safely
         // remove all previous entries.
-        self.ops.remove(&key);
-        self.ops.insert(
+        let previous = self.ops.insert(
             key.clone(),
             smallvec![WriteOp::Put(key, value, options.clone())],
         );
+        self.op_count += 1;
+        if let Some(previous) = previous {
+            self.op_count -= previous.len();
+        }
     }
 
     /// Merge a key-value pair into the batch. Keys must not be empty.
@@ -267,6 +273,7 @@ impl WriteBatch {
             ));
 
         self.has_merge_ops = true;
+        self.op_count += 1;
     }
 
     /// Delete a key-value pair into the batch. Keys must not be empty.
@@ -277,9 +284,13 @@ impl WriteBatch {
 
         // delete will overwrite the existing key so we can safely
         // remove all previous entries.
-        self.ops.remove(&key);
-        self.ops
+        let previous = self
+            .ops
             .insert(key.clone(), smallvec![WriteOp::Delete(key)]);
+        self.op_count += 1;
+        if let Some(previous) = previous {
+            self.op_count -= previous.len();
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -291,7 +302,7 @@ impl WriteBatch {
     }
 
     pub(crate) fn op_count(&self) -> usize {
-        self.ops.values().map(|ops| ops.len()).sum()
+        self.op_count
     }
 
     pub(crate) fn keys(&self) -> HashSet<Bytes> {
@@ -593,6 +604,7 @@ mod tests {
         batch.put(b"key1", b"value2"); // Should overwrite previous
 
         assert_eq!(batch.ops.len(), 1); // Only one entry due to deduplication
+        assert_eq!(batch.op_count(), 1);
         let op = only_op(&batch, b"key1");
         match op {
             WriteOp::Put(_, value, _) => assert_eq!(value.as_ref(), b"value2"),
@@ -962,6 +974,14 @@ mod tests {
         batch.put(b"key1", b"final");
 
         assert!(batch.has_merge_ops());
+        assert_eq!(batch.op_count(), 1);
+        match only_op(&batch, b"key1") {
+            WriteOp::Put(key, value, _) => {
+                assert_eq!(key.as_ref(), b"key1");
+                assert_eq!(value.as_ref(), b"final");
+            }
+            _ => panic!("Expected Put operation"),
+        }
     }
 
     #[test]
@@ -1071,6 +1091,7 @@ mod tests {
 
         // Then: only the put operation should remain (merge is deduplicated by put)
         assert_eq!(batch.ops.len(), 1);
+        assert_eq!(batch.op_count(), 1);
 
         let op = only_op(&batch, b"key1");
         match op {
@@ -1093,6 +1114,7 @@ mod tests {
 
         // Then: only the delete operation should remain (merge is deduplicated by delete)
         assert_eq!(batch.ops.len(), 1);
+        assert_eq!(batch.op_count(), 1);
 
         let op = only_op(&batch, b"key1");
         match op {

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -407,6 +407,33 @@ impl WriteBatch {
     }
 }
 
+#[cfg(feature = "bench-internal")]
+pub mod benches {
+    use super::WriteBatch;
+    use crate::{Error, MergeOperator, PrefixExtractor, RowEntry};
+    use bytes::Bytes;
+    use std::collections::{BTreeSet, HashSet};
+    use std::sync::Arc;
+
+    pub fn keys(batch: &WriteBatch) -> HashSet<Bytes> {
+        batch.keys()
+    }
+
+    pub async fn extract_entries(
+        batch: &WriteBatch,
+        seq: u64,
+        now: i64,
+        default_ttl: Option<u64>,
+        merger: Option<Arc<dyn MergeOperator + Send + Sync>>,
+        extractor: Option<&dyn PrefixExtractor>,
+    ) -> Result<(Vec<RowEntry>, BTreeSet<Bytes>, u64), Error> {
+        batch
+            .extract_entries(seq, now, default_ttl, merger, extractor)
+            .await
+            .map_err(Into::into)
+    }
+}
+
 /// Iterator over `WriteBatch` entries.
 pub(crate) struct WriteBatchIterator {
     iter: Peekable<Box<dyn Iterator<Item = (SequencedKey, RowEntry)> + Send + Sync>>,

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -52,7 +52,7 @@ use uuid::Uuid;
 pub struct WriteBatch {
     pub(crate) ops: BTreeMap<Bytes, SmallVec<[WriteOp; 1]>>,
     pub(crate) txn_id: Option<Uuid>,
-    pub(crate) merge_op_count: usize,
+    pub(crate) has_merge_ops: bool,
 }
 
 impl Default for WriteBatch {
@@ -142,17 +142,7 @@ impl WriteBatch {
         WriteBatch {
             ops: BTreeMap::new(),
             txn_id: None,
-            merge_op_count: 0,
-        }
-    }
-
-    /// Remove all existing ops for the given user key from the batch.
-    fn remove_ops_by_key(&mut self, key: &Bytes) {
-        if let Some(ops) = self.ops.remove(key) {
-            self.merge_op_count -= ops
-                .iter()
-                .filter(|op| matches!(op, WriteOp::Merge(..)))
-                .count();
+            has_merge_ops: false,
         }
     }
 
@@ -160,7 +150,7 @@ impl WriteBatch {
         Self {
             ops: self.ops,
             txn_id: Some(txn_id),
-            merge_op_count: self.merge_op_count,
+            has_merge_ops: self.has_merge_ops,
         }
     }
 
@@ -242,7 +232,7 @@ impl WriteBatch {
 
         // put will overwrite the existing key so we can safely
         // remove all previous entries.
-        self.remove_ops_by_key(&key);
+        self.ops.remove(&key);
         self.ops.insert(
             key.clone(),
             smallvec![WriteOp::Put(key, value, options.clone())],
@@ -276,7 +266,7 @@ impl WriteBatch {
                 options.clone(),
             ));
 
-        self.merge_op_count += 1;
+        self.has_merge_ops = true;
     }
 
     /// Delete a key-value pair into the batch. Keys must not be empty.
@@ -287,7 +277,7 @@ impl WriteBatch {
 
         // delete will overwrite the existing key so we can safely
         // remove all previous entries.
-        self.remove_ops_by_key(&key);
+        self.ops.remove(&key);
         self.ops
             .insert(key.clone(), smallvec![WriteOp::Delete(key)]);
     }
@@ -297,7 +287,7 @@ impl WriteBatch {
     }
 
     pub(crate) fn has_merge_ops(&self) -> bool {
-        self.merge_op_count > 0
+        self.has_merge_ops
     }
 
     pub(crate) fn op_count(&self) -> usize {
@@ -960,11 +950,10 @@ mod tests {
         batch.merge(b"key1", b"value1");
 
         assert!(batch.has_merge_ops());
-        assert_eq!(batch.merge_op_count, 1);
     }
 
     #[test]
-    fn should_clear_merge_presence_when_put_overwrites_merge_ops() {
+    fn should_remember_merge_presence_when_put_overwrites_merge_ops() {
         let mut batch = WriteBatch::new();
         batch.merge(b"key1", b"value1");
         batch.merge(b"key1", b"value2");
@@ -972,22 +961,34 @@ mod tests {
 
         batch.put(b"key1", b"final");
 
-        assert!(!batch.has_merge_ops());
-        assert_eq!(batch.merge_op_count, 0);
+        assert!(batch.has_merge_ops());
     }
 
     #[test]
-    fn should_preserve_merge_presence_when_removing_only_one_keys_merges() {
+    fn should_remember_merge_presence_when_delete_overwrites_merge_ops() {
         let mut batch = WriteBatch::new();
         batch.merge(b"key1", b"value1");
         batch.merge(b"key2", b"value2");
         assert!(batch.has_merge_ops());
-        assert_eq!(batch.merge_op_count, 2);
 
         batch.delete(b"key1");
 
         assert!(batch.has_merge_ops());
-        assert_eq!(batch.merge_op_count, 1);
+        assert_eq!(batch.ops.len(), 2);
+        assert_eq!(batch.op_count(), 2);
+
+        match only_op(&batch, b"key1") {
+            WriteOp::Delete(key) => assert_eq!(key.as_ref(), b"key1"),
+            _ => panic!("Expected Delete operation"),
+        }
+
+        match only_op(&batch, b"key2") {
+            WriteOp::Merge(key, value, _) => {
+                assert_eq!(key.as_ref(), b"key2");
+                assert_eq!(value.as_ref(), b"value2");
+            }
+            _ => panic!("Expected Merge operation"),
+        }
     }
 
     #[test]

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -7,21 +7,21 @@
 use crate::config::{MergeOptions, PutOptions};
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator};
-use crate::mem_table::{KVTableInternalKeyRange, SequencedKey};
 use crate::merge_operator::{MergeOperatorIterator, MergeOperatorType};
 use crate::prefix_extractor::{PrefixExtractor, PrefixTarget};
 use crate::types::{RowEntry, ValueDeletable};
 use async_trait::async_trait;
 use bytes::Bytes;
+use smallvec::{smallvec, SmallVec};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::iter::Peekable;
 use std::ops::RangeBounds;
 use uuid::Uuid;
 
-/// A batch of write operations (puts and/or deletes). All operations in the
-/// batch are applied atomically to the database. If multiple operations appear
-/// for a a single key, the last operation will be applied. The others will be
-/// dropped.
+/// A batch of write operations (puts, deletes, and merges). All operations in
+/// the batch are applied atomically to the database. Put and delete operations
+/// replace earlier operations for the same key, while merge operations are
+/// preserved until a later put or delete replaces them.
 ///
 /// # Examples
 /// ```rust
@@ -50,13 +50,8 @@ use uuid::Uuid;
 /// means that WAL SSTs could get large if there's a large batch write.
 #[derive(Clone, Debug)]
 pub struct WriteBatch {
-    pub(crate) ops: BTreeMap<SequencedKey, WriteOp>,
+    pub(crate) ops: BTreeMap<Bytes, SmallVec<[WriteOp; 1]>>,
     pub(crate) txn_id: Option<Uuid>,
-    /// due to merges, multiple writes may happen for the same key in one batch,
-    /// this write_idx tracks the order in which writes happen within a single
-    /// batch (unrelated to the sequence number of the batch, which is assigned
-    /// atomically by the oracle when the batch is committed).
-    pub(crate) write_idx: u64,
     pub(crate) merge_op_count: usize,
 }
 
@@ -147,29 +142,17 @@ impl WriteBatch {
         WriteBatch {
             ops: BTreeMap::new(),
             txn_id: None,
-            write_idx: 0,
             merge_op_count: 0,
         }
     }
 
     /// Remove all existing ops for the given user key from the batch.
     fn remove_ops_by_key(&mut self, key: &Bytes) {
-        // Find the contiguous range of entries for this user key and delete them in place.
-        let start = SequencedKey::new(key.clone(), u64::MAX);
-        let end = SequencedKey::new(key.clone(), 0);
-
-        // Collect keys to remove
-        let keys_to_remove: Vec<SequencedKey> = self
-            .ops
-            .range(start..=end)
-            .map(|(k, _)| k.clone())
-            .collect();
-
-        // Remove them
-        for k in keys_to_remove {
-            if let Some(WriteOp::Merge(..)) = self.ops.remove(&k) {
-                self.merge_op_count -= 1
-            }
+        if let Some(ops) = self.ops.remove(key) {
+            self.merge_op_count -= ops
+                .iter()
+                .filter(|op| matches!(op, WriteOp::Merge(..)))
+                .count();
         }
     }
 
@@ -177,7 +160,6 @@ impl WriteBatch {
         Self {
             ops: self.ops,
             txn_id: Some(txn_id),
-            write_idx: self.write_idx,
             merge_op_count: self.merge_op_count,
         }
     }
@@ -262,11 +244,9 @@ impl WriteBatch {
         // remove all previous entries.
         self.remove_ops_by_key(&key);
         self.ops.insert(
-            SequencedKey::new(key.clone(), self.write_idx),
-            WriteOp::Put(key, value, options.clone()),
+            key.clone(),
+            smallvec![WriteOp::Put(key, value, options.clone())],
         );
-
-        self.write_idx += 1;
     }
 
     /// Merge a key-value pair into the batch. Keys must not be empty.
@@ -287,13 +267,16 @@ impl WriteBatch {
         self.assert_kv(&key, &value);
 
         let key = Bytes::copy_from_slice(key.as_ref());
-        self.ops.insert(
-            SequencedKey::new(key.clone(), self.write_idx),
-            WriteOp::Merge(key, Bytes::copy_from_slice(value.as_ref()), options.clone()),
-        );
+        self.ops
+            .entry(key.clone())
+            .or_default()
+            .push(WriteOp::Merge(
+                key,
+                Bytes::copy_from_slice(value.as_ref()),
+                options.clone(),
+            ));
 
         self.merge_op_count += 1;
-        self.write_idx += 1;
     }
 
     /// Delete a key-value pair into the batch. Keys must not be empty.
@@ -305,12 +288,8 @@ impl WriteBatch {
         // delete will overwrite the existing key so we can safely
         // remove all previous entries.
         self.remove_ops_by_key(&key);
-        self.ops.insert(
-            SequencedKey::new(key.clone(), self.write_idx),
-            WriteOp::Delete(key),
-        );
-
-        self.write_idx += 1;
+        self.ops
+            .insert(key.clone(), smallvec![WriteOp::Delete(key)]);
     }
 
     pub fn is_empty(&self) -> bool {
@@ -321,8 +300,12 @@ impl WriteBatch {
         self.merge_op_count > 0
     }
 
+    pub(crate) fn op_count(&self) -> usize {
+        self.ops.values().map(|ops| ops.len()).sum()
+    }
+
     pub(crate) fn keys(&self) -> HashSet<Bytes> {
-        self.ops.keys().map(|key| key.user_key.clone()).collect()
+        self.ops.keys().cloned().collect()
     }
 
     /// Converts a WriteBatch into a vector of RowEntry objects with
@@ -441,6 +424,28 @@ pub(crate) struct WriteBatchIterator {
 }
 
 impl WriteBatchIterator {
+    /// Converts a batch write operation into a [`RowEntry`] with the supplied
+    /// sequence number and optional batch-local timestamp metadata.
+    ///
+    /// This wrapper exists because [`WriteOp::to_row_entry`] expects the caller
+    /// to provide a precomputed expiration timestamp. The iterator is where we
+    /// still have the write options, current time, and default TTL together, so
+    /// it computes the effective expiration before delegating to the lower-level
+    /// conversion.
+    fn write_op_to_row_entry(
+        op: &WriteOp,
+        seq: u64,
+        now: Option<i64>,
+        default_ttl: Option<u64>,
+    ) -> RowEntry {
+        let expire_ts = match (op, now) {
+            (WriteOp::Put(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
+            (WriteOp::Merge(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
+            _ => None,
+        };
+        op.to_row_entry(seq, now, expire_ts)
+    }
+
     pub(crate) fn new(
         batch: &WriteBatch,
         range: impl RangeBounds<Bytes>,
@@ -449,25 +454,21 @@ impl WriteBatchIterator {
         now: Option<i64>,
         default_ttl: Option<u64>,
     ) -> Self {
-        let range = KVTableInternalKeyRange::from(range);
-        let mut entries: Vec<RowEntry> = batch
-            .ops
-            .range(range)
-            .map(|(_, v)| {
-                let expire_ts = match (v, now) {
-                    (WriteOp::Put(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
-                    (WriteOp::Merge(_, _, opts), Some(now)) => {
-                        opts.expire_ts_from(default_ttl, now)
-                    }
-                    _ => None,
-                };
-                v.to_row_entry(seq, now, expire_ts)
-            })
-            .collect();
-
-        if matches!(ordering, IterationOrder::Descending) {
-            entries.reverse();
-        }
+        let entries: Vec<RowEntry> = match ordering {
+            IterationOrder::Ascending => batch
+                .ops
+                .range(range)
+                .flat_map(|(_, ops)| ops.iter().rev())
+                .map(|op| Self::write_op_to_row_entry(op, seq, now, default_ttl))
+                .collect(),
+            IterationOrder::Descending => batch
+                .ops
+                .range(range)
+                .rev()
+                .flat_map(|(_, ops)| ops.iter().rev())
+                .map(|op| Self::write_op_to_row_entry(op, seq, now, default_ttl))
+                .collect(),
+        };
 
         let iter: Box<dyn Iterator<Item = RowEntry> + Send + Sync> = Box::new(entries.into_iter());
 
@@ -520,6 +521,17 @@ mod tests {
         options: PutOptions,
     }
 
+    fn ops_for_key<'a>(batch: &'a WriteBatch, key: &[u8]) -> &'a [WriteOp] {
+        let key = Bytes::copy_from_slice(key);
+        batch.ops.get(&key).expect("missing key").as_slice()
+    }
+
+    fn only_op<'a>(batch: &'a WriteBatch, key: &[u8]) -> &'a WriteOp {
+        let ops = ops_for_key(batch, key);
+        assert_eq!(ops.len(), 1);
+        &ops[0]
+    }
+
     #[rstest]
     #[case(vec![WriteOpTestCase {
         key: b"key".to_vec(),
@@ -557,8 +569,8 @@ mod tests {
     }])]
     fn test_put_delete_batch(#[case] test_case: Vec<WriteOpTestCase>) {
         let mut batch = WriteBatch::new();
-        let mut expected_ops: BTreeMap<SequencedKey, WriteOp> = BTreeMap::new();
-        for (seq, test_case) in test_case.into_iter().enumerate() {
+        let mut expected_ops: BTreeMap<Bytes, SmallVec<[WriteOp; 1]>> = BTreeMap::new();
+        for test_case in test_case {
             if let Some(value) = test_case.value {
                 batch.put_with_options(
                     test_case.key.as_slice(),
@@ -566,18 +578,18 @@ mod tests {
                     &test_case.options,
                 );
                 expected_ops.insert(
-                    SequencedKey::new(Bytes::from(test_case.key.clone()), seq as u64),
-                    WriteOp::Put(
+                    Bytes::from(test_case.key.clone()),
+                    smallvec![WriteOp::Put(
                         Bytes::from(test_case.key),
                         Bytes::from(value),
                         test_case.options,
-                    ),
+                    )],
                 );
             } else {
                 batch.delete(test_case.key.as_slice());
                 expected_ops.insert(
-                    SequencedKey::new(Bytes::from(test_case.key.clone()), seq as u64),
-                    WriteOp::Delete(Bytes::from(test_case.key)),
+                    Bytes::from(test_case.key.clone()),
+                    smallvec![WriteOp::Delete(Bytes::from(test_case.key))],
                 );
             }
         }
@@ -591,10 +603,7 @@ mod tests {
         batch.put(b"key1", b"value2"); // Should overwrite previous
 
         assert_eq!(batch.ops.len(), 1); // Only one entry due to deduplication
-        let op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 1))
-            .unwrap();
+        let op = only_op(&batch, b"key1");
         match op {
             WriteOp::Put(_, value, _) => assert_eq!(value.as_ref(), b"value2"),
             _ => panic!("Expected Put operation"),
@@ -858,10 +867,7 @@ mod tests {
 
         // Then: the batch should contain one merge operation with default options
         assert_eq!(batch.ops.len(), 1);
-        let op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 0))
-            .unwrap();
+        let op = only_op(&batch, b"key1");
         match op {
             WriteOp::Merge(key, value, options) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -885,10 +891,7 @@ mod tests {
 
         // Then: the batch should contain one merge operation with the custom options
         assert_eq!(batch.ops.len(), 1);
-        let op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 0))
-            .unwrap();
+        let op = only_op(&batch, b"key1");
         match op {
             WriteOp::Merge(key, value, options) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -910,21 +913,14 @@ mod tests {
         batch.merge(b"key1", b"value3");
 
         // Then: all merge operations should be preserved (not deduplicated)
-        assert_eq!(batch.ops.len(), 3);
+        assert_eq!(batch.ops.len(), 1);
+        assert_eq!(batch.op_count(), 3);
 
-        // And: all three operations should exist with different sequence numbers
-        let op1 = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 0))
-            .unwrap();
-        let op2 = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 1))
-            .unwrap();
-        let op3 = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 2))
-            .unwrap();
+        // And: all three operations should exist for the key in insertion order
+        let ops = ops_for_key(&batch, b"key1");
+        let op1 = &ops[0];
+        let op2 = &ops[1];
+        let op3 = &ops[2];
 
         match (op1, op2, op3) {
             (WriteOp::Merge(_, v1, _), WriteOp::Merge(_, v2, _), WriteOp::Merge(_, v3, _)) => {
@@ -948,17 +944,12 @@ mod tests {
 
         // Then: all merge operations should be preserved
         assert_eq!(batch.ops.len(), 3);
+        assert_eq!(batch.op_count(), 3);
 
-        // And: all keys should exist with correct sequence numbers
-        assert!(batch
-            .ops
-            .contains_key(&SequencedKey::new(Bytes::from_static(b"key1"), 0)));
-        assert!(batch
-            .ops
-            .contains_key(&SequencedKey::new(Bytes::from_static(b"key2"), 1)));
-        assert!(batch
-            .ops
-            .contains_key(&SequencedKey::new(Bytes::from_static(b"key3"), 2)));
+        // And: all keys should exist
+        assert!(batch.ops.contains_key(&Bytes::from_static(b"key1")));
+        assert!(batch.ops.contains_key(&Bytes::from_static(b"key2")));
+        assert!(batch.ops.contains_key(&Bytes::from_static(b"key3")));
     }
 
     #[test]
@@ -1009,13 +1000,12 @@ mod tests {
         batch.merge(b"key1", b"merge_value");
 
         // Then: both operations should remain (merge accumulates on top of put)
-        assert_eq!(batch.ops.len(), 2);
+        assert_eq!(batch.ops.len(), 1);
+        assert_eq!(batch.op_count(), 2);
+        let ops = ops_for_key(&batch, b"key1");
 
         // Verify the put operation exists
-        let put_op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 0))
-            .unwrap();
+        let put_op = &ops[0];
         match put_op {
             WriteOp::Put(key, value, _) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -1025,10 +1015,7 @@ mod tests {
         }
 
         // Verify the merge operation exists
-        let merge_op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 1))
-            .unwrap();
+        let merge_op = &ops[1];
         match merge_op {
             WriteOp::Merge(key, value, _) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -1048,13 +1035,12 @@ mod tests {
         batch.merge(b"key1", b"merge_value");
 
         // Then: both operations should remain (merge accumulates on top of delete)
-        assert_eq!(batch.ops.len(), 2);
+        assert_eq!(batch.ops.len(), 1);
+        assert_eq!(batch.op_count(), 2);
+        let ops = ops_for_key(&batch, b"key1");
 
         // Verify the delete operation exists
-        let delete_op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 0))
-            .unwrap();
+        let delete_op = &ops[0];
         match delete_op {
             WriteOp::Delete(key) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -1063,10 +1049,7 @@ mod tests {
         }
 
         // Verify the merge operation exists
-        let merge_op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 1))
-            .unwrap();
+        let merge_op = &ops[1];
         match merge_op {
             WriteOp::Merge(key, value, _) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -1088,10 +1071,7 @@ mod tests {
         // Then: only the put operation should remain (merge is deduplicated by put)
         assert_eq!(batch.ops.len(), 1);
 
-        let op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 1))
-            .unwrap();
+        let op = only_op(&batch, b"key1");
         match op {
             WriteOp::Put(key, value, _) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -1113,10 +1093,7 @@ mod tests {
         // Then: only the delete operation should remain (merge is deduplicated by delete)
         assert_eq!(batch.ops.len(), 1);
 
-        let op = batch
-            .ops
-            .get(&SequencedKey::new(Bytes::from_static(b"key1"), 1))
-            .unwrap();
+        let op = only_op(&batch, b"key1");
         match op {
             WriteOp::Delete(key) => {
                 assert_eq!(key.as_ref(), b"key1");
@@ -1230,14 +1207,14 @@ mod tests {
             ),
             RowEntry::new(
                 Bytes::from_static(b"key1"),
-                ValueDeletable::Merge(Bytes::from_static(b"merge1")),
+                ValueDeletable::Merge(Bytes::from_static(b"merge3")),
                 u64::MAX,
                 None,
                 None,
             ),
             RowEntry::new(
                 Bytes::from_static(b"key1"),
-                ValueDeletable::Merge(Bytes::from_static(b"merge3")),
+                ValueDeletable::Merge(Bytes::from_static(b"merge1")),
                 u64::MAX,
                 None,
                 None,
@@ -1330,6 +1307,61 @@ mod tests {
                 None => Ok(operand),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn should_preserve_interleaved_merge_order_by_key() {
+        let mut batch = WriteBatch::new();
+        batch.merge(b"key1", b"a");
+        batch.merge(b"key2", b"x");
+        batch.merge(b"key1", b"b");
+
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+
+        let expected = vec![
+            RowEntry::new(
+                Bytes::from_static(b"key1"),
+                ValueDeletable::Merge(Bytes::from_static(b"b")),
+                u64::MAX,
+                None,
+                None,
+            ),
+            RowEntry::new(
+                Bytes::from_static(b"key1"),
+                ValueDeletable::Merge(Bytes::from_static(b"a")),
+                u64::MAX,
+                None,
+                None,
+            ),
+            RowEntry::new(
+                Bytes::from_static(b"key2"),
+                ValueDeletable::Merge(Bytes::from_static(b"x")),
+                u64::MAX,
+                None,
+                None,
+            ),
+        ];
+        assert_iterator(&mut iter, expected).await;
+
+        let merge_operator = Some(std::sync::Arc::new(StringConcatMergeOperator)
+            as crate::merge_operator::MergeOperatorType);
+        let (result, _, _) = batch
+            .extract_entries(100, 1000, None, merge_operator, None)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].key, Bytes::from_static(b"key1"));
+        assert_eq!(
+            result[0].value,
+            ValueDeletable::Merge(Bytes::from_static(b"ab"))
+        );
+        assert_eq!(result[1].key, Bytes::from_static(b"key2"));
+        assert_eq!(
+            result[1].value,
+            ValueDeletable::Merge(Bytes::from_static(b"x"))
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -353,12 +353,12 @@ impl WriteBatch {
             return Err(SlateDBError::MergeOperatorMissing);
         }
 
-        let mut it: Box<dyn RowEntryIterator> = Box::new(WriteBatchIterator::new_with_seq_and_ttl(
+        let mut it: Box<dyn RowEntryIterator> = Box::new(WriteBatchIterator::new(
             self,
             ..,
             IterationOrder::Ascending,
             seq,
-            now,
+            Some(now),
             default_ttl,
         ));
         if let Some(ref merge_operator) = merger {
@@ -445,33 +445,8 @@ impl WriteBatchIterator {
         batch: &WriteBatch,
         range: impl RangeBounds<Bytes>,
         ordering: IterationOrder,
-    ) -> Self {
-        let range = KVTableInternalKeyRange::from(range);
-        let mut entries: Vec<(SequencedKey, RowEntry)> = batch
-            .ops
-            .range(range)
-            .map(|(k, v)| (k.clone(), v.to_row_entry(u64::MAX, None, None)))
-            .collect();
-
-        if matches!(ordering, IterationOrder::Descending) {
-            entries.reverse();
-        }
-
-        let iter: Box<dyn Iterator<Item = (SequencedKey, RowEntry)> + Send + Sync> =
-            Box::new(entries.into_iter());
-
-        Self {
-            iter: iter.peekable(),
-            ordering,
-        }
-    }
-
-    pub(crate) fn new_with_seq_and_ttl(
-        batch: &WriteBatch,
-        range: impl RangeBounds<Bytes>,
-        ordering: IterationOrder,
         seq: u64,
-        now: i64,
+        now: Option<i64>,
         default_ttl: Option<u64>,
     ) -> Self {
         let range = KVTableInternalKeyRange::from(range);
@@ -479,12 +454,14 @@ impl WriteBatchIterator {
             .ops
             .range(range)
             .map(|(k, v)| {
-                let expire_ts = match v {
-                    WriteOp::Put(_, _, opts) => opts.expire_ts_from(default_ttl, now),
-                    WriteOp::Merge(_, _, opts) => opts.expire_ts_from(default_ttl, now),
-                    WriteOp::Delete(_) => None,
+                let expire_ts = match (v, now) {
+                    (WriteOp::Put(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
+                    (WriteOp::Merge(_, _, opts), Some(now)) => {
+                        opts.expire_ts_from(default_ttl, now)
+                    }
+                    _ => None,
                 };
-                (k.clone(), v.to_row_entry(seq, Some(now), expire_ts))
+                (k.clone(), v.to_row_entry(seq, now, expire_ts))
             })
             .collect();
 
@@ -633,7 +610,8 @@ mod tests {
         batch.put(b"key2", b"value2");
         batch.delete(b"key4");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         let expected = vec![
             RowEntry::new_value(b"key1", b"value1", u64::MAX),
@@ -663,6 +641,9 @@ mod tests {
             &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
         );
 
         let expected = vec![RowEntry::new_value(b"key3", b"value3", u64::MAX)];
@@ -677,7 +658,8 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key2", b"value2");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Descending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Descending, u64::MAX, None, None);
 
         let expected = vec![
             RowEntry::new_value(b"key3", b"value3", u64::MAX),
@@ -695,7 +677,8 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key5", b"value5");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Seek to key3
         iter.seek(b"key3").await.unwrap();
@@ -716,7 +699,8 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key5", b"value5");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Descending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Descending, u64::MAX, None, None);
 
         // Seek to key3 (in descending, we want keys <= key3)
         iter.seek(b"key3").await.unwrap();
@@ -733,7 +717,8 @@ mod tests {
     #[tokio::test]
     async fn test_writebatch_iterator_empty_batch() {
         let batch = WriteBatch::new();
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         let result = iter.next().await.unwrap();
         assert!(result.is_none());
@@ -745,7 +730,8 @@ mod tests {
         batch.put(b"key1", b"value1");
         batch.put(b"key3", b"value3");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Seek to key2 (doesn't exist)
         iter.seek(b"key2").await.unwrap();
@@ -767,7 +753,8 @@ mod tests {
         batch.put(b"key1", b"value1");
         batch.put(b"key3", b"value3");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Seek beyond maximum key
         iter.seek(b"key9").await.unwrap();
@@ -785,7 +772,8 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.delete(b"key4");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         let expected = vec![
             RowEntry::new_value(b"key1", b"value1", u64::MAX),
@@ -815,7 +803,8 @@ mod tests {
         batch.put(b"key2", b"value2");
         batch.put(b"key3", b"value3");
 
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Seek before first key
         iter.seek(b"key1").await.unwrap();
@@ -841,6 +830,9 @@ mod tests {
             &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
         );
 
         let expected = vec![
@@ -1144,7 +1136,8 @@ mod tests {
         batch.delete(b"key3");
 
         // When: creating an iterator
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Then: the iterator should return all operations in order
         let expected = vec![
@@ -1184,7 +1177,8 @@ mod tests {
         batch.merge(b"key1", b"merge3");
 
         // When: creating an iterator
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Then: the iterator should return all merge operations
         let expected = vec![
@@ -1223,7 +1217,8 @@ mod tests {
         batch.merge(b"key1", b"merge3");
 
         // When: creating a descending iterator
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Descending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Descending, u64::MAX, None, None);
 
         // Then: the iterator should return operations in descending order
         let expected = vec![
@@ -1266,6 +1261,9 @@ mod tests {
             &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
         );
 
         // Then: the iterator should only return merges within the range
@@ -1289,7 +1287,8 @@ mod tests {
         batch.merge(b"key5", b"merge5");
 
         // When: creating an iterator and seeking to key3
-        let mut iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let mut iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
         iter.seek(b"key3").await.unwrap();
 
         // Then: the iterator should return key3 and key5

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -65,9 +65,9 @@ impl Default for WriteBatch {
 /// A write operation in a batch.
 #[derive(PartialEq, Clone)]
 pub(crate) enum WriteOp {
-    Put(Bytes, Bytes, PutOptions),
-    Delete(Bytes),
-    Merge(Bytes, Bytes, MergeOptions),
+    Put(Bytes, PutOptions),
+    Delete,
+    Merge(Bytes, MergeOptions),
 }
 
 impl std::fmt::Debug for WriteOp {
@@ -81,19 +81,14 @@ impl std::fmt::Debug for WriteOp {
         }
 
         match self {
-            WriteOp::Put(key, value, options) => {
-                let key = trunc(key);
+            WriteOp::Put(value, options) => {
                 let value = trunc(value);
-                write!(f, "Put({key}, {value}, {:?})", options)
+                write!(f, "Put({value}, {:?})", options)
             }
-            WriteOp::Delete(key) => {
-                let key = trunc(key);
-                write!(f, "Delete({key})")
-            }
-            WriteOp::Merge(key, value, options) => {
-                let key = trunc(key);
+            WriteOp::Delete => write!(f, "Delete"),
+            WriteOp::Merge(value, options) => {
                 let value = trunc(value);
-                write!(f, "Merge({key}, {value}, {:?})", options)
+                write!(f, "Merge({value}, {:?})", options)
             }
         }
     }
@@ -103,12 +98,13 @@ impl WriteOp {
     /// Convert WriteOp to RowEntry for queries
     pub(crate) fn to_row_entry(
         &self,
+        key: &Bytes,
         seq: u64,
         create_ts: Option<i64>,
         expire_ts: Option<i64>,
     ) -> RowEntry {
         match self {
-            WriteOp::Put(key, value, _options) => {
+            WriteOp::Put(value, _options) => {
                 // For queries, we don't need to compute expiration time here
                 // since these are uncommitted writes. The expiration will be
                 // computed when the batch is actually written.
@@ -120,14 +116,14 @@ impl WriteOp {
                     expire_ts,
                 )
             }
-            WriteOp::Delete(key) => RowEntry::new(
+            WriteOp::Delete => RowEntry::new(
                 key.clone(),
                 ValueDeletable::Tombstone,
                 seq,
                 create_ts,
                 expire_ts,
             ),
-            WriteOp::Merge(key, value, _options) => RowEntry::new(
+            WriteOp::Merge(value, _options) => RowEntry::new(
                 key.clone(),
                 ValueDeletable::Merge(value.clone()),
                 seq,
@@ -235,10 +231,9 @@ impl WriteBatch {
 
         // put will overwrite the existing key so we can safely
         // remove all previous entries.
-        let previous = self.ops.insert(
-            key.clone(),
-            smallvec![WriteOp::Put(key, value, options.clone())],
-        );
+        let previous = self
+            .ops
+            .insert(key, smallvec![WriteOp::Put(value, options.clone())]);
         self.op_count += 1;
         if let Some(previous) = previous {
             self.op_count -= previous.len();
@@ -263,14 +258,12 @@ impl WriteBatch {
         self.assert_kv(&key, &value);
 
         let key = Bytes::copy_from_slice(key.as_ref());
-        self.ops
-            .entry(key.clone())
-            .or_default()
-            .push(WriteOp::Merge(
-                key,
-                Bytes::copy_from_slice(value.as_ref()),
-                options.clone(),
-            ));
+        let op = WriteOp::Merge(Bytes::copy_from_slice(value.as_ref()), options.clone());
+        if let Some(ops) = self.ops.get_mut(&key) {
+            ops.push(op);
+        } else {
+            self.ops.insert(key, smallvec![op]);
+        }
 
         self.has_merge_ops = true;
         self.op_count += 1;
@@ -284,9 +277,7 @@ impl WriteBatch {
 
         // delete will overwrite the existing key so we can safely
         // remove all previous entries.
-        let previous = self
-            .ops
-            .insert(key.clone(), smallvec![WriteOp::Delete(key)]);
+        let previous = self.ops.insert(key, smallvec![WriteOp::Delete]);
         self.op_count += 1;
         if let Some(previous) = previous {
             self.op_count -= previous.len();
@@ -428,23 +419,24 @@ impl WriteBatchIterator {
     /// Converts a batch write operation into a [`RowEntry`] with the supplied
     /// sequence number and optional batch-local timestamp metadata.
     ///
-    /// This wrapper exists because [`WriteOp::to_row_entry`] expects the caller
-    /// to provide a precomputed expiration timestamp. The iterator is where we
-    /// still have the write options, current time, and default TTL together, so
-    /// it computes the effective expiration before delegating to the lower-level
-    /// conversion.
+    /// This wrapper exists because a [`WriteOp`] stores only the value-level
+    /// operation payload while the key lives in the batch map. The iterator is
+    /// where that key is available alongside the write options, current time,
+    /// and default TTL, so it computes the effective expiration timestamp and
+    /// passes both the key and timestamp metadata to [`WriteOp::to_row_entry`].
     fn write_op_to_row_entry(
+        key: &Bytes,
         op: &WriteOp,
         seq: u64,
         now: Option<i64>,
         default_ttl: Option<u64>,
     ) -> RowEntry {
         let expire_ts = match (op, now) {
-            (WriteOp::Put(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
-            (WriteOp::Merge(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
+            (WriteOp::Put(_, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
+            (WriteOp::Merge(_, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
             _ => None,
         };
-        op.to_row_entry(seq, now, expire_ts)
+        op.to_row_entry(key, seq, now, expire_ts)
     }
 
     pub(crate) fn new(
@@ -459,15 +451,15 @@ impl WriteBatchIterator {
             IterationOrder::Ascending => batch
                 .ops
                 .range(range)
-                .flat_map(|(_, ops)| ops.iter().rev())
-                .map(|op| Self::write_op_to_row_entry(op, seq, now, default_ttl))
+                .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
+                .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
                 .collect(),
             IterationOrder::Descending => batch
                 .ops
                 .range(range)
                 .rev()
-                .flat_map(|(_, ops)| ops.iter().rev())
-                .map(|op| Self::write_op_to_row_entry(op, seq, now, default_ttl))
+                .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
+                .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
                 .collect(),
         };
 
@@ -580,17 +572,13 @@ mod tests {
                 );
                 expected_ops.insert(
                     Bytes::from(test_case.key.clone()),
-                    smallvec![WriteOp::Put(
-                        Bytes::from(test_case.key),
-                        Bytes::from(value),
-                        test_case.options,
-                    )],
+                    smallvec![WriteOp::Put(Bytes::from(value), test_case.options)],
                 );
             } else {
                 batch.delete(test_case.key.as_slice());
                 expected_ops.insert(
                     Bytes::from(test_case.key.clone()),
-                    smallvec![WriteOp::Delete(Bytes::from(test_case.key))],
+                    smallvec![WriteOp::Delete],
                 );
             }
         }
@@ -607,7 +595,7 @@ mod tests {
         assert_eq!(batch.op_count(), 1);
         let op = only_op(&batch, b"key1");
         match op {
-            WriteOp::Put(_, value, _) => assert_eq!(value.as_ref(), b"value2"),
+            WriteOp::Put(value, _) => assert_eq!(value.as_ref(), b"value2"),
             _ => panic!("Expected Put operation"),
         }
     }
@@ -871,8 +859,7 @@ mod tests {
         assert_eq!(batch.ops.len(), 1);
         let op = only_op(&batch, b"key1");
         match op {
-            WriteOp::Merge(key, value, options) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Merge(value, options) => {
                 assert_eq!(value.as_ref(), b"value1");
                 assert_eq!(options, &MergeOptions::default());
             }
@@ -895,8 +882,7 @@ mod tests {
         assert_eq!(batch.ops.len(), 1);
         let op = only_op(&batch, b"key1");
         match op {
-            WriteOp::Merge(key, value, options) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Merge(value, options) => {
                 assert_eq!(value.as_ref(), b"value1");
                 assert_eq!(options.ttl, Ttl::ExpireAfter(3600));
             }
@@ -925,7 +911,7 @@ mod tests {
         let op3 = &ops[2];
 
         match (op1, op2, op3) {
-            (WriteOp::Merge(_, v1, _), WriteOp::Merge(_, v2, _), WriteOp::Merge(_, v3, _)) => {
+            (WriteOp::Merge(v1, _), WriteOp::Merge(v2, _), WriteOp::Merge(v3, _)) => {
                 assert_eq!(v1.as_ref(), b"value1");
                 assert_eq!(v2.as_ref(), b"value2");
                 assert_eq!(v3.as_ref(), b"value3");
@@ -976,8 +962,7 @@ mod tests {
         assert!(batch.has_merge_ops());
         assert_eq!(batch.op_count(), 1);
         match only_op(&batch, b"key1") {
-            WriteOp::Put(key, value, _) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Put(value, _) => {
                 assert_eq!(value.as_ref(), b"final");
             }
             _ => panic!("Expected Put operation"),
@@ -998,13 +983,12 @@ mod tests {
         assert_eq!(batch.op_count(), 2);
 
         match only_op(&batch, b"key1") {
-            WriteOp::Delete(key) => assert_eq!(key.as_ref(), b"key1"),
+            WriteOp::Delete => {}
             _ => panic!("Expected Delete operation"),
         }
 
         match only_op(&batch, b"key2") {
-            WriteOp::Merge(key, value, _) => {
-                assert_eq!(key.as_ref(), b"key2");
+            WriteOp::Merge(value, _) => {
                 assert_eq!(value.as_ref(), b"value2");
             }
             _ => panic!("Expected Merge operation"),
@@ -1028,8 +1012,7 @@ mod tests {
         // Verify the put operation exists
         let put_op = &ops[0];
         match put_op {
-            WriteOp::Put(key, value, _) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Put(value, _) => {
                 assert_eq!(value.as_ref(), b"put_value");
             }
             _ => panic!("Expected Put operation"),
@@ -1038,8 +1021,7 @@ mod tests {
         // Verify the merge operation exists
         let merge_op = &ops[1];
         match merge_op {
-            WriteOp::Merge(key, value, _) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Merge(value, _) => {
                 assert_eq!(value.as_ref(), b"merge_value");
             }
             _ => panic!("Expected Merge operation"),
@@ -1063,17 +1045,14 @@ mod tests {
         // Verify the delete operation exists
         let delete_op = &ops[0];
         match delete_op {
-            WriteOp::Delete(key) => {
-                assert_eq!(key.as_ref(), b"key1");
-            }
+            WriteOp::Delete => {}
             _ => panic!("Expected Delete operation"),
         }
 
         // Verify the merge operation exists
         let merge_op = &ops[1];
         match merge_op {
-            WriteOp::Merge(key, value, _) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Merge(value, _) => {
                 assert_eq!(value.as_ref(), b"merge_value");
             }
             _ => panic!("Expected Merge operation"),
@@ -1095,8 +1074,7 @@ mod tests {
 
         let op = only_op(&batch, b"key1");
         match op {
-            WriteOp::Put(key, value, _) => {
-                assert_eq!(key.as_ref(), b"key1");
+            WriteOp::Put(value, _) => {
                 assert_eq!(value.as_ref(), b"put_value");
             }
             _ => panic!("Expected Put operation"),
@@ -1118,9 +1096,7 @@ mod tests {
 
         let op = only_op(&batch, b"key1");
         match op {
-            WriteOp::Delete(key) => {
-                assert_eq!(key.as_ref(), b"key1");
-            }
+            WriteOp::Delete => {}
             _ => panic!("Expected Delete operation"),
         }
     }

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -436,7 +436,7 @@ pub mod benches {
 
 /// Iterator over `WriteBatch` entries.
 pub(crate) struct WriteBatchIterator {
-    iter: Peekable<Box<dyn Iterator<Item = (SequencedKey, RowEntry)> + Send + Sync>>,
+    iter: Peekable<Box<dyn Iterator<Item = RowEntry> + Send + Sync>>,
     ordering: IterationOrder,
 }
 
@@ -450,10 +450,10 @@ impl WriteBatchIterator {
         default_ttl: Option<u64>,
     ) -> Self {
         let range = KVTableInternalKeyRange::from(range);
-        let mut entries: Vec<(SequencedKey, RowEntry)> = batch
+        let mut entries: Vec<RowEntry> = batch
             .ops
             .range(range)
-            .map(|(k, v)| {
+            .map(|(_, v)| {
                 let expire_ts = match (v, now) {
                     (WriteOp::Put(_, _, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
                     (WriteOp::Merge(_, _, opts), Some(now)) => {
@@ -461,7 +461,7 @@ impl WriteBatchIterator {
                     }
                     _ => None,
                 };
-                (k.clone(), v.to_row_entry(seq, now, expire_ts))
+                v.to_row_entry(seq, now, expire_ts)
             })
             .collect();
 
@@ -469,8 +469,7 @@ impl WriteBatchIterator {
             entries.reverse();
         }
 
-        let iter: Box<dyn Iterator<Item = (SequencedKey, RowEntry)> + Send + Sync> =
-            Box::new(entries.into_iter());
+        let iter: Box<dyn Iterator<Item = RowEntry> + Send + Sync> = Box::new(entries.into_iter());
 
         Self {
             iter: iter.peekable(),
@@ -486,14 +485,14 @@ impl RowEntryIterator for WriteBatchIterator {
     }
 
     async fn next(&mut self) -> Result<Option<RowEntry>, crate::error::SlateDBError> {
-        Ok(self.iter.next().map(|(_, entry)| entry))
+        Ok(self.iter.next())
     }
 
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), crate::error::SlateDBError> {
-        while let Some((key, _)) = self.iter.peek() {
+        while let Some(entry) = self.iter.peek() {
             if match self.ordering {
-                IterationOrder::Ascending => key.user_key.as_ref() < next_key,
-                IterationOrder::Descending => key.user_key.as_ref() > next_key,
+                IterationOrder::Ascending => entry.key.as_ref() < next_key,
+                IterationOrder::Descending => entry.key.as_ref() > next_key,
             } {
                 self.iter.next();
             } else {

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -257,12 +257,13 @@ impl WriteBatch {
     {
         self.assert_kv(&key, &value);
 
-        let key = Bytes::copy_from_slice(key.as_ref());
-        let op = WriteOp::Merge(Bytes::copy_from_slice(value.as_ref()), options.clone());
-        if let Some(ops) = self.ops.get_mut(&key) {
+        let key = key.as_ref();
+        let value = value.as_ref();
+        let op = WriteOp::Merge(Bytes::copy_from_slice(value), options.clone());
+        if let Some(ops) = self.ops.get_mut(key) {
             ops.push(op);
         } else {
-            self.ops.insert(key, smallvec![op]);
+            self.ops.insert(Bytes::copy_from_slice(key), smallvec![op]);
         }
 
         self.has_merge_ops = true;

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -126,7 +126,7 @@ impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
 
 impl DbInner {
     #[allow(clippy::panic)]
-    #[instrument(level = "trace", skip_all, fields(batch_size = batch.ops.len()))]
+    #[instrument(level = "trace", skip_all, fields(batch_size = batch.op_count()))]
     async fn write_batch(&self, batch: WriteBatch, options: &WriteOptions) -> WriteBatchResult {
         let _options = options;
         #[cfg(not(dst))]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -305,7 +305,7 @@ impl DbInner {
         options: &WriteOptions,
     ) -> Result<WriteHandle, SlateDBError> {
         self.db_stats.write_batch_count.increment(1);
-        self.db_stats.write_ops.increment(batch.ops.len() as u64);
+        self.db_stats.write_ops.increment(batch.op_count() as u64);
         self.check_closed()?;
         if batch.ops.is_empty() {
             return Err(SlateDBError::EmptyBatch);

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -565,7 +565,8 @@ mod tests {
         batch.put(b"key3", b"value3");
 
         // Create WriteBatchIterator
-        let wb_iter = WriteBatchIterator::new(&batch, .., IterationOrder::Ascending);
+        let wb_iter =
+            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
 
         // Create DbIterator with WriteBatch
         let mem_iters: VecDeque<Box<dyn RowEntryIterator + 'static>> = VecDeque::new();

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -164,6 +164,9 @@ impl DbTransaction {
                 &guard,
                 range,
                 IterationOrder::Ascending,
+                u64::MAX,
+                None,
+                None,
             ))
         };
 
@@ -295,6 +298,9 @@ impl DbTransaction {
                 &guard,
                 range.clone(),
                 options.order,
+                u64::MAX,
+                None,
+                None,
             ))
         };
 

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -90,6 +90,8 @@ pub mod seq_tracker;
 pub mod size_tiered_compaction;
 
 mod batch;
+#[cfg(feature = "bench-internal")]
+pub use batch::benches as write_batch_benches;
 mod batch_write;
 mod blob;
 mod block_iterator;

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -450,6 +450,9 @@ mod tests {
                 wb,
                 BytesRange::from_slice(key..=key),
                 IterationOrder::Ascending,
+                u64::MAX,
+                None,
+                None,
             )
         })
     }
@@ -461,7 +464,7 @@ mod tests {
     ) -> Option<WriteBatchIterator> {
         write_batch
             .as_ref()
-            .map(|wb| WriteBatchIterator::new(wb, range.clone(), order))
+            .map(|wb| WriteBatchIterator::new(wb, range.clone(), order, u64::MAX, None, None))
     }
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
     use crate::db_status::DbStatusManager;


### PR DESCRIPTION
## Summary

This is a first pass at improving `WriteBatch` performance for #1597. I explored many approaches but ultimately landed on this one to keep it simple.

## Changes

- Adds performance tests for `WriteBatch` and `DbTransaction`
- Unifies the `WriteBatchIterator::new` constructors into one (used for both `extract_entries` and `DbTransaction`).
- Replaces `SequencedKey` `WriteBatch` keys with `Bytes`. Merges are now modeled as `SmallVec<WriteOp>`.
- A few minor tweaks to stats counting and clones/copies to reduce overhead.

## Notes for Reviewers

This PR still keeps `BTreeMap`. I will experiment with swapping `BTreeMap` for `HashMap` in a subsequent PR. I did not find conclusive gains when doing so yet.

Please make sure to look at the new perf tests. I used Codex 5.5 xhigh to generate them. They seem reasonable to me, but more eyes the better.

## Performance

| Benchmark | Time | Change | Result |
|---|---:|---:|---|
| `write_batch/put_bytes_with_options/empty_batch` | 34.715 ns | -22.94% | Improved |
| `write_batch/put_bytes_with_options/new_key_populated` | 73.200 ns | -58.11% | Improved |
| `write_batch/put_bytes_with_options/overwrite_existing_key` | 81.326 ns | -83.76% | Improved |
| `write_batch/merge_with_options/empty_batch` | 59.301 ns | -39.50% | Improved |
| `write_batch/merge_with_options/new_key_populated` | 167.77 ns | -11.22% | Improved |
| `write_batch/merge_with_options/existing_key_with_merges` | 134.48 ns | -22.19% | Improved |
| `write_batch/delete/empty_batch` | 40.796 ns | -60.40% | Improved |
| `write_batch/delete/new_key_populated` | 115.39 ns | -53.65% | Improved |
| `write_batch/delete/existing_key` | 108.25 ns | -80.86% | Improved |
| `write_batch/keys` | 29.570 µs | -15.44% | Improved |
| `write_batch/extract_entries/no_merges` | 123.60 µs | -12.31% | Improved |
| `write_batch/extract_entries/with_merges` | 159.43 µs | -33.37% | Improved |
| `write_batch/drop/no_merges` | 10.175 µs | -8.13% | Improved |
| `write_batch/drop/with_merges` | 7.7730 µs | -32.01% | Improved |
| `write_batch/drop/repeated_overwrites` | 31.458 ns | -0.53% | Within noise |
| `db_transaction/get_key_value_with_options` | 1.1622 µs | -3.99% | Improved |
| `db_transaction/scan_with_options` | 444.14 µs | +3.44% | Regressed |
| `db_transaction/scan_prefix_with_options` | 552.74 µs | +3.55% | Regressed |
| `db_transaction/put_with_options/empty_transaction` | 84.296 ns | -20.59% | Improved |
| `db_transaction/put_with_options/new_key_populated` | 155.07 ns | -42.97% | Improved |
| `db_transaction/put_with_options/overwrite_existing_key` | 169.06 ns | -75.25% | Improved |
| `db_transaction/mark_read` | 118.95 ns | -1.52% | No change |
| `db_transaction/unmark_write` | 90.730 ns | -0.94% | No change |
| `db_transaction/merge_with_options/empty_transaction` | 86.769 ns | -9.83% | Improved |
| `db_transaction/merge_with_options/new_key_populated` | 192.52 ns | +15.94% | Regressed |
| `db_transaction/merge_with_options/existing_key_with_merges` | 164.93 ns | +16.09% | Regressed |
| `db_transaction/delete/empty_transaction` | 71.079 ns | -24.45% | Improved |
| `db_transaction/delete/new_key_populated` | 123.77 ns | -52.09% | Improved |
| `db_transaction/delete/existing_key` | 154.49 ns | -76.99% | Improved |
| `db_transaction/commit_with_options/empty_transaction` | 190.54 ns | +5.16% | Regressed |
| `db_transaction/commit_with_options/one_put` | 10.199 µs | -3.17% | Improved |
| `db_transaction/drop/no_merges` | 26.684 µs | -30.56% | Improved |
| `db_transaction/drop/with_merges` | 18.894 µs | -54.91% | Improved |
| `db_transaction/drop/repeated_overwrites` | 1.1760 µs | -12.33% | Improved |

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
