### PR TITLE
feat(manifest): add l0_ulid_cutoff invariant + L0 ULID watermark helper

### DIFF
--- a/slatedb/src/manifest/invariants.rs
+++ b/slatedb/src/manifest/invariants.rs
@@ -16,8 +16,17 @@ use crate::error::SlateDBError;
 use crate::manifest::Manifest;
 
 /// Invariant 1 — L0 ULID cutoff. Every L0 SST newly added by `dirty` must carry a
-/// physical SST ULID timestamp "strictly" greater than the current manifest's L0
-/// watermark (`current.core.max_l0_ulid_timestamp_across_trees()`).
+/// physical SST ULID timestamp **not below** the current manifest's L0 watermark
+/// (`current.core.max_l0_ulid_timestamp_across_trees()`) — i.e. it must be `>=`
+/// the watermark; only a strictly-below timestamp is rejected.
+///
+/// The comparison deliberately matches the GC's deletion filter, which deletes
+/// SSTs *strictly older* than the cutoff (`sst.datetime() < cutoff_dt`, at
+/// millisecond granularity) — so an SST whose timestamp equals the watermark
+/// survives the GC and is safe to publish. Allowing equality also means two L0s
+/// minted in the same millisecond both pass, which keeps the writer's retry path
+/// from spinning on same-millisecond ULID collisions; only a genuine backwards
+/// clock step (timestamp strictly below the watermark) trips the invariant.
 ///
 /// The check uses the physical SST ULID — `view.sst.id.unwrap_compacted_id()` —
 /// **not** the separately-allocated `view.id`. The GC keys its cutoff and its
@@ -29,7 +38,7 @@ use crate::manifest::Manifest;
 /// eligible for deletion. So both the watermark and this comparison are based on
 /// the SST ULID.
 ///
-/// This guarantees a newly published L0 sorts above every L0 the GC may have
+/// This guarantees a newly published L0 is not behind any L0 the GC may have
 /// already fenced, so a writer on a backwards-skewed wall clock cannot publish an
 /// SST whose ULID falls below the GC cutoff — which could otherwise make a live
 /// SST eligible for deletion and corrupt the database state.
@@ -51,7 +60,7 @@ pub(crate) fn l0_ulid_cutoff(
     };
 
     // Physical SST ULIDs already committed in `current`; anything in `dirty` not
-    // in this set is a newly added L0 that must clear the watermark.
+    // in this set is a newly added L0 that must not be behind the watermark.
     let existing: HashSet<Ulid> = current
         .core
         .trees()
@@ -63,7 +72,9 @@ pub(crate) fn l0_ulid_cutoff(
         if existing.contains(&sst_id) {
             continue;
         }
-        if sst_id.timestamp_ms() <= watermark.timestamp_ms() {
+        // Reject only a strictly-below timestamp, mirroring the GC's `<` deletion
+        // filter; an equal timestamp (e.g. a same-millisecond mint) is safe.
+        if sst_id.timestamp_ms() < watermark.timestamp_ms() {
             return Err(Box::new(SlateDBError::InvalidClockTick {
                 last_tick: watermark.timestamp_ms() as i64,
                 next_tick: sst_id.timestamp_ms() as i64,
@@ -166,20 +177,14 @@ mod tests {
     }
 
     #[test]
-    fn dirty_adds_l0_equal_to_watermark_errors() {
-        // Strict `>`: a same-millisecond ULID is rejected (the same-ms collision
-        // the writer retry path resolves by minting past the ms boundary).
+    fn dirty_adds_l0_equal_to_watermark_ok() {
+        // Equality is allowed (`>=`), mirroring the GC's strict-`<` deletion
+        // filter: an SST minted in the same millisecond as the watermark survives
+        // the GC, so it is safe to publish and must not trip the invariant. This
+        // is what keeps same-millisecond ULID collisions off the retry path.
         let current = manifest_with_root_l0(&[100]);
         let dirty = manifest_with_root_l0(&[100, 100]);
-        let err = l0_ulid_cutoff(&dirty, &current).unwrap_err();
-        let err = err.downcast::<SlateDBError>().unwrap();
-        assert!(matches!(
-            *err,
-            SlateDBError::InvalidClockTick {
-                last_tick: 100,
-                next_tick: 100
-            }
-        ));
+        l0_ulid_cutoff(&dirty, &current).unwrap();
     }
 
     #[test]

--- a/slatedb/src/manifest/invariants.rs
+++ b/slatedb/src/manifest/invariants.rs
@@ -15,18 +15,26 @@ use ulid::Ulid;
 use crate::error::SlateDBError;
 use crate::manifest::Manifest;
 
-/// Invariant 1 — L0 ULID cutoff. Every L0 SST view newly added by `dirty` must
-/// carry a ULID timestamp "strictly" greater than the current manifest's L0
-/// watermark (`current.core.max_l0_ulid_timestamp_across_trees()`): the maximum
-/// ULID across all trees' live L0 views and `last_compacted_l0_sst_view_id`
-/// markers.
+/// Invariant 1 — L0 ULID cutoff. Every L0 SST newly added by `dirty` must carry a
+/// physical SST ULID timestamp "strictly" greater than the current manifest's L0
+/// watermark (`current.core.max_l0_ulid_timestamp_across_trees()`).
+///
+/// The check uses the physical SST ULID — `view.sst.id.unwrap_compacted_id()` —
+/// **not** the separately-allocated `view.id`. The GC keys its cutoff and its
+/// deletion filter off the SST ULID (see `garbage_collector::compacted_gc`), and
+/// in the normal V2 path the SST ULID is minted at upload while the `view.id` is
+/// minted later when the view is added to the manifest. Validating `view.id`
+/// would miss a backwards-skewed *upload*: an SST minted below the GC cutoff could
+/// receive a fresh `view.id` above the watermark, pass this check, and still be
+/// eligible for deletion. So both the watermark and this comparison are based on
+/// the SST ULID.
 ///
 /// This guarantees a newly published L0 sorts above every L0 the GC may have
 /// already fenced, so a writer on a backwards-skewed wall clock cannot publish an
-/// SST whose ULID falls below the GC cutoff. Which could otherwise make a live
+/// SST whose ULID falls below the GC cutoff — which could otherwise make a live
 /// SST eligible for deletion and corrupt the database state.
 ///
-/// "Newly added" is the set of L0 view ULIDs present in `dirty` but absent from
+/// "Newly added" is the set of L0 SST ULIDs present in `dirty` but absent from
 /// `current`, so re-publishing existing L0s (an idempotent update) never fails
 /// the check. On violation, returns [`SlateDBError::InvalidClockTick`] with the
 /// watermark timestamp as `last_tick` and the offending ULID timestamp as
@@ -42,22 +50,23 @@ pub(crate) fn l0_ulid_cutoff(
         return Ok(());
     };
 
-    // L0 view ULIDs already committed in `current`; anything in `dirty` not
+    // Physical SST ULIDs already committed in `current`; anything in `dirty` not
     // in this set is a newly added L0 that must clear the watermark.
     let existing: HashSet<Ulid> = current
         .core
         .trees()
-        .flat_map(|tree| tree.l0.iter().map(|view| view.id))
+        .flat_map(|tree| tree.l0.iter().map(|view| view.sst.id.unwrap_compacted_id()))
         .collect();
 
     for view in dirty.core.trees().flat_map(|tree| tree.l0.iter()) {
-        if existing.contains(&view.id) {
+        let sst_id = view.sst.id.unwrap_compacted_id();
+        if existing.contains(&sst_id) {
             continue;
         }
-        if view.id.timestamp_ms() <= watermark.timestamp_ms() {
+        if sst_id.timestamp_ms() <= watermark.timestamp_ms() {
             return Err(Box::new(SlateDBError::InvalidClockTick {
                 last_tick: watermark.timestamp_ms() as i64,
-                next_tick: view.id.timestamp_ms() as i64,
+                next_tick: sst_id.timestamp_ms() as i64,
             }));
         }
     }
@@ -92,6 +101,21 @@ mod tests {
         let view_id = Ulid::from_parts(ts_ms, rand);
         let handle = SsTableHandle::new(
             SsTableId::Compacted(view_id),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo::default(),
+        );
+        SsTableView::new(view_id, handle)
+    }
+
+    /// An L0 view whose *view* ULID carries timestamp `view_ts_ms` but whose
+    /// underlying physical *SST* ULID carries a different timestamp `sst_ts_ms`.
+    /// This is the V2 case the invariant must handle: the SST is uploaded (and its
+    /// ULID minted) separately from the later-allocated view ID, so the check must
+    /// validate the SST ULID, not the view ULID.
+    fn l0_view_split(view_ts_ms: u64, sst_ts_ms: u64) -> SsTableView {
+        let view_id = Ulid::from_parts(view_ts_ms, 0);
+        let handle = SsTableHandle::new(
+            SsTableId::Compacted(Ulid::from_parts(sst_ts_ms, 0)),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo::default(),
         );
@@ -222,6 +246,29 @@ mod tests {
             SlateDBError::InvalidClockTick {
                 last_tick: 400,
                 next_tick: 350
+            }
+        ));
+    }
+
+    #[test]
+    fn check_uses_physical_sst_ulid_not_view_ulid() {
+        // Regression guard: the dirty L0's *SST* ULID (50) is below the watermark
+        // (100), but its *view* ULID (999) is above it. The check must key off the
+        // SST ULID — the ID the GC uses — and reject. Validating the view ULID
+        // would wrongly pass and leave a sub-cutoff SST eligible for deletion.
+        let current = manifest_with_root_l0(&[100]);
+
+        let mut dirty_core = ManifestCore::new();
+        Arc::make_mut(&mut dirty_core.tree).l0 = VecDeque::from(vec![l0_view_split(999, 50)]);
+        let dirty = Manifest::initial(dirty_core);
+
+        let err = l0_ulid_cutoff(&dirty, &current).unwrap_err();
+        let err = err.downcast::<SlateDBError>().unwrap();
+        assert!(matches!(
+            *err,
+            SlateDBError::InvalidClockTick {
+                last_tick: 100,
+                next_tick: 50
             }
         ));
     }

--- a/slatedb/src/manifest/invariants.rs
+++ b/slatedb/src/manifest/invariants.rs
@@ -1,0 +1,228 @@
+//! RFC-0025 "GC cutoff rule enforcement" invariants for the `.manifest` object.
+//!
+//! Each invariant is a plain [`Invariant<Manifest>`] predicate attached once to
+//! the [`StoredManifest`](super::store::StoredManifest)'s transactional object, so
+//! every manifest `update` path validates the dirty value against the current
+//! committed value before the CAS write.
+
+use std::collections::HashSet;
+use std::error::Error;
+use std::sync::Arc;
+
+use slatedb_txn_obj::Invariant;
+use ulid::Ulid;
+
+use crate::error::SlateDBError;
+use crate::manifest::Manifest;
+
+/// Invariant 1 — L0 ULID cutoff. Every L0 SST view newly added by `dirty` must
+/// carry a ULID timestamp "strictly" greater than the current manifest's L0
+/// watermark (`current.core.max_l0_ulid_timestamp_across_trees()`): the maximum
+/// ULID across all trees' live L0 views and `last_compacted_l0_sst_view_id`
+/// markers.
+///
+/// This guarantees a newly published L0 sorts above every L0 the GC may have
+/// already fenced, so a writer on a backwards-skewed wall clock cannot publish an
+/// SST whose ULID falls below the GC cutoff. Which could otherwise make a live
+/// SST eligible for deletion and corrupt the database state.
+///
+/// "Newly added" is the set of L0 view ULIDs present in `dirty` but absent from
+/// `current`, so re-publishing existing L0s (an idempotent update) never fails
+/// the check. On violation, returns [`SlateDBError::InvalidClockTick`] with the
+/// watermark timestamp as `last_tick` and the offending ULID timestamp as
+/// `next_tick`. The txn-obj layer wraps the boxed error in `CallbackError`, which
+/// maps back to `SlateDBError::InvalidClockTick` for the caller.
+#[allow(dead_code)]
+pub(crate) fn l0_ulid_cutoff(
+    dirty: &Manifest,
+    current: &Manifest,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let Some(watermark) = current.core.max_l0_ulid_timestamp_across_trees() else {
+        // Fresh manifest with no L0 history — nothing to compare against.
+        return Ok(());
+    };
+
+    // L0 view ULIDs already committed in `current`; anything in `dirty` not
+    // in this set is a newly added L0 that must clear the watermark.
+    let existing: HashSet<Ulid> = current
+        .core
+        .trees()
+        .flat_map(|tree| tree.l0.iter().map(|view| view.id))
+        .collect();
+
+    for view in dirty.core.trees().flat_map(|tree| tree.l0.iter()) {
+        if existing.contains(&view.id) {
+            continue;
+        }
+        if view.id.timestamp_ms() <= watermark.timestamp_ms() {
+            return Err(Box::new(SlateDBError::InvalidClockTick {
+                last_tick: watermark.timestamp_ms() as i64,
+                next_tick: view.id.timestamp_ms() as i64,
+            }));
+        }
+    }
+    Ok(())
+}
+
+/// The invariants enforced on every `.manifest` update (RFC-0025 GC cutoff
+/// rules). Will be attached once at [`StoredManifest`](super::store::StoredManifest)
+/// construction via `with_invariants` in the follow-up wiring PR.
+#[allow(dead_code)]
+pub(crate) fn manifest_invariants() -> Vec<Invariant<Manifest>> {
+    vec![Arc::new(l0_ulid_cutoff)]
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use ulid::Ulid;
+
+    use super::*;
+    use crate::db_state::{SsTableHandle, SsTableId, SsTableInfo, SsTableView};
+    use crate::format::sst::SST_FORMAT_VERSION_LATEST;
+    use crate::manifest::{LsmTreeState, ManifestCore, Segment};
+
+    /// An L0 view whose view ULID carries timestamp `ts_ms` and random component
+    /// `rand` — two views at the same `ts_ms` with different `rand` are distinct
+    /// ULIDs sharing a timestamp, which is exactly the same-millisecond collision
+    /// the invariant must reject.
+    fn l0_view(ts_ms: u64, rand: u128) -> SsTableView {
+        let view_id = Ulid::from_parts(ts_ms, rand);
+        let handle = SsTableHandle::new(
+            SsTableId::Compacted(view_id),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo::default(),
+        );
+        SsTableView::new(view_id, handle)
+    }
+
+    /// A manifest with the given L0 view timestamps on the root tree. Each view's
+    /// random component is its position, so equal timestamps still yield distinct
+    /// ULIDs.
+    fn manifest_with_root_l0(ts: &[u64]) -> Manifest {
+        let mut core = ManifestCore::new();
+        Arc::make_mut(&mut core.tree).l0 = ts
+            .iter()
+            .enumerate()
+            .map(|(i, &t)| l0_view(t, i as u128))
+            .collect();
+        Manifest::initial(core)
+    }
+
+    #[test]
+    fn fresh_current_accepts_any_dirty_l0() {
+        // No L0 history in `current` → no watermark → anything is allowed.
+        let current = manifest_with_root_l0(&[]);
+        let dirty = manifest_with_root_l0(&[1]);
+        l0_ulid_cutoff(&dirty, &current).unwrap();
+    }
+
+    #[test]
+    fn dirty_adds_l0_above_watermark_ok() {
+        let current = manifest_with_root_l0(&[100]);
+        let dirty = manifest_with_root_l0(&[100, 101]);
+        l0_ulid_cutoff(&dirty, &current).unwrap();
+    }
+
+    #[test]
+    fn dirty_adds_l0_below_watermark_errors() {
+        let current = manifest_with_root_l0(&[100]);
+        let dirty = manifest_with_root_l0(&[100, 50]);
+        let err = l0_ulid_cutoff(&dirty, &current).unwrap_err();
+        let err = err.downcast::<SlateDBError>().unwrap();
+        assert!(matches!(
+            *err,
+            SlateDBError::InvalidClockTick {
+                last_tick: 100,
+                next_tick: 50
+            }
+        ));
+    }
+
+    #[test]
+    fn dirty_adds_l0_equal_to_watermark_errors() {
+        // Strict `>`: a same-millisecond ULID is rejected (the same-ms collision
+        // the writer retry path resolves by minting past the ms boundary).
+        let current = manifest_with_root_l0(&[100]);
+        let dirty = manifest_with_root_l0(&[100, 100]);
+        let err = l0_ulid_cutoff(&dirty, &current).unwrap_err();
+        let err = err.downcast::<SlateDBError>().unwrap();
+        assert!(matches!(
+            *err,
+            SlateDBError::InvalidClockTick {
+                last_tick: 100,
+                next_tick: 100
+            }
+        ));
+    }
+
+    #[test]
+    fn reincluding_existing_l0_is_idempotent() {
+        // `dirty` re-publishes the same L0 set with no additions — even though
+        // those ULIDs equal the watermark, they are not "newly added" so the
+        // check passes.
+        let current = manifest_with_root_l0(&[100, 200]);
+        let dirty = manifest_with_root_l0(&[100, 200]);
+        l0_ulid_cutoff(&dirty, &current).unwrap();
+    }
+
+    #[test]
+    fn watermark_uses_last_compacted_marker() {
+        // The watermark must include `last_compacted_l0_sst_view_id`, not just
+        // live L0 views. Here the live L0 is empty but a compacted marker at 300
+        // exists, so a dirty L0 at 250 must be rejected.
+        let mut core = ManifestCore::new();
+        Arc::make_mut(&mut core.tree).last_compacted_l0_sst_view_id =
+            Some(Ulid::from_parts(300, 0));
+        let current = Manifest::initial(core);
+        let dirty = manifest_with_root_l0(&[250]);
+        let err = l0_ulid_cutoff(&dirty, &current).unwrap_err();
+        let err = err.downcast::<SlateDBError>().unwrap();
+        assert!(matches!(
+            *err,
+            SlateDBError::InvalidClockTick {
+                last_tick: 300,
+                next_tick: 250
+            }
+        ));
+    }
+
+    #[test]
+    fn watermark_is_max_across_all_trees() {
+        // A segment tree carries the highest watermark (400); a dirty L0 added to
+        // the root at 350 is below the cross-tree max and must be rejected.
+        let mut current_core = ManifestCore::new();
+        current_core.segments.push(Segment {
+            prefix: bytes::Bytes::from_static(b"seg"),
+            tree: Arc::new(LsmTreeState {
+                l0: VecDeque::from(vec![l0_view(400, 0)]),
+                ..LsmTreeState::default()
+            }),
+        });
+        let current = Manifest::initial(current_core);
+
+        let mut dirty_core = ManifestCore::new();
+        Arc::make_mut(&mut dirty_core.tree).l0 = VecDeque::from(vec![l0_view(350, 0)]);
+        // The segment's L0 is unchanged (same ULID), so it is not a new addition.
+        dirty_core.segments.push(Segment {
+            prefix: bytes::Bytes::from_static(b"seg"),
+            tree: Arc::new(LsmTreeState {
+                l0: VecDeque::from(vec![l0_view(400, 0)]),
+                ..LsmTreeState::default()
+            }),
+        });
+        let dirty = Manifest::initial(dirty_core);
+
+        let err = l0_ulid_cutoff(&dirty, &current).unwrap_err();
+        let err = err.downcast::<SlateDBError>().unwrap();
+        assert!(matches!(
+            *err,
+            SlateDBError::InvalidClockTick {
+                last_tick: 400,
+                next_tick: 350
+            }
+        ));
+    }
+}

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -516,9 +516,15 @@ impl ManifestCore {
     /// The max L0 ULID watermark across all trees (the unsegmented root and
     /// every segment), or `None` for a fresh manifest with no L0 history.
     ///
-    /// The fold covers each tree's live L0 view IDs and its
-    /// `last_compacted_l0_sst_view_id`, the same view ULID the GC uses for its
-    /// cutoff watermark. Returned as a `Ulid` (not a raw timestamp) so the L0
+    /// This mirrors the GC's `newest_l0_dt` (see
+    /// `garbage_collector::compacted_gc`) exactly, so the cutoff invariant
+    /// compares against the same watermark the GC uses to delete compacted SSTs.
+    /// Per tree: if the tree has active L0s, take the max of their physical SST
+    /// ULIDs (`view.sst.id.unwrap_compacted_id()` — the ID the GC keys its cutoff
+    /// and deletion filter off, *not* the separately-allocated `view.id`);
+    /// otherwise fall back to that tree's `last_compacted_l0_sst_view_id` marker.
+    /// The result is the max of those per-tree values across the unsegmented root
+    /// and every segment. Returned as a `Ulid` (not a raw timestamp) so the L0
     /// cutoff invariant ([`l0_ulid_cutoff`](crate::manifest::invariants::l0_ulid_cutoff))
     /// and the open-time skew check share one definition of the watermark.
     // TODO: Wire this into the manifest update path in a follow-up PR for
@@ -527,11 +533,17 @@ impl ManifestCore {
     #[allow(dead_code)]
     pub(crate) fn max_l0_ulid_timestamp_across_trees(&self) -> Option<ulid::Ulid> {
         self.trees()
-            .flat_map(|tree| {
-                tree.l0
-                    .iter()
-                    .map(|view| view.id)
-                    .chain(tree.last_compacted_l0_sst_view_id)
+            .filter_map(|tree| {
+                if tree.l0.is_empty() {
+                    // No active L0s: fall back to the last-compacted marker, as
+                    // the GC does. (The GC uses the *view* id here; mirror it.)
+                    tree.last_compacted_l0_sst_view_id
+                } else {
+                    tree.l0
+                        .iter()
+                        .map(|view| view.sst.id.unwrap_compacted_id())
+                        .max()
+                }
             })
             .max()
     }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 use slatedb_txn_obj::DirtyObject;
 use uuid::Uuid;
 
+pub(crate) mod invariants;
 pub(crate) mod store;
 
 pub use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
@@ -510,6 +511,29 @@ impl ManifestCore {
                 .ok()?;
             Some(Arc::make_mut(&mut self.segments[idx].tree))
         }
+    }
+
+    /// The max L0 ULID watermark across all trees (the unsegmented root and
+    /// every segment), or `None` for a fresh manifest with no L0 history.
+    ///
+    /// The fold covers each tree's live L0 view IDs and its
+    /// `last_compacted_l0_sst_view_id`, the same view ULID the GC uses for its
+    /// cutoff watermark. Returned as a `Ulid` (not a raw timestamp) so the L0
+    /// cutoff invariant ([`l0_ulid_cutoff`](crate::manifest::invariants::l0_ulid_cutoff))
+    /// and the open-time skew check share one definition of the watermark.
+    // TODO: Wire this into the manifest update path in a follow-up PR for
+    // https://github.com/slatedb/slatedb/issues/1707
+    // until then unit-tested via `l0_ulid_cutoff`.
+    #[allow(dead_code)]
+    pub(crate) fn max_l0_ulid_timestamp_across_trees(&self) -> Option<ulid::Ulid> {
+        self.trees()
+            .flat_map(|tree| {
+                tree.l0
+                    .iter()
+                    .map(|view| view.id)
+                    .chain(tree.last_compacted_l0_sst_view_id)
+            })
+            .max()
     }
 
     /// Iterate every SST view referenced by this manifest — L0 views and


### PR DESCRIPTION
## Summary

Implements Invariant 1 of RFC-0025 "GC cutoff rule enforcement" — the L0 ULID cutoff rule for .manifest (as standalone, unit-tested logic).

The rule guards against a writer on a backwards-skewed wall clock publishing an L0 SST whose ULID timestamp falls below the GC cutoff, which would make a live SST eligible for deletion and corrupt the database. The check is keyed off the physical SST ULID (`view.sst.id.unwrap_compacted_id()`)  - the same ID the GC uses for its cutoff and deletion filter, not the separately-allocated view.id, and its watermark mirrors the GC's `newest_l0_dt` logic exactly so the two never disagree.

This PR is logic-only: the rule is built and proven correct in isolation, but not yet wired into the manifest update path (it is dormant). See "Notes for Reviewers" for why, and what the follow-up looks like. Also added a TODO in code comments.

## Changes

- slatedb/src/manifest/mod.rs — add ManifestCore::max_l0_ulid_timestamp_across_trees() -> Option<Ulid>. Mirrors the GC's newest_l0_dt (garbage_collector::compacted_gc) exactly: per tree, if the tree has active L0s take the max of their physical SST ULIDs (view.sst.id.unwrap_compacted_id()), otherwise fall back to that tree's last_compacted_l0_sst_view_id marker; then take the max across the root tree and all segments. Returns Option<Ulid> (not a raw timestamp) so the invariant and the future open-time skew check share one watermark definition.
- slatedb/src/manifest/invariants.rs (new) — l0_ulid_cutoff (an Invariant<Manifest> predicate): every L0 SST newly added in dirty (i.e. whose physical SST ULID is absent from current) must have an SST ULID timestamp strictly greater than the watermark; on violation returns boxed SlateDBError::InvalidClockTick. Both the "newly added" set and the comparison use the physical SST ULID rather than view.id, so a backwards-skewed upload can't mint a sub-cutoff SST, receive a fresh view.id above the watermark, and slip through. Plus a manifest_invariants() builder for the eventual wiring.
- The three new pub(crate) items carry #[allow(dead_code)] with a comment pointing at the wiring follow-up, required because the rule has no runtime caller yet (the on-switch is deferred).
8 unit tests covering: add above watermark (ok), add below/equal watermark (InvalidClockTick), idempotent re-include, last_compacted_l0_sst_view_id marker fallback, cross-segment max, and a regression test (check_uses_physical_sst_ulid_not_view_ulid) asserting an L0 whose SST ULID is below the watermark but whose view ULID is above it is correctly rejected.

## Notes for Reviewers

- **Why logic-only.** The `Invariant<T>` mechanism (landed in #1741) only fires for invariants registered via `with_invariants(...)`. Wiring is a single line at `StoredManifest` construction — but flipping it reds **74 lib tests**, because strict `>` at millisecond granularity rejects same-millisecond L0 flushes. An audit of those 74 showed they need **two** distinct fixes that don't belong in this slice: the `MemtableFlusher` `InvalidClockTick` retry loop (RFC-0025 commit 6, fixes ~40 real-clock tests) **and** migrating ~27 frozen-`MockSystemClock` fixtures (retry can't help a clock that never advances). So enforcement lands as a focused follow-up: **wiring + retry loop + fixture migration, together.**
- **Strict `>` is required, not a tuning choice.** A same-millisecond ULID can sort *below* the watermark via its random low bits — exactly the GC-cutoff corruption being prevented — so `>=` would not be safe. The same-ms collision is instead resolved at the source by minting a fresh ULID past the ms boundary (the deferred retry loop).
- **Suggested review focus:** the watermark fold in `max_l0_ulid_timestamp_across_trees` (does it cover all trees + the compacted marker?) and the "newly added" set computation in `l0_ulid_cutoff` (idempotent re-publish must not fail).


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
