### PR TITLE
chore: use `SlateDBError` instead of `debug_assert`

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -6453,7 +6453,10 @@ mod tests {
             2
         );
 
-        let result = probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
+        let result = probe_table_store
+            .delete_ssts(&[SsTableId::Wal(1)])
+            .await
+            .unwrap();
         assert_eq!(result.deleted, 1);
         assert_eq!(result.failed, 0);
         gated_store.head_gate.release();
@@ -6518,7 +6521,10 @@ mod tests {
             .wait_for_arrivals(head_arrivals_before + 1)
             .await;
 
-        let result = probe_table_store.delete_ssts(&[SsTableId::Wal(1)]).await;
+        let result = probe_table_store
+            .delete_ssts(&[SsTableId::Wal(1)])
+            .await
+            .unwrap();
         assert_eq!(result.deleted, 1);
         assert_eq!(result.failed, 0);
         gated_store.head_gate.release();

--- a/slatedb/src/db_cache_manager.rs
+++ b/slatedb/src/db_cache_manager.rs
@@ -655,7 +655,7 @@ mod tests {
         flush_to_l0(&db).await;
         let sst_id = first_l0_sst_id(&db);
         db.evict_cached_sst(sst_id).await.expect("evict");
-        let result = db.inner.table_store.delete_ssts(&[sst_id]).await;
+        let result = db.inner.table_store.delete_ssts(&[sst_id]).await.unwrap();
         assert_eq!(result.deleted, 1);
         assert_eq!(result.failed, 0);
 

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -232,7 +232,7 @@ impl GcTask for CompactedGcTask {
                 sst_ids_to_delete,
             );
             let DeleteResult { deleted, failed } =
-                self.table_store.delete_ssts(&sst_ids_to_delete).await;
+                self.table_store.delete_ssts(&sst_ids_to_delete).await?;
             self.stats.gc_compacted_count.increment(deleted as u64);
             if failed > 0 {
                 log::warn!(

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -142,7 +142,7 @@ impl GcTask for WalGcTask {
                 sst_ids_to_delete,
             );
             let DeleteResult { deleted, failed } =
-                self.table_store.delete_ssts(&sst_ids_to_delete).await;
+                self.table_store.delete_ssts(&sst_ids_to_delete).await?;
             match self.mode {
                 WalGcMode::Regular => self.stats.gc_wal_count.increment(deleted as u64),
                 WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(deleted as u64),

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -441,7 +441,8 @@ impl TableStore {
     /// All `ids` in one call must be of the same kind (all
     /// [`SsTableId::Compacted`] or all [`SsTableId::Wal`]) so they route to the
     /// same store; the GC `collect` functions that call this always satisfy
-    /// that. Forwarding the whole batch lets backends that support bulk delete
+    /// that, and a mixed batch returns [`SlateDBError::InvalidDeletion`].
+    /// Forwarding the whole batch lets backends that support bulk delete
     /// (S3, Azure) collapse thousands of deletes into a handful of API calls.
     ///
     /// `NotFound` is treated as success — the object is already gone, so the
@@ -451,17 +452,20 @@ impl TableStore {
     /// The whole stream is drained even when some deletes fail, so a per-path
     /// failure is recorded in [`DeleteResult::failed`] rather than aborting the
     /// batch.
-    pub(crate) async fn delete_ssts(&self, ids: &[SsTableId]) -> DeleteResult {
+    pub(crate) async fn delete_ssts(
+        &self,
+        ids: &[SsTableId],
+    ) -> Result<DeleteResult, SlateDBError> {
         if ids.is_empty() {
-            return DeleteResult::default();
+            return Ok(DeleteResult::default());
         }
-        // ids in a single call are all the same kind, so they route to one store.
-        debug_assert!(
-            ids.iter()
-                .all(|id| std::mem::discriminant(id) == std::mem::discriminant(&ids[0])),
-            "all SSTs in a `delete_ssts` batch must be the same kind (all Wal or all \
-             Compacted)"
-        );
+        // ids in a single call must all be the same kind, so they route to one store.
+        if ids
+            .iter()
+            .any(|id| std::mem::discriminant(id) != std::mem::discriminant(&ids[0]))
+        {
+            return Err(SlateDBError::InvalidDeletion);
+        }
         let object_store = self.object_stores.store_for(&ids[0]);
         let paths: Vec<Path> = ids.iter().map(|id| self.path(id)).collect();
         debug!("deleting {} SSTs", paths.len());
@@ -481,7 +485,7 @@ impl TableStore {
                 }
             }
         }
-        result
+        Ok(result)
     }
 
     /// Reads metadata for a specific SST object (WAL or compacted).
@@ -2285,7 +2289,7 @@ mod tests {
         let ssts = ts.list_compacted_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        let result = ts.delete_ssts(&[id1]).await;
+        let result = ts.delete_ssts(&[id1]).await.unwrap();
         assert_eq!(result.deleted, 1);
         assert_eq!(result.failed, 0);
 
@@ -2322,14 +2326,31 @@ mod tests {
         }
 
         // All three exist -> all counted as deleted, none failed.
-        let result = ts.delete_ssts(&ids).await;
+        let result = ts.delete_ssts(&ids).await.unwrap();
         assert_eq!(result.deleted, 3);
         assert_eq!(result.failed, 0);
         assert_eq!(count_ssts_in(&main_store).await, 0);
 
         // Empty batch is a no-op with zeroed counts.
-        let result = ts.delete_ssts(&[]).await;
+        let result = ts.delete_ssts(&[]).await.unwrap();
         assert_eq!(result, DeleteResult::default());
+    }
+
+    #[tokio::test]
+    async fn test_delete_ssts_mixed_kinds_errors() {
+        // A batch mixing Wal and Compacted ids would route to two different
+        // stores, so it must be rejected rather than partially deleted.
+        let main_store = make_store();
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(main_store.clone(), Some(make_store())),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+        ));
+
+        let ids = vec![SsTableId::Compacted(ulid::Ulid::new()), SsTableId::Wal(1)];
+        let err = ts.delete_ssts(&ids).await.unwrap_err();
+        assert!(matches!(err, error::SlateDBError::InvalidDeletion));
     }
 
     #[tokio::test]
@@ -2350,7 +2371,7 @@ mod tests {
             .map(|_| SsTableId::Compacted(ulid::Ulid::new()))
             .collect();
 
-        let result = ts.delete_ssts(&ids).await;
+        let result = ts.delete_ssts(&ids).await.unwrap();
         assert_eq!(
             result,
             DeleteResult {
@@ -2400,7 +2421,7 @@ mod tests {
         let ssts = ts.list_wal_ssts(..).await.unwrap();
         assert_eq!(ssts.len(), 2);
 
-        let result = ts.delete_ssts(&[id1]).await;
+        let result = ts.delete_ssts(&[id1]).await.unwrap();
         assert_eq!(result.deleted, 1);
         assert_eq!(result.failed, 0);
 


### PR DESCRIPTION
## Summary
`TableStore::delete_ssts` previously returned a bare `DeleteResult` and relied on a `debug_assert!` to guard the precondition that all ids in a batch are the same kind (all `Wal` or all `Compacted`) so they route to a single object store. Since `debug_assert!` is compiled out in release builds, a mixed-kind batch would silently route by `ids[0]`'s kind instead of failing. Per review feedback, this restores the `Result` return type so the precondition violation surfaces as a real error.

## Changes

- `delete_ssts` now returns `Result<DeleteResult, SlateDBError>`, returning `SlateDBError::InvalidDeletion` on a mixed-kind batch instead of `debug_assert!`
- Propagate the error with `?` in the WAL/compacted GC callers; 
- Added a test covering the mixed-kind error path

## Notes for Reviewers

None

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
