### PR TITLE
Add HashMap support to WriteBatch

### DIFF
--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -367,7 +367,13 @@ fn bench_write_batch(c: &mut Criterion) {
 
     group.bench_function("extract_entries/no_merges", |b| {
         b.to_async(&runtime).iter_batched(
-            || batch_without_merges.clone(),
+            || {
+                let mut batch = batch_without_merges.clone();
+                if !write_batch_benches::is_sorted(&batch) {
+                    write_batch_benches::sort(&mut batch);
+                }
+                batch
+            },
             |batch| async move {
                 black_box(
                     write_batch_benches::extract_entries(&batch, 100, 1_000, None, None, None)
@@ -389,7 +395,13 @@ fn bench_write_batch(c: &mut Criterion) {
             batch_with_merges,
             |b, batch_with_merges| {
                 b.to_async(&runtime).iter_batched(
-                    || batch_with_merges.clone(),
+                    || {
+                        let mut batch = (*batch_with_merges).clone();
+                        if !write_batch_benches::is_sorted(&batch) {
+                            write_batch_benches::sort(&mut batch);
+                        }
+                        batch
+                    },
                     |batch| async move {
                         black_box(
                             write_batch_benches::extract_entries(

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -6,6 +6,9 @@
 use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
+use rand::seq::SliceRandom;
+use rand::SeedableRng;
+use rand_xoshiro::Xoroshiro128PlusPlus;
 use slatedb::config::{MergeOptions, PutOptions, Ttl};
 use slatedb::{write_batch_benches, MergeOperator, MergeOperatorError, WriteBatch};
 use std::sync::{Arc, OnceLock};
@@ -14,6 +17,8 @@ use tokio::runtime::Runtime;
 
 const VALUE_SIZE: usize = 128;
 const EXTRACT_ENTRY_COUNT: usize = 1_024;
+const LOAD_BATCH_KEY_COUNTS: &[usize] = &[1_000, 10_000, 100_000];
+const LOAD_BATCH_SHUFFLE_SEED: u64 = 0x5EED_5EED;
 const MERGE_BATCH_SCENARIOS: &[(usize, usize)] = &[
     // Each scenario is (key_count, merges_per_key).
     (256, 3),
@@ -123,11 +128,26 @@ fn make_batch_with_repeated_overwrites() -> WriteBatch {
     batch
 }
 
+fn make_load_batch_put_entries(key_count: usize) -> Vec<(Bytes, Bytes)> {
+    let mut indices: Vec<_> = (0..key_count).collect();
+    let mut rng = Xoroshiro128PlusPlus::seed_from_u64(LOAD_BATCH_SHUFFLE_SEED ^ key_count as u64);
+    indices.shuffle(&mut rng);
+    indices
+        .into_iter()
+        .map(|index| (key(index), value(index)))
+        .collect()
+}
+
 fn bench_write_batch(c: &mut Criterion) {
     let runtime = Runtime::new().expect("failed to create runtime");
     let put_options = put_options();
     let merge_options = merge_options();
     let batch_without_merges = make_batch_without_merges();
+    let load_batch_put_entries: Vec<_> = LOAD_BATCH_KEY_COUNTS
+        .iter()
+        .copied()
+        .map(|key_count| (key_count, make_load_batch_put_entries(key_count)))
+        .collect();
     let batches_with_merges: Vec<_> = MERGE_BATCH_SCENARIOS
         .iter()
         .copied()
@@ -162,6 +182,26 @@ fn bench_write_batch(c: &mut Criterion) {
             BatchSize::SmallInput,
         );
     });
+
+    for (key_count, put_entries) in &load_batch_put_entries {
+        let key_count = *key_count;
+        group.bench_with_input(
+            BenchmarkId::new("load_batch/puts", format!("{key_count}_keys")),
+            put_entries,
+            |b, put_entries| {
+                b.iter_batched(
+                    WriteBatch::new,
+                    |mut batch| {
+                        for (key, value) in put_entries {
+                            batch.put_bytes_with_options(key.clone(), value.clone(), &put_options);
+                        }
+                        black_box(batch)
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
 
     group.bench_function("put_bytes_with_options/new_key_populated", |b| {
         b.iter_batched(

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -9,6 +9,7 @@ use pprof::criterion::{Output, PProfProfiler};
 use slatedb::config::{MergeOptions, PutOptions, Ttl};
 use slatedb::{write_batch_benches, MergeOperator, MergeOperatorError, WriteBatch};
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 use tokio::runtime::Runtime;
 
 const VALUE_SIZE: usize = 128;
@@ -142,6 +143,8 @@ fn bench_write_batch(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("write_batch");
     group.sample_size(1_000);
+    group.warm_up_time(Duration::from_secs(5));
+    group.measurement_time(Duration::from_secs(10));
 
     group.bench_function("put_bytes_with_options/empty_batch", |b| {
         b.iter_batched(

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -36,6 +36,7 @@ impl Default for WriteBatchMap {
 }
 
 impl WriteBatchMap {
+    #[inline]
     pub(crate) fn len(&self) -> usize {
         match self {
             Self::Hashed(map) => map.len(),
@@ -43,6 +44,7 @@ impl WriteBatchMap {
         }
     }
 
+    #[inline]
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -55,6 +57,7 @@ impl WriteBatchMap {
         }
     }
 
+    #[inline]
     fn get_mut(&mut self, key: &[u8]) -> Option<&mut WriteOpList> {
         match self {
             Self::Hashed(map) => map.get_mut(key),
@@ -62,6 +65,7 @@ impl WriteBatchMap {
         }
     }
 
+    #[inline]
     fn insert(&mut self, key: Bytes, ops: WriteOpList) -> Option<WriteOpList> {
         match self {
             Self::Hashed(map) => map.insert(key, ops),
@@ -69,6 +73,7 @@ impl WriteBatchMap {
         }
     }
 
+    #[inline]
     fn maybe_use_hashmap(&mut self) {
         if let Self::Sorted(map) = self {
             if map.len() >= MIN_HASHMAP_KEY_COUNT {
@@ -78,7 +83,13 @@ impl WriteBatchMap {
         }
     }
 
-    fn sorted(&mut self) {
+    #[inline]
+    fn is_sorted(&self) -> bool {
+        matches!(self, Self::Sorted(_))
+    }
+
+    #[inline]
+    fn sort(&mut self) {
         if let Self::Hashed(map) = self {
             let map = std::mem::take(map);
             *self = Self::Sorted(map.into_iter().collect());
@@ -122,6 +133,7 @@ pub struct WriteBatch {
     pub(crate) op_count: usize,
     pub(crate) txn_id: Option<Uuid>,
     pub(crate) has_merge_ops: bool,
+    force_sorted: bool,
 }
 
 impl Default for WriteBatch {
@@ -164,6 +176,7 @@ impl std::fmt::Debug for WriteOp {
 
 impl WriteOp {
     /// Convert WriteOp to RowEntry for queries
+    #[inline]
     pub(crate) fn to_row_entry(
         &self,
         key: &Bytes,
@@ -209,6 +222,7 @@ impl WriteBatch {
             op_count: 0,
             txn_id: None,
             has_merge_ops: false,
+            force_sorted: false,
         }
     }
 
@@ -218,9 +232,11 @@ impl WriteBatch {
             op_count: self.op_count,
             txn_id: Some(txn_id),
             has_merge_ops: self.has_merge_ops,
+            force_sorted: self.force_sorted,
         }
     }
 
+    #[inline]
     fn assert_kv<K, V>(&self, key: &K, value: &V)
     where
         K: AsRef<[u8]>,
@@ -306,7 +322,7 @@ impl WriteBatch {
         if let Some(previous) = previous {
             self.op_count -= previous.len();
         } else {
-            self.ops.maybe_use_hashmap();
+            self.maybe_use_hashmap();
         }
     }
 
@@ -334,7 +350,7 @@ impl WriteBatch {
             ops.push(op);
         } else {
             self.ops.insert(Bytes::copy_from_slice(key), smallvec![op]);
-            self.ops.maybe_use_hashmap();
+            self.maybe_use_hashmap();
         }
 
         self.has_merge_ops = true;
@@ -354,22 +370,26 @@ impl WriteBatch {
         if let Some(previous) = previous {
             self.op_count -= previous.len();
         } else {
-            self.ops.maybe_use_hashmap();
+            self.maybe_use_hashmap();
         }
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.ops.is_empty()
     }
 
+    #[inline]
     pub(crate) fn has_merge_ops(&self) -> bool {
         self.has_merge_ops
     }
 
+    #[inline]
     pub(crate) fn op_count(&self) -> usize {
         self.op_count
     }
 
+    #[inline]
     pub(crate) fn keys(&self) -> HashSet<Bytes> {
         match &self.ops {
             WriteBatchMap::Hashed(map) => map.keys().cloned().collect(),
@@ -377,8 +397,24 @@ impl WriteBatch {
         }
     }
 
-    pub(crate) fn sorted(&mut self) {
-        self.ops.sorted();
+    #[inline]
+    pub(crate) fn sort(&mut self) {
+        self.force_sorted = true;
+        if !self.is_sorted() {
+            self.ops.sort();
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_sorted(&self) -> bool {
+        self.ops.is_sorted()
+    }
+
+    #[inline]
+    fn maybe_use_hashmap(&mut self) {
+        if !self.force_sorted {
+            self.ops.maybe_use_hashmap();
+        }
     }
 
     /// Converts a WriteBatch into a vector of RowEntry objects with
@@ -473,6 +509,15 @@ pub mod benches {
 
     pub fn keys(batch: &WriteBatch) -> HashSet<Bytes> {
         batch.keys()
+    }
+
+    #[inline]
+    pub fn sort(batch: &mut WriteBatch) {
+        batch.sort();
+    }
+
+    pub fn is_sorted(batch: &WriteBatch) -> bool {
+        batch.is_sorted()
     }
 
     pub async fn extract_entries(
@@ -721,6 +766,7 @@ mod tests {
     fn should_default_to_sorted_map() {
         let batch = WriteBatch::new();
 
+        assert!(batch.is_sorted());
         assert!(matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.is_empty()));
     }
 
@@ -747,6 +793,7 @@ mod tests {
         assert!(
             matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == MIN_HASHMAP_KEY_COUNT - 1)
         );
+        assert!(batch.is_sorted());
 
         batch.put_bytes(
             numbered_key(MIN_HASHMAP_KEY_COUNT - 1),
@@ -756,6 +803,21 @@ mod tests {
         assert!(
             matches!(&batch.ops, WriteBatchMap::Hashed(map) if map.len() == MIN_HASHMAP_KEY_COUNT)
         );
+        assert!(!batch.is_sorted());
+        assert_eq!(batch.op_count(), MIN_HASHMAP_KEY_COUNT);
+    }
+
+    #[test]
+    fn should_not_switch_to_hashmap_after_sort_is_called() {
+        let mut batch = WriteBatch::new();
+
+        batch.sort();
+        put_numbered_keys(&mut batch, MIN_HASHMAP_KEY_COUNT);
+
+        assert!(
+            matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == MIN_HASHMAP_KEY_COUNT)
+        );
+        assert!(batch.is_sorted());
         assert_eq!(batch.op_count(), MIN_HASHMAP_KEY_COUNT);
     }
 
@@ -780,10 +842,15 @@ mod tests {
         put_numbered_keys(&mut batch, MIN_HASHMAP_KEY_COUNT);
         assert!(matches!(&batch.ops, WriteBatchMap::Hashed(_)));
 
-        batch.sorted();
+        batch.sort();
+        batch.put_bytes(
+            numbered_key(MIN_HASHMAP_KEY_COUNT),
+            numbered_value(MIN_HASHMAP_KEY_COUNT),
+        );
 
+        assert!(batch.is_sorted());
         assert!(
-            matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == MIN_HASHMAP_KEY_COUNT)
+            matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == MIN_HASHMAP_KEY_COUNT + 1)
         );
         match only_op(&batch, numbered_key(7).as_ref()) {
             WriteOp::Put(value, _) => assert_eq!(value, &numbered_value(7)),

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -4,6 +4,7 @@
 //! collection of write operations (puts and/or deletes) that are applied
 //! atomically to the database.
 
+use crate::bytes_range::BytesRange;
 use crate::config::{MergeOptions, PutOptions};
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator};
@@ -13,10 +14,77 @@ use crate::types::{RowEntry, ValueDeletable};
 use async_trait::async_trait;
 use bytes::Bytes;
 use smallvec::{smallvec, SmallVec};
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::iter::Peekable;
 use std::ops::RangeBounds;
 use uuid::Uuid;
+
+pub(crate) type WriteOpList = SmallVec<[WriteOp; 1]>;
+
+pub(crate) const MIN_HASHMAP_KEY_COUNT: usize = 1024;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum WriteBatchMap {
+    Hashed(HashMap<Bytes, WriteOpList>),
+    Sorted(BTreeMap<Bytes, WriteOpList>),
+}
+
+impl Default for WriteBatchMap {
+    fn default() -> Self {
+        Self::Sorted(BTreeMap::new())
+    }
+}
+
+impl WriteBatchMap {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Hashed(map) => map.len(),
+            Self::Sorted(map) => map.len(),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[cfg(test)]
+    fn get(&self, key: &[u8]) -> Option<&WriteOpList> {
+        match self {
+            Self::Hashed(map) => map.get(key),
+            Self::Sorted(map) => map.get(key),
+        }
+    }
+
+    fn get_mut(&mut self, key: &[u8]) -> Option<&mut WriteOpList> {
+        match self {
+            Self::Hashed(map) => map.get_mut(key),
+            Self::Sorted(map) => map.get_mut(key),
+        }
+    }
+
+    fn insert(&mut self, key: Bytes, ops: WriteOpList) -> Option<WriteOpList> {
+        match self {
+            Self::Hashed(map) => map.insert(key, ops),
+            Self::Sorted(map) => map.insert(key, ops),
+        }
+    }
+
+    fn maybe_use_hashmap(&mut self) {
+        if let Self::Sorted(map) = self {
+            if map.len() >= MIN_HASHMAP_KEY_COUNT {
+                let map = std::mem::take(map);
+                *self = Self::Hashed(map.into_iter().collect());
+            }
+        }
+    }
+
+    fn sorted(&mut self) {
+        if let Self::Hashed(map) = self {
+            let map = std::mem::take(map);
+            *self = Self::Sorted(map.into_iter().collect());
+        }
+    }
+}
 
 /// A batch of write operations (puts, deletes, and merges). All operations in
 /// the batch are applied atomically to the database. Put and delete operations
@@ -50,7 +118,7 @@ use uuid::Uuid;
 /// means that WAL SSTs could get large if there's a large batch write.
 #[derive(Clone, Debug)]
 pub struct WriteBatch {
-    pub(crate) ops: BTreeMap<Bytes, SmallVec<[WriteOp; 1]>>,
+    pub(crate) ops: WriteBatchMap,
     pub(crate) op_count: usize,
     pub(crate) txn_id: Option<Uuid>,
     pub(crate) has_merge_ops: bool,
@@ -137,7 +205,7 @@ impl WriteOp {
 impl WriteBatch {
     pub fn new() -> Self {
         WriteBatch {
-            ops: BTreeMap::new(),
+            ops: WriteBatchMap::default(),
             op_count: 0,
             txn_id: None,
             has_merge_ops: false,
@@ -237,6 +305,8 @@ impl WriteBatch {
         self.op_count += 1;
         if let Some(previous) = previous {
             self.op_count -= previous.len();
+        } else {
+            self.ops.maybe_use_hashmap();
         }
     }
 
@@ -264,6 +334,7 @@ impl WriteBatch {
             ops.push(op);
         } else {
             self.ops.insert(Bytes::copy_from_slice(key), smallvec![op]);
+            self.ops.maybe_use_hashmap();
         }
 
         self.has_merge_ops = true;
@@ -282,6 +353,8 @@ impl WriteBatch {
         self.op_count += 1;
         if let Some(previous) = previous {
             self.op_count -= previous.len();
+        } else {
+            self.ops.maybe_use_hashmap();
         }
     }
 
@@ -298,7 +371,14 @@ impl WriteBatch {
     }
 
     pub(crate) fn keys(&self) -> HashSet<Bytes> {
-        self.ops.keys().cloned().collect()
+        match &self.ops {
+            WriteBatchMap::Hashed(map) => map.keys().cloned().collect(),
+            WriteBatchMap::Sorted(map) => map.keys().cloned().collect(),
+        }
+    }
+
+    pub(crate) fn sorted(&mut self) {
+        self.ops.sorted();
     }
 
     /// Converts a WriteBatch into a vector of RowEntry objects with
@@ -325,14 +405,14 @@ impl WriteBatch {
         extractor: Option<&dyn PrefixExtractor>,
     ) -> Result<(Vec<RowEntry>, BTreeSet<Bytes>, u64), SlateDBError> {
         let mut entries_bytes: u64 = 0;
-        let mut it: Box<dyn RowEntryIterator> = Box::new(WriteBatchIterator::new(
+        let mut it: Box<dyn RowEntryIterator> = Box::new(WriteBatchIterator::new_sorted(
             self,
-            ..,
+            BytesRange::from(..),
             IterationOrder::Ascending,
             seq,
             Some(now),
             default_ttl,
-        ));
+        )?);
         if self.has_merge_ops() {
             if let Some(ref merge_operator) = merger {
                 it = Box::new(MergeOperatorIterator::new(
@@ -413,7 +493,7 @@ pub mod benches {
 /// Iterator over `WriteBatch` entries.
 pub(crate) struct WriteBatchIterator {
     iter: Peekable<Box<dyn Iterator<Item = RowEntry> + Send + Sync>>,
-    ordering: IterationOrder,
+    ordering: Option<IterationOrder>,
 }
 
 impl WriteBatchIterator {
@@ -440,25 +520,55 @@ impl WriteBatchIterator {
         op.to_row_entry(key, seq, now, expire_ts)
     }
 
-    pub(crate) fn new(
+    pub(crate) fn new_sorted(
         batch: &WriteBatch,
         range: impl RangeBounds<Bytes>,
         ordering: IterationOrder,
         seq: u64,
         now: Option<i64>,
         default_ttl: Option<u64>,
+    ) -> Result<Self, SlateDBError> {
+        let range = BytesRange::from(range);
+        let entries: Vec<RowEntry> = match &batch.ops {
+            WriteBatchMap::Sorted(map) => match ordering {
+                IterationOrder::Ascending => map
+                    .range(range)
+                    .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
+                    .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
+                    .collect(),
+                IterationOrder::Descending => map
+                    .range(range)
+                    .rev()
+                    .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
+                    .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
+                    .collect(),
+            },
+            WriteBatchMap::Hashed(_) => return Err(SlateDBError::UnsortedWriteBatch),
+        };
+
+        let iter: Box<dyn Iterator<Item = RowEntry> + Send + Sync> = Box::new(entries.into_iter());
+
+        Ok(Self {
+            iter: iter.peekable(),
+            ordering: Some(ordering),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new_unsorted(
+        batch: &WriteBatch,
+        seq: u64,
+        now: Option<i64>,
+        default_ttl: Option<u64>,
     ) -> Self {
-        let entries: Vec<RowEntry> = match ordering {
-            IterationOrder::Ascending => batch
-                .ops
-                .range(range)
+        let entries: Vec<RowEntry> = match &batch.ops {
+            WriteBatchMap::Hashed(map) => map
+                .iter()
                 .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
                 .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
                 .collect(),
-            IterationOrder::Descending => batch
-                .ops
-                .range(range)
-                .rev()
+            WriteBatchMap::Sorted(map) => map
+                .iter()
                 .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
                 .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
                 .collect(),
@@ -468,7 +578,7 @@ impl WriteBatchIterator {
 
         Self {
             iter: iter.peekable(),
-            ordering,
+            ordering: None,
         }
     }
 }
@@ -484,8 +594,12 @@ impl RowEntryIterator for WriteBatchIterator {
     }
 
     async fn seek(&mut self, next_key: &[u8]) -> Result<(), crate::error::SlateDBError> {
+        let Some(ordering) = self.ordering else {
+            return Err(SlateDBError::UnsortedWriteBatch);
+        };
+
         while let Some(entry) = self.iter.peek() {
-            if match self.ordering {
+            if match ordering {
                 IterationOrder::Ascending => entry.key.as_ref() < next_key,
                 IterationOrder::Descending => entry.key.as_ref() > next_key,
             } {
@@ -524,6 +638,20 @@ mod tests {
         let ops = ops_for_key(batch, key);
         assert_eq!(ops.len(), 1);
         &ops[0]
+    }
+
+    fn numbered_key(i: usize) -> Bytes {
+        Bytes::from(format!("key-{i:04}").into_bytes())
+    }
+
+    fn numbered_value(i: usize) -> Bytes {
+        Bytes::from(format!("value-{i:04}").into_bytes())
+    }
+
+    fn put_numbered_keys(batch: &mut WriteBatch, count: usize) {
+        for i in 0..count {
+            batch.put_bytes(numbered_key(i), numbered_value(i));
+        }
     }
 
     #[rstest]
@@ -583,7 +711,17 @@ mod tests {
                 );
             }
         }
-        assert_eq!(batch.ops, expected_ops);
+        match &batch.ops {
+            WriteBatchMap::Sorted(ops) => assert_eq!(ops, &expected_ops),
+            WriteBatchMap::Hashed(_) => panic!("expected sorted map"),
+        }
+    }
+
+    #[test]
+    fn should_default_to_sorted_map() {
+        let batch = WriteBatch::new();
+
+        assert!(matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.is_empty()));
     }
 
     #[test]
@@ -601,6 +739,58 @@ mod tests {
         }
     }
 
+    #[test]
+    fn should_switch_to_hashmap_when_new_key_count_reaches_threshold() {
+        let mut batch = WriteBatch::new();
+        put_numbered_keys(&mut batch, MIN_HASHMAP_KEY_COUNT - 1);
+
+        assert!(
+            matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == MIN_HASHMAP_KEY_COUNT - 1)
+        );
+
+        batch.put_bytes(
+            numbered_key(MIN_HASHMAP_KEY_COUNT - 1),
+            numbered_value(MIN_HASHMAP_KEY_COUNT - 1),
+        );
+
+        assert!(
+            matches!(&batch.ops, WriteBatchMap::Hashed(map) if map.len() == MIN_HASHMAP_KEY_COUNT)
+        );
+        assert_eq!(batch.op_count(), MIN_HASHMAP_KEY_COUNT);
+    }
+
+    #[test]
+    fn should_not_switch_to_hashmap_for_overwrites() {
+        let mut batch = WriteBatch::new();
+        for i in 0..MIN_HASHMAP_KEY_COUNT {
+            batch.put_bytes(Bytes::from_static(b"key"), numbered_value(i));
+        }
+
+        assert!(matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == 1));
+        assert_eq!(batch.op_count(), 1);
+        match only_op(&batch, b"key") {
+            WriteOp::Put(value, _) => assert_eq!(value, &numbered_value(MIN_HASHMAP_KEY_COUNT - 1)),
+            _ => panic!("Expected Put operation"),
+        }
+    }
+
+    #[test]
+    fn should_force_hashed_batch_back_to_sorted() {
+        let mut batch = WriteBatch::new();
+        put_numbered_keys(&mut batch, MIN_HASHMAP_KEY_COUNT);
+        assert!(matches!(&batch.ops, WriteBatchMap::Hashed(_)));
+
+        batch.sorted();
+
+        assert!(
+            matches!(&batch.ops, WriteBatchMap::Sorted(map) if map.len() == MIN_HASHMAP_KEY_COUNT)
+        );
+        match only_op(&batch, numbered_key(7).as_ref()) {
+            WriteOp::Put(value, _) => assert_eq!(value, &numbered_value(7)),
+            _ => panic!("Expected Put operation"),
+        }
+    }
+
     #[tokio::test]
     async fn test_writebatch_iterator_basic() {
         let mut batch = WriteBatch::new();
@@ -609,8 +799,15 @@ mod tests {
         batch.put(b"key2", b"value2");
         batch.delete(b"key4");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         let expected = vec![
             RowEntry::new_value(b"key1", b"value1", u64::MAX),
@@ -629,6 +826,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_error_creating_sorted_iterator_over_hashed_map() {
+        let mut batch = WriteBatch::new();
+        for i in (0..MIN_HASHMAP_KEY_COUNT).rev() {
+            batch.put_bytes(numbered_key(i), numbered_value(i));
+        }
+        assert!(matches!(&batch.ops, WriteBatchMap::Hashed(_)));
+
+        let result = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(numbered_key(998)..=numbered_key(1000)),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        );
+
+        match result {
+            Err(SlateDBError::UnsortedWriteBatch) => {}
+            Err(other) => panic!("expected UnsortedWriteBatch, got {other:?}"),
+            Ok(_) => panic!("expected sorted iterator construction to fail"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_error_when_seeking_unsorted_iterator() {
+        let mut batch = WriteBatch::new();
+        batch.put(b"key1", b"value1");
+
+        let mut iter = WriteBatchIterator::new_unsorted(&batch, u64::MAX, None, None);
+        let err = iter.seek(b"key1").await.unwrap_err();
+
+        assert!(matches!(err, SlateDBError::UnsortedWriteBatch));
+    }
+
+    #[tokio::test]
     async fn test_writebatch_iterator_range() {
         let mut batch = WriteBatch::new();
         batch.put(b"key1", b"value1");
@@ -636,14 +868,15 @@ mod tests {
         batch.put(b"key5", b"value5");
 
         // Test range [key2, key4)
-        let mut iter = WriteBatchIterator::new(
+        let mut iter = WriteBatchIterator::new_sorted(
             &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
             u64::MAX,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         let expected = vec![RowEntry::new_value(b"key3", b"value3", u64::MAX)];
 
@@ -657,8 +890,15 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key2", b"value2");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Descending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Descending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         let expected = vec![
             RowEntry::new_value(b"key3", b"value3", u64::MAX),
@@ -676,8 +916,15 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key5", b"value5");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Seek to key3
         iter.seek(b"key3").await.unwrap();
@@ -698,8 +945,15 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.put(b"key5", b"value5");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Descending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Descending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Seek to key3 (in descending, we want keys <= key3)
         iter.seek(b"key3").await.unwrap();
@@ -716,8 +970,15 @@ mod tests {
     #[tokio::test]
     async fn test_writebatch_iterator_empty_batch() {
         let batch = WriteBatch::new();
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         let result = iter.next().await.unwrap();
         assert!(result.is_none());
@@ -729,8 +990,15 @@ mod tests {
         batch.put(b"key1", b"value1");
         batch.put(b"key3", b"value3");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Seek to key2 (doesn't exist)
         iter.seek(b"key2").await.unwrap();
@@ -752,8 +1020,15 @@ mod tests {
         batch.put(b"key1", b"value1");
         batch.put(b"key3", b"value3");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Seek beyond maximum key
         iter.seek(b"key9").await.unwrap();
@@ -771,8 +1046,15 @@ mod tests {
         batch.put(b"key3", b"value3");
         batch.delete(b"key4");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         let expected = vec![
             RowEntry::new_value(b"key1", b"value1", u64::MAX),
@@ -802,8 +1084,15 @@ mod tests {
         batch.put(b"key2", b"value2");
         batch.put(b"key3", b"value3");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Seek before first key
         iter.seek(b"key1").await.unwrap();
@@ -825,14 +1114,15 @@ mod tests {
         batch.put(b"key5", b"value5");
 
         // Range [key2, key4) should include tombstones
-        let mut iter = WriteBatchIterator::new(
+        let mut iter = WriteBatchIterator::new_sorted(
             &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
             u64::MAX,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         let expected = vec![
             RowEntry::new(
@@ -936,9 +1226,9 @@ mod tests {
         assert_eq!(batch.op_count(), 3);
 
         // And: all keys should exist
-        assert!(batch.ops.contains_key(&Bytes::from_static(b"key1")));
-        assert!(batch.ops.contains_key(&Bytes::from_static(b"key2")));
-        assert!(batch.ops.contains_key(&Bytes::from_static(b"key3")));
+        assert!(batch.ops.get(&Bytes::from_static(b"key1")).is_some());
+        assert!(batch.ops.get(&Bytes::from_static(b"key2")).is_some());
+        assert!(batch.ops.get(&Bytes::from_static(b"key3")).is_some());
     }
 
     #[test]
@@ -1112,8 +1402,15 @@ mod tests {
         batch.delete(b"key3");
 
         // When: creating an iterator
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Then: the iterator should return all operations in order
         let expected = vec![
@@ -1153,8 +1450,15 @@ mod tests {
         batch.merge(b"key1", b"merge3");
 
         // When: creating an iterator
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Then: the iterator should return all merge operations
         let expected = vec![
@@ -1193,8 +1497,15 @@ mod tests {
         batch.merge(b"key1", b"merge3");
 
         // When: creating a descending iterator
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Descending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Descending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Then: the iterator should return operations in descending order
         let expected = vec![
@@ -1233,14 +1544,15 @@ mod tests {
         batch.merge(b"key5", b"merge5");
 
         // When: creating an iterator with a range filter
-        let mut iter = WriteBatchIterator::new(
+        let mut iter = WriteBatchIterator::new_sorted(
             &batch,
             BytesRange::from(Bytes::from_static(b"key2")..Bytes::from_static(b"key4")),
             IterationOrder::Ascending,
             u64::MAX,
             None,
             None,
-        );
+        )
+        .unwrap();
 
         // Then: the iterator should only return merges within the range
         let expected = vec![RowEntry::new(
@@ -1263,8 +1575,15 @@ mod tests {
         batch.merge(b"key5", b"merge5");
 
         // When: creating an iterator and seeking to key3
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
         iter.seek(b"key3").await.unwrap();
 
         // Then: the iterator should return key3 and key5
@@ -1316,8 +1635,15 @@ mod tests {
         batch.merge(b"key2", b"x");
         batch.merge(b"key1", b"b");
 
-        let mut iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let mut iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         let expected = vec![
             RowEntry::new(

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -127,7 +127,7 @@ impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
 impl DbInner {
     #[allow(clippy::panic)]
     #[instrument(level = "trace", skip_all, fields(batch_size = batch.op_count()))]
-    async fn write_batch(&self, batch: WriteBatch, options: &WriteOptions) -> WriteBatchResult {
+    async fn write_batch(&self, mut batch: WriteBatch, options: &WriteOptions) -> WriteBatchResult {
         let _options = options;
         #[cfg(not(dst))]
         let now = self.mono_clock.now().await?;
@@ -161,6 +161,7 @@ impl DbInner {
 
         // Count batch-local merge folding on the flush path so DB-side merge
         // resolution uses one metric for both write batches and memtable flushes.
+        batch.sorted();
         let (entries, touched_segments, entries_size) = batch
             .extract_entries(
                 commit_seq,

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -127,7 +127,7 @@ impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
 impl DbInner {
     #[allow(clippy::panic)]
     #[instrument(level = "trace", skip_all, fields(batch_size = batch.op_count()))]
-    async fn write_batch(&self, mut batch: WriteBatch, options: &WriteOptions) -> WriteBatchResult {
+    async fn write_batch(&self, batch: WriteBatch, options: &WriteOptions) -> WriteBatchResult {
         let _options = options;
         #[cfg(not(dst))]
         let now = self.mono_clock.now().await?;
@@ -161,7 +161,6 @@ impl DbInner {
 
         // Count batch-local merge folding on the flush path so DB-side merge
         // resolution uses one metric for both write batches and memtable flushes.
-        batch.sorted();
         let (entries, touched_segments, entries_size) = batch
             .extract_entries(
                 commit_seq,

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -565,8 +565,15 @@ mod tests {
         batch.put(b"key3", b"value3");
 
         // Create WriteBatchIterator
-        let wb_iter =
-            WriteBatchIterator::new(&batch, .., IterationOrder::Ascending, u64::MAX, None, None);
+        let wb_iter = WriteBatchIterator::new_sorted(
+            &batch,
+            BytesRange::from(..),
+            IterationOrder::Ascending,
+            u64::MAX,
+            None,
+            None,
+        )
+        .unwrap();
 
         // Create DbIterator with WriteBatch
         let mem_iters: VecDeque<Box<dyn RowEntryIterator + 'static>> = VecDeque::new();

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -152,22 +152,23 @@ impl DbTransaction {
 
         let db_state = self.db_inner.state.read().view();
 
-        // Build the write batch iterator synchronously while holding the read
-        // guard, avoiding a clone of the full batch. The iterator materializes
-        // only the entries overlapping the read range (a single key for a
-        // point get), so this is O(log N) instead of O(N).
+        // Build the write batch iterator synchronously while holding the write
+        // guard, avoiding a clone of the full batch. Force the batch back to a
+        // sorted map before range iteration so the sorted iterator contract
+        // holds even after large transactions switched to a HashMap.
         let key_slice = key.as_ref();
         let range = BytesRange::from_slice(key_slice..=key_slice);
         let write_batch_iter = {
-            let guard = self.write_batch.read();
-            Some(WriteBatchIterator::new(
+            let mut guard = self.write_batch.write();
+            guard.sorted();
+            Some(WriteBatchIterator::new_sorted(
                 &guard,
                 range,
                 IterationOrder::Ascending,
                 u64::MAX,
                 None,
                 None,
-            ))
+            )?)
         };
 
         let kv = self
@@ -289,19 +290,21 @@ impl DbTransaction {
         self.db_inner.check_closed()?;
         let db_state = self.db_inner.state.read().view();
 
-        // Build the write batch iterator synchronously while holding the read
-        // guard, avoiding a clone of the full batch. The iterator materializes
-        // only the entries in the scan range.
+        // Build the write batch iterator synchronously while holding the write
+        // guard, avoiding a clone of the full batch. Force the batch back to a
+        // sorted map before range iteration so scans keep ordered seek
+        // semantics even after large transactions switched to a HashMap.
         let write_batch_iter = {
-            let guard = self.write_batch.read();
-            Some(WriteBatchIterator::new(
+            let mut guard = self.write_batch.write();
+            guard.sorted();
+            Some(WriteBatchIterator::new_sorted(
                 &guard,
                 range.clone(),
                 options.order,
                 u64::MAX,
                 None,
                 None,
-            ))
+            )?)
         };
 
         self.db_inner

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -160,7 +160,7 @@ impl DbTransaction {
         let range = BytesRange::from_slice(key_slice..=key_slice);
         let write_batch_iter = {
             let mut guard = self.write_batch.write();
-            guard.sorted();
+            guard.sort();
             Some(WriteBatchIterator::new_sorted(
                 &guard,
                 range,
@@ -296,7 +296,7 @@ impl DbTransaction {
         // semantics even after large transactions switched to a HashMap.
         let write_batch_iter = {
             let mut guard = self.write_batch.write();
-            guard.sorted();
+            guard.sort();
             Some(WriteBatchIterator::new_sorted(
                 &guard,
                 range.clone(),

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -197,6 +197,9 @@ pub(crate) enum SlateDBError {
     #[error("cannot seek to a key less than the last returned key")]
     SeekKeyLessThanLastReturnedKey,
 
+    #[error("write batch is unsorted")]
+    UnsortedWriteBatch,
+
     #[error(
         "parent path must be different from the clone's path. parent_path=`{0}`, clone_path=`{0}`"
     )]
@@ -602,6 +605,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::CheckpointLifetimeTooShort { .. } => Error::invalid(msg),
             SlateDBError::SeekKeyOutOfRange { .. } => Error::invalid(msg),
             SlateDBError::SeekKeyLessThanLastReturnedKey => Error::invalid(msg),
+            SlateDBError::UnsortedWriteBatch => Error::invalid(msg),
             SlateDBError::IdenticalClonePaths { .. } => Error::invalid(msg),
             SlateDBError::DuplicatedCloneSourcePath(_) => Error::invalid(msg),
             SlateDBError::InvalidUnionSourceWithWal { .. } => Error::invalid(msg),

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -446,7 +446,7 @@ mod tests {
 
     fn wb_point_iter(write_batch: &Option<WriteBatch>, key: &[u8]) -> Option<WriteBatchIterator> {
         write_batch.as_ref().map(|wb| {
-            WriteBatchIterator::new(
+            WriteBatchIterator::new_sorted(
                 wb,
                 BytesRange::from_slice(key..=key),
                 IterationOrder::Ascending,
@@ -454,6 +454,7 @@ mod tests {
                 None,
                 None,
             )
+            .unwrap()
         })
     }
 
@@ -462,9 +463,9 @@ mod tests {
         range: &BytesRange,
         order: IterationOrder,
     ) -> Option<WriteBatchIterator> {
-        write_batch
-            .as_ref()
-            .map(|wb| WriteBatchIterator::new(wb, range.clone(), order, u64::MAX, None, None))
+        write_batch.as_ref().map(|wb| {
+            WriteBatchIterator::new_sorted(wb, range.clone(), order, u64::MAX, None, None).unwrap()
+        })
     }
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId};
     use crate::db_status::DbStatusManager;


### PR DESCRIPTION
## Summary

This PR adds `HashMap` support to `WriteBatch`. `HashMap`s are intended to be used when the batch has a large key cardinality (> 512 keys). The PR starts with a `BTreeMap` but switches to a `HashMap` when the key cardinality reaches 1024.

From @agavra:

<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/88432694-522c-4b20-a7fb-07ca1675e4d0" />

This is not an exact replica, but it's close enough. I chose 1024 to be conservative since we pay a cost to swap from `BTreeMap` to `HashMap`.

Fixes #1597

## Changes

- Increase warmup/perf test time to get more accurate results
- Add a `load_batch` perf test that loosely mirrors @FiV0's workload (large batch sizes > 10k keys)
- Add a `WriteBatchMap` enum to `WriteBatch::ops` that supports both `BTreeMap` and `HashMap`
- Update `WriteBatchIterator` to  support both sorted/unsorted iteration.

## Notes for Reviewers

There are some improvements I want to make before I merge this:

1. Add a `WriteBatch::new_unsorted` pub fn and make `sort()` public as well.
2. Add Rustdocs explaining these changes.
3. Disable HashMap for DST so we have deterministic iteration when needed.
4. Run perf test for db_transaction.rs as well.

## Performance

Note the peculiar regressions at `1_keys/1000_merges_per_key`. I spent some time with codex and they are almost certainly allocator cliffs with `SmallVec`. I added some temporary tests at 512/1024/1500/2048/4096. The 2048/4096 length lists significantly outperformed the 1000 length lists, which only makes sense if the allocator is misbehaving.

All the other tests look good to me, and the large (10000+ batches) crush the old BTreeMap.

name | % change | improvement/regression/noise
-- | -- | --
write_batch/put_bytes_with_options/empty_batch | -1.1540% | noise
write_batch/load_batch/puts/1000_keys | +2.1041% | regression
write_batch/load_batch/puts/10000_keys | -42.818% | improvement
write_batch/load_batch/puts/100000_keys | -59.115% | improvement
write_batch/put_bytes_with_options/new_key_populated | -21.095% | improvement
write_batch/put_bytes_with_options/overwrite_existing_key/256_keys/3_merges_per_key | -7.7302% | improvement
write_batch/put_bytes_with_options/overwrite_existing_key/256_keys/100_merges_per_key | -1.3689% | improvement
write_batch/put_bytes_with_options/overwrite_existing_key/16_keys/1000_merges_per_key | -0.4095% | noise
write_batch/put_bytes_with_options/overwrite_existing_key/1_keys/1000_merges_per_key | +55.068% | regression
write_batch/put_bytes_with_options/overwrite_existing_key/1_keys/10000_merges_per_key | +0.6145% | noise
write_batch/merge_with_options/empty_batch | +2.3954% | regression
write_batch/merge_with_options/new_key_populated | -33.807% | improvement
write_batch/merge_with_options/existing_key_with_merges/256_keys/3_merges_per_key | -5.3574% | noise
write_batch/merge_with_options/existing_key_with_merges/256_keys/100_merges_per_key | -11.426% | improvement
write_batch/merge_with_options/existing_key_with_merges/16_keys/1000_merges_per_key | -11.030% | improvement
write_batch/merge_with_options/existing_key_with_merges/1_keys/1000_merges_per_key | +17.385% | regression
write_batch/merge_with_options/existing_key_with_merges/1_keys/10000_merges_per_key | -3.9167% | improvement
write_batch/delete/empty_batch | +5.1633% | regression
write_batch/delete/new_key_populated | -19.789% | improvement
write_batch/delete/existing_key/256_keys/3_merges_per_key | -6.8922% | improvement
write_batch/delete/existing_key/256_keys/100_merges_per_key | -3.0772% | improvement
write_batch/delete/existing_key/16_keys/1000_merges_per_key | +0.1033% | noise
write_batch/delete/existing_key/1_keys/1000_merges_per_key | +189.86% | regression
write_batch/delete/existing_key/1_keys/10000_merges_per_key | -0.1699% | noise
write_batch/keys | -9.9480% | improvement
write_batch/extract_entries/no_merges | +31.620% | regression
write_batch/extract_entries/with_merges/256_keys/3_merges_per_key | +9.5767% | regression
write_batch/extract_entries/with_merges/256_keys/100_merges_per_key | +1.5425% | regression
write_batch/extract_entries/with_merges/16_keys/1000_merges_per_key | +1.6419% | regression
write_batch/extract_entries/with_merges/1_keys/1000_merges_per_key | +69.537% | regression
write_batch/extract_entries/with_merges/1_keys/10000_merges_per_key | +5.9871% | regression
write_batch/drop/no_merges | -53.647% | improvement
write_batch/drop/with_merges/256_keys/3_merges_per_key | -11.403% | improvement
write_batch/drop/with_merges/256_keys/100_merges_per_key | -0.1930% | noise
write_batch/drop/with_merges/16_keys/1000_merges_per_key | -14.143% | improvement
write_batch/drop/with_merges/1_keys/1000_merges_per_key | +257.12% | regression
write_batch/drop/with_merges/1_keys/10000_merges_per_key | +3.0052% | regression
write_batch/drop/repeated_overwrites | +1.6942% | regression

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
