### PR TITLE
feat(manifest): enforce l0_ulid_cutoff invariant on manifest update

### DIFF
--- a/slatedb/src/manifest/invariants.rs
+++ b/slatedb/src/manifest/invariants.rs
@@ -49,7 +49,6 @@ use crate::manifest::Manifest;
 /// watermark timestamp as `last_tick` and the offending ULID timestamp as
 /// `next_tick`. The txn-obj layer wraps the boxed error in `CallbackError`, which
 /// maps back to `SlateDBError::InvalidClockTick` for the caller.
-#[allow(dead_code)]
 pub(crate) fn l0_ulid_cutoff(
     dirty: &Manifest,
     current: &Manifest,
@@ -85,9 +84,9 @@ pub(crate) fn l0_ulid_cutoff(
 }
 
 /// The invariants enforced on every `.manifest` update (RFC-0025 GC cutoff
-/// rules). Will be attached once at [`StoredManifest`](super::store::StoredManifest)
-/// construction via `with_invariants` in the follow-up wiring PR.
-#[allow(dead_code)]
+/// rules). Attached once at [`StoredManifest`](super::store::StoredManifest)
+/// construction via `with_invariants`, so every manifest `update` validates the
+/// dirty value against the current committed value before the CAS write.
 pub(crate) fn manifest_invariants() -> Vec<Invariant<Manifest>> {
     vec![Arc::new(l0_ulid_cutoff)]
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -527,10 +527,6 @@ impl ManifestCore {
     /// and every segment. Returned as a `Ulid` (not a raw timestamp) so the L0
     /// cutoff invariant ([`l0_ulid_cutoff`](crate::manifest::invariants::l0_ulid_cutoff))
     /// and the open-time skew check share one definition of the watermark.
-    // TODO: Wire this into the manifest update path in a follow-up PR for
-    // https://github.com/slatedb/slatedb/issues/1707
-    // until then unit-tested via `l0_ulid_cutoff`.
-    #[allow(dead_code)]
     pub(crate) fn max_l0_ulid_timestamp_across_trees(&self) -> Option<ulid::Ulid> {
         self.trees()
             .filter_map(|tree| {

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -5,6 +5,7 @@ use crate::error::SlateDBError::{
     CheckpointMissing, InvalidDBState, LatestTransactionalObjectVersionMissing, ManifestMissing,
 };
 use crate::flatbuffer_types::FlatBufferManifestCodec;
+use crate::manifest::invariants::manifest_invariants;
 use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
 use chrono::Utc;
 use log::debug;
@@ -69,6 +70,14 @@ impl FenceableManifest {
 
     pub(crate) fn local_epoch(&self) -> u64 {
         self.inner.local_epoch()
+    }
+
+    /// The current **committed** manifest state — the same value the
+    /// `l0_ulid_cutoff` invariant compares the dirty manifest against in
+    /// `SimpleTransactionalObject::update`. Used by the flusher to normalize
+    /// staged L0 ULIDs against the L0 watermark before publishing.
+    pub(crate) fn db_state(&self) -> &ManifestCore {
+        &self.inner.object().core
     }
 
     pub(crate) async fn refresh(&mut self) -> Result<&Manifest, SlateDBError> {
@@ -172,6 +181,16 @@ pub(crate) struct StoredManifest {
 }
 
 impl StoredManifest {
+    /// The single place a `StoredManifest` is assembled from its inner txn-obj.
+    /// Attaches the RFC-0025 manifest invariants here so every construction path
+    /// enforces them — no constructor can forget.
+    fn new(inner: SimpleTransactionalObject<Manifest>, clock: Arc<dyn SystemClock>) -> Self {
+        Self {
+            inner: inner.with_invariants(manifest_invariants()),
+            clock,
+        }
+    }
+
     async fn init(
         store: Arc<ManifestStore>,
         manifest: Manifest,
@@ -184,7 +203,7 @@ impl StoredManifest {
             manifest.clone(),
         )
         .await?;
-        Ok(Self { inner, clock })
+        Ok(Self::new(inner, clock))
     }
 
     /// Create the initial manifest for a new database.
@@ -219,7 +238,7 @@ impl StoredManifest {
         else {
             return Ok(None);
         };
-        Ok(Some(Self { inner, clock }))
+        Ok(Some(Self::new(inner, clock)))
     }
 
     /// Load the current manifest from the supplied manifest store. If successful,
@@ -229,11 +248,9 @@ impl StoredManifest {
         store: Arc<ManifestStore>,
         clock: Arc<dyn SystemClock>,
     ) -> Result<Self, SlateDBError> {
-        SimpleTransactionalObject::<Manifest>::try_load(Arc::clone(&store.inner)
-            as Arc<dyn TransactionalStorageProtocol<Manifest, MonotonicId>>)
-        .await?
-        .map(|inner| Self { inner, clock })
-        .ok_or(LatestTransactionalObjectVersionMissing)
+        Self::try_load(store, clock)
+            .await?
+            .ok_or(LatestTransactionalObjectVersionMissing)
     }
 
     #[allow(dead_code)]
@@ -652,6 +669,61 @@ mod tests {
         let version = ms.read_latest_manifest().await.unwrap().id;
 
         assert_eq!(version, 2);
+    }
+
+    /// End-to-end check that the RFC-0025 `l0_ulid_cutoff` invariant is actually
+    /// registered on the `StoredManifest` update path (not just unit-tested as a
+    /// bare predicate). Publishing an L0 above the watermark succeeds; a later
+    /// update adding an L0 whose SST ULID is strictly below the watermark is
+    /// rejected with `InvalidClockTick` before the CAS write.
+    #[tokio::test]
+    async fn test_update_rejects_l0_below_ulid_watermark() {
+        use crate::db_state::{SsTableHandle, SsTableId, SsTableInfo, SsTableView};
+        use crate::format::sst::SST_FORMAT_VERSION_LATEST;
+        use ulid::Ulid;
+
+        fn l0_view(ts_ms: u64) -> SsTableView {
+            let id = Ulid::from_parts(ts_ms, 0);
+            let handle = SsTableHandle::new(
+                SsTableId::Compacted(id),
+                SST_FORMAT_VERSION_LATEST,
+                SsTableInfo::default(),
+            );
+            SsTableView::new(id, handle)
+        }
+
+        let ms = new_memory_manifest_store();
+        let mut sm = StoredManifest::create_new_db(
+            ms.clone(),
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        // Publish an L0 at timestamp 100 — establishes the watermark.
+        let mut dirty = sm.prepare_dirty().unwrap();
+        Arc::make_mut(&mut dirty.value.core.tree)
+            .l0
+            .push_front(l0_view(100));
+        sm.update(dirty).await.unwrap();
+
+        // Adding an L0 whose SST ULID is below the watermark must be rejected.
+        let mut dirty = sm.prepare_dirty().unwrap();
+        Arc::make_mut(&mut dirty.value.core.tree)
+            .l0
+            .push_front(l0_view(50));
+        let err = sm.update(dirty).await.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SlateDBError::InvalidClockTick {
+                    last_tick: 100,
+                    next_tick: 50
+                }
+            ),
+            "expected InvalidClockTick, got {err:?}"
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -31,7 +31,7 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use std::cmp;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -472,8 +472,11 @@ impl ManifestWriterHandler {
     /// Called before **every** CAS attempt (see [`Self::write_manifest_update_safely`]):
     /// the committed watermark is re-read each time, so a conflict-triggered
     /// reload that raised the watermark is handled on the following attempt.
-    async fn remint_l0s_below_watermark(&self) -> Result<(), SlateDBError> {
-        let Some((watermark_ts, below)) = self.l0s_below_committed_watermark() else {
+    async fn remint_l0s_below_watermark(
+        &self,
+        staged_l0_ids: &mut HashSet<ulid::Ulid>,
+    ) -> Result<(), SlateDBError> {
+        let Some((watermark_ts, below)) = self.l0s_below_committed_watermark(staged_l0_ids) else {
             return Ok(());
         };
 
@@ -483,17 +486,22 @@ impl ManifestWriterHandler {
         // by the GC (the uploader uses the same "left for the GC" handling).
         let mut remap: Vec<(ulid::Ulid, SsTableHandle)> = Vec::with_capacity(below.len());
         for l0 in below {
-            let new_id = SsTableId::Compacted(self.mint_l0_ulid_at_or_above(watermark_ts).await?);
+            let new_ulid = self.mint_l0_ulid_at_or_above(watermark_ts).await?;
+            let new_id = SsTableId::Compacted(new_ulid);
             self.db
                 .table_store
                 .copy_sst(&SsTableId::Compacted(l0.old_id), &new_id)
                 .await?;
-            // only the id changes, so the view's derived
-            // `effective_range` is unaffected.
+            // Only the id changes, so the view's derived `effective_range` is
+            // unaffected.
             remap.push((
                 l0.old_id,
                 SsTableHandle::new(new_id, l0.format_version, l0.info),
             ));
+            // Keep the staged set current so a later retry (after a reload that
+            // raised the watermark) re-mints the same logical L0 by its new id.
+            staged_l0_ids.remove(&l0.old_id);
+            staged_l0_ids.insert(new_ulid);
         }
 
         self.swap_l0_handles(&remap);
@@ -504,19 +512,21 @@ impl ManifestWriterHandler {
     /// it. Returns `None` when there is nothing to re-mint (fresh manifest, or
     /// every staged L0 already at/above the watermark).
     ///
-    /// The candidate set is exactly the invariant's "newly added" comparison: an
-    /// L0 qualifies only if it is absent from the committed manifest *and* its
-    /// SST-ULID timestamp is below the committed cross-tree watermark.
-    fn l0s_below_committed_watermark(&self) -> Option<(u64, Vec<BelowWatermarkL0>)> {
-        let committed = self.manifest.db_state();
-        let watermark_ts = committed
+    /// Only L0s in `staged_l0_ids` — the SSTs *this* flush uploaded — are
+    /// candidates. Pre-existing state L0s are never touched: they are already
+    /// committed or owned by another writer, and we hold no guarantee their
+    /// blobs are copyable. A candidate qualifies when its SST-ULID timestamp is
+    /// below the committed cross-tree watermark, mirroring the invariant's
+    /// strict `<`.
+    fn l0s_below_committed_watermark(
+        &self,
+        staged_l0_ids: &HashSet<ulid::Ulid>,
+    ) -> Option<(u64, Vec<BelowWatermarkL0>)> {
+        let watermark_ts = self
+            .manifest
+            .db_state()
             .max_l0_ulid_timestamp_across_trees()?
             .timestamp_ms();
-        let committed_ids: std::collections::HashSet<ulid::Ulid> = committed
-            .trees()
-            .flat_map(|tree| tree.l0.iter())
-            .map(|view| view.sst.id.unwrap_compacted_id())
-            .collect();
 
         let below: Vec<BelowWatermarkL0> = {
             let guard = self.db.state.read();
@@ -527,7 +537,7 @@ impl ManifestWriterHandler {
                 .flat_map(|tree| tree.l0.iter())
                 .filter_map(|view| {
                     let old_id = view.sst.id.unwrap_compacted_id();
-                    (!committed_ids.contains(&old_id) && old_id.timestamp_ms() < watermark_ts).then(
+                    (staged_l0_ids.contains(&old_id) && old_id.timestamp_ms() < watermark_ts).then(
                         || BelowWatermarkL0 {
                             old_id,
                             format_version: view.sst.format_version,
@@ -604,6 +614,14 @@ impl ManifestWriterHandler {
     ) -> Result<(), SlateDBError> {
         self.apply_uploaded_state(&staged_batch)?;
 
+        // The SST ULIDs published by this flush — the only L0s re-mint may lift
+        // below the watermark. Pre-existing state L0s are left untouched.
+        let staged_l0_ids: HashSet<ulid::Ulid> = staged_batch
+            .iter()
+            .flat_map(|uploaded| uploaded.segments.iter())
+            .map(|segment| segment.sst_handle.id.unwrap_compacted_id())
+            .collect();
+
         for uploaded in &staged_batch {
             uploaded.imm_memtable.notify_uploaded(Ok(()));
         }
@@ -618,6 +636,7 @@ impl ManifestWriterHandler {
                     .iter()
                     .map(|c| &c.options)
                     .collect::<Vec<_>>(),
+                staged_l0_ids,
             )
             .await
         {
@@ -713,11 +732,13 @@ impl ManifestWriterHandler {
     async fn write_manifest_update_safely(
         &mut self,
         checkpoint_options: &[&CheckpointOptions],
+        mut staged_l0_ids: HashSet<ulid::Ulid>,
     ) -> Result<Vec<CheckpointCreateResult>, SlateDBError> {
         loop {
             // Lift any staged L0 below the committed L0 watermark before the CAS
-            // so the `l0_ulid_cutoff` invariant, accepts the write.
-            self.remint_l0s_below_watermark().await?;
+            // so the `l0_ulid_cutoff` invariant accepts the write. Re-read each
+            // attempt: a conflict reload below may have raised the watermark.
+            self.remint_l0s_below_watermark(&mut staged_l0_ids).await?;
             let result = self.write_manifest_update(checkpoint_options).await;
             if matches!(result.as_ref(), Err(err) if err.is_sequenced_write_conflict()) {
                 self.load_manifest().await?;
@@ -828,7 +849,10 @@ impl ManifestWriterHandler {
         options: &CheckpointOptions,
     ) -> Result<CheckpointCreateResult, SlateDBError> {
         self.load_manifest().await?;
-        let mut results = self.write_manifest_update_safely(&[options]).await?;
+        // Checkpoint-only update publishes no new L0s, so nothing to re-mint.
+        let mut results = self
+            .write_manifest_update_safely(&[options], HashSet::new())
+            .await?;
         Ok(results
             .pop()
             .expect("checkpoint write should return exactly one result"))
@@ -1378,7 +1402,10 @@ mod tests {
         let start_id = stage_manifest_boundary_conflict(&path, Arc::clone(&object_store)).await;
 
         // The safe update path should reload the live newer manifest and retry safely.
-        let checkpoints = handler.write_manifest_update_safely(&[]).await.unwrap();
+        let checkpoints = handler
+            .write_manifest_update_safely(&[], std::collections::HashSet::new())
+            .await
+            .unwrap();
 
         let final_id = manifest_store.read_latest_manifest().await.unwrap().id;
         assert!(checkpoints.is_empty());

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -19,7 +19,7 @@ use super::uploader::UploadedMemtable;
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::SsTableView;
+use crate::db_state::{SsTableHandle, SsTableId, SsTableView};
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
@@ -193,6 +193,22 @@ impl ManifestWriter {
             log::warn!("failed to shutdown l0 manifest writer [error={:?}]", e);
         }
     }
+}
+
+/// Maximum re-mint attempts for a single staged L0 SST before surfacing
+/// `InvalidClockTick`. Each attempt mints a fresh ULID from the (monotonic)
+/// system clock and re-uploads the SST; with a forward-only clock the first
+/// attempt already clears the watermark, so this bound only matters under a
+/// genuine backwards wall-clock skew where the clock never catches up.
+const MAX_L0_ULID_REMINT_ATTEMPTS: usize = 10;
+
+/// A staged L0 SST whose ULID is below the committed watermark and must be
+/// re-minted before publishing. Carries everything needed to rebuild its handle
+/// under a fresh id without re-reading the SST.
+struct BelowWatermarkL0 {
+    old_id: ulid::Ulid,
+    format_version: u16,
+    info: crate::db_state::SsTableInfo,
 }
 
 struct ManifestWriterHandler {
@@ -437,6 +453,149 @@ impl ManifestWriterHandler {
         satisfied
     }
 
+    /// Re-mint any locally-staged L0 SST whose ULID is below the **committed**
+    /// L0 watermark, so the RFC-0025 `l0_ulid_cutoff` manifest invariant cannot
+    /// reject the next CAS.
+    ///
+    /// L0 SST ULIDs are minted at upload time (see `UploadHandler`), but the
+    /// manifest publish order across independent segments (RFC-0024) need not
+    /// match upload order, and a concurrent compactor can advance the watermark
+    /// (`last_compacted_l0_sst_view_id`) between publishes — so a freshly-staged
+    /// L0 can sit below the cross-tree watermark even though the wall clock only
+    /// moved forward.
+    ///
+    /// For each such SST we mint a fresh ULID from the current
+    /// (monotonic) clock and copy the SST blob to the new id, then swap the
+    /// staged view's handle in the in-memory state so it matches what the
+    /// manifest will record.
+    ///
+    /// Called before **every** CAS attempt (see [`Self::write_manifest_update_safely`]):
+    /// the committed watermark is re-read each time, so a conflict-triggered
+    /// reload that raised the watermark is handled on the following attempt.
+    async fn remint_l0s_below_watermark(&self) -> Result<(), SlateDBError> {
+        let Some((watermark_ts, below)) = self.l0s_below_committed_watermark() else {
+            return Ok(());
+        };
+
+        // Mint a fresh id at/above the watermark and copy the blob to it. The
+        // ULID is the object key, so re-minting requires duplicating the blob;
+        // the orphaned old-keyed blob is never referenced again and is reclaimed
+        // by the GC (the uploader uses the same "left for the GC" handling).
+        let mut remap: Vec<(ulid::Ulid, SsTableHandle)> = Vec::with_capacity(below.len());
+        for l0 in below {
+            let new_id = SsTableId::Compacted(self.mint_l0_ulid_at_or_above(watermark_ts).await?);
+            self.db
+                .table_store
+                .copy_sst(&SsTableId::Compacted(l0.old_id), &new_id)
+                .await?;
+            // only the id changes, so the view's derived
+            // `effective_range` is unaffected.
+            remap.push((
+                l0.old_id,
+                SsTableHandle::new(new_id, l0.format_version, l0.info),
+            ));
+        }
+
+        self.swap_l0_handles(&remap);
+        Ok(())
+    }
+
+    /// Snapshot the committed L0 watermark and the staged L0s that fall below
+    /// it. Returns `None` when there is nothing to re-mint (fresh manifest, or
+    /// every staged L0 already at/above the watermark).
+    ///
+    /// The candidate set is exactly the invariant's "newly added" comparison: an
+    /// L0 qualifies only if it is absent from the committed manifest *and* its
+    /// SST-ULID timestamp is below the committed cross-tree watermark.
+    fn l0s_below_committed_watermark(&self) -> Option<(u64, Vec<BelowWatermarkL0>)> {
+        let committed = self.manifest.db_state();
+        let watermark_ts = committed
+            .max_l0_ulid_timestamp_across_trees()?
+            .timestamp_ms();
+        let committed_ids: std::collections::HashSet<ulid::Ulid> = committed
+            .trees()
+            .flat_map(|tree| tree.l0.iter())
+            .map(|view| view.sst.id.unwrap_compacted_id())
+            .collect();
+
+        let below: Vec<BelowWatermarkL0> = {
+            let guard = self.db.state.read();
+            guard
+                .state()
+                .core()
+                .trees()
+                .flat_map(|tree| tree.l0.iter())
+                .filter_map(|view| {
+                    let old_id = view.sst.id.unwrap_compacted_id();
+                    (!committed_ids.contains(&old_id) && old_id.timestamp_ms() < watermark_ts).then(
+                        || BelowWatermarkL0 {
+                            old_id,
+                            format_version: view.sst.format_version,
+                            info: view.sst.info.clone(),
+                        },
+                    )
+                })
+                .collect()
+        };
+        (!below.is_empty()).then_some((watermark_ts, below))
+    }
+
+    /// Mint a fresh L0 SST ULID at or above `watermark_ts`. With a forward-only
+    /// clock this returns on the first attempt; only a genuine backwards
+    /// wall-clock skew makes it sleep-and-retry, surfacing `InvalidClockTick`
+    /// after `MAX_L0_ULID_REMINT_ATTEMPTS` (mirrors `MonotonicClock::now`).
+    async fn mint_l0_ulid_at_or_above(
+        &self,
+        watermark_ts: u64,
+    ) -> Result<ulid::Ulid, SlateDBError> {
+        let mut attempts = 0usize;
+        loop {
+            let candidate = self.db.rand.rng().gen_ulid(self.db.system_clock.as_ref());
+            if candidate.timestamp_ms() >= watermark_ts {
+                return Ok(candidate);
+            }
+            attempts += 1;
+            if attempts >= MAX_L0_ULID_REMINT_ATTEMPTS {
+                return Err(SlateDBError::InvalidClockTick {
+                    last_tick: watermark_ts as i64,
+                    next_tick: candidate.timestamp_ms() as i64,
+                });
+            }
+            self.db
+                .system_clock
+                .sleep(self.manifest_poll_interval)
+                .await;
+        }
+    }
+
+    /// Swap re-minted handles into the in-memory state's L0 views, matching by
+    /// the old (pre-re-mint) SST id. Runs under the state write lock with no
+    /// awaits — the blob copies have already completed — so writers are only
+    /// briefly blocked, the same pattern as `apply_uploaded_state`.
+    fn swap_l0_handles(&self, remap: &[(ulid::Ulid, SsTableHandle)]) {
+        let mut guard = self.db.state.write();
+        let manifest = guard.modify(|modifier| {
+            let core = &mut modifier.state.manifest.value.core;
+            let patch_tree = |tree: &mut crate::manifest::LsmTreeState| {
+                for view in tree.l0.iter_mut() {
+                    if let Some((_, handle)) = remap
+                        .iter()
+                        .find(|(old, _)| view.sst.id == SsTableId::Compacted(*old))
+                    {
+                        view.sst = handle.clone();
+                    }
+                }
+            };
+            patch_tree(Arc::make_mut(&mut core.tree));
+            for segment in core.segments.iter_mut() {
+                patch_tree(Arc::make_mut(&mut segment.tree));
+            }
+            modifier.state.manifest.clone()
+        });
+        drop(guard);
+        self.db.status_manager.report_manifest(manifest.into());
+    }
+
     async fn apply_ready_batch(
         &mut self,
         staged_batch: Vec<UploadedMemtable>,
@@ -556,6 +715,9 @@ impl ManifestWriterHandler {
         checkpoint_options: &[&CheckpointOptions],
     ) -> Result<Vec<CheckpointCreateResult>, SlateDBError> {
         loop {
+            // Lift any staged L0 below the committed L0 watermark before the CAS
+            // so the `l0_ulid_cutoff` invariant, accepts the write.
+            self.remint_l0s_below_watermark().await?;
             let result = self.write_manifest_update(checkpoint_options).await;
             if matches!(result.as_ref(), Err(err) if err.is_sequenced_write_conflict()) {
                 self.load_manifest().await?;

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -434,6 +434,25 @@ impl TableStore {
         object_store.delete(&path).await.map_err(SlateDBError::from)
     }
 
+    /// Copy an SSTable blob to a new id, leaving the source in place. Used by
+    /// the flusher to re-mint an L0 SST's ULID (which is its object key) when
+    /// the originally-minted id falls below the committed L0 watermark; the new
+    /// id is published instead and the orphaned source is reclaimed by the GC.
+    /// Both ids must route to the same object store (true for `Compacted` ids).
+    pub(crate) async fn copy_sst(
+        &self,
+        from: &SsTableId,
+        to: &SsTableId,
+    ) -> Result<(), SlateDBError> {
+        let object_store = self.object_stores.store_for(to);
+        let from_path = self.path(from);
+        let to_path = self.path(to);
+        object_store
+            .copy(&from_path, &to_path)
+            .await
+            .map_err(SlateDBError::from)
+    }
+
     /// Reads metadata for a specific SST object (WAL or compacted).
     ///
     /// ## Arguments
@@ -1499,6 +1518,41 @@ mod tests {
         assert_eq!(os.put_attempts(), 0);
         assert_eq!(os.multipart_attempts(), 1);
         ts.open_sst(&id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_copy_sst_duplicates_blob_under_new_id() {
+        // given: a compacted SST written under `from`.
+        let os: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let format = SsTableFormat::default();
+        let ts = Arc::new(TableStore::new(
+            ObjectStores::new(os.clone(), None),
+            format.clone(),
+            Path::from(ROOT),
+            None,
+        ));
+        let from = SsTableId::Compacted(ulid::Ulid::new());
+        let to = SsTableId::Compacted(ulid::Ulid::new());
+        let sst = build_test_sst(&format, 3).await;
+        let from_handle = ts.write_sst(&from, &sst, false).await.unwrap();
+
+        // when: copied to a fresh id (mirrors the flusher re-minting an L0 ULID).
+        ts.copy_sst(&from, &to).await.unwrap();
+
+        // then: the source survives and the copy is byte-identical and opens as
+        // a valid SST with the same structure.
+        let from_bytes = os
+            .get(&ts.path(&from))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let to_bytes = os.get(&ts.path(&to)).await.unwrap().bytes().await.unwrap();
+        assert_eq!(from_bytes, to_bytes);
+        let to_handle = ts.open_sst(&to).await.unwrap();
+        assert_eq!(to_handle.id, to);
+        assert_eq!(to_handle.info, from_handle.info);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Builds on [#1747](https://github.com/geeknarrator/slatedb/issues/1747), which added the RFC-0025 l0_ulid_cutoff manifest invariant but deliberately left it unregistered (logic-only). This PR enforces it on the manifest update path, and adds the writer-side handling needed to make enforcement safe in segmented databases.

Once registered, the invariant rejects any newly-published L0 whose SST ULID is below the committed cross-tree watermark. This surfaced a benign failure in DST (test_dst_segments_is_deterministic): with independent segments flushing concurrently against a forward-only clock, manifest publish order doesn't match upload order (and the compactor can advance the watermark mid-flight), so an L0 minted earlier could be published after a higher watermark was committed — tripping the invariant even with no real clock skew. The flusher now re-mints such L0s (fresh ULID + blob copy) before the CAS, so only a genuine backwards clock skew terminates with InvalidClockTick.

Without reminting the DST showed race condition related failure which was expected.
https://github.com/slatedb/slatedb/actions/runs/26933619745/job/79458280269?pr=1758

## Changes

- Register the invariant: funnel all StoredManifest construction through one private Self::new that attaches manifest_invariants() — no construction path can forget it. Remove the now-stale #[allow(dead_code)] on l0_ulid_cutoff, manifest_invariants, and max_l0_ulid_timestamp_across_trees.
- Flusher re-mint: before every manifest CAS attempt, remint_l0s_below_watermark finds staged L0s below the committed watermark, mints a fresh ULID at/above it, copies the SST blob to the new key, and swaps the in-memory L0 view's handle. Re-reads the watermark each attempt so a conflict-triggered reload (e.g. compactor) is handled on the next pass.
- TableStore::copy_sst: server-side blob copy to a new id (the orphaned old blob is reclaimed by GC).
- FenceableManifest::db_state(): read accessor for the committed manifest.
- Tests: end-to-end invariant-enforcement test, copy_sst unit test; DST suite is the integration test for the re-mint path.

## Notes for Reviewers

- The core logic is remint_l0s_below_watermark and its three helpers in manifest_writer.rs. It's a thin orchestrator: find candidates → mint+copy → swap handles.
- the ULID is the object key, so re-minting requires the SST to exist under the new key. Copy preserves exact bytes and needs no memtable.
- Thread-safety: runs inside the single-threaded ManifestWriter actor; tree.l0 is only mutated by this actor. Blob copies happen holding no lock; the state write lock is taken only for the (await-free) handle swap.
- Retry bound (MAX_L0_ULID_REMINT_ATTEMPTS = 10): the happy path never retries (zero cost); the bound only caps the worst-case delay under genuine backwards skew. Want me to reduce it?
- Out of scope / follow-up: compactor SR and compaction-job invariants (only l0_ulid_cutoff is wired here).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
