### PR TITLE
Implement list_segments() in DbStatus

### DIFF
--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -299,9 +299,8 @@ impl DbInner {
         let memtable = guard.memtable();
         memtable.record_touched_segments(touched_segments.clone());
         entries.into_iter().for_each(|entry| memtable.put(entry));
-        let watcher = memtable.table().durable_watcher();
         self.status_manager.add_memtable_segments(touched_segments);
-        watcher
+        memtable.table().durable_watcher()
     }
 
     fn record_memtable_sequence(&self, seq: u64) {

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -297,9 +297,11 @@ impl DbInner {
     ) -> WatchableOnceCellReader<Result<(), SlateDBError>> {
         let guard = self.state.read();
         let memtable = guard.memtable();
-        memtable.record_touched_segments(touched_segments);
+        memtable.record_touched_segments(touched_segments.clone());
         entries.into_iter().for_each(|entry| memtable.put(entry));
-        memtable.table().durable_watcher()
+        let watcher = memtable.table().durable_watcher();
+        self.status_manager.add_memtable_segments(touched_segments);
+        watcher
     }
 
     fn record_memtable_sequence(&self, seq: u64) {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -9606,12 +9606,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_new_in_memory_segments_in_subscription() {
-        use crate::config::DurabilityLevel;
-
+    async fn should_report_new_memtable_segments_in_subscription() {
         // given
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = "/tmp/test_subscribe_reports_in_memory_segments";
+        let path = "/tmp/test_subscribe_reports_memtable_segments";
         let mut settings = test_db_options(0, 16 * 1024, None);
         settings.flush_interval = None;
         let db = Db::builder(path, object_store.clone())
@@ -9621,11 +9619,7 @@ mod tests {
             .await
             .unwrap();
         let mut rx = db.subscribe();
-        assert!(rx
-            .borrow_and_update()
-            .list_segments(DurabilityLevel::Memory)
-            .unwrap()
-            .is_empty());
+        assert!(rx.borrow_and_update().list_segments().unwrap().is_empty());
         let write_opts = WriteOptions {
             await_durable: false,
             ..Default::default()
@@ -9638,7 +9632,7 @@ mod tests {
 
         // then
         rx.wait_for(|s| {
-            s.list_segments(DurabilityLevel::Memory)
+            s.list_segments()
                 .unwrap()
                 .iter()
                 .any(|seg| seg.prefix.as_ref() == b"abc")
@@ -9653,7 +9647,7 @@ mod tests {
 
         // then
         rx.wait_for(|s| {
-            s.list_segments(DurabilityLevel::Memory)
+            s.list_segments()
                 .unwrap()
                 .into_iter()
                 .map(|seg| seg.prefix)
@@ -9665,12 +9659,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_persisted_segments_after_flush() {
-        use crate::config::DurabilityLevel;
-
+    async fn should_report_segments_in_manifest_after_flush() {
         // given
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = "/tmp/test_flush_shrinks_in_memory_segments";
+        let path = "/tmp/test_report_segments_in_manifest_after_flush";
         let mut settings = test_db_options(0, 16 * 1024, None);
         settings.flush_interval = None;
         let db = Db::builder(path, object_store.clone())
@@ -9697,7 +9689,7 @@ mod tests {
 
         // then
         rx.wait_for(|s| {
-            s.list_segments(DurabilityLevel::Memory)
+            s.list_segments()
                 .unwrap()
                 .iter()
                 .any(|seg| seg.prefix.as_ref() == b"abc")
@@ -9714,7 +9706,7 @@ mod tests {
 
         // then
         rx.wait_for(|s| {
-            s.list_segments(DurabilityLevel::Remote)
+            s.list_segments()
                 .unwrap()
                 .into_iter()
                 .map(|seg| seg.prefix)
@@ -9723,15 +9715,6 @@ mod tests {
         })
         .await
         .unwrap();
-        assert_eq!(
-            db.status()
-                .list_segments(DurabilityLevel::Memory)
-                .unwrap()
-                .into_iter()
-                .map(|seg| seg.prefix)
-                .collect::<Vec<_>>(),
-            vec![Bytes::from_static(b"abc")]
-        );
 
         // when
         // the segments are deleted from the manifest (as a full compaction would)
@@ -9743,15 +9726,7 @@ mod tests {
         db.inner.status_manager.report_manifest(manifest.into());
 
         // then
-        let status = db.status();
-        assert!(status
-            .list_segments(DurabilityLevel::Remote)
-            .unwrap()
-            .is_empty());
-        assert!(status
-            .list_segments(DurabilityLevel::Memory)
-            .unwrap()
-            .is_empty());
+        assert!(db.status().list_segments().unwrap().is_empty());
     }
 
     #[derive(Clone, Copy, Debug)]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -10309,6 +10309,7 @@ mod tests {
         db.close().await.unwrap();
 
         let reader = DbReaderBuilder::new(path, object_store)
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
             .build()
             .await
             .unwrap();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -20,7 +20,7 @@
 //! }
 //! ```
 
-pub use crate::db_status::DbStatus;
+pub use crate::db_status::{DbStatus, SegmentPrefix};
 
 use crate::db_cache_manager::{self, CacheTarget};
 use std::ops::{Range, RangeBounds};
@@ -53,7 +53,7 @@ use crate::config::{
 };
 use crate::db_iter::{DbIterator, DbRecencyIterator};
 use crate::db_snapshot::DbSnapshot;
-use crate::db_state::{DbState, SsTableId};
+use crate::db_state::{collect_touched_segments, DbState, SsTableId};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
@@ -589,6 +589,10 @@ impl DbInner {
             self.maybe_apply_backpressure().await?;
             self.replay_memtable(replayed_table)?;
         }
+
+        let view = self.state.read().view();
+        self.status_manager
+            .report_memtable_segments(collect_touched_segments(&view));
 
         Ok(())
     }
@@ -9599,6 +9603,155 @@ mod tests {
             err.to_string().contains("empty prefix"),
             "expected empty-prefix error, got: {err}"
         );
+    }
+
+    #[tokio::test]
+    async fn should_report_new_in_memory_segments_in_subscription() {
+        use crate::config::DurabilityLevel;
+
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_subscribe_reports_in_memory_segments";
+        let mut settings = test_db_options(0, 16 * 1024, None);
+        settings.flush_interval = None;
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(settings)
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let mut rx = db.subscribe();
+        assert!(rx
+            .borrow_and_update()
+            .list_segments(DurabilityLevel::Memory)
+            .unwrap()
+            .is_empty());
+        let write_opts = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+
+        // when
+        db.put_with_options(b"abc-1", b"v1", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+
+        // then
+        rx.wait_for(|s| {
+            s.list_segments(DurabilityLevel::Memory)
+                .unwrap()
+                .iter()
+                .any(|seg| seg.prefix.as_ref() == b"abc")
+        })
+        .await
+        .unwrap();
+
+        // when
+        db.put_with_options(b"xyz-1", b"v2", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+
+        // then
+        rx.wait_for(|s| {
+            s.list_segments(DurabilityLevel::Memory)
+                .unwrap()
+                .into_iter()
+                .map(|seg| seg.prefix)
+                .collect::<Vec<_>>()
+                == vec![Bytes::from_static(b"abc"), Bytes::from_static(b"xyz")]
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_report_persisted_segments_after_flush() {
+        use crate::config::DurabilityLevel;
+
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_flush_shrinks_in_memory_segments";
+        let mut settings = test_db_options(0, 16 * 1024, None);
+        settings.flush_interval = None;
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(settings)
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let mut rx = db.subscribe();
+        rx.borrow_and_update();
+
+        // when
+        db.put_with_options(
+            b"abc-1",
+            b"v1",
+            &PutOptions::default(),
+            &WriteOptions {
+                await_durable: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        // then
+        rx.wait_for(|s| {
+            s.list_segments(DurabilityLevel::Memory)
+                .unwrap()
+                .iter()
+                .any(|seg| seg.prefix.as_ref() == b"abc")
+        })
+        .await
+        .unwrap();
+
+        // when
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // then
+        rx.wait_for(|s| {
+            s.list_segments(DurabilityLevel::Remote)
+                .unwrap()
+                .into_iter()
+                .map(|seg| seg.prefix)
+                .collect::<Vec<_>>()
+                == vec![Bytes::from_static(b"abc")]
+        })
+        .await
+        .unwrap();
+        assert_eq!(
+            db.status()
+                .list_segments(DurabilityLevel::Memory)
+                .unwrap()
+                .into_iter()
+                .map(|seg| seg.prefix)
+                .collect::<Vec<_>>(),
+            vec![Bytes::from_static(b"abc")]
+        );
+
+        // when
+        // the segments are deleted from the manifest (as a full compaction would)
+        db.inner
+            .state
+            .write()
+            .modify(|m| m.state.manifest.value.core.segments.clear());
+        let manifest = db.inner.state.read().state().manifest.clone();
+        db.inner.status_manager.report_manifest(manifest.into());
+
+        // then
+        let status = db.status();
+        assert!(status
+            .list_segments(DurabilityLevel::Remote)
+            .unwrap()
+            .is_empty());
+        assert!(status
+            .list_segments(DurabilityLevel::Memory)
+            .unwrap()
+            .is_empty());
     }
 
     #[derive(Clone, Copy, Debug)]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -575,6 +575,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         let status_manager = DbStatusManager::new_with_manifest(
             manifest_dirty.value.core.last_l0_seq,
             manifest_dirty.clone().into(),
+            self.segment_extractor.is_some(),
         );
 
         // Setup communication channels wired to the shared closed state.
@@ -1275,6 +1276,7 @@ pub struct DbReaderBuilder<P: Into<Path>> {
     merge_operator: Option<MergeOperatorType>,
     block_transformer: Option<Arc<dyn BlockTransformer>>,
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
+    segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
     options: DbReaderOptions,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -1293,6 +1295,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             merge_operator: None,
             block_transformer: None,
             filter_policies: default_filter_policies(),
+            segment_extractor: None,
             options: DbReaderOptions::default(),
             system_clock: Arc::new(DefaultSystemClock::default()),
             rand: Arc::new(DbRand::default()),
@@ -1317,6 +1320,18 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
     /// Sets the merge operator to use when reading merge operands.
     pub fn with_merge_operator(mut self, merge_operator: MergeOperatorType) -> Self {
         self.merge_operator = Some(merge_operator);
+        self
+    }
+
+    /// Sets the segment extractor (RFC-0024). When configured, the reader
+    /// re-derives each WAL-replayed entry's segment prefix so that in-memory
+    /// segments are reported via [`DbReader::subscribe`]. Must match the
+    /// extractor the database was created with.
+    pub fn with_segment_extractor(
+        mut self,
+        extractor: Arc<dyn crate::prefix_extractor::PrefixExtractor>,
+    ) -> Self {
+        self.segment_extractor = Some(extractor);
         self
     }
 
@@ -1472,6 +1487,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             &store_provider,
             self.checkpoint_id,
             self.merge_operator,
+            self.segment_extractor,
             self.options,
             self.system_clock,
             self.rand,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1257,8 +1257,8 @@ mod tests {
     use super::CheckpointState;
     use crate::clock::MonotonicClock;
     use crate::config::{
-        CheckpointOptions, CheckpointScope, DurabilityLevel, FlushOptions, FlushType, MergeOptions,
-        PutOptions, Settings, WriteOptions,
+        CheckpointOptions, CheckpointScope, FlushOptions, FlushType, MergeOptions, PutOptions,
+        Settings, WriteOptions,
     };
     use crate::db_reader::{DbReader, DbReaderInner, DbReaderOptions};
     use crate::db_state::SsTableId;
@@ -1415,10 +1415,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_in_memory_segments_to_subscription() {
+    async fn should_report_memtable_segments_to_subscription() {
         // given
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = "/tmp/test_reader_subscribe_reports_in_memory_segments";
+        let path = "/tmp/test_reader_subscribe_reports_memtable_segments";
         let db = Db::builder(path, object_store.clone())
             .with_settings(Settings::default())
             .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
@@ -1448,7 +1448,7 @@ mod tests {
         // then
         let prefixes: Vec<Bytes> = reader
             .status()
-            .list_segments(DurabilityLevel::Memory)
+            .list_segments()
             .unwrap()
             .into_iter()
             .map(|seg| seg.prefix)
@@ -1460,62 +1460,7 @@ mod tests {
 
         // then
         let status = reader_no_extractor.status();
-        let err = status.list_segments(DurabilityLevel::Memory).unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
-        let source = std::error::Error::source(&err)
-            .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
-        assert!(matches!(
-            source,
-            Some(crate::error::SlateDBError::SegmentExtractorRequired)
-        ));
-        assert!(status
-            .list_segments(DurabilityLevel::Remote)
-            .unwrap()
-            .is_empty());
-    }
-
-    #[tokio::test]
-    async fn should_list_remote_segments_without_extractor() {
-        // given
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = "/tmp/test_reader_lists_remote_segments_without_extractor";
-        let db = Db::builder(path, object_store.clone())
-            .with_settings(Settings::default())
-            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
-            .build()
-            .await
-            .unwrap();
-        db.put_with_options(
-            b"abc-1",
-            b"v1",
-            &PutOptions::default(),
-            &WriteOptions {
-                await_durable: false,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
-        db.flush_with_options(FlushOptions {
-            flush_type: FlushType::MemTable,
-        })
-        .await
-        .unwrap();
-        db.close().await.unwrap();
-
-        // when
-        let reader = DbReader::builder(path, object_store).build().await.unwrap();
-
-        // then
-        let status = reader.status();
-        let remote: Vec<Bytes> = status
-            .list_segments(DurabilityLevel::Remote)
-            .unwrap()
-            .into_iter()
-            .map(|seg| seg.prefix)
-            .collect();
-        assert_eq!(remote, vec![Bytes::from_static(b"abc")]);
-        let err = status.list_segments(DurabilityLevel::Memory).unwrap_err();
+        let err = status.list_segments().unwrap_err();
         assert_eq!(err.kind(), crate::ErrorKind::Invalid);
         let source = std::error::Error::source(&err)
             .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
@@ -1615,21 +1560,14 @@ mod tests {
             .unwrap();
 
         // then
-        let status = reader.status();
-        let remote: Vec<Bytes> = status
-            .list_segments(DurabilityLevel::Remote)
+        let segments: Vec<Bytes> = reader
+            .status()
+            .list_segments()
             .unwrap()
             .into_iter()
             .map(|seg| seg.prefix)
             .collect();
-        assert_eq!(remote, vec![Bytes::from_static(b"abc")]);
-        let memory: Vec<Bytes> = status
-            .list_segments(DurabilityLevel::Memory)
-            .unwrap()
-            .into_iter()
-            .map(|seg| seg.prefix)
-            .collect();
-        assert_eq!(memory, vec![Bytes::from_static(b"abc")]);
+        assert_eq!(segments, vec![Bytes::from_static(b"abc")]);
     }
 
     #[tokio::test]

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -785,11 +785,9 @@ impl DbReader {
             return Err(SlateDBError::InvalidDBState);
         }
 
-        if let Some(extractor) = segment_extractor.as_deref() {
-            manifest
-                .db_state()
-                .validate_extractor_configuration(Some(extractor))?;
-        }
+        manifest
+            .db_state()
+            .validate_extractor_configuration(segment_extractor.as_deref())?;
 
         let inner = Arc::new(
             DbReaderInner::new(
@@ -1454,20 +1452,6 @@ mod tests {
             .map(|seg| seg.prefix)
             .collect();
         assert_eq!(prefixes, vec![Bytes::from_static(b"abc")]);
-
-        // when
-        let reader_no_extractor = DbReader::builder(path, object_store).build().await.unwrap();
-
-        // then
-        let status = reader_no_extractor.status();
-        let err = status.list_segments().unwrap_err();
-        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
-        let source = std::error::Error::source(&err)
-            .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
-        assert!(matches!(
-            source,
-            Some(crate::error::SlateDBError::SegmentExtractorMismatch { .. })
-        ));
     }
 
     #[tokio::test]
@@ -1508,10 +1492,20 @@ mod tests {
         assert_eq!(err.kind(), crate::ErrorKind::Invalid);
 
         // when
-        let remote_only = DbReader::builder(path, object_store).build().await;
+        // a segmented database also rejects a reader opened without any extractor
+        let err = match DbReader::builder(path, object_store).build().await {
+            Ok(_) => panic!("expected missing-extractor error"),
+            Err(err) => err,
+        };
 
         // then
-        assert!(remote_only.is_ok());
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        let source = std::error::Error::source(&err)
+            .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
+        assert!(matches!(
+            source,
+            Some(crate::error::SlateDBError::SegmentExtractorMismatch { .. })
+        ));
     }
 
     #[tokio::test]

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -3,7 +3,7 @@ use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
 use crate::db_cache_manager::{self, CacheTarget};
-use crate::db_state::SsTableId;
+use crate::db_state::{collect_touched_segments, SsTableId};
 use crate::db_stats::DbStats;
 use crate::db_status::{ClosedResultWriter, DbStatus, DbStatusManager};
 use crate::dispatcher::{MessageFactory, MessageHandler, MessageHandlerExecutor};
@@ -11,10 +11,11 @@ use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
-use crate::mem_table::{ImmutableMemtable, KVTable};
+use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
 use crate::merge_operator::MergeOperatorType;
 use crate::oracle::DbReaderOracle;
 use crate::paths::PathResolver;
+use crate::prefix_extractor::PrefixExtractor;
 use crate::rand::DbRand;
 use crate::reader::{DbStateReader, Reader, ScanContext};
 use crate::sst_iter::SstIteratorOptions;
@@ -33,7 +34,7 @@ use object_store::path::Path;
 use object_store::ObjectStore;
 use parking_lot::RwLock;
 use slatedb_common::clock::SystemClock;
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::ops::{RangeBounds, Sub};
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -60,6 +61,7 @@ struct DbReaderInner {
     oracle: Arc<DbReaderOracle>,
     reader: Reader,
     status_manager: DbStatusManager,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     rand: Arc<DbRand>,
     /// Kept alive so the underlying `MetricsRecorder` is not dropped while
     /// metric handles in `DbStats` (and other stats structs) are still in use.
@@ -111,7 +113,7 @@ impl DbReaderInner {
         options: DbReaderOptions,
         checkpoint_id: Option<Uuid>,
         merge_operator: Option<MergeOperatorType>,
-        status_manager: DbStatusManager,
+        segment_extractor: Option<Arc<dyn PrefixExtractor>>,
         system_clock: Arc<dyn SystemClock>,
         rand: Arc<DbRand>,
         recorder: slatedb_common::metrics::MetricsRecorderHelper,
@@ -127,6 +129,7 @@ impl DbReaderInner {
                 Arc::clone(&manifest_store),
                 Arc::clone(&table_store),
                 &options,
+                segment_extractor.as_ref(),
                 checkpoint,
                 replay_new_wals,
             )
@@ -143,8 +146,11 @@ impl DbReaderInner {
         let initial_durable_seq = initial_state
             .last_remote_persisted_seq
             .max(initial_state.core().last_l0_seq);
-        status_manager.report_durable_seq(initial_durable_seq);
-        status_manager.report_manifest(VersionedManifest::from(initial_state.as_ref()));
+        let status_manager = DbStatusManager::new_with_manifest(
+            initial_durable_seq,
+            VersionedManifest::from(initial_state.as_ref()),
+            segment_extractor.is_some(),
+        );
         let oracle = Arc::new(DbReaderOracle::new(
             initial_durable_seq,
             status_manager.clone(),
@@ -161,7 +167,7 @@ impl DbReaderInner {
             merge_operator,
         );
 
-        Ok(Self {
+        let inner = Self {
             manifest_store,
             table_store,
             options,
@@ -171,9 +177,14 @@ impl DbReaderInner {
             oracle,
             reader,
             status_manager,
+            segment_extractor,
             rand,
             recorder,
-        })
+        };
+        inner
+            .status_manager
+            .report_memtable_segments(collect_touched_segments(inner.state.read().as_ref()));
+        Ok(inner)
     }
 
     async fn get_or_create_checkpoint(
@@ -281,6 +292,8 @@ impl DbReaderInner {
         *write_guard = Arc::new(new_checkpoint_state);
         drop(write_guard);
         self.status_manager.report_manifest(versioned_manifest);
+        self.status_manager
+            .report_memtable_segments(collect_touched_segments(self.state.read().as_ref()));
         Ok(())
     }
 
@@ -303,6 +316,7 @@ impl DbReaderInner {
                 current_checkpoint.core(),
                 &mut imm_memtable,
                 true,
+                self.segment_extractor.as_ref(),
             )
             .await?;
 
@@ -315,6 +329,9 @@ impl DbReaderInner {
                 last_wal_id,
                 last_remote_persisted_seq: last_committed_seq,
             });
+            drop(write_guard);
+            self.status_manager
+                .report_memtable_segments(collect_touched_segments(self.state.read().as_ref()));
         }
         Ok(())
     }
@@ -323,6 +340,7 @@ impl DbReaderInner {
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,
         options: &DbReaderOptions,
+        segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
         checkpoint: Checkpoint,
         replay_new_wals: bool,
     ) -> Result<CheckpointState, SlateDBError> {
@@ -335,6 +353,7 @@ impl DbReaderInner {
             replay_new_wals,
             Arc::clone(&table_store),
             options,
+            segment_extractor,
         )
         .await
     }
@@ -378,6 +397,7 @@ impl DbReaderInner {
             !self.options.skip_wal_replay,
             Arc::clone(&self.table_store),
             &self.options,
+            self.segment_extractor.as_ref(),
         )
         .await
     }
@@ -389,6 +409,7 @@ impl DbReaderInner {
         replay_new_wals: bool,
         table_store: Arc<TableStore>,
         options: &DbReaderOptions,
+        segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<CheckpointState, SlateDBError> {
         let (last_wal_id, last_committed_seq) = Self::replay_wal_into(
             Arc::clone(&table_store),
@@ -396,6 +417,7 @@ impl DbReaderInner {
             &manifest.core,
             &mut imm_memtable,
             replay_new_wals,
+            segment_extractor,
         )
         .await?;
 
@@ -458,6 +480,7 @@ impl DbReaderInner {
         core: &ManifestCore,
         into_tables: &mut VecDeque<Arc<ImmutableMemtable>>,
         replay_new_wals: bool,
+        segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<(u64, u64), SlateDBError> {
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 1,
@@ -518,6 +541,12 @@ impl DbReaderInner {
                 // out entries <= last_committed_seq when creating the replay iterator.
                 assert!(first_seq > last_committed_seq);
                 last_committed_seq = replayed_table.last_seq;
+                if let Some(extractor) = segment_extractor {
+                    Self::record_replayed_touched_segments(
+                        extractor.as_ref(),
+                        &replayed_table.table,
+                    )?;
+                }
                 let imm_memtable =
                     ImmutableMemtable::new(replayed_table.table, replayed_table.last_wal_id);
                 into_tables.push_front(Arc::new(imm_memtable));
@@ -525,6 +554,31 @@ impl DbReaderInner {
         }
 
         Ok((replay_after_wal_id, last_committed_seq))
+    }
+
+    /// Re-derive each replayed entry's segment prefix (RFC-0024) and record the
+    /// table's touched-segment set, mirroring the writer's replay path. Durable
+    /// WAL entries were validated when accepted, so the antichain check is not
+    /// re-run; an empty/absent prefix under the configured extractor remains a
+    /// hard error.
+    fn record_replayed_touched_segments(
+        extractor: &dyn PrefixExtractor,
+        table: &WritableKVTable,
+    ) -> Result<(), SlateDBError> {
+        let mut touched_segments: BTreeSet<Bytes> = BTreeSet::new();
+        let mut iter = table.table().iter();
+        while let Some(entry) = iter.next_sync() {
+            match extractor.prefix_len(&crate::PrefixTarget::Point(entry.key.clone())) {
+                Some(0) | None => {
+                    return Err(SlateDBError::EmptySegmentPrefix { key: entry.key });
+                }
+                Some(n) => {
+                    touched_segments.insert(entry.key.slice(0..n));
+                }
+            }
+        }
+        table.record_touched_segments(touched_segments);
+        Ok(())
     }
 
     /// Returns the latest database status.
@@ -714,6 +768,7 @@ impl DbReader {
         store_provider: &dyn StoreProvider,
         checkpoint_id: Option<Uuid>,
         merge_operator: Option<MergeOperatorType>,
+        segment_extractor: Option<Arc<dyn PrefixExtractor>>,
         options: DbReaderOptions,
         system_clock: Arc<dyn SystemClock>,
         rand: Arc<DbRand>,
@@ -730,12 +785,12 @@ impl DbReader {
             return Err(SlateDBError::InvalidDBState);
         }
 
-        let status_manager = DbStatusManager::new_with_manifest(
-            manifest.db_state().last_l0_seq,
-            VersionedManifest::from_manifest(manifest.id(), manifest.manifest().clone()),
-        );
-        let task_executor =
-            MessageHandlerExecutor::new(Arc::new(status_manager.clone()), system_clock.clone());
+        if let Some(extractor) = segment_extractor.as_deref() {
+            manifest
+                .db_state()
+                .validate_extractor_configuration(Some(extractor))?;
+        }
+
         let inner = Arc::new(
             DbReaderInner::new(
                 manifest_store,
@@ -743,13 +798,17 @@ impl DbReader {
                 options,
                 checkpoint_id,
                 merge_operator,
-                status_manager,
-                system_clock,
+                segment_extractor,
+                system_clock.clone(),
                 rand,
                 recorder,
                 manifest,
             )
             .await?,
+        );
+        let task_executor = MessageHandlerExecutor::new(
+            Arc::new(inner.status_manager.clone()),
+            system_clock.clone(),
         );
 
         // If no checkpoint was provided, then we have established a new checkpoint
@@ -1198,8 +1257,8 @@ mod tests {
     use super::CheckpointState;
     use crate::clock::MonotonicClock;
     use crate::config::{
-        CheckpointOptions, CheckpointScope, FlushOptions, FlushType, MergeOptions, Settings,
-        WriteOptions,
+        CheckpointOptions, CheckpointScope, DurabilityLevel, FlushOptions, FlushType, MergeOptions,
+        PutOptions, Settings, WriteOptions,
     };
     use crate::db_reader::{DbReader, DbReaderInner, DbReaderOptions};
     use crate::db_state::SsTableId;
@@ -1307,6 +1366,7 @@ mod tests {
             &test_provider,
             Some(checkpoint_result.id),
             None,
+            None,
             DbReaderOptions::default(),
             test_provider.system_clock.clone(),
             test_provider.rand.clone(),
@@ -1352,6 +1412,224 @@ mod tests {
             reader.get(key).await.unwrap(),
             Some(Bytes::from_static(checkpoint_value))
         );
+    }
+
+    #[tokio::test]
+    async fn should_report_in_memory_segments_to_subscription() {
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_subscribe_reports_in_memory_segments";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let write_opts = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+        db.put_with_options(b"abc-1", b"v1", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::Wal,
+        })
+        .await
+        .unwrap();
+
+        // when
+        let reader = DbReader::builder(path, object_store.clone())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+
+        // then
+        let prefixes: Vec<Bytes> = reader
+            .status()
+            .list_segments(DurabilityLevel::Memory)
+            .unwrap()
+            .into_iter()
+            .map(|seg| seg.prefix)
+            .collect();
+        assert_eq!(prefixes, vec![Bytes::from_static(b"abc")]);
+
+        // when
+        let reader_no_extractor = DbReader::builder(path, object_store).build().await.unwrap();
+
+        // then
+        let status = reader_no_extractor.status();
+        let err = status.list_segments(DurabilityLevel::Memory).unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        let source = std::error::Error::source(&err)
+            .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
+        assert!(matches!(
+            source,
+            Some(crate::error::SlateDBError::SegmentExtractorRequired)
+        ));
+        assert!(status
+            .list_segments(DurabilityLevel::Remote)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_list_remote_segments_without_extractor() {
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_lists_remote_segments_without_extractor";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        db.put_with_options(
+            b"abc-1",
+            b"v1",
+            &PutOptions::default(),
+            &WriteOptions {
+                await_durable: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        db.close().await.unwrap();
+
+        // when
+        let reader = DbReader::builder(path, object_store).build().await.unwrap();
+
+        // then
+        let status = reader.status();
+        let remote: Vec<Bytes> = status
+            .list_segments(DurabilityLevel::Remote)
+            .unwrap()
+            .into_iter()
+            .map(|seg| seg.prefix)
+            .collect();
+        assert_eq!(remote, vec![Bytes::from_static(b"abc")]);
+        let err = status.list_segments(DurabilityLevel::Memory).unwrap_err();
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        let source = std::error::Error::source(&err)
+            .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
+        assert!(matches!(
+            source,
+            Some(crate::error::SlateDBError::SegmentExtractorRequired)
+        ));
+    }
+
+    #[tokio::test]
+    async fn should_reject_reader_with_mismatched_extractor() {
+        #[derive(Debug)]
+        struct OtherExtractor;
+        impl crate::prefix_extractor::PrefixExtractor for OtherExtractor {
+            fn name(&self) -> &str {
+                "other"
+            }
+            fn prefix_len(&self, _target: &crate::prefix_extractor::PrefixTarget) -> Option<usize> {
+                Some(3)
+            }
+        }
+
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_rejects_mismatched_extractor";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        db.close().await.unwrap();
+
+        // when
+        let err = match DbReader::builder(path, object_store.clone())
+            .with_segment_extractor(Arc::new(OtherExtractor))
+            .build()
+            .await
+        {
+            Ok(_) => panic!("expected mismatched-extractor error"),
+            Err(err) => err,
+        };
+
+        // then
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+
+        // when
+        let remote_only = DbReader::builder(path, object_store).build().await;
+
+        // then
+        assert!(remote_only.is_ok());
+    }
+
+    #[tokio::test]
+    async fn should_list_checkpoint_segments_for_checkpoint_reader() {
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_lists_checkpoint_segments";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let write_opts = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+        db.put_with_options(b"abc-1", b"v1", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        let checkpoint = db
+            .create_checkpoint(CheckpointScope::All, &CheckpointOptions::default())
+            .await
+            .unwrap();
+        db.put_with_options(b"xyz-1", b"v2", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        db.close().await.unwrap();
+
+        // when
+        let reader = DbReader::builder(path, object_store)
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .with_checkpoint_id(checkpoint.id)
+            .build()
+            .await
+            .unwrap();
+
+        // then
+        let status = reader.status();
+        let remote: Vec<Bytes> = status
+            .list_segments(DurabilityLevel::Remote)
+            .unwrap()
+            .into_iter()
+            .map(|seg| seg.prefix)
+            .collect();
+        assert_eq!(remote, vec![Bytes::from_static(b"abc")]);
+        let memory: Vec<Bytes> = status
+            .list_segments(DurabilityLevel::Memory)
+            .unwrap()
+            .into_iter()
+            .map(|seg| seg.prefix)
+            .collect();
+        assert_eq!(memory, vec![Bytes::from_static(b"abc")]);
     }
 
     #[tokio::test]
@@ -1587,6 +1865,7 @@ mod tests {
             &core,
             &mut into_tables,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1651,6 +1930,7 @@ mod tests {
             &core,
             &mut into_tables,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1702,6 +1982,7 @@ mod tests {
             &core,
             &mut into_tables,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1737,6 +2018,7 @@ mod tests {
             &core,
             &mut into_tables,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1767,6 +2049,7 @@ mod tests {
             &core,
             &mut into_tables,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1812,6 +2095,7 @@ mod tests {
             &core,
             &mut into_tables,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -2084,6 +2368,7 @@ mod tests {
                 self,
                 checkpoint,
                 merge_operator,
+                None,
                 options,
                 self.system_clock.clone(),
                 self.rand.clone(),
@@ -2276,6 +2561,7 @@ mod tests {
             oracle,
             reader,
             status_manager: DbStatusManager::new(0),
+            segment_extractor: None,
             rand: test_provider.rand.clone(),
             recorder,
         };
@@ -2357,6 +2643,7 @@ mod tests {
             oracle,
             reader,
             status_manager: DbStatusManager::new(0),
+            segment_extractor: None,
             rand: test_provider.rand.clone(),
             recorder,
         }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1466,7 +1466,7 @@ mod tests {
             .and_then(|s| s.downcast_ref::<crate::error::SlateDBError>());
         assert!(matches!(
             source,
-            Some(crate::error::SlateDBError::SegmentExtractorRequired)
+            Some(crate::error::SlateDBError::SegmentExtractorMismatch { .. })
         ));
     }
 

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -661,7 +661,7 @@ impl DbStateReader for DbStateView {
 /// Union of the segment prefixes (RFC-0024) touched across a handle's live
 /// memtables — the active memtable plus every immutable memtable.
 ///
-/// Used to (re)establish or shrink the published in-memory segment set at the
+/// Used to (re)establish or shrink the published memtable segment set at the
 /// points where the live-memtable set changes in a way a single write cannot
 /// express: open / WAL replay / checkpoint refresh, and right after a flush pops
 /// a memtable and folds its prefixes into the manifest. Recomputing the union

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -658,6 +658,34 @@ impl DbStateReader for DbStateView {
     }
 }
 
+/// Union of the segment prefixes (RFC-0024) touched across a handle's live
+/// memtables — the active memtable plus every immutable memtable.
+///
+/// Used to (re)establish or shrink the published in-memory segment set at the
+/// points where the live-memtable set changes in a way a single write cannot
+/// express: open / WAL replay / checkpoint refresh, and right after a flush pops
+/// a memtable and folds its prefixes into the manifest. Recomputing the union
+/// here makes the set drop a prefix once the last live memtable holding it has
+/// flushed (and keeps it while any other live memtable still holds it). The
+/// write path, by contrast, only ever *adds* prefixes, so it publishes
+/// incrementally via [`DbStatusManager::add_memtable_segments`] instead of
+/// calling this.
+///
+/// The set is empty for a non-segmented database — one whose manifest records
+/// no segment extractor — so the caller need not gate the call itself.
+pub(crate) fn collect_touched_segments(
+    reader: &dyn DbStateReader,
+) -> std::collections::BTreeSet<Bytes> {
+    if reader.core().segment_extractor_name.is_none() {
+        return std::collections::BTreeSet::new();
+    }
+    let mut set = reader.memtable().touched_segments();
+    for imm in reader.imm_memtable() {
+        set.extend(imm.table().touched_segments());
+    }
+    set
+}
+
 impl DbState {
     pub(crate) fn new(manifest: DirtyObject<Manifest>) -> Self {
         Self {

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -63,13 +63,13 @@ impl DbStatus {
     /// [`Db`](crate::Db) validates its extractor at open time, so this method
     /// never errors for a writer.
     pub fn list_segments(&self) -> Result<Vec<SegmentPrefix>, crate::Error> {
-        let db_is_segmented = self
-            .current_manifest
-            .core()
-            .segment_extractor_name
-            .is_some();
-        if db_is_segmented && !self.has_segment_extractor {
-            return Err(SlateDBError::SegmentExtractorRequired.into());
+        let persisted_extractor = self.current_manifest.core().segment_extractor_name.clone();
+        if persisted_extractor.is_some() && !self.has_segment_extractor {
+            return Err(SlateDBError::SegmentExtractorMismatch {
+                persisted: persisted_extractor,
+                configured: None,
+            }
+            .into());
         }
         let mut set: BTreeSet<Bytes> = self
             .current_manifest
@@ -383,7 +383,7 @@ mod tests {
         let source = std::error::Error::source(&err).and_then(|s| s.downcast_ref::<SlateDBError>());
         assert!(matches!(
             source,
-            Some(SlateDBError::SegmentExtractorRequired)
+            Some(SlateDBError::SegmentExtractorMismatch { .. })
         ));
     }
 

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeSet;
 use bytes::Bytes;
 use tokio::sync::watch;
 
-use crate::config::DurabilityLevel;
 use crate::error::SlateDBError;
 use crate::manifest::VersionedManifest;
 use crate::utils::WatchableOnceCell;
@@ -35,45 +34,43 @@ pub struct DbStatus {
     /// The current in-memory manifest snapshot observed by this handle,
     /// paired with its manifest version ID.
     pub current_manifest: VersionedManifest,
-    /// In-memory segment prefixes (RFC-0024) touched by writes or WAL replay on
-    /// this handle that have not yet been folded into the manifest. Empty when
-    /// no segment extractor is configured. Read it via
-    /// [`DbStatus::list_segments`], which merges in the persisted segments.
-    inmemory_segments: Vec<SegmentPrefix>,
+    /// Segment prefixes (RFC-0024) touched by writes or WAL replay in this
+    /// handle's memtables but not yet flushed to the manifest. Empty when no
+    /// segment extractor is configured. Read it via
+    /// [`DbStatus::list_segments`], which merges in the segments in the manifest.
+    memtable_segments: Vec<SegmentPrefix>,
     /// Whether this handle has a segment extractor configured. Determines
-    /// whether [`list_segments`](DbStatus::list_segments) can satisfy a
-    /// [`DurabilityLevel::Memory`] request.
+    /// whether [`list_segments`](DbStatus::list_segments) can derive the
+    /// segments in the memtables.
     has_segment_extractor: bool,
     /// Set once the database has been closed, indicating the reason.
     pub close_reason: Option<CloseReason>,
 }
 
 impl DbStatus {
-    /// List segment prefixes (RFC-0024) at the requested durability level.
-    ///
-    /// - [`DurabilityLevel::Remote`]: only segments persisted in the current
-    ///   manifest.
-    /// - [`DurabilityLevel::Memory`]: persisted segments plus in-memory
-    ///   prefixes not yet flushed to object storage.
+    /// List all segment prefixes (RFC-0024): those in the current manifest
+    /// unioned with those touched in this handle's memtables but not yet
+    /// flushed.
     ///
     /// The result is sorted ascending by prefix and deduplicated.
     ///
-    /// [`DurabilityLevel::Remote`] always succeeds — the persisted segments come
-    /// from the manifest and need no extractor, so a handle without one still
-    /// observes them.
-    ///
     /// # Errors
     ///
-    /// Returns an error only when [`DurabilityLevel::Memory`] is requested on a
-    /// *segmented* database whose handle has no segment extractor configured —
-    /// the in-memory set cannot be derived, so the answer would be silently
-    /// incomplete. This can happen for a [`DbReader`](crate::DbReader) opened
-    /// without an extractor; a [`Db`](crate::Db) validates its extractor at open
-    /// time, so this method never errors for a writer.
-    pub fn list_segments(
-        &self,
-        durability_level: DurabilityLevel,
-    ) -> Result<Vec<SegmentPrefix>, crate::Error> {
+    /// Returns an error on a *segmented* database whose handle has no segment
+    /// extractor configured — the memtable segments cannot be derived, so the
+    /// answer would be silently incomplete. This can happen for a
+    /// [`DbReader`](crate::DbReader) opened without an extractor; a
+    /// [`Db`](crate::Db) validates its extractor at open time, so this method
+    /// never errors for a writer.
+    pub fn list_segments(&self) -> Result<Vec<SegmentPrefix>, crate::Error> {
+        let db_is_segmented = self
+            .current_manifest
+            .core()
+            .segment_extractor_name
+            .is_some();
+        if db_is_segmented && !self.has_segment_extractor {
+            return Err(SlateDBError::SegmentExtractorRequired.into());
+        }
         let mut set: BTreeSet<Bytes> = self
             .current_manifest
             .core()
@@ -81,17 +78,7 @@ impl DbStatus {
             .iter()
             .map(|segment| segment.prefix().clone())
             .collect();
-        if matches!(durability_level, DurabilityLevel::Memory) {
-            let db_is_segmented = self
-                .current_manifest
-                .core()
-                .segment_extractor_name
-                .is_some();
-            if db_is_segmented && !self.has_segment_extractor {
-                return Err(SlateDBError::SegmentExtractorRequired.into());
-            }
-            set.extend(self.inmemory_segments.iter().map(|s| s.prefix.clone()));
-        }
+        set.extend(self.memtable_segments.iter().map(|s| s.prefix.clone()));
         Ok(set
             .into_iter()
             .map(|prefix| SegmentPrefix { prefix })
@@ -135,7 +122,7 @@ impl DbStatusManager {
         let (tx, _) = watch::channel(DbStatus {
             durable_seq: initial_durable_seq,
             current_manifest: initial_manifest,
-            inmemory_segments: Vec::new(),
+            memtable_segments: Vec::new(),
             has_segment_extractor,
             close_reason: None,
         });
@@ -167,7 +154,7 @@ impl DbStatusManager {
         });
     }
 
-    /// Replace the published set of in-memory segment prefixes (RFC-0024) with
+    /// Replace the published set of memtable segment prefixes (RFC-0024) with
     /// the union over the handle's currently live memtables. This is the path
     /// that lets the set *shrink*: it is called when establishing the set (open
     /// / WAL replay / checkpoint refresh) and right after a flush pops a memtable
@@ -180,8 +167,8 @@ impl DbStatusManager {
             .map(|prefix| SegmentPrefix { prefix })
             .collect();
         self.tx.send_if_modified(|s| {
-            if s.inmemory_segments != segments {
-                s.inmemory_segments = segments;
+            if s.memtable_segments != segments {
+                s.memtable_segments = segments;
                 true
             } else {
                 false
@@ -189,7 +176,7 @@ impl DbStatusManager {
         });
     }
 
-    /// Add newly touched in-memory segment prefixes (RFC-0024) to the published
+    /// Add newly touched memtable segment prefixes (RFC-0024) to the published
     /// set. This is the write-path counterpart to
     /// [`Self::report_memtable_segments`]: a write can only *grow* the set, so
     /// rather than recomputing the full union over all live memtables on the hot
@@ -205,10 +192,10 @@ impl DbStatusManager {
             let mut changed = false;
             for prefix in prefixes {
                 if let Err(idx) = s
-                    .inmemory_segments
+                    .memtable_segments
                     .binary_search_by(|sp| sp.prefix.cmp(&prefix))
                 {
-                    s.inmemory_segments.insert(idx, SegmentPrefix { prefix });
+                    s.memtable_segments.insert(idx, SegmentPrefix { prefix });
                     changed = true;
                 }
             }
@@ -299,10 +286,10 @@ mod tests {
         }
     }
 
-    /// The published in-memory segments as an order-independent set (ordering is
+    /// The published memtable segments as an order-independent set (ordering is
     /// a property of `list_segments`, not of the raw field).
     fn segment_set(status: &DbStatus) -> BTreeSet<SegmentPrefix> {
-        status.inmemory_segments.iter().cloned().collect()
+        status.memtable_segments.iter().cloned().collect()
     }
 
     #[test]
@@ -314,10 +301,7 @@ mod tests {
         let status = mgr.status();
 
         // then
-        assert!(status
-            .list_segments(DurabilityLevel::Remote)
-            .unwrap()
-            .is_empty());
+        assert!(status.list_segments().unwrap().is_empty());
     }
 
     #[test]
@@ -331,27 +315,13 @@ mod tests {
 
         // then
         assert_eq!(
-            status.list_segments(DurabilityLevel::Remote).unwrap(),
+            status.list_segments().unwrap(),
             vec![segment_prefix(b"a"), segment_prefix(b"b")]
         );
     }
 
     #[test]
-    fn should_list_only_manifest_segments_for_remote() {
-        // given
-        let mgr =
-            DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]), true);
-        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"c")]));
-
-        // when
-        let remote = mgr.status().list_segments(DurabilityLevel::Remote).unwrap();
-
-        // then
-        assert_eq!(remote, vec![segment_prefix(b"a"), segment_prefix(b"b")]);
-    }
-
-    #[test]
-    fn should_union_and_dedup_segments_for_memory() {
+    fn should_union_and_dedup_segments() {
         // given
         let mgr =
             DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]), true);
@@ -361,11 +331,11 @@ mod tests {
         ]));
 
         // when
-        let memory = mgr.status().list_segments(DurabilityLevel::Memory).unwrap();
+        let segments = mgr.status().list_segments().unwrap();
 
         // then
         assert_eq!(
-            memory,
+            segments,
             vec![
                 segment_prefix(b"a"),
                 segment_prefix(b"b"),
@@ -375,7 +345,7 @@ mod tests {
     }
 
     #[test]
-    fn should_return_sorted_segments_for_memory() {
+    fn should_return_sorted_segments() {
         // given
         let mgr =
             DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"d", b"b"]), true);
@@ -385,11 +355,11 @@ mod tests {
         ]));
 
         // when
-        let memory = mgr.status().list_segments(DurabilityLevel::Memory).unwrap();
+        let segments = mgr.status().list_segments().unwrap();
 
         // then
         assert_eq!(
-            memory,
+            segments,
             vec![
                 segment_prefix(b"a"),
                 segment_prefix(b"b"),
@@ -400,13 +370,13 @@ mod tests {
     }
 
     #[test]
-    fn should_error_for_memory_without_extractor() {
+    fn should_error_without_extractor() {
         // given
         let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a"]), false);
         let status = mgr.status();
 
         // when
-        let err = status.list_segments(DurabilityLevel::Memory).unwrap_err();
+        let err = status.list_segments().unwrap_err();
 
         // then
         assert_eq!(err.kind(), crate::ErrorKind::Invalid);
@@ -415,10 +385,6 @@ mod tests {
             source,
             Some(SlateDBError::SegmentExtractorRequired)
         ));
-        assert_eq!(
-            status.list_segments(DurabilityLevel::Remote).unwrap(),
-            vec![segment_prefix(b"a")]
-        );
     }
 
     #[test]
@@ -434,7 +400,7 @@ mod tests {
         // then
         assert!(rx.has_changed().unwrap());
         assert_eq!(
-            rx.borrow_and_update().inmemory_segments,
+            rx.borrow_and_update().memtable_segments,
             vec![segment_prefix(b"x")]
         );
     }

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -1,9 +1,24 @@
+use std::collections::BTreeSet;
+
+use bytes::Bytes;
 use tokio::sync::watch;
 
+use crate::config::DurabilityLevel;
 use crate::error::SlateDBError;
 use crate::manifest::VersionedManifest;
 use crate::utils::WatchableOnceCell;
 use crate::CloseReason;
+
+/// A segment (RFC-0024), identified by the key prefix it owns; the segment
+/// spans the key interval `[prefix, prefix++)`.
+///
+/// Note: this is distinct from [`crate::manifest::Segment`], which also carries
+/// per-segment LSM state. This type is prefix-only.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SegmentPrefix {
+    /// The key prefix owned by the segment.
+    pub prefix: Bytes,
+}
 
 /// Current status of the database, exposed via [`crate::Db::subscribe`].
 ///
@@ -20,8 +35,68 @@ pub struct DbStatus {
     /// The current in-memory manifest snapshot observed by this handle,
     /// paired with its manifest version ID.
     pub current_manifest: VersionedManifest,
+    /// In-memory segment prefixes (RFC-0024) touched by writes or WAL replay on
+    /// this handle that have not yet been folded into the manifest. Empty when
+    /// no segment extractor is configured. Read it via
+    /// [`DbStatus::list_segments`], which merges in the persisted segments.
+    inmemory_segments: Vec<SegmentPrefix>,
+    /// Whether this handle has a segment extractor configured. Determines
+    /// whether [`list_segments`](DbStatus::list_segments) can satisfy a
+    /// [`DurabilityLevel::Memory`] request.
+    has_segment_extractor: bool,
     /// Set once the database has been closed, indicating the reason.
     pub close_reason: Option<CloseReason>,
+}
+
+impl DbStatus {
+    /// List segment prefixes (RFC-0024) at the requested durability level.
+    ///
+    /// - [`DurabilityLevel::Remote`]: only segments persisted in the current
+    ///   manifest.
+    /// - [`DurabilityLevel::Memory`]: persisted segments plus in-memory
+    ///   prefixes not yet flushed to object storage.
+    ///
+    /// The result is sorted ascending by prefix and deduplicated.
+    ///
+    /// [`DurabilityLevel::Remote`] always succeeds — the persisted segments come
+    /// from the manifest and need no extractor, so a handle without one still
+    /// observes them.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error only when [`DurabilityLevel::Memory`] is requested on a
+    /// *segmented* database whose handle has no segment extractor configured —
+    /// the in-memory set cannot be derived, so the answer would be silently
+    /// incomplete. This can happen for a [`DbReader`](crate::DbReader) opened
+    /// without an extractor; a [`Db`](crate::Db) validates its extractor at open
+    /// time, so this method never errors for a writer.
+    pub fn list_segments(
+        &self,
+        durability_level: DurabilityLevel,
+    ) -> Result<Vec<SegmentPrefix>, crate::Error> {
+        let mut set: BTreeSet<Bytes> = self
+            .current_manifest
+            .core()
+            .segments
+            .iter()
+            .map(|segment| segment.prefix().clone())
+            .collect();
+        if matches!(durability_level, DurabilityLevel::Memory) {
+            let db_is_segmented = self
+                .current_manifest
+                .core()
+                .segment_extractor_name
+                .is_some();
+            if db_is_segmented && !self.has_segment_extractor {
+                return Err(SlateDBError::SegmentExtractorRequired.into());
+            }
+            set.extend(self.inmemory_segments.iter().map(|s| s.prefix.clone()));
+        }
+        Ok(set
+            .into_iter()
+            .map(|prefix| SegmentPrefix { prefix })
+            .collect())
+    }
 }
 
 pub(crate) trait ClosedResultWriter: std::fmt::Debug + Send + Sync + 'static {
@@ -48,16 +123,20 @@ impl DbStatusManager {
                 id: 1,
                 manifest: Manifest::initial(ManifestCore::new()),
             },
+            false,
         )
     }
 
     pub(crate) fn new_with_manifest(
         initial_durable_seq: u64,
         initial_manifest: VersionedManifest,
+        has_segment_extractor: bool,
     ) -> Self {
         let (tx, _) = watch::channel(DbStatus {
             durable_seq: initial_durable_seq,
             current_manifest: initial_manifest,
+            inmemory_segments: Vec::new(),
+            has_segment_extractor,
             close_reason: None,
         });
         Self {
@@ -85,6 +164,55 @@ impl DbStatusManager {
             } else {
                 false
             }
+        });
+    }
+
+    /// Replace the published set of in-memory segment prefixes (RFC-0024) with
+    /// the union over the handle's currently live memtables. This is the path
+    /// that lets the set *shrink*: it is called when establishing the set (open
+    /// / WAL replay / checkpoint refresh) and right after a flush pops a memtable
+    /// and folds its prefixes into the manifest, so a prefix held only by the
+    /// flushed memtable drops out. Notifies subscribers only when the sorted set
+    /// actually changes.
+    pub(crate) fn report_memtable_segments(&self, prefixes: BTreeSet<Bytes>) {
+        let segments: Vec<SegmentPrefix> = prefixes
+            .into_iter()
+            .map(|prefix| SegmentPrefix { prefix })
+            .collect();
+        self.tx.send_if_modified(|s| {
+            if s.inmemory_segments != segments {
+                s.inmemory_segments = segments;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    /// Add newly touched in-memory segment prefixes (RFC-0024) to the published
+    /// set. This is the write-path counterpart to
+    /// [`Self::report_memtable_segments`]: a write can only *grow* the set, so
+    /// rather than recomputing the full union over all live memtables on the hot
+    /// path, we insert just the prefixes this write touched and notify only when
+    /// at least one was not already published. Prefixes leave the set via
+    /// [`Self::report_memtable_segments`] when their memtable is flushed. Keeps
+    /// `segments` sorted ascending.
+    pub(crate) fn add_memtable_segments(&self, prefixes: BTreeSet<Bytes>) {
+        if prefixes.is_empty() {
+            return;
+        }
+        self.tx.send_if_modified(|s| {
+            let mut changed = false;
+            for prefix in prefixes {
+                if let Err(idx) = s
+                    .inmemory_segments
+                    .binary_search_by(|sp| sp.prefix.cmp(&prefix))
+                {
+                    s.inmemory_segments.insert(idx, SegmentPrefix { prefix });
+                    changed = true;
+                }
+            }
+            changed
         });
     }
 
@@ -147,11 +275,242 @@ mod tests {
         }
     }
 
+    fn manifest_with_segments(id: u64, prefixes: &[&[u8]]) -> VersionedManifest {
+        use crate::manifest::{LsmTreeState, Segment};
+        use std::sync::Arc;
+        let mut core = ManifestCore::new();
+        core.segment_extractor_name = Some("test".to_string());
+        core.segments = prefixes
+            .iter()
+            .map(|p| Segment {
+                prefix: Bytes::from(p.to_vec()),
+                tree: Arc::new(LsmTreeState::default()),
+            })
+            .collect();
+        VersionedManifest {
+            id,
+            manifest: Manifest::initial(core),
+        }
+    }
+
+    fn segment_prefix(prefix: &[u8]) -> SegmentPrefix {
+        SegmentPrefix {
+            prefix: Bytes::from(prefix.to_vec()),
+        }
+    }
+
+    /// The published in-memory segments as an order-independent set (ordering is
+    /// a property of `list_segments`, not of the raw field).
+    fn segment_set(status: &DbStatus) -> BTreeSet<SegmentPrefix> {
+        status.inmemory_segments.iter().cloned().collect()
+    }
+
+    #[test]
+    fn should_initialize_with_no_segments_from_empty_manifest() {
+        // given
+        let mgr = DbStatusManager::new_with_manifest(0, versioned_manifest(1), false);
+
+        // when
+        let status = mgr.status();
+
+        // then
+        assert!(status
+            .list_segments(DurabilityLevel::Remote)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn should_initialize_with_segments_from_manifest() {
+        // given
+        let mgr =
+            DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]), true);
+
+        // when
+        let status = mgr.status();
+
+        // then
+        assert_eq!(
+            status.list_segments(DurabilityLevel::Remote).unwrap(),
+            vec![segment_prefix(b"a"), segment_prefix(b"b")]
+        );
+    }
+
+    #[test]
+    fn should_list_only_manifest_segments_for_remote() {
+        // given
+        let mgr =
+            DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]), true);
+        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"c")]));
+
+        // when
+        let remote = mgr.status().list_segments(DurabilityLevel::Remote).unwrap();
+
+        // then
+        assert_eq!(remote, vec![segment_prefix(b"a"), segment_prefix(b"b")]);
+    }
+
+    #[test]
+    fn should_union_and_dedup_segments_for_memory() {
+        // given
+        let mgr =
+            DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]), true);
+        mgr.report_memtable_segments(BTreeSet::from([
+            Bytes::from_static(b"b"),
+            Bytes::from_static(b"c"),
+        ]));
+
+        // when
+        let memory = mgr.status().list_segments(DurabilityLevel::Memory).unwrap();
+
+        // then
+        assert_eq!(
+            memory,
+            vec![
+                segment_prefix(b"a"),
+                segment_prefix(b"b"),
+                segment_prefix(b"c")
+            ]
+        );
+    }
+
+    #[test]
+    fn should_return_sorted_segments_for_memory() {
+        // given
+        let mgr =
+            DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"d", b"b"]), true);
+        mgr.report_memtable_segments(BTreeSet::from([
+            Bytes::from_static(b"c"),
+            Bytes::from_static(b"a"),
+        ]));
+
+        // when
+        let memory = mgr.status().list_segments(DurabilityLevel::Memory).unwrap();
+
+        // then
+        assert_eq!(
+            memory,
+            vec![
+                segment_prefix(b"a"),
+                segment_prefix(b"b"),
+                segment_prefix(b"c"),
+                segment_prefix(b"d")
+            ]
+        );
+    }
+
+    #[test]
+    fn should_error_for_memory_without_extractor() {
+        // given
+        let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a"]), false);
+        let status = mgr.status();
+
+        // when
+        let err = status.list_segments(DurabilityLevel::Memory).unwrap_err();
+
+        // then
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        let source = std::error::Error::source(&err).and_then(|s| s.downcast_ref::<SlateDBError>());
+        assert!(matches!(
+            source,
+            Some(SlateDBError::SegmentExtractorRequired)
+        ));
+        assert_eq!(
+            status.list_segments(DurabilityLevel::Remote).unwrap(),
+            vec![segment_prefix(b"a")]
+        );
+    }
+
+    #[test]
+    fn should_notify_when_reported_segments_change() {
+        // given
+        let mgr = DbStatusManager::new(0);
+        let mut rx = mgr.subscribe();
+        rx.borrow_and_update();
+
+        // when
+        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
+
+        // then
+        assert!(rx.has_changed().unwrap());
+        assert_eq!(
+            rx.borrow_and_update().inmemory_segments,
+            vec![segment_prefix(b"x")]
+        );
+    }
+
+    #[test]
+    fn should_notify_when_adding_a_new_segment() {
+        // given
+        let mgr = DbStatusManager::new(0);
+        let mut rx = mgr.subscribe();
+        rx.borrow_and_update();
+
+        // when
+        mgr.add_memtable_segments(BTreeSet::from([Bytes::from_static(b"m")]));
+
+        // then
+        assert!(rx.has_changed().unwrap());
+        assert_eq!(
+            segment_set(&rx.borrow_and_update()),
+            BTreeSet::from([segment_prefix(b"m")])
+        );
+
+        // when
+        mgr.add_memtable_segments(BTreeSet::from([Bytes::from_static(b"a")]));
+
+        // then
+        assert!(rx.has_changed().unwrap());
+        assert_eq!(
+            segment_set(&rx.borrow_and_update()),
+            BTreeSet::from([segment_prefix(b"a"), segment_prefix(b"m")])
+        );
+    }
+
+    #[test]
+    fn should_not_notify_when_adding_a_known_segment() {
+        // given
+        let mgr = DbStatusManager::new(0);
+        mgr.add_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
+        let mut rx = mgr.subscribe();
+        rx.borrow_and_update();
+
+        // when
+        mgr.add_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
+
+        // then
+        assert!(!rx.has_changed().unwrap());
+
+        // when
+        mgr.add_memtable_segments(BTreeSet::from([
+            Bytes::from_static(b"x"),
+            Bytes::from_static(b"y"),
+        ]));
+
+        // then
+        assert!(rx.has_changed().unwrap());
+    }
+
+    #[test]
+    fn should_not_notify_when_reported_segments_unchanged() {
+        // given
+        let mgr = DbStatusManager::new(0);
+        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
+        let mut rx = mgr.subscribe();
+        rx.borrow_and_update();
+
+        // when
+        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
+
+        // then
+        assert!(!rx.has_changed().unwrap());
+    }
+
     #[test]
     fn should_not_notify_on_same_manifest() {
         // given
         let initial = versioned_manifest(1);
-        let mgr = DbStatusManager::new_with_manifest(0, initial.clone());
+        let mgr = DbStatusManager::new_with_manifest(0, initial.clone(), false);
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 
@@ -165,7 +524,7 @@ mod tests {
     #[test]
     fn should_not_notify_on_older_manifest() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, versioned_manifest(5));
+        let mgr = DbStatusManager::new_with_manifest(0, versioned_manifest(5), false);
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -58,10 +58,10 @@ impl DbStatus {
     ///
     /// Returns an error on a *segmented* database whose handle has no segment
     /// extractor configured — the memtable segments cannot be derived, so the
-    /// answer would be silently incomplete. This can happen for a
-    /// [`DbReader`](crate::DbReader) opened without an extractor; a
-    /// [`Db`](crate::Db) validates its extractor at open time, so this method
-    /// never errors for a writer.
+    /// answer would be silently incomplete. Both [`Db`](crate::Db) and
+    /// [`DbReader`](crate::DbReader) validate their extractor against the
+    /// manifest at open time, so in practice a handle on a segmented database
+    /// always has one; this remains a defensive guard.
     pub fn list_segments(&self) -> Result<Vec<SegmentPrefix>, crate::Error> {
         let persisted_extractor = self.current_manifest.core().segment_extractor_name.clone();
         if persisted_extractor.is_some() && !self.has_segment_extractor {

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -103,12 +103,6 @@ pub(crate) enum SlateDBError {
     #[error("segment extractor produced an empty prefix for key {key:?}")]
     EmptySegmentPrefix { key: Bytes },
 
-    #[error(
-        "listing in-memory segments requires a segment extractor, but none is \
-         configured on this handle"
-    )]
-    SegmentExtractorRequired,
-
     #[error("compaction executor failed")]
     CompactionExecutorFailed,
 
@@ -619,12 +613,17 @@ impl From<SlateDBError> for Error {
             SlateDBError::InvalidCompaction => Error::invalid(msg),
             SlateDBError::InvalidSegmentPrefix { .. } => Error::invalid(msg),
             SlateDBError::RecencyScanPrefixSpansMultipleSegments => Error::invalid(msg),
-            SlateDBError::SegmentExtractorMismatch { .. } => Error::invalid(msg),
+            SlateDBError::SegmentExtractorMismatch {
+                persisted,
+                configured,
+            } => {
+                Error::invalid(msg).with_source(Box::new(SlateDBError::SegmentExtractorMismatch {
+                    persisted,
+                    configured,
+                }))
+            }
             SlateDBError::SegmentPrefixNotRecognized { .. } => Error::invalid(msg),
             SlateDBError::EmptySegmentPrefix { .. } => Error::invalid(msg),
-            SlateDBError::SegmentExtractorRequired => {
-                Error::invalid(msg).with_source(Box::new(SlateDBError::SegmentExtractorRequired))
-            }
             SlateDBError::InvalidClockTick { .. } => Error::invalid(msg),
             SlateDBError::InvalidDeletion => Error::invalid(msg),
             SlateDBError::MergeOperatorError(err) => Error::invalid(msg).with_source(Box::new(err)),

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -103,6 +103,12 @@ pub(crate) enum SlateDBError {
     #[error("segment extractor produced an empty prefix for key {key:?}")]
     EmptySegmentPrefix { key: Bytes },
 
+    #[error(
+        "listing in-memory segments requires a segment extractor, but none is \
+         configured on this handle"
+    )]
+    SegmentExtractorRequired,
+
     #[error("compaction executor failed")]
     CompactionExecutorFailed,
 
@@ -616,6 +622,9 @@ impl From<SlateDBError> for Error {
             SlateDBError::SegmentExtractorMismatch { .. } => Error::invalid(msg),
             SlateDBError::SegmentPrefixNotRecognized { .. } => Error::invalid(msg),
             SlateDBError::EmptySegmentPrefix { .. } => Error::invalid(msg),
+            SlateDBError::SegmentExtractorRequired => {
+                Error::invalid(msg).with_source(Box::new(SlateDBError::SegmentExtractorRequired))
+            }
             SlateDBError::InvalidClockTick { .. } => Error::invalid(msg),
             SlateDBError::InvalidDeletion => Error::invalid(msg),
             SlateDBError::MergeOperatorError(err) => Error::invalid(msg).with_source(Box::new(err)),

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -43,7 +43,7 @@ pub use compaction_filter::{
 pub use compactor::CompactorBuilder;
 pub use compactor_state::VersionedCompactions;
 pub use config::{Settings, SstBlockSize};
-pub use db::{Db, DbBuilder, DbReaderBuilder, DbStatus, WriteHandle};
+pub use db::{Db, DbBuilder, DbReaderBuilder, DbStatus, SegmentPrefix, WriteHandle};
 pub use db_cache::stats as db_cache_stats;
 pub use db_cache_manager::CacheTarget;
 pub use db_iter::{DbIterator, DbRecencyIterator};

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -328,16 +328,6 @@ impl ImmutableMemtable {
     /// remains the same.
     pub(crate) fn filter_after_seq(&self, seq: u64) -> Self {
         let new_table = WritableKVTable::new();
-        // Recompute the touched-segment set from the surviving rows rather than
-        // copying the original: filtering by seq can drop every row of a prefix
-        // (e.g. WAL replay grouped prefixes `a` and `b`, and only `a` was below
-        // `seq`), and reporting `a` here would leave it in the published
-        // in-memory segment set with no live memtable backing it. The set is an
-        // antichain, so each key falls under at most one prefix; stop scanning
-        // once every prefix is accounted for. For a segmented DB every written
-        // key recorded its prefix, so a non-empty filtered table still yields a
-        // populated set (the invariant the build path relies on); for a
-        // non-segmented DB the original set is empty and this is a no-op.
         let original_segments = self.table.touched_segments();
         let mut surviving_segments = std::collections::BTreeSet::new();
         let mut table_iter = self.table.iter();

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -328,18 +328,33 @@ impl ImmutableMemtable {
     /// remains the same.
     pub(crate) fn filter_after_seq(&self, seq: u64) -> Self {
         let new_table = WritableKVTable::new();
+        // Recompute the touched-segment set from the surviving rows rather than
+        // copying the original: filtering by seq can drop every row of a prefix
+        // (e.g. WAL replay grouped prefixes `a` and `b`, and only `a` was below
+        // `seq`), and reporting `a` here would leave it in the published
+        // in-memory segment set with no live memtable backing it. The set is an
+        // antichain, so each key falls under at most one prefix; stop scanning
+        // once every prefix is accounted for. For a segmented DB every written
+        // key recorded its prefix, so a non-empty filtered table still yields a
+        // populated set (the invariant the build path relies on); for a
+        // non-segmented DB the original set is empty and this is a no-op.
+        let original_segments = self.table.touched_segments();
+        let mut surviving_segments = std::collections::BTreeSet::new();
         let mut table_iter = self.table.iter();
         while let Some(entry) = table_iter.next_sync() {
             if entry.seq > seq {
+                if surviving_segments.len() < original_segments.len() {
+                    for prefix in &original_segments {
+                        if entry.key.starts_with(prefix.as_ref()) {
+                            surviving_segments.insert(prefix.clone());
+                            break;
+                        }
+                    }
+                }
                 new_table.put(entry);
             }
         }
-        // Preserve the touched-segment set on the filtered table:
-        // filtering by seq can remove rows but never changes which
-        // segment prefixes the imm's surviving keys could route to,
-        // and the build path requires `KVTable` non-empty ⇒
-        // `touched_segments` populated.
-        new_table.record_touched_segments(self.table.touched_segments());
+        new_table.record_touched_segments(surviving_segments);
         Self::new(new_table, self.recent_flushed_wal_id)
     }
 }
@@ -950,6 +965,86 @@ mod tests {
         assert!(!table
             .ensure_valid_segment(&Bytes::from_static(b"zzz"))
             .unwrap());
+    }
+
+    fn surviving_keys(imm: &ImmutableMemtable) -> Vec<Bytes> {
+        let mut iter = imm.table().iter();
+        let mut keys = Vec::new();
+        while let Some(entry) = iter.next_sync() {
+            keys.push(entry.key);
+        }
+        keys
+    }
+
+    #[test]
+    fn should_drop_prefix_with_no_surviving_rows() {
+        // given
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"a1", b"v", 1));
+        table.put(RowEntry::new_value(b"a2", b"v", 2));
+        table.put(RowEntry::new_value(b"b1", b"v", 3));
+        table.put(RowEntry::new_value(b"b2", b"v", 4));
+        table.record_touched_segments(touched(&[b"a", b"b"]));
+        let imm = ImmutableMemtable::new(table, 0);
+
+        // when
+        let filtered = imm.filter_after_seq(2);
+
+        // then
+        assert_eq!(filtered.table().touched_segments(), touched(&[b"b"]));
+        assert_eq!(
+            surviving_keys(&filtered),
+            vec![Bytes::from_static(b"b1"), Bytes::from_static(b"b2")]
+        );
+    }
+
+    #[test]
+    fn should_keep_prefixes_with_surviving_rows() {
+        // given
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"a1", b"v", 1));
+        table.put(RowEntry::new_value(b"b1", b"v", 2));
+        table.record_touched_segments(touched(&[b"a", b"b"]));
+        let imm = ImmutableMemtable::new(table, 0);
+
+        // when
+        let filtered = imm.filter_after_seq(0);
+
+        // then
+        assert_eq!(filtered.table().touched_segments(), touched(&[b"a", b"b"]));
+    }
+
+    #[test]
+    fn should_empty_touched_segments_when_no_rows_survive() {
+        // given
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"a1", b"v", 1));
+        table.put(RowEntry::new_value(b"b1", b"v", 2));
+        table.record_touched_segments(touched(&[b"a", b"b"]));
+        let imm = ImmutableMemtable::new(table, 0);
+
+        // when
+        let filtered = imm.filter_after_seq(10);
+
+        // then
+        assert!(filtered.table().touched_segments().is_empty());
+        assert!(surviving_keys(&filtered).is_empty());
+    }
+
+    #[test]
+    fn should_leave_touched_segments_empty_for_non_segmented() {
+        // given
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(b"a1", b"v", 1));
+        table.put(RowEntry::new_value(b"b1", b"v", 2));
+        let imm = ImmutableMemtable::new(table, 0);
+
+        // when
+        let filtered = imm.filter_after_seq(1);
+
+        // then
+        assert!(filtered.table().touched_segments().is_empty());
+        assert_eq!(surviving_keys(&filtered), vec![Bytes::from_static(b"b1")]);
     }
 
     #[tokio::test]

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -19,7 +19,7 @@ use super::uploader::UploadedMemtable;
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::SsTableView;
+use crate::db_state::{collect_touched_segments, SsTableView};
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
@@ -546,8 +546,9 @@ impl ManifestWriterHandler {
             Ok(modifier.state.manifest.clone())
         })?;
 
-        drop(guard);
+        let segments = collect_touched_segments(&guard.view());
         self.db.status_manager.report_manifest(manifest.into());
+        self.db.status_manager.report_memtable_segments(segments);
         Ok(())
     }
 

--- a/slatedb/src/ops.rs
+++ b/slatedb/src/ops.rs
@@ -521,7 +521,7 @@ pub trait DbMetadataOps {
     /// Returns a [`tokio::sync::watch::Receiver<DbStatus>`] that always
     /// reflects the latest database status. The status includes the latest durable
     /// sequence number and the current manifest snapshot observed by this
-    /// handle. For [`Db`](crate::Db) is is the current in-memory snapshot and
+    /// handle. For [`Db`](crate::Db) is the current in-memory snapshot and
     /// for [`DbReader`](crate::DbReader) it is the latest manifest polled from object storage.
     /// For example, you can wait for a specific sequence number to
     /// become durable:
@@ -530,6 +530,25 @@ pub trait DbMetadataOps {
     /// let seq = 42; // sequence number from a write operation
     /// let mut rx = db.subscribe();
     /// rx.wait_for(|s| s.durable_seq >= seq).await.expect("db dropped");
+    /// ```
+    ///
+    /// The status also exposes the segment prefixes (RFC-0024) known to the
+    /// handle via [`DbStatus::list_segments`](crate::DbStatus::list_segments),
+    /// which returns the persisted set (`Remote`) or the union of persisted and
+    /// in-memory prefixes not yet folded into the manifest (`Memory`). For
+    /// example, you can wait for a segment to appear:
+    ///
+    /// ```ignore
+    /// use slatedb::config::DurabilityLevel;
+    /// let want = b"prefix".to_vec();
+    /// let mut rx = db.subscribe();
+    /// rx.wait_for(|s| {
+    ///     s.list_segments(DurabilityLevel::Memory)
+    ///         .map(|segs| segs.iter().any(|seg| seg.prefix == want))
+    ///         .unwrap_or(false)
+    /// })
+    /// .await
+    /// .expect("db dropped");
     /// ```
     ///
     /// # Deadlock risk

--- a/slatedb/src/ops.rs
+++ b/slatedb/src/ops.rs
@@ -534,16 +534,15 @@ pub trait DbMetadataOps {
     ///
     /// The status also exposes the segment prefixes (RFC-0024) known to the
     /// handle via [`DbStatus::list_segments`](crate::DbStatus::list_segments),
-    /// which returns the persisted set (`Remote`) or the union of persisted and
-    /// in-memory prefixes not yet folded into the manifest (`Memory`). For
-    /// example, you can wait for a segment to appear:
+    /// which returns all segments — the union of those in the manifest and those
+    /// touched in the memtables but not yet flushed. For example, you can wait
+    /// for a segment to appear:
     ///
     /// ```ignore
-    /// use slatedb::config::DurabilityLevel;
     /// let want = b"prefix".to_vec();
     /// let mut rx = db.subscribe();
     /// rx.wait_for(|s| {
-    ///     s.list_segments(DurabilityLevel::Memory)
+    ///     s.list_segments()
     ///         .map(|segs| segs.iter().any(|seg| seg.prefix == want))
     ///         .unwrap_or(false)
     /// })


### PR DESCRIPTION
## Summary

Implements the `list_segments()` API as proposed in https://github.com/slatedb/slatedb/pull/1731. The `list_segments()` method returns the segments that are persisted on object store and optionally also the ones that only exist in memory in memtables. The method is added to the `DbStatus` struct returned by `Db/DbReader::subscribe()`.

## Changes

- extended `DbStatus` with method `list_segments()`
- extended `DbStatusManager` with methods to update the current in-memory segments
- `DbReader` can now optionally be configured with a prefix extractor to produce segments when reading WAL SSTs.
- added an error `SegmentExtractorRequired` for the case when in-memory segments should be returned from a reader but the reader does not have a prefix extractor.

## Notes for Reviewers

- Please read the following two comments and confirm that my changes do not break any assumption:
  - https://github.com/slatedb/slatedb/pull/1759/changes#r3356361212
  - https://github.com/slatedb/slatedb/pull/1759/changes#r3356448872
- I plan to look into the bindings for other languages after this PR is merged. 

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
