### PR TITLE
perf(compaction): pipeline SST close() off the main merge loop

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -8,6 +8,7 @@ use chrono::TimeDelta;
 use futures::future::{join, join_all};
 use parking_lot::Mutex;
 use tokio::task::JoinHandle;
+use tokio_util::task::AbortOnDropHandle;
 
 #[cfg(feature = "compaction_filters")]
 use crate::compaction_filter::CompactionFilterSupplier;
@@ -400,6 +401,27 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
         }
     }
 
+    /// Awaits an in-flight SST close, records its stats, and appends the
+    /// resulting handle to `output_ssts`. Handles are appended in spawn order,
+    /// which preserves the ascending-key ordering required within a sorted run.
+    async fn collect_close(
+        &self,
+        pending: AbortOnDropHandle<Result<SsTableHandle, SlateDBError>>,
+        output_ssts: &mut Vec<SsTableHandle>,
+    ) -> Result<(), SlateDBError> {
+        let sst = pending.await.map_err(|e| {
+            let name = "compactor_sst_close".to_string();
+            if e.is_cancelled() {
+                SlateDBError::BackgroundTaskCancelled(name)
+            } else {
+                SlateDBError::BackgroundTaskPanic(name)
+            }
+        })??;
+        self.stats.bytes_compacted.increment(sst.info.filter_offset);
+        output_ssts.push(sst);
+        Ok(())
+    }
+
     /// Executes a single compaction job and returns the resulting [`SortedRun`].
     ///
     /// ## Steps
@@ -427,10 +449,20 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
             estimate_bytes_before_key(args.sorted_runs.as_slice(), k)
         });
 
+        // At most one SST close runs in the background at a time (depth-1
+        // pipeline). While a finished SST flushes to the object store we keep
+        // merging input and filling the next SST, instead of stalling the loop
+        // on close(). Only one buffered SST is held outstanding, which bounds
+        // memory and applies backpressure when the object store is slow.
+        let mut pending_close: Option<AbortOnDropHandle<Result<SsTableHandle, SlateDBError>>> =
+            None;
+
         while let Some(kv) = all_iter.next().await? {
             let duration_since_last_report =
                 self.clock.now().signed_duration_since(last_progress_report);
             if duration_since_last_report > TimeDelta::seconds(1) {
+                // Report only the durable prefix (output_ssts); a still-in-flight
+                // close is folded in when it's drained at the next SST boundary.
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
                 self.send_compaction_progress(args.id, total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();
@@ -441,23 +473,37 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
             }
 
             if bytes_written > self.options.max_sst_size {
+                // Depth-1 backpressure: drain the previous close (collecting its
+                // handle in order) before starting another.
+                if let Some(pending) = pending_close.take() {
+                    self.collect_close(pending, &mut output_ssts).await?;
+                }
                 let finished_writer = mem::replace(
                     &mut current_writer,
                     self.table_store.table_writer(SsTableId::Compacted(
                         self.rand.rng().gen_ulid(self.clock.as_ref()),
                     )),
                 );
-                let sst = finished_writer.close().await?;
-
-                self.stats.bytes_compacted.increment(sst.info.filter_offset);
-                output_ssts.push(sst);
+                pending_close = Some(AbortOnDropHandle::new(spawn_bg_task(
+                    "compactor_sst_close".to_string(),
+                    &self.handle,
+                    |_| {},
+                    async move { finished_writer.close().await },
+                )));
                 bytes_written = 0;
+                // Report progress for the durable prefix only; the SST that is
+                // now closing is excluded until it completes.
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
                 self.send_compaction_progress(args.id, total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();
             }
         }
 
+        // Drain the in-flight close, then flush the final partial SST. Order
+        // matters: the pending SST's keys all precede the final writer's keys.
+        if let Some(pending) = pending_close.take() {
+            self.collect_close(pending, &mut output_ssts).await?;
+        }
         if !current_writer.is_drained() {
             let sst = current_writer.close().await?;
 
@@ -567,7 +613,7 @@ mod tests {
     use crate::proptest_util::arbitrary;
     use crate::sst_iter::SstView;
     use crate::test_utils::StringConcatMergeOperator;
-    use crate::test_utils::{build_row_entries, build_sorted_runs, write_ssts};
+    use crate::test_utils::{build_row_entries, build_sorted_runs, write_ssts, GatedObjectStore};
     use crate::types::{RowEntry, ValueDeletable};
     use crate::Db;
     use bytes::Bytes;
@@ -1341,6 +1387,165 @@ mod tests {
 
             });
         });
+    }
+
+    /// A blocked SST `close()` (the object-store flush of a finished output SST)
+    /// must not stall the merge loop. We gate the object store's `put` so the
+    /// first output SST's flush blocks indefinitely, then assert the executor
+    /// still makes progress (emits a progress message) while that flush is in
+    /// flight. Before `close()` was pipelined off the loop, the loop would be
+    /// parked inside `close()` and emit nothing until the flush completed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_keep_processing_while_sst_flush_is_blocked() {
+        // given: an executor writing through a gated object store, with a tiny
+        // max_sst_size so each finished block rolls into a new output SST
+        // (guaranteeing several SST boundaries, and thus background closes).
+        let handle = tokio::runtime::Handle::current();
+        let options = Arc::new(CompactorOptions {
+            max_sst_size: 1,
+            ..CompactorOptions::default()
+        });
+        let (tx, rx) = async_channel::unbounded::<CompactorMessage>();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated = Arc::new(GatedObjectStore::new(inner));
+        let object_store: Arc<dyn ObjectStore> = gated.clone();
+        let root_path = Path::from("testdb-flush-no-block");
+        let clock = Arc::new(DefaultSystemClock::new());
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            SsTableFormat {
+                block_size: 64,
+                ..SsTableFormat::default()
+            },
+            root_path.clone(),
+            None,
+        ));
+        let manifest_store = Arc::new(ManifestStore::new(&root_path, object_store.clone()));
+        StoredManifest::create_new_db(manifest_store.clone(), ManifestCore::new(), clock.clone())
+            .await
+            .unwrap();
+
+        let executor = TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
+            handle,
+            options,
+            worker_tx: tx,
+            table_store: table_store.clone(),
+            rand: Arc::new(DbRand::new(100u64)),
+            stats: {
+                let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+                Arc::new(CompactionStats::new(&recorder))
+            },
+            clock,
+            manifest_store,
+            merge_operator: None,
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: None,
+        });
+
+        // given: a single L0 SST with enough rows to span many output SSTs.
+        let entries: Vec<RowEntry> = (0u64..64)
+            .map(|i| {
+                RowEntry::new_value(
+                    format!("key{i:04}").as_bytes(),
+                    format!("val{i:04}").as_bytes(),
+                    i + 1,
+                )
+            })
+            .collect();
+        let input_ssts = write_sst(&table_store, &entries, usize::MAX).await;
+        let sst_views: Vec<SsTableView> =
+            input_ssts.into_iter().map(SsTableView::identity).collect();
+
+        // given: the object-store flush (`put`) for output SSTs is blocked. Setup
+        // writes above ran with the gate open (the default), so only the
+        // compaction's output flushes are affected. The gate counts every call
+        // (even pass-throughs), so baseline the setup puts to reason relatively.
+        let setup_puts = gated.put_opts_gate.arrivals();
+        gated.put_opts_gate.close();
+
+        // when: the compaction job runs.
+        executor.start_compaction_job(StartCompactionJobArgs {
+            id: Ulid::new(),
+            compaction_id: Ulid::new(),
+            destination: 0,
+            sst_views,
+            sorted_runs: vec![],
+            output_ssts: vec![],
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+        });
+
+        // when: the first output SST's flush is parked at the closed gate.
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            gated.put_opts_gate.wait_for_arrivals(setup_puts + 1),
+        )
+        .await
+        .expect("a close() should reach the blocked put gate");
+
+        // then: the loop keeps running and emits a progress message while the
+        // flush is blocked. A `Finished` message here would mean the job somehow
+        // completed despite the blocked flush.
+        let progressed = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match rx.recv().await.unwrap() {
+                    CompactorMessage::CompactionJobProgress { .. } => break,
+                    CompactorMessage::CompactionJobFinished { .. } => {
+                        panic!("job finished while its SST flush was blocked")
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await;
+        assert!(
+            progressed.is_ok(),
+            "expected a progress message while the SST flush was blocked"
+        );
+
+        // then: depth-1 backpressure holds — only one close is in flight at a
+        // time, since the loop parks at the next boundary draining it.
+        assert_eq!(gated.put_opts_gate.arrivals(), setup_puts + 1);
+
+        // when: the blocked flush is released.
+        gated.put_opts_gate.release();
+        let result = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let CompactorMessage::CompactionJobFinished { result, .. } =
+                    rx.recv().await.unwrap()
+                {
+                    return result;
+                }
+            }
+        })
+        .await
+        .expect("job should finish after the gate is released")
+        .expect("compaction should succeed");
+
+        // then: multiple output SSTs were produced (proving real boundaries and
+        // background closes ran) ...
+        assert!(
+            result.sst_views.len() >= 2,
+            "expected multiple output SSTs, got {}",
+            result.sst_views.len()
+        );
+        // ... and the merged output preserves every key in ascending order.
+        let mut read_back = Vec::new();
+        for sst in &result.sst_views {
+            let mut iter = SstIterator::new(
+                SstView::Borrowed(sst, BytesRange::from(..)),
+                table_store.clone(),
+                SstIteratorOptions::default(),
+            )
+            .unwrap();
+            iter.init().await.unwrap();
+            while let Some(entry) = iter.next().await.unwrap() {
+                read_back.push(entry.key);
+            }
+        }
+        let expected: Vec<Bytes> = entries.iter().map(|e| e.key.clone()).collect();
+        assert_eq!(read_back, expected);
     }
 
     /// Test context for compaction executor tests.

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -458,6 +458,18 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
             None;
 
         while let Some(kv) = all_iter.next().await? {
+            // Opportunistically collect a finished background close without
+            // stalling the merge loop to promptly lets us report progress
+            // and persist the newly uploaded output SST in compactor state
+            // as soon as the close finishes, rather than waiting until the
+            // next SST fills up.
+            if let Some(pending) = pending_close.take_if(|p| p.is_finished()) {
+                self.collect_close(pending, &mut output_ssts).await?;
+                let total_bytes = start_bytes_processed + all_iter.bytes_processed();
+                self.send_compaction_progress(args.id, total_bytes, &output_ssts);
+                last_progress_report = self.clock.now();
+            }
+
             let duration_since_last_report =
                 self.clock.now().signed_duration_since(last_progress_report);
             if duration_since_last_report > TimeDelta::seconds(1) {

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -461,8 +461,6 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
             let duration_since_last_report =
                 self.clock.now().signed_duration_since(last_progress_report);
             if duration_since_last_report > TimeDelta::seconds(1) {
-                // Report only the durable prefix (output_ssts); a still-in-flight
-                // close is folded in when it's drained at the next SST boundary.
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
                 self.send_compaction_progress(args.id, total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();
@@ -485,14 +483,12 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
                     )),
                 );
                 pending_close = Some(AbortOnDropHandle::new(spawn_bg_task(
-                    "compactor_sst_close".to_string(),
+                    format!("compactor_sst_close:{:?}", finished_writer.id()),
                     &self.handle,
                     |_| {},
                     async move { finished_writer.close().await },
                 )));
                 bytes_written = 0;
-                // Report progress for the durable prefix only; the SST that is
-                // now closing is excluded until it completes.
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
                 self.send_compaction_progress(args.id, total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -102,7 +102,7 @@ impl BlockFormat {
 }
 
 impl SsTableFormat {
-    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder<'static> {
+    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder {
         let mut builder = EncodedSsTableBuilder::new(
             self.block_size,
             self.min_filter_keys,
@@ -123,14 +123,14 @@ impl SsTableFormat {
 }
 
 /// Builds an SSTable from key-value pairs.
-pub(crate) struct EncodedSsTableBuilder<'a> {
+pub(crate) struct EncodedSsTableBuilder {
     builder: BlockBuilderWithStats,
-    index_builder: flatbuffers::FlatBufferBuilder<'a, DefaultAllocator>,
-    first_key: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
+    index_builder: flatbuffers::FlatBufferBuilder<'static, DefaultAllocator>,
+    first_key: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'static, u8>>>,
     sst_first_key: Option<Bytes>,
     sst_last_key: Option<Bytes>,
     current_block_max_key: Option<Bytes>,
-    block_meta: Vec<flatbuffers::WIPOffset<BlockMeta<'a>>>,
+    block_meta: Vec<flatbuffers::WIPOffset<BlockMeta<'static>>>,
     current_len: u64,
     blocks: VecDeque<EncodedSsTableBlock>,
     block_size: usize,
@@ -144,7 +144,7 @@ pub(crate) struct EncodedSsTableBuilder<'a> {
     block_transformer: Option<Arc<dyn BlockTransformer>>,
 }
 
-impl EncodedSsTableBuilder<'_> {
+impl EncodedSsTableBuilder {
     /// Create a builder based on target block size.
     pub(crate) fn new(
         block_size: usize,

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -102,7 +102,7 @@ impl BlockFormat {
 }
 
 impl SsTableFormat {
-    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder<'_> {
+    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder<'static> {
         let mut builder = EncodedSsTableBuilder::new(
             self.block_size,
             self.min_filter_keys,

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1069,6 +1069,10 @@ impl EncodedSsTableWriter {
         self.builder.is_drained()
     }
 
+    pub(crate) fn id(&self) -> SsTableId {
+        self.id
+    }
+
     #[cfg(test)]
     pub(crate) fn blocks_written(&self) -> usize {
         self.blocks_written

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -274,20 +274,20 @@ impl TableStore {
         Ok(self.last_seen_wal_id(wal_id_last_compacted).await? + 1)
     }
 
-    pub(crate) fn table_writer(&self, id: SsTableId) -> EncodedSsTableWriter<'_> {
+    pub(crate) fn table_writer(self: &Arc<Self>, id: SsTableId) -> EncodedSsTableWriter {
         let object_store = self.object_stores.store_for(&id);
         let path = self.path(&id);
         EncodedSsTableWriter {
             id,
             builder: self.sst_format.table_builder(),
             writer: BufWriter::new(object_store, path),
-            table_store: self,
+            table_store: self.clone(),
             #[cfg(test)]
             blocks_written: 0,
         }
     }
 
-    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder<'_> {
+    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder<'static> {
         self.sst_format.table_builder()
     }
 
@@ -1017,16 +1017,16 @@ async fn write_sst_streaming_in_object_store(
     Ok(())
 }
 
-pub(crate) struct EncodedSsTableWriter<'a> {
+pub(crate) struct EncodedSsTableWriter {
     id: SsTableId,
-    builder: EncodedSsTableBuilder<'a>,
+    builder: EncodedSsTableBuilder<'static>,
     writer: BufWriter,
-    table_store: &'a TableStore,
+    table_store: Arc<TableStore>,
     #[cfg(test)]
     blocks_written: usize,
 }
 
-impl EncodedSsTableWriter<'_> {
+impl EncodedSsTableWriter {
     /// Adds an entry to the SSTable and returns the size of the block that was finished if any.
     /// The block size is calculated after applying any compression if enabled.
     /// The block size is None if the builder has not finished compacting a block yet.

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -287,7 +287,7 @@ impl TableStore {
         }
     }
 
-    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder<'static> {
+    pub(crate) fn table_builder(&self) -> EncodedSsTableBuilder {
         self.sst_format.table_builder()
     }
 
@@ -1019,7 +1019,7 @@ async fn write_sst_streaming_in_object_store(
 
 pub(crate) struct EncodedSsTableWriter {
     id: SsTableId,
-    builder: EncodedSsTableBuilder<'static>,
+    builder: EncodedSsTableBuilder,
     writer: BufWriter,
     table_store: Arc<TableStore>,
     #[cfg(test)]


### PR DESCRIPTION
## Summary

When an output SST crosses `max_sst_size` a network round-trip stalls the merge/read loop. This patch spawns the network write as a background task so the loop keeps merging input and filling the next SST while a finished SST flushes.

## Changes

- Pipeline the SST close/upload with processing the next blocks
- Some refactoring to the EncodedSsTableWriter to make it possible to pass the close future around
- tests

## Notes for Reviewers

I did some testing and it seems like a pipeline depth of 1 is probably the right bet, but we could decide to generalize this to have multiple ongoing pushes of SSTs to storage. The reason I'm skeptical about it being necessary is (1) empirical testing using the compaction bencher showed a pipeline depth of 1 was sufficient to never cause write stalls, (2) it just kinda makes sense that it's pretty infrequent. The downside of more pipeline depth is potential memory usage. 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
