### PR TITLE
perf(compaction): increase blocks_to_fetch default (+ configuration)

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -98,6 +98,7 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         max_sst_size: rng.random_range(KIB_8..GIB_2),
         max_concurrent_compactions: rng.random_range(1..=4),
         max_fetch_tasks: rng.random_range(1..=8),
+        bytes_to_fetch: rng.random_range(KIB_8..=(8 * MIB_1)),
         scheduler_options: SizeTieredCompactionSchedulerOptions {
             min_compaction_sources,
             max_compaction_sources,

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -662,6 +662,7 @@ pub(crate) fn build_handler(
     let executor_compactor_options = Arc::new(CompactorOptions {
         max_sst_size: options.max_sst_size,
         max_fetch_tasks: options.max_fetch_tasks,
+        bytes_to_fetch: options.bytes_to_fetch,
         ..CompactorOptions::default()
     });
     let executor = Arc::new(TokioCompactionExecutor::<WorkerMessage>::new(

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -297,7 +297,7 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
         };
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: self.options.max_fetch_tasks,
-            blocks_to_fetch: 256,
+            blocks_to_fetch: self.options.blocks_to_fetch,
             cache_blocks: false, // don't clobber the cache
             eager_spawn: true,
             order: IterationOrder::Ascending,

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -297,7 +297,9 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
         };
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: self.options.max_fetch_tasks,
-            blocks_to_fetch: self.options.blocks_to_fetch,
+            blocks_to_fetch: self
+                .table_store
+                .bytes_to_blocks(self.options.bytes_to_fetch),
             cache_blocks: false, // don't clobber the cache
             eager_spawn: true,
             order: IterationOrder::Ascending,

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1089,12 +1089,21 @@ pub struct CompactorOptions {
     /// more resources. The default is 4.
     pub max_fetch_tasks: usize,
 
-    /// The number of blocks to fetch in a single read-ahead request while
-    /// iterating over input SSTs during compaction. Higher values issue larger
-    /// reads against the object store, improving throughput at the cost of more
-    /// memory per fetch. The default is 512 (2MiB at the default 4KiB block
-    /// size).
-    pub blocks_to_fetch: usize,
+    /// The number of bytes to fetch in a single read-ahead request while
+    /// iterating over input SSTs during compaction. The value is rounded up to
+    /// the nearest block size when fetching from object storage. Higher values
+    /// issue larger reads against the object store, improving throughput at the
+    /// cost of more memory per fetch. The default is 2MiB.
+    ///
+    /// This works together with [`CompactorOptions::max_fetch_tasks`], which
+    /// bounds how many of these requests are in flight concurrently per input
+    /// SST. `bytes_to_fetch` is the size of each individual read-ahead request,
+    /// while `max_fetch_tasks` is how many of them run at once, so the peak
+    /// outstanding read-ahead per SST iterator is roughly
+    /// `bytes_to_fetch * max_fetch_tasks`. For example, with the defaults of
+    /// `bytes_to_fetch = 2MiB` and `max_fetch_tasks = 4`, the iterator keeps up
+    /// to four ~2MiB reads in flight, prefetching ~8MiB ahead of the cursor.
+    pub bytes_to_fetch: usize,
 
     /// Scheduler-specific options expressed as string key/value pairs.
     #[serde(default)]
@@ -1113,7 +1122,7 @@ impl Default for CompactorOptions {
             max_sst_size: 256 * 1024 * 1024,
             max_concurrent_compactions: 4,
             max_fetch_tasks: 4,
-            blocks_to_fetch: 512,
+            bytes_to_fetch: 2 * 1024 * 1024,
             scheduler_options: HashMap::new(),
         }
     }
@@ -1131,7 +1140,7 @@ impl std::fmt::Debug for CompactorOptions {
                 &self.max_concurrent_compactions,
             )
             .field("max_fetch_tasks", &self.max_fetch_tasks)
-            .field("blocks_to_fetch", &self.blocks_to_fetch)
+            .field("bytes_to_fetch", &self.bytes_to_fetch)
             .field("scheduler_options", &self.scheduler_options)
             .finish()
     }
@@ -1163,10 +1172,18 @@ pub struct CompactionWorkerOptions {
     /// compaction. Higher values can improve throughput but use more resources.
     pub max_fetch_tasks: usize,
 
-    /// Number of blocks to fetch in a single read-ahead request while iterating
-    /// over input SSTs during compaction. The default is 512 (2MiB at the
-    /// default 4KiB block size).
-    pub blocks_to_fetch: usize,
+    /// Number of bytes to fetch in a single read-ahead request while iterating
+    /// over input SSTs during compaction. The value is rounded up to the nearest
+    /// block size when fetching from object storage. The default is 2MiB.
+    ///
+    /// This pairs with [`CompactionWorkerOptions::max_fetch_tasks`]:
+    /// `bytes_to_fetch` is the size of each read-ahead request while
+    /// `max_fetch_tasks` is how many run concurrently per input SST, so peak
+    /// outstanding read-ahead per SST iterator is roughly
+    /// `bytes_to_fetch * max_fetch_tasks`. With the defaults
+    /// (`bytes_to_fetch = 2MiB`, `max_fetch_tasks = 4`) that is ~8MiB prefetched
+    /// ahead of the cursor.
+    pub bytes_to_fetch: usize,
 }
 
 /// Default options for the compaction worker.
@@ -1180,7 +1197,7 @@ impl Default for CompactionWorkerOptions {
             heartbeat_min_interval: Duration::from_secs(5),
             max_sst_size: 256 * 1024 * 1024,
             max_fetch_tasks: 4,
-            blocks_to_fetch: 512,
+            bytes_to_fetch: 2 * 1024 * 1024,
         }
     }
 }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1089,6 +1089,13 @@ pub struct CompactorOptions {
     /// more resources. The default is 4.
     pub max_fetch_tasks: usize,
 
+    /// The number of blocks to fetch in a single read-ahead request while
+    /// iterating over input SSTs during compaction. Higher values issue larger
+    /// reads against the object store, improving throughput at the cost of more
+    /// memory per fetch. The default is 512 (2MiB at the default 4KiB block
+    /// size).
+    pub blocks_to_fetch: usize,
+
     /// Scheduler-specific options expressed as string key/value pairs.
     #[serde(default)]
     pub scheduler_options: HashMap<String, String>,
@@ -1106,6 +1113,7 @@ impl Default for CompactorOptions {
             max_sst_size: 256 * 1024 * 1024,
             max_concurrent_compactions: 4,
             max_fetch_tasks: 4,
+            blocks_to_fetch: 512,
             scheduler_options: HashMap::new(),
         }
     }
@@ -1123,6 +1131,7 @@ impl std::fmt::Debug for CompactorOptions {
                 &self.max_concurrent_compactions,
             )
             .field("max_fetch_tasks", &self.max_fetch_tasks)
+            .field("blocks_to_fetch", &self.blocks_to_fetch)
             .field("scheduler_options", &self.scheduler_options)
             .finish()
     }
@@ -1153,6 +1162,11 @@ pub struct CompactionWorkerOptions {
     /// Maximum number of concurrent tasks for fetching SST blocks during
     /// compaction. Higher values can improve throughput but use more resources.
     pub max_fetch_tasks: usize,
+
+    /// Number of blocks to fetch in a single read-ahead request while iterating
+    /// over input SSTs during compaction. The default is 512 (2MiB at the
+    /// default 4KiB block size).
+    pub blocks_to_fetch: usize,
 }
 
 /// Default options for the compaction worker.
@@ -1166,6 +1180,7 @@ impl Default for CompactionWorkerOptions {
             heartbeat_min_interval: Duration::from_secs(5),
             max_sst_size: 256 * 1024 * 1024,
             max_fetch_tasks: 4,
+            blocks_to_fetch: 512,
         }
     }
 }


### PR DESCRIPTION
## Summary

Empirically I found that using 512 blocks_to_fetch performs better (fewer read stalls) than 256, so I set that to be the default. This was based on compaction bencher with 4x 1GB input SSTs. I'm also making it configurable since it's likely a better knob to tune than just `max_fetch_tasks` because that increases GET API requests. Bumping it up too much more causes memory pressure.

See this eval table:

```
MFT: max fetch tasks
BFT: blocks to fetch

  ┌───────────┬──────────┬──────┬────────────┬─────────┐
  │ MFT × BTF │ mem/iter │ wall │ read_stall │   RSS   │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 16 × 2048 │ 128 MiB  │ 36 s │ 0.93 s     │ 987 MiB │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 8 × 1024  │ 32 MiB   │ 36 s │ 0.66 s     │ 463 MiB │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 8 × 512   │ 16 MiB   │ 38 s │ 0.58 s     │ 438 MiB │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 4 × 512   │ 8 MiB    │ 37 s │ 0.96 s     │ 359 MiB │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 4 × 256   │ 4 MiB    │ 42 s │ 6.55 s     │ 354 MiB │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 2 × 256   │ 2 MiB    │ 58 s │ 23.4 s     │ 317 MiB │
  ├───────────┼──────────┼──────┼────────────┼─────────┤
  │ 2 × 128   │ 1 MiB    │ 78 s │ 45.0 s     │ 252 MiB │
  └───────────┴──────────┴──────┴────────────┴─────────┘
```



## Changes

- add config for blocks_to_fetch for compactor
- change default to 512

## Notes for Reviewers

N/A

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
