### PR TITLE
Extend DST nightly timeout length

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -258,7 +258,7 @@ jobs:
 
   deterministic-simulation-test:
     runs-on: warp-ubuntu-latest-x64-16x
-    timeout-minutes: 25
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,10 +12,8 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 permissions:
-  # Required for PR comments
-  pull-requests: write
-  # Required for storing benchmark results
-  contents: write
+  contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -286,33 +284,6 @@ jobs:
           tar -tf "${TARBALL}" | grep -Fx 'package/slatedb-ffi.d.ts'
           tar -tf "${TARBALL}" | grep -Fx 'package/runtime/ffi-types.js'
           tar -tf "${TARBALL}" | grep -Fx 'package/prebuilds/linux-x64-gnu/libslatedb_uniffi.so'
-
-  microbenchmarks:
-    runs-on: ubuntu-latest
-    needs: tests
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run benchmark
-        run: cargo bench --features bench-internal -- --output-format bencher | tee output.txt
-
-      - name: Download nightly benchmark data
-        uses: actions/cache/restore@v4
-        with:
-          path: ./microbenchmarks-cache
-          key: ${{ runner.os }}-microbenchmarks
-
-      - name: Update benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: cargo bench
-          tool: 'cargo'
-          output-file-path: output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
-          comment-on-alert: true
-          summary-always: true
-          max-items-in-chart: 30
 
   test_website:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

I noticed DST has been timing out since May 20. This extends it to 60m. With the new segment tests and such, it needs extra time to run.

I also removed the microbenchmark job from pr.yaml. It makes no sense to run perf tests on a GH action machine; they're very noisy.

## Changes

- See summary