### PR TITLE
Fix nightly microbenchmark baseline updates

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -31,6 +31,8 @@ jobs:
             ${{ runner.os }}-microbenchmarks-
 
       - name: Update microbenchmark result
+        id: update_microbenchmark_result
+        continue-on-error: true
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: cargo bench
@@ -47,6 +49,10 @@ jobs:
         with:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks-${{ github.run_id }}
+
+      - name: Fail on microbenchmark alert
+        if: steps.update_microbenchmark_result.outcome == 'failure'
+        run: exit 1
 
   benchmarks:
     runs-on: warp-ubuntu-latest-x64-16x


### PR DESCRIPTION
## Summary

Allow nightly microbenchmark results to be saved even when a regression alert fails the job.

Once a regression occurs, it just keeps failing since the regression is triggered every night. This update makes it fail, but still saves the results so it doesn't fail forever.

## Changes

- Continue after the benchmark alert step so the updated cache is saved
- Fail the job afterward if the alert step failed

## Notes for Reviewers

Workflow-only change. The goal is for an accepted regression to fail once, then become the new baseline for future nightly runs.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant