### PR TITLE
Remove boundary checks in GC deletion path

### DIFF
--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -594,19 +594,11 @@ impl Harness {
     ///   an actor returned or joined with an error.
     pub fn run(self) -> Result<(), Error> {
         let runtime_seed = self.rand.rng().next_u64();
-        let clock_rand = Arc::clone(&self.rand);
-        let system_clock: Arc<dyn SystemClock> = self.system_clock.clone();
-        let clock_advance_ms = self.clock_advance_ms.clone();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .rng_seed(RngSeed::from_bytes(&runtime_seed.to_le_bytes()))
             .build_local(Default::default())
             .expect("failed to build dst harness runtime");
-        runtime.block_on(async move {
-            let clock_driver = ClockDriver::spawn(system_clock, clock_rand, clock_advance_ms);
-            let result = self.run_inner().await;
-            clock_driver.shutdown().await;
-            result
-        })
+        runtime.block_on(async move { self.run_inner().await })
     }
 
     async fn run_inner(self) -> Result<(), Error> {
@@ -617,7 +609,7 @@ impl Harness {
             path,
             main_object_store,
             wal_object_store,
-            clock_advance_ms: _,
+            clock_advance_ms,
             merge_operator,
             segment_extractor,
             startup_factory,
@@ -632,6 +624,11 @@ impl Harness {
         let path_seed = rand.seed();
         let path = path.unwrap_or_else(|| Path::from(format!("dst/{name}/{path_seed:016x}")));
         let system_clock: Arc<dyn SystemClock> = system_clock;
+        let clock_driver = ClockDriver::spawn(
+            Arc::clone(&system_clock),
+            Arc::clone(&rand),
+            clock_advance_ms,
+        );
         let fp_registry = Arc::new(FailPointRegistry::new());
         let failure_controller = FailingObjectStoreController::new(Arc::clone(&rand));
         let failing_main_object_store: Arc<dyn ObjectStore> = Arc::new(FailingObjectStore::new(
@@ -729,7 +726,6 @@ impl Harness {
                 }
             }
         }
-
         let failure_controller = shared.startup_ctx.failure_controller();
         failure_controller.clear_toxics();
         failure_controller.clear_http_failures();
@@ -739,6 +735,7 @@ impl Harness {
             Some(compactor) => compactor.stop().await,
             None => Ok(()),
         };
+        clock_driver.shutdown().await;
         info!("final random [value={}]", rand.rng().next_u64());
         db_result?;
         compactor_result

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -222,7 +222,7 @@ impl ObjectStoreBoundaryObject {
         boundary: MonotonicId,
     ) -> Result<(), TransactionalObjectError> {
         if id <= boundary {
-            warn!(
+            debug!(
                 "object version is behind boundary: id={:?}, boundary={:?}",
                 id.id(),
                 boundary.id()

--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -4,6 +4,7 @@ use crate::error::SlateDBError;
 use crate::error::SlateDBError::LatestTransactionalObjectVersionMissing;
 use crate::flatbuffer_types::FlatBufferCompactionsCodec;
 use chrono::Utc;
+use log::debug;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use serde::Serialize;
@@ -218,7 +219,21 @@ impl CompactionsStore {
 
     /// Delete a compactions file from the object store.
     pub(crate) async fn delete_compactions(&self, id: u64) -> Result<(), SlateDBError> {
+        let latest_compactions = self.read_latest_compactions().await?;
+        if latest_compactions.id == id {
+            return Err(SlateDBError::InvalidDeletion);
+        }
+
+        debug!("deleting compactions [id={}]", id);
         Ok(self.inner.delete(MonotonicId::new(id)).await?)
+    }
+
+    /// Delete a compactions file without validating it against the latest compactions file.
+    ///
+    /// Callers must ensure the compactions file is not the latest file and is safe to delete.
+    pub(crate) async fn delete_compactions_unchecked(&self, id: u64) -> Result<(), SlateDBError> {
+        debug!("deleting compactions [id={}]", id);
+        Ok(self.inner.delete_unchecked(MonotonicId::new(id)).await?)
     }
 
     /// Read a compactions file from the object store. The last element in an unbounded
@@ -257,7 +272,6 @@ impl CompactionsStore {
         })?)
     }
 
-    #[cfg(test)]
     pub(crate) async fn read_latest_compactions(
         &self,
     ) -> Result<VersionedCompactions, SlateDBError> {
@@ -489,6 +503,17 @@ mod tests {
         let compactions = store.list_compactions(..).await.unwrap();
         assert_eq!(compactions.len(), 1);
         assert_eq!(compactions[0].id, 2);
+    }
+
+    #[tokio::test]
+    async fn test_delete_latest_compactions_should_fail() {
+        let store = new_memory_compactions_store();
+        let mut sc = StoredCompactions::create(store.clone(), 0).await.unwrap();
+        sc.update(sc.prepare_dirty().unwrap()).await.unwrap();
+
+        let result = store.delete_compactions(2).await;
+
+        assert!(matches!(result, Err(SlateDBError::InvalidDeletion)));
     }
 
     #[tokio::test]

--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -218,6 +218,7 @@ impl CompactionsStore {
     }
 
     /// Delete a compactions file from the object store.
+    #[allow(unused)]
     pub(crate) async fn delete_compactions(&self, id: u64) -> Result<(), SlateDBError> {
         let latest_compactions = self.read_latest_compactions().await?;
         if latest_compactions.id == id {
@@ -272,6 +273,7 @@ impl CompactionsStore {
         })?)
     }
 
+    #[allow(unused)]
     pub(crate) async fn read_latest_compactions(
         &self,
     ) -> Result<VersionedCompactions, SlateDBError> {

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::mem;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
@@ -236,7 +236,7 @@ impl<M: ExecutorMessage> TokioCompactionExecutor<M> {
                 worker_tx: opts.worker_tx,
                 table_store: opts.table_store,
                 rand: opts.rand,
-                tasks: Arc::new(Mutex::new(HashMap::new())),
+                tasks: Arc::new(Mutex::new(BTreeMap::new())),
                 stats,
                 clock: opts.clock,
                 is_stopped: AtomicBool::new(false),
@@ -272,7 +272,7 @@ pub(crate) struct TokioCompactionExecutorInner<M = CompactorMessage> {
     handle: tokio::runtime::Handle,
     worker_tx: async_channel::Sender<M>,
     table_store: Arc<TableStore>,
-    tasks: Arc<Mutex<HashMap<u32, TokioCompactionTask>>>,
+    tasks: Arc<Mutex<BTreeMap<u32, TokioCompactionTask>>>,
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     clock: Arc<dyn SystemClock>,
@@ -582,10 +582,15 @@ impl<M: ExecutorMessage> TokioCompactionExecutorInner<M> {
         // lock and remove the task from the map.
         let task_handles = {
             let mut tasks = self.tasks.lock();
-            for task in tasks.values() {
+            // BTreeMap keeps abort/join order stable by destination. HashMap
+            // iteration order is randomized, which can feed the DST runtime a
+            // process-dependent shutdown order.
+            let mut task_handles = Vec::with_capacity(tasks.len());
+            while let Some((_, task)) = tasks.pop_first() {
                 task.task.abort();
+                task_handles.push(task.task);
             }
-            tasks.drain().map(|(_, task)| task.task).collect::<Vec<_>>()
+            task_handles
         };
 
         let wait_for_task_termination = async move {

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -65,6 +65,7 @@ pub(crate) enum SlateDBError {
     InvalidTransactionalObjectState,
 
     #[error("invalid deletion")]
+    #[allow(unused)]
     InvalidDeletion,
 
     #[error("invalid sst error")]

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -106,7 +106,7 @@ impl GcTask for CompactionsGcTask {
             }
             if let Err(e) = self
                 .compactions_store
-                .delete_compactions(compactions_metadata.id)
+                .delete_compactions_unchecked(compactions_metadata.id)
                 .await
             {
                 error!(

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -101,7 +101,7 @@ impl GcTask for ManifestGcTask {
             }
             if let Err(e) = self
                 .manifest_store
-                .delete_unchecked(manifest_metadata.id)
+                .delete_manifest_unchecked(manifest_metadata.id)
                 .await
             {
                 error!(

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -101,7 +101,7 @@ impl GcTask for ManifestGcTask {
             }
             if let Err(e) = self
                 .manifest_store
-                .delete_manifest(manifest_metadata.id)
+                .delete_unchecked(manifest_metadata.id)
                 .await
             {
                 error!(

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -503,7 +503,7 @@ impl ManifestStore {
     ///
     /// Callers must ensure the manifest is not the latest manifest, is not referenced
     /// by an active checkpoint, and is safe to delete.
-    pub(crate) async fn delete_unchecked(&self, id: u64) -> Result<(), SlateDBError> {
+    pub(crate) async fn delete_manifest_unchecked(&self, id: u64) -> Result<(), SlateDBError> {
         debug!("deleting manifest [id={}]", id);
         Ok(self.inner.delete_unchecked(MonotonicId::new(id)).await?)
     }

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -499,6 +499,15 @@ impl ManifestStore {
         Ok(self.inner.delete(MonotonicId::new(id)).await?)
     }
 
+    /// Delete a manifest without validating it against the latest manifest.
+    ///
+    /// Callers must ensure the manifest is not the latest manifest, is not referenced
+    /// by an active checkpoint, and is safe to delete.
+    pub(crate) async fn delete_unchecked(&self, id: u64) -> Result<(), SlateDBError> {
+        debug!("deleting manifest [id={}]", id);
+        Ok(self.inner.delete_unchecked(MonotonicId::new(id)).await?)
+    }
+
     /// Read a manifest from the object store. The last element in an unbounded
     /// range is the current manifest.
     /// # Arguments

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -479,6 +479,7 @@ impl ManifestStore {
     }
 
     /// Delete a manifest from the object store.
+    #[allow(unused)]
     pub(crate) async fn delete_manifest(&self, id: u64) -> Result<(), SlateDBError> {
         let latest_manifest = self.read_latest_manifest().await?;
         if latest_manifest.id == id {


### PR DESCRIPTION
## Summary

`nightly.yaml` has been timing out since May 5:

https://github.com/slatedb/slatedb/actions/workflows/nightly.yaml

I dug into it today (well, OK, Codex did). `manifest_gc.rs` is doing a boundary check (in `ManifestStore::delete_manifest`) for every call. This happens _after_ the GC has already verified that the files are behind the manifest; it's pointless. With large directories, it gets very slow--each deletion does a full list on the directory.

I also cleaned up several other things Codex found. See below.

## Changes

- Add `delete_manifest_unchecked` and update `manifest_gc.rs` to call it.
- Add `delete_compactions_unchecked` and update `delete_compactions` to do a safety check similar to `ManifestStore::delete_manifest.
- Update `compactions_gc.rs` to use the `delete_compactions_unchecked` fn.
- Drop the `check` log from `warn!` to `debug!`. It was logging a `warn!` for every file GC deleted. This is no longer case due to the edits above, but I felt `warn!` was still too strong since we usually recover from boundary issues or return an error later.
- Update the compactor executor to store tasks in a `BTreeMap` since we iterate over them. They're a `HashMap` right now, which is non-deterministic on iteration.
- Move clock driver inside `run_inner`. The DST was failing on the segment test with non-determinism. The `HashMap` fix (above) alone didn't fix it. Codex was _very_ insistent that moving the clock this way fixes the issue. It does indeed appear to, but I don't understand why. The failure was showing an off-by-one rng generation--the value of run 0 was one older/younger than run 1. This adjustment fixed that.

## Notes for Reviewers

I'd review them commit-by-commit.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
