### PR TITLE
Improve nightly microbenchmark failure reporting

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run microbenchmark
-        run: cargo bench --features bench-internal -- --output-format bencher | tee output.txt
+        shell: bash
+        run: cargo bench --features bench-internal --benches -- --output-format bencher | tee output.txt
 
       - name: Download nightly microbenchmark data
         uses: actions/cache/restore@v4
@@ -42,6 +43,7 @@ jobs:
           external-data-json-path: ./microbenchmarks-cache/benchmark-data.json
           fail-on-alert: true
           summary-always: true
+          comment-on-alert: true
           max-items-in-chart: 30
 
       - name: Save nightly microbenchmark data
@@ -50,9 +52,20 @@ jobs:
           path: ./microbenchmarks-cache
           key: ${{ runner.os }}-microbenchmarks-${{ github.run_id }}
 
-      - name: Fail on microbenchmark alert
+      - name: Report microbenchmark alert
         if: steps.update_microbenchmark_result.outcome == 'failure'
-        run: exit 1
+        shell: bash
+        run: |
+          message="Microbenchmark regression detected. Benchmark data was saved to the nightly cache; see the 'Update microbenchmark result' step and job summary for details."
+          echo "::error title=Microbenchmark regression::$message"
+          {
+            echo "## Microbenchmark regression"
+            echo ""
+            echo "$message"
+            echo ""
+            echo "The benchmark update step was allowed to continue so this run could save the new nightly baseline before failing."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
   benchmarks:
     runs-on: warp-ubuntu-latest-x64-16x


### PR DESCRIPTION
## Summary

#1765 error messages are rather opaque now. The PR accomplished what I wanted (saving results before failing), but the fail task just says exit 1:

https://github.com/slatedb/slatedb/actions/runs/27089853248/job/79951292038

This PR gives a better error message. (Codex wrote the PR.)

## Changes

- Run microbenchmarks with `shell: bash` and `--benches` so pipeline failures and benchmark output parsing failures are surfaced correctly
- Enable benchmark alert comments
- Replace the bare `exit 1` failure step with an error annotation and job summary explaining the regression

## Notes for Reviewers

Workflow-only change. The key behavior to review is that regression alerts still fail the job after the cache save step, but now the failing step points reviewers back to the
benchmark alert details.

Validated with YAML parsing and `git diff --check`.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant
