### PR TITLE
Require a matching segment extractor when opening a DbReader

### DIFF
--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -5,10 +5,11 @@
 //! atomically to the database.
 
 use crate::config::{MergeOptions, PutOptions};
+use crate::db_common::extract_segment_prefix;
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator};
 use crate::merge_operator::{MergeOperatorIterator, MergeOperatorType};
-use crate::prefix_extractor::{PrefixExtractor, PrefixTarget};
+use crate::prefix_extractor::PrefixExtractor;
 use crate::types::{RowEntry, ValueDeletable};
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -353,16 +354,7 @@ impl WriteBatch {
                 _ => {}
             }
             if let Some(ext) = extractor {
-                match ext.prefix_len(&PrefixTarget::Point(entry.key.clone())) {
-                    Some(0) | None => {
-                        return Err(SlateDBError::EmptySegmentPrefix {
-                            key: entry.key.clone(),
-                        });
-                    }
-                    Some(n) => {
-                        touched_segments.insert(entry.key.slice(0..n));
-                    }
-                }
+                touched_segments.insert(extract_segment_prefix(ext, &entry.key)?);
             }
             entries_bytes += (entry.key.len() + entry.value.len()) as u64;
             entries.push(entry);

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -51,6 +51,7 @@ use crate::config::{
     FlushOptions, FlushType, MergeOptions, PutOptions, ReadOptions, ScanOptions, Settings,
     WriteOptions,
 };
+use crate::db_common::extract_segment_prefix;
 use crate::db_iter::{DbIterator, DbRecencyIterator};
 use crate::db_snapshot::DbSnapshot;
 use crate::db_state::{collect_touched_segments, DbState, SsTableId};
@@ -566,14 +567,8 @@ impl DbInner {
                     std::collections::BTreeSet::new();
                 let mut iter = replayed_table.table.table().iter();
                 while let Some(entry) = iter.next_sync() {
-                    match extractor.prefix_len(&crate::PrefixTarget::Point(entry.key.clone())) {
-                        Some(0) | None => {
-                            return Err(SlateDBError::EmptySegmentPrefix { key: entry.key });
-                        }
-                        Some(n) => {
-                            touched_segments.insert(entry.key.slice(0..n));
-                        }
-                    }
+                    touched_segments
+                        .insert(extract_segment_prefix(extractor.as_ref(), &entry.key)?);
                 }
                 replayed_table
                     .table

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -10636,6 +10636,7 @@ mod tests {
         db.close().await.unwrap();
 
         let reader = DbReaderBuilder::new(path, object_store)
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
             .build()
             .await
             .unwrap();

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1419,6 +1419,7 @@ pub struct DbReaderBuilder<P: Into<Path>> {
     merge_operator: Option<MergeOperatorType>,
     block_transformer: Option<Arc<dyn BlockTransformer>>,
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
+    segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
     options: DbReaderOptions,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -1437,6 +1438,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             merge_operator: None,
             block_transformer: None,
             filter_policies: default_filter_policies(),
+            segment_extractor: None,
             options: DbReaderOptions::default(),
             system_clock: Arc::new(DefaultSystemClock::default()),
             rand: Arc::new(DbRand::default()),
@@ -1461,6 +1463,18 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
     /// Sets the merge operator to use when reading merge operands.
     pub fn with_merge_operator(mut self, merge_operator: MergeOperatorType) -> Self {
         self.merge_operator = Some(merge_operator);
+        self
+    }
+
+    /// Sets the segment extractor (RFC-0024). When configured, the reader
+    /// re-derives each WAL-replayed entry's segment prefix so that in-memory
+    /// segments are reported via [`DbReader::subscribe`]. Must match the
+    /// extractor the database was created with.
+    pub fn with_segment_extractor(
+        mut self,
+        extractor: Arc<dyn crate::prefix_extractor::PrefixExtractor>,
+    ) -> Self {
+        self.segment_extractor = Some(extractor);
         self
     }
 
@@ -1616,6 +1630,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             &store_provider,
             self.checkpoint_id,
             self.merge_operator,
+            self.segment_extractor,
             self.options,
             self.system_clock,
             self.rand,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -101,7 +101,7 @@
 //! }
 //! ```
 //!
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 
@@ -574,9 +574,10 @@ impl<P: Into<Path>> DbBuilder<P> {
 
         // Shared lifecycle state — created before DbInner so it can be shared
         // with the executor and future channel construction.
-        let status_manager = DbStatusManager::new_with_manifest(
+        let status_manager = DbStatusManager::new_with_initial_values(
             manifest_dirty.value.core.last_l0_seq,
             manifest_dirty.clone().into(),
+            BTreeSet::new(),
         );
 
         // Setup communication channels wired to the shared closed state.

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -1,10 +1,31 @@
+use bytes::Bytes;
 use parking_lot::RwLockWriteGuard;
 
 use crate::db::DbInner;
 use crate::db_state::DbState;
 use crate::error::SlateDBError;
 use crate::oracle::Oracle;
+use crate::prefix_extractor::{PrefixExtractor, PrefixTarget};
 use crate::wal_replay::ReplayedMemtable;
+
+/// Extract the segment prefix (RFC-0024) from `key` under `extractor`.
+///
+/// Returns the prefix bytes — a cheap refcount slice of `key`. An
+/// absent or zero-length prefix is a hard error
+/// ([`SlateDBError::EmptySegmentPrefix`]): every key in a segmented DB
+/// must map to a non-empty segment. This is the single point where a
+/// key's segment prefix is derived; the write path, WAL replay, and
+/// checkpoint filtering all route through it so they agree on both the
+/// extraction and the empty-prefix error.
+pub(crate) fn extract_segment_prefix(
+    extractor: &dyn PrefixExtractor,
+    key: &Bytes,
+) -> Result<Bytes, SlateDBError> {
+    match extractor.prefix_len(&PrefixTarget::Point(key.clone())) {
+        Some(0) | None => Err(SlateDBError::EmptySegmentPrefix { key: key.clone() }),
+        Some(n) => Ok(key.slice(0..n)),
+    }
+}
 
 impl DbInner {
     pub(crate) fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -3,6 +3,7 @@ use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
 use crate::db_cache_manager::{self, CacheTarget};
+use crate::db_common::extract_segment_prefix;
 use crate::db_state::{collect_touched_segments, SsTableId};
 use crate::db_stats::DbStats;
 use crate::db_status::{ClosedResultWriter, DbStatus, DbStatusManager};
@@ -381,7 +382,10 @@ impl DbReaderInner {
                 // have sequence numbers < manifest.core.last_l0_seq, while others have sequence
                 // numbers > manifest.core.last_l0_seq. Retain only those that are more recent
                 // than the manifest's last L0 sequence number.
-                let filtered_table = table.filter_after_seq(manifest.core.last_l0_seq);
+                let filtered_table = table.filter_after_seq(
+                    manifest.core.last_l0_seq,
+                    self.segment_extractor.as_deref(),
+                )?;
                 // Push to the back because we are iterating prior from newest to oldest, and we
                 // want the imm memtables in checkpoint state to be ordered the same way.
                 imm_memtable.push_back(Arc::new(filtered_table));
@@ -583,14 +587,7 @@ impl DbReaderInner {
         let mut touched_segments: BTreeSet<Bytes> = BTreeSet::new();
         let mut iter = table.table().iter();
         while let Some(entry) = iter.next_sync() {
-            match extractor.prefix_len(&crate::PrefixTarget::Point(entry.key.clone())) {
-                Some(0) | None => {
-                    return Err(SlateDBError::EmptySegmentPrefix { key: entry.key });
-                }
-                Some(n) => {
-                    touched_segments.insert(entry.key.slice(0..n));
-                }
-            }
+            touched_segments.insert(extract_segment_prefix(extractor, &entry.key)?);
         }
         table.record_touched_segments(touched_segments);
         Ok(())

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -290,9 +290,10 @@ impl DbReaderInner {
         let mut write_guard = self.state.write();
         *write_guard = Arc::new(new_checkpoint_state);
         drop(write_guard);
-        self.status_manager.report_manifest(versioned_manifest);
-        self.status_manager
-            .report_memtable_segments(collect_touched_segments(self.state.read().as_ref()));
+        self.status_manager.report_manifest_and_memtable_segments(
+            versioned_manifest,
+            collect_touched_segments(self.state.read().as_ref()),
+        );
         Ok(())
     }
 
@@ -1425,7 +1426,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_report_memtable_segments_to_subscription() {
+    async fn should_report_memtable_segments_in_status() {
         // given
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_reader_subscribe_reports_memtable_segments";

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -146,9 +146,10 @@ impl DbReaderInner {
         let initial_durable_seq = initial_state
             .last_remote_persisted_seq
             .max(initial_state.core().last_l0_seq);
-        let status_manager = DbStatusManager::new_with_manifest(
+        let status_manager = DbStatusManager::new_with_initial_values(
             initial_durable_seq,
             VersionedManifest::from(initial_state.as_ref()),
+            collect_touched_segments(initial_state.as_ref()),
         );
         let oracle = Arc::new(DbReaderOracle::new(
             initial_durable_seq,
@@ -180,9 +181,6 @@ impl DbReaderInner {
             rand,
             recorder,
         };
-        inner
-            .status_manager
-            .report_memtable_segments(collect_touched_segments(inner.state.read().as_ref()));
         Ok(inner)
     }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -3,7 +3,7 @@ use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
 use crate::db_cache_manager::{self, CacheTarget};
-use crate::db_state::SsTableId;
+use crate::db_state::{collect_touched_segments, SsTableId};
 use crate::db_stats::DbStats;
 use crate::db_status::{ClosedResultWriter, DbStatus, DbStatusManager};
 use crate::dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef};
@@ -11,10 +11,11 @@ use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
-use crate::mem_table::{ImmutableMemtable, KVTable};
+use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
 use crate::merge_operator::MergeOperatorType;
 use crate::oracle::DbReaderOracle;
 use crate::paths::PathResolver;
+use crate::prefix_extractor::PrefixExtractor;
 use crate::reader::{DbStateReader, Reader, ScanContext};
 use crate::sst_iter::SstIteratorOptions;
 use crate::store_provider::StoreProvider;
@@ -33,7 +34,7 @@ use object_store::ObjectStore;
 use parking_lot::RwLock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::DbRand;
-use std::collections::VecDeque;
+use std::collections::{BTreeSet, VecDeque};
 use std::ops::{RangeBounds, Sub};
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -59,6 +60,7 @@ struct DbReaderInner {
     oracle: Arc<DbReaderOracle>,
     reader: Reader,
     status_manager: DbStatusManager,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     rand: Arc<DbRand>,
     /// Kept alive so the underlying `MetricsRecorder` is not dropped while
     /// metric handles in `DbStats` (and other stats structs) are still in use.
@@ -110,7 +112,7 @@ impl DbReaderInner {
         options: DbReaderOptions,
         checkpoint_id: Option<Uuid>,
         merge_operator: Option<MergeOperatorType>,
-        status_manager: DbStatusManager,
+        segment_extractor: Option<Arc<dyn PrefixExtractor>>,
         system_clock: Arc<dyn SystemClock>,
         rand: Arc<DbRand>,
         recorder: slatedb_common::metrics::MetricsRecorderHelper,
@@ -126,6 +128,7 @@ impl DbReaderInner {
                 Arc::clone(&manifest_store),
                 Arc::clone(&table_store),
                 &options,
+                segment_extractor.as_ref(),
                 checkpoint,
                 replay_new_wals,
             )
@@ -142,8 +145,10 @@ impl DbReaderInner {
         let initial_durable_seq = initial_state
             .last_remote_persisted_seq
             .max(initial_state.core().last_l0_seq);
-        status_manager.report_durable_seq(initial_durable_seq);
-        status_manager.report_manifest(VersionedManifest::from(initial_state.as_ref()));
+        let status_manager = DbStatusManager::new_with_manifest(
+            initial_durable_seq,
+            VersionedManifest::from(initial_state.as_ref()),
+        );
         let oracle = Arc::new(DbReaderOracle::new(
             initial_durable_seq,
             status_manager.clone(),
@@ -160,7 +165,7 @@ impl DbReaderInner {
             merge_operator,
         );
 
-        Ok(Self {
+        let inner = Self {
             manifest_store,
             table_store,
             options,
@@ -170,9 +175,14 @@ impl DbReaderInner {
             oracle,
             reader,
             status_manager,
+            segment_extractor,
             rand,
             recorder,
-        })
+        };
+        inner
+            .status_manager
+            .report_memtable_segments(collect_touched_segments(inner.state.read().as_ref()));
+        Ok(inner)
     }
 
     async fn get_or_create_checkpoint(
@@ -280,6 +290,8 @@ impl DbReaderInner {
         *write_guard = Arc::new(new_checkpoint_state);
         drop(write_guard);
         self.status_manager.report_manifest(versioned_manifest);
+        self.status_manager
+            .report_memtable_segments(collect_touched_segments(self.state.read().as_ref()));
         Ok(())
     }
 
@@ -302,6 +314,7 @@ impl DbReaderInner {
                 current_checkpoint.core(),
                 &mut imm_memtable,
                 true,
+                self.segment_extractor.as_ref(),
             )
             .await?;
 
@@ -314,6 +327,9 @@ impl DbReaderInner {
                 last_wal_id,
                 last_remote_persisted_seq: last_committed_seq,
             });
+            drop(write_guard);
+            self.status_manager
+                .report_memtable_segments(collect_touched_segments(self.state.read().as_ref()));
         }
         Ok(())
     }
@@ -322,6 +338,7 @@ impl DbReaderInner {
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,
         options: &DbReaderOptions,
+        segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
         checkpoint: Checkpoint,
         replay_new_wals: bool,
     ) -> Result<CheckpointState, SlateDBError> {
@@ -334,6 +351,7 @@ impl DbReaderInner {
             replay_new_wals,
             Arc::clone(&table_store),
             options,
+            segment_extractor,
         )
         .await
     }
@@ -377,6 +395,7 @@ impl DbReaderInner {
             !self.options.skip_wal_replay,
             Arc::clone(&self.table_store),
             &self.options,
+            self.segment_extractor.as_ref(),
         )
         .await
     }
@@ -388,6 +407,7 @@ impl DbReaderInner {
         replay_new_wals: bool,
         table_store: Arc<TableStore>,
         options: &DbReaderOptions,
+        segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<CheckpointState, SlateDBError> {
         let (last_wal_id, last_committed_seq) = Self::replay_wal_into(
             Arc::clone(&table_store),
@@ -395,6 +415,7 @@ impl DbReaderInner {
             &manifest.core,
             &mut imm_memtable,
             replay_new_wals,
+            segment_extractor,
         )
         .await?;
 
@@ -473,6 +494,7 @@ impl DbReaderInner {
         core: &ManifestCore,
         into_tables: &mut VecDeque<Arc<ImmutableMemtable>>,
         replay_new_wals: bool,
+        segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<(u64, u64), SlateDBError> {
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 1,
@@ -534,6 +556,12 @@ impl DbReaderInner {
                 // out entries <= last_committed_seq when creating the replay iterator.
                 assert!(first_seq > last_committed_seq);
                 last_committed_seq = replayed_table.last_seq;
+                if let Some(extractor) = segment_extractor {
+                    Self::record_replayed_touched_segments(
+                        extractor.as_ref(),
+                        &replayed_table.table,
+                    )?;
+                }
                 let imm_memtable =
                     ImmutableMemtable::new(replayed_table.table, replayed_table.last_wal_id);
                 into_tables.push_front(Arc::new(imm_memtable));
@@ -541,6 +569,31 @@ impl DbReaderInner {
         }
 
         Ok((replay_after_wal_id, last_committed_seq))
+    }
+
+    /// Re-derive each replayed entry's segment prefix (RFC-0024) and record the
+    /// table's touched-segment set, mirroring the writer's replay path. Durable
+    /// WAL entries were validated when accepted, so the antichain check is not
+    /// re-run; an empty/absent prefix under the configured extractor remains a
+    /// hard error.
+    fn record_replayed_touched_segments(
+        extractor: &dyn PrefixExtractor,
+        table: &WritableKVTable,
+    ) -> Result<(), SlateDBError> {
+        let mut touched_segments: BTreeSet<Bytes> = BTreeSet::new();
+        let mut iter = table.table().iter();
+        while let Some(entry) = iter.next_sync() {
+            match extractor.prefix_len(&crate::PrefixTarget::Point(entry.key.clone())) {
+                Some(0) | None => {
+                    return Err(SlateDBError::EmptySegmentPrefix { key: entry.key });
+                }
+                Some(n) => {
+                    touched_segments.insert(entry.key.slice(0..n));
+                }
+            }
+        }
+        table.record_touched_segments(touched_segments);
+        Ok(())
     }
 
     /// Returns the latest database status.
@@ -730,6 +783,7 @@ impl DbReader {
         store_provider: &dyn StoreProvider,
         checkpoint_id: Option<Uuid>,
         merge_operator: Option<MergeOperatorType>,
+        segment_extractor: Option<Arc<dyn PrefixExtractor>>,
         options: DbReaderOptions,
         system_clock: Arc<dyn SystemClock>,
         rand: Arc<DbRand>,
@@ -746,12 +800,10 @@ impl DbReader {
             return Err(SlateDBError::InvalidDBState);
         }
 
-        let status_manager = DbStatusManager::new_with_manifest(
-            manifest.db_state().last_l0_seq,
-            VersionedManifest::from_manifest(manifest.id(), manifest.manifest().clone()),
-        );
-        let task_executor =
-            MessageHandlerExecutor::new(Arc::new(status_manager.clone()), system_clock.clone());
+        manifest
+            .db_state()
+            .validate_extractor_configuration(segment_extractor.as_deref())?;
+
         let inner = Arc::new(
             DbReaderInner::new(
                 manifest_store,
@@ -759,13 +811,17 @@ impl DbReader {
                 options,
                 checkpoint_id,
                 merge_operator,
-                status_manager,
-                system_clock,
+                segment_extractor,
+                system_clock.clone(),
                 rand,
                 recorder,
                 manifest,
             )
             .await?,
+        );
+        let task_executor = MessageHandlerExecutor::new(
+            Arc::new(inner.status_manager.clone()),
+            system_clock.clone(),
         );
 
         // If no checkpoint was provided, then we have established a new checkpoint
@@ -1214,8 +1270,8 @@ mod tests {
     use super::CheckpointState;
     use crate::clock::MonotonicClock;
     use crate::config::{
-        CheckpointOptions, CheckpointScope, FlushOptions, FlushType, MergeOptions, Settings,
-        WriteOptions,
+        CheckpointOptions, CheckpointScope, FlushOptions, FlushType, MergeOptions, PutOptions,
+        Settings, WriteOptions,
     };
     use crate::db_reader::{DbReader, DbReaderInner, DbReaderOptions};
     use crate::db_state::SsTableId;
@@ -1323,6 +1379,7 @@ mod tests {
             &test_provider,
             Some(checkpoint_result.id),
             None,
+            None,
             DbReaderOptions::default(),
             test_provider.system_clock.clone(),
             test_provider.rand.clone(),
@@ -1368,6 +1425,155 @@ mod tests {
             reader.get(key).await.unwrap(),
             Some(Bytes::from_static(checkpoint_value))
         );
+    }
+
+    #[tokio::test]
+    async fn should_report_memtable_segments_to_subscription() {
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_subscribe_reports_memtable_segments";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let write_opts = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+        db.put_with_options(b"abc-1", b"v1", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::Wal,
+        })
+        .await
+        .unwrap();
+
+        // when
+        let reader = DbReader::builder(path, object_store.clone())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+
+        // then
+        let prefixes: Vec<Bytes> = reader
+            .status()
+            .list_segments()
+            .into_iter()
+            .map(|seg| seg.prefix)
+            .collect();
+        assert_eq!(prefixes, vec![Bytes::from_static(b"abc")]);
+    }
+
+    #[tokio::test]
+    async fn should_reject_reader_with_mismatched_extractor() {
+        #[derive(Debug)]
+        struct OtherExtractor;
+        impl crate::prefix_extractor::PrefixExtractor for OtherExtractor {
+            fn name(&self) -> &str {
+                "other"
+            }
+            fn prefix_len(&self, _target: &crate::prefix_extractor::PrefixTarget) -> Option<usize> {
+                Some(3)
+            }
+        }
+
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_rejects_mismatched_extractor";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        db.close().await.unwrap();
+
+        // when
+        let err = match DbReader::builder(path, object_store.clone())
+            .with_segment_extractor(Arc::new(OtherExtractor))
+            .build()
+            .await
+        {
+            Ok(_) => panic!("expected mismatched-extractor error"),
+            Err(err) => err,
+        };
+
+        // then
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+
+        // when
+        // a segmented database also rejects a reader opened without any extractor
+        let err = match DbReader::builder(path, object_store).build().await {
+            Ok(_) => panic!("expected missing-extractor error"),
+            Err(err) => err,
+        };
+
+        // then
+        assert_eq!(err.kind(), crate::ErrorKind::Invalid);
+        assert!(
+            err.to_string()
+                .contains("segment extractor configuration mismatch"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_list_checkpoint_segments_for_checkpoint_reader() {
+        // given
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_reader_lists_checkpoint_segments";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(Settings::default())
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let write_opts = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+        db.put_with_options(b"abc-1", b"v1", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        let checkpoint = db
+            .create_checkpoint(CheckpointScope::All, &CheckpointOptions::default())
+            .await
+            .unwrap();
+        db.put_with_options(b"xyz-1", b"v2", &PutOptions::default(), &write_opts)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        db.close().await.unwrap();
+
+        // when
+        let reader = DbReader::builder(path, object_store)
+            .with_segment_extractor(Arc::new(test_utils::FixedThreeBytePrefixExtractor))
+            .with_checkpoint_id(checkpoint.id)
+            .build()
+            .await
+            .unwrap();
+
+        // then
+        let segments: Vec<Bytes> = reader
+            .status()
+            .list_segments()
+            .into_iter()
+            .map(|seg| seg.prefix)
+            .collect();
+        assert_eq!(segments, vec![Bytes::from_static(b"abc")]);
     }
 
     #[tokio::test]
@@ -1562,13 +1768,6 @@ mod tests {
         )
         .await
         .unwrap();
-        let status_manager = DbStatusManager::new_with_manifest(
-            stored_manifest.db_state().last_l0_seq,
-            VersionedManifest::from_manifest(
-                stored_manifest.id(),
-                stored_manifest.manifest().clone(),
-            ),
-        );
         let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
 
         // Build DbReaderInner directly instead of DbReader so no spawned poller
@@ -1583,7 +1782,7 @@ mod tests {
             },
             None,
             None,
-            status_manager,
+            None,
             clock.clone(),
             test_provider.rand.clone(),
             recorder,
@@ -1708,6 +1907,7 @@ mod tests {
             &core,
             &mut into_tables,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1772,6 +1972,7 @@ mod tests {
             &core,
             &mut into_tables,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1823,6 +2024,7 @@ mod tests {
             &core,
             &mut into_tables,
             false,
+            None,
         )
         .await
         .unwrap();
@@ -1858,6 +2060,7 @@ mod tests {
             &core,
             &mut into_tables,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1888,6 +2091,7 @@ mod tests {
             &core,
             &mut into_tables,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1933,6 +2137,7 @@ mod tests {
             &core,
             &mut into_tables,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -2205,6 +2410,7 @@ mod tests {
                 self,
                 checkpoint,
                 merge_operator,
+                None,
                 options,
                 self.system_clock.clone(),
                 self.rand.clone(),
@@ -2397,6 +2603,7 @@ mod tests {
             oracle,
             reader,
             status_manager: DbStatusManager::new(0),
+            segment_extractor: None,
             rand: test_provider.rand.clone(),
             recorder,
         };
@@ -2478,6 +2685,7 @@ mod tests {
             oracle,
             reader,
             status_manager: DbStatusManager::new(0),
+            segment_extractor: None,
             rand: test_provider.rand.clone(),
             recorder,
         }

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -82,23 +82,25 @@ impl DbStatusManager {
     pub(crate) fn new(initial_durable_seq: u64) -> Self {
         use crate::manifest::Manifest;
         use crate::manifest::ManifestCore;
-        Self::new_with_manifest(
+        Self::new_with_initial_values(
             initial_durable_seq,
             VersionedManifest {
                 id: 1,
                 manifest: Manifest::initial(ManifestCore::new()),
             },
+            BTreeSet::new(),
         )
     }
 
-    pub(crate) fn new_with_manifest(
+    pub(crate) fn new_with_initial_values(
         initial_durable_seq: u64,
         initial_manifest: VersionedManifest,
+        initial_memtable_segments: BTreeSet<Bytes>,
     ) -> Self {
         let (tx, _) = watch::channel(DbStatus {
             durable_seq: initial_durable_seq,
             current_manifest: initial_manifest,
-            memtable_segments: BTreeSet::new(),
+            memtable_segments: initial_memtable_segments,
             close_reason: None,
         });
         Self {
@@ -287,7 +289,8 @@ mod tests {
     #[test]
     fn should_initialize_with_no_segments_from_empty_manifest() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, versioned_manifest(1));
+        let mgr =
+            DbStatusManager::new_with_initial_values(0, versioned_manifest(1), BTreeSet::new());
 
         // when
         let status = mgr.status();
@@ -299,7 +302,11 @@ mod tests {
     #[test]
     fn should_initialize_with_segments_from_manifest() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]));
+        let mgr = DbStatusManager::new_with_initial_values(
+            0,
+            manifest_with_segments(1, &[b"a", b"b"]),
+            BTreeSet::new(),
+        );
 
         // when
         let status = mgr.status();
@@ -314,11 +321,11 @@ mod tests {
     #[test]
     fn should_union_and_dedup_segments() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a", b"b"]));
-        mgr.report_memtable_segments(BTreeSet::from([
-            Bytes::from_static(b"b"),
-            Bytes::from_static(b"c"),
-        ]));
+        let mgr = DbStatusManager::new_with_initial_values(
+            0,
+            manifest_with_segments(1, &[b"a", b"b"]),
+            BTreeSet::from([Bytes::from_static(b"b"), Bytes::from_static(b"c")]),
+        );
 
         // when
         let segments = mgr.status().list_segments();
@@ -337,11 +344,11 @@ mod tests {
     #[test]
     fn should_return_sorted_segments() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"d", b"b"]));
-        mgr.report_memtable_segments(BTreeSet::from([
-            Bytes::from_static(b"c"),
-            Bytes::from_static(b"a"),
-        ]));
+        let mgr = DbStatusManager::new_with_initial_values(
+            0,
+            manifest_with_segments(1, &[b"d", b"b"]),
+            BTreeSet::from([Bytes::from_static(b"c"), Bytes::from_static(b"a")]),
+        );
 
         // when
         let segments = mgr.status().list_segments();
@@ -462,7 +469,7 @@ mod tests {
     fn should_not_notify_on_same_manifest() {
         // given
         let initial = versioned_manifest(1);
-        let mgr = DbStatusManager::new_with_manifest(0, initial.clone());
+        let mgr = DbStatusManager::new_with_initial_values(0, initial.clone(), BTreeSet::new());
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 
@@ -476,7 +483,8 @@ mod tests {
     #[test]
     fn should_not_notify_on_older_manifest() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, versioned_manifest(5));
+        let mgr =
+            DbStatusManager::new_with_initial_values(0, versioned_manifest(5), BTreeSet::new());
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 
@@ -491,11 +499,11 @@ mod tests {
     fn should_update_manifest_and_segments_atomically() {
         // given: manifest has no segments yet, and "a"/"b" are touched in the
         // memtables.
-        let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[]));
-        mgr.report_memtable_segments(BTreeSet::from([
-            Bytes::from_static(b"a"),
-            Bytes::from_static(b"b"),
-        ]));
+        let mgr = DbStatusManager::new_with_initial_values(
+            0,
+            manifest_with_segments(1, &[]),
+            BTreeSet::from([Bytes::from_static(b"a"), Bytes::from_static(b"b")]),
+        );
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 
@@ -527,8 +535,11 @@ mod tests {
     #[test]
     fn should_not_notify_when_manifest_and_segments_unchanged() {
         // given
-        let mgr = DbStatusManager::new_with_manifest(0, manifest_with_segments(1, &[b"a"]));
-        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"b")]));
+        let mgr = DbStatusManager::new_with_initial_values(
+            0,
+            manifest_with_segments(1, &[b"a"]),
+            BTreeSet::from([Bytes::from_static(b"b")]),
+        );
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -14,8 +14,10 @@ use std::sync::atomic::Ordering::SeqCst;
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
 
+use crate::db_common::extract_segment_prefix;
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator};
+use crate::prefix_extractor::PrefixExtractor;
 use crate::seq_tracker::{SequenceTracker, TrackedSeq};
 use crate::types::RowEntry;
 use crate::utils::{WatchableOnceCell, WatchableOnceCellReader};
@@ -326,26 +328,34 @@ impl ImmutableMemtable {
     /// Returns a new [`ImmutableMemtable`] that only contains entries with sequence
     /// number greater than the given `seq`. [`ImmutableMemtable::recent_flushed_wal_id`]
     /// remains the same.
-    pub(crate) fn filter_after_seq(&self, seq: u64) -> Self {
+    ///
+    /// When `segment_extractor` is `Some`, the surviving entries are run
+    /// through it to rebuild the touched-segment set (RFC-0024) from
+    /// scratch — the same derivation the writer applies in
+    /// [`WriteBatch::extract_entries`], via the shared
+    /// [`extract_segment_prefix`]. Prefixes whose every row was filtered
+    /// out are therefore dropped, and no row's prefix can survive without
+    /// its row. An empty/absent prefix is an `EmptySegmentPrefix` error,
+    /// matching the write and replay paths. When `segment_extractor` is
+    /// `None`, the new table records no segments.
+    pub(crate) fn filter_after_seq(
+        &self,
+        seq: u64,
+        segment_extractor: Option<&dyn PrefixExtractor>,
+    ) -> Result<Self, SlateDBError> {
         let new_table = WritableKVTable::new();
-        let original_segments = self.table.touched_segments();
         let mut surviving_segments = std::collections::BTreeSet::new();
         let mut table_iter = self.table.iter();
         while let Some(entry) = table_iter.next_sync() {
             if entry.seq > seq {
-                if surviving_segments.len() < original_segments.len() {
-                    for prefix in &original_segments {
-                        if entry.key.starts_with(prefix.as_ref()) {
-                            surviving_segments.insert(prefix.clone());
-                            break;
-                        }
-                    }
+                if let Some(extractor) = segment_extractor {
+                    surviving_segments.insert(extract_segment_prefix(extractor, &entry.key)?);
                 }
                 new_table.put(entry);
             }
         }
         new_table.record_touched_segments(surviving_segments);
-        Self::new(new_table, self.recent_flushed_wal_id)
+        Ok(Self::new(new_table, self.recent_flushed_wal_id))
     }
 }
 
@@ -570,6 +580,7 @@ mod tests {
     use super::*;
     use crate::bytes_range::BytesRange;
     use crate::merge_iterator::MergeIterator;
+    use crate::prefix_extractor::PrefixTarget;
     use crate::proptest_util::{arbitrary, sample};
     use crate::test_utils::assert_iterator;
     use crate::{proptest_util, test_utils};
@@ -866,6 +877,23 @@ mod tests {
         prefixes.iter().map(|p| Bytes::copy_from_slice(p)).collect()
     }
 
+    /// Extracts a single-byte segment prefix, matching the 1-byte
+    /// prefixes used by the `filter_after_seq` tests.
+    #[derive(Debug)]
+    struct SingleByteExtractor;
+
+    impl PrefixExtractor for SingleByteExtractor {
+        fn name(&self) -> &str {
+            "single-byte-test-only"
+        }
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let len = match target {
+                PrefixTarget::Point(b) | PrefixTarget::Prefix(b) => b.len(),
+            };
+            (len >= 1).then_some(1)
+        }
+    }
+
     fn assert_invalid_segment_prefix(err: SlateDBError, prefix: &[u8], conflict: &[u8]) {
         match err {
             SlateDBError::InvalidSegmentPrefix {
@@ -978,7 +1006,7 @@ mod tests {
         let imm = ImmutableMemtable::new(table, 0);
 
         // when
-        let filtered = imm.filter_after_seq(2);
+        let filtered = imm.filter_after_seq(2, Some(&SingleByteExtractor)).unwrap();
 
         // then
         assert_eq!(filtered.table().touched_segments(), touched(&[b"b"]));
@@ -998,7 +1026,7 @@ mod tests {
         let imm = ImmutableMemtable::new(table, 0);
 
         // when
-        let filtered = imm.filter_after_seq(0);
+        let filtered = imm.filter_after_seq(0, Some(&SingleByteExtractor)).unwrap();
 
         // then
         assert_eq!(filtered.table().touched_segments(), touched(&[b"a", b"b"]));
@@ -1014,7 +1042,9 @@ mod tests {
         let imm = ImmutableMemtable::new(table, 0);
 
         // when
-        let filtered = imm.filter_after_seq(10);
+        let filtered = imm
+            .filter_after_seq(10, Some(&SingleByteExtractor))
+            .unwrap();
 
         // then
         assert!(filtered.table().touched_segments().is_empty());
@@ -1030,7 +1060,7 @@ mod tests {
         let imm = ImmutableMemtable::new(table, 0);
 
         // when
-        let filtered = imm.filter_after_seq(1);
+        let filtered = imm.filter_after_seq(1, None).unwrap();
 
         // then
         assert!(filtered.table().touched_segments().is_empty());


### PR DESCRIPTION
## Summary

Add `DbReaderBuilder::with_segment_extractor` and thread the extractor through WAL replay so the reader re-derives each replayed entry's segment prefix, mirroring the writer, and reports the resulting memtable segments on open, checkpoint refresh, and WAL replay.

`DbReader::open_internal` now validates the configured extractor against the manifest unconditionally, so opening a reader on a segmented database without a matching extractor is rejected with `SegmentExtractorMismatch` rather than silently yielding incomplete segment listings — matching the `Db` writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changes

- collects segments on the WAL replay path
- requires a segment extractor for a DB reader on a segmented DB 

## Notes for Reviewers
- Part 3 of 3 of a stack splitting the `list_segments()` work for review. This PR is stacked on #1774. Review only the latest commit ("Require a matching segment ..."). Merge #1774 first.
- Note the following comment: https://github.com/slatedb/slatedb/pull/1775/changes#r3380629820

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏