### PR TITLE
Enforce ordering in FlatBuffer maps

### DIFF
--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -11,7 +11,7 @@
 //! heartbeat emission and coordinator-side failure-detection / reclamation
 //! protocol are added in a follow-up.
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -259,7 +259,7 @@ pub(crate) struct CompactionWorkerHandler {
     /// Compactions currently being executed by this worker (claimed but not
     /// yet `Compacted`). Used to gate capacity and to know what to reset on
     /// graceful shutdown.
-    active_jobs: HashSet<Ulid>,
+    active_jobs: BTreeSet<Ulid>,
     rand: Arc<DbRand>,
     /// Lazily-initialized handle for CAS reads/writes on `.compactions`. The
     /// coordinator creates the file on first run; the worker tolerates its
@@ -284,7 +284,7 @@ impl CompactionWorkerHandler {
             manifest_store,
             executor,
             clock,
-            active_jobs: HashSet::new(),
+            active_jobs: BTreeSet::new(),
             rand,
             stored: None,
         }
@@ -629,7 +629,7 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
         let _ = tokio::task::spawn_blocking(move || executor.stop()).await;
         #[cfg(dst)]
         let _ = tokio::spawn(async move { executor.stop() }).await;
-        let claimed: Vec<Ulid> = self.active_jobs.drain().collect();
+        let claimed = std::mem::take(&mut self.active_jobs);
         for id in claimed {
             if let Err(e) = self.release_claim(id).await {
                 error!(
@@ -965,6 +965,18 @@ mod tests {
         assert_eq!(c.status(), CompactionStatus::Submitted);
         assert!(c.worker().is_none());
         assert!(fx.handler.active_jobs.is_empty());
+    }
+
+    #[test]
+    fn test_worker_cleanup_releases_active_claims_in_id_order() {
+        let id1 = Ulid::from_parts(1, 0);
+        let id2 = Ulid::from_parts(2, 0);
+        let id3 = Ulid::from_parts(3, 0);
+
+        let active_jobs = BTreeSet::from([id3, id1, id2]);
+        let release_order = active_jobs.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(release_order, vec![id1, id2, id3]);
     }
 
     #[tokio::test]

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -341,7 +341,7 @@ pub(crate) fn max_l0_overlap(l0: &VecDeque<SsTableView>) -> usize {
 }
 
 /// An identifier for an SSTable, which can be either a WAL SST or a compacted SST.
-#[derive(Clone, PartialEq, Hash, Eq, Copy, Serialize)]
+#[derive(Clone, PartialEq, PartialOrd, Ord, Hash, Eq, Copy, Serialize)]
 pub enum SsTableId {
     /// A WAL SST identified by its unique WAL ID.
     Wal(u64),

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -1176,8 +1176,8 @@ impl<'b> DbFlatBufferBuilder<'b> {
         let core = &manifest.core;
 
         // Collect all unique SSTs from l0, compacted runs, and segments.
-        let mut unique_ssts: std::collections::HashMap<Ulid, &SsTableHandle> =
-            std::collections::HashMap::new();
+        let mut unique_ssts: std::collections::BTreeMap<Ulid, &SsTableHandle> =
+            std::collections::BTreeMap::new();
         for tree in core.trees() {
             for view in tree.l0.iter() {
                 if let SsTableId::Compacted(ulid) = view.sst.id {
@@ -1193,15 +1193,9 @@ impl<'b> DbFlatBufferBuilder<'b> {
             }
         }
         let ssts = {
-            // HashMap iteration order is randomly seeded. Since FlatBuffers lay out
-            // nested variable-size SST metadata with alignment padding, different
-            // orders can produce different bytes and even different payload sizes
-            // for the same semantic manifest.
-            let mut unique_ssts = unique_ssts.into_iter().collect::<Vec<_>>();
-            unique_ssts.sort_by_key(|(id, _)| *id);
             let sst_offsets: Vec<WIPOffset<CompactedSsTableV2>> = unique_ssts
-                .iter()
-                .map(|(_, handle)| *handle)
+                .values()
+                .copied()
                 .map(|handle| self.add_compacted_sst_v2(handle))
                 .collect();
             self.builder.create_vector(sst_offsets.as_ref())

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -1193,8 +1193,15 @@ impl<'b> DbFlatBufferBuilder<'b> {
             }
         }
         let ssts = {
+            // HashMap iteration order is randomly seeded. Since FlatBuffers lay out
+            // nested variable-size SST metadata with alignment padding, different
+            // orders can produce different bytes and even different payload sizes
+            // for the same semantic manifest.
+            let mut unique_ssts = unique_ssts.into_iter().collect::<Vec<_>>();
+            unique_ssts.sort_by_key(|(id, _)| *id);
             let sst_offsets: Vec<WIPOffset<CompactedSsTableV2>> = unique_ssts
-                .values()
+                .iter()
+                .map(|(_, handle)| *handle)
                 .map(|handle| self.add_compacted_sst_v2(handle))
                 .collect();
             self.builder.create_vector(sst_offsets.as_ref())
@@ -1589,6 +1596,65 @@ mod tests {
 
         // then:
         assert_eq!(manifest, decoded);
+    }
+
+    #[test]
+    fn test_should_encode_manifest_v2_deterministically() {
+        fn new_sst_view(index: u64) -> SsTableView {
+            let ulid = ulid::Ulid::from_parts(index, u128::from(index * 17));
+            SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(ulid),
+                SST_FORMAT_VERSION_LATEST,
+                SsTableInfo {
+                    first_entry: Some(Bytes::from(format!("first-{index:03}"))),
+                    last_entry: Some(Bytes::from(format!("last-{index:03}"))),
+                    index_offset: index * 100,
+                    index_len: 17 + index,
+                    filter_offset: 2000 + index,
+                    filter_len: 11 + index,
+                    ..Default::default()
+                },
+            ))
+        }
+
+        let mut manifest = Manifest::initial(ManifestCore::new());
+        let root = Arc::make_mut(&mut manifest.core.tree);
+        root.l0 = (0..16).map(new_sst_view).collect();
+        root.compacted = (0..4)
+            .map(|run| SortedRun {
+                id: run as u32,
+                sst_views: (0..8)
+                    .map(|offset| new_sst_view(100 + run * 8 + offset))
+                    .collect(),
+            })
+            .collect();
+        manifest.core.segment_extractor_name = Some("test".to_string());
+        manifest.core.segments = (0..4)
+            .map(|segment| {
+                let mut tree = LsmTreeState::default();
+                tree.l0 = (0..4)
+                    .map(|offset| new_sst_view(1_000 + segment * 16 + offset))
+                    .collect();
+                tree.compacted = vec![SortedRun {
+                    id: 100 + segment as u32,
+                    sst_views: (0..4)
+                        .map(|offset| new_sst_view(2_000 + segment * 16 + offset))
+                        .collect(),
+                }];
+                Segment {
+                    prefix: Bytes::from(format!("segment-{segment}")),
+                    tree: Arc::new(tree),
+                }
+            })
+            .collect();
+
+        let expected = FlatBufferManifestCodec::create_from_manifest(&manifest);
+        for _ in 0..64 {
+            assert_eq!(
+                expected,
+                FlatBufferManifestCodec::create_from_manifest(&manifest)
+            );
+        }
     }
 
     #[tokio::test]

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -1625,16 +1625,18 @@ mod tests {
         manifest.core.segment_extractor_name = Some("test".to_string());
         manifest.core.segments = (0..4)
             .map(|segment| {
-                let mut tree = LsmTreeState::default();
-                tree.l0 = (0..4)
-                    .map(|offset| new_sst_view(1_000 + segment * 16 + offset))
-                    .collect();
-                tree.compacted = vec![SortedRun {
-                    id: 100 + segment as u32,
-                    sst_views: (0..4)
-                        .map(|offset| new_sst_view(2_000 + segment * 16 + offset))
+                let tree = LsmTreeState {
+                    l0: (0..4)
+                        .map(|offset| new_sst_view(1_000 + segment * 16 + offset))
                         .collect(),
-                }];
+                    compacted: vec![SortedRun {
+                        id: 100 + segment as u32,
+                        sst_views: (0..4)
+                            .map(|offset| new_sst_view(2_000 + segment * 16 + offset))
+                            .collect(),
+                    }],
+                    ..Default::default()
+                };
                 Segment {
                     prefix: Bytes::from(format!("segment-{segment}")),
                     tree: Arc::new(tree),

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -1,5 +1,5 @@
 use std::cmp::{max, min, Ordering};
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt::Debug;
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
@@ -1429,14 +1429,18 @@ impl Manifest {
             core.last_l0_seq = max(core.last_l0_seq, source.manifest.core.last_l0_seq);
         }
 
+        // Canonicalize before generating final checkpoint IDs. The manifest
+        // stores both external_dbs and nested sst_ids as vectors, so unordered
+        // iteration here would make manifest bytes and UUID assignment depend
+        // on HashMap/HashSet seed order.
         let external_dbs_merged = Self::build_external_dbs(&ordered_sources)
             .into_iter()
             .fold(
-                HashMap::new(),
-                |mut map: HashMap<(String, Uuid), HashSet<SsTableId>>, db| {
+                BTreeMap::new(),
+                |mut map: BTreeMap<(String, Uuid), BTreeSet<SsTableId>>, db| {
                     map.entry((db.path, db.source_checkpoint_id))
                         .or_default()
-                        .extend::<HashSet<SsTableId>>(HashSet::from_iter(db.sst_ids));
+                        .extend(db.sst_ids);
                     map
                 },
             )
@@ -3329,6 +3333,85 @@ mod tests {
         let merged_ids: HashSet<SsTableId> = shared_entries[0].sst_ids.iter().copied().collect();
         let expected_ids: HashSet<SsTableId> = [sst_a, sst_b, sst_c].iter().copied().collect();
         assert_eq!(merged_ids, expected_ids);
+    }
+
+    #[test]
+    fn test_union_orders_external_dbs_and_sst_ids_deterministically() {
+        let source1_cp = Uuid::from_u128(100);
+        let source2_cp = Uuid::from_u128(200);
+        let ancestor_a_final_cp = Uuid::from_u128(10);
+        let ancestor_z_final_cp = Uuid::from_u128(30);
+
+        let ancestor_a_sst1 = SsTableId::Compacted(Ulid::from_parts(1000, 0));
+        let ancestor_a_sst2 = SsTableId::Compacted(Ulid::from_parts(1001, 0));
+        let ancestor_z_sst1 = SsTableId::Compacted(Ulid::from_parts(3000, 0));
+        let ancestor_z_sst2 = SsTableId::Compacted(Ulid::from_parts(3001, 0));
+        let source1_sst = SsTableId::Compacted(Ulid::from_parts(5000, 0));
+        let source2_sst = SsTableId::Compacted(Ulid::from_parts(6000, 0));
+
+        let mut manifest1 =
+            manifest_with_one_compacted_sst(source1_sst, b"a", BytesRange::from_ref("a".."m"));
+        manifest1.external_dbs.push(ExternalDb {
+            path: "z-parent".to_string(),
+            source_checkpoint_id: Uuid::from_u128(31),
+            final_checkpoint_id: Some(ancestor_z_final_cp),
+            sst_ids: vec![ancestor_z_sst2, ancestor_z_sst1],
+        });
+
+        let mut manifest2 =
+            manifest_with_one_compacted_sst(source2_sst, b"m", BytesRange::from_ref("m"..));
+        manifest2.external_dbs.push(ExternalDb {
+            path: "a-parent".to_string(),
+            source_checkpoint_id: Uuid::from_u128(11),
+            final_checkpoint_id: Some(ancestor_a_final_cp),
+            sst_ids: vec![ancestor_a_sst2, ancestor_a_sst1],
+        });
+
+        let union = Manifest::cloned_from_union(
+            vec![
+                CloneSource {
+                    manifest: manifest1,
+                    path: Path::from("/tmp/db1"),
+                    checkpoint: new_checkpoint(source1_cp),
+                },
+                CloneSource {
+                    manifest: manifest2,
+                    path: Path::from("/tmp/db2"),
+                    checkpoint: new_checkpoint(source2_cp),
+                },
+            ],
+            Arc::new(DbRand::default()),
+        )
+        .unwrap();
+
+        let actual: Vec<_> = union
+            .external_dbs
+            .iter()
+            .map(|db| {
+                (
+                    db.path.as_str(),
+                    db.source_checkpoint_id,
+                    db.sst_ids.clone(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            actual,
+            vec![
+                (
+                    "a-parent",
+                    ancestor_a_final_cp,
+                    vec![ancestor_a_sst1, ancestor_a_sst2],
+                ),
+                ("tmp/db1", source1_cp, vec![source1_sst]),
+                ("tmp/db2", source2_cp, vec![source2_sst]),
+                (
+                    "z-parent",
+                    ancestor_z_final_cp,
+                    vec![ancestor_z_sst1, ancestor_z_sst2],
+                ),
+            ]
+        );
     }
 
     fn segment_with_prefix(prefix: &[u8], seed: u64) -> super::Segment {


### PR DESCRIPTION
## Summary

The nightly.yaml deterministic-simulation-test job failed two nights ago:

https://github.com/slatedb/slatedb/actions/runs/27152232697/job/80145922434

It appears the issue is caused by non-determinism introduced in `flatbuffer_types.rs`. The flatbuffer iterates over a HashMap when creating/encoding a manifest. This causes the following problem:

1. FlatBuffer Manifest has non-deterministic key/value ordering.
2. FlatBuffer uses differential encoding on key/values, which results in non-deterministic Manifest file sizes.
3. `FailingObjectStore` in `slatedb-dst` sees non-deterministic file sizes and sleeps for a non-deterministic period of time when bandwidth throttling toxics are used.

I also took the opportunity to clean up a couple of other HashMaps/HashSets that are iterated upon.

## Changes

- Use BTreeMap for unique_ssts in flatbuffer_types.rs
- Use BTreeMap/BTreeSet for external_dbs_merged
- Keep active jobs in compaction worker sorted

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
