### PR TITLE
Bump commit compacted interval to 5s in DST

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -116,7 +116,7 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         }),
         metric_level: None,
         commit_compacted_interval: rng
-            .random_range(Duration::from_millis(1)..Duration::from_secs(1)),
+            .random_range(Duration::from_millis(1)..Duration::from_secs(5)),
     }
 }
 


### PR DESCRIPTION
## Summary

#1753 wired in distributed compaction. @ryandielhenn mentioned that he saw a hang on DST when 5s was used for `commit_compacted_interval`. I tried to reproduce locally and was unable to do so. I'm setting it here. If see it hang on nightly, we can then debug.