### PR TITLE
Distributed Compaction (RFC-0025) Phase 4: Add worker heartbeats and job reclamation

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -117,6 +117,8 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         metric_level: None,
         commit_compacted_interval: rng
             .random_range(Duration::from_millis(1)..Duration::from_secs(5)),
+        worker_heartbeat_timeout: rng
+            .random_range(Duration::from_millis(100)..Duration::from_secs(60)),
     }
 }
 

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -92,6 +92,16 @@ pub fn build_reader_options(rand: &DbRand) -> DbReaderOptions {
 pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
     let min_compaction_sources = rng.random_range(2..=4);
     let max_compaction_sources = rng.random_range(min_compaction_sources..=16);
+
+    // Draw the worker's poll interval and minimum heartbeat interval first, then derive
+    // `worker_heartbeat_timeout` from them. Drawing the heartbeat timeout independently can
+    // produce `timeout < interval`, which reclaims healthy jobs and livelocks compaction.
+    let compactions_poll_interval =
+        rng.random_range(Duration::from_millis(1)..Duration::from_secs(5));
+    let heartbeat_min_interval = rng.random_range(Duration::from_millis(1)..Duration::from_secs(5));
+    let max_worker_heartbeat = heartbeat_min_interval.max(compactions_poll_interval);
+    let worker_heartbeat_timeout = max_worker_heartbeat * rng.random_range(3..=10);
+
     CompactorOptions {
         poll_interval: rng.random_range(Duration::from_millis(1)..Duration::from_secs(5)),
         manifest_update_timeout: rng
@@ -105,10 +115,8 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         .into(),
         worker: Some(CompactionWorkerOptions {
             max_concurrent_compactions: rng.random_range(1..=4),
-            compactions_poll_interval: rng
-                .random_range(Duration::from_millis(1)..Duration::from_secs(5)),
-            heartbeat_min_interval: rng
-                .random_range(Duration::from_millis(1)..Duration::from_secs(5)),
+            compactions_poll_interval,
+            heartbeat_min_interval,
             max_sst_size: rng.random_range(KIB_8..GIB_2),
             max_fetch_tasks: rng.random_range(1..=8),
             bytes_to_fetch: rng.random_range(KIB_8..=(8 * MIB_1)),
@@ -117,8 +125,7 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         metric_level: None,
         commit_compacted_interval: rng
             .random_range(Duration::from_millis(1)..Duration::from_secs(5)),
-        worker_heartbeat_timeout: rng
-            .random_range(Duration::from_millis(100)..Duration::from_secs(60)),
+        worker_heartbeat_timeout,
     }
 }
 

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -367,7 +367,7 @@ impl CompactionWorkerHandler {
                     self.job_progress.insert(
                         compaction.id(),
                         JobProgressState {
-                            last_hb_sst_count: 0,
+                            last_hb_sst_count: compaction.output_ssts().len(),
                             last_hb_bytes: 0,
                             last_hb_ms: self.clock.now().timestamp_millis() as u64,
                         },
@@ -390,21 +390,21 @@ impl CompactionWorkerHandler {
 
     /// Writes a heartbeat for `compaction_id`, updating `last_heartbeat_ms`
     /// and (when provided) the `output_ssts` list. Only writes if this worker
-    /// still owns the entry; silently returns otherwise.
+    /// still owns the entry.
     ///
     /// Returns `Ok(true)` iff a heartbeat was actually persisted. Callers use
     /// this to avoid advancing their in-memory progress bookkeeping when the
-    /// write was skipped (entry gone, ownership lost, or `.compactions` not yet
-    /// loaded) — otherwise they would mark progress as heartbeated that was
-    /// never durably recorded.
+    /// write was skipped (entry gone or ownership lost returns `Ok(false)`) —
+    /// otherwise they would mark progress as heartbeated that was never durably recorded.
+    ///
+    /// We only ever heartbeat a compaction this worker has already claimed, and
+    /// claiming requires `.compactions` to be loaded, so `self.stored` is
+    /// guaranteed to be `Some` here (expected via `EXPECT_LOADED` below).
     async fn write_heartbeat(
         &mut self,
         compaction_id: Ulid,
         output_ssts: Option<Vec<crate::db_state::SsTableHandle>>,
     ) -> Result<bool, SlateDBError> {
-        if !self.ensure_loaded().await? {
-            return Ok(false);
-        }
         loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -379,13 +379,19 @@ impl CompactionWorkerHandler {
     /// Writes a heartbeat for `compaction_id`, updating `last_heartbeat_ms`
     /// and (when provided) the `output_ssts` list. Only writes if this worker
     /// still owns the entry; silently returns otherwise.
+    ///
+    /// Returns `Ok(true)` iff a heartbeat was actually persisted. Callers use
+    /// this to avoid advancing their in-memory progress bookkeeping when the
+    /// write was skipped (entry gone, ownership lost, or `.compactions` not yet
+    /// loaded) — otherwise they would mark progress as heartbeated that was
+    /// never durably recorded.
     async fn write_heartbeat(
         &mut self,
         compaction_id: Ulid,
         output_ssts: Option<Vec<crate::db_state::SsTableHandle>>,
-    ) -> Result<(), SlateDBError> {
+    ) -> Result<bool, SlateDBError> {
         if !self.ensure_loaded().await? {
-            return Ok(());
+            return Ok(false);
         }
         loop {
             let stored = self.stored.as_mut().expect("ensure_loaded set stored");
@@ -395,14 +401,14 @@ impl CompactionWorkerHandler {
                     "heartbeat: compaction entry missing [id={}]; skipping",
                     compaction_id
                 );
-                return Ok(());
+                return Ok(false);
             };
             if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
                 debug!(
                     "heartbeat: no longer owner of compaction [id={}]; skipping",
                     compaction_id
                 );
-                return Ok(());
+                return Ok(false);
             }
             let now_ms = self.clock.now().timestamp_millis() as u64;
             let new_worker = WorkerSpec::new(self.worker_id.clone(), now_ms);
@@ -421,7 +427,7 @@ impl CompactionWorkerHandler {
                         "wrote heartbeat [worker_id={}, id={}, now_ms={}]",
                         self.worker_id, compaction_id, now_ms
                     );
-                    return Ok(());
+                    return Ok(true);
                 }
                 Err(e) if e.is_sequenced_write_conflict() => continue,
                 Err(e) => return Err(e),
@@ -433,6 +439,17 @@ impl CompactionWorkerHandler {
     /// - An **SST heartbeat** when `output_ssts` grew since the last report.
     /// - A **bytes heartbeat** when cumulative bytes since the last bytes-hb
     ///   exceeds `heartbeat_bytes` and `heartbeat_min_interval` has elapsed.
+    ///
+    /// `output_ssts` and `bytes_processed` are *cumulative* per job (the full
+    /// produced-SST list and the running byte total), not deltas — the SST
+    /// trigger relies on this by comparing `output_ssts.len()` against the
+    /// count last heartbeated.
+    ///
+    /// In-memory progress bookkeeping (`last_hb_sst_count`, `last_hb_bytes`,
+    /// and the worker-global `worker_last_bytes_hb_ms`) is only advanced after
+    /// `write_heartbeat` confirms a durable write, so a skipped write (entry
+    /// gone / ownership lost) does not mark un-persisted progress as
+    /// heartbeated.
     async fn handle_progress(
         &mut self,
         id: Ulid,
@@ -440,63 +457,64 @@ impl CompactionWorkerHandler {
         output_ssts: Vec<crate::db_state::SsTableHandle>,
     ) -> Result<(), SlateDBError> {
         // --- SST trigger -------------------------------------------------------
-        // Check and update state in a scoped block so the borrow ends before
-        // we call the async `write_heartbeat`.
-        let sst_trigger = {
-            let Some(state) = self.job_progress.get_mut(&id) else {
+        // Decide whether to write in a scoped borrow so it ends before the
+        // async `write_heartbeat`; state is updated afterwards only on success.
+        let new_sst_count = {
+            let Some(state) = self.job_progress.get(&id) else {
                 // No state for this job: stale progress message, ignore.
                 return Ok(());
             };
-            if output_ssts.len() > state.last_hb_sst_count {
-                let new_count = output_ssts.len();
-                state.last_hb_sst_count = new_count;
-                state.last_hb_bytes = bytes_processed;
-                Some(new_count)
-            } else {
-                None
-            }
+            (output_ssts.len() > state.last_hb_sst_count).then_some(output_ssts.len())
         };
 
-        if let Some(new_count) = sst_trigger {
+        if let Some(new_count) = new_sst_count {
             info!(
                 "SST heartbeat [worker_id={}, id={}, ssts={}]",
                 self.worker_id, id, new_count
             );
-            self.write_heartbeat(id, Some(output_ssts)).await?;
-            // Update the worker-level bytes heartbeat timestamp so the bytes
-            // trigger doesn't immediately re-fire after an SST heartbeat.
-            self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
+            if self.write_heartbeat(id, Some(output_ssts)).await? {
+                if let Some(state) = self.job_progress.get_mut(&id) {
+                    state.last_hb_sst_count = new_count;
+                    state.last_hb_bytes = bytes_processed;
+                }
+                // Update the worker-level bytes heartbeat timestamp so the bytes
+                // trigger doesn't immediately re-fire after an SST heartbeat.
+                self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
+            }
             return Ok(());
         }
 
         // --- Bytes trigger -----------------------------------------------------
-        let bytes_trigger = {
-            let Some(state) = self.job_progress.get_mut(&id) else {
+        // Note: `worker_last_bytes_hb_ms` is worker-global (shared across all
+        // jobs on this worker) while `last_hb_bytes` is per-job, so one job's
+        // bytes heartbeat can suppress another's for up to `heartbeat_min_interval`.
+        // That is intentional: the throttle bounds heartbeat write rate per
+        // worker, not per job.
+        let should_write = {
+            let Some(state) = self.job_progress.get(&id) else {
                 return Ok(());
             };
             let bytes_since_last_hb = bytes_processed.saturating_sub(state.last_hb_bytes);
             if bytes_since_last_hb >= self.options.heartbeat_bytes {
                 let now_ms = self.clock.now().timestamp_millis() as u64;
                 let min_interval_ms = self.options.heartbeat_min_interval.as_millis() as u64;
-                let elapsed = now_ms.saturating_sub(self.worker_last_bytes_hb_ms);
-                if elapsed >= min_interval_ms {
-                    state.last_hb_bytes = bytes_processed;
-                    true
-                } else {
-                    false
-                }
+                now_ms.saturating_sub(self.worker_last_bytes_hb_ms) >= min_interval_ms
             } else {
                 false
             }
         };
 
-        if bytes_trigger {
+        if should_write {
             info!(
                 "bytes heartbeat [worker_id={}, id={}, bytes={}]",
                 self.worker_id, id, bytes_processed
             );
-            self.write_heartbeat(id, None).await?;
-            self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
+            if self.write_heartbeat(id, None).await? {
+                if let Some(state) = self.job_progress.get_mut(&id) {
+                    state.last_hb_bytes = bytes_processed;
+                }
+                self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
+            }
         }
 
         Ok(())

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -392,10 +392,12 @@ impl CompactionWorkerHandler {
     /// and (when provided) the `output_ssts` list. Only writes if this worker
     /// still owns the entry.
     ///
-    /// Returns `Ok(true)` iff a heartbeat was actually persisted. Callers use
-    /// this to avoid advancing their in-memory progress bookkeeping when the
-    /// write was skipped (entry gone or ownership lost returns `Ok(false)`) —
-    /// otherwise they would mark progress as heartbeated that was never durably recorded.
+    /// Returns `Ok(Some(ms))` with the persisted heartbeat timestamp iff a
+    /// heartbeat was actually written, or `Ok(None)` if the write was skipped
+    /// (entry gone or ownership lost). Callers use the returned timestamp to
+    /// advance their in-memory progress bookkeeping consistently with what was
+    /// durably recorded, and treat `None` as "do not advance" so they never
+    /// mark progress as heartbeated that was never persisted.
     ///
     /// We only ever heartbeat a compaction this worker has already claimed, and
     /// claiming requires `.compactions` to be loaded, so `self.stored` is
@@ -404,7 +406,7 @@ impl CompactionWorkerHandler {
         &mut self,
         compaction_id: Ulid,
         output_ssts: Option<Vec<crate::db_state::SsTableHandle>>,
-    ) -> Result<bool, SlateDBError> {
+    ) -> Result<Option<u64>, SlateDBError> {
         loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
@@ -415,7 +417,7 @@ impl CompactionWorkerHandler {
                     self.worker_id,
                     compaction_id
                 );
-                return Ok(false);
+                return Ok(None);
             };
             if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
                 debug!(
@@ -423,7 +425,19 @@ impl CompactionWorkerHandler {
                     self.worker_id,
                     compaction_id
                 );
-                return Ok(false);
+                return Ok(None);
+            }
+            // output_ssts is cumulative per job, so a new list must extend the
+            // one already persisted (same prefix, only-grows). A violation means
+            // the executor reported an inconsistent SST set.
+            if let Some(ssts) = output_ssts.as_ref() {
+                let prev = existing.output_ssts();
+                debug_assert!(
+                    ssts.len() >= prev.len() && prev.iter().zip(ssts).all(|(a, b)| a.id == b.id),
+                    "heartbeat output_ssts must extend the persisted list [worker_id={}, compaction_id={}]",
+                    self.worker_id,
+                    compaction_id
+                );
             }
             let now_ms = self.clock.now().timestamp_millis() as u64;
             let new_spec = WorkerSpec::new(self.worker_id.clone(), now_ms);
@@ -439,7 +453,7 @@ impl CompactionWorkerHandler {
                         "wrote heartbeat [worker_id={}, id={}, now_ms={}]",
                         self.worker_id, compaction_id, now_ms
                     );
-                    return Ok(true);
+                    return Ok(Some(now_ms));
                 }
                 Err(e) if e.is_sequenced_write_conflict() => continue,
                 Err(e) => return Err(e),
@@ -467,70 +481,61 @@ impl CompactionWorkerHandler {
         bytes_processed: u64,
         output_ssts: Vec<crate::db_state::SsTableHandle>,
     ) -> Result<(), SlateDBError> {
-        // --- SST trigger -------------------------------------------------------
-        // Decide whether to write in a scoped borrow so it ends before the
-        // async `write_heartbeat`; state is updated afterwards only on success.
-        let new_sst_count = {
+        // Compute both triggers from a single borrow, then bail if this job is
+        // unknown (stale progress message). The borrow ends before the async
+        // `write_heartbeat`; state is advanced afterwards only on a confirmed
+        // durable write.
+        //
+        // Bytes-trigger liveness is tied to *this job's own* progress: both the
+        // threshold (`last_hb_bytes`) and the throttle (`last_hb_ms`) are
+        // per-job, so a job that stops making byte progress stops heartbeating
+        // and is reclaimed even while its siblings on this worker stay busy.
+        let now_ms = self.clock.now().timestamp_millis() as u64;
+        let (new_sst_count, bytes_trigger) = {
             let Some(state) = self.job_progress.get(&id) else {
-                // No state for this job: stale progress message, ignore.
                 return Ok(());
             };
-            (output_ssts.len() > state.last_hb_sst_count).then_some(output_ssts.len())
+            let new_sst_count =
+                (output_ssts.len() > state.last_hb_sst_count).then_some(output_ssts.len());
+            let bytes_trigger = bytes_processed.saturating_sub(state.last_hb_bytes)
+                >= self.options.heartbeat_bytes
+                && now_ms.saturating_sub(state.last_hb_ms)
+                    >= self.options.heartbeat_min_interval.as_millis() as u64;
+            (new_sst_count, bytes_trigger)
         };
 
-        if let Some(new_count) = new_sst_count {
-            info!(
-                "SST heartbeat [worker_id={}, id={}, ssts={}]",
-                self.worker_id, id, new_count
-            );
-            if self.write_heartbeat(id, Some(output_ssts)).await? {
-                let now_ms = self.clock.now().timestamp_millis() as u64;
-                if let Some(state) = self.job_progress.get_mut(&id) {
-                    state.last_hb_sst_count = new_count;
-                    state.last_hb_bytes = bytes_processed;
-                    // Reset this job's bytes-heartbeat throttle so it doesn't
-                    // immediately re-fire right after an SST heartbeat.
-                    state.last_hb_ms = now_ms;
-                }
-            }
+        if new_sst_count.is_none() && !bytes_trigger {
             return Ok(());
         }
 
-        // --- Bytes trigger -----------------------------------------------------
-        // Liveness is tied to *this job's own* progress: both the threshold
-        // (`last_hb_bytes`) and the throttle (`last_hb_ms`) are per-job, so a
-        // job that stops making byte progress stops heartbeating and is
-        // reclaimed by the coordinator even while its siblings on this worker
-        // stay busy. That lets a stalled job be handed off to a less-loaded
-        // worker rather than being kept alive by a busy neighbor.
-        let should_write = {
-            let Some(state) = self.job_progress.get(&id) else {
-                return Ok(());
-            };
-            let bytes_since_last_hb = bytes_processed.saturating_sub(state.last_hb_bytes);
-            if bytes_since_last_hb >= self.options.heartbeat_bytes {
-                let now_ms = self.clock.now().timestamp_millis() as u64;
-                let min_interval_ms = self.options.heartbeat_min_interval.as_millis() as u64;
-                now_ms.saturating_sub(state.last_hb_ms) >= min_interval_ms
-            } else {
-                false
+        // Carry the SST list only when it grew; a bytes-only heartbeat just
+        // refreshes liveness (`last_heartbeat_ms`). On a confirmed write, record
+        // the timestamp that was actually persisted so in-memory throttling
+        // stays consistent with the durable entry.
+        if let Some(hb_ms) = self
+            .write_heartbeat(id, new_sst_count.map(|_| output_ssts))
+            .await?
+        {
+            let state = self
+                .job_progress
+                .get_mut(&id)
+                .expect("active job must have progress bookkeeping");
+            if let Some(count) = new_sst_count {
+                state.last_hb_sst_count = count;
             }
-        };
-
-        if should_write {
-            info!(
-                "bytes heartbeat [worker_id={}, id={}, bytes={}]",
-                self.worker_id, id, bytes_processed
-            );
-            if self.write_heartbeat(id, None).await? {
-                let now_ms = self.clock.now().timestamp_millis() as u64;
-                if let Some(state) = self.job_progress.get_mut(&id) {
-                    state.last_hb_bytes = bytes_processed;
-                    state.last_hb_ms = now_ms;
-                }
+            state.last_hb_bytes = bytes_processed;
+            state.last_hb_ms = hb_ms;
+            match new_sst_count {
+                Some(count) => info!(
+                    "SST heartbeat [worker_id={}, id={}, ssts={}]",
+                    self.worker_id, id, count
+                ),
+                None => info!(
+                    "bytes heartbeat [worker_id={}, id={}, bytes={}]",
+                    self.worker_id, id, bytes_processed
+                ),
             }
         }
-
         Ok(())
     }
 

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -18,6 +18,10 @@
 //!    *and* at least `heartbeat_min_interval` has elapsed since the last such
 //!    write, the worker emits a cheap heartbeat (no output_ssts update).
 //!
+//! Both triggers are strictly per-job: a job that stops making progress stops
+//! heartbeating and is reclaimed independently of its siblings on the same
+//! worker, so a stalled job can be handed off to a less-loaded worker.
+//!
 //! The coordinator reclaims stale Running compactions whose
 //! `last_heartbeat_ms` is older than `CompactorOptions::worker_heartbeat_timeout`.
 
@@ -140,6 +144,10 @@ struct JobProgressState {
     last_hb_sst_count: usize,
     /// Total bytes processed as of the last bytes-based heartbeat write.
     last_hb_bytes: u64,
+    /// Wall-clock timestamp (ms) of this job's most recent heartbeat write
+    /// (either trigger). Used to throttle the bytes trigger to at most one
+    /// write per `heartbeat_min_interval`, independently of sibling jobs.
+    last_hb_ms: u64,
 }
 
 /// Internal `MessageHandler` for the worker's event loop.
@@ -164,9 +172,6 @@ pub(crate) struct CompactionWorkerHandler {
     rand: Arc<DbRand>,
     /// Per-job heartbeat bookkeeping. Entry present iff the job is active.
     job_progress: HashMap<Ulid, JobProgressState>,
-    /// Wall-clock timestamp (ms) of the most recent bytes-based heartbeat
-    /// write (across all jobs). Used to enforce `heartbeat_min_interval`.
-    worker_last_bytes_hb_ms: u64,
 }
 
 impl CompactionWorkerHandler {
@@ -190,7 +195,6 @@ impl CompactionWorkerHandler {
             stored: None,
             rand,
             job_progress: HashMap::new(),
-            worker_last_bytes_hb_ms: 0,
         }
     }
 
@@ -365,6 +369,7 @@ impl CompactionWorkerHandler {
                         JobProgressState {
                             last_hb_sst_count: 0,
                             last_hb_bytes: 0,
+                            last_hb_ms: self.clock.now().timestamp_millis() as u64,
                         },
                     );
                     Self::dispatch_to_executor(&self.executor, args);
@@ -452,11 +457,10 @@ impl CompactionWorkerHandler {
     /// trigger relies on this by comparing `output_ssts.len()` against the
     /// count last heartbeated.
     ///
-    /// In-memory progress bookkeeping (`last_hb_sst_count`, `last_hb_bytes`,
-    /// and the worker-global `worker_last_bytes_hb_ms`) is only advanced after
-    /// `write_heartbeat` confirms a durable write, so a skipped write (entry
-    /// gone / ownership lost) does not mark un-persisted progress as
-    /// heartbeated.
+    /// Per-job progress bookkeeping (`last_hb_sst_count`, `last_hb_bytes`, and
+    /// `last_hb_ms`) is only advanced after `write_heartbeat` confirms a durable
+    /// write, so a skipped write (entry gone / ownership lost) does not mark
+    /// un-persisted progress as heartbeated.
     async fn handle_progress(
         &mut self,
         id: Ulid,
@@ -480,23 +484,25 @@ impl CompactionWorkerHandler {
                 self.worker_id, id, new_count
             );
             if self.write_heartbeat(id, Some(output_ssts)).await? {
+                let now_ms = self.clock.now().timestamp_millis() as u64;
                 if let Some(state) = self.job_progress.get_mut(&id) {
                     state.last_hb_sst_count = new_count;
                     state.last_hb_bytes = bytes_processed;
+                    // Reset this job's bytes-heartbeat throttle so it doesn't
+                    // immediately re-fire right after an SST heartbeat.
+                    state.last_hb_ms = now_ms;
                 }
-                // Update the worker-level bytes heartbeat timestamp so the bytes
-                // trigger doesn't immediately re-fire after an SST heartbeat.
-                self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
             }
             return Ok(());
         }
 
         // --- Bytes trigger -----------------------------------------------------
-        // Note: `worker_last_bytes_hb_ms` is worker-global (shared across all
-        // jobs on this worker) while `last_hb_bytes` is per-job, so one job's
-        // bytes heartbeat can suppress another's for up to `heartbeat_min_interval`.
-        // That is intentional: the throttle bounds heartbeat write rate per
-        // worker, not per job.
+        // Liveness is tied to *this job's own* progress: both the threshold
+        // (`last_hb_bytes`) and the throttle (`last_hb_ms`) are per-job, so a
+        // job that stops making byte progress stops heartbeating and is
+        // reclaimed by the coordinator even while its siblings on this worker
+        // stay busy. That lets a stalled job be handed off to a less-loaded
+        // worker rather than being kept alive by a busy neighbor.
         let should_write = {
             let Some(state) = self.job_progress.get(&id) else {
                 return Ok(());
@@ -505,7 +511,7 @@ impl CompactionWorkerHandler {
             if bytes_since_last_hb >= self.options.heartbeat_bytes {
                 let now_ms = self.clock.now().timestamp_millis() as u64;
                 let min_interval_ms = self.options.heartbeat_min_interval.as_millis() as u64;
-                now_ms.saturating_sub(self.worker_last_bytes_hb_ms) >= min_interval_ms
+                now_ms.saturating_sub(state.last_hb_ms) >= min_interval_ms
             } else {
                 false
             }
@@ -517,10 +523,11 @@ impl CompactionWorkerHandler {
                 self.worker_id, id, bytes_processed
             );
             if self.write_heartbeat(id, None).await? {
+                let now_ms = self.clock.now().timestamp_millis() as u64;
                 if let Some(state) = self.job_progress.get_mut(&id) {
                     state.last_hb_bytes = bytes_processed;
+                    state.last_hb_ms = now_ms;
                 }
-                self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
             }
         }
 

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -360,6 +360,13 @@ impl CompactionWorkerHandler {
                         compaction.id()
                     );
                     self.active_jobs.insert(compaction.id());
+                    self.job_progress.insert(
+                        compaction.id(),
+                        JobProgressState {
+                            last_hb_sst_count: 0,
+                            last_hb_bytes: 0,
+                        },
+                    );
                     Self::dispatch_to_executor(&self.executor, args);
                 }
                 Err(e) => {

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -394,33 +394,33 @@ impl CompactionWorkerHandler {
             return Ok(false);
         }
         loop {
-            let stored = self.stored.as_mut().expect("ensure_loaded set stored");
+            let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
-            let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+            let mut dirty = stored.prepare_dirty()?;
+            let Some(existing) = dirty.value.get(&compaction_id).cloned() else {
                 debug!(
-                    "heartbeat: compaction entry missing [id={}]; skipping",
+                    "heartbeat: compaction entry missing [worker_id={}, compaction_id={}]; skipping",
+                    self.worker_id,
                     compaction_id
                 );
                 return Ok(false);
             };
             if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
                 debug!(
-                    "heartbeat: no longer owner of compaction [id={}]; skipping",
+                    "heartbeat: no longer owner of compaction [worker_id={} compaction_id={}]; skipping",
+                    self.worker_id,
                     compaction_id
                 );
                 return Ok(false);
             }
             let now_ms = self.clock.now().timestamp_millis() as u64;
-            let new_worker = WorkerSpec::new(self.worker_id.clone(), now_ms);
-            let updated = if let Some(ssts) = output_ssts.clone() {
-                existing
-                    .with_worker(Some(new_worker))
-                    .with_output_ssts(ssts)
+            let new_spec = WorkerSpec::new(self.worker_id.clone(), now_ms);
+            let updated_compaction = if let Some(ssts) = output_ssts.clone() {
+                existing.with_worker(Some(new_spec)).with_output_ssts(ssts)
             } else {
-                existing.with_worker(Some(new_worker))
+                existing.with_worker(Some(new_spec))
             };
-            let mut dirty = stored.prepare_dirty()?;
-            dirty.value.insert(updated);
+            dirty.value.insert(updated_compaction);
             match stored.update(dirty).await {
                 Ok(()) => {
                     debug!(

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -7,11 +7,22 @@
 //! coordinator separately observes those `Compacted` entries and commits the
 //! manifest update (see [`crate::compactor::CompactorEventHandler::commit_compacted_entries`]).
 //!
-//! This implements the claim / execute / complete portion of the worker. The
-//! heartbeat emission and coordinator-side failure-detection / reclamation
-//! protocol are added in a follow-up.
+//! Workers emit heartbeats to prove liveness. A heartbeat is a CAS write that
+//! bumps `last_heartbeat_ms` in the worker's `.compactions` entry. Two triggers:
+//!
+//! 1. **SST trigger**: whenever `output_ssts` grows (the executor finished
+//!    writing one or more SSTs), the worker writes a heartbeat carrying the
+//!    latest `output_ssts` list.
+//! 2. **Bytes trigger**: when the cumulative bytes processed since the last
+//!    bytes-based heartbeat exceeds `CompactionWorkerOptions::heartbeat_bytes`
+//!    *and* at least `heartbeat_min_interval` has elapsed since the last such
+//!    write, the worker emits a cheap heartbeat (no output_ssts update).
+//!
+//! The coordinator reclaims stale Running compactions whose
+//! `last_heartbeat_ms` is older than `CompactorOptions::worker_heartbeat_timeout`.
 
 use std::collections::BTreeSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -120,6 +131,17 @@ impl CompactionWorker {
     }
 }
 
+/// Per-job state used to detect when new SSTs have been produced and when the
+/// bytes threshold has been crossed.
+struct JobProgressState {
+    /// Number of output SSTs reported in the most recent progress message that
+    /// triggered a heartbeat write. Comparing against the new count lets the
+    /// worker detect when additional SSTs have appeared.
+    last_hb_sst_count: usize,
+    /// Total bytes processed as of the last bytes-based heartbeat write.
+    last_hb_bytes: u64,
+}
+
 /// Internal `MessageHandler` for the worker's event loop.
 ///
 /// Reuses [`CompactorMessage`] so the embedded [`TokioCompactionExecutor`] can
@@ -140,6 +162,11 @@ pub(crate) struct CompactionWorkerHandler {
     /// absence on early ticks.
     stored: Option<StoredCompactions>,
     rand: Arc<DbRand>,
+    /// Per-job heartbeat bookkeeping. Entry present iff the job is active.
+    job_progress: HashMap<Ulid, JobProgressState>,
+    /// Wall-clock timestamp (ms) of the most recent bytes-based heartbeat
+    /// write (across all jobs). Used to enforce `heartbeat_min_interval`.
+    worker_last_bytes_hb_ms: u64,
 }
 
 impl CompactionWorkerHandler {
@@ -162,6 +189,8 @@ impl CompactionWorkerHandler {
             active_jobs: BTreeSet::new(),
             stored: None,
             rand,
+            job_progress: HashMap::new(),
+            worker_last_bytes_hb_ms: 0,
         }
     }
 
@@ -347,6 +376,132 @@ impl CompactionWorkerHandler {
         Ok(())
     }
 
+    /// Writes a heartbeat for `compaction_id`, updating `last_heartbeat_ms`
+    /// and (when provided) the `output_ssts` list. Only writes if this worker
+    /// still owns the entry; silently returns otherwise.
+    async fn write_heartbeat(
+        &mut self,
+        compaction_id: Ulid,
+        output_ssts: Option<Vec<crate::db_state::SsTableHandle>>,
+    ) -> Result<(), SlateDBError> {
+        if !self.ensure_loaded().await? {
+            return Ok(());
+        }
+        loop {
+            let stored = self.stored.as_mut().expect("ensure_loaded set stored");
+            stored.refresh().await?;
+            let Some(existing) = stored.compactions().get(&compaction_id).cloned() else {
+                debug!(
+                    "heartbeat: compaction entry missing [id={}]; skipping",
+                    compaction_id
+                );
+                return Ok(());
+            };
+            if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
+                debug!(
+                    "heartbeat: no longer owner of compaction [id={}]; skipping",
+                    compaction_id
+                );
+                return Ok(());
+            }
+            let now_ms = self.clock.now().timestamp_millis() as u64;
+            let new_worker = WorkerSpec::new(self.worker_id.clone(), now_ms);
+            let updated = if let Some(ssts) = output_ssts.clone() {
+                existing
+                    .with_worker(Some(new_worker))
+                    .with_output_ssts(ssts)
+            } else {
+                existing.with_worker(Some(new_worker))
+            };
+            let mut dirty = stored.prepare_dirty()?;
+            dirty.value.insert(updated);
+            match stored.update(dirty).await {
+                Ok(()) => {
+                    debug!(
+                        "wrote heartbeat [worker_id={}, id={}, now_ms={}]",
+                        self.worker_id, compaction_id, now_ms
+                    );
+                    return Ok(());
+                }
+                Err(e) if e.is_sequenced_write_conflict() => continue,
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// Handles a progress update from the executor. Triggers:
+    /// - An **SST heartbeat** when `output_ssts` grew since the last report.
+    /// - A **bytes heartbeat** when cumulative bytes since the last bytes-hb
+    ///   exceeds `heartbeat_bytes` and `heartbeat_min_interval` has elapsed.
+    async fn handle_progress(
+        &mut self,
+        id: Ulid,
+        bytes_processed: u64,
+        output_ssts: Vec<crate::db_state::SsTableHandle>,
+    ) -> Result<(), SlateDBError> {
+        // --- SST trigger -------------------------------------------------------
+        // Check and update state in a scoped block so the borrow ends before
+        // we call the async `write_heartbeat`.
+        let sst_trigger = {
+            let Some(state) = self.job_progress.get_mut(&id) else {
+                // No state for this job: stale progress message, ignore.
+                return Ok(());
+            };
+            if output_ssts.len() > state.last_hb_sst_count {
+                let new_count = output_ssts.len();
+                state.last_hb_sst_count = new_count;
+                state.last_hb_bytes = bytes_processed;
+                Some(new_count)
+            } else {
+                None
+            }
+        };
+
+        if let Some(new_count) = sst_trigger {
+            info!(
+                "SST heartbeat [worker_id={}, id={}, ssts={}]",
+                self.worker_id, id, new_count
+            );
+            self.write_heartbeat(id, Some(output_ssts)).await?;
+            // Update the worker-level bytes heartbeat timestamp so the bytes
+            // trigger doesn't immediately re-fire after an SST heartbeat.
+            self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
+            return Ok(());
+        }
+
+        // --- Bytes trigger -----------------------------------------------------
+        let bytes_trigger = {
+            let Some(state) = self.job_progress.get_mut(&id) else {
+                return Ok(());
+            };
+            let bytes_since_last_hb = bytes_processed.saturating_sub(state.last_hb_bytes);
+            if bytes_since_last_hb >= self.options.heartbeat_bytes {
+                let now_ms = self.clock.now().timestamp_millis() as u64;
+                let min_interval_ms = self.options.heartbeat_min_interval.as_millis() as u64;
+                let elapsed = now_ms.saturating_sub(self.worker_last_bytes_hb_ms);
+                if elapsed >= min_interval_ms {
+                    state.last_hb_bytes = bytes_processed;
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        if bytes_trigger {
+            info!(
+                "bytes heartbeat [worker_id={}, id={}, bytes={}]",
+                self.worker_id, id, bytes_processed
+            );
+            self.write_heartbeat(id, None).await?;
+            self.worker_last_bytes_hb_ms = self.clock.now().timestamp_millis() as u64;
+        }
+
+        Ok(())
+    }
+
     fn build_job_args(
         compaction: &Compaction,
         db_state: &ManifestCore,
@@ -504,6 +659,7 @@ impl CompactionWorkerHandler {
         result: Result<crate::db_state::SortedRun, SlateDBError>,
     ) -> Result<(), SlateDBError> {
         self.active_jobs.remove(&id);
+        self.job_progress.remove(&id);
         match result {
             Ok(sr) => {
                 let output_ssts: Vec<crate::db_state::SsTableHandle> =
@@ -548,10 +704,14 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
             WorkerMessage::CompactionJobFinished { id, result } => {
                 self.handle_finished(id, result).await?;
             }
-            // Heartbeat emission is added in the failure-detection follow-up;
-            // for now progress messages are ignored. The executor still
-            // produces them; we just drop them.
-            WorkerMessage::CompactionJobProgress { .. } => {}
+            WorkerMessage::CompactionJobProgress {
+                id,
+                bytes_processed,
+                output_ssts,
+            } => {
+                self.handle_progress(id, bytes_processed, output_ssts)
+                    .await?;
+            }
         }
         Ok(())
     }
@@ -565,6 +725,7 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
         // workers can pick them up immediately rather than waiting for the
         // heartbeat-timeout reclamation path.
         self.executor.stop();
+        self.job_progress.clear();
         let claimed = self.active_jobs.clone().into_iter();
         for id in claimed {
             if let Err(e) = self.release_claim(id).await {
@@ -580,6 +741,8 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use crate::compactor_state::{Compaction, CompactionSpec, SourceId};
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
@@ -593,6 +756,7 @@ mod tests {
     use object_store::ObjectStore;
     use parking_lot::Mutex;
     use slatedb_common::clock::DefaultSystemClock;
+    use slatedb_common::MockSystemClock;
 
     const ROOT: &str = "/worker-test";
 
@@ -633,11 +797,19 @@ mod tests {
 
     impl WorkerFixture {
         async fn new(worker_id: &str) -> Self {
+            let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+            Self::new_with_clock(worker_id, clock, CompactionWorkerOptions::default()).await
+        }
+
+        async fn new_with_clock(
+            worker_id: &str,
+            clock: Arc<dyn SystemClock>,
+            options: CompactionWorkerOptions,
+        ) -> Self {
             let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
             let path = Path::from(ROOT);
             let manifest_store = Arc::new(ManifestStore::new(&path, object_store.clone()));
             let compactions_store = Arc::new(CompactionsStore::new(&path, object_store.clone()));
-            let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
 
             // Seed manifest with one L0 view so the worker can validate spec
             // sources during the claim flow. The unsegmented V1 manifest
@@ -668,7 +840,7 @@ mod tests {
             let executor = Arc::new(NoopExecutor::new());
             let mut handler = CompactionWorkerHandler::new(
                 worker_id.to_string(),
-                Arc::new(CompactionWorkerOptions::default()),
+                Arc::new(options),
                 compactions_store.clone(),
                 manifest_store.clone(),
                 executor.clone(),
@@ -895,5 +1067,108 @@ mod tests {
             .stop()
             .await
             .expect("failed to stop compaction worker");
+    }
+
+    /// When the executor produces new output SSTs the worker must write a
+    /// heartbeat that bumps `last_heartbeat_ms` and also stores the current
+    /// `output_ssts` list.
+    #[tokio::test]
+    async fn test_worker_emits_sst_heartbeat_on_progress() {
+        use tokio::time::pause;
+        pause(); // Use Tokio's time-pausing so MockSystemClock::advance works.
+
+        let mock_clock = Arc::new(MockSystemClock::new());
+        // Start clock at 1000 ms so timestamps are clearly non-zero.
+        mock_clock.set(1000);
+
+        let options = CompactionWorkerOptions {
+            // Set a large bytes threshold so the bytes trigger never fires.
+            heartbeat_bytes: u64::MAX,
+            ..CompactionWorkerOptions::default()
+        };
+        let clock: Arc<dyn SystemClock> = mock_clock.clone();
+        let mut fx = WorkerFixture::new_with_clock("worker-hb", clock, options).await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        // Advance clock so the heartbeat timestamp is distinguishable from the
+        // initial claim timestamp.
+        mock_clock.advance(Duration::from_secs(5)).await;
+
+        // Synthesize an output SST handle.
+        let output_handle = SsTableHandle::new(
+            SsTableId::Compacted(Ulid::from_parts(9000, 0)),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                first_entry: Some(Bytes::from_static(b"a")),
+                ..SsTableInfo::default()
+            },
+        );
+
+        // Send a progress message with 1 new output SST.
+        fx.handler
+            .handle_progress(id, 1024, vec![output_handle.clone()])
+            .await
+            .unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        // Status should still be Running (not yet Compacted).
+        assert_eq!(c.status(), CompactionStatus::Running);
+        // The worker's heartbeat_ms should have advanced beyond 1000.
+        let worker = c.worker().expect("worker spec missing");
+        assert!(
+            worker.last_heartbeat_ms > 1000,
+            "heartbeat_ms should have been updated; got {}",
+            worker.last_heartbeat_ms
+        );
+        // The output_ssts list should have been written as part of the heartbeat.
+        assert_eq!(c.output_ssts().len(), 1);
+        assert_eq!(c.output_ssts()[0].id, output_handle.id);
+    }
+
+    /// When the bytes-processed counter crosses `heartbeat_bytes` and enough
+    /// time has elapsed since the last bytes-based heartbeat, the worker must
+    /// write a heartbeat (without changing output_ssts).
+    #[tokio::test]
+    async fn test_worker_emits_bytes_heartbeat_on_threshold() {
+        use tokio::time::pause;
+        pause();
+
+        let mock_clock = Arc::new(MockSystemClock::new());
+        mock_clock.set(1000);
+
+        let options = CompactionWorkerOptions {
+            // Very small threshold (1 byte) so any progress triggers the bytes hb.
+            heartbeat_bytes: 1,
+            // Short min-interval so it fires immediately.
+            heartbeat_min_interval: Duration::from_millis(1),
+            ..CompactionWorkerOptions::default()
+        };
+        let clock: Arc<dyn SystemClock> = mock_clock.clone();
+        let mut fx = WorkerFixture::new_with_clock("worker-hb2", clock, options).await;
+        let id = Ulid::from_parts(2, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        // Advance clock past heartbeat_min_interval.
+        mock_clock.advance(Duration::from_secs(2)).await;
+
+        // Send progress with bytes > threshold but NO new SSTs (empty list).
+        // This should trigger the bytes-based heartbeat path.
+        fx.handler.handle_progress(id, 1000, vec![]).await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Running);
+        let worker = c.worker().expect("worker spec missing");
+        assert!(
+            worker.last_heartbeat_ms > 1000,
+            "heartbeat_ms should have been updated; got {}",
+            worker.last_heartbeat_ms
+        );
+        // output_ssts should be empty (bytes hb does not update them).
+        assert!(c.output_ssts().is_empty());
     }
 }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -698,8 +698,9 @@ impl CompactorEventHandler {
     }
 
     /// Reclaims `Running` compactions whose workers have not emitted a heartbeat
-    /// within [`CompactorOptions::worker_heartbeat_timeout`]. Reclaimed compactions
-    /// are reset to `Submitted` (with no worker) so they can be picked up again.
+    /// within [`CompactorOptions::worker_heartbeat_timeout`], as well as any
+    /// `Running` entry with no worker at all. Reclaimed compactions are reset to
+    /// `Submitted` (with no worker) so they can be picked up again.
     ///
     /// This is the coordinator-side half of the failure-detection protocol described
     /// in RFC-0025. The worker side emits heartbeats (updating `last_heartbeat_ms`)
@@ -708,16 +709,23 @@ impl CompactorEventHandler {
         let now_ms = self.system_clock.now().timestamp_millis() as u64;
         let timeout_ms = self.options.worker_heartbeat_timeout.as_millis() as u64;
 
-        // Capture the owning worker id alongside the compaction id so the log
-        // below doesn't have to re-look-up the entry (a Running compaction
-        // always has a worker, so the filter guarantees one is present).
+        // A Running compaction is stale if its worker's heartbeat has aged past
+        // the timeout, or if it has no worker at all — the protocol shouldn't
+        // produce the latter, but it would otherwise be stuck in Running forever.
+        // Capture the owning worker id for the log ("<none>" when absent).
         let stale: Vec<(Ulid, String)> = self
             .state()
             .compactions_with_status(&[CompactionStatus::Running])
-            .filter_map(|c| {
-                c.worker()
-                    .filter(|w| now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms)
-                    .map(|w| (c.id(), w.worker_id.clone()))
+            .filter(|c| match c.worker() {
+                Some(w) => now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms,
+                None => true,
+            })
+            .map(|c| {
+                let worker_id = c
+                    .worker()
+                    .map(|w| w.worker_id.clone())
+                    .unwrap_or_else(|| "<none>".to_string());
+                (c.id(), worker_id)
             })
             .collect();
 
@@ -5987,5 +5995,62 @@ mod tests {
             "should NOT be reclaimed"
         );
         assert!(c.worker().is_some(), "worker should still be set");
+    }
+
+    /// A Running compaction with no worker at all must also be reclaimed to
+    /// Submitted — the claim protocol shouldn't produce this state, but if it
+    /// somehow arises the entry would otherwise be stuck in Running forever.
+    #[tokio::test]
+    async fn test_reclaim_worker_less_running_compaction() {
+        let system_clock = Arc::new(MockSystemClock::new());
+        let options = Arc::new(CompactorOptions {
+            worker_heartbeat_timeout: Duration::from_secs(30),
+            ..compactor_options()
+        });
+        let mut fixture = CompactorEventHandlerTestFixture::new_with_clock(
+            system_clock.clone() as Arc<dyn SystemClock>,
+            options,
+        )
+        .await;
+
+        fixture.handler.state_writer.refresh().await.unwrap();
+
+        // Seed a Running compaction with no worker set.
+        let compaction_id = Ulid::new();
+        let compaction = Compaction::new(compaction_id, CompactionSpec::new(vec![], 0))
+            .with_status(CompactionStatus::Running);
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(compaction);
+        fixture
+            .handler
+            .state_writer
+            .write_compactions_safely()
+            .await
+            .expect("failed to persist seeded compaction");
+
+        // when: reclaim should treat the worker-less entry as stale regardless
+        // of how much time has (not) passed.
+        fixture
+            .handler
+            .reclaim_stale_workers()
+            .await
+            .expect("reclaim_stale_workers failed");
+
+        // then: the compaction is now Submitted with no worker.
+        let stored = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        let c = stored.get(&compaction_id).expect("compaction missing");
+        assert_eq!(
+            c.status(),
+            CompactionStatus::Submitted,
+            "should be reclaimed"
+        );
+        assert!(c.worker().is_none(), "worker should remain cleared");
     }
 }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1180,7 +1180,6 @@ pub mod stats {
     pub const COMPACTOR_EPOCH: &str = compactor_stat_name!("epoch");
     pub const LAST_COMPACTION_TS_SEC: &str = compactor_stat_name!("last_compaction_timestamp_sec");
     pub const RUNNING_COMPACTIONS: &str = compactor_stat_name!("running_compactions");
-    pub const SSTS_WRITTEN: &str = compactor_stat_name!("ssts_written");
     pub const TOTAL_BYTES_BEING_COMPACTED: &str =
         compactor_stat_name!("total_bytes_being_compacted");
     pub const TOTAL_THROUGHPUT_BYTES_PER_SEC: &str =
@@ -1193,13 +1192,6 @@ pub mod stats {
     pub const ENTRY_TYPE_LABEL: &str = "entry_type";
     pub const ENTRY_TYPE_VALUE: &str = "value";
     pub const ENTRY_TYPE_MERGE: &str = "merge";
-    /// Coordinator-side counter: `Submitted → Running` transitions observed via `.compactions`.
-    pub const JOBS_CLAIMED: &str = compactor_stat_name!("jobs_claimed");
-    /// Coordinator-side counter: stale `Running` jobs reset to `Submitted`.
-    pub const JOBS_RECLAIMED: &str = compactor_stat_name!("jobs_reclaimed");
-    /// Coordinator-side gauge: last observed heartbeat timestamp (ms) per worker.
-    pub const WORKER_LAST_HEARTBEAT_MS: &str = compactor_stat_name!("worker_last_heartbeat_ms");
-    pub const WORKER_ID_LABEL: &str = "worker_id";
 
     pub(crate) struct CompactionStats {
         pub(crate) compactor_epoch: Arc<dyn GaugeFn>,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -723,32 +723,27 @@ impl CompactorEventHandler {
         let now_ms = self.system_clock.now().timestamp_millis() as u64;
         let timeout_ms = self.options.worker_heartbeat_timeout.as_millis() as u64;
 
-        let stale: Vec<Ulid> = self
+        // Capture the owning worker id alongside the compaction id so the log
+        // below doesn't have to re-look-up the entry (a Running compaction
+        // always has a worker, so the filter guarantees one is present).
+        let stale: Vec<(Ulid, String)> = self
             .state()
             .compactions_with_status(&[CompactionStatus::Running])
-            .filter(|c| {
+            .filter_map(|c| {
                 c.worker()
-                    .map(|w| now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms)
-                    .unwrap_or(false)
+                    .filter(|w| now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms)
+                    .map(|w| (c.id(), w.worker_id.clone()))
             })
-            .map(|c| c.id())
             .collect();
 
         if stale.is_empty() {
             return Ok(());
         }
 
-        for id in &stale {
+        for (id, worker_id) in &stale {
             info!(
                 "reclaiming stale compaction [worker_id={}, id={}]",
-                self.state()
-                    .compactions()
-                    .value
-                    .get(id)
-                    .and_then(|c| c.worker())
-                    .map(|w| w.worker_id.as_str())
-                    .unwrap_or("unknown"),
-                id
+                worker_id, id
             );
             self.state_mut().update_compaction(id, |c| {
                 c.set_status(CompactionStatus::Submitted);

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -54,7 +54,7 @@
 //! represents a description (Spec), a durable decision (Compaction), or a running
 //! attempt (JobSpec).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -85,7 +85,6 @@ use crate::tablestore::TableStore;
 use crate::utils::{format_bytes_si, IdGenerator};
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorderHelper;
-use slatedb_common::metrics::{GaugeFn, MetricsRecorderHelper};
 use slatedb_common::DbRand;
 
 pub use crate::compactor_state::{
@@ -313,7 +312,6 @@ pub struct Compactor {
     compactor_runtime: Handle,
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
-    recorder: MetricsRecorderHelper,
     system_clock: Arc<dyn SystemClock>,
     merge_operator: Option<MergeOperatorType>,
     #[cfg(feature = "compaction_filters")]
@@ -353,7 +351,6 @@ impl Compactor {
             compactor_runtime,
             rand,
             stats,
-            recorder: recorder.clone(),
             system_clock,
             merge_operator,
             #[cfg(feature = "compaction_filters")]
@@ -386,7 +383,6 @@ impl Compactor {
             scheduler,
             self.rand.clone(),
             self.stats.clone(),
-            self.recorder.clone(),
             self.system_clock.clone(),
         )
         .await?;
@@ -509,13 +505,6 @@ pub(crate) struct CompactorEventHandler {
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     system_clock: Arc<dyn SystemClock>,
-    /// Recorder kept for lazily registering per-worker heartbeat gauges.
-    recorder: MetricsRecorderHelper,
-    /// IDs of `Running` compactions observed on the previous tick; used to
-    /// detect new claims and increment `jobs_claimed`.
-    prev_running_jobs: HashSet<Ulid>,
-    /// Lazily-created per-worker heartbeat gauges keyed by `worker_id`.
-    worker_heartbeat_gauges: HashMap<String, Arc<dyn GaugeFn>>,
 }
 
 #[async_trait]
@@ -566,7 +555,6 @@ impl CompactorEventHandler {
         scheduler: Arc<dyn CompactionScheduler + Send + Sync>,
         rand: Arc<DbRand>,
         stats: Arc<CompactionStats>,
-        recorder: MetricsRecorderHelper,
         system_clock: Arc<dyn SystemClock>,
     ) -> Result<Self, SlateDBError> {
         let state_writer = CompactorStateWriter::new(
@@ -585,10 +573,7 @@ impl CompactorEventHandler {
             scheduler,
             rand,
             stats,
-            recorder,
             system_clock,
-            prev_running_jobs: HashSet::new(),
-            worker_heartbeat_gauges: HashMap::new(),
         })
     }
 
@@ -1226,8 +1211,6 @@ pub mod stats {
         pub(crate) merge_operator_compact_operands: Arc<dyn CounterFn>,
         pub(crate) expired_entries_purged_value: Arc<dyn CounterFn>,
         pub(crate) expired_entries_purged_merge: Arc<dyn CounterFn>,
-        pub(crate) jobs_claimed: Arc<dyn CounterFn>,
-        pub(crate) jobs_reclaimed: Arc<dyn CounterFn>,
     }
 
     impl CompactionStats {
@@ -1254,8 +1237,6 @@ pub mod stats {
                     .labels(&[(ENTRY_TYPE_LABEL, ENTRY_TYPE_MERGE)])
                     .description(EXPIRED_ENTRIES_PURGED_DESCRIPTION)
                     .register(),
-                jobs_claimed: recorder.counter(JOBS_CLAIMED).register(),
-                jobs_reclaimed: recorder.counter(JOBS_RECLAIMED).register(),
             }
         }
 
@@ -4402,7 +4383,6 @@ mod tests {
                 scheduler.clone(),
                 rand.clone(),
                 compactor_stats.clone(),
-                recorder,
                 Arc::new(DefaultSystemClock::new()),
             )
             .await
@@ -4473,7 +4453,6 @@ mod tests {
                 scheduler.clone(),
                 rand.clone(),
                 compactor_stats.clone(),
-                recorder,
                 system_clock.clone(),
             )
             .await
@@ -4935,7 +4914,6 @@ mod tests {
             scheduler,
             rand,
             compactor_stats,
-            recorder,
             system_clock,
         )
         .await

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -54,7 +54,7 @@
 //! represents a description (Spec), a durable decision (Compaction), or a running
 //! attempt (JobSpec).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -85,6 +85,7 @@ use crate::tablestore::TableStore;
 use crate::utils::{format_bytes_si, IdGenerator};
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorderHelper;
+use slatedb_common::metrics::{GaugeFn, MetricsRecorderHelper};
 use slatedb_common::DbRand;
 
 pub use crate::compactor_state::{
@@ -312,6 +313,7 @@ pub struct Compactor {
     compactor_runtime: Handle,
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
+    recorder: MetricsRecorderHelper,
     system_clock: Arc<dyn SystemClock>,
     merge_operator: Option<MergeOperatorType>,
     #[cfg(feature = "compaction_filters")]
@@ -351,6 +353,7 @@ impl Compactor {
             compactor_runtime,
             rand,
             stats,
+            recorder: recorder.clone(),
             system_clock,
             merge_operator,
             #[cfg(feature = "compaction_filters")]
@@ -383,6 +386,7 @@ impl Compactor {
             scheduler,
             self.rand.clone(),
             self.stats.clone(),
+            self.recorder.clone(),
             self.system_clock.clone(),
         )
         .await?;
@@ -505,6 +509,13 @@ pub(crate) struct CompactorEventHandler {
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     system_clock: Arc<dyn SystemClock>,
+    /// Recorder kept for lazily registering per-worker heartbeat gauges.
+    recorder: MetricsRecorderHelper,
+    /// IDs of `Running` compactions observed on the previous tick; used to
+    /// detect new claims and increment `jobs_claimed`.
+    prev_running_jobs: HashSet<Ulid>,
+    /// Lazily-created per-worker heartbeat gauges keyed by `worker_id`.
+    worker_heartbeat_gauges: HashMap<String, Arc<dyn GaugeFn>>,
 }
 
 #[async_trait]
@@ -555,6 +566,7 @@ impl CompactorEventHandler {
         scheduler: Arc<dyn CompactionScheduler + Send + Sync>,
         rand: Arc<DbRand>,
         stats: Arc<CompactionStats>,
+        recorder: MetricsRecorderHelper,
         system_clock: Arc<dyn SystemClock>,
     ) -> Result<Self, SlateDBError> {
         let state_writer = CompactorStateWriter::new(
@@ -573,7 +585,10 @@ impl CompactorEventHandler {
             scheduler,
             rand,
             stats,
+            recorder,
             system_clock,
+            prev_running_jobs: HashSet::new(),
+            worker_heartbeat_gauges: HashMap::new(),
         })
     }
 
@@ -691,8 +706,57 @@ impl CompactorEventHandler {
     async fn handle_ticker(&mut self) -> Result<(), SlateDBError> {
         self.state_writer.refresh().await?;
         self.commit_compacted_entries().await?;
+        self.reclaim_stale_workers().await?;
         self.maybe_schedule_compactions().await?;
         self.maybe_validate_submitted_compactions().await?;
+        Ok(())
+    }
+
+    /// Reclaims `Running` compactions whose workers have not emitted a heartbeat
+    /// within [`CompactorOptions::worker_heartbeat_timeout`]. Reclaimed compactions
+    /// are reset to `Submitted` (with no worker) so they can be picked up again.
+    ///
+    /// This is the coordinator-side half of the failure-detection protocol described
+    /// in RFC-0025. The worker side emits heartbeats (updating `last_heartbeat_ms`)
+    /// periodically; the coordinator scans for stale entries on each tick.
+    async fn reclaim_stale_workers(&mut self) -> Result<(), SlateDBError> {
+        let now_ms = self.system_clock.now().timestamp_millis() as u64;
+        let timeout_ms = self.options.worker_heartbeat_timeout.as_millis() as u64;
+
+        let stale: Vec<Ulid> = self
+            .state()
+            .compactions_with_status(&[CompactionStatus::Running])
+            .filter(|c| {
+                c.worker()
+                    .map(|w| now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms)
+                    .unwrap_or(false)
+            })
+            .map(|c| c.id())
+            .collect();
+
+        if stale.is_empty() {
+            return Ok(());
+        }
+
+        for id in &stale {
+            info!(
+                "reclaiming stale compaction [worker_id={}, id={}]",
+                self.state()
+                    .compactions()
+                    .value
+                    .get(id)
+                    .and_then(|c| c.worker())
+                    .map(|w| w.worker_id.as_str())
+                    .unwrap_or("unknown"),
+                id
+            );
+            self.state_mut().update_compaction(id, |c| {
+                c.set_status(CompactionStatus::Submitted);
+                c.set_worker(None);
+            });
+        }
+
+        self.state_writer.write_compactions_safely().await?;
         Ok(())
     }
 
@@ -1136,6 +1200,7 @@ pub mod stats {
     pub const COMPACTOR_EPOCH: &str = compactor_stat_name!("epoch");
     pub const LAST_COMPACTION_TS_SEC: &str = compactor_stat_name!("last_compaction_timestamp_sec");
     pub const RUNNING_COMPACTIONS: &str = compactor_stat_name!("running_compactions");
+    pub const SSTS_WRITTEN: &str = compactor_stat_name!("ssts_written");
     pub const TOTAL_BYTES_BEING_COMPACTED: &str =
         compactor_stat_name!("total_bytes_being_compacted");
     pub const TOTAL_THROUGHPUT_BYTES_PER_SEC: &str =
@@ -1148,6 +1213,13 @@ pub mod stats {
     pub const ENTRY_TYPE_LABEL: &str = "entry_type";
     pub const ENTRY_TYPE_VALUE: &str = "value";
     pub const ENTRY_TYPE_MERGE: &str = "merge";
+    /// Coordinator-side counter: `Submitted → Running` transitions observed via `.compactions`.
+    pub const JOBS_CLAIMED: &str = compactor_stat_name!("jobs_claimed");
+    /// Coordinator-side counter: stale `Running` jobs reset to `Submitted`.
+    pub const JOBS_RECLAIMED: &str = compactor_stat_name!("jobs_reclaimed");
+    /// Coordinator-side gauge: last observed heartbeat timestamp (ms) per worker.
+    pub const WORKER_LAST_HEARTBEAT_MS: &str = compactor_stat_name!("worker_last_heartbeat_ms");
+    pub const WORKER_ID_LABEL: &str = "worker_id";
 
     pub(crate) struct CompactionStats {
         pub(crate) compactor_epoch: Arc<dyn GaugeFn>,
@@ -1159,6 +1231,8 @@ pub mod stats {
         pub(crate) merge_operator_compact_operands: Arc<dyn CounterFn>,
         pub(crate) expired_entries_purged_value: Arc<dyn CounterFn>,
         pub(crate) expired_entries_purged_merge: Arc<dyn CounterFn>,
+        pub(crate) jobs_claimed: Arc<dyn CounterFn>,
+        pub(crate) jobs_reclaimed: Arc<dyn CounterFn>,
     }
 
     impl CompactionStats {
@@ -1185,6 +1259,8 @@ pub mod stats {
                     .labels(&[(ENTRY_TYPE_LABEL, ENTRY_TYPE_MERGE)])
                     .description(EXPIRED_ENTRIES_PURGED_DESCRIPTION)
                     .register(),
+                jobs_claimed: recorder.counter(JOBS_CLAIMED).register(),
+                jobs_reclaimed: recorder.counter(JOBS_RECLAIMED).register(),
             }
         }
 
@@ -1223,7 +1299,7 @@ mod tests {
     };
     use crate::compactor_state::Compaction;
     use crate::compactor_state::CompactionStatus;
-    use crate::compactor_state::SourceId;
+    use crate::compactor_state::{SourceId, WorkerSpec};
     use crate::config::{
         CompactionWorkerOptions, FlushOptions, FlushType, MergeOptions, PutOptions, Settings,
         SizeTieredCompactionSchedulerOptions, Ttl, WriteOptions,
@@ -4331,6 +4407,7 @@ mod tests {
                 scheduler.clone(),
                 rand.clone(),
                 compactor_stats.clone(),
+                recorder,
                 Arc::new(DefaultSystemClock::new()),
             )
             .await
@@ -4339,6 +4416,76 @@ mod tests {
                 StoredManifest::load(manifest_store.clone(), Arc::new(DefaultSystemClock::new()))
                     .await
                     .unwrap();
+            Self {
+                manifest,
+                manifest_store,
+                compactions_store,
+                options,
+                db,
+                scheduler,
+                real_executor_rx,
+                real_executor,
+                test_recorder,
+                handler,
+            }
+        }
+
+        /// Like `new()` but accepts an explicit `system_clock` so tests can
+        /// control time (e.g. to exercise heartbeat-timeout reclamation).
+        async fn new_with_clock(
+            system_clock: Arc<dyn SystemClock>,
+            compactor_options: Arc<CompactorOptions>,
+        ) -> Self {
+            let options = db_options(None);
+
+            let os = Arc::new(InMemory::new());
+            let (manifest_store, compactions_store, table_store) = build_test_stores(os.clone());
+            let db = Db::builder(PATH, os.clone())
+                .with_settings(options.clone())
+                .build()
+                .await
+                .unwrap();
+
+            let scheduler = Arc::new(MockScheduler::new());
+            let (real_executor_tx, real_executor_rx) = async_channel::unbounded();
+            let rand = Arc::new(DbRand::default());
+            let test_recorder = Arc::new(slatedb_common::metrics::DefaultMetricsRecorder::new());
+            let recorder = MetricsRecorderHelper::new(
+                test_recorder.clone() as Arc<dyn slatedb_common::metrics::MetricsRecorder>,
+                slatedb_common::metrics::MetricLevel::default(),
+            );
+            let compactor_stats = Arc::new(CompactionStats::new(&recorder));
+            let worker_options = Arc::new(CompactionWorkerOptions::default());
+            let real_executor = Arc::new(TokioCompactionExecutor::new(
+                TokioCompactionExecutorOptions {
+                    handle: Handle::current(),
+                    options: worker_options,
+                    worker_tx: real_executor_tx,
+                    table_store,
+                    rand: rand.clone(),
+                    stats: compactor_stats.clone(),
+                    clock: system_clock.clone(),
+                    manifest_store: manifest_store.clone(),
+                    merge_operator: None,
+                    #[cfg(feature = "compaction_filters")]
+                    compaction_filter_supplier: None,
+                },
+            ));
+            let handler = CompactorEventHandler::new(
+                manifest_store.clone(),
+                compactions_store.clone(),
+                compactor_options.clone(),
+                scheduler.clone(),
+                rand.clone(),
+                compactor_stats.clone(),
+                recorder,
+                system_clock.clone(),
+            )
+            .await
+            .unwrap();
+            let manifest = StoredManifest::load(manifest_store.clone(), system_clock)
+                .await
+                .unwrap();
             Self {
                 manifest,
                 manifest_store,
@@ -4793,6 +4940,7 @@ mod tests {
             scheduler,
             rand,
             compactor_stats,
+            recorder,
             system_clock,
         )
         .await
@@ -5745,5 +5893,134 @@ mod tests {
                 .status(),
             CompactionStatus::Failed,
         );
+    }
+
+    /// A Running compaction whose heartbeat is older than the timeout must be
+    /// reset to Submitted (worker cleared) by `reclaim_stale_workers`.
+    #[tokio::test]
+    async fn test_reclaim_stale_running_compaction() {
+        // given: clock starts at 0 ms
+        let system_clock = Arc::new(MockSystemClock::new());
+        let timeout = Duration::from_secs(30);
+        let options = Arc::new(CompactorOptions {
+            worker_heartbeat_timeout: timeout,
+            ..compactor_options()
+        });
+        let mut fixture = CompactorEventHandlerTestFixture::new_with_clock(
+            system_clock.clone() as Arc<dyn SystemClock>,
+            options,
+        )
+        .await;
+
+        fixture.handler.state_writer.refresh().await.unwrap();
+
+        // Seed a Running compaction in-memory with last_heartbeat_ms = 0 (epoch).
+        // Then persist it so that the compactions_store reflects the seeded state.
+        let compaction_id = Ulid::new();
+        let worker = WorkerSpec::new("worker-1".to_string(), 0);
+        let compaction = Compaction::new(compaction_id, CompactionSpec::new(vec![], 0))
+            .with_status(CompactionStatus::Running)
+            .with_worker(Some(worker));
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(compaction);
+        fixture
+            .handler
+            .state_writer
+            .write_compactions_safely()
+            .await
+            .expect("failed to persist seeded compaction");
+
+        // Advance clock well past the timeout (2× the timeout = 60 s).
+        system_clock.advance(Duration::from_secs(60)).await;
+
+        // when: call reclaim_stale_workers directly to avoid the scheduling
+        // side-effects of handle_ticker (which would try to start the reclaimed
+        // Submitted compaction with an empty spec and mark it Failed).
+        fixture
+            .handler
+            .reclaim_stale_workers()
+            .await
+            .expect("reclaim_stale_workers failed");
+
+        // then: the compaction is now Submitted with no worker.
+        let stored = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        let c = stored.get(&compaction_id).expect("compaction missing");
+        assert_eq!(
+            c.status(),
+            CompactionStatus::Submitted,
+            "should be reclaimed"
+        );
+        assert!(c.worker().is_none(), "worker should be cleared");
+    }
+
+    /// A Running compaction whose heartbeat is within the timeout must NOT be
+    /// reclaimed by `reclaim_stale_workers`.
+    #[tokio::test]
+    async fn test_does_not_reclaim_fresh_running_compaction() {
+        // given: clock starts at 0 ms; heartbeat is also at 0 ms.
+        let system_clock = Arc::new(MockSystemClock::new());
+        let timeout = Duration::from_secs(30);
+        let options = Arc::new(CompactorOptions {
+            worker_heartbeat_timeout: timeout,
+            ..compactor_options()
+        });
+        let mut fixture = CompactorEventHandlerTestFixture::new_with_clock(
+            system_clock.clone() as Arc<dyn SystemClock>,
+            options,
+        )
+        .await;
+
+        fixture.handler.state_writer.refresh().await.unwrap();
+
+        // Seed a Running compaction with heartbeat = "now" (0 ms).
+        let compaction_id = Ulid::new();
+        let now_ms = system_clock.now().timestamp_millis() as u64;
+        let worker = WorkerSpec::new("worker-2".to_string(), now_ms);
+        let compaction = Compaction::new(compaction_id, CompactionSpec::new(vec![], 0))
+            .with_status(CompactionStatus::Running)
+            .with_worker(Some(worker));
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(compaction);
+        fixture
+            .handler
+            .state_writer
+            .write_compactions_safely()
+            .await
+            .expect("failed to persist seeded compaction");
+
+        // Advance clock by only 5 s — well within the 30 s timeout.
+        system_clock.advance(Duration::from_secs(5)).await;
+
+        // when:
+        fixture
+            .handler
+            .reclaim_stale_workers()
+            .await
+            .expect("reclaim_stale_workers failed");
+
+        // then: the compaction is still Running (no reclaim write happened).
+        // Since nothing was written, re-read from the store and verify.
+        let stored = fixture
+            .compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions;
+        let c = stored.get(&compaction_id).expect("compaction missing");
+        assert_eq!(
+            c.status(),
+            CompactionStatus::Running,
+            "should NOT be reclaimed"
+        );
+        assert!(c.worker().is_some(), "worker should still be set");
     }
 }

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -737,22 +737,6 @@ impl CompactorState {
         // coordinator having seen the entry as `Submitted` and promoted it to
         // `Scheduled`, so a Vacant entry in any of those states is anomalous and
         // logged.
-        //
-        // For known compactions (Occupied), accept these remote transitions:
-        //   - `Compacted`: the worker's signal that execution finished; the
-        //     coordinator must commit the output SSTs to the manifest.
-        //   - `Scheduled → Running`: a worker has claimed the job; adopt the
-        //     Running entry so the coordinator's local copy carries the worker
-        //     claim. Without this, write_compactions_safely() would overwrite
-        //     the claim with a stale Scheduled/no-worker copy, causing the
-        //     worker to discard its result and potentially re-run the job.
-        //   - `Running → Scheduled`: a worker released its claim (execution
-        //     failed, post-claim validation rejected the job, or graceful
-        //     shutdown). Adopt the release so the job can be re-claimed;
-        //     otherwise the coordinator's stale Running/claimed copy would be
-        //     written back and no worker would ever pick the job up again.
-        //   - TODO `Running -> Running`: should accept heartbeat updates when heartbeats land
-        // All other remote updates are ignored.
         for compaction in remote_compactions.value.iter() {
             match merged.entry(compaction.id()) {
                 Entry::Vacant(v) => {
@@ -766,12 +750,7 @@ impl CompactorState {
                     v.insert(compaction.clone());
                 }
                 Entry::Occupied(mut o) => {
-                    let adopt = matches!(compaction.status(), CompactionStatus::Compacted)
-                        || (matches!(o.get().status(), CompactionStatus::Scheduled)
-                            && matches!(compaction.status(), CompactionStatus::Running))
-                        || (matches!(o.get().status(), CompactionStatus::Running)
-                            && matches!(compaction.status(), CompactionStatus::Scheduled));
-                    if adopt {
+                    if Self::should_adopt_state_transition(o.get().clone(), compaction.clone()) {
                         o.insert(compaction.clone());
                     } else {
                         debug!(
@@ -792,6 +771,35 @@ impl CompactorState {
         merged_compactions.retain_active_and_last_finished();
         remote_compactions.value = merged_compactions;
         self.set_compactions(remote_compactions);
+    }
+
+    /// State transitions made by CompactionWorker that should be accepted into local state
+    /// during [`CompactorState::merge_remote_compactions`]
+    ///
+    // For known compactions (Occupied), accept these remote transitions:
+    //   - `Compacted`: the worker's signal that execution finished; the
+    //     coordinator must commit the output SSTs to the manifest.
+    //   - `Scheduled → Running`: a worker has claimed the job; adopt the
+    //     Running entry so the coordinator's local copy carries the worker
+    //     claim. Without this, write_compactions_safely() would overwrite
+    //     the claim with a stale Scheduled/no-worker copy, causing the
+    //     worker to discard its result and potentially re-run the job.
+    //   - `Running → Scheduled`: a worker released its claim (execution
+    //     failed, post-claim validation rejected the job, or graceful
+    //     shutdown). Adopt the release so the job can be re-claimed;
+    //     otherwise the coordinator's stale Running/claimed copy would be
+    //     written back and no worker would ever pick the job up again.
+    //   - `Running -> Running`: should accept heartbeat updates when heartbeats
+    //     land for a job that is already in local state
+    // All other remote updates are ignored.
+    fn should_adopt_state_transition(occupied: Compaction, updated: Compaction) -> bool {
+        (matches!(updated.status(), CompactionStatus::Compacted)
+            || (matches!(occupied.status(), CompactionStatus::Scheduled)
+                && matches!(updated.status(), CompactionStatus::Running))
+            || (matches!(occupied.status(), CompactionStatus::Running)
+                && matches!(updated.status(), CompactionStatus::Scheduled)
+                || (matches!(occupied.status(), CompactionStatus::Running)
+                    && matches!(updated.status(), CompactionStatus::Running))))
     }
 
     /// Merges the remote (writer) manifest view into the compactor's local state.

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -296,7 +296,7 @@ impl CompactionStatus {
     ///   - `Running -> Running`: should accept heartbeat updates when heartbeats
     ///     land for a job that is already in local state
     ///
-    ///     All other remote updates are ignored.
+    /// All other remote updates are ignored.
     fn should_adopt_state_transition(&self, updated_status: CompactionStatus) -> bool {
         match self {
             Self::Scheduled => matches!(updated_status, Self::Running | Self::Compacted),

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -276,6 +276,34 @@ impl CompactionStatus {
     fn finished(self) -> bool {
         matches!(self, CompactionStatus::Completed | CompactionStatus::Failed)
     }
+
+    /// State transitions made by CompactionWorker that should be accepted into local state
+    /// during [`CompactorState::merge_remote_compactions`]
+    ///
+    // For known compactions (Occupied), accept these remote transitions:
+    //   - `Compacted`: the worker's signal that execution finished; the
+    //     coordinator must commit the output SSTs to the manifest.
+    //   - `Scheduled → Running`: a worker has claimed the job; adopt the
+    //     Running entry so the coordinator's local copy carries the worker
+    //     claim. Without this, write_compactions_safely() would overwrite
+    //     the claim with a stale Scheduled/no-worker copy, causing the
+    //     worker to discard its result and potentially re-run the job.
+    //   - `Running → Scheduled`: a worker released its claim (execution
+    //     failed, post-claim validation rejected the job, or graceful
+    //     shutdown). Adopt the release so the job can be re-claimed;
+    //     otherwise the coordinator's stale Running/claimed copy would be
+    //     written back and no worker would ever pick the job up again.
+    //   - `Running -> Running`: should accept heartbeat updates when heartbeats
+    //     land for a job that is already in local state
+    // All other remote updates are ignored.
+    fn should_adopt_state_transition(&self, updated_status: CompactionStatus) -> bool {
+        match (self, updated_status) {
+            (_, CompactionStatus::Compacted) => true,
+            (Self::Scheduled, CompactionStatus::Running) => true,
+            (Self::Running, CompactionStatus::Scheduled | CompactionStatus::Running) => true,
+            _ => false,
+        }
+    }
 }
 
 /// Identity and liveness for the worker currently executing a compaction.
@@ -750,7 +778,10 @@ impl CompactorState {
                     v.insert(compaction.clone());
                 }
                 Entry::Occupied(mut o) => {
-                    if Self::should_adopt_state_transition(o.get().clone(), compaction.clone()) {
+                    if o.get()
+                        .status
+                        .should_adopt_state_transition(compaction.status)
+                    {
                         o.insert(compaction.clone());
                     } else {
                         debug!(
@@ -771,35 +802,6 @@ impl CompactorState {
         merged_compactions.retain_active_and_last_finished();
         remote_compactions.value = merged_compactions;
         self.set_compactions(remote_compactions);
-    }
-
-    /// State transitions made by CompactionWorker that should be accepted into local state
-    /// during [`CompactorState::merge_remote_compactions`]
-    ///
-    // For known compactions (Occupied), accept these remote transitions:
-    //   - `Compacted`: the worker's signal that execution finished; the
-    //     coordinator must commit the output SSTs to the manifest.
-    //   - `Scheduled → Running`: a worker has claimed the job; adopt the
-    //     Running entry so the coordinator's local copy carries the worker
-    //     claim. Without this, write_compactions_safely() would overwrite
-    //     the claim with a stale Scheduled/no-worker copy, causing the
-    //     worker to discard its result and potentially re-run the job.
-    //   - `Running → Scheduled`: a worker released its claim (execution
-    //     failed, post-claim validation rejected the job, or graceful
-    //     shutdown). Adopt the release so the job can be re-claimed;
-    //     otherwise the coordinator's stale Running/claimed copy would be
-    //     written back and no worker would ever pick the job up again.
-    //   - `Running -> Running`: should accept heartbeat updates when heartbeats
-    //     land for a job that is already in local state
-    // All other remote updates are ignored.
-    fn should_adopt_state_transition(occupied: Compaction, updated: Compaction) -> bool {
-        (matches!(updated.status(), CompactionStatus::Compacted)
-            || (matches!(occupied.status(), CompactionStatus::Scheduled)
-                && matches!(updated.status(), CompactionStatus::Running))
-            || (matches!(occupied.status(), CompactionStatus::Running)
-                && matches!(updated.status(), CompactionStatus::Scheduled)
-                || (matches!(occupied.status(), CompactionStatus::Running)
-                    && matches!(updated.status(), CompactionStatus::Running))))
     }
 
     /// Merges the remote (writer) manifest view into the compactor's local state.

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -280,22 +280,23 @@ impl CompactionStatus {
     /// State transitions made by CompactionWorker that should be accepted into local state
     /// during [`CompactorState::merge_remote_compactions`]
     ///
-    // For known compactions (Occupied), accept these remote transitions:
-    //   - `Compacted`: the worker's signal that execution finished; the
-    //     coordinator must commit the output SSTs to the manifest.
-    //   - `Scheduled → Running`: a worker has claimed the job; adopt the
-    //     Running entry so the coordinator's local copy carries the worker
-    //     claim. Without this, write_compactions_safely() would overwrite
-    //     the claim with a stale Scheduled/no-worker copy, causing the
-    //     worker to discard its result and potentially re-run the job.
-    //   - `Running → Scheduled`: a worker released its claim (execution
-    //     failed, post-claim validation rejected the job, or graceful
-    //     shutdown). Adopt the release so the job can be re-claimed;
-    //     otherwise the coordinator's stale Running/claimed copy would be
-    //     written back and no worker would ever pick the job up again.
-    //   - `Running -> Running`: should accept heartbeat updates when heartbeats
-    //     land for a job that is already in local state
-    // All other remote updates are ignored.
+    /// For known compactions (Occupied), accept these remote transitions:
+    ///   - `Compacted`: the worker's signal that execution finished; the
+    ///     coordinator must commit the output SSTs to the manifest.
+    ///   - `Scheduled → Running`: a worker has claimed the job; adopt the
+    ///     Running entry so the coordinator's local copy carries the worker
+    ///     claim. Without this, write_compactions_safely() would overwrite
+    ///     the claim with a stale Scheduled/no-worker copy, causing the
+    ///     worker to discard its result and potentially re-run the job.
+    ///   - `Running → Scheduled`: a worker released its claim (execution
+    ///     failed, post-claim validation rejected the job, or graceful
+    ///     shutdown). Adopt the release so the job can be re-claimed;
+    ///     otherwise the coordinator's stale Running/claimed copy would be
+    ///     written back and no worker would ever pick the job up again.
+    ///   - `Running -> Running`: should accept heartbeat updates when heartbeats
+    ///     land for a job that is already in local state
+    ///
+    ///     All other remote updates are ignored.
     fn should_adopt_state_transition(&self, updated_status: CompactionStatus) -> bool {
         match self {
             Self::Scheduled => matches!(updated_status, Self::Running | Self::Compacted),

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -297,11 +297,13 @@ impl CompactionStatus {
     //     land for a job that is already in local state
     // All other remote updates are ignored.
     fn should_adopt_state_transition(&self, updated_status: CompactionStatus) -> bool {
-        match (self, updated_status) {
-            (_, CompactionStatus::Compacted) => true,
-            (Self::Scheduled, CompactionStatus::Running) => true,
-            (Self::Running, CompactionStatus::Scheduled | CompactionStatus::Running) => true,
-            _ => false,
+        match self {
+            Self::Scheduled => matches!(updated_status, Self::Running | Self::Compacted),
+            Self::Running => matches!(
+                updated_status,
+                Self::Scheduled | Self::Running | Self::Compacted
+            ),
+            _ => matches!(updated_status, Self::Compacted),
         }
     }
 }

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -509,7 +509,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_new_resets_running_to_submitted_and_preserves_submitted() {
+    async fn test_new_resets_scheduled_to_submitted_and_preserves_submitted() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let manifest_store = Arc::new(ManifestStore::new(
             &Path::from(ROOT),
@@ -536,7 +536,7 @@ mod tests {
         let submitted_id = Ulid::from_parts(1, 0);
         let failed_old_id = Ulid::from_parts(2, 0);
         let completed_old_id = Ulid::from_parts(3, 0);
-        let running_id = Ulid::from_parts(4, 0);
+        let scheduled_id = Ulid::from_parts(4, 0);
         let mut dirty = stored_compactions.prepare_dirty().unwrap();
         dirty.value.insert(Compaction::new(
             submitted_id,
@@ -551,12 +551,12 @@ mod tests {
                 .with_status(CompactionStatus::Completed),
         );
         dirty.value.insert(
-            Compaction::new(running_id, CompactionSpec::new(vec![], 0))
-                .with_status(CompactionStatus::Running),
+            Compaction::new(scheduled_id, CompactionSpec::new(vec![], 0))
+                .with_status(CompactionStatus::Scheduled),
         );
         stored_compactions.update(dirty).await.unwrap();
 
-        // Initialize a new writer (restart) which should flip Running -> Submitted and trim.
+        // Initialize a new writer (restart) which should flip Scheduled -> Submitted and trim.
         let options = CompactorOptions::default();
         let rand = Arc::new(DbRand::new(7));
 
@@ -570,7 +570,7 @@ mod tests {
         .await
         .unwrap();
 
-        // Submitted should remain; Running should become Submitted; older finished should be trimmed.
+        // Submitted should remain; Scheduled should become Submitted; older finished should be trimmed.
         let compactions = &writer.state.compactions().value;
         assert_eq!(
             compactions
@@ -581,8 +581,8 @@ mod tests {
         );
         assert_eq!(
             compactions
-                .get(&running_id)
-                .expect("missing running compaction")
+                .get(&scheduled_id)
+                .expect("missing scheduled compaction")
                 .status(),
             CompactionStatus::Submitted
         );
@@ -591,7 +591,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_new_resets_running_to_submitted_and_preserves_output_ssts() {
+    async fn test_new_preserves_running_output_ssts() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let manifest_store = Arc::new(ManifestStore::new(
             &Path::from(ROOT),
@@ -661,16 +661,20 @@ mod tests {
             .value
             .get(&running_id)
             .expect("missing running compaction");
-        assert_eq!(compaction.status(), CompactionStatus::Submitted);
+        // new() leaves Running entries untouched and preserves their output_ssts
+        // through the load; reclaiming stale ones is the ticker's job.
+        assert_eq!(compaction.status(), CompactionStatus::Running);
         assert_eq!(compaction.output_ssts(), &output_ssts);
     }
 
-    /// On restart, a `Running` compaction whose worker is still heartbeating
-    /// (fresh `last_heartbeat_ms`) must be left in `Running` so the live worker
-    /// can finish, while a `Running` compaction with a stale heartbeat is reset
-    /// to `Submitted` for another worker to claim.
+    /// `CompactorStateWriter::new` no longer reclaims stale `Running`
+    /// compactions on restart — that moved to `reclaim_stale_workers`, which
+    /// runs on the first tick (covered by `test_reclaim_stale_running_compaction`
+    /// and `test_does_not_reclaim_fresh_running_compaction` in compactor.rs). So
+    /// `new` must leave every `Running` compaction untouched, stale or fresh, and
+    /// only reset `Scheduled` entries.
     #[tokio::test]
-    async fn test_new_only_resets_stale_running_compactions() {
+    async fn test_new_preserves_running_compactions() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let manifest_store = Arc::new(ManifestStore::new(
             &Path::from(ROOT),
@@ -735,7 +739,7 @@ mod tests {
 
         let compactions = &writer.state.compactions().value;
 
-        // Live worker is left undisturbed.
+        // new() leaves the live worker undisturbed.
         let fresh = compactions
             .get(&fresh_id)
             .expect("missing fresh compaction");
@@ -745,12 +749,16 @@ mod tests {
             Some("worker-fresh")
         );
 
-        // Stale worker is reclaimed.
+        // new() also leaves the stale worker in Running; reclaiming it is the
+        // ticker's job (reclaim_stale_workers), not the writer's at startup.
         let stale = compactions
             .get(&stale_id)
             .expect("missing stale compaction");
-        assert_eq!(stale.status(), CompactionStatus::Submitted);
-        assert!(stale.worker().is_none());
+        assert_eq!(stale.status(), CompactionStatus::Running);
+        assert_eq!(
+            stale.worker().map(|w| w.worker_id.as_str()),
+            Some("worker-stale")
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -150,11 +150,14 @@ impl CompactorStateWriter {
             // post-restart manifest before any worker can claim them again. Submitted
             // compactions are left intact for future scheduling. Keep only the most recent
             // finished compaction for GC safety (#1044).
+            let now_ms = system_clock.now().timestamp_millis() as u64;
+            let timeout_ms = options.worker_heartbeat_timeout.as_millis() as u64;
             dirty_compactions.value.iter_mut().for_each(|c| {
-                if matches!(
-                    c.status(),
-                    CompactionStatus::Running | CompactionStatus::Scheduled
-                ) {
+                let stale_running = matches!(c.status(), CompactionStatus::Running)
+                    && c.worker()
+                        .map(|w| now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms)
+                        .unwrap_or(true);
+                if matches!(c.status(), CompactionStatus::Scheduled) || stale_running {
                     c.set_status(CompactionStatus::Submitted);
                     c.set_worker(None);
                 }

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -343,7 +343,7 @@ mod tests {
     use crate::compactions_store::{CompactionsStore, StoredCompactions};
     use crate::compactor_state::{
         Compaction, CompactionSpec, CompactionStatus, Compactions, CompactorState,
-        VersionedCompactions,
+        VersionedCompactions, WorkerSpec,
     };
     use crate::db_state::{SsTableHandle, SsTableId, SsTableInfo};
     use crate::error::SlateDBError;
@@ -355,6 +355,7 @@ mod tests {
     use object_store::path::Path;
     use object_store::ObjectStore;
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
+    use slatedb_common::MockSystemClock;
     use slatedb_txn_obj::test_utils::new_dirty_object;
     use std::sync::Arc;
     use ulid::Ulid;
@@ -668,6 +669,94 @@ mod tests {
             .expect("missing running compaction");
         assert_eq!(compaction.status(), CompactionStatus::Submitted);
         assert_eq!(compaction.output_ssts(), &output_ssts);
+    }
+
+    /// On restart, a `Running` compaction whose worker is still heartbeating
+    /// (fresh `last_heartbeat_ms`) must be left in `Running` so the live worker
+    /// can finish, while a `Running` compaction with a stale heartbeat is reset
+    /// to `Submitted` for another worker to claim.
+    #[tokio::test]
+    async fn test_new_only_resets_stale_running_compactions() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&object_store),
+        ));
+        let compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&object_store),
+        ));
+
+        // Fix the clock so heartbeat ages are deterministic.
+        let mock_clock = Arc::new(MockSystemClock::new());
+        let now_ms: u64 = 100_000;
+        mock_clock.set(now_ms as i64);
+        let system_clock: Arc<dyn SystemClock> = mock_clock.clone();
+
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            system_clock.clone(),
+        )
+        .await
+        .unwrap();
+
+        let options = CompactorOptions::default();
+        let timeout_ms = options.worker_heartbeat_timeout.as_millis() as u64;
+
+        // fresh: heartbeat at "now" (age 0). stale: heartbeat well past timeout.
+        let fresh_id = Ulid::from_parts(1, 0);
+        let stale_id = Ulid::from_parts(2, 0);
+        let stale_hb_ms = now_ms - (timeout_ms * 2);
+
+        let mut stored_compactions = StoredCompactions::create(compactions_store.clone(), 0)
+            .await
+            .unwrap();
+        let mut dirty = stored_compactions.prepare_dirty().unwrap();
+        dirty.value.insert(
+            Compaction::new(fresh_id, CompactionSpec::new(vec![], 0))
+                .with_status(CompactionStatus::Running)
+                .with_worker(Some(WorkerSpec::new("worker-fresh".to_string(), now_ms))),
+        );
+        dirty.value.insert(
+            Compaction::new(stale_id, CompactionSpec::new(vec![], 0))
+                .with_status(CompactionStatus::Running)
+                .with_worker(Some(WorkerSpec::new(
+                    "worker-stale".to_string(),
+                    stale_hb_ms,
+                ))),
+        );
+        stored_compactions.update(dirty).await.unwrap();
+
+        let rand = Arc::new(DbRand::new(7));
+        let writer = CompactorStateWriter::new(
+            manifest_store,
+            compactions_store,
+            system_clock,
+            &options,
+            rand,
+        )
+        .await
+        .unwrap();
+
+        let compactions = &writer.state.compactions().value;
+
+        // Live worker is left undisturbed.
+        let fresh = compactions
+            .get(&fresh_id)
+            .expect("missing fresh compaction");
+        assert_eq!(fresh.status(), CompactionStatus::Running);
+        assert_eq!(
+            fresh.worker().map(|w| w.worker_id.as_str()),
+            Some("worker-fresh")
+        );
+
+        // Stale worker is reclaimed.
+        let stale = compactions
+            .get(&stale_id)
+            .expect("missing stale compaction");
+        assert_eq!(stale.status(), CompactionStatus::Submitted);
+        assert!(stale.worker().is_none());
     }
 
     #[tokio::test]

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -145,19 +145,13 @@ impl CompactorStateWriter {
         let dirty_manifest = manifest.prepare_dirty()?;
         let dirty_compactions = loop {
             let mut dirty_compactions = compactions.prepare_dirty()?;
-            // Reset scheduled and stale running compactions back to submitted on restart.
-            // Scheduled compactions have no worker yet, so they always reset. Running
-            // compactions are only reset if the worker's heartbeat has gone stale: a
-            // worker that is still alive and heartbeating is left in Running so it can
-            // finish without being interrupted by the restarted coordinator.
-            let now_ms = system_clock.now().timestamp_millis() as u64;
-            let timeout_ms = options.worker_heartbeat_timeout.as_millis() as u64;
+            // Reset unclaimed scheduled compactions back to submitted on restart.
+            // Scheduled compactions have no worker yet, so they always reset.
+            // Stale Running compactions are left alone here: reclaim_stale_workers
+            // reclaims them on the first tick (and before scheduling), so handling
+            // them at startup too would just duplicate that logic.
             dirty_compactions.value.iter_mut().for_each(|c| {
-                let stale_running = matches!(c.status(), CompactionStatus::Running)
-                    && c.worker()
-                        .map(|w| now_ms.saturating_sub(w.last_heartbeat_ms) > timeout_ms)
-                        .unwrap_or(true);
-                if matches!(c.status(), CompactionStatus::Scheduled) || stale_running {
+                if matches!(c.status(), CompactionStatus::Scheduled) {
                     c.set_status(CompactionStatus::Submitted);
                     c.set_worker(None);
                 }

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -145,11 +145,11 @@ impl CompactorStateWriter {
         let dirty_manifest = manifest.prepare_dirty()?;
         let dirty_compactions = loop {
             let mut dirty_compactions = compactions.prepare_dirty()?;
-            // Move running and scheduled compactions back to submitted so we can resume them
-            // after restart. Re-routing through Submitted forces re-validation against the
-            // post-restart manifest before any worker can claim them again. Submitted
-            // compactions are left intact for future scheduling. Keep only the most recent
-            // finished compaction for GC safety (#1044).
+            // Reset scheduled and stale running compactions back to submitted on restart.
+            // Scheduled compactions have no worker yet, so they always reset. Running
+            // compactions are only reset if the worker's heartbeat has gone stale: a
+            // worker that is still alive and heartbeating is left in Running so it can
+            // finish without being interrupted by the restarted coordinator.
             let now_ms = system_clock.now().timestamp_millis() as u64;
             let timeout_ms = options.worker_heartbeat_timeout.as_millis() as u64;
             dirty_compactions.value.iter_mut().for_each(|c| {

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1123,14 +1123,6 @@ pub struct CompactorOptions {
     #[serde(default = "default_compaction_worker_options")]
     pub worker: Option<CompactionWorkerOptions>,
 
-    /// How long the coordinator will wait without a heartbeat before reclaiming
-    /// a `Running` compaction from its worker and resetting it to `Submitted`.
-    /// A worker that crashes or stalls will have its jobs reclaimed after this
-    /// timeout. Default is 30 seconds.
-    #[serde(deserialize_with = "deserialize_duration")]
-    #[serde(serialize_with = "serialize_duration")]
-    pub worker_heartbeat_timeout: Duration,
-
     /// Optional metrics reporting level for standalone compactors. When a
     /// compactor is owned by a [`Settings`] configured DB, unset means inherit
     /// [`Settings::metric_level`].
@@ -1141,6 +1133,14 @@ pub struct CompactorOptions {
     #[serde(deserialize_with = "deserialize_duration")]
     #[serde(serialize_with = "serialize_duration")]
     pub commit_compacted_interval: Duration,
+
+    /// How long the coordinator will wait without a heartbeat before reclaiming
+    /// a `Running` compaction from its worker and resetting it to `Submitted`.
+    /// A worker that crashes or stalls will have its jobs reclaimed after this
+    /// timeout. Default is 30 seconds.
+    #[serde(deserialize_with = "deserialize_duration")]
+    #[serde(serialize_with = "serialize_duration")]
+    pub worker_heartbeat_timeout: Duration,
 }
 
 /// Default options for the compactor. Currently, only a

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1123,6 +1123,14 @@ pub struct CompactorOptions {
     #[serde(default = "default_compaction_worker_options")]
     pub worker: Option<CompactionWorkerOptions>,
 
+    /// How long the coordinator will wait without a heartbeat before reclaiming
+    /// a `Running` compaction from its worker and resetting it to `Submitted`.
+    /// A worker that crashes or stalls will have its jobs reclaimed after this
+    /// timeout. Default is 30 seconds.
+    #[serde(deserialize_with = "deserialize_duration")]
+    #[serde(serialize_with = "serialize_duration")]
+    pub worker_heartbeat_timeout: Duration,
+
     /// Optional metrics reporting level for standalone compactors. When a
     /// compactor is owned by a [`Settings`] configured DB, unset means inherit
     /// [`Settings::metric_level`].
@@ -1149,6 +1157,7 @@ impl Default for CompactorOptions {
             worker: Some(CompactionWorkerOptions::default()),
             metric_level: None,
             commit_compacted_interval: Duration::from_secs(1),
+            worker_heartbeat_timeout: Duration::from_secs(30),
         }
     }
 }
@@ -1167,6 +1176,7 @@ impl std::fmt::Debug for CompactorOptions {
             .field("worker", &self.worker)
             .field("metric_level", &self.metric_level)
             .field("commit_compacted_interval", &self.commit_compacted_interval)
+            .field("worker_heartbeat_timeout", &self.worker_heartbeat_timeout)
             .finish()
     }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1211,6 +1211,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             scheduler,
             self.rand.clone(),
             stats.clone(),
+            recorder.clone(),
             self.system_clock.clone(),
         )
         .await?;

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1211,7 +1211,6 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             scheduler,
             self.rand.clone(),
             stats.clone(),
-            recorder.clone(),
             self.system_clock.clone(),
         )
         .await?;


### PR DESCRIPTION
## Summary

Adds worker heartbeating and coordinator-side job reclamation for the distributed compaction worker (RFC-0025 follow-up to the claim/execute/complete implementation).

Workers emit a heartbeat (a CAS write bumping last_heartbeat_ms) on two triggers: when output SSTs are produced, and after processing `heartbeat_bytes` as long as the processing time is greater than `min_heartbeat_interval`. The coordinator uses these heartbeats to detect stale workers. Any Running compaction whose last heartbeat exceeds `worker_heartbeat_timeout` is reclaimed and reset to Submitted so another worker can pick it up.

## Changes

  - compaction_worker.rs: Emit heartbeats on SST progress; track per-job progress state (last_hb_sst_count, last_hb_bytes) to detect when output has grown; release claims on graceful shutdown
  - compactor.rs: Add reclaim_stale_workers() called each coordinator tick; track worker_heartbeat_timeout from options
  - compactor_state_protocols.rs: On coordinator restart, only reset Running -> Submitted when the heartbeat is stale; live workers are left undisturbed
  - config.rs: Add worker_heartbeat_timeout: Duration to CompactorOptions (default 30s)

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏

