### PR TITLE
Retry in compactor state protocol instantiation

### DIFF
--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -143,24 +143,31 @@ impl CompactorStateWriter {
         )
         .await?;
         let dirty_manifest = manifest.prepare_dirty()?;
-        let mut dirty_compactions = compactions.prepare_dirty()?;
-        // Move running and scheduled compactions back to submitted so we can resume them
-        // after restart. Re-routing through Submitted forces re-validation against the
-        // post-restart manifest before any worker can claim them again. Submitted
-        // compactions are left intact for future scheduling. Keep only the most recent
-        // finished compaction for GC safety (#1044).
-        dirty_compactions.value.iter_mut().for_each(|c| {
-            if matches!(
-                c.status(),
-                CompactionStatus::Running | CompactionStatus::Scheduled
-            ) {
-                c.set_status(CompactionStatus::Submitted);
-                c.set_worker(None);
+        let dirty_compactions = loop {
+            let mut dirty_compactions = compactions.prepare_dirty()?;
+            // Move running and scheduled compactions back to submitted so we can resume them
+            // after restart. Re-routing through Submitted forces re-validation against the
+            // post-restart manifest before any worker can claim them again. Submitted
+            // compactions are left intact for future scheduling. Keep only the most recent
+            // finished compaction for GC safety (#1044).
+            dirty_compactions.value.iter_mut().for_each(|c| {
+                if matches!(
+                    c.status(),
+                    CompactionStatus::Running | CompactionStatus::Scheduled
+                ) {
+                    c.set_status(CompactionStatus::Submitted);
+                    c.set_worker(None);
+                }
+            });
+            dirty_compactions.value.retain_active_and_last_finished();
+            match compactions.update(dirty_compactions.clone()).await {
+                Ok(()) => break dirty_compactions,
+                Err(err) if err.is_sequenced_write_conflict() => {
+                    compactions.refresh().await?;
+                }
+                Err(err) => return Err(err),
             }
-        });
-        dirty_compactions.value.retain_active_and_last_finished();
-        // Persist recovery state before any refresh() can overwrite it.
-        compactions.update(dirty_compactions.clone()).await?;
+        };
         let state = CompactorState::new(dirty_manifest, dirty_compactions);
         Ok(Self {
             state,


### PR DESCRIPTION
## Summary

Nightly DST failed last night:

https://github.com/slatedb/slatedb/actions/runs/27496387780?notification_referrer_id=NT_kwHOAAKOkdoAK1JlcG9zaXRvcnk7Nzc3OTEyNzczO0NoZWNrU3VpdGU7NzM5ODUyNzQyNjU

The issue is caused by the compactor state protocol not retrying. Before distributed compaction, we only had one writer in the healthy path, so I didn't think retrying was necessary. Now, with workers, we have something else advancing the .compactions file. We need to loop if the file already exists rather than failing outright.

## Changes

- Add a retry loop using `err.is_sequenced_write_conflict` to detect and retry on .compaction write races

## Notes for Reviewers

This is going to conflict with #1786 most likely. @ryandielhenn if you like, you can add this change directly to your PR. Otherwise, we can merge this and you'll have to rebase.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
