### PR TITLE
Don't advance manifest GC boundary past active checkpoints

### DIFF
--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -64,11 +64,14 @@ impl GcTask for ManifestGcTask {
             .map(|checkpoint| checkpoint.manifest_id)
             .collect();
 
-        // Advance the boundary to the latest manifest that is older than min_age
+        // Advance the boundary to the latest manifest that is older than min_age and not referenced
+        // by an active checkpoint.
+        let min_active_id = active_manifest_ids.iter().copied().min();
         if let Some(boundary) = manifest_metadata_list
             .iter()
             .filter(|manifest_metadata| {
                 utc_now.signed_duration_since(manifest_metadata.last_modified) > min_age
+                    && min_active_id.is_none_or(|min_active| min_active > manifest_metadata.id)
             })
             .map(|manifest_metadata| manifest_metadata.id)
             .max()
@@ -124,6 +127,7 @@ impl GcTask for ManifestGcTask {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::CheckpointOptions;
     use crate::manifest::{
         store::{ManifestStore, StoredManifest},
         ManifestCore,
@@ -133,6 +137,7 @@ mod tests {
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::MetricsRecorderHelper;
     use std::time::Duration;
+    use uuid::Uuid;
 
     #[tokio::test]
     async fn test_collect_advances_boundary_for_old_manifest_files() {
@@ -187,6 +192,97 @@ mod tests {
                 .iter()
                 .map(|manifest| manifest.id)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_does_not_advance_boundary_past_active_checkpoint() {
+        let object_store = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from("/root"),
+            object_store.clone(),
+        ));
+        let mut stored_manifest = StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        // Create a checkpoint that pins an early manifest, then write newer
+        // manifests on top of it so the checkpoint's manifest is neither the
+        // latest nor the highest old manifest.
+        let checkpoint = stored_manifest
+            .write_checkpoint(Uuid::new_v4(), &CheckpointOptions::default())
+            .await
+            .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+
+        // Sanity check: the checkpoint pins a manifest below the latest, with at
+        // least one older non-active manifest above it.
+        let all_ids = manifest_store
+            .list_manifests(..)
+            .await
+            .unwrap()
+            .iter()
+            .map(|m| m.id)
+            .collect::<Vec<_>>();
+        let latest_id = *all_ids.last().unwrap();
+        assert!(checkpoint.manifest_id < latest_id);
+        assert!(all_ids
+            .iter()
+            .any(|&id| id > checkpoint.manifest_id && id < latest_id));
+
+        let recorder = MetricsRecorderHelper::noop();
+        let task = ManifestGcTask::new(
+            manifest_store.clone(),
+            Arc::new(GcStats::new(&recorder)),
+            GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(1),
+                interval: None,
+                dry_run: false,
+            },
+        );
+        task.collect(Utc::now() + TimeDelta::hours(1))
+            .await
+            .unwrap();
+
+        // The boundary must stay strictly below the active checkpoint's manifest,
+        // so it is never fenced even when older manifests above it are deleted.
+        let raw_boundary = object_store
+            .get(&Path::from("/root/gc/manifest.boundary"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let boundary: u64 = std::str::from_utf8(&raw_boundary).unwrap().parse().unwrap();
+        assert!(
+            boundary < checkpoint.manifest_id,
+            "boundary {boundary} advanced past active checkpoint manifest {}",
+            checkpoint.manifest_id
+        );
+
+        // The checkpoint's manifest file must be retained.
+        let remaining = manifest_store
+            .list_manifests(..)
+            .await
+            .unwrap()
+            .iter()
+            .map(|m| m.id)
+            .collect::<Vec<_>>();
+        assert!(
+            remaining.contains(&checkpoint.manifest_id),
+            "active checkpoint manifest {} was deleted; remaining={remaining:?}",
+            checkpoint.manifest_id
         );
     }
 }


### PR DESCRIPTION
## Summary

The boundary-advance step in ManifestGcTask::collect filtered candidate manifests only by min_age, while the deletion step additionally skips manifests referenced by active checkpoints. As a result the boundary could advance past a manifest whose file the deletion step intentionally retains, fencing live, checkpoint-referenced state behind the boundary.

The boundary is a contiguous watermark (everything <= boundary is fenced), so excluding active ids individually before max() is not enough. Cap the boundary strictly below the lowest active checkpoint manifest so an active manifest is never fenced, even when a higher non-active manifest is eligible.

## Notes for Reviewers

Related to #1657 .

IIUC, there should be no impact as of today.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
