### PR TITLE
Fix bug in segment reporting

### DIFF
--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -185,7 +185,7 @@ impl DbStatusManager {
         self.tx.send_if_modified(|s| {
             let mut changed = false;
             for prefix in prefixes {
-                changed = changed || s.memtable_segments.insert(prefix.clone());
+                changed |= s.memtable_segments.insert(prefix.clone());
             }
             changed
         });
@@ -274,8 +274,6 @@ mod tests {
         }
     }
 
-    /// The published memtable segments as an order-independent set (ordering is
-    /// a property of `list_segments`, not of the raw field).
     fn segment_set(status: &DbStatus) -> BTreeSet<SegmentPrefix> {
         status
             .memtable_segments
@@ -384,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn should_notify_when_adding_a_new_segment() {
+    fn should_notify_when_adding_new_segments() {
         // given
         let mgr = DbStatusManager::new(0);
         let mut rx = mgr.subscribe();
@@ -401,21 +399,31 @@ mod tests {
         );
 
         // when
-        mgr.add_memtable_segments(&BTreeSet::from([Bytes::from_static(b"a")]));
+        mgr.add_memtable_segments(&BTreeSet::from([
+            Bytes::from_static(b"a"),
+            Bytes::from_static(b"z"),
+        ]));
 
         // then
         assert!(rx.has_changed().unwrap());
         assert_eq!(
             segment_set(&rx.borrow_and_update()),
-            BTreeSet::from([segment_prefix(b"a"), segment_prefix(b"m")])
+            BTreeSet::from([
+                segment_prefix(b"a"),
+                segment_prefix(b"m"),
+                segment_prefix(b"z")
+            ])
         );
     }
 
     #[test]
     fn should_not_notify_when_adding_a_known_segment() {
         // given
-        let mgr = DbStatusManager::new(0);
-        mgr.add_memtable_segments(&BTreeSet::from([Bytes::from_static(b"x")]));
+        let mgr = DbStatusManager::new_with_initial_values(
+            0,
+            manifest_with_segments(1, &[b"a", b"b"]),
+            BTreeSet::from([Bytes::from_static(b"x"), Bytes::from_static(b"y")]),
+        );
         let mut rx = mgr.subscribe();
         rx.borrow_and_update();
 
@@ -429,6 +437,16 @@ mod tests {
         mgr.add_memtable_segments(&BTreeSet::from([
             Bytes::from_static(b"x"),
             Bytes::from_static(b"y"),
+        ]));
+
+        // then
+        assert!(!rx.has_changed().unwrap());
+
+        // when
+        mgr.add_memtable_segments(&BTreeSet::from([
+            Bytes::from_static(b"x"),
+            Bytes::from_static(b"y"),
+            Bytes::from_static(b"z"),
         ]));
 
         // then
@@ -448,21 +466,6 @@ mod tests {
         // then
         assert!(!rx.has_changed().unwrap());
         assert!(rx.borrow_and_update().list_segments().is_empty());
-    }
-
-    #[test]
-    fn should_not_notify_when_reported_segments_unchanged() {
-        // given
-        let mgr = DbStatusManager::new(0);
-        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
-        let mut rx = mgr.subscribe();
-        rx.borrow_and_update();
-
-        // when
-        mgr.report_memtable_segments(BTreeSet::from([Bytes::from_static(b"x")]));
-
-        // then
-        assert!(!rx.has_changed().unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes a bug in reporting added memtable segments to the DB status manager.

Method `DbStatusManager::add_memtable_segments()` checked whether added memtable segments change the DB status with `changed = changed || s.memtable_segments.insert(prefix.clone());` for each added segment. Once the first
segment in a call was new -- i.e. `insert()` returns `true` -- the following added segments were not inserted in `memtable_segments` since `changed` was true and consequently `insert()` was not evaluated.    
The bug is fixed by using `changed |=` instead of `changed = changed |`.


## Changes

- Replaces `changed = changed |` with `changed |=`
- Extends a unit test to expose the bug
- Removes duplicate unit test
- Minor maintenance  

## Notes for Reviewers

N/A

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
