### PR TITLE
Add `scan` command to slatedb-cli (#1788)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,6 +3320,7 @@ dependencies = [
  "rstest",
  "serde_json",
  "slatedb",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tracing",

--- a/slatedb-cli/Cargo.toml
+++ b/slatedb-cli/Cargo.toml
@@ -24,6 +24,7 @@ uuid = { workspace = true, features = ["v4", "serde"] }
 
 [dev-dependencies]
 rstest = { workspace = true }
+tempfile = { workspace = true }
 
 [[bin]]
 name = "slatedb"

--- a/slatedb-cli/README.md
+++ b/slatedb-cli/README.md
@@ -101,6 +101,31 @@ Options:
 slatedb --path <PATH> list-checkpoints
 ```
 
+#### Scan
+
+Dumps the key/value pairs of the database to stdout:
+
+```bash
+slatedb --path <PATH> scan [OPTIONS]
+```
+
+The database is opened as a non-fencing reader, so `scan` is safe to point at a database that a service is actively writing. Output is one entry per line as `<key>\t<value>`.
+
+Options:
+- `--prefix <K>`: Restrict the scan to keys starting with these bytes. Conflicts with `--from`/`--to`.
+- `--from <K>`: Inclusive lower bound of the scanned key range.
+- `--to <K>`: Exclusive upper bound of the scanned key range.
+- `--key <auto|hex|utf8>`: How keys are rendered, and how `--prefix`/`--from`/`--to` are parsed. Default `auto`.
+- `--value <auto|hex|utf8|len|none>`: How values are rendered. `none` prints keys only. Default `auto`.
+- `--max-keys <N>`: Stop after emitting `N` entries.
+- `--count`: Print only `<N> entries, <B> bytes` instead of the entries themselves. When combined with `--max-keys`, only the entries up to the cap are counted.
+- `--checkpoint <UUID>`: Scan an existing checkpoint for a point-in-time scan that needs only read access to the store. Without it, the reader writes a transient checkpoint, so it needs write access to the store.
+
+Encoding rules:
+- `--key`/`--value` control both how the bound arguments are parsed and how keys/values are rendered. In `hex`, bound arguments are hex digits with an optional `0x` prefix. In `utf8`, they are taken literally. In `auto`, a bound is hex-decoded when it starts with `0x`/`0X` and taken literally otherwise.
+- In `auto`, a key is rendered as bare text only when it is clean UTF-8 (no control characters) and does not itself start with `0x`; otherwise it is rendered as `0x`-prefixed lowercase hex. For example a key `user/42` prints as `user/42`, while a key with bytes `00 42` prints as `0x0042`.
+- For values in `auto`, clean text is shown as-is and anything else as `<binary N bytes>`; switch to `--value hex` to see the raw bytes.
+
 #### Garbage Collection
 
 SlateDB provides garbage collection functionality for various resources:
@@ -144,6 +169,18 @@ slatedb --path my-database list-manifests
 
 ```bash
 slatedb --path my-database create-checkpoint --lifetime "7days"
+```
+
+### Scanning the Key/Value Pairs
+
+```bash
+slatedb --path my-database scan --prefix user --value utf8
+```
+
+Count the entries under a binary key prefix without printing them:
+
+```bash
+slatedb --path my-database scan --prefix 0x40 --count
 ```
 
 ### Running Garbage Collection on WAL Files

--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -1,3 +1,4 @@
+use crate::scan::{KeyMode, ValueMode};
 use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use slatedb::compactor::CompactionRequest;
 use slatedb::seq_tracker::FindOption;
@@ -134,6 +135,54 @@ pub(crate) enum CliCommands {
         /// all checkpoints will be returned.
         #[arg(short, long)]
         name: Option<String>,
+    },
+
+    /// Dumps the key/value pairs of the database to stdout, in the spirit of RocksDB's
+    /// `ldb scan`.
+    ///
+    /// Output is one entry per line as `<key>\t<value>` (or `<key>` with
+    /// `--value none`). Logs go to stderr, so stdout is exactly the scan output.
+    ///
+    /// Opens the database as a non-fencing reader, so it is safe to run against a
+    /// database that a service is actively writing.
+    Scan {
+        /// Restrict the scan to keys starting with these bytes. Parsed according to
+        /// `--key`. Conflicts with `--from`/`--to`.
+        #[arg(long, conflicts_with_all = ["from", "to"])]
+        prefix: Option<String>,
+
+        /// Inclusive lower bound of the scanned key range. Parsed according to `--key`.
+        #[arg(long)]
+        from: Option<String>,
+
+        /// Exclusive upper bound of the scanned key range. Parsed according to `--key`.
+        #[arg(long)]
+        to: Option<String>,
+
+        /// How keys are rendered, and how `--prefix`/`--from`/`--to` are parsed.
+        #[arg(long, value_enum, default_value = "auto")]
+        key: KeyMode,
+
+        /// How each value is rendered.
+        #[arg(long, value_enum, default_value = "auto")]
+        value: ValueMode,
+
+        /// Stop after emitting this many entries.
+        #[arg(long)]
+        max_keys: Option<u64>,
+
+        /// Print only the number of matching entries and their total byte size, not the
+        /// entries themselves. When combined with `--max-keys`, only the entries up to
+        /// that cap are counted.
+        #[arg(long)]
+        count: bool,
+
+        /// Scan an existing checkpoint by its UUID, rather than the database's current
+        /// state. This needs only read access to the store; without it the reader writes
+        /// a transient checkpoint and so needs write access.
+        #[arg(long)]
+        #[clap(value_parser = uuid::Uuid::parse_str)]
+        checkpoint: Option<Uuid>,
     },
 
     /// Runs a garbage collection for a specific resource type once
@@ -330,6 +379,7 @@ fn parse_find_option(s: &str) -> Result<FindOption, String> {
 #[cfg(test)]
 mod tests {
     use super::{parse_gc_schedule, CliArgs, CliCommands, GcResource};
+    use crate::scan::{KeyMode, ValueMode};
     use clap::Parser;
     use rstest::rstest;
     use std::time::Duration;
@@ -410,6 +460,91 @@ mod tests {
             }
             command => panic!("unexpected command: {command:?}"),
         }
+    }
+
+    #[test]
+    fn parses_scan_defaults() {
+        let args = CliArgs::try_parse_from(["slatedb", "--path", "/tmp/slatedb", "scan"]).unwrap();
+
+        match args.command {
+            CliCommands::Scan {
+                prefix,
+                from,
+                to,
+                key,
+                value,
+                max_keys,
+                count,
+                checkpoint,
+            } => {
+                assert!(prefix.is_none());
+                assert!(from.is_none());
+                assert!(to.is_none());
+                assert_eq!(key, KeyMode::Auto);
+                assert_eq!(value, ValueMode::Auto);
+                assert!(max_keys.is_none());
+                assert!(!count);
+                assert!(checkpoint.is_none());
+            }
+            command => panic!("unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_scan_flags() {
+        let args = CliArgs::try_parse_from([
+            "slatedb",
+            "--path",
+            "/tmp/slatedb",
+            "scan",
+            "--from",
+            "00",
+            "--to",
+            "ff",
+            "--key",
+            "hex",
+            "--value",
+            "len",
+            "--max-keys",
+            "10",
+            "--count",
+        ])
+        .unwrap();
+
+        match args.command {
+            CliCommands::Scan {
+                from,
+                to,
+                key,
+                value,
+                max_keys,
+                count,
+                ..
+            } => {
+                assert_eq!(from.as_deref(), Some("00"));
+                assert_eq!(to.as_deref(), Some("ff"));
+                assert_eq!(key, KeyMode::Hex);
+                assert_eq!(value, ValueMode::Len);
+                assert_eq!(max_keys, Some(10));
+                assert!(count);
+            }
+            command => panic!("unexpected command: {command:?}"),
+        }
+    }
+
+    #[test]
+    fn scan_prefix_conflicts_with_bounds() {
+        let result = CliArgs::try_parse_from([
+            "slatedb",
+            "--path",
+            "/tmp/slatedb",
+            "scan",
+            "--prefix",
+            "40",
+            "--from",
+            "00",
+        ]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -20,6 +20,7 @@ use ulid::Ulid;
 use uuid::Uuid;
 
 mod args;
+mod scan;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -27,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-        .with_test_writer()
+        .with_writer(std::io::stderr)
         .init();
 
     let args: CliArgs = parse_args();
@@ -81,6 +82,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 .await?
         }
         CliCommands::RunWorker => exec_run_worker(&admin, cancellation_token).await?,
+        CliCommands::Scan {
+            prefix,
+            from,
+            to,
+            key,
+            value,
+            max_keys,
+            count,
+            checkpoint,
+        } => {
+            scan::exec_scan(
+                path.clone(),
+                object_store.clone(),
+                prefix,
+                from,
+                to,
+                key,
+                value,
+                max_keys,
+                count,
+                checkpoint,
+            )
+            .await?
+        }
         CliCommands::ScheduleGarbageCollection {
             manifest,
             wal,

--- a/slatedb-cli/src/scan.rs
+++ b/slatedb-cli/src/scan.rs
@@ -1,0 +1,313 @@
+use std::error::Error;
+use std::io::{self, Write};
+use std::ops::Bound;
+use std::sync::Arc;
+
+use object_store::path::Path;
+use object_store::ObjectStore;
+use slatedb::config::ScanOptions;
+use slatedb::DbReader;
+use uuid::Uuid;
+
+type KeyRange = (Bound<Vec<u8>>, Bound<Vec<u8>>);
+
+/// How keys are rendered, and how `--prefix`/`--from`/`--to` are parsed.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum KeyMode {
+    /// Bounds hex-decode only with a `0x` prefix; keys render as text unless binary or
+    /// `0x`-prefixed.
+    Auto,
+    /// Bounds are hex (optional `0x` prefix); keys render as `0x` hex.
+    Hex,
+    /// Bounds are taken literally; keys render via lossy UTF-8.
+    Utf8,
+}
+
+/// How each value is rendered.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum ValueMode {
+    /// Clean text is shown as-is, otherwise `<binary N bytes>`.
+    Auto,
+    /// Lowercase `0x` hex.
+    Hex,
+    /// Raw bytes, lossily decoded as UTF-8.
+    Utf8,
+    /// Just the byte length.
+    Len,
+    /// Omit values entirely; print keys only.
+    None,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn exec_scan(
+    path: Path,
+    object_store: Arc<dyn ObjectStore>,
+    prefix: Option<String>,
+    from: Option<String>,
+    to: Option<String>,
+    key_mode: KeyMode,
+    value_mode: ValueMode,
+    max_keys: Option<u64>,
+    count: bool,
+    checkpoint: Option<Uuid>,
+) -> Result<(), Box<dyn Error>> {
+    // Decode the range selectors before opening the reader, so a bad spec fails fast.
+    let prefix = prefix
+        .as_deref()
+        .map(|p| decode_bound(p, key_mode))
+        .transpose()?;
+    let range = build_range(from.as_deref(), to.as_deref(), key_mode)?;
+
+    let mut builder = DbReader::builder(path, object_store);
+    if let Some(checkpoint_id) = checkpoint {
+        builder = builder.with_checkpoint_id(checkpoint_id);
+    }
+    let reader = builder.build().await?;
+
+    // The scan defaults fetch one SST data block per request with no prefetch, which
+    // turns a cacheless remote scan into thousands of serial round-trips.  Read ahead in
+    // chunks and fetch several in parallel instead.
+    let scan_opts = ScanOptions::default()
+        .with_read_ahead_bytes(4 * 1024 * 1024)
+        .with_max_fetch_tasks(4);
+    let mut scan_iter = match prefix {
+        Some(prefix) => {
+            reader
+                .scan_prefix_with_options(prefix, .., &scan_opts)
+                .await?
+        }
+        None => {
+            reader
+                .scan_with_options::<Vec<u8>, _>(range, &scan_opts)
+                .await?
+        }
+    };
+
+    let mut out = io::BufWriter::new(io::stdout().lock());
+    let mut emitted: u64 = 0;
+    let mut total_bytes: u64 = 0;
+
+    while let Some(kv) = scan_iter.next().await? {
+        if max_keys.is_some_and(|max| emitted >= max) {
+            break;
+        }
+        emitted += 1;
+        total_bytes += (kv.key.len() + kv.value.len()) as u64;
+        if !count {
+            render_key(&mut out, &kv.key, key_mode)?;
+            if !matches!(value_mode, ValueMode::None) {
+                out.write_all(b"\t")?;
+                render_value(&mut out, &kv.value, value_mode)?;
+            }
+            out.write_all(b"\n")?;
+        }
+    }
+    out.flush()?;
+    drop(out);
+    reader.close().await?;
+
+    if count {
+        println!("{emitted} entries, {total_bytes} bytes");
+    }
+    Ok(())
+}
+
+fn build_range(from: Option<&str>, to: Option<&str>, mode: KeyMode) -> Result<KeyRange, String> {
+    let lower = match from {
+        Some(s) => Bound::Included(decode_bound(s, mode)?),
+        None => Bound::Unbounded,
+    };
+    let upper = match to {
+        Some(s) => Bound::Excluded(decode_bound(s, mode)?),
+        None => Bound::Unbounded,
+    };
+    Ok((lower, upper))
+}
+
+fn decode_bound(spec: &str, mode: KeyMode) -> Result<Vec<u8>, String> {
+    match mode {
+        KeyMode::Hex => decode_hex(spec),
+        KeyMode::Utf8 => Ok(spec.as_bytes().to_vec()),
+        KeyMode::Auto => {
+            if spec.starts_with("0x") || spec.starts_with("0X") {
+                decode_hex(spec)
+            } else {
+                Ok(spec.as_bytes().to_vec())
+            }
+        }
+    }
+}
+
+fn render_key(out: &mut impl Write, key: &[u8], mode: KeyMode) -> io::Result<()> {
+    match mode {
+        KeyMode::Hex => write_hex_0x(out, key),
+        KeyMode::Utf8 => out.write_all(String::from_utf8_lossy(key).as_bytes()),
+        KeyMode::Auto => {
+            if is_text_key(key) {
+                out.write_all(key)
+            } else {
+                write_hex_0x(out, key)
+            }
+        }
+    }
+}
+
+fn render_value(out: &mut impl Write, value: &[u8], mode: ValueMode) -> io::Result<()> {
+    match mode {
+        ValueMode::None => Ok(()),
+        ValueMode::Hex => write_hex_0x(out, value),
+        ValueMode::Len => write!(out, "{} bytes", value.len()),
+        ValueMode::Utf8 => out.write_all(String::from_utf8_lossy(value).as_bytes()),
+        ValueMode::Auto => {
+            if is_clean_text(value) {
+                out.write_all(value)
+            } else {
+                write!(out, "<binary {} bytes>", value.len())
+            }
+        }
+    }
+}
+
+fn write_hex_0x(out: &mut impl Write, bytes: &[u8]) -> io::Result<()> {
+    out.write_all(b"0x")?;
+    for b in bytes {
+        write!(out, "{b:02x}")?;
+    }
+    Ok(())
+}
+
+fn is_text_key(key: &[u8]) -> bool {
+    // Exclude a leading 0x so a 0x prefix in the output always means hex.
+    is_clean_text(key) && !key.starts_with(b"0x") && !key.starts_with(b"0X")
+}
+
+fn is_clean_text(value: &[u8]) -> bool {
+    // Reject control chars (tab, newline, NUL) so a value stays on one line.
+    match std::str::from_utf8(value) {
+        Ok(s) => s.chars().all(|c| !c.is_control()),
+        Err(_) => false,
+    }
+}
+
+fn decode_hex(spec: &str) -> Result<Vec<u8>, String> {
+    let s = spec
+        .strip_prefix("0x")
+        .or_else(|| spec.strip_prefix("0X"))
+        .unwrap_or(spec);
+    // Reject non-ASCII before the 2-byte slicing below, which would panic on a multi-byte
+    // UTF-8 char boundary.
+    if !s.is_ascii() {
+        return Err(format!("not a hex string: {spec:?}"));
+    }
+    if !s.len().is_multiple_of(2) {
+        return Err(format!(
+            "hex string must have an even number of digits: {spec:?}"
+        ));
+    }
+    (0..s.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&s[i..i + 2], 16).map_err(|e| format!("invalid hex {spec:?}: {e}"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_str(key: &[u8], mode: KeyMode) -> String {
+        let mut buf = Vec::new();
+        render_key(&mut buf, key, mode).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn value_str(value: &[u8], mode: ValueMode) -> String {
+        let mut buf = Vec::new();
+        render_value(&mut buf, value, mode).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn decode_bound_hex() {
+        assert_eq!(
+            decode_bound("40ff", KeyMode::Hex).unwrap(),
+            vec![0x40, 0xff]
+        );
+        assert_eq!(
+            decode_bound("0x40ff", KeyMode::Hex).unwrap(),
+            vec![0x40, 0xff]
+        );
+        assert!(decode_bound("4", KeyMode::Hex).is_err());
+        assert!(decode_bound("4g", KeyMode::Hex).is_err());
+        assert!(decode_bound("zz", KeyMode::Hex).is_err());
+    }
+
+    #[test]
+    fn decode_bound_utf8() {
+        assert_eq!(
+            decode_bound("0x40", KeyMode::Utf8).unwrap(),
+            b"0x40".to_vec()
+        );
+        assert_eq!(decode_bound("hi", KeyMode::Utf8).unwrap(), b"hi".to_vec());
+    }
+
+    #[test]
+    fn decode_bound_auto() {
+        // Leading 0x -> hex-decoded.
+        assert_eq!(decode_bound("0x40", KeyMode::Auto).unwrap(), vec![0x40]);
+        assert_eq!(decode_bound("0X40", KeyMode::Auto).unwrap(), vec![0x40]);
+        // Otherwise literal bytes.
+        assert_eq!(
+            decode_bound("user", KeyMode::Auto).unwrap(),
+            b"user".to_vec()
+        );
+    }
+
+    #[test]
+    fn build_range_bounds() {
+        assert_eq!(
+            build_range(None, None, KeyMode::Auto).unwrap(),
+            (Bound::Unbounded, Bound::Unbounded)
+        );
+        assert_eq!(
+            build_range(Some("a"), Some("c"), KeyMode::Utf8).unwrap(),
+            (
+                Bound::Included(b"a".to_vec()),
+                Bound::Excluded(b"c".to_vec())
+            )
+        );
+        assert_eq!(
+            build_range(Some("00"), None, KeyMode::Hex).unwrap(),
+            (Bound::Included(vec![0x00]), Bound::Unbounded)
+        );
+    }
+
+    #[test]
+    fn render_key_auto() {
+        assert_eq!(key_str(b"user/42", KeyMode::Auto), "user/42");
+        assert_eq!(key_str(&[0x40, 0x00], KeyMode::Auto), "0x4000");
+        assert_eq!(key_str(b"0xabc", KeyMode::Auto), "0x3078616263");
+    }
+
+    #[test]
+    fn render_key_hex_and_utf8() {
+        assert_eq!(key_str(&[0x40, 0xff], KeyMode::Hex), "0x40ff");
+        assert_eq!(key_str(b"hi", KeyMode::Utf8), "hi");
+        // utf8 mode is lossy on invalid sequences.
+        assert_eq!(key_str(&[0xff], KeyMode::Utf8), "\u{fffd}");
+    }
+
+    #[test]
+    fn render_value_modes() {
+        assert_eq!(value_str(b"hello", ValueMode::Auto), "hello");
+        assert_eq!(
+            value_str(&[0, 1, 2, 3], ValueMode::Auto),
+            "<binary 4 bytes>"
+        );
+        assert_eq!(value_str(&[0x00, 0x01], ValueMode::Hex), "0x0001");
+        assert_eq!(value_str(&[0xff], ValueMode::Utf8), "\u{fffd}");
+        assert_eq!(value_str(&[0, 1, 2], ValueMode::Len), "3 bytes");
+        assert_eq!(value_str(b"anything", ValueMode::None), "");
+    }
+}

--- a/slatedb-cli/tests/scan.rs
+++ b/slatedb-cli/tests/scan.rs
@@ -1,0 +1,120 @@
+//! Integration tests for `slatedb scan`.
+
+use std::process::Command;
+use std::sync::Arc;
+
+use object_store::local::LocalFileSystem;
+use object_store::ObjectStore;
+use slatedb::Db;
+
+async fn populate(root: &std::path::Path) {
+    let store: Arc<dyn ObjectStore> = Arc::new(LocalFileSystem::new_with_prefix(root).unwrap());
+    let db = Db::builder("db", store).build().await.unwrap();
+    db.put(b"user/1", b"alice").await.unwrap();
+    db.put(b"user/2", b"bob").await.unwrap();
+    db.put(b"user/3", b"carol").await.unwrap();
+    db.put(b"config", b"v1").await.unwrap();
+    db.put([0x00u8, 0x42], [0u8, 1, 2, 3]).await.unwrap();
+    db.flush().await.unwrap();
+    db.close().await.unwrap();
+}
+
+fn run(root: &std::path::Path, extra: &[&str]) -> std::process::Output {
+    let mut args = vec!["--path", "db", "scan"];
+    args.extend_from_slice(extra);
+    Command::new(env!("CARGO_BIN_EXE_slatedb"))
+        .args(args)
+        // The CLI reads object-store config from the environment, so set up a filesystem
+        // store at `root`.
+        .env("CLOUD_PROVIDER", "local")
+        .env("LOCAL_PATH", root)
+        .env("RUST_LOG", "error")
+        .output()
+        .unwrap()
+}
+
+fn stdout(out: &std::process::Output) -> String {
+    assert!(out.status.success(), "slatedb scan failed: {out:?}");
+    String::from_utf8(out.stdout.clone()).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn full_scan_renders_text_and_binary() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    let out = stdout(&run(tmp.path(), &[]));
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 5);
+    // Keys sort by raw bytes, so the 0x00-prefixed binary key comes first and
+    // renders as 0x hex with the binary-value marker.
+    assert_eq!(lines[0], "0x0042\t<binary 4 bytes>");
+    // Text keys and values render bare.
+    assert!(out.contains("config\tv1"));
+    assert!(out.contains("user/1\talice"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prefix_filters_keys() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    let out = stdout(&run(tmp.path(), &["--prefix", "user"]));
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines.iter().all(|l| l.starts_with("user/")));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn from_to_bounds_filter_range() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    // [config, user/2) includes config and user/1 (inclusive lower) but stops
+    // before user/2 (exclusive upper); the 0x00 binary key sorts below config.
+    let out = stdout(&run(
+        tmp.path(),
+        &["--from", "config", "--to", "user/2", "--value", "none"],
+    ));
+    assert_eq!(out.lines().collect::<Vec<_>>(), vec!["config", "user/1"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn value_hex_dumps_raw_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    // A 0x-prefixed prefix is hex-decoded in auto mode, selecting the binary key.
+    let out = stdout(&run(tmp.path(), &["--prefix", "0x00", "--value", "hex"]));
+    assert_eq!(out.trim_end(), "0x0042\t0x00010203");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn value_none_prints_keys_only() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    let out = stdout(&run(tmp.path(), &["--prefix", "user", "--value", "none"]));
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(lines.len(), 3);
+    assert!(lines.iter().all(|l| !l.contains('\t')));
+    assert_eq!(lines[0], "user/1");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn count_reports_totals() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    assert!(stdout(&run(tmp.path(), &["--count"])).starts_with("5 entries"));
+    assert!(stdout(&run(tmp.path(), &["--prefix", "user", "--count"])).starts_with("3 entries"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn max_keys_caps_output() {
+    let tmp = tempfile::tempdir().unwrap();
+    populate(tmp.path()).await;
+
+    let out = stdout(&run(tmp.path(), &["--value", "none", "--max-keys", "2"]));
+    assert_eq!(out.lines().count(), 2);
+}


### PR DESCRIPTION
Adds a read-only `scan` command that dumps key/value pairs of a database, in the spirit of RocksDB's `ldb scan`. See #1788 for motivation.

slatedb CLI logs are now written to stderr, so they are not mixed with the output. This could be considered a breaking change, but I believe it's the right thing. If needed, we could apply it only to the `scan` command, but I believe it's better to be consistent.

This makes use of the new range argument to `scan_prefix_with_options()` to implement prefix matching.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏