### PR TITLE
Add `GcFilter` to garbage collector

### DIFF
--- a/slatedb-common/src/object_metadata.rs
+++ b/slatedb-common/src/object_metadata.rs
@@ -5,7 +5,7 @@ use object_store::{path::Path, ObjectMeta};
 ///
 /// This mirrors [`object_store::ObjectMeta`] so SlateDB crates can use a common
 /// public type without exposing the upstream crate's type directly.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectMetadata {
     /// The full path to the object.
     pub location: Path,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -146,8 +146,8 @@ use crate::error::SlateDBError;
 use crate::fence::{WriterFenceResult, WriterFencer};
 use crate::filter_policy::{BloomFilterPolicy, FilterPolicy};
 use crate::format::sst::{BlockTransformer, SsTableFormat};
-use crate::garbage_collector::GarbageCollector;
 use crate::garbage_collector::GC_TASK_NAME;
+use crate::garbage_collector::{GarbageCollector, GcFilter};
 use crate::instrumented_object_store::{InstrumentedObjectStore, ObjectStoreComponent};
 use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::ManifestCore;
@@ -821,6 +821,7 @@ pub struct GarbageCollectorBuilder<P: Into<Path>> {
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     options: GarbageCollectorOptions,
+    gc_filter: Option<Arc<dyn GcFilter>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -833,6 +834,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             main_object_store,
             wal_object_store: None,
             options: GarbageCollectorOptions::default(),
+            gc_filter: None,
             metrics_recorder: Arc::new(NoopMetricsRecorder::new()),
             system_clock: Arc::new(DefaultSystemClock::default()),
             rand: Arc::new(DbRand::default()),
@@ -846,6 +848,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             main_object_store: self.main_object_store,
             wal_object_store: self.wal_object_store,
             options: self.options,
+            gc_filter: self.gc_filter,
             metrics_recorder: self.metrics_recorder,
             system_clock: self.system_clock,
             rand: self.rand,
@@ -855,6 +858,15 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
     /// Sets the options to use for the garbage collector.
     pub fn with_options(mut self, options: GarbageCollectorOptions) -> Self {
         self.options = options;
+        self
+    }
+
+    /// Sets a garbage-collection filter for deletion candidates.
+    ///
+    /// The filter receives objects that SlateDB has already determined are
+    /// eligible for GC and returns the subset that may be physically deleted.
+    pub fn with_gc_filter(mut self, gc_filter: Arc<dyn GcFilter>) -> Self {
+        self.gc_filter = Some(gc_filter);
         self
     }
 
@@ -902,6 +914,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             self.options,
             &recorder,
             self.system_clock,
+            self.gc_filter,
         )
     }
 
@@ -955,6 +968,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             self.options,
             &recorder,
             self.system_clock,
+            self.gc_filter,
         )
     }
 }

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -317,6 +317,7 @@ mod tests {
                 gc_opts,
                 &MetricsRecorderHelper::noop(),
                 Arc::new(DefaultSystemClock::new()),
+                None,
             );
             gc.run_gc_once().await;
             // verify all regular (size > 0) wals up to wal_id are deleted (the wal

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -45,9 +45,12 @@ use wal_gc::{WalGcMode, WalGcTask};
 mod compacted_gc;
 mod compactions_gc;
 mod detach_gc;
+mod filter;
 mod manifest_gc;
 pub mod stats;
 mod wal_gc;
+
+pub use filter::GcFilter;
 
 pub(crate) const DEFAULT_MIN_AGE: Duration = Duration::from_secs(300);
 pub(crate) const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);
@@ -224,6 +227,7 @@ impl GarbageCollector {
         options: GarbageCollectorOptions,
         recorder: &MetricsRecorderHelper,
         system_clock: Arc<dyn SystemClock>,
+        gc_filter: Option<Arc<dyn GcFilter>>,
     ) -> Self {
         let stats = Arc::new(GcStats::new(recorder));
         // The standalone GC lifecycle does not surface a closed result yet, so the
@@ -240,6 +244,7 @@ impl GarbageCollector {
                 stats.clone(),
                 wal_options,
                 WalGcMode::Regular,
+                gc_filter.clone(),
             )
         });
         let wal_fence_gc_task = options.wal_fence_options.map(|wal_fence_options| {
@@ -249,6 +254,7 @@ impl GarbageCollector {
                 stats.clone(),
                 wal_fence_options,
                 WalGcMode::Fence,
+                gc_filter.clone(),
             )
         });
         let compacted_gc_task = options.compacted_options.map(|compacted_options| {
@@ -258,6 +264,7 @@ impl GarbageCollector {
                 table_store.clone(),
                 stats.clone(),
                 compacted_options,
+                gc_filter.clone(),
             )
         });
         let compactions_gc_task = options.compactions_options.map(|compactions_options| {
@@ -265,10 +272,16 @@ impl GarbageCollector {
                 compactions_store.clone(),
                 stats.clone(),
                 compactions_options,
+                gc_filter.clone(),
             )
         });
         let manifest_gc_task = options.manifest_options.map(|manifest_options| {
-            ManifestGcTask::new(manifest_store.clone(), stats.clone(), manifest_options)
+            ManifestGcTask::new(
+                manifest_store.clone(),
+                stats.clone(),
+                manifest_options,
+                gc_filter.clone(),
+            )
         });
         let detach_gc_task = options.detach_options.map(|detach_options| {
             DetachGcTask::new(
@@ -437,6 +450,7 @@ mod tests {
     use slatedb_common::metrics::{
         lookup_metric_with_labels, DefaultMetricsRecorder, MetricsRecorderHelper,
     };
+    use slatedb_common::ObjectMetadata;
 
     use crate::format::sst::SsTableFormat;
     use crate::{
@@ -447,6 +461,20 @@ mod tests {
         },
         tablestore::TableStore,
     };
+
+    struct LocationGcFilter {
+        allowed_locations: HashSet<Path>,
+    }
+
+    #[async_trait]
+    impl GcFilter for LocationGcFilter {
+        async fn filter(&self, candidates: HashSet<ObjectMetadata>) -> HashSet<ObjectMetadata> {
+            candidates
+                .into_iter()
+                .filter(|metadata| self.allowed_locations.contains(&metadata.location))
+                .collect()
+        }
+    }
 
     #[tokio::test]
     async fn test_collect_garbage_manifest() {
@@ -1134,6 +1162,7 @@ mod tests {
             gc_opts,
             &MetricsRecorderHelper::noop(),
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1201,6 +1230,7 @@ mod tests {
             gc_opts,
             &helper,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1263,6 +1293,7 @@ mod tests {
             gc_opts,
             &MetricsRecorderHelper::noop(),
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1340,6 +1371,7 @@ mod tests {
             gc_opts,
             &MetricsRecorderHelper::noop(),
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1793,6 +1825,7 @@ mod tests {
             gc_opts,
             recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1867,6 +1900,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         // Send a WAL GC message. Correct behavior: only WAL GC runs.
@@ -1936,6 +1970,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
         gc.run_gc_once().await;
 
@@ -1984,6 +2019,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         let intervals: Vec<_> = gc.tickers().into_iter().map(|def| def.interval).collect();
@@ -2036,6 +2072,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
         gc.start().expect("failed to start garbage collector");
         gc.stop().await.expect("failed to stop garbage collector");
@@ -2256,6 +2293,242 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_gc_filter_can_reject_all_directory_gc_deletes() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+        let now = DefaultSystemClock::default().now();
+        let expired_ms = (now - TimeDelta::seconds(7200)).timestamp_millis() as u64;
+        let unexpired_ms = (now - TimeDelta::seconds(1800)).timestamp_millis() as u64;
+
+        // Create regular WALs and a fence WAL, then age the GC-eligible ones.
+        let old_wal_id = SsTableId::Wal(1);
+        write_sst(table_store.clone(), &old_wal_id).await.unwrap();
+        let recent_wal_id = SsTableId::Wal(2);
+        write_sst(table_store.clone(), &recent_wal_id)
+            .await
+            .unwrap();
+        let old_fence_id = SsTableId::Wal(3);
+        table_store.write_wal_fence(3).await.unwrap();
+
+        set_modified(
+            local_object_store.clone(),
+            &path_resolver.table_path(&old_wal_id),
+            86400,
+        );
+        set_modified(
+            local_object_store.clone(),
+            &path_resolver.table_path(&old_fence_id),
+            86400,
+        );
+
+        // Create one inactive compacted SST that would normally be collected.
+        let inactive_expired_handle = create_sst(table_store.clone(), expired_ms).await;
+        let active_l0_handle = create_sst(table_store.clone(), unexpired_ms).await;
+
+        // Create two manifests so the older manifest is eligible for manifest GC.
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 4;
+        state.next_wal_sst_id = 5;
+        Arc::make_mut(&mut state.tree)
+            .l0
+            .push_back(SsTableView::identity(active_l0_handle));
+        let mut stored_manifest = StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        set_modified(
+            local_object_store.clone(),
+            &Path::from(format!("manifest/{:020}.manifest", 1)),
+            86400,
+        );
+
+        // Create compactions files and age all of them so every non-latest file is eligible.
+        let mut stored_compactions = StoredCompactions::create(
+            compactions_store.clone(),
+            stored_manifest.manifest().compactor_epoch,
+        )
+        .await
+        .unwrap();
+        let mut compactions_dirty = stored_compactions.prepare_dirty().unwrap();
+        compactions_dirty.value.insert(Compaction::new(
+            ulid::Ulid::from_parts(now.timestamp_millis() as u64, 0),
+            CompactionSpec::new(vec![SourceId::SortedRun(0)], 0),
+        ));
+        stored_compactions.update(compactions_dirty).await.unwrap();
+
+        let compaction_ids = compactions_store
+            .list_compactions(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<Vec<_>>();
+        for id in &compaction_ids {
+            set_modified(
+                local_object_store.clone(),
+                &Path::from(format!("compactions/{id:020}.compactions")),
+                86400,
+            );
+        }
+
+        // Use an empty location filter to reject every GC candidate.
+        let options = GarbageCollectorDirectoryOptions {
+            min_age: Duration::from_secs(3600),
+            interval: None,
+            dry_run: false,
+        };
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: Some(options),
+            wal_options: Some(options),
+            wal_fence_options: Some(options),
+            compacted_options: Some(options),
+            compactions_options: Some(options),
+            detach_options: None,
+            metric_level: None,
+        };
+        let recorder = MetricsRecorderHelper::noop();
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store.clone(),
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &recorder,
+            Arc::new(DefaultSystemClock::default()),
+            Some(Arc::new(LocationGcFilter {
+                allowed_locations: HashSet::new(),
+            })),
+        );
+
+        // Run every directory GC task with candidates present for each task type.
+        gc.run_gc_once().await;
+
+        // The filter should prevent manifest deletion.
+        let manifests = manifest_store.list_manifests(..).await.unwrap();
+        assert_eq!(manifests.len(), 2);
+
+        // The filter should prevent both WAL and fence WAL deletion.
+        let wal_ids = table_store
+            .list_wal_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<HashSet<_>>();
+        assert!(wal_ids.contains(&old_wal_id));
+        assert!(wal_ids.contains(&recent_wal_id));
+        assert!(wal_ids.contains(&old_fence_id));
+
+        // The filter should prevent compacted SST deletion.
+        let compacted_ids = table_store
+            .list_compacted_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<HashSet<_>>();
+        assert!(compacted_ids.contains(&inactive_expired_handle.id));
+
+        // The filter should prevent compactions file deletion.
+        assert_eq!(
+            compactions_store.list_compactions(..).await.unwrap().len(),
+            compaction_ids.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gc_filter_allows_subset_and_stats_count_successful_deletes() {
+        let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
+        let path_resolver = PathResolver::new("/");
+
+        // Create three old WALs below the replay boundary so all would be eligible
+        // without a filter. The middle one is the only filter-approved delete.
+        let rejected_before_wal_id = SsTableId::Wal(1);
+        let allowed_wal_id = SsTableId::Wal(2);
+        let rejected_after_wal_id = SsTableId::Wal(3);
+        for id in [
+            rejected_before_wal_id,
+            allowed_wal_id,
+            rejected_after_wal_id,
+        ] {
+            write_sst(table_store.clone(), &id).await.unwrap();
+            set_modified(
+                local_object_store.clone(),
+                &path_resolver.table_path(&id),
+                86400,
+            );
+        }
+
+        // Keep the replay boundary above every test WAL so boundary retention
+        // cannot explain any remaining WAL.
+        let mut state = ManifestCore::new();
+        state.replay_after_wal_id = 4;
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            state,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        let gc_opts = GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: Some(GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(3600),
+                interval: None,
+                dry_run: false,
+            }),
+            wal_fence_options: None,
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+            metric_level: None,
+        };
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(recorder.clone(), Default::default());
+        let gc = GarbageCollector::new(
+            manifest_store.clone(),
+            compactions_store,
+            table_store.clone(),
+            Arc::new(object_store::memory::InMemory::new()),
+            gc_opts,
+            &helper,
+            Arc::new(DefaultSystemClock::default()),
+            Some(Arc::new(LocationGcFilter {
+                allowed_locations: HashSet::from([path_resolver.table_path(&allowed_wal_id)]),
+            })),
+        );
+
+        // Run WAL GC with a filter that permits only one of the eligible WALs.
+        gc.run_gc_once().await;
+
+        // Only the two filter-rejected WALs should remain, and stats should count one delete.
+        let wal_ids = table_store
+            .list_wal_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|metadata| metadata.id)
+            .collect::<Vec<_>>();
+        assert_eq!(wal_ids, vec![rejected_before_wal_id, rejected_after_wal_id]);
+        assert_eq!(
+            lookup_metric_with_labels(
+                &recorder,
+                crate::garbage_collector::stats::DELETED_COUNT,
+                &[("resource", "wal")]
+            ),
+            Some(1)
+        );
+    }
+
+    #[tokio::test]
     async fn test_dry_run_skips_directory_gc_deletes() {
         let (manifest_store, compactions_store, table_store, local_object_store) = build_objects();
         let path_resolver = PathResolver::new("/");
@@ -2360,6 +2633,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
         );
 
         gc.run_gc_once().await;

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -13,7 +13,8 @@ use log::error;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::{GcStats, GcTask};
+use super::filter::retain_allowed_by_gc_filter;
+use super::{GcFilter, GcStats, GcTask};
 
 #[derive(Clone)]
 pub(crate) struct CompactedGcTask {
@@ -22,6 +23,7 @@ pub(crate) struct CompactedGcTask {
     table_store: Arc<TableStore>,
     stats: Arc<GcStats>,
     compacted_options: GarbageCollectorDirectoryOptions,
+    gc_filter: Option<Arc<dyn GcFilter>>,
 }
 
 impl std::fmt::Debug for CompactedGcTask {
@@ -39,6 +41,7 @@ impl CompactedGcTask {
         table_store: Arc<TableStore>,
         stats: Arc<GcStats>,
         compacted_options: GarbageCollectorDirectoryOptions,
+        gc_filter: Option<Arc<dyn GcFilter>>,
     ) -> Self {
         CompactedGcTask {
             manifest_store,
@@ -46,6 +49,7 @@ impl CompactedGcTask {
             table_store,
             stats,
             compacted_options,
+            gc_filter,
         }
     }
 
@@ -206,17 +210,23 @@ impl GcTask for CompactedGcTask {
             compaction_low_watermark_dt,
             newest_l0_dt,
         );
-        let sst_ids_to_delete = self
+        let ssts_to_delete = self
             .table_store
             // List all SSTs in the table store
             .list_compacted_ssts(..)
             .await?
             .into_iter()
-            .map(|sst| sst.id)
             // Filter out SSTs that were more recently created than the cutoff_dt
-            .filter(|id| DateTime::<Utc>::from(id.unwrap_compacted_id().datetime()) < cutoff_dt)
+            .filter(|sst| {
+                DateTime::<Utc>::from(sst.id.unwrap_compacted_id().datetime()) < cutoff_dt
+            })
             // Filter out SSTs that are active in the manifest (including actively checkpointed SSTs)
-            .filter(|id| !active_ssts.contains(id))
+            .filter(|sst| !active_ssts.contains(&sst.id))
+            .collect::<Vec<_>>();
+        let ssts_to_delete = retain_allowed_by_gc_filter(&self.gc_filter, ssts_to_delete).await;
+        let sst_ids_to_delete = ssts_to_delete
+            .into_iter()
+            .map(|sst| sst.id)
             .collect::<Vec<_>>();
 
         if self.compacted_options.dry_run && !sst_ids_to_delete.is_empty() {
@@ -350,6 +360,7 @@ mod tests {
             table_store.clone(),
             stats,
             opts,
+            None,
         );
 
         let utc_now = DateTime::<Utc>::from_timestamp_millis(10_000).unwrap();
@@ -455,6 +466,7 @@ mod tests {
             table_store.clone(),
             stats,
             opts,
+            None,
         );
 
         let utc_now = DateTime::<Utc>::from_timestamp_millis(10_000).unwrap();
@@ -556,6 +568,7 @@ mod tests {
             table_store.clone(),
             stats,
             opts,
+            None,
         );
 
         // Run GC at a fixed time and verify only the SST strictly
@@ -649,6 +662,7 @@ mod tests {
             table_store.clone(),
             stats,
             opts,
+            None,
         );
 
         let utc_now = DateTime::<Utc>::from_timestamp_millis(10_000).unwrap();

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -83,10 +83,9 @@ impl GcTask for CompactionsGcTask {
                 utc_now.signed_duration_since(compactions_metadata.metadata.last_modified) > min_age
             })
             .collect::<Vec<_>>();
-        let compactions_to_delete =
-            retain_allowed_by_gc_filter(&self.gc_filter, compactions_to_delete).await;
 
-        // Advance the boundary to the latest compactions file that the filter allowed for deletion.
+        // Advance the boundary to the latest compactions file selected by the GC model. The
+        // optional GC filter only gates the final deletion pass.
         if let Some(boundary) = compactions_to_delete
             .iter()
             .map(|compactions_metadata| compactions_metadata.id)
@@ -94,6 +93,8 @@ impl GcTask for CompactionsGcTask {
         {
             self.compactions_store.advance_boundary(boundary).await?;
         }
+        let compactions_to_delete =
+            retain_allowed_by_gc_filter(&self.gc_filter, compactions_to_delete).await;
         if self.compactions_options.dry_run && !compactions_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping compactions deletion [count={}]",
@@ -134,10 +135,22 @@ impl GcTask for CompactionsGcTask {
 mod tests {
     use super::*;
     use crate::compactions_store::{CompactionsStore, StoredCompactions};
+    use async_trait::async_trait;
     use chrono::TimeDelta;
     use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
     use slatedb_common::metrics::MetricsRecorderHelper;
+    use slatedb_common::ObjectMetadata;
+    use std::collections::HashSet;
     use std::time::Duration;
+
+    struct DenyAllGcFilter;
+
+    #[async_trait]
+    impl GcFilter for DenyAllGcFilter {
+        async fn filter(&self, _candidates: HashSet<ObjectMetadata>) -> HashSet<ObjectMetadata> {
+            HashSet::new()
+        }
+    }
 
     #[tokio::test]
     async fn test_collect_advances_boundary_for_old_compactions_files() {
@@ -190,5 +203,60 @@ mod tests {
                 .map(|compactions| compactions.id)
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn test_collect_advances_boundary_before_filtering_compactions_files() {
+        let object_store = Arc::new(InMemory::new());
+        let compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from("/root"),
+            object_store.clone(),
+        ));
+        let mut stored_compactions = StoredCompactions::create(compactions_store.clone(), 0)
+            .await
+            .unwrap();
+        stored_compactions
+            .update(stored_compactions.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        stored_compactions
+            .update(stored_compactions.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+
+        let recorder = MetricsRecorderHelper::noop();
+        let task = CompactionsGcTask::new(
+            compactions_store.clone(),
+            Arc::new(GcStats::new(&recorder)),
+            GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(1),
+                interval: None,
+                dry_run: false,
+            },
+            Some(Arc::new(DenyAllGcFilter) as Arc<dyn GcFilter>),
+        );
+        task.collect(Utc::now() + TimeDelta::hours(1))
+            .await
+            .unwrap();
+
+        let raw_boundary = object_store
+            .get(&Path::from("/root/gc/compactions.boundary"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!("2", std::str::from_utf8(&raw_boundary).unwrap());
+
+        assert!(compactions_store
+            .try_read_compactions(1)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(compactions_store
+            .try_read_compactions(2)
+            .await
+            .unwrap()
+            .is_some());
     }
 }

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -26,13 +26,15 @@ use chrono::{DateTime, Utc};
 use log::error;
 use std::sync::Arc;
 
-use super::{GcStats, GcTask};
+use super::filter::retain_allowed_by_gc_filter;
+use super::{GcFilter, GcStats, GcTask};
 
 #[derive(Clone)]
 pub(crate) struct CompactionsGcTask {
     compactions_store: Arc<CompactionsStore>,
     stats: Arc<GcStats>,
     compactions_options: GarbageCollectorDirectoryOptions,
+    gc_filter: Option<Arc<dyn GcFilter>>,
 }
 
 impl std::fmt::Debug for CompactionsGcTask {
@@ -48,11 +50,13 @@ impl CompactionsGcTask {
         compactions_store: Arc<CompactionsStore>,
         stats: Arc<GcStats>,
         compactions_options: GarbageCollectorDirectoryOptions,
+        gc_filter: Option<Arc<dyn GcFilter>>,
     ) -> Self {
         Self {
             compactions_store,
             stats,
             compactions_options,
+            gc_filter,
         }
     }
 
@@ -72,18 +76,6 @@ impl GcTask for CompactionsGcTask {
         // Remove the last element so we never delete the latest compactions file
         compactions_metadata_list.pop();
 
-        // Advance the boundary to the latest compactions file that is older than min_age
-        if let Some(boundary) = compactions_metadata_list
-            .iter()
-            .filter(|compactions_metadata| {
-                utc_now.signed_duration_since(compactions_metadata.metadata.last_modified) > min_age
-            })
-            .map(|compactions_metadata| compactions_metadata.id)
-            .max()
-        {
-            self.compactions_store.advance_boundary(boundary).await?;
-        }
-
         // Delete compactions files older than min_age
         let compactions_to_delete = compactions_metadata_list
             .into_iter()
@@ -91,6 +83,17 @@ impl GcTask for CompactionsGcTask {
                 utc_now.signed_duration_since(compactions_metadata.metadata.last_modified) > min_age
             })
             .collect::<Vec<_>>();
+        let compactions_to_delete =
+            retain_allowed_by_gc_filter(&self.gc_filter, compactions_to_delete).await;
+
+        // Advance the boundary to the latest compactions file that the filter allowed for deletion.
+        if let Some(boundary) = compactions_to_delete
+            .iter()
+            .map(|compactions_metadata| compactions_metadata.id)
+            .max()
+        {
+            self.compactions_store.advance_boundary(boundary).await?;
+        }
         if self.compactions_options.dry_run && !compactions_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping compactions deletion [count={}]",
@@ -164,6 +167,7 @@ mod tests {
                 interval: None,
                 dry_run: false,
             },
+            None,
         );
         task.collect(Utc::now() + TimeDelta::hours(1))
             .await

--- a/slatedb/src/garbage_collector/filter.rs
+++ b/slatedb/src/garbage_collector/filter.rs
@@ -1,0 +1,131 @@
+use async_trait::async_trait;
+use log::warn;
+use slatedb_common::{IdentifiedObjectMetadata, ObjectMetadata};
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Filters garbage-collection deletion candidates.
+///
+/// Implementations receive the complete set of objects that SlateDB has already
+/// determined are eligible for deletion. The returned set is the subset that may
+/// actually be deleted. Objects returned by the filter that were not in the input
+/// are ignored.
+#[async_trait]
+pub trait GcFilter: Send + Sync {
+    /// Returns the subset of `candidates` that may be deleted.
+    async fn filter(&self, candidates: HashSet<ObjectMetadata>) -> HashSet<ObjectMetadata>;
+}
+
+pub(crate) async fn retain_allowed_by_gc_filter<Id>(
+    gc_filter: &Option<Arc<dyn GcFilter>>,
+    candidates: Vec<IdentifiedObjectMetadata<Id>>,
+) -> Vec<IdentifiedObjectMetadata<Id>> {
+    let Some(gc_filter) = gc_filter else {
+        return candidates;
+    };
+
+    let candidate_metadata = candidates
+        .iter()
+        .map(|candidate| candidate.metadata.clone())
+        .collect::<HashSet<_>>();
+    let allowed_metadata = gc_filter.filter(candidate_metadata.clone()).await;
+    let mut sanitized_allowed_metadata = HashSet::with_capacity(allowed_metadata.len());
+    for metadata in allowed_metadata {
+        if candidate_metadata.contains(&metadata) {
+            sanitized_allowed_metadata.insert(metadata);
+        } else {
+            warn!(
+                "GC filter returned non-candidate object; dropping [location={}, size={}]",
+                metadata.location, metadata.size
+            );
+        }
+    }
+
+    candidates
+        .into_iter()
+        .filter(|candidate| sanitized_allowed_metadata.contains(&candidate.metadata))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use object_store::path::Path;
+
+    struct StaticGcFilter {
+        allowed: HashSet<ObjectMetadata>,
+    }
+
+    #[async_trait]
+    impl GcFilter for StaticGcFilter {
+        async fn filter(&self, _candidates: HashSet<ObjectMetadata>) -> HashSet<ObjectMetadata> {
+            self.allowed.clone()
+        }
+    }
+
+    fn metadata(location: &str) -> ObjectMetadata {
+        ObjectMetadata {
+            location: Path::from(location),
+            last_modified: DateTime::<Utc>::UNIX_EPOCH,
+            size: 1,
+            e_tag: None,
+            version: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_retain_allowed_by_gc_filter_without_filter_keeps_all_candidates() {
+        let metadata_a = metadata("a");
+        let metadata_b = metadata("b");
+        let candidates = vec![
+            IdentifiedObjectMetadata::new(1, metadata_a.clone()),
+            IdentifiedObjectMetadata::new(2, metadata_b.clone()),
+        ];
+
+        let retained = retain_allowed_by_gc_filter(&None, candidates).await;
+
+        assert_eq!(
+            retained,
+            vec![
+                IdentifiedObjectMetadata::new(1, metadata_a),
+                IdentifiedObjectMetadata::new(2, metadata_b),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_retain_allowed_by_gc_filter_keeps_only_allowed_candidates() {
+        let metadata_a = metadata("a");
+        let metadata_b = metadata("b");
+        let candidates = vec![
+            IdentifiedObjectMetadata::new(1, metadata_a),
+            IdentifiedObjectMetadata::new(2, metadata_b.clone()),
+        ];
+        let gc_filter = Some(Arc::new(StaticGcFilter {
+            allowed: HashSet::from([metadata_b.clone()]),
+        }) as Arc<dyn GcFilter>);
+
+        let retained = retain_allowed_by_gc_filter(&gc_filter, candidates).await;
+
+        assert_eq!(retained, vec![IdentifiedObjectMetadata::new(2, metadata_b)]);
+    }
+
+    #[tokio::test]
+    async fn test_retain_allowed_by_gc_filter_drops_non_candidate_returns() {
+        let metadata_a = metadata("a");
+        let metadata_b = metadata("b");
+        let injected = metadata("injected");
+        let candidates = vec![
+            IdentifiedObjectMetadata::new(1, metadata_a.clone()),
+            IdentifiedObjectMetadata::new(2, metadata_b),
+        ];
+        let gc_filter = Some(Arc::new(StaticGcFilter {
+            allowed: HashSet::from([metadata_a.clone(), injected]),
+        }) as Arc<dyn GcFilter>);
+
+        let retained = retain_allowed_by_gc_filter(&gc_filter, candidates).await;
+
+        assert_eq!(retained, vec![IdentifiedObjectMetadata::new(1, metadata_a)]);
+    }
+}

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -79,10 +79,9 @@ impl GcTask for ManifestGcTask {
                         > min_age
             })
             .collect::<Vec<_>>();
-        let manifests_to_delete =
-            retain_allowed_by_gc_filter(&self.gc_filter, manifests_to_delete).await;
 
-        // Advance the boundary to the latest manifest that the filter allowed for deletion.
+        // Advance the boundary to the latest manifest selected by the GC model. The optional GC
+        // filter only gates the final deletion pass.
         if let Some(boundary) = manifests_to_delete
             .iter()
             .map(|manifest_metadata| manifest_metadata.id)
@@ -90,6 +89,8 @@ impl GcTask for ManifestGcTask {
         {
             self.manifest_store.advance_boundary(boundary).await?;
         }
+        let manifests_to_delete =
+            retain_allowed_by_gc_filter(&self.gc_filter, manifests_to_delete).await;
         if self.manifest_options.dry_run && !manifests_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping manifest deletion [count={}]",
@@ -133,11 +134,22 @@ mod tests {
         store::{ManifestStore, StoredManifest},
         ManifestCore,
     };
+    use async_trait::async_trait;
     use chrono::TimeDelta;
     use object_store::{memory::InMemory, path::Path, ObjectStoreExt};
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::MetricsRecorderHelper;
+    use slatedb_common::ObjectMetadata;
     use std::time::Duration;
+
+    struct DenyAllGcFilter;
+
+    #[async_trait]
+    impl GcFilter for DenyAllGcFilter {
+        async fn filter(&self, _candidates: HashSet<ObjectMetadata>) -> HashSet<ObjectMetadata> {
+            HashSet::new()
+        }
+    }
 
     #[tokio::test]
     async fn test_collect_advances_boundary_for_old_manifest_files() {
@@ -194,5 +206,56 @@ mod tests {
                 .map(|manifest| manifest.id)
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn test_collect_advances_boundary_before_filtering_manifest_files() {
+        let object_store = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from("/root"),
+            object_store.clone(),
+        ));
+        let mut stored_manifest = StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+
+        let recorder = MetricsRecorderHelper::noop();
+        let task = ManifestGcTask::new(
+            manifest_store.clone(),
+            Arc::new(GcStats::new(&recorder)),
+            GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(1),
+                interval: None,
+                dry_run: false,
+            },
+            Some(Arc::new(DenyAllGcFilter) as Arc<dyn GcFilter>),
+        );
+        task.collect(Utc::now() + TimeDelta::hours(1))
+            .await
+            .unwrap();
+
+        let raw_boundary = object_store
+            .get(&Path::from("/root/gc/manifest.boundary"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!("2", std::str::from_utf8(&raw_boundary).unwrap());
+
+        assert!(manifest_store.try_read_manifest(1).await.unwrap().is_some());
+        assert!(manifest_store.try_read_manifest(2).await.unwrap().is_some());
     }
 }

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -6,13 +6,15 @@ use log::error;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use super::{GcStats, GcTask};
+use super::filter::retain_allowed_by_gc_filter;
+use super::{GcFilter, GcStats, GcTask};
 
 #[derive(Clone)]
 pub(crate) struct ManifestGcTask {
     manifest_store: Arc<ManifestStore>,
     stats: Arc<GcStats>,
     manifest_options: GarbageCollectorDirectoryOptions,
+    gc_filter: Option<Arc<dyn GcFilter>>,
 }
 
 impl std::fmt::Debug for ManifestGcTask {
@@ -28,11 +30,13 @@ impl ManifestGcTask {
         manifest_store: Arc<ManifestStore>,
         stats: Arc<GcStats>,
         manifest_options: GarbageCollectorDirectoryOptions,
+        gc_filter: Option<Arc<dyn GcFilter>>,
     ) -> Self {
         ManifestGcTask {
             manifest_store,
             stats,
             manifest_options,
+            gc_filter,
         }
     }
 
@@ -65,18 +69,6 @@ impl GcTask for ManifestGcTask {
             .map(|checkpoint| checkpoint.manifest_id)
             .collect();
 
-        // Advance the boundary to the latest manifest that is older than min_age
-        if let Some(boundary) = manifest_metadata_list
-            .iter()
-            .filter(|manifest_metadata| {
-                utc_now.signed_duration_since(manifest_metadata.metadata.last_modified) > min_age
-            })
-            .map(|manifest_metadata| manifest_metadata.id)
-            .max()
-        {
-            self.manifest_store.advance_boundary(boundary).await?;
-        }
-
         // Delete manifests older than min_age
         let manifests_to_delete = manifest_metadata_list
             .into_iter()
@@ -87,6 +79,17 @@ impl GcTask for ManifestGcTask {
                         > min_age
             })
             .collect::<Vec<_>>();
+        let manifests_to_delete =
+            retain_allowed_by_gc_filter(&self.gc_filter, manifests_to_delete).await;
+
+        // Advance the boundary to the latest manifest that the filter allowed for deletion.
+        if let Some(boundary) = manifests_to_delete
+            .iter()
+            .map(|manifest_metadata| manifest_metadata.id)
+            .max()
+        {
+            self.manifest_store.advance_boundary(boundary).await?;
+        }
         if self.manifest_options.dry_run && !manifests_to_delete.is_empty() {
             log::info!(
                 "dry run: skipping manifest deletion [count={}]",
@@ -168,6 +171,7 @@ mod tests {
                 interval: None,
                 dry_run: false,
             },
+            None,
         );
         task.collect(Utc::now() + TimeDelta::hours(1))
             .await

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -5,11 +5,12 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use log::error;
-use slatedb_common::object_metadata::IdentifiedObjectMetadata;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use super::{GcStats, GcTask};
+use super::filter::retain_allowed_by_gc_filter;
+use super::{GcFilter, GcStats, GcTask};
+use slatedb_common::object_metadata::IdentifiedObjectMetadata;
 
 /// Selects which class of WAL object a [`WalGcTask`] collects.
 ///
@@ -36,6 +37,7 @@ pub(crate) struct WalGcTask {
     stats: Arc<GcStats>,
     wal_options: GarbageCollectorDirectoryOptions,
     mode: WalGcMode,
+    gc_filter: Option<Arc<dyn GcFilter>>,
 }
 
 impl std::fmt::Debug for WalGcTask {
@@ -54,6 +56,7 @@ impl WalGcTask {
         stats: Arc<GcStats>,
         wal_options: GarbageCollectorDirectoryOptions,
         mode: WalGcMode,
+        gc_filter: Option<Arc<dyn GcFilter>>,
     ) -> Self {
         WalGcTask {
             manifest_store,
@@ -61,6 +64,7 @@ impl WalGcTask {
             stats,
             wal_options,
             mode,
+            gc_filter,
         }
     }
 
@@ -99,7 +103,7 @@ impl GcTask for WalGcTask {
             .await?;
         let last_compacted_wal_sst_id = latest_manifest.manifest.core.replay_after_wal_id;
         let min_age = self.wal_sst_min_age();
-        let sst_ids_to_delete = self
+        let ssts_to_delete = self
             .table_store
             .list_wal_ssts(..last_compacted_wal_sst_id)
             .await?
@@ -119,6 +123,10 @@ impl GcTask for WalGcTask {
                     &active_manifests,
                 )
             })
+            .collect::<Vec<_>>();
+        let ssts_to_delete = retain_allowed_by_gc_filter(&self.gc_filter, ssts_to_delete).await;
+        let sst_ids_to_delete = ssts_to_delete
+            .into_iter()
             .map(|wal_sst| wal_sst.id)
             .collect::<Vec<_>>();
 

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -59,7 +59,7 @@ pub use filter_policy::{
 };
 pub use format::sst::BlockTransformer;
 pub use garbage_collector::stats as garbage_collector_stats;
-pub use garbage_collector::GarbageCollectorBuilder;
+pub use garbage_collector::{GarbageCollectorBuilder, GcFilter};
 pub use instrumented_object_store::stats as instrumented_object_store_stats;
 pub use iter::IterationOrder;
 pub use manifest::VersionedManifest;

--- a/website/src/content/docs/docs/design/gc.mdx
+++ b/website/src/content/docs/docs/design/gc.mdx
@@ -9,6 +9,26 @@ The garbage collector has a configurable minimum age and interval for each file 
 
 Each garbage collection directory type supports a `dry_run` option. When enabled, the collector logs files that would be deleted without actually deleting them. This is useful for testing or verifying garbage collection behavior before enabling actual deletion.
 
+## Filtering Deletion Candidates
+
+SlateDB supports custom filtering of garbage collection candidates through the `GcFilter` trait. This allows users to intercept files before deletion and approve or reject them based on custom logic.
+
+The `GcFilter::filter` method receives a set of files that SlateDB has already determined are eligible for deletion (files older than `min_age` that are not referenced by any active manifest or checkpoint). The filter returns the subset of files that may be physically deleted. Any files not returned by the filter are retained.
+
+A common use case for `GcFilter` is verifying that files have been replicated to another bucket before allowing deletion. For example, in a mirror-maker-like scenario for cross-region or cross-cloud replication, the filter can check that a file exists in the destination bucket before approving it for deletion from the source.
+
+To configure a filter, use the `with_gc_filter()` method on `GarbageCollectorBuilder`:
+
+```rust
+let gc_filter = Arc::new(MyGcFilter::new());
+let gc = GarbageCollectorBuilder::new(path, object_store)
+    .with_gc_filter(gc_filter)
+    .build()
+    .await?;
+```
+
+The filter is optional. If no filter is configured, garbage collection proceeds normally based on age and reference checks alone.
+
 Below is a diagram illustrating the high-level flow of garbage collection in SlateDB:
 
 ```mermaid
@@ -19,17 +39,20 @@ flowchart TD
     B --> C[Run WAL SST GC Task]
     C --> C1[List WAL SSTs older than last compacted ID]
     C1 --> C2[Filter by min_age and active references]
-    C2 --> C3[Delete eligible WAL SSTs]
+    C2 --> C2a[Apply GcFilter if configured]
+    C2a --> C3[Delete eligible WAL SSTs]
 
     B --> D[Run Compacted SST GC Task]
     D --> D1[List all compacted and L0 SSTs]
     D1 --> D2[Gather active SST IDs from manifests]
-    D2 --> D3[Delete SSTs not referenced and older than min_age]
+    D2 --> D2a[Apply GcFilter if configured]
+    D2a --> D3[Delete SSTs not referenced and older than min_age]
 
     B --> E[Run Manifest GC Task]
     E --> E1["List all manifests (exclude latest)"]
     E1 --> E2[Gather active manifest IDs from checkpoints]
-    E2 --> E3[Delete manifests not referenced and older than min_age]
+    E2 --> E2a[Apply GcFilter if configured]
+    E2a --> E3[Delete manifests not referenced and older than min_age]
 
     C3 & D3 & E3 --> G[Wait for Next Interval or Shutdown]
 ```


### PR DESCRIPTION
## Summary

This PR adds a callback to `GarbageCollector` called `GcFilter::filter`. The `filter` receives a list of files that a `GcTask` would otherwise delete and returns a set of files approved for deletion.

I found this to be useful when exploring a miror-maker-like use case. The idea was to replicate SlateDB data from one bucket to another (in another region or on another cloud provider). `GcFilter` allows users to verify that files have actually been replicated and reject deletion in cases where they haven't (or optionally replicate in-process).

This change has a few side-effects:

1. If users write a slow `GcFilter`, it will slow down garbage collection. Not much we can do about that. The impact is mostly that `list()` calls will be slower and they'll pay more for (useless) storage.
2. The boundary maintenance changes slightly. We now take the max of `GcFilter`-approved deletion files to use for the boundary update in .compactions/.manifest boundary maintenance. This means the boundary might be held back farther than it otherwise would. Shouldn't impact much.

Also, the bindings are not updated to support this. Neither GC nor compactor instantiation are currently supported in the bindings.

## Changes

- Add `filter.rs` with `GcFilter` and `retain_allowed_by_gc_filter` helper.
- Update all file-based `GcTask`s
- Add a couple tests

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
