### PR TITLE
feat: add ByteRangeBounds to improve scan and scan_prefix ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Error> {
     kv_store.put(b"test_key4", b"test_value4").await?;
 
     // Scan over unbound range
-    let mut iter = kv_store.scan::<Vec<u8>, _>(..).await?;
+    let mut iter = kv_store.scan(..).await?;
     let mut count = 1;
     while let Ok(Some(item)) = iter.next().await {
         assert_eq!(
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Error> {
     assert_eq!(item.value.as_ref(), b"test_value2");
 
     // Seek ahead to next key
-    let mut iter = kv_store.scan::<Vec<u8>, _>(..).await?;
+    let mut iter = kv_store.scan(..).await?;
     let next_key = b"test_key4";
     iter.seek(next_key).await?;
     let item = iter.next().await?.expect("missing test_key4");

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -87,7 +87,7 @@ impl Db {
     /// Scans rows inside `range`.
     pub async fn scan(&self, range: KeyRange) -> Result<Arc<DbIterator>, Error> {
         let range = range.into_bounds()?;
-        let iter = self.inner.scan::<Vec<u8>, _>(range).await?;
+        let iter = self.inner.scan(range).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 
@@ -99,10 +99,7 @@ impl Db {
     ) -> Result<Arc<DbIterator>, Error> {
         let range = range.into_bounds()?;
         let options = options.try_into()?;
-        let iter = self
-            .inner
-            .scan_with_options::<Vec<u8>, _>(range, &options)
-            .await?;
+        let iter = self.inner.scan_with_options(range, &options).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 

--- a/bindings/uniffi/src/db_reader.rs
+++ b/bindings/uniffi/src/db_reader.rs
@@ -75,7 +75,7 @@ impl DbReader {
     /// Scans rows inside `range`.
     pub async fn scan(&self, range: KeyRange) -> Result<Arc<DbIterator>, Error> {
         let range = range.into_bounds()?;
-        let iter = self.inner.scan::<Vec<u8>, _>(range).await?;
+        let iter = self.inner.scan(range).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 
@@ -87,10 +87,7 @@ impl DbReader {
     ) -> Result<Arc<DbIterator>, Error> {
         let range = range.into_bounds()?;
         let options = options.try_into()?;
-        let iter = self
-            .inner
-            .scan_with_options::<Vec<u8>, _>(range, &options)
-            .await?;
+        let iter = self.inner.scan_with_options(range, &options).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 

--- a/bindings/uniffi/src/db_snapshot.rs
+++ b/bindings/uniffi/src/db_snapshot.rs
@@ -65,7 +65,7 @@ impl DbSnapshot {
     /// Scans rows inside `range` as of this snapshot.
     pub async fn scan(&self, range: KeyRange) -> Result<Arc<DbIterator>, Error> {
         let range = range.into_bounds()?;
-        let iter = self.inner.scan::<Vec<u8>, _>(range).await?;
+        let iter = self.inner.scan(range).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 
@@ -77,10 +77,7 @@ impl DbSnapshot {
     ) -> Result<Arc<DbIterator>, Error> {
         let range = range.into_bounds()?;
         let options = options.try_into()?;
-        let iter = self
-            .inner
-            .scan_with_options::<Vec<u8>, _>(range, &options)
-            .await?;
+        let iter = self.inner.scan_with_options(range, &options).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 

--- a/bindings/uniffi/src/db_transaction.rs
+++ b/bindings/uniffi/src/db_transaction.rs
@@ -173,7 +173,7 @@ impl DbTransaction {
         let range = range.into_bounds()?;
         let guard = self.inner.lock().await;
         let tx = guard.as_ref().ok_or(SlateDbError::TransactionCompleted)?;
-        let iter = tx.scan::<Vec<u8>, _>(range).await?;
+        let iter = tx.scan(range).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 
@@ -187,7 +187,7 @@ impl DbTransaction {
         let options = options.try_into()?;
         let guard = self.inner.lock().await;
         let tx = guard.as_ref().ok_or(SlateDbError::TransactionCompleted)?;
-        let iter = tx.scan_with_options::<Vec<u8>, _>(range, &options).await?;
+        let iter = tx.scan_with_options(range, &options).await?;
         Ok(Arc::new(DbIterator::new(iter)))
     }
 

--- a/examples/src/full_example.rs
+++ b/examples/src/full_example.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Error> {
     kv_store.put(b"test_key4", b"test_value4").await?;
 
     // Scan over unbound range
-    let mut iter = kv_store.scan::<Vec<u8>, _>(..).await?;
+    let mut iter = kv_store.scan(..).await?;
     let mut count = 1;
     while let Ok(Some(item)) = iter.next().await {
         assert_eq!(item.key, format!("test_key{count}").into_bytes());
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Error> {
     assert_eq!(kv2.value, b"test_value2".as_slice());
 
     // Seek ahead to next key
-    let mut iter = kv_store.scan::<Vec<u8>, _>(..).await?;
+    let mut iter = kv_store.scan(..).await?;
     let next_key = b"test_key4";
     iter.seek(next_key).await?;
     let kv4 = iter.next().await?.unwrap();

--- a/examples/src/range_scans.rs
+++ b/examples/src/range_scans.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Error> {
     db.put(b"test_key10", b"test_value10").await?;
 
     // Scan over unbound range
-    let mut iter = db.scan::<Vec<u8>, _>(..).await?;
+    let mut iter = db.scan(..).await?;
     // Scans return bytewise key order
     let expected = [
         ("test_key1", "test_value1"),
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Error> {
     assert_eq!(iter.next().await?, None);
 
     // Seek ahead to next key
-    let mut iter = db.scan::<Vec<u8>, _>(..).await?;
+    let mut iter = db.scan(..).await?;
     let next_key = b"test_key4";
     iter.seek(next_key).await?;
     let kv4 = iter.next().await?.unwrap();

--- a/slatedb-cli/src/scan.rs
+++ b/slatedb-cli/src/scan.rs
@@ -76,11 +76,7 @@ pub(crate) async fn exec_scan(
                 .scan_prefix_with_options(prefix, .., &scan_opts)
                 .await?
         }
-        None => {
-            reader
-                .scan_with_options::<Vec<u8>, _>(range, &scan_opts)
-                .await?
-        }
+        None => reader.scan_with_options(range, &scan_opts).await?,
     };
 
     let mut out = io::BufWriter::new(io::stdout().lock());

--- a/slatedb/src/bytes_range.rs
+++ b/slatedb/src/bytes_range.rs
@@ -1,7 +1,9 @@
 use bytes::Bytes;
 use serde::Serialize;
 use std::ops::Bound::{Excluded, Included, Unbounded};
-use std::ops::{Bound, RangeBounds};
+use std::ops::{
+    Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive,
+};
 
 use crate::comparable_range::{ComparableRange, EndBound, StartBound};
 
@@ -10,6 +12,107 @@ use crate::comparable_range::{ComparableRange, EndBound, StartBound};
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct BytesRange {
     inner: ComparableRange<Bytes>,
+}
+
+pub trait ByteRangeBounds {
+    fn start_bound(&self) -> Bound<&[u8]>;
+    fn end_bound(&self) -> Bound<&[u8]>;
+}
+
+fn bound_as_bytes<K: AsRef<[u8]>>(bound: Bound<&K>) -> Bound<&[u8]> {
+    match bound {
+        Bound::Included(k) => Bound::Included(k.as_ref()),
+        Bound::Excluded(k) => Bound::Excluded(k.as_ref()),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+impl<K: AsRef<[u8]>> ByteRangeBounds for Range<K> {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        Bound::Included(self.start.as_ref())
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        Bound::Excluded(self.end.as_ref())
+    }
+}
+
+impl<K: AsRef<[u8]>> ByteRangeBounds for RangeInclusive<K> {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        bound_as_bytes(std::ops::RangeBounds::start_bound(self))
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        bound_as_bytes(std::ops::RangeBounds::end_bound(self))
+    }
+}
+
+impl<K: AsRef<[u8]>> ByteRangeBounds for RangeFrom<K> {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        Bound::Included(self.start.as_ref())
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        Bound::Unbounded
+    }
+}
+
+impl<K: AsRef<[u8]>> ByteRangeBounds for RangeTo<K> {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        Bound::Unbounded
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        Bound::Excluded(self.end.as_ref())
+    }
+}
+
+impl<K: AsRef<[u8]>> ByteRangeBounds for RangeToInclusive<K> {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        Bound::Unbounded
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        Bound::Included(self.end.as_ref())
+    }
+}
+
+impl ByteRangeBounds for RangeFull {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        Bound::Unbounded
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        Bound::Unbounded
+    }
+}
+
+impl ByteRangeBounds for BytesRange {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        RangeBounds::start_bound(self).map(|b| b.as_ref())
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        RangeBounds::end_bound(self).map(|b| b.as_ref())
+    }
+}
+
+impl<T: AsRef<[u8]>> ByteRangeBounds for (Bound<T>, Bound<T>) {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        match &self.0 {
+            Bound::Included(v) => Bound::Included(v.as_ref()),
+            Bound::Excluded(v) => Bound::Excluded(v.as_ref()),
+            Bound::Unbounded => Bound::Unbounded,
+        }
+    }
+
+    fn end_bound(&self) -> Bound<&[u8]> {
+        match &self.1 {
+            Bound::Included(v) => Bound::Included(v.as_ref()),
+            Bound::Excluded(v) => Bound::Excluded(v.as_ref()),
+            Bound::Unbounded => Bound::Unbounded,
+        }
+    }
 }
 
 impl Serialize for BytesRange {
@@ -114,11 +217,8 @@ impl BytesRange {
     /// - `from_prefix_and_subrange(prefix, ..)` is equivalent to
     ///   [`Self::from_prefix`]; an empty prefix degenerates to a plain range
     ///   over the subrange bounds.
-    pub(crate) fn from_prefix_and_subrange<'a>(
-        prefix: &[u8],
-        subrange: impl RangeBounds<&'a [u8]>,
-    ) -> Self {
-        let concat = |suffix: &&[u8]| {
+    pub(crate) fn from_prefix_and_subrange(prefix: &[u8], subrange: impl ByteRangeBounds) -> Self {
+        let concat = |suffix: &[u8]| {
             let mut key = Vec::with_capacity(prefix.len() + suffix.len());
             key.extend_from_slice(prefix);
             key.extend_from_slice(suffix);
@@ -178,7 +278,7 @@ impl BytesRange {
     }
 
     pub(crate) fn is_start_bound_included_or_unbounded(&self) -> bool {
-        !matches!(self.start_bound(), Excluded(_))
+        !matches!(ByteRangeBounds::start_bound(self), Excluded(_))
     }
 
     #[cfg(test)]
@@ -200,7 +300,7 @@ impl BytesRange {
     }
 
     pub(crate) fn as_point(&self) -> Option<&Bytes> {
-        match (self.start_bound(), self.end_bound()) {
+        match (RangeBounds::start_bound(self), RangeBounds::end_bound(self)) {
             (Bound::Included(start), Bound::Included(end)) if start == end => Some(start),
             _ => None,
         }
@@ -216,7 +316,7 @@ pub(crate) mod tests {
     use bytes::Bytes;
     use proptest::{prop_assert, prop_assert_eq, proptest};
     use std::ops::Bound;
-    use std::ops::Bound::Unbounded;
+    use std::ops::Bound::{Included, Unbounded};
     use std::ops::RangeBounds;
 
     #[test]
@@ -242,6 +342,29 @@ pub(crate) mod tests {
                 BytesRange::from_prefix(&prefix)
             );
         });
+    }
+
+    #[test]
+    fn test_byte_range_bounds_for_common_shapes() {
+        let full = BytesRange::from_prefix_and_subrange(b"p", ..);
+        assert_eq!(full.start_bound(), Included(&Bytes::from_static(b"p")));
+        assert_eq!(full.end_bound(), Bound::Excluded(&Bytes::from_static(b"q")));
+
+        let range = BytesRange::from_prefix_and_subrange(b"", b"a".to_vec()..=b"b".to_vec());
+        assert_eq!(range.start_bound(), Included(&Bytes::from_static(b"a")));
+        assert_eq!(range.end_bound(), Included(&Bytes::from_static(b"b")));
+
+        let tuple = BytesRange::from_prefix_and_subrange(
+            b"ab",
+            (Bound::Excluded(&b"x"[..]), Bound::Included(&b"y"[..])),
+        );
+        assert_eq!(
+            tuple,
+            BytesRange::from_prefix_and_subrange(
+                b"ab",
+                (Bound::Excluded(&b"x"[..]), Bound::Included(&b"y"[..]))
+            )
+        );
     }
 
     #[test]
@@ -297,6 +420,12 @@ pub(crate) mod tests {
         assert_eq!(range, BytesRange::from_slice(&b"a"[..]..&b"b"[..]));
         let unbounded = BytesRange::from_prefix_and_subrange(b"", ..);
         assert_eq!(unbounded, BytesRange::unbounded());
+    }
+
+    #[test]
+    #[should_panic(expected = "Range must be non-empty")]
+    fn test_from_prefix_and_subrange_rejects_reversed_bounds() {
+        let _ = BytesRange::from_prefix_and_subrange(b"ab", b"z".to_vec()..b"a".to_vec());
     }
 
     #[test]

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -484,7 +484,7 @@ mod tests {
     use slatedb_common::SystemClock;
     use std::collections::BTreeMap;
     use std::ops::Bound;
-    use std::ops::{RangeBounds, RangeFull};
+    use std::ops::RangeBounds;
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -551,7 +551,7 @@ mod tests {
         let clone_db = Db::open(clone_path.clone(), object_store.clone())
             .await
             .unwrap();
-        let mut db_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut db_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&table, .., IterationOrder::Ascending, &mut db_iter)
             .await;
         clone_db.close().await.unwrap();
@@ -620,7 +620,7 @@ mod tests {
             .build()
             .await
             .unwrap();
-        let mut db_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut db_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(
             &checkpoint_table,
             ..,
@@ -1382,7 +1382,7 @@ mod tests {
         // segments are untouched.
         let mut expected = table.clone();
         expected.remove(&Bytes::from_static(b"aaa-001"));
-        let mut full_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut full_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&expected, .., IterationOrder::Ascending, &mut full_iter)
             .await;
         clone_db.close().await.unwrap();
@@ -1422,12 +1422,12 @@ mod tests {
             Settings::default(),
         )
         .await;
-        let mut full_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut full_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&table, .., IterationOrder::Ascending, &mut full_iter)
             .await;
         assert_segment_prefix_scan(&clone_db, &table, b"bbb", b"bbc").await;
         let mut cross_iter = clone_db
-            .scan::<Vec<u8>, _>(b"aaa".to_vec()..=b"ddd-999".to_vec())
+            .scan(b"aaa".to_vec()..=b"ddd-999".to_vec())
             .await
             .unwrap();
         test_utils::assert_ranged_db_scan(
@@ -1503,7 +1503,7 @@ mod tests {
         expected.extend(table_b.clone());
         let clone_db =
             open_segmented_clone(&clone_path, object_store.clone(), extractor, settings).await;
-        let mut full_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut full_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&expected, .., IterationOrder::Ascending, &mut full_iter)
             .await;
         assert_segment_prefix_scan(&clone_db, &expected, b"bbb", b"bbc").await;
@@ -1613,7 +1613,7 @@ mod tests {
 
         let clone_db =
             open_segmented_clone(&clone_path, object_store.clone(), extractor, settings).await;
-        let mut full_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut full_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&expected, .., IterationOrder::Ascending, &mut full_iter)
             .await;
         assert_segment_prefix_scan(&clone_db, &expected, b"bbb", b"bbc").await;
@@ -1715,7 +1715,7 @@ mod tests {
 
         let clone_db =
             open_segmented_clone(&clone_path, object_store.clone(), extractor, settings).await;
-        let mut full_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut full_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&expected, .., IterationOrder::Ascending, &mut full_iter)
             .await;
         // The prefix scan on the shared `bbb` segment must surface rows from
@@ -1759,7 +1759,7 @@ mod tests {
 
         let clone_db =
             open_segmented_clone(&clone_path, object_store.clone(), extractor, settings).await;
-        let mut full_iter = clone_db.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut full_iter = clone_db.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(
             &table,
             Bytes::from_static(b"bbb")..Bytes::from_static(b"ddd"),

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1881,7 +1881,7 @@ mod tests {
         .expect("not every segment compacted before scan");
 
         // Full ascending scan crosses every segment in prefix order.
-        let mut iter = db.scan::<Vec<u8>, _>(..).await.unwrap();
+        let mut iter = db.scan(..).await.unwrap();
         let mut collected: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
         while let Some(kv) = iter.next().await.unwrap() {
             collected.push((kv.key.to_vec(), kv.value.to_vec()));
@@ -1909,7 +1909,7 @@ mod tests {
         // Cross-segment range scan: spans the tail of aaa, all of bbb, and stops
         // before the head of ccc.
         let mut iter = db
-            .scan::<Vec<u8>, _>(b"aaa-002".to_vec()..b"ccc-001".to_vec())
+            .scan(b"aaa-002".to_vec()..b"ccc-001".to_vec())
             .await
             .unwrap();
         let mut keys: Vec<Vec<u8>> = Vec::new();

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -1096,6 +1096,7 @@ impl Db {
     ///     assert_eq!(None, iter.next().await?);
     ///
     ///     // Restrict the scan to suffixes from b"a" onward.
+    ///     // Ordinary Rust range syntax works here; `as_slice()` is optional.
     ///     let mut iter = db.scan_prefix(b"ab", b"a".as_slice()..).await?;
     ///     let kv = iter.next().await?.unwrap();
     ///     assert_eq!(kv.key.as_ref(), b"aba");

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -23,7 +23,7 @@
 pub use crate::db_status::{DbStatus, SegmentPrefix};
 
 use crate::db_cache_manager::{self, CacheTarget};
-use std::ops::{Range, RangeBounds};
+use std::ops::Range;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -44,7 +44,7 @@ use std::time::Duration;
 
 use crate::batch::WriteBatch;
 use crate::batch_write::{WriteBatchMessage, WRITE_BATCH_TASK_NAME};
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{
@@ -998,10 +998,9 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
+    pub async fn scan<T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_with_options(range, &ScanOptions::default()).await
     }
@@ -1038,21 +1037,16 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan_with_options<K, T>(
+    pub async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
-        let start = range
-            .start_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
-        let end = range
-            .end_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
+        let start = range.start_bound().map(Bytes::copy_from_slice);
+        let end = range.end_bound().map(Bytes::copy_from_slice);
         let range = (start, end);
         self.inner
             .scan_with_options(BytesRange::from(range), options, None)
@@ -1109,14 +1103,14 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan_prefix<'a, P, T>(
+    pub async fn scan_prefix<P, T>(
         &self,
         prefix: P,
         subrange: T,
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_prefix_with_options(prefix, subrange, &ScanOptions::default())
             .await
@@ -1166,7 +1160,7 @@ impl Db {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan_prefix_with_options<'a, P, T>(
+    pub async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -1174,7 +1168,7 @@ impl Db {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         let prefix = Bytes::copy_from_slice(prefix.as_ref());
         let range = BytesRange::from_prefix_and_subrange(prefix.as_ref(), subrange);
@@ -1911,19 +1905,18 @@ impl DbReadOps for Db {
         Db::get_key_value_with_options(self, key, options).await
     }
 
-    async fn scan_with_options<K, T>(
+    async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         Db::scan_with_options(self, range, options).await
     }
 
-    async fn scan_prefix_with_options<'a, P, T>(
+    async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -1931,7 +1924,7 @@ impl DbReadOps for Db {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         Db::scan_prefix_with_options(self, prefix, subrange, options).await
     }
@@ -2354,6 +2347,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_scan_and_prefix_range_forms_are_accepted() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let kv_store = Db::builder("/tmp/test_scan_range_forms", object_store)
+            .with_settings(test_db_options(0, 1024, None))
+            .build()
+            .await
+            .unwrap();
+
+        kv_store.put(b"a", b"v0").await.unwrap();
+        kv_store.put(b"aa", b"v1").await.unwrap();
+        kv_store.put(b"ab", b"v2").await.unwrap();
+        kv_store.put(b"b", b"v3").await.unwrap();
+
+        let mut all = kv_store.scan(..).await.unwrap();
+        assert_eq!(all.next().await.unwrap().unwrap().key.as_ref(), b"a");
+        assert_eq!(all.next().await.unwrap().unwrap().key.as_ref(), b"aa");
+        assert_eq!(all.next().await.unwrap().unwrap().key.as_ref(), b"ab");
+        assert_eq!(all.next().await.unwrap().unwrap().key.as_ref(), b"b");
+        assert_eq!(all.next().await.unwrap(), None);
+
+        let mut range = kv_store.scan(b"a".to_vec()..=b"ab".to_vec()).await.unwrap();
+        assert_eq!(range.next().await.unwrap().unwrap().key.as_ref(), b"a");
+        assert_eq!(range.next().await.unwrap().unwrap().key.as_ref(), b"aa");
+        assert_eq!(range.next().await.unwrap().unwrap().key.as_ref(), b"ab");
+        assert_eq!(range.next().await.unwrap(), None);
+
+        let mut prefix = kv_store.scan_prefix(b"a", b"".to_vec()..).await.unwrap();
+        assert_eq!(prefix.next().await.unwrap().unwrap().key.as_ref(), b"a");
+        assert_eq!(prefix.next().await.unwrap().unwrap().key.as_ref(), b"aa");
+        assert_eq!(prefix.next().await.unwrap().unwrap().key.as_ref(), b"ab");
+        assert_eq!(prefix.next().await.unwrap(), None);
+
+        let mut bounded_prefix = kv_store
+            .scan_prefix(b"a", b"a".to_vec()..=b"b".to_vec())
+            .await
+            .unwrap();
+        assert_eq!(
+            bounded_prefix.next().await.unwrap().unwrap().key.as_ref(),
+            b"aa"
+        );
+        assert_eq!(
+            bounded_prefix.next().await.unwrap().unwrap().key.as_ref(),
+            b"ab"
+        );
+        assert_eq!(bounded_prefix.next().await.unwrap(), None);
+
+        kv_store.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_scan_descending_returns_records_in_reverse_order() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let kv_store = Db::builder("/tmp/test_scan_descending", object_store)
@@ -2369,10 +2412,7 @@ mod tests {
         kv_store.put(b"d", b"v3").await.unwrap();
 
         let scan_options = ScanOptions::default().with_order(IterationOrder::Descending);
-        let mut iter = kv_store
-            .scan_with_options::<Vec<u8>, _>(.., &scan_options)
-            .await
-            .unwrap();
+        let mut iter = kv_store.scan_with_options(.., &scan_options).await.unwrap();
         assert_eq!(iter.next().await.unwrap().unwrap().key.as_ref(), b"d");
         assert_eq!(iter.next().await.unwrap().unwrap().key.as_ref(), b"c");
         assert_eq!(iter.next().await.unwrap().unwrap().key.as_ref(), b"b");
@@ -2399,7 +2439,7 @@ mod tests {
 
         let scan_options = ScanOptions::default().with_order(IterationOrder::Descending);
         let mut iter = kv_store
-            .scan_with_options::<Vec<u8>, _>(b"b".to_vec()..b"d".to_vec(), &scan_options)
+            .scan_with_options(b"b".to_vec()..b"d".to_vec(), &scan_options)
             .await
             .unwrap();
         assert_eq!(iter.next().await.unwrap().unwrap().key.as_ref(), b"c");
@@ -2426,10 +2466,7 @@ mod tests {
         kv_store.delete(b"d").await.unwrap();
 
         let scan_options = ScanOptions::default().with_order(IterationOrder::Descending);
-        let mut iter = kv_store
-            .scan_with_options::<Vec<u8>, _>(.., &scan_options)
-            .await
-            .unwrap();
+        let mut iter = kv_store.scan_with_options(.., &scan_options).await.unwrap();
         assert_eq!(iter.next().await.unwrap().unwrap().key.as_ref(), b"c");
         assert_eq!(iter.next().await.unwrap().unwrap().key.as_ref(), b"a");
         assert_eq!(iter.next().await.unwrap(), None);
@@ -3986,7 +4023,10 @@ mod tests {
             let seek_key = sample::bytes_in_range(rng, scan_range);
             iter.seek(seek_key.clone()).await.unwrap();
 
-            let seek_range = BytesRange::new(Included(seek_key), scan_range.end_bound().cloned());
+            let seek_range = BytesRange::new(
+                Included(seek_key),
+                std::ops::RangeBounds::end_bound(scan_range).cloned(),
+            );
             test_utils::assert_ranged_db_scan(
                 table,
                 seek_range,
@@ -9183,7 +9223,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut iter = db.scan::<Bytes, _>(..).await.unwrap();
+        let mut iter = db.scan(..).await.unwrap();
 
         let row_entry1 = iter.next_entry().await.unwrap().unwrap();
         assert_eq!(row_entry1.key, Bytes::from_static(b"key1"));
@@ -9285,7 +9325,7 @@ mod tests {
         db.put(b"k1", b"v1").await.unwrap();
 
         // when:
-        let mut iter = db.scan::<&[u8], _>(..).await.unwrap();
+        let mut iter = db.scan(..).await.unwrap();
         let _ = iter.next().await;
 
         // then:
@@ -10601,7 +10641,7 @@ mod tests {
         .await;
 
         let mut asc_iter = reader
-            .scan::<Vec<u8>, _>(b"aaa".to_vec()..=b"ddd-999".to_vec())
+            .scan(b"aaa".to_vec()..=b"ddd-999".to_vec())
             .await
             .unwrap();
         test_utils::assert_ranged_db_scan(
@@ -10614,7 +10654,7 @@ mod tests {
 
         let desc_options = ScanOptions::default().with_order(IterationOrder::Descending);
         let mut desc_iter = reader
-            .scan_with_options::<Vec<u8>, _>(b"aaa".to_vec()..=b"ddd-999".to_vec(), &desc_options)
+            .scan_with_options(b"aaa".to_vec()..=b"ddd-999".to_vec(), &desc_options)
             .await
             .unwrap();
         test_utils::assert_ranged_db_scan(
@@ -10626,7 +10666,7 @@ mod tests {
         .await;
 
         let mut gap_iter = reader
-            .scan::<Vec<u8>, _>(b"bbc".to_vec()..=b"ddd-002".to_vec())
+            .scan(b"bbc".to_vec()..=b"ddd-002".to_vec())
             .await
             .unwrap();
         test_utils::assert_ranged_db_scan(

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1,4 +1,4 @@
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
@@ -36,7 +36,7 @@ use parking_lot::RwLock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::DbRand;
 use std::collections::{BTreeSet, VecDeque};
-use std::ops::{RangeBounds, Sub};
+use std::ops::Sub;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use tokio::runtime::Handle;
@@ -999,10 +999,9 @@ impl DbReader {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
+    pub async fn scan<T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_with_options(range, &ScanOptions::default()).await
     }
@@ -1053,21 +1052,16 @@ impl DbReader {
     ///     assert_eq!(None, iter.next().await?);
     ///     Ok(())
     /// }
-    pub async fn scan_with_options<K, T>(
+    pub async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
-        let start = range
-            .start_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
-        let end = range
-            .end_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
+        let start = range.start_bound().map(Bytes::copy_from_slice);
+        let end = range.end_bound().map(Bytes::copy_from_slice);
         let range = BytesRange::from((start, end));
         self.inner
             .scan_with_options(range, options, None)
@@ -1089,14 +1083,14 @@ impl DbReader {
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
-    pub async fn scan_prefix<'a, P, T>(
+    pub async fn scan_prefix<P, T>(
         &self,
         prefix: P,
         subrange: T,
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_prefix_with_options(prefix, subrange, &ScanOptions::default())
             .await
@@ -1114,7 +1108,7 @@ impl DbReader {
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
-    pub async fn scan_prefix_with_options<'a, P, T>(
+    pub async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -1122,7 +1116,7 @@ impl DbReader {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         let prefix = Bytes::copy_from_slice(prefix.as_ref());
         let range = BytesRange::from_prefix_and_subrange(prefix.as_ref(), subrange);
@@ -1187,19 +1181,18 @@ impl DbReadOps for DbReader {
         DbReader::get_key_value_with_options(self, key, options).await
     }
 
-    async fn scan_with_options<K, T>(
+    async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         DbReader::scan_with_options(self, range, options).await
     }
 
-    async fn scan_prefix_with_options<'a, P, T>(
+    async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -1207,7 +1200,7 @@ impl DbReadOps for DbReader {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         DbReader::scan_prefix_with_options(self, prefix, subrange, options).await
     }
@@ -1319,7 +1312,6 @@ mod tests {
     use slatedb_common::DbRand;
     use slatedb_common::MockSystemClock;
     use std::collections::{BTreeMap, VecDeque};
-    use std::ops::RangeFull;
     use std::sync::Arc;
     use std::time::Duration;
     use uuid::Uuid;
@@ -1646,7 +1638,7 @@ mod tests {
             .await
             .unwrap();
 
-        let mut db_iter = reader.scan::<Vec<u8>, RangeFull>(..).await.unwrap();
+        let mut db_iter = reader.scan(..).await.unwrap();
         let mut table = BTreeMap::new();
         table.insert(
             Bytes::copy_from_slice(checkpoint_key),
@@ -1688,7 +1680,7 @@ mod tests {
         db.flush().await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(20)).await;
-        let mut db_iter = reader.scan::<Vec<u8>, _>(..).await.unwrap();
+        let mut db_iter = reader.scan(..).await.unwrap();
         test_utils::assert_ranged_db_scan(&table, .., IterationOrder::Ascending, &mut db_iter)
             .await;
 

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -1,9 +1,8 @@
 use bytes::Bytes;
-use std::ops::RangeBounds;
 use std::sync::Arc;
 use uuid::Uuid;
 
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::config::{ReadOptions, ScanOptions};
 use crate::db_iter::DbIterator;
 use crate::types::KeyValue;
@@ -97,10 +96,9 @@ impl DbSnapshot {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
+    pub async fn scan<T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_with_options(range, &ScanOptions::default()).await
     }
@@ -113,22 +111,17 @@ impl DbSnapshot {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan_with_options<K, T>(
+    pub async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         // TODO: this range conversion logic can be extract to an util
-        let start = range
-            .start_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
-        let end = range
-            .end_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
+        let start = range.start_bound().map(Bytes::copy_from_slice);
+        let end = range.end_bound().map(Bytes::copy_from_slice);
         let range = BytesRange::from((start, end));
         self.scan_inner(range, options, None).await
     }
@@ -147,14 +140,14 @@ impl DbSnapshot {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan_prefix<'a, P, T>(
+    pub async fn scan_prefix<P, T>(
         &self,
         prefix: P,
         subrange: T,
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_prefix_with_options(prefix, subrange, &ScanOptions::default())
             .await
@@ -172,7 +165,7 @@ impl DbSnapshot {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan_prefix_with_options<'a, P, T>(
+    pub async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -180,7 +173,7 @@ impl DbSnapshot {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         let prefix = Bytes::copy_from_slice(prefix.as_ref());
         let range = BytesRange::from_prefix_and_subrange(prefix.as_ref(), subrange);
@@ -230,19 +223,18 @@ impl DbReadOps for DbSnapshot {
         DbSnapshot::get_key_value_with_options(self, key, options).await
     }
 
-    async fn scan_with_options<K, T>(
+    async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         DbSnapshot::scan_with_options(self, range, options).await
     }
 
-    async fn scan_prefix_with_options<'a, P, T>(
+    async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -250,7 +242,7 @@ impl DbReadOps for DbSnapshot {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         DbSnapshot::scan_prefix_with_options(self, prefix, subrange, options).await
     }

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -1,12 +1,11 @@
 use bytes::Bytes;
 use parking_lot::{Mutex, RwLock};
 use std::collections::HashSet;
-use std::ops::RangeBounds;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::batch::{WriteBatch, WriteBatchIterator};
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::config::{MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions};
 use crate::db::DbInner;
 use crate::db::WriteHandle;
@@ -193,10 +192,9 @@ impl DbTransaction {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
+    pub async fn scan<T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_with_options(range, &ScanOptions::default()).await
     }
@@ -210,22 +208,17 @@ impl DbTransaction {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan_with_options<K, T>(
+    pub async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         // TODO: this range conversion logic can be extract to an util
-        let start = range
-            .start_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
-        let end = range
-            .end_bound()
-            .map(|b| Bytes::copy_from_slice(b.as_ref()));
+        let start = range.start_bound().map(Bytes::copy_from_slice);
+        let end = range.end_bound().map(Bytes::copy_from_slice);
         let range = BytesRange::from((start, end));
         self.scan_inner(range, options, None).await
     }
@@ -245,14 +238,14 @@ impl DbTransaction {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan_prefix<'a, P, T>(
+    pub async fn scan_prefix<P, T>(
         &self,
         prefix: P,
         subrange: T,
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_prefix_with_options(prefix, subrange, &ScanOptions::default())
             .await
@@ -271,7 +264,7 @@ impl DbTransaction {
     ///
     /// ## Returns
     /// - `Result<DbIterator, SlateDBError>`: An iterator with the results of the scan
-    pub async fn scan_prefix_with_options<'a, P, T>(
+    pub async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -279,7 +272,7 @@ impl DbTransaction {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         let prefix = Bytes::copy_from_slice(prefix.as_ref());
         let range = BytesRange::from_prefix_and_subrange(prefix.as_ref(), subrange);
@@ -649,19 +642,18 @@ impl DbReadOps for DbTransaction {
         DbTransaction::get_key_value_with_options(self, key, options).await
     }
 
-    async fn scan_with_options<K, T>(
+    async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         DbTransaction::scan_with_options(self, range, options).await
     }
 
-    async fn scan_prefix_with_options<'a, P, T>(
+    async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -669,7 +661,7 @@ impl DbReadOps for DbTransaction {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         DbTransaction::scan_prefix_with_options(self, prefix, subrange, options).await
     }

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -33,6 +33,7 @@ pub use fail_parallel;
 pub use object_store;
 
 pub use batch::WriteBatch;
+pub use bytes_range::ByteRangeBounds;
 pub use cached_object_store::stats as cached_object_store_stats;
 pub use checkpoint::{Checkpoint, CheckpointCreateResult};
 #[cfg(feature = "compaction_filters")]

--- a/slatedb/src/ops.rs
+++ b/slatedb/src/ops.rs
@@ -1,9 +1,8 @@
 use bytes::Bytes;
-use std::ops::RangeBounds;
 use uuid::Uuid;
 
 use crate::batch::WriteBatch;
-use crate::bytes_range::BytesRange;
+use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::config::{
     FlushOptions, MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions,
 };
@@ -128,10 +127,9 @@ pub trait DbReadOps {
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
-    async fn scan<K, T>(&self, range: T) -> Result<DbIterator, crate::Error>
+    async fn scan<T>(&self, range: T) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_with_options(range, &ScanOptions::default()).await
     }
@@ -149,14 +147,13 @@ pub trait DbReadOps {
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
-    async fn scan_with_options<K, T>(
+    async fn scan_with_options<T>(
         &self,
         range: T,
         options: &ScanOptions,
     ) -> Result<DbIterator, crate::Error>
     where
-        K: AsRef<[u8]> + Send,
-        T: RangeBounds<K> + Send;
+        T: ByteRangeBounds + Send;
 
     /// Scan keys that share the provided prefix, restricted to `subrange`,
     /// using the default scan options.
@@ -172,14 +169,10 @@ pub trait DbReadOps {
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
-    async fn scan_prefix<'a, P, T>(
-        &self,
-        prefix: P,
-        subrange: T,
-    ) -> Result<DbIterator, crate::Error>
+    async fn scan_prefix<P, T>(&self, prefix: P, subrange: T) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         self.scan_prefix_with_options(prefix, subrange, &ScanOptions::default())
             .await
@@ -197,7 +190,7 @@ pub trait DbReadOps {
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
-    async fn scan_prefix_with_options<'a, P, T>(
+    async fn scan_prefix_with_options<P, T>(
         &self,
         prefix: P,
         subrange: T,
@@ -205,7 +198,7 @@ pub trait DbReadOps {
     ) -> Result<DbIterator, crate::Error>
     where
         P: AsRef<[u8]> + Send,
-        T: RangeBounds<&'a [u8]> + Send,
+        T: ByteRangeBounds + Send,
     {
         let range = BytesRange::from_prefix_and_subrange(prefix.as_ref(), subrange);
         self.scan_with_options(range, options).await

--- a/slatedb/tests/prefix_filter.rs
+++ b/slatedb/tests/prefix_filter.rs
@@ -388,7 +388,9 @@ mod prop_test {
     use proptest::prelude::*;
     use slatedb::config::{PutOptions, ScanOptions, Settings, WriteOptions};
     use slatedb::object_store::memory::InMemory;
-    use slatedb::{BloomFilterPolicy, Db, FilterPolicy, PrefixExtractor, PrefixTarget};
+    use slatedb::{
+        BloomFilterPolicy, ByteRangeBounds, Db, FilterPolicy, PrefixExtractor, PrefixTarget,
+    };
     use tokio::runtime::Runtime;
 
     const PREFIX_LEN: usize = 3;
@@ -461,10 +463,10 @@ mod prop_test {
         db.flush().await.expect("flush failed");
     }
 
-    async fn collect_prefix_scan<'a>(
+    async fn collect_prefix_scan(
         db: &Db,
         prefix: &[u8],
-        subrange: impl std::ops::RangeBounds<&'a [u8]> + Send,
+        subrange: impl ByteRangeBounds + Send,
     ) -> Vec<(Vec<u8>, Vec<u8>)> {
         let mut iter = db
             .scan_prefix_with_options(prefix, subrange, &ScanOptions::default())

--- a/website/src/content/docs/docs/tutorials/range-scans.mdx
+++ b/website/src/content/docs/docs/tutorials/range-scans.mdx
@@ -13,7 +13,7 @@ SlateDB stores key-value pairs sorted by key in lexicographic byte order. A rang
 Use `Db::scan(..)` to iterate over the full keyspace. Range scans follow bytewise key order, so `test_key10` sorts before `test_key2`. If numeric order matters, use fixed-width encodings such as `test_key02` and `test_key10`.
 
 ```rust
-let mut entries = db.scan::<Vec<u8>, _>(..).await?;
+let mut entries = db.scan(..).await?;
 while let Some(kv) = entries.next().await? {
     println!("{:?} = {:?}", kv.key, kv.value);
 }
@@ -28,7 +28,7 @@ db.scan("test_key2".."test_key4").await?;  // excludes test_key4
 db.scan("test_key2"..="test_key4").await?; // includes test_key4
 db.scan("test_key2"..).await?;             // test_key2 and later
 db.scan(.."test_key4").await?;             // before test_key4
-db.scan::<Vec<u8>, _>(..).await?;          // all keys
+db.scan(..).await?;          // all keys
 ```
 
 ## Seek within a scan
@@ -36,7 +36,7 @@ db.scan::<Vec<u8>, _>(..).await?;          // all keys
 Call `seek` on an iterator to fast-forward to the first key equal to or greater than the requested key. The seek target must stay inside the original scan range and must move forward from the iterator's current position.
 
 ```rust
-let mut iter = db.scan::<Vec<u8>, _>(..).await?;
+let mut iter = db.scan(..).await?;
 iter.seek(b"test_key3").await?;
 let kv = iter.next().await?.unwrap();
 assert_eq!(kv.key.as_ref(), b"test_key3");
@@ -44,11 +44,11 @@ assert_eq!(kv.key.as_ref(), b"test_key3");
 
 ## Scan for prefixes
 
-If your access pattern is "all keys that start with this prefix," use `scan_prefix` instead of manually building a start and end range. The second argument restricts the scan to a range of key *suffixes* relative to the prefix; pass `..` to scan the prefix's entire keyspace.
+If your access pattern is "all keys that start with this prefix," use `scan_prefix` instead of manually building a start and end range. The second argument restricts the scan to a range of key *suffixes* relative to the prefix; pass `..` to scan the prefix's entire keyspace. You can pass ordinary Rust range syntax directly, including suffix ranges over byte slices or `Vec<u8>`.
 
 ```rust
 let mut iter = db.scan_prefix(b"test_key", ..).await?;   // all keys with the prefix
-let mut iter = db.scan_prefix(b"test_key", b"2".as_slice()..).await?; // test_key2 onward
+let mut iter = db.scan_prefix(b"test_key", b"2"..).await?; // test_key2 onward
 ```
 
 ## Complete example


### PR DESCRIPTION
## Summary

Improve the ergonomics of range arguments for `scan` and `scan_prefix` by introducing a byte-slice range adapter and using it across the core read APIs.

Closes #1800.

## Changes

- Added `ByteRangeBounds` trait
- Updated `scan`, `scan_with_options`, `scan_prefix`, `scan_prefix_with_options`
- Added the API change in `Db`, `DbReader`, `DbSnapshot`, `DbTransaction`, `DbReadOps`
- Updated the binding wrappers to compile with the new signatures
- Added tests
- Updated docs

## Notes for Reviewers

- Did not expose `scan_prefix(prefix, subrange)` through UniFFI.  We will be tackling this in a follow-up PR as mentioned in issue #1801, which requires this PR to land first.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
