### PR TITLE
feat: multi_get support

### DIFF
--- a/rfcs/0027-multi-get.md
+++ b/rfcs/0027-multi-get.md
@@ -1,0 +1,416 @@
+# SlateDB RFC: Batched Point Reads (`multi_get`)
+
+Table of Contents:
+
+<!-- TOC start (generate with https://bitdowntoc.derlin.ch) -->
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Goals](#goals)
+- [Non-Goals](#non-goals)
+- [Design](#design)
+  - [Public API](#public-api)
+  - [Semantics](#semantics)
+  - [Read orchestration](#read-orchestration)
+  - [Batched per-SST reads](#batched-per-sst-reads)
+  - [Precedence by rank instead of a sequential layer walk](#precedence-by-rank-instead-of-a-sequential-layer-walk)
+  - [Value resolution](#value-resolution)
+  - [Concurrency control](#concurrency-control)
+- [Impact Analysis](#impact-analysis)
+- [Operations](#operations)
+- [Testing](#testing)
+- [Rollout](#rollout)
+- [Alternatives](#alternatives)
+- [Open Questions](#open-questions)
+- [References](#references)
+
+<!-- TOC end -->
+
+Status: Draft
+
+Authors:
+
+* [Roman Grebennikov](https://github.com/shuttie)
+
+## Summary
+
+This RFC adds a batched point-read API, `multi_get`, to `Db`, `DbReader`,
+`DbSnapshot`, and `DbTransaction`. A batch of keys is resolved against a single
+consistent snapshot in one pass that visits each candidate SST exactly once for
+all of its keys, and fans every SST read out concurrently — across L0 and all
+sorted runs — instead of walking layers sequentially. Compared to a loop of
+`get` calls, this removes repeated index/filter loads, coalesces block fetches
+within each SST, and collapses end-to-end latency to roughly one object-store
+round trip per batch regardless of LSM depth.
+
+## Motivation
+
+Point lookups against object storage are dominated by round-trip latency.
+Applications that need N keys today must issue N independent `get` calls, which
+costs:
+
+1. **Repeated metadata I/O.** Each `get` loads the SST index and bloom filters
+   of every SST it probes, even when consecutive gets probe the same SSTs.
+   These are cacheable, but cold reads and cache pressure both scale with N.
+2. **No block coalescing.** Two keys that live in adjacent blocks of the same
+   SST are fetched as two object-store GETs instead of one ranged GET.
+3. **Serialized latency.** Even if the application issues gets concurrently,
+   each individual get still walks the LSM newest-first: L0, then sorted run 0,
+   then run 1, … — one dependent round trip per layer until the key is found.
+4. **No deduplication or shared snapshot.** Each get re-establishes its
+   visibility bounds, and duplicate keys in the workload resolve repeatedly.
+
+A microbenchmark of 1,000 keys spread over ~16 L0 SSTs (in-memory object store,
+no block cache) shows a `get` loop at ~10.5 ms versus `multi_get` at ~3.5 ms —
+a 3× improvement that comes purely from items (1) and (2); against a real
+object store, item (3) dominates and the gap widens with the number of sorted
+runs.
+
+## Goals
+
+- A `multi_get` API whose result is **bit-for-bit equivalent** to calling `get`
+  for each key against the same snapshot (including tombstones, TTL, merge
+  operands, and `ReadOptions` semantics).
+- All keys in a batch observe **one consistent snapshot**.
+- Visit each candidate SST **once per batch**, loading its index and filters
+  once and coalescing its block fetches.
+- Batch latency of approximately **one object-store round trip**, independent
+  of the number of sorted runs.
+- Support on all read surfaces: `Db`, `DbReader`, `DbSnapshot`,
+  `DbTransaction` (including reads-through-write-batch and SSI conflict
+  tracking).
+
+## Non-Goals
+
+- A streaming or unordered-result API (results are returned positionally, in
+  input order).
+- Batched writes (already covered by `WriteBatch`).
+- Cross-batch caching or memoization beyond the existing block/object caches.
+- Changing the on-disk format, manifest, or compaction in any way.
+
+## Design
+
+### Public API
+
+Four methods are added to the `DbReadOps` trait (and therefore to every read
+surface), mirroring the existing `get` family:
+
+```rust
+async fn multi_get<K: AsRef<[u8]> + Send + Sync>(
+    &self, keys: &[K],
+) -> Result<Vec<Option<Bytes>>, Error>;
+
+async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+    &self, keys: &[K], options: &ReadOptions,
+) -> Result<Vec<Option<Bytes>>, Error>;
+
+async fn multi_get_key_value<K: AsRef<[u8]> + Send + Sync>(
+    &self, keys: &[K],
+) -> Result<Vec<Option<KeyValue>>, Error>;
+
+async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+    &self, keys: &[K], options: &ReadOptions,
+) -> Result<Vec<Option<KeyValue>>, Error>;
+```
+
+### Semantics
+
+- One result slot per input key, in input order. `None` marks a key that is
+  missing, deleted, or expired.
+- Duplicate input keys are deduplicated for I/O and resolved once; the result
+  is scattered back to every input position.
+- The whole batch reads one snapshot: visibility bounds (`max_seq`, durability
+  filter, dirty reads) are computed once up front, exactly as `get` computes
+  them per call.
+- On `DbTransaction`, the transaction's uncommitted write batch takes
+  precedence over the database, and under SSI every key in the batch is added
+  to the transaction's read set (each key is tracked as a point range, the same
+  as a single `get`).
+
+### Read orchestration
+
+The orchestrator (`Reader::multi_get_with_options` in `reader.rs`) proceeds in
+four phases. Phases 1–2 are in-memory and free; phase 3 is the only one that
+performs I/O.
+
+```
+keys ──dedup──▶ unique keys
+                   │
+  1. write batch (transactions only)        ─┐  resolve keys early:
+  2. memtable + immutable memtables          ─┘  no disk I/O for keys found here
+                   │ still-pending keys
+  3. fan out: every (SST view, keys) pair across all trees & layers,
+     one bounded concurrent batch ──▶ per-SST results, tagged with rank
+                   │ sort by rank, apply newest-first per key
+  4. per key: replay accumulated versions through GetIterator
+     (+ MergeOperatorIterator) ──▶ Option<RowEntry> ──scatter──▶ results
+```
+
+Each unique key has an accumulator of `RowEntry` versions (newest-first) and a
+`resolved` flag. A key is *resolved* when a `Value` or `Tombstone` visible at
+the snapshot has been appended; `Merge` operands do **not** resolve a key,
+because operands legitimately span layers and the resolution must keep
+descending until it finds the base value. Entries with `seq > max_seq` are
+filtered *before* the resolve check, so a too-new value can never hide an older
+visible one.
+
+Keys resolved by the write batch or memtables never generate any disk work.
+
+For segmented databases, pending keys are grouped by the LSM tree that covers
+them (via `select_segments`); a key that no segment covers has no on-disk data
+and is skipped. Trees cover disjoint key ranges, which the rank merge below
+relies on.
+
+### Batched per-SST reads
+
+`multi_sst::read_sst_for_keys` visits one SST exactly once for a set of keys:
+
+1. **Load metadata once**: the SST index and bloom filters are read once for
+   the whole key set (vs. once per key in a `get` loop).
+2. **Prune**: each key is dropped if it falls outside the view's visible range
+   (segment/clone projections) or if any bloom filter rejects it. Filter
+   positive/negative/false-positive stats are recorded with the same meaning as
+   the single-key path.
+3. **Plan and coalesce blocks**: surviving keys map to block ranges via the
+   same `partitions_covering_range` logic as `get` (a key's versions can span a
+   block boundary). The union of all needed blocks is coalesced into contiguous
+   fetch runs, tolerating up to 2 intervening unwanted blocks per run
+   (`COALESCE_GAP_BLOCKS`): reading a couple of extra ~4 KiB blocks is cheaper
+   than another object-store round trip. Fetches go through the existing
+   `read_blocks_using_index`, which already handles the block cache, range
+   coalescing of uncached spans, and parallel decode.
+4. **Scan**: each key's blocks are scanned with a `DataBlockIterator`,
+   collecting that key's raw `RowEntry` versions newest-first. No
+   sequence/merge/tombstone resolution happens here — the raw entries are
+   returned to the orchestrator so resolution stays in one place.
+
+### Precedence by rank instead of a sequential layer walk
+
+A single-key `get` reads layers newest-first and stops at the first hit, which
+is I/O-minimal but serializes round trips: a database with R sorted runs costs
+up to 1 + R dependent round trips. An earlier iteration of this design kept
+that structure for batches (read L0, shrink the pending set, read run 0,
+shrink, …) and inherited the same latency profile.
+
+Instead, the orchestrator builds **one flat work list** of `(rank, sst_view,
+pending_keys)` items covering every SST that might hold a pending key — all L0
+SSTs and, for each sorted run, the specific views covering each key (found by
+binary search) — and executes the entire list as a single bounded-concurrency
+batch. Newest-first precedence is restored *after* the I/O completes:
+
+- `rank` encodes precedence within a tree: L0 SSTs by position (front =
+  newest), then sorted runs in manifest order, then views within a run by
+  ascending index (a key's versions may span adjacent views; the single-key
+  path reads them in the same order). Rank offsets advance by each run's full
+  view count so two runs never alias.
+- Ranks from different trees may collide, but trees cover disjoint keys, so any
+  given key's results all carry ranks from one tree and a single global sort
+  applies them correctly.
+- Results are sorted by rank and applied per key in order: versions are
+  appended until the first visible `Value`/`Tombstone`, after which that key's
+  older-rank results are dropped — reproducing exactly what the sequential walk
+  would have kept.
+
+The trade-off is **speculative I/O for latency**: an older run is probed even
+for keys that turn out to live in a newer layer. The waste is bounded — the
+speculative probe costs an index + filter load (small, aggressively cached),
+and the bloom filter then prunes the block fetch for almost all such keys
+(false-positive rate ~1% at default settings). In exchange, batch latency is
+one round trip instead of one per run. Section [Alternatives](#alternatives)
+discusses the sequential variant.
+
+### Value resolution
+
+The final value for each key is *not* computed by reimplementing
+tombstone/merge/TTL logic. The key's accumulated versions are replayed through
+a `VecRowIterator` feeding the same `GetIterator` +
+`MergeOperatorIterator`/`MergeOperatorRequiredIterator` stack the single-key
+`get` path uses. Equivalence with `get` is therefore structural, not
+coincidental: both paths share one resolution implementation, and the batch
+path only changes *how the versions are fetched*.
+
+### Concurrency control
+
+All SST reads across the batch share one concurrency bound
+(`MAX_CONCURRENT_SST_READS = 32`, via the existing `build_concurrent` helper).
+Reads are object-store-I/O bound, so a generous bound pays off; the constant
+caps worst-case in-flight requests per `multi_get` call regardless of batch
+size or LSM shape.
+
+## Impact Analysis
+
+SlateDB features and components that this RFC interacts with. Check all that apply.
+
+### Core API & Query Semantics
+
+- [x] Basic KV API (`get`/`put`/`delete`)
+- [ ] Range queries, iterators, seek semantics
+- [ ] Range deletions
+- [ ] Error model, API errors
+
+### Consistency, Isolation, and Multi-Versioning
+
+- [x] Transactions
+- [x] Snapshots
+- [x] Sequence numbers
+
+### Time, Retention, and Derived State
+
+- [x] Time to live (TTL)
+- [ ] Compaction filters
+- [x] Merge operator
+- [ ] Change Data Capture (CDC)
+
+### Metadata, Coordination, and Lifecycles
+
+- [ ] Manifest format
+- [ ] Checkpoints
+- [x] Clones
+- [ ] Garbage collection
+- [x] Database splitting and merging
+- [ ] Multi-writer
+
+### Compaction
+
+- [ ] Compaction state persistence
+- [ ] Compaction filters
+- [ ] Compaction strategies
+- [ ] Distributed compaction
+- [ ] Compactions format
+
+### Storage Engine Internals
+
+- [ ] Write-ahead log (WAL)
+- [x] Block cache
+- [ ] Object store cache
+- [x] Indexing (bloom filters, metadata)
+- [ ] SST format or block format
+
+### Ecosystem & Operations
+
+- [ ] CLI tools
+- [ ] Language bindings (Go/Python/etc)
+- [x] Observability (metrics/logging/tracing)
+
+## Operations
+
+### Performance & Cost
+
+- **Latency**: ~1 object-store round trip per batch (plus parallel block
+  fetches), versus up to `1 + sorted_runs` dependent round trips per key for a
+  `get` loop. Microbenchmark (1k keys, ~16 L0 SSTs, in-memory store, no cache):
+  3.5 ms vs 10.5 ms.
+- **GET request count**: strictly fewer than an equivalent `get` loop for
+  metadata (index/filters loaded once per SST per batch) and usually fewer for
+  data (block coalescing). The fan-out adds speculative index/filter loads in
+  older runs for keys resolved in newer layers; these are small and cached, and
+  bloom filters suppress the corresponding block GETs except on false
+  positives.
+- **Read amplification**: block coalescing may fetch up to `COALESCE_GAP_BLOCKS`
+  unwanted blocks between two wanted blocks in the same SST — bytes traded
+  for round trips, the same trade `read_blocks_using_index` already makes.
+- **Memory**: O(batch size) accumulators of raw `RowEntry`s; bounded per key by
+  early termination at the first visible base value.
+
+### Observability
+
+- No configuration changes; `MAX_CONCURRENT_SST_READS` and
+  `COALESCE_GAP_BLOCKS` are internal constants (see Open Questions).
+- Existing metrics are reused: `get_requests` increments by batch size;
+  `sst_filter_point_{positives,negatives,false_positives}` are recorded by the
+  batched path with unchanged meaning. Note that the fan-out increases filter
+  *negative* counts relative to a `get` loop (speculative probes of older runs
+  are pruned by filters) — dashboards tracking filter hit ratios will see a
+  shift, not a regression.
+
+### Compatibility
+
+- No on-disk or manifest format changes; works on existing databases.
+- Purely additive API (new trait methods with default-option wrappers);
+  existing code is unaffected. Bindings can adopt the API incrementally.
+- No mixed-version concerns: behavior is reader-local.
+
+## Testing
+
+- **Unit tests** (`reader.rs`): layered scenarios built from a synthetic DB
+  state (write batch / memtable / L0 / sorted runs), covering distinct keys
+  across layers, duplicates, tombstones, merge operands spanning layers, a
+  newer-run base shadowing an older-run stale value under fan-out, sequence
+  filtering (`max_seq` must not let a too-new value resolve a key), and empty
+  batches. Every unit scenario also asserts the **differential invariant**:
+  `multi_get` result == per-key `get` against the same state.
+- **Integration tests** (`tests/multi_get.rs`): end-to-end differential checks
+  against a real `Db` with and without block cache and merge operator;
+  `DbReader`, `DbSnapshot`, and transaction coverage; SSI test asserting all
+  batch keys enter the read set (a conflicting concurrent write to *any* batch
+  key aborts the transaction).
+- **Performance tests**: `benches/db_operations.rs` compares `multi_get` vs an
+  equivalent `get` loop (1k keys over many small L0 SSTs, no cache).
+
+## Rollout
+
+- Single PR; no feature flag needed (additive API, no behavior change for
+  existing calls).
+- Docs updates: API docs on the `DbReadOps` trait methods (included).
+- Follow-up: expose `multi_get` in language bindings (Go/Python) once the Rust
+  API stabilizes.
+
+## Alternatives
+
+- **Status quo (loop of `get`s)**: simplest, but pays per-key metadata loads,
+  no block coalescing, and per-key sequential layer walks. The 3× benchmark gap
+  on a cache-less L0-heavy database understates the win against real object
+  stores with many sorted runs.
+- **Concurrent `get` loop (client-side `join_all`)**: removes wall-clock
+  serialization *across* keys but keeps every other inefficiency, plus N×
+  snapshot setup. Doesn't require any engine change, but also can't dedupe SST
+  visits.
+- **Sequential newest-first layer walk with early exit** (the initial
+  implementation of this feature): groups keys per SST within one layer, reads
+  layers in order, and shrinks the pending set between layers. I/O-minimal — a
+  key found in L0 never touches sorted runs — but latency scales with the
+  number of sorted runs (dependent round trips), and the bookkeeping (per-tree
+  local/global index remapping, per-layer barriers) was the most complex code
+  in the feature. Rejected in favor of fan-out: on object storage, round trips
+  dominate and bloom filters make the speculative I/O cheap. A future hybrid
+  (fan out filters, sequence block reads) is possible if the speculative reads
+  ever matter; see Open Questions.
+- **Reusing `SstIterator` per key instead of `read_sst_for_keys`**: would avoid
+  the new `multi_sst` module but reloads the index per key and cannot coalesce
+  blocks across keys — i.e., it forfeits most of the batching benefit inside an
+  SST.
+- **Reimplementing tombstone/merge/TTL resolution in the batch path**: would
+  avoid materializing per-key version vectors, but creates a second copy of the
+  trickiest read-path semantics that must be kept in lockstep with `get`.
+  Rejected; the batch path deliberately replays versions through the single-key
+  resolution stack.
+
+## Open Questions
+
+- Should `MAX_CONCURRENT_SST_READS` (and possibly `COALESCE_GAP_BLOCKS`) be
+  exposed in `Settings`, or derived from the object-store profile?
+- Is a hybrid mode worthwhile for very read-amplification-sensitive deployments:
+  fan out index/filter loads (cheap), then issue block reads newest-first with
+  early exit (one extra round trip in the rare false-positive case)?
+- Should bindings expose `multi_get` as soon as this merges, or after the Rust
+  API has soaked for a release?
+
+## References
+
+- `slatedb/src/reader.rs` — orchestrator (`multi_get_with_options`,
+  `build_sst_work`, rank merge, resolution).
+- `slatedb/src/multi_sst.rs` — batched per-SST point reads.
+- `slatedb/src/ops.rs` — `DbReadOps` API surface.
+- `slatedb/tests/multi_get.rs` — differential and SSI integration tests.
+- RocksDB `MultiGet` — prior art for batched point reads in an LSM
+  (per-level batching with filter-first pruning):
+  https://github.com/facebook/rocksdb/wiki/MultiGet-Performance
+- [RFC 0006: Merge Operator](0006-merge-operator.md) — operand semantics the
+  batch path must preserve.
+- [RFC 0011: Transactions](0011-transaction.md) — SSI read-set tracking.
+- [RFC 0024: Segment-Oriented Compaction](0024-segment-oriented-compaction.md)
+  — the segmented tree layout the orchestrator groups keys by.
+
+## Updates
+
+- 2026-06-09: Initial draft.

--- a/slatedb/benches/db_operations.rs
+++ b/slatedb/benches/db_operations.rs
@@ -1,10 +1,10 @@
 // our microbenchmarks use pprof, but it doesn't work on windows
 #![cfg(not(windows))]
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use object_store::memory::InMemory;
 use pprof::criterion::{Output, PProfProfiler};
-use slatedb::config::{PutOptions, WriteOptions};
+use slatedb::config::{PutOptions, Settings, WriteOptions};
 use slatedb::Db;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -39,6 +39,68 @@ fn criterion_benchmark(c: &mut Criterion) {
                 .await
                 .expect("open failed");
             db.close().await.expect("close failed");
+        })
+    });
+
+    bench_batch_reads(c, &runtime);
+}
+
+/// Compare a single batched `multi_get` against an equivalent loop of `get`s
+/// over a database whose keys span many L0 SSTs with no block cache — the case
+/// where multi_get's per-SST batching (load index/filter once, coalesce block
+/// reads) wins most.
+fn bench_batch_reads(c: &mut Criterion, runtime: &Runtime) {
+    let object_store = Arc::new(InMemory::new());
+    let settings = Settings {
+        l0_sst_size_bytes: 4096,
+        min_filter_keys: 0,
+        ..Default::default()
+    };
+    let db = runtime.block_on(async {
+        let db = Db::builder("/tmp/bench_multi_get", object_store)
+            .with_settings(settings)
+            .build()
+            .await
+            .expect("open failed");
+        for i in 0..4000u32 {
+            let key = format!("key{i:06}");
+            let value = format!("value{i:06}");
+            db.put_with_options(
+                key.as_bytes(),
+                value.as_bytes(),
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("put failed");
+            if i % 250 == 249 {
+                db.flush().await.expect("flush failed");
+            }
+        }
+        db.flush().await.expect("flush failed");
+        db
+    });
+
+    // 32 keys spread across the key space (so they land in many distinct SSTs).
+    let keys: Vec<Vec<u8>> = (0..1000u32)
+        .map(|i| format!("key{:06}", i * 4).into_bytes())
+        .collect();
+
+    c.bench_function("multi_get_1k", |b| {
+        b.to_async(runtime).iter(|| async {
+            black_box(db.multi_get(&keys).await.expect("multi_get failed"));
+        })
+    });
+    c.bench_function("get_loop_1k", |b| {
+        b.to_async(runtime).iter(|| async {
+            let mut out = Vec::with_capacity(keys.len());
+            for key in &keys {
+                out.push(db.get(key).await.expect("get failed"));
+            }
+            black_box(out);
         })
     });
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -69,7 +69,7 @@ use crate::snapshot_manager::SnapshotManager;
 use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
 use crate::transaction_manager::TransactionManager;
-use crate::types::KeyValue;
+use crate::types::{KeyValue, RowEntry};
 use crate::utils::{format_bytes_si, SafeSender};
 use crate::wal_buffer::{WalBufferManager, WAL_BUFFER_TASK_NAME};
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
@@ -234,6 +234,40 @@ impl DbInner {
         let db_state = self.state.read().view();
         self.reader
             .get_key_value_with_options(key, options, &db_state, None, None)
+            .await
+    }
+
+    pub(crate) async fn multi_get_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries
+            .into_iter()
+            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
+            .collect())
+    }
+
+    pub(crate) async fn multi_get_key_value_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, SlateDBError> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+    }
+
+    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<RowEntry>>, SlateDBError> {
+        self.check_closed()?;
+        let key_bytes: Vec<Bytes> = keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
+        let db_state = self.state.read().view();
+        self.reader
+            .multi_get_with_options(&key_bytes, options, &db_state, None, None)
             .await
     }
 
@@ -964,6 +998,52 @@ impl Db {
             .await
             .map_err(crate::Error::from)?;
         Ok(kv)
+    }
+
+    /// Get multiple values in one snapshot-consistent batch, in input order.
+    /// See [`DbReadOps::multi_get`](crate::DbReadOps::multi_get).
+    pub async fn multi_get<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.multi_get_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple values in one snapshot-consistent batch with custom read
+    /// options. See [`DbReadOps::multi_get`](crate::DbReadOps::multi_get).
+    pub async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.inner
+            .multi_get_with_options(keys, options)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Get multiple key-value pairs in one snapshot-consistent batch, in input
+    /// order. See [`DbReadOps::multi_get_key_value`](crate::DbReadOps::multi_get_key_value).
+    pub async fn multi_get_key_value<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.multi_get_key_value_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple key-value pairs in one snapshot-consistent batch with custom
+    /// read options. See [`DbReadOps::multi_get_key_value`](crate::DbReadOps::multi_get_key_value).
+    pub async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.inner
+            .multi_get_key_value_with_options(keys, options)
+            .await
+            .map_err(crate::Error::from)
     }
 
     /// Scan a range of keys using the default scan options.
@@ -1909,6 +1989,22 @@ impl DbReadOps for Db {
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
         Db::get_key_value_with_options(self, key, options).await
+    }
+
+    async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        Db::multi_get_with_options(self, keys, options).await
+    }
+
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        Db::multi_get_key_value_with_options(self, keys, options).await
     }
 
     async fn scan_with_options<K, T>(

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -64,7 +64,7 @@ use crate::merge_operator::{instrument_merge_operator, MergeOperatorType};
 use crate::oracle::{DbOracle, Oracle};
 use crate::paths::PathResolver;
 use crate::prefix_extractor::PrefixExtractor;
-use crate::reader::{Reader, ScanContext};
+use crate::reader::{entries_to_key_values, entries_to_values, Reader, ScanContext};
 use crate::snapshot_manager::SnapshotManager;
 use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
@@ -237,37 +237,33 @@ impl DbInner {
             .await
     }
 
-    pub(crate) async fn multi_get_with_options<K: AsRef<[u8]>>(
+    pub(crate) async fn multi_get_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries
-            .into_iter()
-            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
-            .collect())
+        Ok(entries_to_values(entries))
     }
 
-    pub(crate) async fn multi_get_key_value_with_options<K: AsRef<[u8]>>(
+    pub(crate) async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<KeyValue>>, SlateDBError> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+        Ok(entries_to_key_values(entries))
     }
 
-    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+    async fn multi_get_entries_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<RowEntry>>, SlateDBError> {
         self.check_closed()?;
-        let key_bytes: Vec<Bytes> = keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
         let db_state = self.state.read().view();
         self.reader
-            .multi_get_with_options(&key_bytes, options, &db_state, None, None)
+            .multi_get_with_options(keys, options, &db_state, None, None)
             .await
     }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -17,7 +17,7 @@ use crate::merge_operator::MergeOperatorType;
 use crate::oracle::DbReaderOracle;
 use crate::paths::PathResolver;
 use crate::prefix_extractor::PrefixExtractor;
-use crate::reader::{DbStateReader, Reader, ScanContext};
+use crate::reader::{entries_to_key_values, entries_to_values, DbStateReader, Reader, ScanContext};
 use crate::sst_iter::SstIteratorOptions;
 use crate::store_provider::StoreProvider;
 use crate::tablestore::TableStore;
@@ -229,38 +229,33 @@ impl DbReaderInner {
             .await
     }
 
-    async fn multi_get_with_options<K: AsRef<[u8]>>(
+    async fn multi_get_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries
-            .into_iter()
-            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
-            .collect())
+        Ok(entries_to_values(entries))
     }
 
-    async fn multi_get_key_value_with_options<K: AsRef<[u8]>>(
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<KeyValue>>, SlateDBError> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+        Ok(entries_to_key_values(entries))
     }
 
-    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+    async fn multi_get_entries_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<RowEntry>>, SlateDBError> {
         self.check_closed()?;
-        let key_bytes: Vec<Bytes> =
-            keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
         let db_state = Arc::clone(&self.state.read());
         self.reader
-            .multi_get_with_options(&key_bytes, options, db_state.as_ref(), None, None)
+            .multi_get_with_options(keys, options, db_state.as_ref(), None, None)
             .await
     }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -21,7 +21,7 @@ use crate::reader::{DbStateReader, Reader, ScanContext};
 use crate::sst_iter::SstIteratorOptions;
 use crate::store_provider::StoreProvider;
 use crate::tablestore::TableStore;
-use crate::types::KeyValue;
+use crate::types::{KeyValue, RowEntry};
 use crate::utils::IdGenerator;
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{Checkpoint, DbIterator};
@@ -226,6 +226,41 @@ impl DbReaderInner {
         let db_state = Arc::clone(&self.state.read());
         self.reader
             .get_key_value_with_options(key, options, db_state.as_ref(), None, None)
+            .await
+    }
+
+    async fn multi_get_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries
+            .into_iter()
+            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
+            .collect())
+    }
+
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, SlateDBError> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+    }
+
+    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<RowEntry>>, SlateDBError> {
+        self.check_closed()?;
+        let key_bytes: Vec<Bytes> =
+            keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
+        let db_state = Arc::clone(&self.state.read());
+        self.reader
+            .multi_get_with_options(&key_bytes, options, db_state.as_ref(), None, None)
             .await
     }
 
@@ -957,6 +992,49 @@ impl DbReader {
         Ok(kv)
     }
 
+    /// Get multiple values from the reader in one snapshot-consistent batch.
+    pub async fn multi_get<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.multi_get_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple values from the reader in one batch with custom read options.
+    pub async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.inner
+            .multi_get_with_options(keys, options)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Get multiple key-value pairs from the reader in one batch.
+    pub async fn multi_get_key_value<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.multi_get_key_value_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple key-value pairs from the reader in one batch with custom
+    /// read options.
+    pub async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.inner
+            .multi_get_key_value_with_options(keys, options)
+            .await
+            .map_err(crate::Error::from)
+    }
+
     /// Scan a range of keys using the default scan options.
     ///
     /// returns a `DbIterator`
@@ -1185,6 +1263,22 @@ impl DbReadOps for DbReader {
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
         DbReader::get_key_value_with_options(self, key, options).await
+    }
+
+    async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        DbReader::multi_get_with_options(self, keys, options).await
+    }
+
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        DbReader::multi_get_key_value_with_options(self, keys, options).await
     }
 
     async fn scan_with_options<K, T>(

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use crate::bytes_range::BytesRange;
 use crate::config::{ReadOptions, ScanOptions};
 use crate::db_iter::DbIterator;
-use crate::types::KeyValue;
+use crate::types::{KeyValue, RowEntry};
 
 use crate::db::DbInner;
 use crate::reader::ScanContext;
@@ -88,6 +88,65 @@ impl DbSnapshot {
             .await
             .map_err(crate::Error::from)?;
         Ok(kv)
+    }
+
+    /// Get multiple values from the snapshot in one batch, in input order.
+    pub async fn multi_get<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.multi_get_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple values from the snapshot in one batch with custom read
+    /// options.
+    pub async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries
+            .into_iter()
+            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
+            .collect())
+    }
+
+    /// Get multiple key-value pairs from the snapshot in one batch.
+    pub async fn multi_get_key_value<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.multi_get_key_value_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple key-value pairs from the snapshot in one batch with custom
+    /// read options.
+    pub async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+    }
+
+    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<RowEntry>>, crate::Error> {
+        self.db_inner.check_closed()?;
+        let key_bytes: Vec<Bytes> =
+            keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
+        let db_state = self.db_inner.state.read().view();
+        self.db_inner
+            .reader
+            .multi_get_with_options(&key_bytes, options, &db_state, None, Some(self.started_seq))
+            .await
+            .map_err(crate::Error::from)
     }
 
     /// Scan a range of keys using the default scan options.
@@ -228,6 +287,22 @@ impl DbReadOps for DbSnapshot {
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
         DbSnapshot::get_key_value_with_options(self, key, options).await
+    }
+
+    async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        DbSnapshot::multi_get_with_options(self, keys, options).await
+    }
+
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        DbSnapshot::multi_get_key_value_with_options(self, keys, options).await
     }
 
     async fn scan_with_options<K, T>(

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -9,7 +9,7 @@ use crate::db_iter::DbIterator;
 use crate::types::{KeyValue, RowEntry};
 
 use crate::db::DbInner;
-use crate::reader::ScanContext;
+use crate::reader::{entries_to_key_values, entries_to_values, ScanContext};
 use crate::DbReadOps;
 
 pub struct DbSnapshot {
@@ -107,10 +107,7 @@ impl DbSnapshot {
         options: &ReadOptions,
     ) -> Result<Vec<Option<Bytes>>, crate::Error> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries
-            .into_iter()
-            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
-            .collect())
+        Ok(entries_to_values(entries))
     }
 
     /// Get multiple key-value pairs from the snapshot in one batch.
@@ -130,21 +127,19 @@ impl DbSnapshot {
         options: &ReadOptions,
     ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+        Ok(entries_to_key_values(entries))
     }
 
-    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+    async fn multi_get_entries_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<RowEntry>>, crate::Error> {
         self.db_inner.check_closed()?;
-        let key_bytes: Vec<Bytes> =
-            keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
         let db_state = self.db_inner.state.read().view();
         self.db_inner
             .reader
-            .multi_get_with_options(&key_bytes, options, &db_state, None, Some(self.started_seq))
+            .multi_get_with_options(keys, options, &db_state, None, Some(self.started_seq))
             .await
             .map_err(crate::Error::from)
     }

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -521,7 +521,7 @@ impl SortedRun {
     ///
     /// This uses the binary-search candidate as the upper bound, then walks
     /// backward only across immediately overlapping views.
-    fn point_table_idx_covering_key(&self, key: &[u8]) -> Range<usize> {
+    pub(crate) fn point_table_idx_covering_key(&self, key: &[u8]) -> Range<usize> {
         let Some(max_idx) = self.find_last_sst_with_range_covering_key(key) else {
             return 0..0;
         };

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -13,7 +13,7 @@ use crate::db::WriteHandle;
 use crate::db_iter::{DbIterator, DbIteratorRangeTracker};
 use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
-use crate::reader::ScanContext;
+use crate::reader::{entries_to_key_values, entries_to_values, ScanContext};
 use crate::transaction_manager::{IsolationLevel, TransactionManager};
 use crate::types::{KeyValue, RowEntry};
 use crate::{DbReadOps, DbTransactionOps};
@@ -203,10 +203,7 @@ impl DbTransaction {
         options: &ReadOptions,
     ) -> Result<Vec<Option<Bytes>>, crate::Error> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries
-            .into_iter()
-            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
-            .collect())
+        Ok(entries_to_values(entries))
     }
 
     /// Get multiple key-value pairs from the transaction in one batch.
@@ -226,21 +223,22 @@ impl DbTransaction {
         options: &ReadOptions,
     ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
         let entries = self.multi_get_entries_with_options(keys, options).await?;
-        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+        Ok(entries_to_key_values(entries))
     }
 
-    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+    async fn multi_get_entries_with_options<K: AsRef<[u8]> + Sync>(
         &self,
         keys: &[K],
         options: &ReadOptions,
     ) -> Result<Vec<Option<RowEntry>>, crate::Error> {
         self.db_inner.check_closed()?;
-        let key_bytes: Vec<Bytes> =
-            keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
 
         // Track all batch keys for SSI conflict detection.
         if self.isolation_level == IsolationLevel::SerializableSnapshot {
-            let read_keys: HashSet<Bytes> = key_bytes.iter().cloned().collect();
+            let read_keys: HashSet<Bytes> = keys
+                .iter()
+                .map(|k| Bytes::copy_from_slice(k.as_ref()))
+                .collect();
             self.txn_manager.track_read_keys(&self.txn_id, read_keys);
         }
 
@@ -251,7 +249,7 @@ impl DbTransaction {
         self.db_inner
             .reader
             .multi_get_with_options(
-                &key_bytes,
+                keys,
                 options,
                 &db_state,
                 Some(&write_batch),

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -15,7 +15,7 @@ use crate::error::SlateDBError;
 use crate::iter::IterationOrder;
 use crate::reader::ScanContext;
 use crate::transaction_manager::{IsolationLevel, TransactionManager};
-use crate::types::KeyValue;
+use crate::types::{KeyValue, RowEntry};
 use crate::{DbReadOps, DbTransactionOps};
 
 /// A database transaction that provides atomic read-write operations with
@@ -183,6 +183,82 @@ impl DbTransaction {
             .await
             .map_err(crate::Error::from)?;
         Ok(kv)
+    }
+
+    /// Get multiple values from the transaction in one batch, in input order.
+    /// In SSI mode every key is tracked for conflict detection.
+    pub async fn multi_get<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.multi_get_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple values from the transaction in one batch with custom read
+    /// options. In SSI mode every key is tracked for conflict detection.
+    pub async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries
+            .into_iter()
+            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
+            .collect())
+    }
+
+    /// Get multiple key-value pairs from the transaction in one batch.
+    pub async fn multi_get_key_value<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.multi_get_key_value_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple key-value pairs from the transaction in one batch with
+    /// custom read options.
+    pub async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        let entries = self.multi_get_entries_with_options(keys, options).await?;
+        Ok(entries.into_iter().map(|e| e.map(KeyValue::from)).collect())
+    }
+
+    async fn multi_get_entries_with_options<K: AsRef<[u8]>>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<RowEntry>>, crate::Error> {
+        self.db_inner.check_closed()?;
+        let key_bytes: Vec<Bytes> =
+            keys.iter().map(|k| Bytes::copy_from_slice(k.as_ref())).collect();
+
+        // Track all batch keys for SSI conflict detection.
+        if self.isolation_level == IsolationLevel::SerializableSnapshot {
+            let read_keys: HashSet<Bytes> = key_bytes.iter().cloned().collect();
+            self.txn_manager.track_read_keys(&self.txn_id, read_keys);
+        }
+
+        let db_state = self.db_inner.state.read().view();
+        // Clone the write batch once (like the commit path) so we can probe every
+        // key against the transaction's uncommitted writes.
+        let write_batch = self.write_batch.read().clone();
+        self.db_inner
+            .reader
+            .multi_get_with_options(
+                &key_bytes,
+                options,
+                &db_state,
+                Some(&write_batch),
+                Some(self.started_seq),
+            )
+            .await
+            .map_err(crate::Error::from)
     }
 
     /// Scan a range of keys using the default scan options.
@@ -647,6 +723,22 @@ impl DbReadOps for DbTransaction {
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error> {
         DbTransaction::get_key_value_with_options(self, key, options).await
+    }
+
+    async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        DbTransaction::multi_get_with_options(self, keys, options).await
+    }
+
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        DbTransaction::multi_get_key_value_with_options(self, keys, options).await
     }
 
     async fn scan_with_options<K, T>(

--- a/slatedb/src/iter.rs
+++ b/slatedb/src/iter.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use std::collections::VecDeque;
 
 use crate::error::SlateDBError;
 use crate::types::RowEntry;
@@ -112,6 +113,50 @@ impl RowEntryIterator for EmptyIterator {
     }
 
     async fn seek(&mut self, _next_key: &[u8]) -> Result<(), SlateDBError> {
+        Ok(())
+    }
+}
+
+/// A [`RowEntryIterator`] backed by an in-memory list of pre-collected entries.
+///
+/// Used by the batched `multi_get` path: a single key's accumulated versions
+/// (in newest-first / sequence-descending order) are replayed through the same
+/// [`crate::db_iter::GetIterator`] + merge-operator resolution the single-key
+/// `get` path uses, so tombstone / merge / sequence semantics are inherited
+/// rather than reimplemented.
+pub(crate) struct VecRowIterator {
+    entries: VecDeque<RowEntry>,
+}
+
+impl VecRowIterator {
+    pub(crate) fn new(entries: impl Into<VecDeque<RowEntry>>) -> Self {
+        Self {
+            entries: entries.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl RowEntryIterator for VecRowIterator {
+    async fn init(&mut self) -> Result<(), SlateDBError> {
+        Ok(())
+    }
+
+    async fn next(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
+        Ok(self.entries.pop_front())
+    }
+
+    async fn seek(&mut self, next_key: &[u8]) -> Result<(), SlateDBError> {
+        // The multi_get resolution path only calls `next`, but `seek` is
+        // implemented for trait completeness. Entries are stored in iteration
+        // order, so drop any leading entries that sort before `next_key`.
+        while let Some(front) = self.entries.front() {
+            if front.key.as_ref() < next_key {
+                self.entries.pop_front();
+            } else {
+                break;
+            }
+        }
         Ok(())
     }
 }

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -139,6 +139,7 @@ mod mem_table;
 mod memtable_flusher;
 mod merge_iterator;
 mod merge_operator;
+mod multi_sst;
 mod object_stores;
 mod ops;
 mod oracle;

--- a/slatedb/src/multi_sst.rs
+++ b/slatedb/src/multi_sst.rs
@@ -1,0 +1,293 @@
+//! Batched per-SST point reads for `multi_get`.
+//!
+//! [`read_sst_for_keys`] visits a single SST exactly once for every key in a
+//! batch that it could satisfy. Unlike calling [`crate::sst_iter::SstIterator`]
+//! once per key — which would reload the index and filters and issue a separate
+//! object-store GET for every key — it loads the index and filters once, prunes
+//! keys with the bloom filter, maps the survivors to blocks, coalesces those
+//! blocks into as few object-store reads as possible (reusing
+//! [`crate::tablestore::TableStore::read_blocks_using_index`], which already
+//! handles caching, range coalescing, and parallel decode), and scans each
+//! fetched block for its keys.
+//!
+//! The reader returns the raw `RowEntry`s each SST holds for a key, newest
+//! first. Sequence/merge/tombstone resolution is intentionally left to the
+//! orchestrator ([`crate::reader::Reader`]) so the final value is produced by
+//! the exact same components the single-key `get` path uses.
+
+use std::collections::BTreeMap;
+use std::ops::Bound::Included;
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+use crate::block_iterator::DataBlockIterator;
+use crate::bytes_range::BytesRange;
+use crate::db_state::{SsTableHandle, SsTableView};
+use crate::db_stats::DbStats;
+use crate::error::SlateDBError;
+use crate::filter_policy::{FilterQuery, NamedFilter};
+use crate::flatbuffer_types::SsTableIndexOwned;
+use crate::format::block::Block;
+use crate::iter::IterationOrder;
+use crate::partitioned_keyspace;
+use crate::sst_iter::{all_filters_might_match, SstIteratorOptions};
+use crate::tablestore::TableStore;
+use crate::types::RowEntry;
+
+/// Number of intervening unwanted blocks tolerated when coalescing the set of
+/// blocks a batch of keys maps to within one SST. Two wanted blocks separated
+/// by at most this many gap blocks are fetched as one coalesced object-store
+/// range: reading a couple of extra 4 KiB blocks is cheaper than a second round
+/// trip on object stores like S3.
+const COALESCE_GAP_BLOCKS: usize = 2;
+
+/// A key from the `multi_get` batch paired with the slot it should resolve into
+/// (an index into the orchestrator's deduplicated key list), so per-SST results
+/// can be scattered back to the correct accumulator.
+#[derive(Clone, Debug)]
+pub(crate) struct PendingKey {
+    pub(crate) idx: usize,
+    pub(crate) key: Bytes,
+}
+
+/// One key that survived pruning, paired with the contiguous block range that
+/// may hold its versions.
+struct Candidate {
+    idx: usize,
+    key: Bytes,
+    blocks: Range<usize>,
+}
+
+/// Visit one SST once for every key in `keys` it could satisfy.
+///
+/// Returns, for each key that produced at least one entry, the collected
+/// `RowEntry`s in sequence-descending (newest-first) order. Entries are not
+/// sequence-filtered or merge-resolved here.
+pub(crate) async fn read_sst_for_keys(
+    view: &SsTableView,
+    keys: &[PendingKey],
+    table_store: &Arc<TableStore>,
+    options: &SstIteratorOptions,
+    db_stats: Option<&DbStats>,
+) -> Result<Vec<(usize, Vec<RowEntry>)>, SlateDBError> {
+    if keys.is_empty() {
+        return Ok(Vec::new());
+    }
+    let handle = &view.sst;
+
+    let (index, filters) = read_metadata(handle, table_store, options.cache_blocks).await?;
+    if index.borrow().block_meta().is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let candidates = plan_candidates(view, keys, &index, &filters, options, db_stats);
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let blocks =
+        fetch_candidate_blocks(handle, &index, &candidates, options.cache_blocks, table_store)
+            .await?;
+
+    scan_candidates(
+        handle.format_version,
+        &candidates,
+        &blocks,
+        !filters.is_empty(),
+        db_stats,
+    )
+    .await
+}
+
+/// Step 1: load the SST index and filters once for the whole batch.
+async fn read_metadata(
+    handle: &SsTableHandle,
+    table_store: &Arc<TableStore>,
+    cache_blocks: bool,
+) -> Result<(Arc<SsTableIndexOwned>, Arc<[NamedFilter]>), SlateDBError> {
+    let index = table_store.read_index(handle, cache_blocks).await?;
+    let filters = table_store.read_filters(handle, cache_blocks).await?;
+    Ok((index, filters))
+}
+
+/// Step 2: prune keys by visible range and bloom filter, then map each survivor
+/// to the block range that may hold its versions. Uses the same
+/// `partitions_covering_range` the single-key path uses, so a key whose versions
+/// span a block boundary is covered correctly. Filter positives/negatives are
+/// recorded here; false positives are recorded after scanning (see
+/// [`scan_candidates`]).
+fn plan_candidates(
+    view: &SsTableView,
+    keys: &[PendingKey],
+    index: &Arc<SsTableIndexOwned>,
+    filters: &[NamedFilter],
+    options: &SstIteratorOptions,
+    db_stats: Option<&DbStats>,
+) -> Vec<Candidate> {
+    let mut candidates = Vec::with_capacity(keys.len());
+    for pk in keys {
+        // Visible-range projection (segments / clones). For identity views this
+        // also prunes keys outside the SST's physical key range. Keys pruned
+        // here are out of range, not filter false positives, so no stats.
+        if view
+            .calculate_view_range(BytesRange::from_slice(pk.key.as_ref()..=pk.key.as_ref()))
+            .is_none()
+        {
+            continue;
+        }
+
+        if !filters.is_empty() {
+            let query =
+                FilterQuery::point(pk.key.clone()).with_context(options.filter_context.clone());
+            if !all_filters_might_match(filters, &query) {
+                if let Some(stats) = db_stats {
+                    stats.sst_filter_point_negatives.increment(1);
+                }
+                continue;
+            }
+            if let Some(stats) = db_stats {
+                stats.sst_filter_point_positives.increment(1);
+            }
+        }
+
+        let blocks = partitioned_keyspace::partitions_covering_range(
+            &index.borrow(),
+            Included(pk.key.as_ref()),
+            Included(pk.key.as_ref()),
+        );
+        candidates.push(Candidate {
+            idx: pk.idx,
+            key: pk.key.clone(),
+            blocks,
+        });
+    }
+    candidates
+}
+
+/// Step 3: collect the union of the candidates' block ranges, coalesce them into
+/// contiguous runs, and fetch each run once. `read_blocks_using_index` handles
+/// caching, per-run range coalescing of uncached blocks, and parallel decode.
+async fn fetch_candidate_blocks(
+    handle: &SsTableHandle,
+    index: &Arc<SsTableIndexOwned>,
+    candidates: &[Candidate],
+    cache_blocks: bool,
+    table_store: &Arc<TableStore>,
+) -> Result<BTreeMap<usize, Arc<Block>>, SlateDBError> {
+    let mut needed: Vec<usize> = Vec::new();
+    for cand in candidates {
+        needed.extend(cand.blocks.clone());
+    }
+    needed.sort_unstable();
+    needed.dedup();
+
+    let mut blocks: BTreeMap<usize, Arc<Block>> = BTreeMap::new();
+    for run in coalesce_runs(&needed, COALESCE_GAP_BLOCKS) {
+        let fetched = table_store
+            .read_blocks_using_index(handle, index.clone(), run.clone(), cache_blocks)
+            .await?;
+        for (offset, block) in fetched.into_iter().enumerate() {
+            blocks.insert(run.start + offset, block);
+        }
+    }
+    Ok(blocks)
+}
+
+/// Step 4: scan each candidate's block range for its key, collecting that key's
+/// `RowEntry`s newest-first. A candidate that yields nothing despite passing the
+/// bloom filter is recorded as a filter false positive.
+async fn scan_candidates(
+    sst_version: u16,
+    candidates: &[Candidate],
+    blocks: &BTreeMap<usize, Arc<Block>>,
+    filters_present: bool,
+    db_stats: Option<&DbStats>,
+) -> Result<Vec<(usize, Vec<RowEntry>)>, SlateDBError> {
+    let mut out = Vec::with_capacity(candidates.len());
+    for cand in candidates {
+        let entries = scan_candidate_key(sst_version, cand, blocks).await?;
+        if entries.is_empty() {
+            if filters_present {
+                if let Some(stats) = db_stats {
+                    stats.sst_filter_point_false_positives.increment(1);
+                }
+            }
+        } else {
+            out.push((cand.idx, entries));
+        }
+    }
+    Ok(out)
+}
+
+/// Scan a single candidate's block range for its key, collecting matching
+/// entries in iteration (sequence-descending) order. Stops as soon as a larger
+/// key is seen, since later blocks only hold larger keys.
+async fn scan_candidate_key(
+    sst_version: u16,
+    cand: &Candidate,
+    blocks: &BTreeMap<usize, Arc<Block>>,
+) -> Result<Vec<RowEntry>, SlateDBError> {
+    let mut entries = Vec::new();
+    for bi in cand.blocks.clone() {
+        let Some(block) = blocks.get(&bi) else {
+            // Every block in a candidate's range was added to `needed` and
+            // fetched, so this is unreachable in practice.
+            break;
+        };
+        let mut iter =
+            DataBlockIterator::new(block.clone(), sst_version, IterationOrder::Ascending)?;
+        iter.seek(cand.key.as_ref()).await?;
+        while let Some(entry) = iter.next().await? {
+            match entry.key.as_ref().cmp(cand.key.as_ref()) {
+                std::cmp::Ordering::Less => continue,
+                std::cmp::Ordering::Equal => entries.push(entry),
+                std::cmp::Ordering::Greater => return Ok(entries),
+            }
+        }
+    }
+    Ok(entries)
+}
+
+/// Group sorted, deduplicated block indices into contiguous fetch ranges,
+/// merging two runs separated by at most `gap` intervening blocks.
+fn coalesce_runs(sorted_blocks: &[usize], gap: usize) -> Vec<Range<usize>> {
+    let mut runs: Vec<Range<usize>> = Vec::new();
+    for &b in sorted_blocks {
+        if let Some(last) = runs.last_mut() {
+            if b < last.end {
+                continue; // already covered
+            }
+            if b - last.end <= gap {
+                last.end = b + 1; // extend, absorbing the small gap
+                continue;
+            }
+        }
+        runs.push(b..b + 1);
+    }
+    runs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coalesce_runs_merges_within_gap_and_splits_beyond() {
+        // Adjacent blocks merge.
+        assert_eq!(coalesce_runs(&[2, 3], 2), vec![2..4]);
+        // Gap within threshold merges (absorbs block 4).
+        assert_eq!(coalesce_runs(&[2, 3, 5], 2), vec![2..6]);
+        // Gap beyond threshold splits.
+        assert_eq!(coalesce_runs(&[2, 3, 9], 2), vec![2..4, 9..10]);
+        // Single block.
+        assert_eq!(coalesce_runs(&[7], 2), vec![7..8]);
+        // Empty.
+        assert_eq!(coalesce_runs(&[], 2), Vec::<Range<usize>>::new());
+        // One intervening block at gap=1 merges.
+        assert_eq!(coalesce_runs(&[0, 2], 1), vec![0..3]);
+        // One intervening block at gap=0 splits.
+        assert_eq!(coalesce_runs(&[0, 2], 0), vec![0..1, 2..3]);
+    }
+}

--- a/slatedb/src/multi_sst.rs
+++ b/slatedb/src/multi_sst.rs
@@ -77,7 +77,11 @@ pub(crate) async fn read_sst_for_keys(
     }
     let handle = &view.sst;
 
-    let (index, filters) = read_metadata(handle, table_store, options.cache_blocks).await?;
+    // Step 1: load the SST index and filters once for the whole batch.
+    let index = table_store.read_index(handle, options.cache_blocks).await?;
+    let filters = table_store
+        .read_filters(handle, options.cache_blocks)
+        .await?;
     if index.borrow().block_meta().is_empty() {
         return Ok(Vec::new());
     }
@@ -87,9 +91,14 @@ pub(crate) async fn read_sst_for_keys(
         return Ok(Vec::new());
     }
 
-    let blocks =
-        fetch_candidate_blocks(handle, &index, &candidates, options.cache_blocks, table_store)
-            .await?;
+    let blocks = fetch_candidate_blocks(
+        handle,
+        &index,
+        &candidates,
+        options.cache_blocks,
+        table_store,
+    )
+    .await?;
 
     scan_candidates(
         handle.format_version,
@@ -99,17 +108,6 @@ pub(crate) async fn read_sst_for_keys(
         db_stats,
     )
     .await
-}
-
-/// Step 1: load the SST index and filters once for the whole batch.
-async fn read_metadata(
-    handle: &SsTableHandle,
-    table_store: &Arc<TableStore>,
-    cache_blocks: bool,
-) -> Result<(Arc<SsTableIndexOwned>, Arc<[NamedFilter]>), SlateDBError> {
-    let index = table_store.read_index(handle, cache_blocks).await?;
-    let filters = table_store.read_filters(handle, cache_blocks).await?;
-    Ok((index, filters))
 }
 
 /// Step 2: prune keys by visible range and bloom filter, then map each survivor

--- a/slatedb/src/ops.rs
+++ b/slatedb/src/ops.rs
@@ -116,6 +116,64 @@ pub trait DbReadOps {
         options: &ReadOptions,
     ) -> Result<Option<KeyValue>, crate::Error>;
 
+    /// Get multiple values in a single snapshot-consistent batch, using default
+    /// read options.
+    ///
+    /// Results are returned in the same order as `keys`; a `None` entry marks a
+    /// key that is missing, deleted, or expired. Duplicate keys yield duplicate
+    /// (positional) results. The whole batch observes one consistent snapshot of
+    /// the database.
+    ///
+    /// This is equivalent to calling [`get`](Self::get) for each key against the
+    /// same snapshot, but resolves all keys in one pass that visits each SST
+    /// once — avoiding the repeated index/filter loads and per-key object-store
+    /// round trips a `get` loop incurs.
+    ///
+    /// ## Arguments
+    /// - `keys`: the keys to look up
+    ///
+    /// ## Returns
+    /// - `Result<Vec<Option<Bytes>>, Error>`: one slot per input key, in order
+    async fn multi_get<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<Bytes>>, crate::Error> {
+        self.multi_get_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple values in a single snapshot-consistent batch, with custom
+    /// read options. See [`multi_get`](Self::multi_get) for batch semantics.
+    ///
+    /// ## Arguments
+    /// - `keys`: the keys to look up
+    /// - `options`: the read options to use
+    async fn multi_get_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<Bytes>>, crate::Error>;
+
+    /// Get multiple key-value pairs in a single snapshot-consistent batch, using
+    /// default read options. Like [`multi_get`](Self::multi_get) but returns
+    /// [`KeyValue`]s with row metadata instead of bare value bytes.
+    async fn multi_get_key_value<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error> {
+        self.multi_get_key_value_with_options(keys, &ReadOptions::default())
+            .await
+    }
+
+    /// Get multiple key-value pairs in a single snapshot-consistent batch, with
+    /// custom read options. See [`multi_get`](Self::multi_get) for batch
+    /// semantics.
+    async fn multi_get_key_value_with_options<K: AsRef<[u8]> + Send + Sync>(
+        &self,
+        keys: &[K],
+        options: &ReadOptions,
+    ) -> Result<Vec<Option<KeyValue>>, crate::Error>;
+
     /// Scan a range of keys using the default scan options.
     ///
     /// returns a `DbIterator`

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -1,24 +1,40 @@
-use crate::batch::WriteBatchIterator;
+use crate::batch::{WriteBatch, WriteBatchIterator};
 use crate::bytes_range::BytesRange;
 use crate::clock::MonotonicClock;
 use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
-use crate::db_iter::{apply_filters, DbRecencyIterator};
+use crate::db_iter::{apply_filters, DbRecencyIterator, GetIterator};
+use crate::db_state::SsTableView;
 use crate::db_stats::DbStats;
-use crate::iter::RowEntryIterator;
-use crate::manifest::{ManifestCore, Segment};
+use crate::filter_iterator::FilterIterator;
+use crate::iter::{IterationOrder, RowEntryIterator, VecRowIterator};
+use crate::manifest::{LsmTreeState, ManifestCore, Segment};
 use crate::mem_table::{ImmutableMemtable, KVTable};
-use crate::merge_operator::{instrument_merge_operator, MergeOperatorType};
+use crate::merge_operator::{
+    instrument_merge_operator, MergeOperatorIterator, MergeOperatorRequiredIterator,
+    MergeOperatorType,
+};
+use crate::multi_sst::{read_sst_for_keys, PendingKey};
 use crate::oracle::Oracle;
 use crate::segment_iterator::{build_segment_iter, SegmentScanContext};
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
-use crate::types::KeyValue;
+use crate::types::{KeyValue, RowEntry, ValueDeletable};
+use crate::utils::build_concurrent;
 use crate::{error::SlateDBError, DbIterator};
 
 use bytes::Bytes;
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
+use ulid::Ulid;
+
+/// Per-SST batched read result for `multi_get`: `(newest-first rank, [(unique
+/// key index, that SST's versions of the key, newest-first)])`.
+type SstBatchResult = (usize, Vec<(usize, Vec<RowEntry>)>);
+
+/// One unit of concurrent SST work for `multi_get`:
+/// `(rank, view, keys to look up in that view)`.
+type SstReadWork = (usize, SsTableView, Arc<Vec<PendingKey>>);
 
 pub(crate) trait DbStateReader {
     fn memtable(&self) -> Arc<KVTable>;
@@ -259,6 +275,300 @@ impl Reader {
             .transpose()
     }
 
+    /// Resolve a batch of point keys against a single snapshot ("group by SST"
+    /// strategy). Returns one `Option<RowEntry>` per input key, in input order;
+    /// duplicate keys yield duplicate results.
+    ///
+    /// Setup (snapshot, max-seq) happens once for the whole batch. The layers
+    /// are then walked newest-first — write batch, memtables, then each
+    /// segment's L0 SSTs and sorted runs — shrinking the pending set as keys
+    /// resolve, so a key found in a newer layer is never read from an older
+    /// one. Each on-disk SST is visited once for all of its pending keys (see
+    /// [`crate::multi_sst::read_sst_for_keys`]).
+    ///
+    /// A key is "resolved" only when a `Value` or `Tombstone` is found; `Merge`
+    /// operands keep it descending to older layers (merge operands legitimately
+    /// span layers). The final value per key is produced by feeding the
+    /// accumulated entries through the same [`GetIterator`] +
+    /// [`MergeOperatorIterator`] resolution the single-key `get` path uses, so
+    /// the result is identical to calling `get` for each key.
+    ///
+    /// Mirrors the arguments of [`Self::get_key_value_with_options`]: a shared
+    /// `db_state` view, an optional per-transaction `write_batch` (consulted
+    /// first), and an optional `max_seq` bound (folded with durability/dirty via
+    /// `prepare_max_seq`).
+    pub(crate) async fn multi_get_with_options(
+        &self,
+        keys: &[Bytes],
+        options: &ReadOptions,
+        db_state: &(dyn DbStateReader + Sync + Send),
+        write_batch: Option<&WriteBatch>,
+        max_seq: Option<u64>,
+    ) -> Result<Vec<Option<RowEntry>>, SlateDBError> {
+        if keys.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.db_stats.get_requests.increment(keys.len() as u64);
+        let max_seq = self.prepare_max_seq(max_seq, options.durability_filter, options.dirty);
+
+        // Deduplicate keys for I/O; results are scattered back to every input
+        // position so duplicates resolve once but appear in each slot.
+        let mut unique_keys: Vec<Bytes> = Vec::new();
+        let mut index_of: HashMap<Bytes, usize> = HashMap::new();
+        let mut orig_to_unique: Vec<usize> = Vec::with_capacity(keys.len());
+        for key in keys {
+            let u = *index_of.entry(key.clone()).or_insert_with(|| {
+                unique_keys.push(key.clone());
+                unique_keys.len() - 1
+            });
+            orig_to_unique.push(u);
+        }
+        let n = unique_keys.len();
+
+        // Per unique key: write-batch entries (unfiltered, highest precedence),
+        // everything-else entries (memtable + on-disk), and whether a base
+        // (Value/Tombstone) has been found yet.
+        let mut wb_acc: Vec<Vec<RowEntry>> = vec![Vec::new(); n];
+        let mut acc: Vec<Vec<RowEntry>> = vec![Vec::new(); n];
+        let mut resolved: Vec<bool> = vec![false; n];
+
+        let sst_options = SstIteratorOptions {
+            cache_blocks: options.cache_blocks,
+            eager_spawn: true,
+            filter_context: options.filter_context.clone(),
+            ..SstIteratorOptions::default()
+        };
+
+        // 1. Write batch (transaction only). Entries carry seq u64::MAX and are
+        //    not max_seq filtered, matching the single-key get path.
+        if let Some(wb) = write_batch {
+            for (u, key) in unique_keys.iter().enumerate() {
+                let mut iter = WriteBatchIterator::new(
+                    wb,
+                    BytesRange::from_slice(key.as_ref()..=key.as_ref()),
+                    IterationOrder::Ascending,
+                );
+                iter.init().await?;
+                let mut entries = Vec::new();
+                while let Some(entry) = iter.next().await? {
+                    if entry.key.as_ref() == key.as_ref() {
+                        entries.push(entry);
+                    }
+                }
+                append_wb_versions(entries, &mut wb_acc[u], &mut resolved[u]);
+            }
+        }
+
+        // 2. Active memtable, then immutable memtables (newest-first).
+        let memtable = db_state.memtable();
+        read_memtable_layer(&memtable, &unique_keys, max_seq, &mut acc, &mut resolved).await?;
+        for imm in db_state.imm_memtable() {
+            let table = imm.table();
+            read_memtable_layer(&table, &unique_keys, max_seq, &mut acc, &mut resolved).await?;
+        }
+
+        // 3. On-disk: group still-pending keys by their LSM tree (segment), then
+        //    walk each tree's L0 + sorted runs. Unsegmented DBs yield one group.
+        let core = db_state.core();
+        let default_tree = core.default_segment().tree;
+        // Group keys by their LSM tree's identity. The key is the tree's Arc
+        // pointer cast to `usize` (a raw pointer would make the future `!Send`).
+        let mut groups: HashMap<usize, (Arc<LsmTreeState>, Vec<PendingKey>)> = HashMap::new();
+        for (u, key) in unique_keys.iter().enumerate() {
+            if resolved[u] {
+                continue;
+            }
+            let tree = match core
+                .select_segments(&BytesRange::from_slice(key.as_ref()..=key.as_ref()))
+            {
+                None => default_tree.clone(),
+                Some(segments) => match segments.last() {
+                    Some(segment) => segment.tree.clone(),
+                    // Configured but no segment covers this key: no on-disk data.
+                    None => continue,
+                },
+            };
+            groups
+                .entry(Arc::as_ptr(&tree) as usize)
+                .or_insert_with(|| (tree.clone(), Vec::new()))
+                .1
+                .push(PendingKey {
+                    idx: u,
+                    key: key.clone(),
+                });
+        }
+        for (_, (tree, group_keys)) in groups {
+            self.read_tree_layer(
+                &tree,
+                &group_keys,
+                &sst_options,
+                max_seq,
+                &mut acc,
+                &mut resolved,
+            )
+            .await?;
+        }
+
+        // 4. Resolve each unique key, then scatter to input positions.
+        let mut resolved_values: Vec<Option<RowEntry>> = Vec::with_capacity(n);
+        for u in 0..n {
+            let wb_entries = std::mem::take(&mut wb_acc[u]);
+            let rest_entries = std::mem::take(&mut acc[u]);
+            resolved_values.push(
+                self.resolve_entry(&unique_keys[u], wb_entries, rest_entries, max_seq)
+                    .await?,
+            );
+        }
+        Ok(orig_to_unique
+            .iter()
+            .map(|&u| resolved_values[u].clone())
+            .collect())
+    }
+
+    /// Walk one LSM tree (segment) for its group of pending keys: all L0 SSTs in
+    /// parallel (newest-first), then each sorted run newest-first with a shrink
+    /// between runs to preserve early-exit.
+    async fn read_tree_layer(
+        &self,
+        tree: &LsmTreeState,
+        group_keys: &[PendingKey],
+        sst_options: &SstIteratorOptions,
+        max_seq: Option<u64>,
+        acc: &mut [Vec<RowEntry>],
+        resolved: &mut [bool],
+    ) -> Result<(), SlateDBError> {
+        // L0: any L0 SST may hold any key, so all of them are read for every
+        // still-pending key. Rank by position (front = newest) and apply
+        // newest-first so the newest SST wins.
+        let l0_pending: Vec<PendingKey> = group_keys
+            .iter()
+            .filter(|pk| !resolved[pk.idx])
+            .cloned()
+            .collect();
+        if !l0_pending.is_empty() && !tree.l0.is_empty() {
+            let shared = Arc::new(l0_pending);
+            let work: Vec<SstReadWork> =tree
+                .l0
+                .iter()
+                .cloned()
+                .enumerate()
+                .map(|(rank, view)| (rank, view, shared.clone()))
+                .collect();
+            let results = self.read_ssts_concurrent(work, sst_options).await?;
+            apply_layer_results(results, max_seq, acc, resolved);
+        }
+
+        // Sorted runs, newest run first. Within a run each key maps (via binary
+        // search) to one SST view, so group keys by covering view and read each
+        // view once. Shrink between runs.
+        for sr in tree.compacted.iter() {
+            let sr_pending: Vec<&PendingKey> =
+                group_keys.iter().filter(|pk| !resolved[pk.idx]).collect();
+            if sr_pending.is_empty() {
+                break;
+            }
+            let view_pos: HashMap<Ulid, usize> = sr
+                .sst_views
+                .iter()
+                .enumerate()
+                .map(|(i, v)| (v.id, i))
+                .collect();
+            // Keyed by view index so iteration is ascending key-range order,
+            // matching the single-key sorted-run point iterators.
+            let mut view_keys: BTreeMap<usize, Vec<PendingKey>> = BTreeMap::new();
+            for pk in sr_pending {
+                for view in sr.tables_covering_point_key(pk.key.as_ref()) {
+                    view_keys
+                        .entry(view_pos[&view.id])
+                        .or_default()
+                        .push(pk.clone());
+                }
+            }
+            if view_keys.is_empty() {
+                continue;
+            }
+            let work: Vec<SstReadWork> =view_keys
+                .into_iter()
+                .map(|(rank, keys)| (rank, sr.sst_views[rank].clone(), Arc::new(keys)))
+                .collect();
+            let results = self.read_ssts_concurrent(work, sst_options).await?;
+            apply_layer_results(results, max_seq, acc, resolved);
+        }
+        Ok(())
+    }
+
+    /// Read a set of `(rank, view, keys)` work items concurrently (bounded), one
+    /// [`read_sst_for_keys`] call per view, and return the per-view results
+    /// sorted by `rank` so the caller can apply them in precedence order.
+    async fn read_ssts_concurrent(
+        &self,
+        work: Vec<SstReadWork>,
+        sst_options: &SstIteratorOptions,
+    ) -> Result<Vec<SstBatchResult>, SlateDBError> {
+        if work.is_empty() {
+            return Ok(Vec::new());
+        }
+        let max_parallel = work.len().clamp(1, 4);
+        let table_store = self.table_store.clone();
+        let opts = sst_options.clone();
+        let stats = self.db_stats.clone();
+        let results = build_concurrent(work, max_parallel, move |(rank, view, keys)| {
+            let table_store = table_store.clone();
+            let opts = opts.clone();
+            let stats = stats.clone();
+            async move {
+                let per_key =
+                    read_sst_for_keys(&view, &keys[..], &table_store, &opts, Some(&stats)).await?;
+                Ok(Some((rank, per_key)))
+            }
+        })
+        .await?;
+        let mut results: Vec<SstBatchResult> = results.into();
+        results.sort_by_key(|(rank, _)| *rank);
+        Ok(results)
+    }
+
+    /// Produce the final entry for one key by replaying its accumulated versions
+    /// through the same components the single-key `get` path uses: a
+    /// [`GetIterator`] (write-batch arm unfiltered, the rest seq-filtered) wrapped
+    /// in the merge operator. Returns `None` for a missing or deleted key.
+    async fn resolve_entry(
+        &self,
+        key: &Bytes,
+        wb_entries: Vec<RowEntry>,
+        rest_entries: Vec<RowEntry>,
+        max_seq: Option<u64>,
+    ) -> Result<Option<RowEntry>, SlateDBError> {
+        if wb_entries.is_empty() && rest_entries.is_empty() {
+            return Ok(None);
+        }
+        let wb_iter: Box<dyn RowEntryIterator + 'static> =
+            Box::new(VecRowIterator::new(wb_entries));
+        let rest_iter: Box<dyn RowEntryIterator + 'static> = Box::new(
+            FilterIterator::new_with_max_seq(VecRowIterator::new(rest_entries), max_seq),
+        );
+        let get_iter = GetIterator::new(
+            key.clone(),
+            wb_iter,
+            std::iter::empty::<Box<dyn RowEntryIterator + 'static>>(),
+            rest_iter,
+        );
+        let mut top: Box<dyn RowEntryIterator + 'static> = match self.read_merge_operator.clone() {
+            Some(merge_operator) => Box::new(MergeOperatorIterator::new(
+                merge_operator,
+                get_iter,
+                true,
+                None,
+            )),
+            None => Box::new(MergeOperatorRequiredIterator::new(get_iter)),
+        };
+        top.init().await?;
+        Ok(match top.next().await? {
+            Some(entry) if entry.value.is_tombstone() => None,
+            other => other,
+        })
+    }
+
     /// Create an iterator over a key range.
     ///
     /// Produces a merged iterator over the provided `write_batch` (if any),
@@ -428,6 +738,93 @@ impl Reader {
         let filtered = apply_filters(all_iters, max_seq);
         Ok(DbRecencyIterator::new(VecDeque::from(filtered)))
     }
+}
+
+/// Append on-disk/memtable versions of one key to its accumulator. Entries with
+/// `seq > max_seq` are dropped (not visible at this snapshot). A `Value` or
+/// `Tombstone` marks the key resolved, so older layers are skipped for it.
+fn append_versions(
+    entries: Vec<RowEntry>,
+    max_seq: Option<u64>,
+    acc: &mut Vec<RowEntry>,
+    resolved: &mut bool,
+) {
+    for entry in entries {
+        if max_seq.is_some_and(|ms| entry.seq > ms) {
+            continue;
+        }
+        if !matches!(entry.value, ValueDeletable::Merge(_)) {
+            *resolved = true;
+        }
+        acc.push(entry);
+    }
+}
+
+/// Append write-batch versions of one key. Write-batch entries are always
+/// visible (seq `u64::MAX`) and are never max_seq filtered, matching the
+/// single-key `get` path.
+fn append_wb_versions(entries: Vec<RowEntry>, acc: &mut Vec<RowEntry>, resolved: &mut bool) {
+    for entry in entries {
+        if !matches!(entry.value, ValueDeletable::Merge(_)) {
+            *resolved = true;
+        }
+        acc.push(entry);
+    }
+}
+
+/// Apply per-view results (already sorted newest-first by rank) to the per-key
+/// accumulators, skipping keys already resolved by a newer view in this layer.
+fn apply_layer_results(
+    results: Vec<SstBatchResult>,
+    max_seq: Option<u64>,
+    acc: &mut [Vec<RowEntry>],
+    resolved: &mut [bool],
+) {
+    for (_rank, per_key) in results {
+        for (u, entries) in per_key {
+            if resolved[u] {
+                continue;
+            }
+            append_versions(entries, max_seq, &mut acc[u], &mut resolved[u]);
+        }
+    }
+}
+
+/// Probe an in-memory table for every still-pending key, appending its versions.
+async fn read_memtable_layer(
+    table: &KVTable,
+    unique_keys: &[Bytes],
+    max_seq: Option<u64>,
+    acc: &mut [Vec<RowEntry>],
+    resolved: &mut [bool],
+) -> Result<(), SlateDBError> {
+    for (u, key) in unique_keys.iter().enumerate() {
+        if resolved[u] {
+            continue;
+        }
+        let entries = kv_table_get_versions(table, key).await?;
+        append_versions(entries, max_seq, &mut acc[u], &mut resolved[u]);
+    }
+    Ok(())
+}
+
+/// Collect all versions of `key` from a `KVTable`, newest-first. The table has
+/// no direct point-get, so this uses a `key..=key` range iterator (in-memory,
+/// O(log n)).
+async fn kv_table_get_versions(
+    table: &KVTable,
+    key: &Bytes,
+) -> Result<Vec<RowEntry>, SlateDBError> {
+    let mut iter = table.range(key.clone()..=key.clone(), IterationOrder::Ascending);
+    iter.init().await?;
+    let mut out = Vec::new();
+    while let Some(entry) = iter.next().await? {
+        if entry.key.as_ref() != key.as_ref() {
+            break;
+        }
+        out.push(entry);
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -1315,6 +1712,175 @@ mod tests {
             expected.map(|b| String::from_utf8_lossy(b))
         );
 
+        Ok(())
+    }
+
+    /// Build a reader over a populated `TestDbState`, run `multi_get` for
+    /// `query_keys`, assert it agrees key-by-key with single `get` against the
+    /// same snapshot (the differential invariant), and return the batch values.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_multi_get(
+        entries: Vec<TestEntry>,
+        query_keys: &[&'static [u8]],
+        dirty: bool,
+        last_committed_seq: Option<u64>,
+        max_seq: Option<u64>,
+        merge: bool,
+    ) -> Result<Vec<Option<Bytes>>, SlateDBError> {
+        let mut test_db_state = TestDbState::new().await;
+        let write_batch = populate_db_state(&mut test_db_state, entries).await?;
+
+        let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+        let db_stats = DbStats::new(&recorder);
+        let test_clock = Arc::new(MockSystemClock::new());
+        let mono_clock = Arc::new(MonotonicClock::new(test_clock as Arc<dyn SystemClock>, 0));
+        let oracle = Arc::new(DbReaderOracle::new(
+            last_committed_seq.unwrap_or(u64::MAX),
+            DbStatusManager::new(0),
+        ));
+        let merge_operator = if merge {
+            Some(Arc::new(StringConcatMergeOperator) as Arc<dyn MergeOperator + Send + Sync>)
+        } else {
+            None
+        };
+        let reader = Reader::new(
+            test_db_state.table_store.clone(),
+            db_stats,
+            mono_clock,
+            oracle,
+            merge_operator,
+        );
+        let read_options = ReadOptions::default().with_dirty(dirty);
+
+        let batch: Vec<Bytes> = query_keys.iter().map(|k| Bytes::copy_from_slice(k)).collect();
+        let multi = reader
+            .multi_get_with_options(
+                &batch,
+                &read_options,
+                &test_db_state,
+                write_batch.as_ref(),
+                max_seq,
+            )
+            .await?;
+        assert_eq!(multi.len(), query_keys.len());
+        let multi_vals: Vec<Option<Bytes>> = multi
+            .into_iter()
+            .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
+            .collect();
+
+        // Differential: each key resolved individually via get must match.
+        for (i, key) in query_keys.iter().enumerate() {
+            let single = reader
+                .get_key_value_with_options(
+                    *key,
+                    &read_options,
+                    &test_db_state,
+                    wb_point_iter(&write_batch, key),
+                    max_seq,
+                )
+                .await?
+                .map(|kv| kv.value);
+            assert_eq!(
+                multi_vals[i], single,
+                "multi_get disagreed with get for key {:?}",
+                String::from_utf8_lossy(key)
+            );
+        }
+        Ok(multi_vals)
+    }
+
+    #[tokio::test]
+    async fn test_multi_get_distinct_keys_across_layers() -> Result<(), SlateDBError> {
+        let entries = vec![
+            TestEntry::value(b"mem_key", b"mem_val", 90),
+            TestEntry::value(b"l0_key", b"l0_val", 70).with_location(LayerLocation::L0Sst(0)),
+            TestEntry::value(b"sr_key", b"sr_val", 50).with_location(LayerLocation::SortedRun(0)),
+            TestEntry::tombstone(b"del_key", 80).with_location(LayerLocation::L0Sst(0)),
+        ];
+        let vals = run_multi_get(
+            entries,
+            &[b"mem_key", b"l0_key", b"sr_key", b"del_key", b"absent"],
+            true,
+            None,
+            None,
+            false,
+        )
+        .await?;
+        assert_eq!(vals[0].as_deref(), Some(b"mem_val".as_ref()));
+        assert_eq!(vals[1].as_deref(), Some(b"l0_val".as_ref()));
+        assert_eq!(vals[2].as_deref(), Some(b"sr_val".as_ref()));
+        assert_eq!(vals[3], None); // tombstone
+        assert_eq!(vals[4], None); // absent
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_get_same_l0_sst_and_duplicates() -> Result<(), SlateDBError> {
+        // Two keys live in the same L0 SST; one key is queried twice.
+        let entries = vec![
+            TestEntry::value(b"key1", b"v1", 50).with_location(LayerLocation::L0Sst(0)),
+            TestEntry::value(b"key2", b"v2", 51).with_location(LayerLocation::L0Sst(0)),
+        ];
+        let vals = run_multi_get(
+            entries,
+            &[b"key1", b"key2", b"key1", b"absent"],
+            true,
+            None,
+            None,
+            false,
+        )
+        .await?;
+        assert_eq!(vals[0].as_deref(), Some(b"v1".as_ref()));
+        assert_eq!(vals[1].as_deref(), Some(b"v2".as_ref()));
+        assert_eq!(vals[2].as_deref(), Some(b"v1".as_ref())); // duplicate slot
+        assert_eq!(vals[3], None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_get_empty_batch() -> Result<(), SlateDBError> {
+        let vals = run_multi_get(
+            vec![TestEntry::value(b"key1", b"v1", 50)],
+            &[],
+            true,
+            None,
+            None,
+            false,
+        )
+        .await?;
+        assert!(vals.is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_get_merge_across_layers() -> Result<(), SlateDBError> {
+        // A key whose value is built from merge operands spanning layers, plus a
+        // plain key and an absent key, resolved in one batch with a merge
+        // operator configured.
+        let entries = vec![
+            TestEntry::merge(b"acc", b"c", 90),
+            TestEntry::merge(b"acc", b"b", 80).with_location(LayerLocation::L0Sst(0)),
+            TestEntry::value(b"acc", b"a", 70).with_location(LayerLocation::SortedRun(0)),
+            TestEntry::value(b"plain", b"p", 60),
+        ];
+        let vals = run_multi_get(entries, &[b"acc", b"plain", b"gone"], true, None, None, true).await?;
+        assert_eq!(vals[0].as_deref(), Some(b"abc".as_ref())); // merge("a","b","c")
+        assert_eq!(vals[1].as_deref(), Some(b"p".as_ref()));
+        assert_eq!(vals[2], None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_get_seq_filtering() -> Result<(), SlateDBError> {
+        // Committed-read + snapshot max_seq filtering applies across the batch:
+        // the newer (uncommitted/over-bound) version is hidden, exposing the
+        // older committed value.
+        let entries = vec![
+            TestEntry::value(b"k", b"newer", 100),
+            TestEntry::value(b"k", b"older", 40).with_location(LayerLocation::L0Sst(0)),
+        ];
+        let vals = run_multi_get(entries, &[b"k"], false, Some(50), Some(60), false).await?;
+        assert_eq!(vals[0].as_deref(), Some(b"older".as_ref()));
         Ok(())
     }
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -361,8 +361,14 @@ impl Reader {
         //    iterator per key; batches are memory-bounded, so the full walk is
         //    cheap even for small key lists.
         if let Some(wb) = write_batch {
-            let mut iter =
-                WriteBatchIterator::new(wb, BytesRange::from(..), IterationOrder::Ascending);
+            let mut iter = WriteBatchIterator::new(
+                wb,
+                BytesRange::from(..),
+                IterationOrder::Ascending,
+                u64::MAX,
+                None,
+                None,
+            );
             iter.init().await?;
             while let Some(entry) = iter.next().await? {
                 if let Some(&u) = index_of.get(entry.key.as_ref()) {

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -26,30 +26,21 @@ use bytes::Bytes;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 
-/// Per-SST batched read result for `multi_get`: `(newest-first rank, [(key
-/// index, that SST's versions of the key, newest-first)])`.
+/// Per-SST batched read result for `multi_get`: `(newest-first rank, [(unique
+/// key index, that SST's versions of the key, newest-first)])`.
 type SstBatchResult = (usize, Vec<(usize, Vec<RowEntry>)>);
 
-/// One unit of concurrent SST work for `multi_get`:
-/// `(rank, view, keys to look up in that view)`.
+/// One unit of concurrent SST work for `multi_get`: `(rank, view, keys to look
+/// up in that view)`. `rank` encodes newest-first precedence among the SSTs of
+/// one LSM tree (L0 by position, then sorted runs in order, then views within
+/// a run by ascending index); trees cover disjoint keys, so tree-local ranks
+/// merge correctly per key in one global sort.
 type SstReadWork = (usize, SsTableView, Arc<Vec<PendingKey>>);
 
-/// Maximum number of SSTs read concurrently within one layer of one tree group
-/// during `multi_get`. Reads are object-store-I/O bound, so a generous buffer
-/// pays off; worst-case in-flight reads ≈ tree groups × this constant.
-const MAX_CONCURRENT_SST_READS: usize = 16;
-
-/// The still-pending `multi_get` keys destined for one LSM tree (segment).
-/// Tree groups are read concurrently, so each group carries the mapping from
-/// its keys' local positions back to the orchestrator's unique-key indexes.
-struct TreeGroup {
-    tree: Arc<LsmTreeState>,
-    /// Local position -> unique-key index.
-    global_idx: Vec<usize>,
-    /// `keys[i].idx == i` (local position), so per-SST results echo local
-    /// positions that are remapped through `global_idx` on merge-back.
-    keys: Vec<PendingKey>,
-}
+/// Maximum number of SSTs read concurrently during `multi_get`. All trees and
+/// layers fan out into one bounded pool; reads are object-store-I/O bound, so
+/// a generous buffer pays off.
+const MAX_CONCURRENT_SST_READS: usize = 32;
 
 pub(crate) trait DbStateReader {
     fn memtable(&self) -> Arc<KVTable>;
@@ -294,15 +285,17 @@ impl Reader {
     /// strategy). Returns one `Option<RowEntry>` per input key, in input order;
     /// duplicate keys yield duplicate results.
     ///
-    /// Setup (snapshot, max-seq) happens once for the whole batch. The layers
-    /// are then walked newest-first — write batch, memtables, then each
-    /// segment's L0 SSTs and sorted runs — shrinking the pending set as keys
-    /// resolve, so a key found in a newer layer is never read from an older
-    /// one. Still-pending keys are grouped by their LSM tree (segment) and the
-    /// tree groups are read concurrently (they cover disjoint keys); within a
-    /// tree, sorted runs are still walked newest-first with early exit. Each
-    /// on-disk SST is visited once for all of its pending keys (see
-    /// [`crate::multi_sst::read_sst_for_keys`]).
+    /// Setup (snapshot, max-seq) happens once for the whole batch. The
+    /// in-memory layers are consulted newest-first — write batch, then
+    /// memtables — resolving keys for free before any I/O. The remaining keys
+    /// then fan out to disk in a single bounded concurrent batch covering every
+    /// SST that might hold them (all trees, L0 and every sorted run at once);
+    /// newest-first precedence is restored at merge time by sorting the per-SST
+    /// results by rank. This trades speculative probes of older runs (their
+    /// index/filter loads, with bloom filters pruning nearly all wasted block
+    /// I/O) for one object-store round trip of latency instead of one per
+    /// sorted run. Each on-disk SST is visited once for all of its pending keys
+    /// (see [`crate::multi_sst::read_sst_for_keys`]).
     ///
     /// A key is "resolved" only when a `Value` or `Tombstone` is found; `Merge`
     /// operands keep it descending to older layers (merge operands legitimately
@@ -373,7 +366,10 @@ impl Reader {
             iter.init().await?;
             while let Some(entry) = iter.next().await? {
                 if let Some(&u) = index_of.get(entry.key.as_ref()) {
-                    append_versions(vec![entry], None, &mut wb_acc[u], &mut resolved[u]);
+                    if !matches!(entry.value, ValueDeletable::Merge(_)) {
+                        resolved[u] = true;
+                    }
+                    wb_acc[u].push(entry);
                 }
             }
         }
@@ -385,61 +381,42 @@ impl Reader {
             read_memtable_layer(&imm.table(), &unique_keys, max_seq, &mut acc, &mut resolved);
         }
 
-        // 3. On-disk: group still-pending keys by their LSM tree (segment),
-        //    then walk every tree's L0 + sorted runs concurrently — groups
-        //    cover disjoint keys, so their results merge without conflicts.
-        //    Unsegmented DBs yield one group.
-        let core = db_state.core();
-        let default_tree = core.default_segment().tree;
-        // Group keys by their LSM tree's identity. The map key is the tree's
-        // Arc pointer cast to `usize` (a raw pointer would make the future
-        // `!Send`).
-        let mut groups: HashMap<usize, TreeGroup> = HashMap::new();
-        for (u, key) in unique_keys.iter().enumerate() {
-            if resolved[u] {
-                continue;
-            }
-            let tree =
-                match core.select_segments(&BytesRange::from_slice(key.as_ref()..=key.as_ref())) {
-                    None => default_tree.clone(),
-                    Some(segments) => match segments.last() {
-                        Some(segment) => segment.tree.clone(),
-                        // Configured but no segment covers this key: no on-disk data.
-                        None => continue,
-                    },
-                };
-            let group = groups
-                .entry(Arc::as_ptr(&tree) as usize)
-                .or_insert_with(|| TreeGroup {
-                    tree,
-                    global_idx: Vec::new(),
-                    keys: Vec::new(),
-                });
-            group.keys.push(PendingKey {
-                idx: group.global_idx.len(),
-                key: key.clone(),
-            });
-            group.global_idx.push(u);
-        }
-        let mut global_idxs = Vec::with_capacity(groups.len());
-        let mut group_futures = Vec::with_capacity(groups.len());
-        for group in groups.into_values() {
-            global_idxs.push(group.global_idx);
-            group_futures.push(self.read_tree_layer(
-                group.tree,
-                Arc::new(group.keys),
-                &sst_options,
-                max_seq,
-            ));
-        }
-        for (global_idx, group_acc) in global_idxs
-            .iter()
-            .zip(futures::future::try_join_all(group_futures).await?)
-        {
-            for (pos, entries) in group_acc.into_iter().enumerate() {
-                // Extend, not assign: memtable merge operands may already be in
-                // the accumulator and must stay first (they are newer).
-                acc[global_idx[pos]].extend(entries);
+        // 3. On-disk: fan out every (SST view, pending keys) pair across all
+        //    trees and layers in one bounded concurrent batch, then restore
+        //    newest-first precedence by applying the per-SST results in rank
+        //    order. Older runs are probed speculatively for keys that turn out
+        //    to live in newer layers, but the latency is one round trip instead
+        //    of one per sorted run. `append_versions` re-filters by max_seq and
+        //    stops each key at its first surviving Value/Tombstone, so older
+        //    ranks' entries are dropped exactly as in the single-key walk.
+        //    Memtable entries are already in `acc` and stay first (they are
+        //    newer than anything on disk).
+        let work = build_sst_work(db_state.core(), &unique_keys, &resolved);
+        if !work.is_empty() {
+            let max_parallel = work.len().clamp(1, MAX_CONCURRENT_SST_READS);
+            let table_store = self.table_store.clone();
+            let opts = sst_options.clone();
+            let stats = self.db_stats.clone();
+            let results = build_concurrent(work, max_parallel, move |(rank, view, keys)| {
+                let table_store = table_store.clone();
+                let opts = opts.clone();
+                let stats = stats.clone();
+                async move {
+                    let per_key =
+                        read_sst_for_keys(&view, &keys[..], &table_store, &opts, Some(&stats))
+                            .await?;
+                    Ok(Some((rank, per_key)))
+                }
+            })
+            .await?;
+            let mut results: Vec<SstBatchResult> = results.into();
+            results.sort_unstable_by_key(|(rank, _)| *rank);
+            for (_rank, per_key) in results {
+                for (u, entries) in per_key {
+                    if !resolved[u] {
+                        append_versions(entries, max_seq, &mut acc[u], &mut resolved[u]);
+                    }
+                }
             }
         }
 
@@ -461,97 +438,6 @@ impl Reader {
             .iter()
             .map(|&u| resolved_values[u].clone())
             .collect())
-    }
-
-    /// Walk one LSM tree (segment) for its group of pending keys: all L0 SSTs in
-    /// parallel (newest-first), then each sorted run newest-first with a shrink
-    /// between runs to preserve early-exit.
-    ///
-    /// Owns its accumulators so tree groups can run concurrently; returns the
-    /// max_seq-filtered versions found for each key, indexed by the key's local
-    /// position (`keys[i].idx == i`).
-    async fn read_tree_layer(
-        &self,
-        tree: Arc<LsmTreeState>,
-        keys: Arc<Vec<PendingKey>>,
-        sst_options: &SstIteratorOptions,
-        max_seq: Option<u64>,
-    ) -> Result<Vec<Vec<RowEntry>>, SlateDBError> {
-        let mut acc: Vec<Vec<RowEntry>> = vec![Vec::new(); keys.len()];
-        let mut resolved: Vec<bool> = vec![false; keys.len()];
-
-        // L0: any L0 SST may hold any key, and no key in the group is resolved
-        // yet, so every L0 SST is read for every key. Rank by position (front =
-        // newest) and apply newest-first so the newest SST wins.
-        if !tree.l0.is_empty() {
-            let work: Vec<SstReadWork> = tree
-                .l0
-                .iter()
-                .cloned()
-                .enumerate()
-                .map(|(rank, view)| (rank, view, keys.clone()))
-                .collect();
-            let results = self.read_ssts_concurrent(work, sst_options).await?;
-            apply_layer_results(results, max_seq, &mut acc, &mut resolved);
-        }
-
-        // Sorted runs, newest run first. Within a run each key maps (via binary
-        // search) to its covering SST views, so group keys by view index and
-        // read each view once. Shrink between runs.
-        for sr in tree.compacted.iter() {
-            if resolved.iter().all(|r| *r) {
-                break;
-            }
-            // Keyed by view index so iteration is ascending key-range order,
-            // matching the single-key sorted-run point iterators.
-            let mut view_keys: BTreeMap<usize, Vec<PendingKey>> = BTreeMap::new();
-            for pk in keys.iter().filter(|pk| !resolved[pk.idx]) {
-                for vi in sr.point_table_idx_covering_key(pk.key.as_ref()) {
-                    view_keys.entry(vi).or_default().push(pk.clone());
-                }
-            }
-            if view_keys.is_empty() {
-                continue;
-            }
-            let work: Vec<SstReadWork> = view_keys
-                .into_iter()
-                .map(|(rank, keys)| (rank, sr.sst_views[rank].clone(), Arc::new(keys)))
-                .collect();
-            let results = self.read_ssts_concurrent(work, sst_options).await?;
-            apply_layer_results(results, max_seq, &mut acc, &mut resolved);
-        }
-        Ok(acc)
-    }
-
-    /// Read a set of `(rank, view, keys)` work items concurrently (bounded), one
-    /// [`read_sst_for_keys`] call per view, and return the per-view results
-    /// sorted by `rank` so the caller can apply them in precedence order.
-    async fn read_ssts_concurrent(
-        &self,
-        work: Vec<SstReadWork>,
-        sst_options: &SstIteratorOptions,
-    ) -> Result<Vec<SstBatchResult>, SlateDBError> {
-        if work.is_empty() {
-            return Ok(Vec::new());
-        }
-        let max_parallel = work.len().clamp(1, MAX_CONCURRENT_SST_READS);
-        let table_store = self.table_store.clone();
-        let opts = sst_options.clone();
-        let stats = self.db_stats.clone();
-        let results = build_concurrent(work, max_parallel, move |(rank, view, keys)| {
-            let table_store = table_store.clone();
-            let opts = opts.clone();
-            let stats = stats.clone();
-            async move {
-                let per_key =
-                    read_sst_for_keys(&view, &keys[..], &table_store, &opts, Some(&stats)).await?;
-                Ok(Some((rank, per_key)))
-            }
-        })
-        .await?;
-        let mut results: Vec<SstBatchResult> = results.into();
-        results.sort_by_key(|(rank, _)| *rank);
-        Ok(results)
     }
 
     /// Produce the final entry for one key by replaying its accumulated versions
@@ -784,10 +670,85 @@ pub(crate) fn entries_to_key_values(entries: Vec<Option<RowEntry>>) -> Vec<Optio
         .collect()
 }
 
-/// Append versions of one key to its accumulator. Entries with `seq > max_seq`
-/// are dropped (not visible at this snapshot); write-batch callers pass `None`
-/// since their entries are never max_seq filtered. A `Value` or `Tombstone`
-/// marks the key resolved, so older layers are skipped for it.
+/// Build the flat fan-out work list for the still-pending `multi_get` keys:
+/// one work item per (SST view, keys that might live in it) pair, across every
+/// tree's L0 SSTs and sorted-run views.
+///
+/// `rank` encodes newest-first precedence within a key's tree: L0 SSTs by
+/// position (front = newest), then sorted runs in order, then views within a
+/// run by ascending index (a key's versions can span adjacent views, and the
+/// single-key path reads them in ascending view order too). Rank offsets
+/// advance by each run's full view count so two runs never alias. Trees cover
+/// disjoint keys, so tree-local ranks merge correctly per key in one global
+/// sort.
+fn build_sst_work(
+    core: &ManifestCore,
+    unique_keys: &[Bytes],
+    resolved: &[bool],
+) -> Vec<SstReadWork> {
+    // Group pending keys by their LSM tree's identity. The map key is the
+    // tree's Arc pointer cast to `usize` (a raw pointer would make the
+    // enclosing future `!Send`).
+    let default_tree = core.default_segment().tree;
+    let mut trees: HashMap<usize, (Arc<LsmTreeState>, Vec<PendingKey>)> = HashMap::new();
+    for (u, key) in unique_keys.iter().enumerate() {
+        if resolved[u] {
+            continue;
+        }
+        let tree = match core.select_segments(&BytesRange::from_slice(key.as_ref()..=key.as_ref()))
+        {
+            None => default_tree.clone(),
+            Some(segments) => match segments.last() {
+                Some(segment) => segment.tree.clone(),
+                // Configured but no segment covers this key: no on-disk data.
+                None => continue,
+            },
+        };
+        trees
+            .entry(Arc::as_ptr(&tree) as usize)
+            .or_insert_with(|| (tree, Vec::new()))
+            .1
+            .push(PendingKey {
+                idx: u,
+                key: key.clone(),
+            });
+    }
+
+    let mut work = Vec::new();
+    for (tree, keys) in trees.into_values() {
+        // L0: any L0 SST may hold any key, so every L0 SST is read for the
+        // whole group.
+        let keys = Arc::new(keys);
+        for (rank, view) in tree.l0.iter().enumerate() {
+            work.push((rank, view.clone(), keys.clone()));
+        }
+        let mut rank_base = tree.l0.len();
+        // Sorted runs: within a run each key maps (via binary search) to its
+        // covering SST views, so group keys by view index and read each view
+        // once.
+        for sr in tree.compacted.iter() {
+            let mut view_keys: BTreeMap<usize, Vec<PendingKey>> = BTreeMap::new();
+            for pk in keys.iter() {
+                for vi in sr.point_table_idx_covering_key(pk.key.as_ref()) {
+                    view_keys.entry(vi).or_default().push(pk.clone());
+                }
+            }
+            for (vi, keys) in view_keys {
+                work.push((rank_base + vi, sr.sst_views[vi].clone(), Arc::new(keys)));
+            }
+            rank_base += sr.sst_views.len();
+        }
+    }
+    work
+}
+
+/// Append versions of one key to its accumulator, newest-first. Entries with
+/// `seq > max_seq` are dropped (not visible at this snapshot) — the filter runs
+/// *before* the resolve check, so a too-new `Value` must not resolve the key.
+/// The first appended `Value` or `Tombstone` marks the key resolved and stops
+/// the append: everything older is shadowed and would never be read by the
+/// resolution iterators anyway. `Merge` operands keep accumulating (they
+/// legitimately span layers).
 fn append_versions(
     entries: Vec<RowEntry>,
     max_seq: Option<u64>,
@@ -798,27 +759,11 @@ fn append_versions(
         if max_seq.is_some_and(|ms| entry.seq > ms) {
             continue;
         }
-        if !matches!(entry.value, ValueDeletable::Merge(_)) {
-            *resolved = true;
-        }
+        let is_base = !matches!(entry.value, ValueDeletable::Merge(_));
         acc.push(entry);
-    }
-}
-
-/// Apply per-view results (already sorted newest-first by rank) to the per-key
-/// accumulators, skipping keys already resolved by a newer view in this layer.
-fn apply_layer_results(
-    results: Vec<SstBatchResult>,
-    max_seq: Option<u64>,
-    acc: &mut [Vec<RowEntry>],
-    resolved: &mut [bool],
-) {
-    for (_rank, per_key) in results {
-        for (u, entries) in per_key {
-            if resolved[u] {
-                continue;
-            }
-            append_versions(entries, max_seq, &mut acc[u], &mut resolved[u]);
+        if is_base {
+            *resolved = true;
+            return;
         }
     }
 }
@@ -1907,6 +1852,22 @@ mod tests {
         assert_eq!(vals[0].as_deref(), Some(b"abc".as_ref())); // merge("a","b","c")
         assert_eq!(vals[1].as_deref(), Some(b"p".as_ref()));
         assert_eq!(vals[2], None);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_multi_get_merge_base_shadows_older_run() -> Result<(), SlateDBError> {
+        // Merge operand in L0, base value in the newer sorted run, and a stale
+        // value in an older sorted run. The fan-out reads all three SSTs, so
+        // the rank merge must stop at the run-1 base and drop the stale run-0
+        // value. (SortedRun test IDs: 0 = oldest.)
+        let entries = vec![
+            TestEntry::merge(b"acc", b"b", 80).with_location(LayerLocation::L0Sst(0)),
+            TestEntry::value(b"acc", b"a", 70).with_location(LayerLocation::SortedRun(1)),
+            TestEntry::value(b"acc", b"stale", 30).with_location(LayerLocation::SortedRun(0)),
+        ];
+        let vals = run_multi_get(entries, &[b"acc"], true, None, None, true).await?;
+        assert_eq!(vals[0].as_deref(), Some(b"ab".as_ref())); // merge("a","b"), no "stale"
         Ok(())
     }
 

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -5,7 +5,6 @@ use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
 use crate::db_iter::{apply_filters, DbRecencyIterator, GetIterator};
 use crate::db_state::SsTableView;
 use crate::db_stats::DbStats;
-use crate::filter_iterator::FilterIterator;
 use crate::iter::{IterationOrder, RowEntryIterator, VecRowIterator};
 use crate::manifest::{LsmTreeState, ManifestCore, Segment};
 use crate::mem_table::{ImmutableMemtable, KVTable};
@@ -26,15 +25,31 @@ use crate::{error::SlateDBError, DbIterator};
 use bytes::Bytes;
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
-use ulid::Ulid;
 
-/// Per-SST batched read result for `multi_get`: `(newest-first rank, [(unique
-/// key index, that SST's versions of the key, newest-first)])`.
+/// Per-SST batched read result for `multi_get`: `(newest-first rank, [(key
+/// index, that SST's versions of the key, newest-first)])`.
 type SstBatchResult = (usize, Vec<(usize, Vec<RowEntry>)>);
 
 /// One unit of concurrent SST work for `multi_get`:
 /// `(rank, view, keys to look up in that view)`.
 type SstReadWork = (usize, SsTableView, Arc<Vec<PendingKey>>);
+
+/// Maximum number of SSTs read concurrently within one layer of one tree group
+/// during `multi_get`. Reads are object-store-I/O bound, so a generous buffer
+/// pays off; worst-case in-flight reads ≈ tree groups × this constant.
+const MAX_CONCURRENT_SST_READS: usize = 16;
+
+/// The still-pending `multi_get` keys destined for one LSM tree (segment).
+/// Tree groups are read concurrently, so each group carries the mapping from
+/// its keys' local positions back to the orchestrator's unique-key indexes.
+struct TreeGroup {
+    tree: Arc<LsmTreeState>,
+    /// Local position -> unique-key index.
+    global_idx: Vec<usize>,
+    /// `keys[i].idx == i` (local position), so per-SST results echo local
+    /// positions that are remapped through `global_idx` on merge-back.
+    keys: Vec<PendingKey>,
+}
 
 pub(crate) trait DbStateReader {
     fn memtable(&self) -> Arc<KVTable>;
@@ -283,7 +298,10 @@ impl Reader {
     /// are then walked newest-first — write batch, memtables, then each
     /// segment's L0 SSTs and sorted runs — shrinking the pending set as keys
     /// resolve, so a key found in a newer layer is never read from an older
-    /// one. Each on-disk SST is visited once for all of its pending keys (see
+    /// one. Still-pending keys are grouped by their LSM tree (segment) and the
+    /// tree groups are read concurrently (they cover disjoint keys); within a
+    /// tree, sorted runs are still walked newest-first with early exit. Each
+    /// on-disk SST is visited once for all of its pending keys (see
     /// [`crate::multi_sst::read_sst_for_keys`]).
     ///
     /// A key is "resolved" only when a `Value` or `Tombstone` is found; `Merge`
@@ -297,9 +315,9 @@ impl Reader {
     /// `db_state` view, an optional per-transaction `write_batch` (consulted
     /// first), and an optional `max_seq` bound (folded with durability/dirty via
     /// `prepare_max_seq`).
-    pub(crate) async fn multi_get_with_options(
+    pub(crate) async fn multi_get_with_options<K: AsRef<[u8]> + Sync>(
         &self,
-        keys: &[Bytes],
+        keys: &[K],
         options: &ReadOptions,
         db_state: &(dyn DbStateReader + Sync + Send),
         write_batch: Option<&WriteBatch>,
@@ -317,96 +335,112 @@ impl Reader {
         let mut index_of: HashMap<Bytes, usize> = HashMap::new();
         let mut orig_to_unique: Vec<usize> = Vec::with_capacity(keys.len());
         for key in keys {
-            let u = *index_of.entry(key.clone()).or_insert_with(|| {
-                unique_keys.push(key.clone());
-                unique_keys.len() - 1
-            });
+            let u = match index_of.get(key.as_ref()) {
+                Some(&u) => u,
+                None => {
+                    let key = Bytes::copy_from_slice(key.as_ref());
+                    unique_keys.push(key.clone());
+                    index_of.insert(key, unique_keys.len() - 1);
+                    unique_keys.len() - 1
+                }
+            };
             orig_to_unique.push(u);
         }
         let n = unique_keys.len();
 
         // Per unique key: write-batch entries (unfiltered, highest precedence),
         // everything-else entries (memtable + on-disk), and whether a base
-        // (Value/Tombstone) has been found yet.
+        // (Value/Tombstone) has been found yet. `append_versions` is the sole
+        // writer into `acc`, so every entry there is already max_seq filtered.
         let mut wb_acc: Vec<Vec<RowEntry>> = vec![Vec::new(); n];
         let mut acc: Vec<Vec<RowEntry>> = vec![Vec::new(); n];
         let mut resolved: Vec<bool> = vec![false; n];
 
         let sst_options = SstIteratorOptions {
             cache_blocks: options.cache_blocks,
-            eager_spawn: true,
             filter_context: options.filter_context.clone(),
             ..SstIteratorOptions::default()
         };
 
         // 1. Write batch (transaction only). Entries carry seq u64::MAX and are
-        //    not max_seq filtered, matching the single-key get path.
+        //    not max_seq filtered (hence `None`), matching the single-key get
+        //    path. One full-range pass over the batch instead of a point
+        //    iterator per key; batches are memory-bounded, so the full walk is
+        //    cheap even for small key lists.
         if let Some(wb) = write_batch {
-            for (u, key) in unique_keys.iter().enumerate() {
-                let mut iter = WriteBatchIterator::new(
-                    wb,
-                    BytesRange::from_slice(key.as_ref()..=key.as_ref()),
-                    IterationOrder::Ascending,
-                );
-                iter.init().await?;
-                let mut entries = Vec::new();
-                while let Some(entry) = iter.next().await? {
-                    if entry.key.as_ref() == key.as_ref() {
-                        entries.push(entry);
-                    }
+            let mut iter =
+                WriteBatchIterator::new(wb, BytesRange::from(..), IterationOrder::Ascending);
+            iter.init().await?;
+            while let Some(entry) = iter.next().await? {
+                if let Some(&u) = index_of.get(entry.key.as_ref()) {
+                    append_versions(vec![entry], None, &mut wb_acc[u], &mut resolved[u]);
                 }
-                append_wb_versions(entries, &mut wb_acc[u], &mut resolved[u]);
             }
         }
 
         // 2. Active memtable, then immutable memtables (newest-first).
         let memtable = db_state.memtable();
-        read_memtable_layer(&memtable, &unique_keys, max_seq, &mut acc, &mut resolved).await?;
+        read_memtable_layer(&memtable, &unique_keys, max_seq, &mut acc, &mut resolved);
         for imm in db_state.imm_memtable() {
-            let table = imm.table();
-            read_memtable_layer(&table, &unique_keys, max_seq, &mut acc, &mut resolved).await?;
+            read_memtable_layer(&imm.table(), &unique_keys, max_seq, &mut acc, &mut resolved);
         }
 
-        // 3. On-disk: group still-pending keys by their LSM tree (segment), then
-        //    walk each tree's L0 + sorted runs. Unsegmented DBs yield one group.
+        // 3. On-disk: group still-pending keys by their LSM tree (segment),
+        //    then walk every tree's L0 + sorted runs concurrently — groups
+        //    cover disjoint keys, so their results merge without conflicts.
+        //    Unsegmented DBs yield one group.
         let core = db_state.core();
         let default_tree = core.default_segment().tree;
-        // Group keys by their LSM tree's identity. The key is the tree's Arc
-        // pointer cast to `usize` (a raw pointer would make the future `!Send`).
-        let mut groups: HashMap<usize, (Arc<LsmTreeState>, Vec<PendingKey>)> = HashMap::new();
+        // Group keys by their LSM tree's identity. The map key is the tree's
+        // Arc pointer cast to `usize` (a raw pointer would make the future
+        // `!Send`).
+        let mut groups: HashMap<usize, TreeGroup> = HashMap::new();
         for (u, key) in unique_keys.iter().enumerate() {
             if resolved[u] {
                 continue;
             }
-            let tree = match core
-                .select_segments(&BytesRange::from_slice(key.as_ref()..=key.as_ref()))
-            {
-                None => default_tree.clone(),
-                Some(segments) => match segments.last() {
-                    Some(segment) => segment.tree.clone(),
-                    // Configured but no segment covers this key: no on-disk data.
-                    None => continue,
-                },
-            };
-            groups
+            let tree =
+                match core.select_segments(&BytesRange::from_slice(key.as_ref()..=key.as_ref())) {
+                    None => default_tree.clone(),
+                    Some(segments) => match segments.last() {
+                        Some(segment) => segment.tree.clone(),
+                        // Configured but no segment covers this key: no on-disk data.
+                        None => continue,
+                    },
+                };
+            let group = groups
                 .entry(Arc::as_ptr(&tree) as usize)
-                .or_insert_with(|| (tree.clone(), Vec::new()))
-                .1
-                .push(PendingKey {
-                    idx: u,
-                    key: key.clone(),
+                .or_insert_with(|| TreeGroup {
+                    tree,
+                    global_idx: Vec::new(),
+                    keys: Vec::new(),
                 });
+            group.keys.push(PendingKey {
+                idx: group.global_idx.len(),
+                key: key.clone(),
+            });
+            group.global_idx.push(u);
         }
-        for (_, (tree, group_keys)) in groups {
-            self.read_tree_layer(
-                &tree,
-                &group_keys,
+        let mut global_idxs = Vec::with_capacity(groups.len());
+        let mut group_futures = Vec::with_capacity(groups.len());
+        for group in groups.into_values() {
+            global_idxs.push(group.global_idx);
+            group_futures.push(self.read_tree_layer(
+                group.tree,
+                Arc::new(group.keys),
                 &sst_options,
                 max_seq,
-                &mut acc,
-                &mut resolved,
-            )
-            .await?;
+            ));
+        }
+        for (global_idx, group_acc) in global_idxs
+            .iter()
+            .zip(futures::future::try_join_all(group_futures).await?)
+        {
+            for (pos, entries) in group_acc.into_iter().enumerate() {
+                // Extend, not assign: memtable merge operands may already be in
+                // the accumulator and must stay first (they are newer).
+                acc[global_idx[pos]].extend(entries);
+            }
         }
 
         // 4. Resolve each unique key, then scatter to input positions.
@@ -415,9 +449,13 @@ impl Reader {
             let wb_entries = std::mem::take(&mut wb_acc[u]);
             let rest_entries = std::mem::take(&mut acc[u]);
             resolved_values.push(
-                self.resolve_entry(&unique_keys[u], wb_entries, rest_entries, max_seq)
+                self.resolve_entry(&unique_keys[u], wb_entries, rest_entries)
                     .await?,
             );
+        }
+        if keys.len() == n {
+            // No duplicate keys: the unique order is the input order.
+            return Ok(resolved_values);
         }
         Ok(orig_to_unique
             .iter()
@@ -428,73 +466,61 @@ impl Reader {
     /// Walk one LSM tree (segment) for its group of pending keys: all L0 SSTs in
     /// parallel (newest-first), then each sorted run newest-first with a shrink
     /// between runs to preserve early-exit.
+    ///
+    /// Owns its accumulators so tree groups can run concurrently; returns the
+    /// max_seq-filtered versions found for each key, indexed by the key's local
+    /// position (`keys[i].idx == i`).
     async fn read_tree_layer(
         &self,
-        tree: &LsmTreeState,
-        group_keys: &[PendingKey],
+        tree: Arc<LsmTreeState>,
+        keys: Arc<Vec<PendingKey>>,
         sst_options: &SstIteratorOptions,
         max_seq: Option<u64>,
-        acc: &mut [Vec<RowEntry>],
-        resolved: &mut [bool],
-    ) -> Result<(), SlateDBError> {
-        // L0: any L0 SST may hold any key, so all of them are read for every
-        // still-pending key. Rank by position (front = newest) and apply
-        // newest-first so the newest SST wins.
-        let l0_pending: Vec<PendingKey> = group_keys
-            .iter()
-            .filter(|pk| !resolved[pk.idx])
-            .cloned()
-            .collect();
-        if !l0_pending.is_empty() && !tree.l0.is_empty() {
-            let shared = Arc::new(l0_pending);
-            let work: Vec<SstReadWork> =tree
+    ) -> Result<Vec<Vec<RowEntry>>, SlateDBError> {
+        let mut acc: Vec<Vec<RowEntry>> = vec![Vec::new(); keys.len()];
+        let mut resolved: Vec<bool> = vec![false; keys.len()];
+
+        // L0: any L0 SST may hold any key, and no key in the group is resolved
+        // yet, so every L0 SST is read for every key. Rank by position (front =
+        // newest) and apply newest-first so the newest SST wins.
+        if !tree.l0.is_empty() {
+            let work: Vec<SstReadWork> = tree
                 .l0
                 .iter()
                 .cloned()
                 .enumerate()
-                .map(|(rank, view)| (rank, view, shared.clone()))
+                .map(|(rank, view)| (rank, view, keys.clone()))
                 .collect();
             let results = self.read_ssts_concurrent(work, sst_options).await?;
-            apply_layer_results(results, max_seq, acc, resolved);
+            apply_layer_results(results, max_seq, &mut acc, &mut resolved);
         }
 
         // Sorted runs, newest run first. Within a run each key maps (via binary
-        // search) to one SST view, so group keys by covering view and read each
-        // view once. Shrink between runs.
+        // search) to its covering SST views, so group keys by view index and
+        // read each view once. Shrink between runs.
         for sr in tree.compacted.iter() {
-            let sr_pending: Vec<&PendingKey> =
-                group_keys.iter().filter(|pk| !resolved[pk.idx]).collect();
-            if sr_pending.is_empty() {
+            if resolved.iter().all(|r| *r) {
                 break;
             }
-            let view_pos: HashMap<Ulid, usize> = sr
-                .sst_views
-                .iter()
-                .enumerate()
-                .map(|(i, v)| (v.id, i))
-                .collect();
             // Keyed by view index so iteration is ascending key-range order,
             // matching the single-key sorted-run point iterators.
             let mut view_keys: BTreeMap<usize, Vec<PendingKey>> = BTreeMap::new();
-            for pk in sr_pending {
-                for view in sr.tables_covering_point_key(pk.key.as_ref()) {
-                    view_keys
-                        .entry(view_pos[&view.id])
-                        .or_default()
-                        .push(pk.clone());
+            for pk in keys.iter().filter(|pk| !resolved[pk.idx]) {
+                for vi in sr.point_table_idx_covering_key(pk.key.as_ref()) {
+                    view_keys.entry(vi).or_default().push(pk.clone());
                 }
             }
             if view_keys.is_empty() {
                 continue;
             }
-            let work: Vec<SstReadWork> =view_keys
+            let work: Vec<SstReadWork> = view_keys
                 .into_iter()
                 .map(|(rank, keys)| (rank, sr.sst_views[rank].clone(), Arc::new(keys)))
                 .collect();
             let results = self.read_ssts_concurrent(work, sst_options).await?;
-            apply_layer_results(results, max_seq, acc, resolved);
+            apply_layer_results(results, max_seq, &mut acc, &mut resolved);
         }
-        Ok(())
+        Ok(acc)
     }
 
     /// Read a set of `(rank, view, keys)` work items concurrently (bounded), one
@@ -508,7 +534,7 @@ impl Reader {
         if work.is_empty() {
             return Ok(Vec::new());
         }
-        let max_parallel = work.len().clamp(1, 4);
+        let max_parallel = work.len().clamp(1, MAX_CONCURRENT_SST_READS);
         let table_store = self.table_store.clone();
         let opts = sst_options.clone();
         let stats = self.db_stats.clone();
@@ -530,23 +556,25 @@ impl Reader {
 
     /// Produce the final entry for one key by replaying its accumulated versions
     /// through the same components the single-key `get` path uses: a
-    /// [`GetIterator`] (write-batch arm unfiltered, the rest seq-filtered) wrapped
-    /// in the merge operator. Returns `None` for a missing or deleted key.
+    /// [`GetIterator`] wrapped in the merge operator. Returns `None` for a
+    /// missing or deleted key.
+    ///
+    /// No max_seq filtering happens here: `rest_entries` were already filtered
+    /// on append (see [`append_versions`]) and write-batch entries are exempt
+    /// by design.
     async fn resolve_entry(
         &self,
         key: &Bytes,
         wb_entries: Vec<RowEntry>,
         rest_entries: Vec<RowEntry>,
-        max_seq: Option<u64>,
     ) -> Result<Option<RowEntry>, SlateDBError> {
         if wb_entries.is_empty() && rest_entries.is_empty() {
             return Ok(None);
         }
         let wb_iter: Box<dyn RowEntryIterator + 'static> =
             Box::new(VecRowIterator::new(wb_entries));
-        let rest_iter: Box<dyn RowEntryIterator + 'static> = Box::new(
-            FilterIterator::new_with_max_seq(VecRowIterator::new(rest_entries), max_seq),
-        );
+        let rest_iter: Box<dyn RowEntryIterator + 'static> =
+            Box::new(VecRowIterator::new(rest_entries));
         let get_iter = GetIterator::new(
             key.clone(),
             wb_iter,
@@ -740,9 +768,26 @@ impl Reader {
     }
 }
 
-/// Append on-disk/memtable versions of one key to its accumulator. Entries with
-/// `seq > max_seq` are dropped (not visible at this snapshot). A `Value` or
-/// `Tombstone` marks the key resolved, so older layers are skipped for it.
+/// Map resolved `multi_get` entries to bare value bytes, preserving slots.
+pub(crate) fn entries_to_values(entries: Vec<Option<RowEntry>>) -> Vec<Option<Bytes>> {
+    entries
+        .into_iter()
+        .map(|entry| entry.and_then(|entry| entry.value.as_bytes()))
+        .collect()
+}
+
+/// Map resolved `multi_get` entries to [`KeyValue`]s, preserving slots.
+pub(crate) fn entries_to_key_values(entries: Vec<Option<RowEntry>>) -> Vec<Option<KeyValue>> {
+    entries
+        .into_iter()
+        .map(|entry| entry.map(KeyValue::from))
+        .collect()
+}
+
+/// Append versions of one key to its accumulator. Entries with `seq > max_seq`
+/// are dropped (not visible at this snapshot); write-batch callers pass `None`
+/// since their entries are never max_seq filtered. A `Value` or `Tombstone`
+/// marks the key resolved, so older layers are skipped for it.
 fn append_versions(
     entries: Vec<RowEntry>,
     max_seq: Option<u64>,
@@ -753,18 +798,6 @@ fn append_versions(
         if max_seq.is_some_and(|ms| entry.seq > ms) {
             continue;
         }
-        if !matches!(entry.value, ValueDeletable::Merge(_)) {
-            *resolved = true;
-        }
-        acc.push(entry);
-    }
-}
-
-/// Append write-batch versions of one key. Write-batch entries are always
-/// visible (seq `u64::MAX`) and are never max_seq filtered, matching the
-/// single-key `get` path.
-fn append_wb_versions(entries: Vec<RowEntry>, acc: &mut Vec<RowEntry>, resolved: &mut bool) {
-    for entry in entries {
         if !matches!(entry.value, ValueDeletable::Merge(_)) {
             *resolved = true;
         }
@@ -791,40 +824,35 @@ fn apply_layer_results(
 }
 
 /// Probe an in-memory table for every still-pending key, appending its versions.
-async fn read_memtable_layer(
+fn read_memtable_layer(
     table: &KVTable,
     unique_keys: &[Bytes],
     max_seq: Option<u64>,
     acc: &mut [Vec<RowEntry>],
     resolved: &mut [bool],
-) -> Result<(), SlateDBError> {
+) {
     for (u, key) in unique_keys.iter().enumerate() {
         if resolved[u] {
             continue;
         }
-        let entries = kv_table_get_versions(table, key).await?;
+        let entries = kv_table_get_versions(table, key);
         append_versions(entries, max_seq, &mut acc[u], &mut resolved[u]);
     }
-    Ok(())
 }
 
 /// Collect all versions of `key` from a `KVTable`, newest-first. The table has
 /// no direct point-get, so this uses a `key..=key` range iterator (in-memory,
-/// O(log n)).
-async fn kv_table_get_versions(
-    table: &KVTable,
-    key: &Bytes,
-) -> Result<Vec<RowEntry>, SlateDBError> {
+/// O(log n), no I/O — hence the synchronous drain via `next_sync`).
+fn kv_table_get_versions(table: &KVTable, key: &Bytes) -> Vec<RowEntry> {
     let mut iter = table.range(key.clone()..=key.clone(), IterationOrder::Ascending);
-    iter.init().await?;
     let mut out = Vec::new();
-    while let Some(entry) = iter.next().await? {
+    while let Some(entry) = iter.next_sync() {
         if entry.key.as_ref() != key.as_ref() {
             break;
         }
         out.push(entry);
     }
-    Ok(out)
+    out
 }
 
 #[cfg(test)]
@@ -1752,7 +1780,10 @@ mod tests {
         );
         let read_options = ReadOptions::default().with_dirty(dirty);
 
-        let batch: Vec<Bytes> = query_keys.iter().map(|k| Bytes::copy_from_slice(k)).collect();
+        let batch: Vec<Bytes> = query_keys
+            .iter()
+            .map(|k| Bytes::copy_from_slice(k))
+            .collect();
         let multi = reader
             .multi_get_with_options(
                 &batch,
@@ -1781,7 +1812,8 @@ mod tests {
                 .await?
                 .map(|kv| kv.value);
             assert_eq!(
-                multi_vals[i], single,
+                multi_vals[i],
+                single,
                 "multi_get disagreed with get for key {:?}",
                 String::from_utf8_lossy(key)
             );
@@ -1863,7 +1895,15 @@ mod tests {
             TestEntry::value(b"acc", b"a", 70).with_location(LayerLocation::SortedRun(0)),
             TestEntry::value(b"plain", b"p", 60),
         ];
-        let vals = run_multi_get(entries, &[b"acc", b"plain", b"gone"], true, None, None, true).await?;
+        let vals = run_multi_get(
+            entries,
+            &[b"acc", b"plain", b"gone"],
+            true,
+            None,
+            None,
+            true,
+        )
+        .await?;
         assert_eq!(vals[0].as_deref(), Some(b"abc".as_ref())); // merge("a","b","c")
         assert_eq!(vals[1].as_deref(), Some(b"p".as_ref()));
         assert_eq!(vals[2], None);

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -159,6 +159,15 @@ enum FilterState {
     Negative,
 }
 
+/// AND across all filters: returns `true` iff every filter thinks `query`
+/// might match. An empty `filters` slice means no filter is configured for the
+/// SST; callers treat that as "might match" (do not skip). Shared by the
+/// single-key [`FilterEvaluator`] and the batched `multi_get` path
+/// ([`crate::multi_sst`]).
+pub(crate) fn all_filters_might_match(filters: &[NamedFilter], query: &FilterQuery) -> bool {
+    filters.iter().all(|nf| nf.filter.might_match(query))
+}
+
 struct FilterEvaluator {
     query: FilterQuery,
     db_stats: Option<DbStats>,
@@ -210,7 +219,7 @@ impl FilterEvaluator {
         // AND logic: if any filter says the key is NOT present, filter it out.
         // All filters reaching here are decoded. TableStore::read_filters
         // resolves any raw cache entries before returning.
-        let might_match = filters.iter().all(|nf| nf.filter.might_match(&self.query));
+        let might_match = all_filters_might_match(filters, &self.query);
 
         if might_match {
             if let Some(stats) = &self.db_stats {

--- a/slatedb/tests/multi_get.rs
+++ b/slatedb/tests/multi_get.rs
@@ -1,0 +1,299 @@
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+//! Integration tests for `multi_get`.
+//!
+//! The core gate is the differential property: `multi_get(keys)` must equal
+//! `[get(k) for k in keys]` against the same database. We assert this over
+//! randomized, layered data (many L0 SSTs from repeated flushes), with and
+//! without a block cache and a merge operator, plus transaction and reader
+//! variants.
+
+use std::sync::Arc;
+
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+use slatedb::bytes::Bytes;
+use slatedb::config::{PutOptions, Settings, WriteOptions};
+use slatedb::db_cache::foyer::FoyerCache;
+use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::ObjectStore;
+use slatedb::{Db, IsolationLevel, MergeOperator, MergeOperatorError};
+
+fn no_durable() -> WriteOptions {
+    WriteOptions {
+        await_durable: false,
+        ..Default::default()
+    }
+}
+
+/// A merge operator that concatenates operands onto the base value.
+struct ConcatMergeOperator;
+
+impl MergeOperator for ConcatMergeOperator {
+    fn merge(
+        &self,
+        _key: &Bytes,
+        existing_value: Option<Bytes>,
+        operand: Bytes,
+    ) -> Result<Bytes, MergeOperatorError> {
+        match existing_value {
+            Some(base) => {
+                let mut merged = base.to_vec();
+                merged.extend_from_slice(&operand);
+                Ok(Bytes::from(merged))
+            }
+            None => Ok(operand),
+        }
+    }
+}
+
+fn key(id: usize) -> Vec<u8> {
+    format!("key{id:05}").into_bytes()
+}
+
+/// THE differential gate: `multi_get` must agree key-by-key with single `get`.
+async fn assert_multi_get_matches_get_loop(db: &Db, keys: &[Vec<u8>]) {
+    let multi = db.multi_get(keys).await.expect("multi_get failed");
+    assert_eq!(multi.len(), keys.len(), "one result slot per input key");
+    for (i, k) in keys.iter().enumerate() {
+        let single = db.get(k).await.expect("get failed");
+        assert_eq!(
+            multi[i],
+            single,
+            "multi_get disagreed with get for {:?}",
+            String::from_utf8_lossy(k)
+        );
+    }
+}
+
+/// Apply a deterministic sequence of random put/delete ops over `key_space`
+/// keys, flushing periodically so data spreads across the memtable and many L0
+/// SSTs. Returns the RNG so the caller can keep generating query batches.
+async fn populate_random(db: &Db, seed: u64, key_space: usize, ops: usize) -> StdRng {
+    let mut rng = StdRng::seed_from_u64(seed);
+    for _ in 0..ops {
+        let k = key(rng.random_range(0..key_space));
+        if rng.random_bool(0.2) {
+            db.delete_with_options(&k, &no_durable()).await.unwrap();
+        } else {
+            let v = format!("v{}", rng.random_range(0..1_000_000)).into_bytes();
+            db.put_with_options(&k, &v, &PutOptions::default(), &no_durable())
+                .await
+                .unwrap();
+        }
+        if rng.random_bool(0.04) {
+            db.flush().await.unwrap();
+        }
+    }
+    db.flush().await.unwrap();
+    rng
+}
+
+/// Query many random batches (with duplicates and absent keys) plus a full
+/// sweep, asserting the differential invariant each time.
+async fn assert_random_batches(db: &Db, rng: &mut StdRng, key_space: usize) {
+    for _ in 0..15 {
+        let batch_size = rng.random_range(0..12);
+        let keys: Vec<Vec<u8>> = (0..batch_size)
+            // key_space + 20 so ~some queried ids are absent
+            .map(|_| key(rng.random_range(0..key_space + 20)))
+            .collect();
+        assert_multi_get_matches_get_loop(db, &keys).await;
+    }
+    let sweep: Vec<Vec<u8>> = (0..key_space + 20).map(key).collect();
+    assert_multi_get_matches_get_loop(db, &sweep).await;
+}
+
+fn layered_settings() -> Settings {
+    Settings {
+        // Small SSTs + always-on filters so a batch spans several bloom-filtered
+        // L0 SSTs — the case multi_get's per-SST batching targets.
+        l0_sst_size_bytes: 1024,
+        min_filter_keys: 0,
+        ..Default::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_multi_get_matches_get_loop_no_cache() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = Db::builder("/tmp/test_multi_get_no_cache", object_store)
+        .with_settings(layered_settings())
+        .build()
+        .await
+        .unwrap();
+
+    let key_space = 80;
+    let mut rng = populate_random(&db, 0xA11CE, key_space, 500).await;
+    assert_random_batches(&db, &mut rng, key_space).await;
+
+    // Explicit edge cases.
+    assert!(db.multi_get::<Vec<u8>>(&[]).await.unwrap().is_empty());
+    let dup = vec![key(0), key(0), key(1), key(0)];
+    let got = db.multi_get(&dup).await.unwrap();
+    assert_eq!(got[0], got[1]);
+    assert_eq!(got[0], got[3]);
+
+    db.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_multi_get_matches_get_loop_with_block_cache() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let cache = Arc::new(FoyerCache::new());
+    let db = Db::builder("/tmp/test_multi_get_cache", object_store)
+        .with_settings(layered_settings())
+        .with_db_cache(cache)
+        .build()
+        .await
+        .unwrap();
+
+    let key_space = 80;
+    let mut rng = populate_random(&db, 0xCACE, key_space, 500).await;
+    // Warm the cache with one sweep, then re-run batches against warm caches.
+    let sweep: Vec<Vec<u8>> = (0..key_space).map(key).collect();
+    assert_multi_get_matches_get_loop(&db, &sweep).await;
+    assert_random_batches(&db, &mut rng, key_space).await;
+
+    db.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_multi_get_matches_get_loop_with_merge_operator() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = Db::builder("/tmp/test_multi_get_merge", object_store)
+        .with_settings(layered_settings())
+        .with_merge_operator(Arc::new(ConcatMergeOperator))
+        .build()
+        .await
+        .unwrap();
+
+    // Random put / merge / delete so values are built from operands that span
+    // the memtable and multiple L0 SSTs.
+    let key_space = 50;
+    let mut rng = StdRng::seed_from_u64(0x3E26E);
+    for _ in 0..600 {
+        let k = key(rng.random_range(0..key_space));
+        let roll = rng.random_range(0..10);
+        if roll < 2 {
+            db.delete_with_options(&k, &no_durable()).await.unwrap();
+        } else if roll < 6 {
+            let v = format!("v{}", rng.random_range(0..1000)).into_bytes();
+            db.put_with_options(&k, &v, &PutOptions::default(), &no_durable())
+                .await
+                .unwrap();
+        } else {
+            let v = format!("m{}", rng.random_range(0..1000)).into_bytes();
+            db.merge_with_options(&k, &v, &Default::default(), &no_durable())
+                .await
+                .unwrap();
+        }
+        if rng.random_bool(0.04) {
+            db.flush().await.unwrap();
+        }
+    }
+    db.flush().await.unwrap();
+    assert_random_batches(&db, &mut rng, key_space).await;
+
+    db.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_multi_get_transaction_sees_buffered_writes() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = Db::builder("/tmp/test_multi_get_txn_buffered", object_store)
+        .with_settings(layered_settings())
+        .build()
+        .await
+        .unwrap();
+
+    db.put(&key(1), b"committed1").await.unwrap();
+    db.put(&key(2), b"committed2").await.unwrap();
+
+    let txn = db.begin(IsolationLevel::Snapshot).await.unwrap();
+    // Buffered (uncommitted) writes are visible to the transaction's own reads.
+    txn.put(key(1), b"txn1").unwrap();
+    txn.delete(key(2)).unwrap();
+    txn.put(key(3), b"txn3").unwrap();
+
+    let got = txn
+        .multi_get(&[key(1), key(2), key(3), key(4)])
+        .await
+        .unwrap();
+    assert_eq!(got[0].as_deref(), Some(b"txn1".as_ref())); // overwritten in txn
+    assert_eq!(got[1], None); // deleted in txn
+    assert_eq!(got[2].as_deref(), Some(b"txn3".as_ref())); // new in txn
+    assert_eq!(got[3], None); // absent
+
+    // The base DB does not see the uncommitted writes.
+    let base = db.multi_get(&[key(1), key(2), key(3)]).await.unwrap();
+    assert_eq!(base[0].as_deref(), Some(b"committed1".as_ref()));
+    assert_eq!(base[1].as_deref(), Some(b"committed2".as_ref()));
+    assert_eq!(base[2], None);
+
+    db.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_multi_get_ssi_tracks_all_batch_keys() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let db = Db::builder("/tmp/test_multi_get_ssi", object_store)
+        .with_settings(layered_settings())
+        .build()
+        .await
+        .unwrap();
+
+    db.put(&key(1), b"a").await.unwrap();
+    db.put(&key(2), b"b").await.unwrap();
+
+    // txn1 reads a batch (which must register every key in the SSI read set).
+    let txn1 = db.begin(IsolationLevel::SerializableSnapshot).await.unwrap();
+    let _ = txn1.multi_get(&[key(1), key(2)]).await.unwrap();
+
+    // txn2 modifies key(2) — one of txn1's batch reads — and commits.
+    let txn2 = db.begin(IsolationLevel::SerializableSnapshot).await.unwrap();
+    txn2.put(key(2), b"b2").unwrap();
+    txn2.commit().await.unwrap();
+
+    // txn1 now writes and commits; it must abort because a key it read via
+    // multi_get was modified by a committed concurrent transaction.
+    txn1.put(key(9), b"x").unwrap();
+    let result = txn1.commit().await;
+    assert!(
+        result.is_err(),
+        "txn1 must abort: multi_get read key(2), which txn2 modified"
+    );
+
+    db.close().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_multi_get_db_reader() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = "/tmp/test_multi_get_reader";
+    let db = Db::builder(path, object_store.clone())
+        .with_settings(layered_settings())
+        .build()
+        .await
+        .unwrap();
+
+    let key_space = 60;
+    populate_random(&db, 0x9EADE2, key_space, 500).await;
+    db.close().await.unwrap();
+
+    // Open a read-only reader over the persisted state and check the
+    // differential invariant against the reader's own single get.
+    let reader = slatedb::DbReader::builder(path, object_store)
+        .build()
+        .await
+        .unwrap();
+    for batch_start in [0usize, 25, 60] {
+        let keys: Vec<Vec<u8>> = (batch_start..batch_start + 30).map(key).collect();
+        let multi = reader.multi_get(&keys).await.unwrap();
+        for (i, k) in keys.iter().enumerate() {
+            let single = reader.get(k).await.unwrap();
+            assert_eq!(multi[i], single, "reader multi_get vs get mismatch");
+        }
+    }
+    reader.close().await.unwrap();
+}

--- a/slatedb/tests/multi_get.rs
+++ b/slatedb/tests/multi_get.rs
@@ -247,11 +247,17 @@ async fn test_multi_get_ssi_tracks_all_batch_keys() {
     db.put(&key(2), b"b").await.unwrap();
 
     // txn1 reads a batch (which must register every key in the SSI read set).
-    let txn1 = db.begin(IsolationLevel::SerializableSnapshot).await.unwrap();
+    let txn1 = db
+        .begin(IsolationLevel::SerializableSnapshot)
+        .await
+        .unwrap();
     let _ = txn1.multi_get(&[key(1), key(2)]).await.unwrap();
 
     // txn2 modifies key(2) — one of txn1's batch reads — and commits.
-    let txn2 = db.begin(IsolationLevel::SerializableSnapshot).await.unwrap();
+    let txn2 = db
+        .begin(IsolationLevel::SerializableSnapshot)
+        .await
+        .unwrap();
     txn2.put(key(2), b"b2").unwrap();
     txn2.commit().await.unwrap();
 


### PR DESCRIPTION
## Summary

An implementation of https://github.com/slatedb/slatedb/issues/301.

Disclaimer: the PR desc is 100% human written. I've used Opus/Fable to assist me with the development.

Some background: I'm building [murrdb](https://github.com/murrdb/murr), an AI/ML inference cache and would like to use SlateDB as an alternative to RocksDB:
* The main problem is that the workload its targering is batch based: e.g. fetch N columns for M rows.
* RocksDB handles this perfectly with multi_get where all the shared parts (e.g. SST reads) are batched together for multiple keys at once. 
* We tried a naive Slatedb implementation with just doing M concurrent reads for each key, but for large M numbers (e.g. 100+) the latency was way worse than RocksDB. You can see some challenges in this blogpost - https://nixiesearch.substack.com/p/benchmarking-slatedb-vs-rocksdb

In this PR we just ported the same approach used in RocksDB but to SlateDB: make batched reads share common code paths.

Benchmark results for a 1M keys locally-hosted database:
```
multi_get/1             time:   [589.45 ns 589.70 ns 589.96 ns]
multi_get/100           time:   [56.722 µs 56.799 µs 56.885 µs]
multi_get/1000          time:   [608.48 µs 609.03 µs 609.66 µs]

get_loop/1              time:   [774.75 ns 775.15 ns 775.56 ns]
get_loop/100            time:   [76.736 µs 76.762 µs 76.789 µs]
get_loop/1000           time:   [802.89 µs 803.24 µs 803.62 µs]
```
^^^ it's mostly just a few SSTs, so not much benefit.

For 10M keys:
```
multi_get/1             time:   [3.5753 µs 3.5867 µs 3.5991 µs]
multi_get/100           time:   [213.81 µs 214.13 µs 214.47 µs]
multi_get/1000          time:   [2.1242 ms 2.1273 ms 2.1305 ms]

get_loop/1              time:   [7.0222 µs 7.0582 µs 7.0966 µs]
get_loop/100            time:   [801.55 µs 805.47 µs 809.63 µs]
get_loop/1000           time:   [7.9969 ms 8.0312 ms 8.0684 ms]
```

For 100M keys:
```
multi_get/1             time:   [7.1159 µs 7.1337 µs 7.1555 µs]
multi_get/100           time:   [252.41 µs 252.88 µs 253.37 µs]
multi_get/1000          time:   [2.4033 ms 2.4058 ms 2.4085 ms]

get_loop/1              time:   [7.8546 µs 7.8997 µs 7.9478 µs]
get_loop/100            time:   [919.94 µs 924.94 µs 930.40 µs]
get_loop/1000           time:   [9.2843 ms 9.3319 ms 9.3845 ms]
```

And for bigger datasets it's a 4X difference!

I haven't benchmarked this PR across real S3 storage - but it's just reusing the existing block store machinery, attempting to batch reads per SST. 

## Changes

Main change: add support to resolve N keys against one snapshot in a single pass,  visiting each candidate SST once and fanning all SST reads out concurrently, instead of N independent `get`s each reloading metadata and walking the LSM layer by layer. Full design in RFC 0027 (not sure about the number - there are some other PRs with the same id)

### code changes

* `ops.rs`: public API. Four new default-method-backed trait methods on `DbReadOps`: `multi_get`,  `multi_get_with_options`, `multi_get_key_value`, `multi_get_key_value_with_options`. Purely additive: the  `*_with_options` pair is the required impl, the rest are default wrappers
* `reader.rs`: orchestration logic. New `multi_get_with_options` runs 4 phases: dedup keys -> resolve from write-batch/memtables (no I/O) -> `build_sst_work` fans out one flat `(rank, sst_view, keys)` list over every candidate SST and runs it under one concurrency bound (`MAX_CONCURRENT_SST_READS = 32`) -> `resolve_entry` replays accumulated versions per key.
* `multi_sst.rs`: batched read support.  `read_sst_for_keys` loads index+filters once, prunes by bloom, plans block ranges (`plan_candidates`), coalesces them into fetch runs tolerating up to  `COALESCE_GAP_BLOCKS = 2` gap blocks (`coalesce_runs`), fetches (`fetch_candidate_blocks`), and scans raw versions newest-first (`scan_candidates`). No seq/merge/tombstone resolution here: raw `RowEntry`s go back to the orchestrator.
* `db.rs` / `db_reader.rs` / `db_snapshot.rs` / `db_transaction.rs`  - wiring the public API. Each surface implements the trait over a shared `multi_get_entries_with_options` core. `db_transaction.rs` additionally layers the uncommitted write batch on top and adds every batch key to the SSI read set.
* `iter.rs` / `sst_iter.rs` / `db_state.rs`: small support stuff. `iter.rs` adds a `VecRowIterator` to feed accumulated versions through the existing `GetIterator` + merge stack; `sst_iter.rs` minor refactor to share planning logic.

### Notes

As we fan-out multiple concurrent reads, we restore key ordering after the actual IO. Results are sorted by rank and a key's
  older-rank entries are dropped once a visible Value/Tombstone is found. 
* Trade: speculative probes of older runs for keys that live in newer layers: bounded to a cached index+filter load, with the bloom filter pruning ~99% of the resulting block fetches. 
* Buys us ~1 round trip per batch instead of `1 + sorted_runs`. 
* Value resolution is not reimplemented: versions replay through the same  `GetIterator`/`MergeOperatorIterator` stack `get` uses, so tombstone/TTL/merge equivalence is structural.

No on-disk/manifest/compaction changes; reader-local and additive.

### Tests

* unit, `reader.rs`: layered scenarios (distinct keys across layers, duplicates, tombstones, merge spanning layers, newer-run base shadowing older stale value, `max_seq` filtering, empty batch). Each asserts the differential invariant `multi_get == per-key get`
* integration, `multi_get.rs`: all four surfaces, with/without block cache and merge operator, plus an SSI test confirming every batched key enters the read set.
* bench, `db_operations.rs`: `multi_get` vs equivalent `get` loop

## Notes for Reviewers

Yes the PR is bigger than 500 lines, but I have a hard time thinking how can it be split into smaller parts. If you have any ideas - let me know, I'm glad to split it into smaller pieces.

As for breaking stuff, this adds 3 new methods to ` Db`, `DbReader`, `DbSnapshot`,
  `DbTransaction` traits, which might be considered a breaking change if there are some other projects implementing it.

 Open Qs: should `MAX_CONCURRENT_SST_READS` / `COALESCE_GAP_BLOCKS` move to `Settings`, and do we expose this in Go/Python bindings now or after a soak? I'd like to align on the core impl, but can also later make PRs for bindings.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
