### PR TITLE
feat(compaction): add subcompaction data model (RFC-0028) [1/N]

### DIFF
--- a/schemas/compactor.fbs
+++ b/schemas/compactor.fbs
@@ -92,6 +92,26 @@ table Compaction {
 
     // Spec of the worker that has claimed this compaction. null = unclaimed
     worker: WorkerSpec;
+
+    // Subcompactions partitioning this compaction into non-overlapping key
+    // ranges (RFC-0028).
+    subcompactions: [Subcompaction];
+}
+
+// A compaction over a sub-range of the parent compaction's key space
+// (RFC-0028). Subcompactions are only valid within the context of a parent
+// `Compaction` and let a single logical compaction execute its disjoint
+// ranges in parallel while resuming at range granularity after a failure.
+table Subcompaction {
+    // Key range covered by this subcompaction. Ranges of the subcompactions
+    // within a parent compaction are non-overlapping and together cover the
+    // full key space.
+    range: BytesRange (required);
+
+    // Output SSTs already produced by this subcompaction. A subcompaction with
+    // output SSTs that cover its full range has completed; on resume, ranges
+    // with no recorded output are re-run from scratch. 
+    output_ssts: [CompactedSsTable];
 }
 
 table CompactionsV1 {

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -11,6 +11,7 @@ use ulid::Ulid;
 use crate::db_state::{SortedRun, SsTableHandle, SsTableView};
 use crate::error::SlateDBError;
 use crate::manifest::{Manifest, ManifestCore};
+use crate::subcompaction::Subcompaction;
 use slatedb_txn_obj::DirtyObject;
 
 /// Identifier for a compaction input source.
@@ -355,6 +356,10 @@ pub struct Compaction {
     /// The worker that has claimed this compaction. `None` means the
     /// compaction is unclaimed (only valid when `status == Submitted`).
     worker: Option<WorkerSpec>,
+    /// Subcompactions partitioning this compaction into non-overlapping key
+    /// ranges (RFC-0028). Empty when the compaction runs as a single merge
+    /// over the full keyspace.
+    subcompactions: Vec<Subcompaction>,
 }
 
 impl Compaction {
@@ -366,6 +371,7 @@ impl Compaction {
             status: CompactionStatus::Submitted,
             output_ssts: Vec::new(),
             worker: None,
+            subcompactions: Vec::new(),
         }
     }
 
@@ -381,6 +387,11 @@ impl Compaction {
 
     pub(crate) fn with_worker(mut self, worker: Option<WorkerSpec>) -> Self {
         self.worker = worker;
+        self
+    }
+
+    pub(crate) fn with_subcompactions(mut self, subcompactions: Vec<Subcompaction>) -> Self {
+        self.subcompactions = subcompactions;
         self
     }
 
@@ -471,6 +482,38 @@ impl Compaction {
         &self.output_ssts
     }
 
+    /// Sets the subcompactions for this compaction. The plan (number of
+    /// subcompactions and their ranges) is immutable once set; updates may
+    /// only advance per-range status and extend per-range output SSTs.
+    #[allow(dead_code)]
+    pub(crate) fn set_subcompactions(&mut self, subcompactions: Vec<Subcompaction>) {
+        if !self.subcompactions.is_empty() {
+            assert_eq!(
+                self.subcompactions.len(),
+                subcompactions.len(),
+                "subcompaction plan must not change once set"
+            );
+            for (prev, next) in self.subcompactions.iter().zip(subcompactions.iter()) {
+                assert_eq!(
+                    prev.range(),
+                    next.range(),
+                    "subcompaction ranges are immutable once set"
+                );
+                assert!(
+                    next.output_ssts()
+                        .starts_with(prev.output_ssts().as_slice()),
+                    "new subcompaction output SSTs must always extend previous output SSTs"
+                );
+            }
+        }
+        self.subcompactions = subcompactions;
+    }
+
+    /// Returns the subcompactions of this compaction, if any.
+    pub fn subcompactions(&self) -> &Vec<Subcompaction> {
+        &self.subcompactions
+    }
+
     /// Sets the current status of this compaction.
     pub(crate) fn set_status(&mut self, status: CompactionStatus) {
         self.status = status;
@@ -498,6 +541,21 @@ impl Display for Compaction {
         if self.bytes_processed > 0 {
             let human_bytes_processed = crate::utils::format_bytes_si(self.bytes_processed);
             write!(f, " ({} processed)", human_bytes_processed)?;
+        }
+        if !self.subcompactions.is_empty() {
+            // Subcompactions carry no status, so report how many ranges have
+            // produced output so far rather than a completion count.
+            let with_output = self
+                .subcompactions
+                .iter()
+                .filter(|s| !s.output_ssts().is_empty())
+                .count();
+            write!(
+                f,
+                " [{}/{} subcompactions with output]",
+                with_output,
+                self.subcompactions.len()
+            )?;
         }
         Ok(())
     }
@@ -1095,6 +1153,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use crate::bytes_range::BytesRange;
     use crate::checkpoint::Checkpoint;
     use crate::compactor_state::SourceId::SstView;
     use crate::config::{FlushOptions, FlushType, Settings};
@@ -1115,6 +1174,87 @@ mod tests {
     use tokio::runtime::{Handle, Runtime};
 
     const PATH: &str = "/test/db";
+
+    fn test_subcompaction_sst(first_key: &[u8]) -> SsTableHandle {
+        SsTableHandle::new(
+            SsTableId::Compacted(Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                first_entry: Some(Bytes::copy_from_slice(first_key)),
+                ..SsTableInfo::default()
+            },
+        )
+    }
+
+    fn test_compaction_with_subcompactions(subcompactions: Vec<Subcompaction>) -> Compaction {
+        Compaction::new(
+            Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SortedRun(1)], 1),
+        )
+        .with_subcompactions(subcompactions)
+    }
+
+    #[test]
+    fn test_should_extend_output_ssts_when_subcompaction_plan_unchanged() {
+        // given: a compaction with one subcompaction that recorded one output SST
+        let range = BytesRange::unbounded();
+        let sst = test_subcompaction_sst(b"a");
+        let mut compaction =
+            test_compaction_with_subcompactions(vec![
+                Subcompaction::new(range.clone()).with_output_ssts(vec![sst.clone()])
+            ]);
+
+        // when: the plan is set again with the output SST list extended
+        compaction.set_subcompactions(vec![
+            Subcompaction::new(range).with_output_ssts(vec![sst, test_subcompaction_sst(b"m")])
+        ]);
+
+        // then: the extended output SSTs are accepted
+        assert_eq!(compaction.subcompactions()[0].output_ssts().len(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "subcompaction plan must not change once set")]
+    fn test_should_panic_when_subcompaction_plan_size_changes() {
+        // given: a compaction with a single-range subcompaction plan
+        let mut compaction =
+            test_compaction_with_subcompactions(vec![Subcompaction::new(BytesRange::unbounded())]);
+
+        // when/then: setting a plan with a different number of ranges panics
+        compaction.set_subcompactions(vec![
+            Subcompaction::new(BytesRange::from_slice(..b"m".as_slice())),
+            Subcompaction::new(BytesRange::from_slice(b"m".as_slice()..)),
+        ]);
+    }
+
+    #[test]
+    #[should_panic(expected = "subcompaction ranges are immutable once set")]
+    fn test_should_panic_when_subcompaction_range_changes() {
+        // given: a compaction with a subcompaction covering (-inf, "m")
+        let mut compaction = test_compaction_with_subcompactions(vec![Subcompaction::new(
+            BytesRange::from_slice(..b"m".as_slice()),
+        )]);
+
+        // when/then: setting a plan whose range differs panics
+        compaction.set_subcompactions(vec![Subcompaction::new(BytesRange::from_slice(
+            ..b"z".as_slice(),
+        ))]);
+    }
+
+    #[test]
+    #[should_panic(expected = "must always extend previous output SSTs")]
+    fn test_should_panic_when_subcompaction_output_ssts_shrink() {
+        // given: a compaction whose subcompaction already recorded output SST "a"
+        let range = BytesRange::unbounded();
+        let mut compaction =
+            test_compaction_with_subcompactions(vec![Subcompaction::new(range.clone())
+                .with_output_ssts(vec![test_subcompaction_sst(b"a")])]);
+
+        // when/then: replacing (rather than extending) the output SSTs panics
+        compaction.set_subcompactions(vec![
+            Subcompaction::new(range).with_output_ssts(vec![test_subcompaction_sst(b"b")])
+        ]);
+    }
 
     #[test]
     fn test_trim_keeps_latest_finished_and_active_compactions() {

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -17,6 +17,7 @@ use crate::compactor_state::{
 };
 use crate::db_state::{self, FilterFormat, SsTableInfo, SsTableInfoCodec, SstType};
 use crate::db_state::{SsTableHandle, SsTableView};
+use crate::subcompaction::Subcompaction as CompactorSubcompaction;
 
 #[path = "./generated/root_generated.rs"]
 #[allow(warnings, clippy::disallowed_macros, clippy::disallowed_types, clippy::disallowed_methods, unreachable_pub)]
@@ -41,6 +42,7 @@ use crate::flatbuffer_types::root_generated::{
     CompactionsV1Args, CompressionFormat, DrainSegmentSpec, DrainSegmentSpecArgs, ManifestV1Args,
     Segment as FbSegment, SegmentArgs as FbSegmentArgs, SortedRun as FbSortedRunV1,
     SortedRunArgs as FbSortedRunV1Args, SortedRunV2, SortedRunV2Args, SstType as FbSstType,
+    Subcompaction as FbSubcompaction, SubcompactionArgs as FbSubcompactionArgs,
     TieredCompactionSpec, TieredCompactionSpecArgs, Ulid as FbUlid, UlidArgs as FbUlidArgs, Uuid,
     UuidArgs,
 };
@@ -603,10 +605,24 @@ impl FlatBufferCompactionsCodec {
             .map(|ssts| ssts.iter().map(Self::compacted_sst).collect())
             .unwrap_or_default();
         let worker = compaction.worker().and_then(Self::worker_spec);
+        let subcompactions = compaction
+            .subcompactions()
+            .map(|subs| subs.iter().map(Self::subcompaction).collect())
+            .unwrap_or_default();
         Ok(CompactorCompaction::new(compaction.id().ulid(), spec)
             .with_status(status)
             .with_output_ssts(output_ssts)
-            .with_worker(worker))
+            .with_worker(worker)
+            .with_subcompactions(subcompactions))
+    }
+
+    fn subcompaction(subcompaction: FbSubcompaction) -> CompactorSubcompaction {
+        let range = FlatBufferManifestCodec::decode_bytes_range(subcompaction.range());
+        let output_ssts = subcompaction
+            .output_ssts()
+            .map(|ssts| ssts.iter().map(Self::compacted_sst).collect())
+            .unwrap_or_default();
+        CompactorSubcompaction::new(range).with_output_ssts(output_ssts)
     }
 
     fn worker_spec(
@@ -1053,6 +1069,8 @@ impl<'b> DbFlatBufferBuilder<'b> {
         let output_ssts = (!compaction.output_ssts().is_empty())
             .then(|| self.add_compacted_ssts(compaction.output_ssts().iter()));
         let worker = compaction.worker().map(|w| self.add_worker_spec(w));
+        let subcompactions = (!compaction.subcompactions().is_empty())
+            .then(|| self.add_subcompactions(compaction.subcompactions().iter()));
         FbCompaction::create(
             &mut self.builder,
             &FbCompactionArgs {
@@ -1062,8 +1080,38 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 status,
                 output_ssts,
                 worker,
+                subcompactions,
             },
         )
+    }
+
+    fn add_subcompaction(
+        &mut self,
+        subcompaction: &CompactorSubcompaction,
+    ) -> WIPOffset<FbSubcompaction<'b>> {
+        let range = self.add_bytes_range(subcompaction.range());
+        let output_ssts = (!subcompaction.output_ssts().is_empty())
+            .then(|| self.add_compacted_ssts(subcompaction.output_ssts().iter()));
+        FbSubcompaction::create(
+            &mut self.builder,
+            &FbSubcompactionArgs {
+                range: Some(range),
+                output_ssts,
+            },
+        )
+    }
+
+    fn add_subcompactions<'a, I>(
+        &mut self,
+        subcompactions: I,
+    ) -> WIPOffset<Vector<'b, ForwardsUOffset<FbSubcompaction<'b>>>>
+    where
+        I: Iterator<Item = &'a CompactorSubcompaction>,
+    {
+        let subcompactions: Vec<WIPOffset<FbSubcompaction>> = subcompactions
+            .map(|sub| self.add_subcompaction(sub))
+            .collect();
+        self.builder.create_vector(subcompactions.as_ref())
     }
 
     fn add_worker_spec(
@@ -1463,6 +1511,7 @@ mod tests {
         FlatBufferCompactionsCodec, FlatBufferManifestCodec, SsTableIndexOwned,
     };
     use crate::manifest::{ExternalDb, LsmTreeState, Manifest, ManifestCore, Segment};
+    use crate::subcompaction::Subcompaction;
     use crate::{checkpoint, error::SlateDBError};
     use slatedb_txn_obj::ObjectCodec;
     use std::collections::VecDeque;
@@ -1974,6 +2023,57 @@ mod tests {
     }
 
     #[test]
+    fn test_should_encode_decode_compaction_with_subcompactions() {
+        fn new_output_sst(first_key: &[u8]) -> SsTableHandle {
+            SsTableHandle::new(
+                SsTableId::Compacted(ulid::Ulid::new()),
+                SST_FORMAT_VERSION_LATEST,
+                SsTableInfo {
+                    first_entry: Some(Bytes::copy_from_slice(first_key)),
+                    ..Default::default()
+                },
+            )
+        }
+
+        // given: a compaction exercising all subcompaction range shapes
+        // (unbounded edges and a bounded middle range), including ranges with
+        // and without output SSTs
+        let subcompactions = vec![
+            Subcompaction::new(BytesRange::new(
+                std::ops::Bound::Unbounded,
+                std::ops::Bound::Excluded(Bytes::from_static(b"g")),
+            ))
+            .with_output_ssts(vec![new_output_sst(b"a"), new_output_sst(b"d")]),
+            Subcompaction::new(BytesRange::new(
+                std::ops::Bound::Included(Bytes::from_static(b"g")),
+                std::ops::Bound::Excluded(Bytes::from_static(b"q")),
+            ))
+            .with_output_ssts(vec![new_output_sst(b"g")]),
+            Subcompaction::new(BytesRange::new(
+                std::ops::Bound::Included(Bytes::from_static(b"q")),
+                std::ops::Bound::Unbounded,
+            )),
+        ];
+        let compaction = Compaction::new(
+            ulid::Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SortedRun(5), SourceId::SortedRun(3)], 3),
+        )
+        .with_status(CompactionStatus::Running)
+        .with_subcompactions(subcompactions);
+        let mut compactions = Compactions::new(1);
+        compactions.insert(compaction.clone());
+
+        // when: the compactions are encoded and decoded
+        let codec = FlatBufferCompactionsCodec {};
+        let bytes = codec.encode(&compactions);
+        let decoded = codec.decode(&bytes).expect("failed to decode compactions");
+
+        // then: the decoded compaction matches the original
+        let decoded_compaction = decoded.get(&compaction.id()).expect("missing compaction");
+        assert_eq!(decoded_compaction, &compaction);
+    }
+
+    #[test]
     fn test_should_roundtrip_v2_l0_only_compaction_destination() {
         // Regression guard for issue #1652: an L0-only tiered compaction has
         // no SR inputs, so the pre-fix decoder inferred destination=0 and
@@ -2407,6 +2507,7 @@ mod tests {
                 status: FbCompactionStatus::Running,
                 output_ssts: Some(output_ssts_vec),
                 worker: None,
+                subcompactions: None,
             },
         );
         let compactions_vec = fbb.create_vector(&[compaction]);
@@ -2482,6 +2583,7 @@ mod tests {
                 status: FbCompactionStatus::Running,
                 output_ssts: None,
                 worker: None,
+                subcompactions: None,
             },
         );
         let compactions_vec = fbb.create_vector(&[compaction]);
@@ -2548,6 +2650,7 @@ mod tests {
                 status: FbCompactionStatus::Running,
                 output_ssts: None,
                 worker: None,
+                subcompactions: None,
             },
         );
         let compactions_vec = fbb.create_vector(&[compaction]);

--- a/slatedb/src/generated/root_generated.rs
+++ b/slatedb/src/generated/root_generated.rs
@@ -2987,6 +2987,7 @@ impl<'a> Compaction<'a> {
   pub const VT_STATUS: flatbuffers::VOffsetT = 10;
   pub const VT_OUTPUT_SSTS: flatbuffers::VOffsetT = 12;
   pub const VT_WORKER: flatbuffers::VOffsetT = 14;
+  pub const VT_SUBCOMPACTIONS: flatbuffers::VOffsetT = 16;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -2998,6 +2999,7 @@ impl<'a> Compaction<'a> {
     args: &'args CompactionArgs<'args>
   ) -> flatbuffers::WIPOffset<Compaction<'bldr>> {
     let mut builder = CompactionBuilder::new(_fbb);
+    if let Some(x) = args.subcompactions { builder.add_subcompactions(x); }
     if let Some(x) = args.worker { builder.add_worker(x); }
     if let Some(x) = args.output_ssts { builder.add_output_ssts(x); }
     if let Some(x) = args.spec { builder.add_spec(x); }
@@ -3051,6 +3053,13 @@ impl<'a> Compaction<'a> {
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<WorkerSpec>>(Compaction::VT_WORKER, None)}
   }
   #[inline]
+  pub fn subcompactions(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Subcompaction<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Subcompaction>>>>(Compaction::VT_SUBCOMPACTIONS, None)}
+  }
+  #[inline]
   #[allow(non_snake_case)]
   pub fn spec_as_tiered_compaction_spec(&self) -> Option<TieredCompactionSpec<'a>> {
     if self.spec_type() == CompactionSpec::TieredCompactionSpec {
@@ -3098,6 +3107,7 @@ impl flatbuffers::Verifiable for Compaction<'_> {
      .visit_field::<CompactionStatus>("status", Self::VT_STATUS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTable>>>>("output_ssts", Self::VT_OUTPUT_SSTS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<WorkerSpec>>("worker", Self::VT_WORKER, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Subcompaction>>>>("subcompactions", Self::VT_SUBCOMPACTIONS, false)?
      .finish();
     Ok(())
   }
@@ -3109,6 +3119,7 @@ pub struct CompactionArgs<'a> {
     pub status: CompactionStatus,
     pub output_ssts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTable<'a>>>>>,
     pub worker: Option<flatbuffers::WIPOffset<WorkerSpec<'a>>>,
+    pub subcompactions: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Subcompaction<'a>>>>>,
 }
 impl<'a> Default for CompactionArgs<'a> {
   #[inline]
@@ -3120,6 +3131,7 @@ impl<'a> Default for CompactionArgs<'a> {
       status: CompactionStatus::Submitted,
       output_ssts: None,
       worker: None,
+      subcompactions: None,
     }
   }
 }
@@ -3152,6 +3164,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> CompactionBuilder<'a, 'b, A> {
   #[inline]
   pub fn add_worker(&mut self, worker: flatbuffers::WIPOffset<WorkerSpec<'b >>) {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<WorkerSpec>>(Compaction::VT_WORKER, worker);
+  }
+  #[inline]
+  pub fn add_subcompactions(&mut self, subcompactions: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Subcompaction<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Compaction::VT_SUBCOMPACTIONS, subcompactions);
   }
   #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> CompactionBuilder<'a, 'b, A> {
@@ -3198,6 +3214,122 @@ impl core::fmt::Debug for Compaction<'_> {
       ds.field("status", &self.status());
       ds.field("output_ssts", &self.output_ssts());
       ds.field("worker", &self.worker());
+      ds.field("subcompactions", &self.subcompactions());
+      ds.finish()
+  }
+}
+pub enum SubcompactionOffset {}
+#[derive(Copy, Clone, PartialEq)]
+
+pub struct Subcompaction<'a> {
+  pub _tab: flatbuffers::Table<'a>,
+}
+
+impl<'a> flatbuffers::Follow<'a> for Subcompaction<'a> {
+  type Inner = Subcompaction<'a>;
+  #[inline]
+  unsafe fn follow(buf: &'a [u8], loc: usize) -> Self::Inner {
+    Self { _tab: flatbuffers::Table::new(buf, loc) }
+  }
+}
+
+impl<'a> Subcompaction<'a> {
+  pub const VT_RANGE: flatbuffers::VOffsetT = 4;
+  pub const VT_OUTPUT_SSTS: flatbuffers::VOffsetT = 6;
+
+  #[inline]
+  pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
+    Subcompaction { _tab: table }
+  }
+  #[allow(unused_mut)]
+  pub fn create<'bldr: 'args, 'args: 'mut_bldr, 'mut_bldr, A: flatbuffers::Allocator + 'bldr>(
+    _fbb: &'mut_bldr mut flatbuffers::FlatBufferBuilder<'bldr, A>,
+    args: &'args SubcompactionArgs<'args>
+  ) -> flatbuffers::WIPOffset<Subcompaction<'bldr>> {
+    let mut builder = SubcompactionBuilder::new(_fbb);
+    if let Some(x) = args.output_ssts { builder.add_output_ssts(x); }
+    if let Some(x) = args.range { builder.add_range(x); }
+    builder.finish()
+  }
+
+
+  #[inline]
+  pub fn range(&self) -> BytesRange<'a> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<BytesRange>>(Subcompaction::VT_RANGE, None).unwrap()}
+  }
+  #[inline]
+  pub fn output_ssts(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTable<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTable>>>>(Subcompaction::VT_OUTPUT_SSTS, None)}
+  }
+}
+
+impl flatbuffers::Verifiable for Subcompaction<'_> {
+  #[inline]
+  fn run_verifier(
+    v: &mut flatbuffers::Verifier, pos: usize
+  ) -> Result<(), flatbuffers::InvalidFlatbuffer> {
+    use self::flatbuffers::Verifiable;
+    v.visit_table(pos)?
+     .visit_field::<flatbuffers::ForwardsUOffset<BytesRange>>("range", Self::VT_RANGE, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTable>>>>("output_ssts", Self::VT_OUTPUT_SSTS, false)?
+     .finish();
+    Ok(())
+  }
+}
+pub struct SubcompactionArgs<'a> {
+    pub range: Option<flatbuffers::WIPOffset<BytesRange<'a>>>,
+    pub output_ssts: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTable<'a>>>>>,
+}
+impl<'a> Default for SubcompactionArgs<'a> {
+  #[inline]
+  fn default() -> Self {
+    SubcompactionArgs {
+      range: None, // required field
+      output_ssts: None,
+    }
+  }
+}
+
+pub struct SubcompactionBuilder<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> {
+  fbb_: &'b mut flatbuffers::FlatBufferBuilder<'a, A>,
+  start_: flatbuffers::WIPOffset<flatbuffers::TableUnfinishedWIPOffset>,
+}
+impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SubcompactionBuilder<'a, 'b, A> {
+  #[inline]
+  pub fn add_range(&mut self, range: flatbuffers::WIPOffset<BytesRange<'b >>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<BytesRange>>(Subcompaction::VT_RANGE, range);
+  }
+  #[inline]
+  pub fn add_output_ssts(&mut self, output_ssts: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<CompactedSsTable<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Subcompaction::VT_OUTPUT_SSTS, output_ssts);
+  }
+  #[inline]
+  pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SubcompactionBuilder<'a, 'b, A> {
+    let start = _fbb.start_table();
+    SubcompactionBuilder {
+      fbb_: _fbb,
+      start_: start,
+    }
+  }
+  #[inline]
+  pub fn finish(self) -> flatbuffers::WIPOffset<Subcompaction<'a>> {
+    let o = self.fbb_.end_table(self.start_);
+    self.fbb_.required(o, Subcompaction::VT_RANGE,"range");
+    flatbuffers::WIPOffset::new(o.value())
+  }
+}
+
+impl core::fmt::Debug for Subcompaction<'_> {
+  fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+    let mut ds = f.debug_struct("Subcompaction");
+      ds.field("range", &self.range());
+      ds.field("output_ssts", &self.output_ssts());
       ds.finish()
   }
 }

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -159,6 +159,7 @@ mod sst_iter;
 mod sst_reader;
 mod sst_stats;
 mod store_provider;
+mod subcompaction;
 mod tablestore;
 #[cfg(test)]
 mod test_utils;

--- a/slatedb/src/subcompaction.rs
+++ b/slatedb/src/subcompaction.rs
@@ -1,0 +1,66 @@
+//! # Subcompaction Data Model
+//!
+//! In-memory record of a subcompaction (RFC-0028): a compaction over a
+//! sub-range of a parent compaction's key space. See [`Subcompaction`].
+
+use serde::Serialize;
+
+use crate::bytes_range::BytesRange;
+use crate::db_state::SsTableHandle;
+
+/// A compaction over a sub-range of the parent compaction's key space
+/// (RFC-0028).
+///
+/// Subcompactions are only valid within the context of a parent
+/// [`Compaction`](crate::compactor_state::Compaction) and let a single logical
+/// compaction execute its disjoint ranges in parallel while resuming at range
+/// granularity after a failure. A subcompaction carries no lifecycle status:
+/// the parent [`Compaction`](crate::compactor_state::Compaction) owns status,
+/// and a range's progress is captured entirely by its recorded `output_ssts`.
+/// On resume every range is re-run from its persisted output; a range that
+/// already finished has nothing left to merge and completes immediately.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct Subcompaction {
+    /// Key range covered by this subcompaction. The ranges of the
+    /// subcompactions within a parent compaction are non-overlapping and
+    /// together cover the full key space.
+    range: BytesRange,
+    /// Output SSTs produced by this subcompaction so far.
+    output_ssts: Vec<SsTableHandle>,
+}
+
+impl Subcompaction {
+    pub(crate) fn new(range: BytesRange) -> Self {
+        Self {
+            range,
+            output_ssts: Vec::new(),
+        }
+    }
+
+    pub(crate) fn with_output_ssts(mut self, output_ssts: Vec<SsTableHandle>) -> Self {
+        self.output_ssts = output_ssts;
+        self
+    }
+
+    /// Returns the key range covered by this subcompaction.
+    pub(crate) fn range(&self) -> &BytesRange {
+        &self.range
+    }
+
+    /// Returns the output SSTs produced by this subcompaction so far.
+    pub fn output_ssts(&self) -> &Vec<SsTableHandle> {
+        &self.output_ssts
+    }
+
+    /// Sets the output SSTs produced by this subcompaction.
+    // Consumed by the subcompaction executor in a follow-up RFC-0028 PR; this
+    // PR only introduces the data model and its extend-only contract.
+    #[allow(dead_code)]
+    pub(crate) fn set_output_ssts(&mut self, output_ssts: Vec<SsTableHandle>) {
+        assert!(
+            output_ssts.starts_with(self.output_ssts.as_slice()),
+            "new subcompaction output SSTs must always extend previous output SSTs"
+        );
+        self.output_ssts = output_ssts;
+    }
+}


### PR DESCRIPTION
## Summary

See #1777 for the full scope. This PR just introduces the data model.

See #1755 and #1749 

## Changes

Introduce the Subcompaction flatbuffer record (key range + output SSTs) and persist it on Compaction via a forward/backward-compatible appended field. Data model only; the planner and parallel executor follow in later PRs.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
