### PR TITLE
feat: comprehensive object-store capability preflight at DB open

### DIFF
--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -191,6 +191,7 @@ pub struct DbBuilder<P: Into<Path>> {
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
     segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
+    skip_conditional_put_probe: bool,
 }
 
 impl<P: Into<Path>> DbBuilder<P> {
@@ -214,7 +215,21 @@ impl<P: Into<Path>> DbBuilder<P> {
             filter_policies: default_filter_policies(),
             metrics_recorder: Arc::new(NoopMetricsRecorder::new()),
             segment_extractor: None,
+            skip_conditional_put_probe: false,
         }
+    }
+
+    /// Skip the startup conditional-PUT (`If-Match`) capability probe.
+    ///
+    /// At `build()` SlateDB probes whether the object store supports conditional
+    /// overwrite, which the garbage collector requires to advance its collection
+    /// boundary; stores that lack it (e.g. DigitalOcean Spaces) otherwise let GC
+    /// silently fail and storage grow without bound. Set this only if you have
+    /// independently confirmed the store supports conditional overwrite, or you
+    /// never run garbage collection against this store.
+    pub fn skip_conditional_put_probe(mut self) -> Self {
+        self.skip_conditional_put_probe = true;
+        self
     }
 
     /// Set the segment extractor (RFC-0024). When configured, every
@@ -411,6 +426,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             ));
         }
 
+        let skip_conditional_put_probe = self.skip_conditional_put_probe;
         let path = self.path.into();
         // TODO: proper URI generation, for now it works just as a flag
         let wal_object_store_uri = self.wal_object_store.as_ref().map(|_| String::new());
@@ -442,6 +458,16 @@ impl<P: Into<Path>> DbBuilder<P> {
                     system_clock.clone(),
                 )
             });
+
+        // Fail fast if the object store cannot perform the conditional overwrite
+        // (HTTP If-Match) that the garbage collector relies on to advance its
+        // collection boundary. Stores that lack it (e.g. DigitalOcean Spaces) let
+        // GC silently fail to advance, growing storage without bound. The probe
+        // runs only on the writer path (DbBuilder), not on DbReaderBuilder.
+        if !skip_conditional_put_probe {
+            crate::object_store_probe::probe_conditional_put(&retrying_main_object_store, &path)
+                .await?;
+        }
 
         // Log the database opening
         if let Ok(settings_json) = self.settings.to_json_string() {

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -191,7 +191,7 @@ pub struct DbBuilder<P: Into<Path>> {
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
     segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
-    skip_conditional_put_probe: bool,
+    skip_object_store_probe: bool,
 }
 
 impl<P: Into<Path>> DbBuilder<P> {
@@ -215,20 +215,23 @@ impl<P: Into<Path>> DbBuilder<P> {
             filter_policies: default_filter_policies(),
             metrics_recorder: Arc::new(NoopMetricsRecorder::new()),
             segment_extractor: None,
-            skip_conditional_put_probe: false,
+            skip_object_store_probe: false,
         }
     }
 
-    /// Skip the startup conditional-PUT (`If-Match`) capability probe.
+    /// Skip the startup object-store capability preflight.
     ///
-    /// At `build()` SlateDB probes whether the object store supports conditional
-    /// overwrite, which the garbage collector requires to advance its collection
-    /// boundary; stores that lack it (e.g. DigitalOcean Spaces) otherwise let GC
-    /// silently fail and storage grow without bound. Set this only if you have
-    /// independently confirmed the store supports conditional overwrite, or you
-    /// never run garbage collection against this store.
-    pub fn skip_conditional_put_probe(mut self) -> Self {
-        self.skip_conditional_put_probe = true;
+    /// At `build()` SlateDB probes the configured object store for the
+    /// capabilities it depends on — basic put/get, ranged GET, head, list,
+    /// conditional create (`If-None-Match`), conditional overwrite (`If-Match`),
+    /// and multipart upload — and hard-fails if a required capability is missing.
+    /// Stores that silently diverge can corrupt SlateDB's fencing/manifest
+    /// integrity or let GC fail silently (e.g. DigitalOcean Spaces lacks
+    /// `If-Match`). Set this only if you have independently confirmed the store is
+    /// compatible, or you accept the consequences of running on an unverified
+    /// store.
+    pub fn skip_object_store_probe(mut self) -> Self {
+        self.skip_object_store_probe = true;
         self
     }
 
@@ -426,7 +429,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             ));
         }
 
-        let skip_conditional_put_probe = self.skip_conditional_put_probe;
+        let skip_object_store_probe = self.skip_object_store_probe;
         let path = self.path.into();
         // TODO: proper URI generation, for now it works just as a flag
         let wal_object_store_uri = self.wal_object_store.as_ref().map(|_| String::new());
@@ -459,14 +462,18 @@ impl<P: Into<Path>> DbBuilder<P> {
                 )
             });
 
-        // Fail fast if the object store cannot perform the conditional overwrite
-        // (HTTP If-Match) that the garbage collector relies on to advance its
-        // collection boundary. Stores that lack it (e.g. DigitalOcean Spaces) let
-        // GC silently fail to advance, growing storage without bound. The probe
-        // runs only on the writer path (DbBuilder), not on DbReaderBuilder.
-        if !skip_conditional_put_probe {
-            crate::object_store_probe::probe_conditional_put(&retrying_main_object_store, &path)
-                .await?;
+        // Fail fast if the object store lacks a capability SlateDB requires
+        // (basic put/get, ranged GET, head, list, conditional create / If-None-Match,
+        // conditional overwrite / If-Match, multipart upload). Stores that silently
+        // diverge can corrupt fencing/manifest integrity or let GC fail silently
+        // (e.g. DigitalOcean Spaces lacks If-Match). Optional capabilities only warn.
+        // The probe runs only on the writer path (DbBuilder), not DbReaderBuilder.
+        if !skip_object_store_probe {
+            crate::object_store_probe::probe_object_store(
+                &path,
+                retrying_main_object_store.as_ref(),
+            )
+            .await?;
         }
 
         // Log the database opening

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -140,6 +140,7 @@ mod mem_table;
 mod memtable_flusher;
 mod merge_iterator;
 mod merge_operator;
+mod object_store_probe;
 mod object_stores;
 mod ops;
 mod oracle;

--- a/slatedb/src/object_store_probe.rs
+++ b/slatedb/src/object_store_probe.rs
@@ -1,115 +1,557 @@
-//! Startup probe for object-store conditional-overwrite (HTTP `If-Match`) support.
+//! Startup capability preflight for the configured object store.
 //!
-//! SlateDB's garbage collector advances its collection boundary with a
-//! conditional overwrite (`PutMode::Update`, i.e. HTTP `If-Match`) — see
-//! `ObjectStoreBoundaryObject::advance` in `slatedb-txn-obj`. Object stores that
-//! support *create-only* conditional writes (`If-None-Match`) but NOT
-//! overwrite-if-match — notably DigitalOcean Spaces — return HTTP 412 on every
-//! boundary advance, so GC silently never advances and garbage accumulates
-//! without bound. There is no capability flag to inspect (`object_store`'s
+//! SlateDB relies on a specific set of object-store capabilities for its
+//! correctness and durability guarantees. Some object stores advertise an
+//! S3-compatible API but silently diverge in ways that corrupt SlateDB's
+//! invariants — most notably:
+//!
+//! * Stores that do not enforce conditional *create* (`If-None-Match`) let two
+//!   writers create the same manifest / fencing / compaction object, silently
+//!   breaking SlateDB's fencing, manifest, compaction and GC-boundary integrity.
+//! * Stores that support create-only conditional writes but NOT
+//!   overwrite-if-match (`If-Match`) — notably DigitalOcean Spaces — return HTTP
+//!   412 on every GC-boundary advance, so GC silently never advances and garbage
+//!   accumulates without bound.
+//!
+//! There is no reliable capability flag to inspect (`object_store`'s
 //! `S3ConditionalPut::ETagMatch` conflates `If-Match` and `If-None-Match`), so we
-//! probe the capability once at DB open and fail fast with an actionable error.
-
-use std::sync::Arc;
+//! probe the capabilities once at DB open (writer path only) and fail fast with
+//! an actionable error. Optional capabilities (custom attributes, copy,
+//! list-with-offset) are probed too and only produce a warning.
 
 use object_store::path::Path;
 use object_store::{
-    Error, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+    Attribute, AttributeValue, Attributes, Error, ObjectStore, ObjectStoreExt, PutMode, PutOptions,
+    PutPayload, UpdateVersion,
 };
-use tracing::debug;
+use std::borrow::Cow;
+use tracing::{debug, warn};
 
-/// Probe whether `object_store` supports conditional overwrite (`PutMode::Update`
-/// / HTTP `If-Match`), which SlateDB's garbage collector requires to advance its
-/// collection boundary. Returns a clear `Invalid` error if the store lacks it.
+/// Probe the object store for the capabilities SlateDB depends on, failing fast
+/// with an actionable [`crate::Error::invalid`] on any missing REQUIRED
+/// capability and emitting a `warn!` for any missing OPTIONAL capability.
 ///
-/// The probe writes (and best-effort deletes) a throwaway object under
-/// `<db_path>/.slatedb_probe/`: an unconditional write to learn the current
-/// version, then a conditional overwrite with that version that must succeed on a
-/// store with working `If-Match`.
-pub(crate) async fn probe_conditional_put(
-    object_store: &Arc<dyn ObjectStore>,
+/// All probe objects are written under `<db_path>/.slatedb_probe/` and are
+/// best-effort deleted before returning (including on the error path).
+pub(crate) async fn probe_object_store(
     db_path: &Path,
+    object_store: &dyn ObjectStore,
 ) -> Result<(), crate::Error> {
-    let probe = Path::from(format!("{db_path}/.slatedb_probe/conditional_put"));
+    let probe_prefix = Path::from(format!("{db_path}/.slatedb_probe"));
+    let p_basic = Path::from(format!("{db_path}/.slatedb_probe/basic"));
+    let p_create = Path::from(format!("{db_path}/.slatedb_probe/create"));
+    let p_match = Path::from(format!("{db_path}/.slatedb_probe/match"));
+    let p_mp = Path::from(format!("{db_path}/.slatedb_probe/multipart"));
+    let p_attr = Path::from(format!("{db_path}/.slatedb_probe/attributes"));
+    let p_copy = Path::from(format!("{db_path}/.slatedb_probe/copy"));
 
-    // 1. Unconditional write to establish the object and learn its version/etag.
-    //    Supported by every store (including ones that lack `If-Match`).
-    let put = object_store
+    let result = run_probe(
+        object_store,
+        &probe_prefix,
+        &p_basic,
+        &p_create,
+        &p_match,
+        &p_mp,
+        &p_attr,
+        &p_copy,
+    )
+    .await;
+
+    // Best-effort cleanup of every probe object regardless of outcome.
+    for p in [&p_basic, &p_create, &p_match, &p_mp, &p_attr, &p_copy] {
+        let _ = object_store.delete(p).await;
+    }
+
+    result
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_probe(
+    object_store: &dyn ObjectStore,
+    probe_prefix: &Path,
+    p_basic: &Path,
+    p_create: &Path,
+    p_match: &Path,
+    p_mp: &Path,
+    p_attr: &Path,
+    p_copy: &Path,
+) -> Result<(), crate::Error> {
+    const PAYLOAD: &[u8] = b"slatedb-probe-payload";
+
+    // 1. [REQUIRED] basic put + get. This is the reachability/creds/bucket/region
+    //    check: if the store is misconfigured this is where it fails.
+    object_store
         .put_opts(
-            &probe,
-            PutPayload::from_static(b"slatedb-conditional-put-probe"),
+            p_basic,
+            PutPayload::from_static(PAYLOAD),
             PutOptions::from(PutMode::Overwrite),
         )
         .await
-        .map_err(|e| probe_io_error("writing the probe object", e))?;
+        .map_err(|e| {
+            crate::Error::invalid(format!(
+                "object-store preflight failed: cannot write to the configured bucket — \
+                 check credentials/endpoint/region/permissions (error: {e}). \
+                 To bypass this check, call DbBuilder::skip_object_store_probe()."
+            ))
+        })?;
+    let got = object_store
+        .get(p_basic)
+        .await
+        .and_then_bytes()
+        .await
+        .map_err(|e| basic_io_error("reading back the basic probe object", e))?;
+    if got.as_ref() != PAYLOAD {
+        return Err(crate::Error::invalid(
+            "object-store preflight failed: basic put+get returned mismatched bytes — \
+             the configured bucket may be misrouting reads/writes. To bypass this check, \
+             call DbBuilder::skip_object_store_probe()."
+                .to_string(),
+        ));
+    }
 
+    // 2. [REQUIRED] ranged get returns the correct sub-slice.
+    let range = object_store
+        .get_range(p_basic, 1..4)
+        .await
+        .map_err(|e| basic_io_error("performing a ranged GET", e))?;
+    if range.as_ref() != &PAYLOAD[1..4] {
+        return Err(required_error(
+            "ranged GET (get_range)",
+            None,
+            "the store returned an incorrect byte sub-range; SlateDB reads SST blocks via \
+             ranged GETs and cannot operate correctly on this store",
+        ));
+    }
+
+    // 3. [REQUIRED] head returns the correct object size.
+    let meta = object_store
+        .head(p_basic)
+        .await
+        .map_err(|e| basic_io_error("performing a HEAD", e))?;
+    if meta.size as usize != PAYLOAD.len() {
+        return Err(required_error(
+            "object metadata (head)",
+            None,
+            "HEAD returned an incorrect object size; SlateDB relies on accurate object \
+             metadata",
+        ));
+    }
+
+    // 4. [REQUIRED] list includes the basic object.
+    {
+        use futures::StreamExt;
+        let mut stream = object_store.list(Some(probe_prefix));
+        let mut found = false;
+        while let Some(item) = stream.next().await {
+            let meta = item.map_err(|e| basic_io_error("listing the probe prefix", e))?;
+            if &meta.location == p_basic {
+                found = true;
+            }
+        }
+        if !found {
+            return Err(required_error(
+                "object listing (list)",
+                None,
+                "a freshly-written object did not appear in a prefix listing; SlateDB relies \
+                 on list to discover manifests, SSTs and WAL segments",
+            ));
+        }
+    }
+
+    // 5. [REQUIRED] If-None-Match ENFORCEMENT (the silent-corruption check).
+    //    The first create must succeed; a SECOND create of the same key MUST fail.
+    //    If it succeeds the store does not enforce conditional create, which makes
+    //    SlateDB's fencing / manifest / compaction / GC-boundary integrity unsafe.
+    object_store
+        .put_opts(
+            p_create,
+            PutPayload::from_static(PAYLOAD),
+            PutOptions::from(PutMode::Create),
+        )
+        .await
+        .map_err(|e| basic_io_error("performing a conditional create (If-None-Match)", e))?;
+    let second_create = object_store
+        .put_opts(
+            p_create,
+            PutPayload::from_static(b"slatedb-probe-payload-2"),
+            PutOptions::from(PutMode::Create),
+        )
+        .await;
+    match second_create {
+        // Correct behaviour: the store rejected the duplicate create.
+        Err(Error::AlreadyExists { .. } | Error::Precondition { .. }) => {}
+        Ok(_) => {
+            return Err(required_error(
+                "conditional create (If-None-Match)",
+                Some(
+                    "stores that do not enforce conditional create may include misconfigured \
+                     S3-compatible gateways",
+                ),
+                "a second conditional CREATE of an existing key SUCCEEDED — the store does not \
+                 enforce If-None-Match, so SlateDB's fencing, manifest, compaction and \
+                 GC-boundary integrity are unsafe on this store (concurrent writers can clobber \
+                 each other's objects). Use a store that enforces conditional create \
+                 (AWS S3, Cloudflare R2, MinIO, GCS, Azure), or configure object_store's \
+                 DynamoDB-backed conditional commit (S3ConditionalPut::Dynamo)",
+            ));
+        }
+        Err(e) => {
+            return Err(basic_io_error(
+                "performing the second conditional create (If-None-Match)",
+                e,
+            ));
+        }
+    }
+
+    // NOTE: SlateDB's only If-Match dependency is the GC-boundary advance. PR #1816 (create-only boundary markers) removes that dependency; if/when it merges, drop this REQUIRED If-Match check (or downgrade it to a warning) — the store is otherwise fully usable without If-Match.
+    // 6. [REQUIRED] If-Match overwrite: write to learn the version, then overwrite
+    //    conditionally on that version. DigitalOcean Spaces returns HTTP 412 here.
+    let put = object_store
+        .put_opts(
+            p_match,
+            PutPayload::from_static(PAYLOAD),
+            PutOptions::from(PutMode::Overwrite),
+        )
+        .await
+        .map_err(|e| basic_io_error("writing the If-Match probe object", e))?;
     let version = UpdateVersion {
         e_tag: put.e_tag,
         version: put.version,
     };
-
-    // 2. Conditional overwrite with the CORRECT version. This MUST succeed on a
-    //    store with working `If-Match`; DigitalOcean Spaces (and any store lacking
-    //    overwrite-if-match) returns HTTP 412 -> `Error::Precondition` here.
-    let result = object_store
+    let if_match = object_store
         .put_opts(
-            &probe,
-            PutPayload::from_static(b"slatedb-conditional-put-probe-2"),
+            p_match,
+            PutPayload::from_static(b"slatedb-probe-payload-2"),
             PutOptions::from(PutMode::Update(version)),
         )
         .await;
-
-    // Best-effort cleanup regardless of outcome.
-    let _ = object_store.delete(&probe).await;
-
-    match result {
-        Ok(_) => {
-            debug!("object store conditional-put (If-Match) probe passed");
-            Ok(())
-        }
+    match if_match {
+        Ok(_) => {}
         Err(
             Error::Precondition { .. } | Error::NotImplemented { .. } | Error::NotSupported { .. },
-        ) => Err(missing_conditional_put_error()),
-        Err(e) => Err(probe_io_error("performing the conditional overwrite", e)),
+        ) => {
+            return Err(required_error(
+                "conditional overwrite (If-Match / PutMode::Update)",
+                Some("DigitalOcean Spaces"),
+                "a conditional overwrite with the CORRECT version was rejected — SlateDB's \
+                 garbage collector advances its collection boundary with a conditional \
+                 overwrite, so on this store GC will silently fail to advance and storage will \
+                 grow without bound. Use a store with full conditional-PUT support \
+                 (AWS S3, Cloudflare R2, MinIO, GCS, Azure), configure object_store's \
+                 DynamoDB-backed conditional commit (S3ConditionalPut::Dynamo), or — if you \
+                 never run GC against this store — bypass this check with \
+                 DbBuilder::skip_object_store_probe()",
+            ));
+        }
+        Err(e) => {
+            return Err(basic_io_error("performing the conditional overwrite", e));
+        }
+    }
+
+    // 7. [REQUIRED] multipart upload (required for large SST flush).
+    match object_store.put_multipart(p_mp).await {
+        Ok(mut upload) => {
+            if let Err(e) = upload.put_part(PutPayload::from_static(PAYLOAD)).await {
+                return Err(multipart_error(e));
+            }
+            if let Err(e) = upload.complete().await {
+                return Err(multipart_error(e));
+            }
+            let got = object_store
+                .get(p_mp)
+                .await
+                .and_then_bytes()
+                .await
+                .map_err(|e| basic_io_error("reading back the multipart probe object", e))?;
+            if got.as_ref() != PAYLOAD {
+                return Err(required_error(
+                    "multipart upload",
+                    None,
+                    "a multipart upload completed but read back mismatched bytes",
+                ));
+            }
+        }
+        Err(e) => return Err(multipart_error(e)),
+    }
+
+    // 8. [WARN] custom attributes (metadata). On unsupported, SlateDB disables
+    //    ULID write-verification and falls back automatically.
+    let mut attributes = Attributes::new();
+    attributes.insert(
+        Attribute::Metadata(Cow::Borrowed("slatedb_probe")),
+        AttributeValue::from("1"),
+    );
+    let attr_result = object_store
+        .put_opts(
+            p_attr,
+            PutPayload::from_static(PAYLOAD),
+            PutOptions {
+                attributes,
+                mode: PutMode::Overwrite,
+                ..Default::default()
+            },
+        )
+        .await;
+    match attr_result {
+        Ok(_) => {}
+        Err(Error::NotImplemented { .. } | Error::NotSupported { .. }) => {
+            warn!(
+                "object-store preflight: custom object attributes (metadata) are unsupported on \
+                 this store; SlateDB's ULID write-verification will be disabled (it falls back \
+                 automatically)"
+            );
+        }
+        Err(e) => {
+            warn!(
+                "object-store preflight: probing custom attributes failed ({e}); SlateDB's ULID \
+                 write-verification may be unavailable"
+            );
+        }
+    }
+
+    // 9. [WARN] copy. Used by checkpoint/clone.
+    match object_store.copy(p_basic, p_copy).await {
+        Ok(()) => match object_store.get(p_copy).await.and_then_bytes().await {
+            Ok(bytes) if bytes.as_ref() == PAYLOAD => {}
+            Ok(_) => warn!(
+                "object-store preflight: object copy produced mismatched bytes — \
+                     checkpoint/clone may be unreliable"
+            ),
+            Err(e) => warn!(
+                "object-store preflight: reading back a copied object failed ({e}) — \
+                     checkpoint/clone may be unavailable"
+            ),
+        },
+        Err(e) => warn!(
+            "object-store preflight: object copy unsupported ({e}) — checkpoint/clone will be \
+             unavailable"
+        ),
+    }
+
+    // 10. [WARN] list_with_offset. Best-effort.
+    {
+        use futures::StreamExt;
+        let mut stream = object_store.list_with_offset(Some(probe_prefix), p_basic);
+        while let Some(item) = stream.next().await {
+            if let Err(e) = item {
+                warn!("object-store preflight: list_with_offset failed ({e})");
+                break;
+            }
+        }
+    }
+
+    debug!("object store capability preflight passed");
+    Ok(())
+}
+
+/// Builds a REQUIRED-capability error message that (a) names the capability,
+/// (b) names the likely culprit store class when known, and (c) mentions the
+/// opt-out flag.
+fn required_error(capability: &str, culprit: Option<&str>, detail: &str) -> crate::Error {
+    let culprit = match culprit {
+        Some(c) => format!(" Likely culprit: {c}."),
+        None => String::new(),
+    };
+    crate::Error::invalid(format!(
+        "object-store preflight failed: the configured object store does not support the \
+         REQUIRED capability '{capability}'. {detail}.{culprit} To bypass this check, call \
+         DbBuilder::skip_object_store_probe()."
+    ))
+}
+
+fn multipart_error(e: Error) -> crate::Error {
+    match e {
+        Error::NotImplemented { .. } | Error::NotSupported { .. } => required_error(
+            "multipart upload",
+            None,
+            "multipart upload unsupported (required for large SST flush)",
+        ),
+        e => basic_io_error("performing a multipart upload", e),
     }
 }
 
-fn missing_conditional_put_error() -> crate::Error {
-    crate::Error::invalid(
-        "the configured object store does not support conditional overwrite \
-         (HTTP If-Match / PutMode::Update). SlateDB's garbage collector advances \
-         its collection boundary with a conditional overwrite, so on this store \
-         garbage collection will silently fail to advance and storage will grow \
-         without bound. Known-unsupported: DigitalOcean Spaces. Use a store with \
-         full conditional-PUT support (AWS S3, Cloudflare R2, MinIO, GCS, Azure), \
-         or configure object_store's DynamoDB-backed conditional commit \
-         (S3ConditionalPut::Dynamo). To bypass this check (for example when GC is \
-         disabled), call DbBuilder::skip_conditional_put_probe()."
-            .to_string(),
-    )
+fn basic_io_error(ctx: &str, e: Error) -> crate::Error {
+    crate::Error::invalid(format!(
+        "object-store preflight failed while {ctx}: {e}. If you are confident the store is \
+         configured correctly, bypass this check with DbBuilder::skip_object_store_probe()."
+    ))
 }
 
-fn probe_io_error(ctx: &str, e: Error) -> crate::Error {
-    crate::Error::invalid(format!(
-        "the object-store conditional-put capability probe failed while {ctx}: {e}. \
-         If you are confident the store supports conditional overwrite (If-Match), \
-         bypass this check with DbBuilder::skip_conditional_put_probe()."
-    ))
+/// Small helper to collect a `GetResult` into bytes in one `.await` chain.
+trait GetResultExt {
+    async fn and_then_bytes(self) -> Result<bytes::Bytes, Error>;
+}
+
+impl GetResultExt for Result<object_store::GetResult, Error> {
+    async fn and_then_bytes(self) -> Result<bytes::Bytes, Error> {
+        self?.bytes().await
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::probe_conditional_put;
-    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use super::probe_object_store;
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::{
+        CopyOptions, Error, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+        ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+        Result as OsResult,
+    };
+    use std::fmt;
     use std::sync::Arc;
+
+    /// Wrapper that delegates every `ObjectStore` method to an inner `InMemory`
+    /// except for the behaviour each test needs to override.
+    struct Wrapper {
+        inner: Arc<InMemory>,
+        /// When true, `PutMode::Create` behaves like `Overwrite` (never rejects).
+        ignore_if_none_match: bool,
+        /// When true, `PutMode::Update` (If-Match) is rejected with `Precondition`.
+        reject_if_match: bool,
+        /// When true, `put_multipart_opts` returns `NotImplemented`.
+        reject_multipart: bool,
+    }
+
+    impl Wrapper {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(InMemory::new()),
+                ignore_if_none_match: false,
+                reject_if_match: false,
+                reject_multipart: false,
+            }
+        }
+    }
+
+    impl fmt::Debug for Wrapper {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Wrapper")
+        }
+    }
+
+    impl fmt::Display for Wrapper {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "Wrapper")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for Wrapper {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> OsResult<PutResult> {
+            if self.ignore_if_none_match && matches!(opts.mode, PutMode::Create) {
+                // Model a store that doesn't enforce If-None-Match: treat Create
+                // like Overwrite, never returning AlreadyExists/Precondition.
+                let mut overwrite = opts;
+                overwrite.mode = PutMode::Overwrite;
+                return self.inner.put_opts(location, payload, overwrite).await;
+            }
+            if self.reject_if_match && matches!(opts.mode, PutMode::Update(_)) {
+                return Err(Error::Precondition {
+                    path: location.to_string(),
+                    source: "injected If-Match rejection (models DigitalOcean Spaces)".into(),
+                });
+            }
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> OsResult<Box<dyn MultipartUpload>> {
+            if self.reject_multipart {
+                return Err(Error::NotImplemented {
+                    operation: "put_multipart_opts".to_string(),
+                    implementer: "Wrapper".to_string(),
+                });
+            }
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OsResult<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OsResult<Path>>,
+        ) -> BoxStream<'static, OsResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OsResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OsResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OsResult<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
 
     #[tokio::test]
     async fn in_memory_store_passes_probe() {
-        // The in-memory store supports conditional put, so the probe must pass.
-        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        // The in-memory store supports all required capabilities.
+        let store = InMemory::new();
         let path = Path::from("test-db");
-        probe_conditional_put(&store, &path)
+        probe_object_store(&path, &store)
             .await
-            .expect("in-memory store supports conditional put");
+            .expect("in-memory store passes all required probe steps");
+    }
+
+    #[tokio::test]
+    async fn store_without_if_none_match_enforcement_fails() {
+        let mut wrapper = Wrapper::new();
+        wrapper.ignore_if_none_match = true;
+        let path = Path::from("test-db");
+        let err = probe_object_store(&path, &wrapper)
+            .await
+            .expect_err("store that ignores If-None-Match must fail the probe");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("conditional create") || msg.contains("If-None-Match"),
+            "error should mention conditional create / If-None-Match, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_rejecting_if_match_fails() {
+        let mut wrapper = Wrapper::new();
+        wrapper.reject_if_match = true;
+        let path = Path::from("test-db");
+        let err = probe_object_store(&path, &wrapper)
+            .await
+            .expect_err("store that rejects If-Match must fail the probe");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("If-Match") || msg.contains("DigitalOcean Spaces"),
+            "error should mention If-Match / DigitalOcean Spaces, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_without_multipart_fails() {
+        let mut wrapper = Wrapper::new();
+        wrapper.reject_multipart = true;
+        let path = Path::from("test-db");
+        let err = probe_object_store(&path, &wrapper)
+            .await
+            .expect_err("store without multipart must fail the probe");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("multipart"),
+            "error should mention multipart, got: {msg}"
+        );
     }
 }

--- a/slatedb/src/object_store_probe.rs
+++ b/slatedb/src/object_store_probe.rs
@@ -1,0 +1,115 @@
+//! Startup probe for object-store conditional-overwrite (HTTP `If-Match`) support.
+//!
+//! SlateDB's garbage collector advances its collection boundary with a
+//! conditional overwrite (`PutMode::Update`, i.e. HTTP `If-Match`) — see
+//! `ObjectStoreBoundaryObject::advance` in `slatedb-txn-obj`. Object stores that
+//! support *create-only* conditional writes (`If-None-Match`) but NOT
+//! overwrite-if-match — notably DigitalOcean Spaces — return HTTP 412 on every
+//! boundary advance, so GC silently never advances and garbage accumulates
+//! without bound. There is no capability flag to inspect (`object_store`'s
+//! `S3ConditionalPut::ETagMatch` conflates `If-Match` and `If-None-Match`), so we
+//! probe the capability once at DB open and fail fast with an actionable error.
+
+use std::sync::Arc;
+
+use object_store::path::Path;
+use object_store::{
+    Error, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+};
+use tracing::debug;
+
+/// Probe whether `object_store` supports conditional overwrite (`PutMode::Update`
+/// / HTTP `If-Match`), which SlateDB's garbage collector requires to advance its
+/// collection boundary. Returns a clear `Invalid` error if the store lacks it.
+///
+/// The probe writes (and best-effort deletes) a throwaway object under
+/// `<db_path>/.slatedb_probe/`: an unconditional write to learn the current
+/// version, then a conditional overwrite with that version that must succeed on a
+/// store with working `If-Match`.
+pub(crate) async fn probe_conditional_put(
+    object_store: &Arc<dyn ObjectStore>,
+    db_path: &Path,
+) -> Result<(), crate::Error> {
+    let probe = Path::from(format!("{db_path}/.slatedb_probe/conditional_put"));
+
+    // 1. Unconditional write to establish the object and learn its version/etag.
+    //    Supported by every store (including ones that lack `If-Match`).
+    let put = object_store
+        .put_opts(
+            &probe,
+            PutPayload::from_static(b"slatedb-conditional-put-probe"),
+            PutOptions::from(PutMode::Overwrite),
+        )
+        .await
+        .map_err(|e| probe_io_error("writing the probe object", e))?;
+
+    let version = UpdateVersion {
+        e_tag: put.e_tag,
+        version: put.version,
+    };
+
+    // 2. Conditional overwrite with the CORRECT version. This MUST succeed on a
+    //    store with working `If-Match`; DigitalOcean Spaces (and any store lacking
+    //    overwrite-if-match) returns HTTP 412 -> `Error::Precondition` here.
+    let result = object_store
+        .put_opts(
+            &probe,
+            PutPayload::from_static(b"slatedb-conditional-put-probe-2"),
+            PutOptions::from(PutMode::Update(version)),
+        )
+        .await;
+
+    // Best-effort cleanup regardless of outcome.
+    let _ = object_store.delete(&probe).await;
+
+    match result {
+        Ok(_) => {
+            debug!("object store conditional-put (If-Match) probe passed");
+            Ok(())
+        }
+        Err(
+            Error::Precondition { .. } | Error::NotImplemented { .. } | Error::NotSupported { .. },
+        ) => Err(missing_conditional_put_error()),
+        Err(e) => Err(probe_io_error("performing the conditional overwrite", e)),
+    }
+}
+
+fn missing_conditional_put_error() -> crate::Error {
+    crate::Error::invalid(
+        "the configured object store does not support conditional overwrite \
+         (HTTP If-Match / PutMode::Update). SlateDB's garbage collector advances \
+         its collection boundary with a conditional overwrite, so on this store \
+         garbage collection will silently fail to advance and storage will grow \
+         without bound. Known-unsupported: DigitalOcean Spaces. Use a store with \
+         full conditional-PUT support (AWS S3, Cloudflare R2, MinIO, GCS, Azure), \
+         or configure object_store's DynamoDB-backed conditional commit \
+         (S3ConditionalPut::Dynamo). To bypass this check (for example when GC is \
+         disabled), call DbBuilder::skip_conditional_put_probe()."
+            .to_string(),
+    )
+}
+
+fn probe_io_error(ctx: &str, e: Error) -> crate::Error {
+    crate::Error::invalid(format!(
+        "the object-store conditional-put capability probe failed while {ctx}: {e}. \
+         If you are confident the store supports conditional overwrite (If-Match), \
+         bypass this check with DbBuilder::skip_conditional_put_probe()."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::probe_conditional_put;
+    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn in_memory_store_passes_probe() {
+        // The in-memory store supports conditional put, so the probe must pass.
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("test-db");
+        probe_conditional_put(&store, &path)
+            .await
+            .expect("in-memory store supports conditional put");
+    }
+}


### PR DESCRIPTION
## Summary

Adds a one-time **object-store capability preflight** at `DbBuilder::build()` (writer
path only) that exercises the set of `object_store` operations SlateDB actually
depends on and **fails fast** with an actionable error when the configured store is
missing a *required* capability — instead of letting the divergence surface later as
silent corruption or unbounded storage growth. Optional capabilities are probed too
and only emit a `warn!`. A single `DbBuilder::skip_object_store_probe()` opt-out
bypasses the whole check.

> This generalizes the earlier conditional-overwrite-only probe. SlateDB has no
> preflight today — it detects store divergence implicitly, on first use of each
> operation, and some divergences (notably non-enforced conditional create) never
> surface as an error at all.

## Why / motivation

Many object stores advertise an S3-compatible API but silently diverge in ways that
break SlateDB's invariants. Two are particularly dangerous because they fail
*silently*:

- **Conditional create not enforced (`If-None-Match`).** Every fenced/sequenced write
  in SlateDB — WAL SSTs, manifest commits, compaction commits, the GC boundary —
  relies on a second `PutMode::Create` to an existing key being *rejected*. A store
  that accepts it lets two writers clobber each other's objects with no error, which
  is unrecoverable corruption.
- **Conditional overwrite not supported (`If-Match`).** Stores that support
  create-only conditional writes but not overwrite-if-match — notably **DigitalOcean
  Spaces** — return HTTP 412 on every GC-boundary advance, so GC silently never
  advances and the bucket grows without bound. (Observed in production: a ~38 GB store
  ~99% obsolete-version garbage, no error surfaced anywhere.)

`object_store` exposes no capability flag to detect these ahead of time
(`S3ConditionalPut::ETagMatch` conflates `If-Match` and `If-None-Match`), so the only
reliable detection is to probe the behavior once at open.

## What's probed

All probe objects are written under `<db_path>/.slatedb_probe/` and best-effort
deleted before `build()` returns (including on the error path).

| # | Capability | Behavior | What a failure means |
|---|------------|----------|----------------------|
| 1 | `put` (Overwrite) + `get` roundtrip | **required** | bad credentials / bucket / endpoint / region / permissions (clear message) |
| 2 | `get_range` | **required** | SST block reads (ranged GETs) are broken |
| 3 | `head` (size) | **required** | object metadata is inaccurate |
| 4 | `list` (prefix) | **required** | manifest / SST / WAL discovery is broken |
| 5 | **`If-None-Match` enforced** | **required** | *silent* fencing / manifest / compaction / GC-boundary corruption |
| 6 | **`If-Match` overwrite** | **required** | GC silently never advances → unbounded growth (DigitalOcean Spaces) |
| 7 | multipart upload | **required** | large SST flush is broken |
| 8 | put with custom attributes | warn | ULID write-verification disabled (SlateDB falls back automatically) |
| 9 | `copy` | warn | checkpoint / clone unavailable |
| 10 | `list_with_offset` | warn | large-directory pagination |

Each required failure returns `Error::invalid(..)` that names the capability, the
likely culprit store class when known, and the `skip_object_store_probe()` opt-out.

## Coupling with #1816 — please read

Step 6 (`If-Match`) is correct against **current `main`**, where the GC boundary
advances via `PutMode::Update` (`If-Match`). **#1816 removes that dependency** by
reworking the boundary to create-only markers (`If-None-Match`). So:

- As long as the GC boundary uses `If-Match`, this required check is correct and
  DigitalOcean Spaces (rightly) fails the probe.
- **If/when #1816 merges, this required `If-Match` check should be dropped** (or
  downgraded to a `warn`) — at that point the store is fully usable without
  `If-Match`, and the probe should no longer reject it. There's an in-code `NOTE`
  marking exactly this. Ideally #1815 and #1816 are reviewed together.

The other required checks (1–5, 7) are independent of #1816.

## What changed

- **`slatedb/src/object_store_probe.rs`** — `probe_object_store(db_path, object_store)`
  implementing the sequence above + helper error constructors + 4 unit tests.
- **`slatedb/src/db/builder.rs`** — renamed `skip_conditional_put_probe` →
  `skip_object_store_probe` (field + builder method), updated the doc comment and the
  call site in `build()` (writer path only — **not** `DbReaderBuilder`).

## Testing

Validated under the pinned `1.91.1` toolchain:

- `cargo build -p slatedb --lib` — clean, no warnings.
- `cargo test -p slatedb --lib object_store_probe` — **4 pass**:
  - `in_memory_store_passes_probe` — `InMemory` satisfies all required steps.
  - `store_without_if_none_match_enforcement_fails` — a wrapper that treats
    `PutMode::Create` like `Overwrite` is rejected with the If-None-Match message.
  - `store_rejecting_if_match_fails` — a wrapper returning `Precondition` on
    `PutMode::Update` (models DO Spaces) is rejected with the If-Match message.
  - `store_without_multipart_fails` — a wrapper returning `NotImplemented` from
    `put_multipart_opts` is rejected with the multipart message.
- `cargo fmt` applied.

## Open questions for maintainers

1. **Writer-only.** The probe runs on the writer build path, not `DbReaderBuilder`.
   Readers don't write, but they do `get`/`get_range`/`list` — should a lighter
   read-capability probe run for readers too?
2. **`copy` / `list_with_offset` as warn vs required.** `copy` gates checkpoint/clone
   and `list_with_offset` is a pagination optimization, so both are warnings today.
   Should either be required?
3. **Probe prefix.** Probe objects live under `<db_path>/.slatedb_probe/` and are
   cleaned up best-effort. Is that location/namespace acceptable, or would you prefer
   a configurable / more-hidden prefix?
4. **Attributes.** Custom-attribute support is a warning because SlateDB already falls
   back when it's unsupported — confirm that's the desired severity.
