### PR TITLE
fix(gc): advance boundary with create-only markers (support stores without If-Match)

### DIFF
--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -4,12 +4,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::StreamExt;
-use log::{debug, error, warn};
+use log::{debug, warn};
 use object_store::path::Path;
 use object_store::Error::AlreadyExists;
-use object_store::{
-    Error, GetOptions, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
-};
+use object_store::{Error, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload};
 use parking_lot::Mutex;
 use slatedb_common::object_metadata::IdentifiedObjectMetadata;
 use std::collections::Bound;
@@ -99,112 +97,179 @@ impl<T> ObjectStoreSequencedStorageProtocol<T> {
 
 /// Implements [`BoundaryObject`] on object storage.
 ///
-/// The boundary is stored as a single ASCII-encoded `u64` at
-/// `<root_path>/gc/<name>.boundary`. A missing boundary file is treated as `0`
-/// even if this process already has a cached boundary observation.
+/// ## Why versioned, create-only markers (not a single overwritten object)
 ///
-/// Successful reads cache the boundary value along with object-store version
-/// metadata. Later reads pass the cached ETag as `if-none-match`, allowing stores
-/// that support conditional GETs to return `NotModified`; in that case the cached
-/// boundary is reused without fetching the object body again.
+/// Earlier versions stored the boundary as a single object at
+/// `<root_path>/gc/<name>.boundary` and advanced it with a conditional
+/// *overwrite* — `PutMode::Update(version)`, i.e. an `If-Match` precondition on
+/// the object's ETag. That requires the object store to support conditional
+/// overwrite-PUT. Several S3-compatible stores support conditional *create*
+/// (`If-None-Match: *`) but NOT conditional *overwrite* (`If-Match`) — notably
+/// DigitalOcean Spaces, which returns `412 PreconditionFailed` on every
+/// `If-Match` PUT. On those stores the very first boundary write (a `Create`)
+/// succeeded, but every later advance was an `Update` that 412'd forever: GC
+/// hot-looped (conditional GET -> 304, conditional PUT -> 412), the boundary
+/// never advanced, and nothing was ever deleted.
+///
+/// The boundary value only ever moves forward (monotonic), so we don't need to
+/// mutate one object. Instead each boundary value is recorded as its own
+/// immutable, create-only marker `<root_path>/gc/<name>/<id:020>.boundary`,
+/// written with `PutMode::Create` (`If-None-Match: *`) — the same primitive the
+/// manifest and compactions sequences already use. The current boundary is the
+/// highest marker id present. Superseded (strictly lower) markers are deleted
+/// best-effort after each advance, so the directory holds ~one object in steady
+/// state.
+///
+/// This needs only conditional *create*, which every supported store provides,
+/// so it works on stores that lack conditional overwrite while remaining correct
+/// on those that have it.
+///
+/// ## Backward compatibility
+///
+/// A database created by an older version has a single `<name>.boundary` object
+/// and no marker directory. [`Self::read_boundary`] falls back to reading that
+/// legacy object when no markers exist, preserving the boundary across upgrade.
+/// The first advance writes a marker (id strictly greater than the legacy value,
+/// since advances below the current boundary are no-ops) and best-effort deletes
+/// the legacy object; subsequent reads use markers only.
 pub struct ObjectStoreBoundaryObject {
-    object_store: Arc<dyn ObjectStore>,
-    filepath: Path,
-    /// Caches the last observed boundary and object-store version metadata for
-    /// conditional reads.
-    cache: Mutex<Option<(MonotonicId, UpdateVersion)>>,
+    /// Object store rooted at `<root_path>/gc`.
+    object_store: Box<dyn ObjectStore>,
+    /// Logical boundary name (e.g. "manifest", "compactions", "wal"); also the
+    /// subdirectory under `gc/` that holds this boundary's markers.
+    name: String,
+    /// Legacy single-object path `<name>.boundary`, read for backward compat.
+    legacy_filepath: Path,
+    /// Caches the last observed boundary so `check` can reject ids at or below a
+    /// known boundary without an object-store round trip. Never moves backward.
+    cache: Mutex<Option<MonotonicId>>,
 }
 
 impl ObjectStoreBoundaryObject {
     pub fn new(root_path: &Path, object_store: Arc<dyn ObjectStore>, name: &str) -> Self {
         Self {
-            object_store,
-            filepath: root_path
-                .clone()
-                .join("gc")
-                .join(format!("{name}.boundary")),
+            object_store: Box::new(::object_store::prefix::PrefixStore::new(
+                object_store,
+                root_path.clone().join("gc"),
+            )),
+            name: name.to_string(),
+            legacy_filepath: Path::from(format!("{name}.boundary")),
             cache: Mutex::new(None),
         }
     }
 
-    /// Updates the cached boundary and version metadata without moving the cached
-    /// boundary backward.
-    ///
-    /// ## Arguments
-    ///
-    /// * `boundary` - The boundary value read from or written to object storage.
-    /// * `version` - The object-store version metadata associated with `boundary`.
-    ///
-    /// ## Returns
-    ///
-    /// The boundary and optional version metadata that callers should use after
-    /// applying the cache's monotonicity rule.
-    fn update_cache(
-        &self,
-        boundary: MonotonicId,
-        version: UpdateVersion,
-    ) -> (MonotonicId, Option<UpdateVersion>) {
-        let mut cache = self.cache.lock();
-        if let Some((cached_id, cached_version)) = cache.as_ref() {
-            if *cached_id > boundary {
-                return (*cached_id, Some(cached_version.clone()));
-            }
-        }
-
-        *cache = Some((boundary, version.clone()));
-        (boundary, Some(version))
+    /// Path of the immutable marker for boundary value `id`, relative to the
+    /// `gc/` prefix store: `<name>/<id:020>.boundary`.
+    fn marker_path(&self, id: MonotonicId) -> Path {
+        Path::from(format!("{}/{:020}.boundary", self.name, id.id()))
     }
 
-    /// Reads the durable boundary, using a conditional GET when cached version
-    /// metadata is present.
-    async fn read_boundary(
-        &self,
-    ) -> Result<(MonotonicId, Option<UpdateVersion>), TransactionalObjectError> {
-        let cached = self.cache.lock().clone();
-        let opts = GetOptions {
-            if_none_match: cached
-                .as_ref()
-                .and_then(|(_, version)| version.e_tag.clone()),
-            ..GetOptions::default()
-        };
+    /// Prefix used to list this boundary's markers: `<name>`. Note this matches
+    /// the `<name>/...` marker directory but NOT the legacy `<name>.boundary`
+    /// object, which is a distinct single path segment.
+    fn markers_prefix(&self) -> Path {
+        Path::from(self.name.clone())
+    }
 
-        match self.object_store.get_opts(&self.filepath, opts).await {
+    /// Parse the boundary value from a marker path's filename, or `None` if the
+    /// path is not a `<id:020>.boundary` marker.
+    fn parse_marker_id(path: &Path) -> Option<MonotonicId> {
+        let filename = path.filename()?;
+        let (stem, ext) = filename.rsplit_once('.')?;
+        if ext != "boundary" {
+            return None;
+        }
+        stem.parse().ok().map(MonotonicId::new)
+    }
+
+    /// Update the cached boundary, never moving it backward. Returns the
+    /// effective (max) boundary after applying the monotonicity rule.
+    ///
+    /// Flooring at the cache is safe: the durable boundary is globally monotonic
+    /// (markers are only added, and cleanup never removes the maximum), so any
+    /// previously cached value is `<=` the true current boundary.
+    fn update_cache(&self, boundary: MonotonicId) -> MonotonicId {
+        let mut cache = self.cache.lock();
+        let effective = match *cache {
+            Some(cached) if cached >= boundary => cached,
+            _ => boundary,
+        };
+        *cache = Some(effective);
+        effective
+    }
+
+    /// Read the legacy single-object boundary value, or `None` if absent.
+    async fn read_legacy_boundary(&self) -> Result<Option<MonotonicId>, TransactionalObjectError> {
+        match self.object_store.get(&self.legacy_filepath).await {
             Ok(result) => {
-                let version = UpdateVersion {
-                    e_tag: result.meta.e_tag.clone(),
-                    version: result.meta.version.clone(),
-                };
                 let bytes = result.bytes().await?;
-                let boundary = MonotonicId::new(
-                    std::str::from_utf8(&bytes)
-                        .map_err(|_| TransactionalObjectError::InvalidObjectState)?
-                        .trim()
-                        .parse()
-                        .map_err(|_| TransactionalObjectError::InvalidObjectState)?,
-                );
-                Ok(self.update_cache(boundary, version))
+                let value: u64 = std::str::from_utf8(&bytes)
+                    .map_err(|_| TransactionalObjectError::InvalidObjectState)?
+                    .trim()
+                    .parse()
+                    .map_err(|_| TransactionalObjectError::InvalidObjectState)?;
+                Ok(Some(MonotonicId::new(value)))
             }
-            Err(Error::NotModified { .. }) => match self.cache.lock().clone() {
-                Some((boundary, version)) => Ok((boundary, Some(version))),
-                // NotModified implies we have a cache, since we need the
-                // version's ETag for the conditional GET. If cache is missing,
-                // treat as invalid state.
-                None => {
-                    error!(
-                        "received NotModified without cache [path={}]",
-                        self.filepath
-                    );
-                    Err(TransactionalObjectError::InvalidObjectState)
-                }
-            },
-            // A missing boundary is treated as zero. Don't use cache because
-            // a write that occurred before a boundary file exists is valid even if
-            // we later have a cached boundary above it. Assume the object store is
-            // infallible here; if the object store loses data, this will return 0
-            // when it should panic. But object stores should never lose data.
-            Err(Error::NotFound { .. }) => Ok((MonotonicId::new(0), None)),
+            Err(Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(TransactionalObjectError::from(e)),
         }
+    }
+
+    /// List boundary markers and return the highest value present, or `None`.
+    async fn read_max_marker(&self) -> Result<Option<MonotonicId>, TransactionalObjectError> {
+        let prefix = self.markers_prefix();
+        let mut stream = self.object_store.list(Some(&prefix));
+        let mut max: Option<MonotonicId> = None;
+        while let Some(meta) = stream
+            .next()
+            .await
+            .transpose()
+            .map_err(TransactionalObjectError::from)?
+        {
+            if let Some(id) = Self::parse_marker_id(&meta.location) {
+                max = Some(max.map_or(id, |m| m.max(id)));
+            }
+        }
+        Ok(max)
+    }
+
+    /// Read the durable boundary: the highest marker id, or — if no markers
+    /// exist yet — the legacy single-object value, or `0` if neither is present.
+    /// Updates (and is floored by) the cache.
+    ///
+    /// Once any marker exists, its id is strictly greater than the legacy value
+    /// (advances below the current boundary are no-ops), so the legacy object is
+    /// only consulted while no marker exists — a single GET that disappears after
+    /// the first advance.
+    async fn read_boundary(&self) -> Result<MonotonicId, TransactionalObjectError> {
+        let boundary = match self.read_max_marker().await? {
+            Some(id) => id,
+            None => self
+                .read_legacy_boundary()
+                .await?
+                .unwrap_or_else(|| MonotonicId::new(0)),
+        };
+        Ok(self.update_cache(boundary))
+    }
+
+    /// Best-effort deletion of markers strictly below `keep` and the legacy
+    /// object. Errors are ignored: stale markers are harmless (reads take the
+    /// max) and will be retried on the next advance. The current maximum is never
+    /// deleted (every caller only removes ids `< keep`, and `keep`'s own marker
+    /// is created before this runs), so the boundary cannot dip.
+    async fn cleanup_below(&self, keep: MonotonicId) {
+        let prefix = self.markers_prefix();
+        let mut stream = self.object_store.list(Some(&prefix));
+        while let Some(meta) = stream.next().await {
+            let Ok(meta) = meta else { continue };
+            if let Some(id) = Self::parse_marker_id(&meta.location) {
+                if id < keep {
+                    let _ = self.object_store.delete(&meta.location).await;
+                }
+            }
+        }
+        // The legacy object is superseded once any marker exists.
+        let _ = self.object_store.delete(&self.legacy_filepath).await;
     }
 
     /// Checks that the given id is above the boundary, returning an error if not.
@@ -217,7 +282,7 @@ impl ObjectStoreBoundaryObject {
     /// - `Ok(())` if the id is above the boundary.
     /// - `Err(TransactionalObjectError::ObjectVersionExists)` if the id is at or
     ///   below the boundary.
-    async fn check_boundary(
+    fn check_boundary(
         &self,
         id: MonotonicId,
         boundary: MonotonicId,
@@ -237,62 +302,58 @@ impl ObjectStoreBoundaryObject {
 #[async_trait]
 impl BoundaryObject for ObjectStoreBoundaryObject {
     async fn check(&self, id: MonotonicId) -> Result<(), TransactionalObjectError> {
-        // Check the cache first to avoid an object store call when the boundary is stable.
-        let cached_boundary = self.cache.lock().clone();
-        if let Some((boundary, _)) = cached_boundary {
-            self.check_boundary(id, boundary).await?;
+        // Check the cache first to avoid an object store call when the id is
+        // already at or below a known boundary (the boundary only grows, so this
+        // can never become a false reject).
+        let cached_boundary = *self.cache.lock();
+        if let Some(boundary) = cached_boundary {
+            self.check_boundary(id, boundary)?;
         }
-        // If cache passed, double check against object store using GET If-None-Match.
-        let (boundary, _) = self.read_boundary().await?;
-        self.check_boundary(id, boundary).await
+        // If the cache passed (or was empty), double check against the store.
+        let boundary = self.read_boundary().await?;
+        self.check_boundary(id, boundary)
     }
 
-    async fn advance(&self, boundary: MonotonicId) -> Result<(), TransactionalObjectError> {
+    async fn advance(&self, target: MonotonicId) -> Result<(), TransactionalObjectError> {
+        // Fast path: a cached boundary already at/above the target.
+        if let Some(cached) = *self.cache.lock() {
+            if cached >= target {
+                return Ok(());
+            }
+        }
         loop {
-            // Use the cache if it's available. If it's stale, we'll refresh the cache when
-            // we check the `put_result`.
-            let cached_boundary = self.cache.lock().clone();
-            let (current_boundary, current_version) =
-                if let Some((boundary, version)) = cached_boundary {
-                    (boundary, Some(version))
-                } else {
-                    // No cache, so we have to go to the object store.
-                    self.read_boundary().await?
-                };
-
-            if current_boundary >= boundary {
+            let current = self.read_boundary().await?;
+            if current >= target {
                 return Ok(());
             }
 
-            let put_result = match current_version {
-                Some(version) => {
-                    self.object_store
-                        .put_opts(
-                            &self.filepath,
-                            PutPayload::from(boundary.id().to_string()),
-                            PutOptions::from(PutMode::Update(version)),
-                        )
-                        .await
-                }
-                None => {
-                    self.object_store
-                        .put_opts(
-                            &self.filepath,
-                            PutPayload::from(boundary.id().to_string()),
-                            PutOptions::from(PutMode::Create),
-                        )
-                        .await
-                }
-            };
+            // Record the new boundary as an immutable, create-only marker. This
+            // uses `If-None-Match: *` (conditional create) rather than the old
+            // `If-Match` (conditional overwrite), so it works on stores that lack
+            // conditional overwrite.
+            let put_result = self
+                .object_store
+                .put_opts(
+                    &self.marker_path(target),
+                    PutPayload::from(target.id().to_string()),
+                    PutOptions::from(PutMode::Create),
+                )
+                .await;
 
             match put_result {
-                Ok(result) => {
-                    self.update_cache(boundary, result.into());
+                // Created the marker, or another writer created exactly this
+                // marker concurrently (idempotent). Either way `target` is now
+                // durable. (A marker `>= target` cannot pre-exist here: we only
+                // reach this point when `current < target`.)
+                Ok(_) | Err(Error::AlreadyExists { .. }) => {
+                    self.update_cache(target);
+                    self.cleanup_below(target).await;
                     return Ok(());
                 }
-                // Try again if the boundary was concurrently updated by another process.
-                Err(Error::AlreadyExists { .. } | Error::Precondition { .. }) => {
-                    // Refresh the cache so re-attempts always use the fresh boundary.
+                // Some stores surface a create conflict as `Precondition` rather
+                // than `AlreadyExists`. Re-read; a concurrent advance to `target`
+                // (or higher) will satisfy the loop's early return next pass.
+                Err(Error::Precondition { .. }) => {
                     self.read_boundary().await?;
                 }
                 Err(e) => return Err(TransactionalObjectError::from(e)),
@@ -441,14 +502,13 @@ mod tests {
     use object_store::path::Path;
     use object_store::{
         CopyOptions, Error as ObjectStoreError, GetOptions, GetResult, ListResult, MultipartUpload,
-        ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload,
-        PutResult, Result as ObjectStoreResult, UpdateVersion,
+        ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutMultipartOptions, PutOptions,
+        PutPayload, PutResult, Result as ObjectStoreResult,
     };
     use std::collections::Bound::{Excluded, Included, Unbounded};
     use std::fmt;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex as StdMutex};
-    use tokio::sync::Notify;
+    use std::sync::Arc;
 
     /// A flaky object store that simulates a missing file on the first list() call.
     /// On the first call to list(), it returns a file with `missing_id`. On subsequent
@@ -562,18 +622,12 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct BlockingNotFoundGet {
-        started: Arc<Notify>,
-        release: Arc<Notify>,
-    }
-
+    /// Counts `get_opts` calls so tests can assert that `check` is served from
+    /// the in-memory cache without an object-store round trip.
     #[derive(Debug)]
     struct CountingGetStore {
         inner: InMemory,
         get_opts_calls: AtomicUsize,
-        if_none_match_gets: AtomicUsize,
-        blocking_not_found: StdMutex<Option<BlockingNotFoundGet>>,
     }
 
     impl CountingGetStore {
@@ -581,19 +635,7 @@ mod tests {
             Self {
                 inner: InMemory::new(),
                 get_opts_calls: AtomicUsize::new(0),
-                if_none_match_gets: AtomicUsize::new(0),
-                blocking_not_found: StdMutex::new(None),
             }
-        }
-
-        fn block_next_get_opts_with_not_found(&self) -> (Arc<Notify>, Arc<Notify>) {
-            let started = Arc::new(Notify::new());
-            let release = Arc::new(Notify::new());
-            *self.blocking_not_found.lock().unwrap() = Some(BlockingNotFoundGet {
-                started: started.clone(),
-                release: release.clone(),
-            });
-            (started, release)
         }
     }
 
@@ -628,21 +670,95 @@ mod tests {
             options: GetOptions,
         ) -> ObjectStoreResult<GetResult> {
             self.get_opts_calls.fetch_add(1, Ordering::SeqCst);
-            if options.if_none_match.is_some() {
-                self.if_none_match_gets.fetch_add(1, Ordering::SeqCst);
+            self.inner.get_opts(location, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, ObjectStoreResult<Path>>,
+        ) -> BoxStream<'static, ObjectStoreResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&Path>,
+        ) -> ObjectStoreResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &Path,
+            to: &Path,
+            options: CopyOptions,
+        ) -> ObjectStoreResult<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+    }
+
+    /// An object store that supports conditional *create* (`PutMode::Create` /
+    /// `If-None-Match: *`) but REJECTS conditional *overwrite*
+    /// (`PutMode::Update` / `If-Match`) with `Precondition` — modeling
+    /// DigitalOcean Spaces, where the old single-object boundary hot-looped.
+    /// `overwrite_attempts` records any conditional-overwrite PUT so a test can
+    /// assert the boundary never issues one.
+    #[derive(Debug)]
+    struct CreateOnlyStore {
+        inner: InMemory,
+        overwrite_attempts: AtomicUsize,
+    }
+
+    impl CreateOnlyStore {
+        fn new() -> Self {
+            Self {
+                inner: InMemory::new(),
+                overwrite_attempts: AtomicUsize::new(0),
             }
-            let blocking = self.blocking_not_found.lock().unwrap().take();
-            if let Some(blocking) = blocking {
-                blocking.started.notify_one();
-                blocking.release.notified().await;
-                return Err(ObjectStoreError::NotFound {
+        }
+    }
+
+    impl fmt::Display for CreateOnlyStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "CreateOnlyStore")
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for CreateOnlyStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            payload: PutPayload,
+            opts: PutOptions,
+        ) -> ObjectStoreResult<PutResult> {
+            if matches!(opts.mode, PutMode::Update(_)) {
+                self.overwrite_attempts.fetch_add(1, Ordering::SeqCst);
+                return Err(ObjectStoreError::Precondition {
                     path: location.to_string(),
-                    source: Box::new(std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        "injected missing boundary",
-                    )),
+                    source: "conditional overwrite (If-Match) not supported".into(),
                 });
             }
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &Path,
+            options: GetOptions,
+        ) -> ObjectStoreResult<GetResult> {
             self.inner.get_opts(location, options).await
         }
 
@@ -695,8 +811,11 @@ mod tests {
         assert!(matches!(err, TransactionalObjectError::ObjectVersionExists));
         boundary.check(MonotonicId::new(3)).await.unwrap();
 
+        // The boundary is recorded as a create-only marker named after its value.
         let raw_boundary = object_store
-            .get(&Path::from("/root/gc/manifest.boundary"))
+            .get(&Path::from(
+                "/root/gc/manifest/00000000000000000002.boundary",
+            ))
             .await
             .unwrap()
             .bytes()
@@ -712,36 +831,54 @@ mod tests {
             ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store.clone(), "manifest");
 
         boundary.advance(MonotonicId::new(3)).await.unwrap();
+        // Advancing to a lower value is a no-op (does not create a marker).
         boundary.advance(MonotonicId::new(2)).await.unwrap();
 
         let err = boundary.check(MonotonicId::new(3)).await.unwrap_err();
         assert!(matches!(err, TransactionalObjectError::ObjectVersionExists));
 
+        // Only the highest marker remains; no marker was written for the lower
+        // (no-op) advance.
         let raw_boundary = object_store
-            .get(&Path::from("/root/gc/manifest.boundary"))
+            .get(&Path::from(
+                "/root/gc/manifest/00000000000000000003.boundary",
+            ))
             .await
             .unwrap()
             .bytes()
             .await
             .unwrap();
         assert_eq!("3", std::str::from_utf8(&raw_boundary).unwrap());
+        assert!(object_store
+            .get(&Path::from(
+                "/root/gc/manifest/00000000000000000002.boundary"
+            ))
+            .await
+            .is_err());
     }
 
+    /// Advancing must never use a conditional *overwrite* (`If-Match`), so the
+    /// boundary works on stores (e.g. DigitalOcean Spaces) that support
+    /// conditional *create* (`If-None-Match`) but reject conditional overwrite.
     #[tokio::test]
-    async fn test_boundary_check_reuses_cache_on_not_modified() {
-        let counting_store = Arc::new(CountingGetStore::new());
-        let object_store: Arc<dyn ObjectStore> = counting_store.clone();
+    async fn test_boundary_advance_never_overwrites() {
+        let create_only = Arc::new(CreateOnlyStore::new());
+        let object_store: Arc<dyn ObjectStore> = create_only.clone();
         let boundary =
-            ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store.clone(), "manifest");
+            ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store, "manifest");
 
+        // A store that rejects overwrite-PUT (like DO Spaces) must still advance
+        // repeatedly — the old `PutMode::Update` path would 412 forever here.
         boundary.advance(MonotonicId::new(2)).await.unwrap();
+        boundary.advance(MonotonicId::new(5)).await.unwrap();
+        boundary.advance(MonotonicId::new(9)).await.unwrap();
 
-        let if_none_match_gets = counting_store.if_none_match_gets.load(Ordering::SeqCst);
-        boundary.check(MonotonicId::new(3)).await.unwrap();
-
+        boundary.check(MonotonicId::new(9)).await.unwrap_err();
+        boundary.check(MonotonicId::new(10)).await.unwrap();
         assert_eq!(
-            if_none_match_gets + 1,
-            counting_store.if_none_match_gets.load(Ordering::SeqCst)
+            0,
+            create_only.overwrite_attempts.load(Ordering::SeqCst),
+            "boundary advance must never attempt a conditional overwrite"
         );
     }
 
@@ -765,7 +902,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_boundary_check_refreshes_cache_when_etag_changes() {
+    async fn test_boundary_check_refreshes_cache_when_marker_advances() {
         let counting_store = Arc::new(CountingGetStore::new());
         let object_store: Arc<dyn ObjectStore> = counting_store.clone();
         let first_boundary =
@@ -773,9 +910,12 @@ mod tests {
         let second_boundary =
             ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store, "manifest");
 
+        // `first` caches boundary=2; `second` (a separate cache) advances to 4.
         first_boundary.advance(MonotonicId::new(2)).await.unwrap();
         second_boundary.advance(MonotonicId::new(4)).await.unwrap();
 
+        // `first`'s stale cache (2) lets the check past the cache gate, but the
+        // store read observes the advanced marker (4) and rejects.
         let err = first_boundary.check(MonotonicId::new(4)).await.unwrap_err();
 
         assert!(matches!(err, TransactionalObjectError::ObjectVersionExists));
@@ -795,7 +935,9 @@ mod tests {
         first_boundary.advance(MonotonicId::new(4)).await.unwrap();
 
         let raw_boundary = object_store
-            .get(&Path::from("/root/gc/manifest.boundary"))
+            .get(&Path::from(
+                "/root/gc/manifest/00000000000000000004.boundary",
+            ))
             .await
             .unwrap()
             .bytes()
@@ -804,35 +946,68 @@ mod tests {
         assert_eq!("4", std::str::from_utf8(&raw_boundary).unwrap());
     }
 
+    /// The cached boundary is a monotonic floor: an empty store (no markers, no
+    /// legacy object) must not regress a process's known boundary back to 0.
     #[tokio::test]
-    async fn test_boundary_read_returns_zero_when_not_found_get_has_cached_boundary() {
-        let counting_store = Arc::new(CountingGetStore::new());
-        let (started, release) = counting_store.block_next_get_opts_with_not_found();
-        let object_store: Arc<dyn ObjectStore> = counting_store;
-        let boundary = Arc::new(ObjectStoreBoundaryObject::new(
-            &Path::from("/root"),
-            object_store,
-            "manifest",
-        ));
+    async fn test_boundary_read_floors_at_cache_when_store_empty() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let boundary =
+            ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store, "manifest");
 
-        let read = tokio::spawn({
-            let boundary = boundary.clone();
-            async move { boundary.read_boundary().await }
-        });
+        *boundary.cache.lock() = Some(MonotonicId::new(2));
 
-        started.notified().await;
-        *boundary.cache.lock() = Some((
-            MonotonicId::new(2),
-            UpdateVersion {
-                e_tag: Some("\"etag\"".to_string()),
-                version: None,
-            },
-        ));
-        release.notify_one();
+        let observed = boundary.read_boundary().await.unwrap();
+        assert_eq!(MonotonicId::new(2), observed);
+    }
 
-        let (observed_boundary, observed_version) = read.await.unwrap().unwrap();
-        assert_eq!(MonotonicId::new(0), observed_boundary);
-        assert!(observed_version.is_none());
+    /// A freshly opened boundary over an empty store reads as 0.
+    #[tokio::test]
+    async fn test_boundary_read_zero_when_empty_and_uncached() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let boundary =
+            ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store, "manifest");
+
+        let observed = boundary.read_boundary().await.unwrap();
+        assert_eq!(MonotonicId::new(0), observed);
+    }
+
+    /// Backward compatibility: a DB written by an older version has a single
+    /// `<name>.boundary` object and no marker directory. Reads must honor it, and
+    /// the first advance must migrate to a marker and drop the legacy object.
+    #[tokio::test]
+    async fn test_boundary_reads_legacy_object_and_migrates_on_advance() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        object_store
+            .put(
+                &Path::from("/root/gc/manifest.boundary"),
+                PutPayload::from("7"),
+            )
+            .await
+            .unwrap();
+        let boundary =
+            ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store.clone(), "manifest");
+
+        // Legacy value is observed.
+        assert_eq!(MonotonicId::new(7), boundary.read_boundary().await.unwrap());
+        boundary.check(MonotonicId::new(7)).await.unwrap_err();
+        boundary.check(MonotonicId::new(8)).await.unwrap();
+
+        // Advancing migrates to a marker and removes the legacy object.
+        boundary.advance(MonotonicId::new(9)).await.unwrap();
+        assert!(object_store
+            .get(&Path::from("/root/gc/manifest.boundary"))
+            .await
+            .is_err());
+        let raw = object_store
+            .get(&Path::from(
+                "/root/gc/manifest/00000000000000000009.boundary",
+            ))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!("9", std::str::from_utf8(&raw).unwrap());
     }
 
     #[tokio::test]

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -170,7 +170,9 @@ mod tests {
             .unwrap();
 
         let raw_boundary = object_store
-            .get(&Path::from("/root/gc/compactions.boundary"))
+            .get(&Path::from(
+                "/root/gc/compactions/00000000000000000002.boundary",
+            ))
             .await
             .unwrap()
             .bytes()

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -174,7 +174,9 @@ mod tests {
             .unwrap();
 
         let raw_boundary = object_store
-            .get(&Path::from("/root/gc/manifest.boundary"))
+            .get(&Path::from(
+                "/root/gc/manifest/00000000000000000002.boundary",
+            ))
             .await
             .unwrap()
             .bytes()


### PR DESCRIPTION
# Advance the GC boundary with create-only markers (support object stores without `If-Match`)

## Summary

`ObjectStoreBoundaryObject::advance` records the GC high-watermark ("boundary")
by **overwriting a single object** `<root>/gc/<name>.boundary` with
`PutMode::Update(version)` — a conditional **overwrite** that maps to an
`If-Match` precondition on the object's ETag.

That assumes the object store supports conditional **overwrite**-PUT. Some
S3-compatible stores support conditional **create** (`If-None-Match: *`) but
**not** conditional **overwrite** (`If-Match`). On those stores GC silently
breaks: the boundary never advances and nothing is ever garbage-collected, so
the bucket (WAL, compacted SSTs, manifests) grows without bound.

This PR changes the boundary to a **versioned, create-only marker** scheme that
needs only conditional *create*, fixing GC on those stores while remaining
correct on stores that do support conditional overwrite.

> Companion to #1813 (binding runtime wedge) and #1815 (a fail-fast probe that
> *detects* stores lacking `If-Match` at open). This PR is the complementary
> *fix* that lets GC keep working on such a store.

## The bug, concretely (DigitalOcean Spaces)

DigitalOcean Spaces honors `If-None-Match: *` (atomic create) but rejects
`If-Match` on `PutObject`. I confirmed this with a standalone probe against a
real Spaces bucket:

```
PUT (unconditional, create)        -> 200 OK            (etag "6654…dc7f")
PUT If-Match: <CORRECT etag>       -> 412 PreconditionFailed   <-- the decider
PUT If-Match: <wrong etag>         -> 412 PreconditionFailed
PUT If-None-Match: * (new key)     -> 200 OK
PUT If-None-Match: * (existing)    -> 412 PreconditionFailed
```

The decisive line is row 2: `If-Match` with the **correct, just-read** ETag
still returns 412 — so it is not an ETag race, the store rejects `If-Match` on
PUT outright. (DO's API reference corroborates this: `If-Match`/`If-None-Match`
are listed for GetObject/HeadObject/CopyObject, but **not** for PutObject.)

What this does to `advance()` in production:

1. The first advance, when no boundary object exists, uses `PutMode::Create`
   (`If-None-Match`) and **succeeds** — so a `<name>.boundary` object appears.
2. Every subsequent advance goes through the `Some(version) => PutMode::Update`
   branch (`If-Match`) and **412s forever**.
3. The retry loop re-reads (conditional GET -> `304 NotModified`, cache reused)
   and immediately retries the `Update` -> `412` again, ~20+ times/second.

Observed in a real deployment: the manifest boundary frozen for days while the
manifest sequence reached tens of thousands of objects; ~16 GB of compacted
SSTs never reclaimed; GC pegged a core spinning GET 304 / PUT 412. GC-on was
strictly worse than GC-off (same unbounded growth, plus the spin).

## Root cause

`advance()` requires **atomic overwrite** of one mutable object, which is only
possible with `If-Match` (or a lock). A blind overwrite would be unsafe (two
racing advancers could move the boundary backward), so the existing design
genuinely needs `If-Match` — and is therefore unusable on stores that lack it.

## Fix

The boundary value is **monotonic**, so it doesn't need a mutable object.
Instead of overwriting one object, record each boundary value as its own
**immutable, create-only marker**:

```
<root>/gc/<name>/<id:020>.boundary      written with PutMode::Create (If-None-Match: *)
```

- **Current boundary** = the highest marker id present (a `list` + max).
- **advance(target)**: if the current boundary < target, `Create` the
  `<target>` marker. `AlreadyExists` (a concurrent advancer created exactly this
  marker) is treated as success — idempotent. Never issues an overwrite.
- **Cleanup**: after a successful advance, best-effort `delete` markers strictly
  below the new value (plain DELETE, no CAS), so the directory holds ~one object
  in steady state. The current maximum is never deleted, so the boundary cannot
  dip.

This is exactly the create-only, monotonic primitive the manifest and
compactions sequences already rely on — now reused for the boundary, so the
boundary works on any store those sequences already work on.

### Concurrency / safety

- The durable boundary is globally monotonic: markers are only added, and
  cleanup never removes the maximum. Two advancers racing to the same value →
  one wins `Create`, the other gets `AlreadyExists` = success. Racing to
  different values → both markers exist, max wins.
- The in-memory cache is now a **monotonic floor** — `read_boundary` never
  regresses a process's known boundary (safe because any cached value was a real
  past observation, hence `<=` the true current boundary). `check()` still
  rejects ids at/below a known boundary straight from cache, no store round trip.

### Backward compatibility

A DB created by an older version has a single `<name>.boundary` object and no
marker directory. `read_boundary()` falls back to reading that legacy object
when no markers exist, so the boundary is preserved across upgrade. The first
advance writes a marker (id strictly greater than the legacy value, since
sub-boundary advances are no-ops) and best-effort deletes the legacy object;
subsequent reads use markers only. No migration step or flag required.

## Trade-offs

- The cheap-read path changes from a single conditional GET (304) to a `list` of
  the marker directory. In steady state that directory holds ~one object, so the
  cost is comparable; the `check()` cache still short-circuits the common case.
- Slowly accumulating stale markers (if a cleanup DELETE fails) are harmless —
  reads take the max and the next advance retries cleanup.

## Testing

Rebased onto current `main` and re-validated under the pinned `1.91.1` toolchain:

- `cargo build -p slatedb-txn-obj -p slatedb --lib` — clean.
- `cargo test -p slatedb-txn-obj` — **29 pass**, including:
  - **`test_boundary_advance_never_overwrites`** — a `CreateOnlyStore` that
    rejects `PutMode::Update` with `Precondition` (modeling DO Spaces) and counts
    overwrite attempts. The boundary advances with **zero** conditional
    overwrites. This test fails on `main` (the old `Update` path 412s) and passes
    here.
  - **`test_boundary_reads_legacy_object_and_migrates_on_advance`** — upgrade
    path: legacy `<name>.boundary` honored on read, migrated to a marker and the
    legacy object removed on first advance.
  - the existing monotonicity/conflict/cache tests, updated to the marker layout.
- `cargo test -p slatedb --lib garbage_collector` — **41 pass** (incl.
  `test_collect_advances_boundary_for_old_manifest_files` /
  `…_compactions_files`).

## Validated in production on DigitalOcean Spaces

Beyond the unit tests, this was deployed to a live service backed by DO Spaces
(SlateDB v0.13.1) that had been stuck for days on the stock binary:

- **Before (stock):** the boundary `If-Match` PUT returned `412` ~23×/sec
  forever; the `manifest.boundary` value was frozen at `144` while the manifest
  sequence grew past 57k; nothing was ever GC'd.
- **After (this patch):** the new versioned create-only marker objects appear
  and are accepted by DO Spaces (e.g. `…/gc/manifest/00000000000000063092.boundary`),
  the legacy single `manifest.boundary` is migrated away, **zero `412`s**, and the
  boundary advanced `144 → 63,092+` within minutes — manifest GC began reclaiming
  immediately. The fix behaves exactly as the unit `CreateOnlyStore` test predicts.

## ⚠️ Unrelated crash observed during the same deployment (NOT caused by this PR)

Flagging this for transparency since we hit it while running the patched binary,
**not** because it is in this diff — this PR does not touch compaction. Full
analysis is in #1813; summary here.

We drive SlateDB through the UniFFI binding (Node/Bun) with a **custom
multi-threaded runtime grafted over `async-compat`** and **in-process** compaction
across **4 stores**. Under sustained heavy writes (thousands/s) concurrent with
compaction, the process **`SIGSEGV`s inside `libslatedb_uniffi`** — exit **139**,
faulting at a **low address (~`0x4`)**, **not** OOM (RSS ~0.15 GB). A low non-null
fault address is the classic signature of a **data race / use-after-free**, not
memory exhaustion. Raising `compactor_options.max_concurrent_compactions` /
`max_fetch_tasks` from `1`→`4` (≈16 concurrent compactions) reproduces it readily;
`1`/`1` is stable.

This is almost certainly **not** a SlateDB-core compaction bug: the **Go binding on
the stock `rt-multi-thread` cdylib** ran the same class of heavy-write + compaction
load for 20h+ with zero crashes, and a separate native-Rust LSM on `rt-multi-thread`
also survived — so the fault tracks the *custom runtime graft over `async-compat`*,
not multi-threaded compaction in general (see #1813, suggestion #1). Operators on
the binding should keep in-process compaction at `1`/`1` or run compaction out of
process until that's addressed upstream.

## Out of scope

Reclaiming the data already orphaned on affected stores (the boundary never
moved, so old WAL/SST/manifests accumulated) — that's a one-off cleanup, not a
code change. This PR stops the bleeding and makes GC functional going forward.
