### PR TITLE
Use multithreaded Tokio runtime for background tasks in bindings

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -23,6 +23,14 @@ If you are working from this repository, that usually means building
 `target/debug` or `target/release`. See [DEVELOPMENT.md](DEVELOPMENT.md) for
 more details.
 
+Writable databases and readers enter a dedicated multi-threaded Tokio runtime
+while opening so SlateDB's long-lived background tasks capture a multi-threaded
+Tokio handle. Foreground binding calls are still made through the normal Go API.
+By default, the runtime uses the host's available parallelism. Set
+`SLATEDB_UNIFFI_RUNTIME_THREADS` to a positive integer before the first
+`DbBuilder.Build()` or `DbReaderBuilder.Build()` call to override the worker
+thread count for the lifetime of the process.
+
 ## Quick Start
 
 ```go

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -51,6 +51,8 @@ Maven:
 - most database operations return `CompletableFuture`
 - native-backed handles implement `AutoCloseable` and should be closed
 
+Writable databases and readers enter a dedicated multi-threaded Tokio runtime while opening so SlateDB's long-lived background tasks capture a multi-threaded Tokio handle. Foreground binding calls are still awaited through the normal Java `CompletableFuture` API. By default, the runtime uses the host's available parallelism. Set `SLATEDB_UNIFFI_RUNTIME_THREADS` to a positive integer before the first `DbBuilder.build()` or `DbReaderBuilder.build()` call to override the worker thread count for the lifetime of the process.
+
 ## Metrics
 
 Use `DefaultMetricsRecorder` when you want to observe SlateDB metrics from Java without wiring a

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -191,6 +191,8 @@ tar -tf "${TARBALL}" | grep -Fx 'package/prebuilds/linux-x64-gnu/libslatedb_unif
 
 The published `@slatedb/uniffi` tarball contains generated JavaScript and TypeScript bindings plus bundled native libraries. Consumers install one npm package; there is no separate Rust build step or native download in normal usage.
 
+Writable databases and readers enter a dedicated multi-threaded Tokio runtime while opening so SlateDB's long-lived background tasks capture a multi-threaded Tokio handle. Foreground binding calls are still awaited through the normal JavaScript async API. By default, the runtime uses the host's available parallelism. Set `SLATEDB_UNIFFI_RUNTIME_THREADS` to a positive integer before the first `DbBuilder.build()` or `DbReaderBuilder.build()` call to override the worker thread count for the lifetime of the process.
+
 At runtime, the package loads the native library that matches the current host from `prebuilds/<target>/`. The published package currently includes:
 
 - `linux-x64-gnu`

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -95,6 +95,10 @@ finally:
     await db.shutdown()
 ```
 
+## Runtime Notes
+
+Writable databases and readers enter a dedicated multi-threaded Tokio runtime while opening so SlateDB's long-lived background tasks capture a multi-threaded Tokio handle. Foreground binding calls are still awaited through the normal Python async API. By default, the runtime uses the host's available parallelism. Set `SLATEDB_UNIFFI_RUNTIME_THREADS` to a positive integer before the first `DbBuilder.build()` or `DbReaderBuilder.build()` call to override the worker thread count for the lifetime of the process.
+
 ## Local Development
 
 This package reuses the shared Rust UniFFI crate at `../uniffi/Cargo.toml`. The generated Python module under `slatedb/uniffi/_slatedb_uniffi/` is build output and should not be edited by hand.

--- a/bindings/uniffi/src/builder.rs
+++ b/bindings/uniffi/src/builder.rs
@@ -254,64 +254,6 @@ impl DbReaderBuilder {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use slatedb::object_store::memory::InMemory;
-
-    use super::{DbBuilder, DbReaderBuilder};
-    use crate::object_store::ObjectStore;
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn db_builder_builds_from_current_thread_runtime() {
-        let store = new_test_store();
-        let builder = DbBuilder::new(
-            "bindings-uniffi-runtime-current-thread-db".to_owned(),
-            store,
-        );
-
-        let db = builder.build().await.expect("failed to build db");
-        db.put(b"key".to_vec(), b"value".to_vec())
-            .await
-            .expect("failed to write value");
-        db.close().await.expect("failed to close db");
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn db_reader_builder_builds_from_current_thread_runtime() {
-        let store = new_test_store();
-        let path = "bindings-uniffi-runtime-current-thread-reader";
-        let db_builder = DbBuilder::new(path.to_owned(), store.clone());
-        let db = db_builder.build().await.expect("failed to build seed db");
-        db.put(b"key".to_vec(), b"value".to_vec())
-            .await
-            .expect("failed to write seed value");
-        db.flush().await.expect("failed to flush seed db");
-        db.close().await.expect("failed to close seed db");
-
-        let reader_builder = DbReaderBuilder::new(path.to_owned(), store);
-        let reader = reader_builder
-            .build()
-            .await
-            .expect("failed to build reader");
-        assert_eq!(
-            reader
-                .get(b"key".to_vec())
-                .await
-                .expect("failed to read value"),
-            Some(b"value".to_vec())
-        );
-        reader.close().await.expect("failed to close reader");
-    }
-
-    fn new_test_store() -> Arc<ObjectStore> {
-        Arc::new(ObjectStore {
-            inner: Arc::new(InMemory::new()),
-        })
-    }
-}
-
 /// Builder for opening an administrative [`crate::Admin`] handle.
 ///
 /// Builders are single-use: calling [`AdminBuilder::build`] consumes the builder.

--- a/bindings/uniffi/src/builder.rs
+++ b/bindings/uniffi/src/builder.rs
@@ -12,6 +12,7 @@ use crate::filter_policy::{
 use crate::merge_operator::{adapt_merge_operator, MergeOperator};
 use crate::metrics::adapt_metrics_recorder;
 use crate::object_store::ObjectStore;
+use crate::runtime;
 use crate::settings::Settings;
 use crate::types::{CloneSourceSpec, KeyRange};
 use crate::MetricsRecorder;
@@ -137,7 +138,7 @@ impl DbBuilder {
     /// Opens the database and consumes this builder.
     pub async fn build(&self) -> Result<Arc<Db>, Error> {
         let builder = self.take_builder()?;
-        let db = builder.build().await?;
+        let db = runtime::enter(async move { builder.build().await.map_err(Error::from) }).await?;
         Ok(Arc::new(Db::new(db)))
     }
 }
@@ -247,8 +248,67 @@ impl DbReaderBuilder {
     /// Opens the reader and consumes this builder.
     pub async fn build(&self) -> Result<Arc<DbReader>, Error> {
         let builder = self.take_builder()?;
-        let reader = builder.build().await?;
+        let reader =
+            runtime::enter(async move { builder.build().await.map_err(Error::from) }).await?;
         Ok(Arc::new(DbReader::new(reader)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use slatedb::object_store::memory::InMemory;
+
+    use super::{DbBuilder, DbReaderBuilder};
+    use crate::object_store::ObjectStore;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn db_builder_builds_from_current_thread_runtime() {
+        let store = new_test_store();
+        let builder = DbBuilder::new(
+            "bindings-uniffi-runtime-current-thread-db".to_owned(),
+            store,
+        );
+
+        let db = builder.build().await.expect("failed to build db");
+        db.put(b"key".to_vec(), b"value".to_vec())
+            .await
+            .expect("failed to write value");
+        db.close().await.expect("failed to close db");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn db_reader_builder_builds_from_current_thread_runtime() {
+        let store = new_test_store();
+        let path = "bindings-uniffi-runtime-current-thread-reader";
+        let db_builder = DbBuilder::new(path.to_owned(), store.clone());
+        let db = db_builder.build().await.expect("failed to build seed db");
+        db.put(b"key".to_vec(), b"value".to_vec())
+            .await
+            .expect("failed to write seed value");
+        db.flush().await.expect("failed to flush seed db");
+        db.close().await.expect("failed to close seed db");
+
+        let reader_builder = DbReaderBuilder::new(path.to_owned(), store);
+        let reader = reader_builder
+            .build()
+            .await
+            .expect("failed to build reader");
+        assert_eq!(
+            reader
+                .get(b"key".to_vec())
+                .await
+                .expect("failed to read value"),
+            Some(b"value".to_vec())
+        );
+        reader.close().await.expect("failed to close reader");
+    }
+
+    fn new_test_store() -> Arc<ObjectStore> {
+        Arc::new(ObjectStore {
+            inner: Arc::new(InMemory::new()),
+        })
     }
 }
 

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -13,6 +13,7 @@ mod logging;
 mod merge_operator;
 mod metrics;
 mod object_store;
+mod runtime;
 mod settings;
 mod types;
 mod validation;

--- a/bindings/uniffi/src/runtime.rs
+++ b/bindings/uniffi/src/runtime.rs
@@ -1,0 +1,122 @@
+//! Dedicated Tokio runtime support for the UniFFI bindings.
+//!
+//! UniFFI's `async_runtime = "tokio"` support can drive exported futures through
+//! `async-compat`'s current-thread runtime. SlateDB captures `Handle::current()`
+//! while opening a `Db` or `DbReader` and uses that handle for long-lived
+//! background tasks, so opening directly on that runtime can leave WAL flush,
+//! memtable flush, compaction, GC, and reader polling on a single thread.
+//!
+//! We cannot simply `spawn` the whole open future onto our runtime, because open
+//! can synchronously invoke foreign callbacks such as custom metrics recorders.
+//! Some bindings, notably Node, expect those callbacks on the original binding
+//! call path. `EnterRuntime` keeps polling on the caller's future path while
+//! making `Handle::current()` resolve to the dedicated multi-threaded runtime
+//! for the duration of each poll.
+
+use std::future::Future;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::OnceLock;
+use std::task::{Context, Poll};
+
+use tokio::runtime::{Builder, Handle, Runtime};
+
+const RUNTIME_THREADS_ENV: &str = "SLATEDB_UNIFFI_RUNTIME_THREADS";
+const FALLBACK_WORKER_THREADS: usize = 4;
+
+/// Polls `future` with the dedicated UniFFI runtime entered as the current
+/// Tokio context. This lets SlateDB capture the multi-threaded runtime handle
+/// during open without moving synchronous foreign callbacks onto runtime worker
+/// threads.
+pub(crate) fn enter<F>(future: F) -> impl Future<Output = F::Output>
+where
+    F: Future,
+{
+    EnterRuntime {
+        handle: runtime().handle().clone(),
+        future: Box::pin(future),
+    }
+}
+
+// Wraps an open future so every poll occurs inside `handle.enter()`.
+//
+// Entering once around `.await` would hold the enter guard across suspension,
+// leaking the runtime context back to the caller. Entering per poll ensures the
+// guard is dropped before returning `Poll::Pending` or `Poll::Ready`.
+struct EnterRuntime<F> {
+    handle: Handle,
+    future: Pin<Box<F>>,
+}
+
+impl<F: Future> Future for EnterRuntime<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let _guard = this.handle.enter();
+        this.future.as_mut().poll(cx)
+    }
+}
+
+fn runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        // The runtime must outlive every Db/DbReader opened through UniFFI,
+        // because their background tasks keep using the handle captured at open.
+        Builder::new_multi_thread()
+            .worker_threads(configured_worker_threads(
+                std::env::var(RUNTIME_THREADS_ENV).ok().as_deref(),
+            ))
+            .enable_all()
+            .thread_name("slatedb-uniffi-rt")
+            .build()
+            .expect("failed to build SlateDB UniFFI runtime")
+    })
+}
+
+fn configured_worker_threads(value: Option<&str>) -> usize {
+    // Invalid env values are ignored so a bad deployment knob cannot prevent
+    // the binding from opening databases.
+    value
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|threads| *threads > 0)
+        .unwrap_or_else(|| {
+            std::thread::available_parallelism()
+                .map(NonZeroUsize::get)
+                .unwrap_or(FALLBACK_WORKER_THREADS)
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+
+    use super::configured_worker_threads;
+
+    #[test]
+    fn worker_threads_uses_positive_env_value() {
+        assert_eq!(configured_worker_threads(Some("8")), 8);
+        assert_eq!(configured_worker_threads(Some(" 3 ")), 3);
+    }
+
+    #[test]
+    fn worker_threads_falls_back_for_invalid_env_values() {
+        let default = configured_worker_threads(None);
+
+        assert_eq!(configured_worker_threads(Some("0")), default);
+        assert_eq!(configured_worker_threads(Some("-1")), default);
+        assert_eq!(configured_worker_threads(Some("not-a-number")), default);
+    }
+
+    #[test]
+    fn default_worker_threads_is_non_zero() {
+        assert!(configured_worker_threads(None) > 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn enter_uses_multi_thread_runtime_context() {
+        let flavor = super::enter(async { Handle::current().runtime_flavor() }).await;
+
+        assert_eq!(flavor, RuntimeFlavor::MultiThread);
+    }
+}


### PR DESCRIPTION
## Summary

Wraps `DbBuilder::build` and `DbReaderBuilder::build` in a runtime wrapper. The wrapper creates a static multithreaded runtime that's shared in the binding. This causes all background tasks to run in the multithreaded runtime.

Foreground API calls still continue to use the `async_compat` runtime, which is just a single threaded one. Per #1813, the user was seeing enough perf gain just by moving the background tasks off. Putting foreground APIs in the `runtime::enter` callpath adds a lock and makes the calls a bit uglier to implement (a macro does help here, though). If we see continued perf issues, we can revisit this decision.

This PR also does not add a runtime handle concept that would allow users to build and supply their own Tokio runtimes through the bindings. This felt like overkill. Again, we can revisit if needed.

Fixes #1813

## Changes

- Add `runtime.rs` that forces the static multithreaded runtime when polling.
- Add a couple tests.
- Update `README.md`s with added info.

## Notes for Reviewers

Some relevant info:

- https://mozilla.github.io/uniffi-rs/next/internals/async-overview.html#can-you-really-just-piggyback-on-the-foreign-async-runtime
- https://github.com/mozilla/uniffi-rs/issues/2576

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
