### PR TITLE
feat(compaction): execute subcompactions in parallel (RFC-0028) [3/N]

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::mem;
+use std::ops::{Bound, RangeBounds};
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
 
@@ -28,6 +29,7 @@ use crate::merge_operator::{
 };
 use crate::peeking_iterator::PeekingIterator;
 use crate::retention_iterator::RetentionIterator;
+use crate::seq_tracker::SequenceTracker;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::subcompaction::Subcompaction;
@@ -76,17 +78,6 @@ pub(crate) struct StartCompactionJobArgs {
     pub(crate) is_dest_last_run: bool,
     /// Optional minimum sequence to retain; lower sequences may be dropped by retention.
     pub(crate) retention_min_seq: Option<u64>,
-}
-
-impl StartCompactionJobArgs {
-    /// Output SSTs to resume the merge from: the produced output of the job's
-    /// single subcompaction (RFC-0028), or empty when none has been recorded.
-    fn resume_output_ssts(&self) -> &[SsTableHandle] {
-        self.subcompactions
-            .first()
-            .map(|s| s.output_ssts().as_slice())
-            .unwrap_or(&[])
-    }
 }
 
 impl std::fmt::Debug for StartCompactionJobArgs {
@@ -255,6 +246,21 @@ struct TokioCompactionTask {
     task: JoinHandle<Result<SortedRun, SlateDBError>>,
 }
 
+/// Progress and completion events sent from subcompaction tasks to their
+/// parent compaction job (RFC-0028). `index` identifies the subcompaction
+/// within the parent's plan.
+enum SubcompactionEvent {
+    Progress {
+        index: usize,
+        bytes_processed: u64,
+        output_ssts: Vec<SsTableHandle>,
+    },
+    Finished {
+        index: usize,
+        result: Result<Vec<SsTableHandle>, SlateDBError>,
+    },
+}
+
 pub(crate) struct TokioCompactionExecutorInner {
     options: Arc<CompactionWorkerOptions>,
     handle: tokio::runtime::Handle,
@@ -272,13 +278,22 @@ pub(crate) struct TokioCompactionExecutorInner {
 }
 
 impl TokioCompactionExecutorInner {
-    /// Builds input iterators for all sources (L0 and SR) and wraps them with optional
-    /// merge, retention, and compaction filter logic.
+    /// Builds input iterators for all sources (L0 and SR) restricted to `range` and
+    /// wraps them with optional merge, retention, and compaction filter logic.
+    ///
+    /// `output_ssts` are the output SSTs already written by a previous attempt of
+    /// this (sub)compaction; the returned iterator is positioned just past the last
+    /// entry they contain. `sequence_tracker` is the manifest's sequence tracker,
+    /// loaded once per job so concurrent subcompactions don't each re-read the
+    /// manifest.
     async fn load_iterators<'a>(
         &self,
         job_args: &'a StartCompactionJobArgs,
+        range: &'a BytesRange,
+        output_ssts: &[SsTableHandle],
+        sequence_tracker: Arc<SequenceTracker>,
     ) -> Result<ResumingIterator<Box<dyn TrackedRowEntryIterator + 'a>>, SlateDBError> {
-        let resume_cursor = match job_args.resume_output_ssts().last() {
+        let resume_cursor = match output_ssts.last() {
             Some(output_sst) => {
                 last_written_key_and_seq(self.table_store.clone(), output_sst).await?
             }
@@ -301,16 +316,30 @@ impl TokioCompactionExecutorInner {
         // L0 (borrowed)
         let l0_iters_futures = build_concurrent(job_args.sst_views.iter(), max_parallel, |h| {
             let sst_iter_options = sst_iter_options.clone();
-            SstIterator::new_borrowed_initialized(.., h, self.table_store.clone(), sst_iter_options)
+            SstIterator::new_borrowed_initialized(
+                range.clone(),
+                h,
+                self.table_store.clone(),
+                sst_iter_options,
+            )
         });
 
         // SR (borrowed)
+        let slice_range: (Bound<&[u8]>, Bound<&[u8]>) = (
+            range.start_bound().map(|b| b.as_ref()),
+            range.end_bound().map(|b| b.as_ref()),
+        );
         let sr_iters_futures = build_concurrent(job_args.sorted_runs.iter(), max_parallel, |sr| {
             let sst_iter_options = sst_iter_options.clone();
             async move {
-                SortedRunIterator::new_borrowed(.., sr, self.table_store.clone(), sst_iter_options)
-                    .await
-                    .map(Some)
+                SortedRunIterator::new_borrowed(
+                    slice_range,
+                    sr,
+                    self.table_store.clone(),
+                    sst_iter_options,
+                )
+                .await
+                .map(Some)
             }
         });
 
@@ -334,8 +363,6 @@ impl TokioCompactionExecutorInner {
                 Box::new(MergeOperatorRequiredIterator::new(merge_iter))
             };
 
-        let stored_manifest =
-            StoredManifest::load(self.manifest_store.clone(), self.clock.clone()).await?;
         let mut retention_iter = RetentionIterator::new(
             merge_iter,
             None,
@@ -343,7 +370,7 @@ impl TokioCompactionExecutorInner {
             job_args.is_dest_last_run,
             job_args.compaction_clock_tick,
             self.clock.clone(),
-            Arc::new(stored_manifest.db_state().sequence_tracker.clone()),
+            sequence_tracker,
             Some(self.stats.retention_metrics()),
         )
         .await?;
@@ -375,13 +402,8 @@ impl TokioCompactionExecutorInner {
         &self,
         id: Ulid,
         bytes_processed: u64,
-        output_ssts: &[SsTableHandle],
+        subcompactions: Vec<Subcompaction>,
     ) {
-        // A job is a single merge over one unbounded range, so report progress
-        // as one subcompaction (RFC-0028) covering the whole key space.
-        let subcompactions = vec![
-            Subcompaction::new(BytesRange::unbounded()).with_output_ssts(output_ssts.to_vec())
-        ];
         // Allow send() because we are treating the executor like an external
         // component. They can do what they want. If the send fails (e.g., during
         // DB shutdown), we log it and continue with the compaction work.
@@ -425,7 +447,9 @@ impl TokioCompactionExecutorInner {
     /// Executes a single compaction job and returns the resulting [`SortedRun`].
     ///
     /// ## Steps
-    /// - Streams and merges input keys across all sources
+    /// - Plans the job's subcompactions and runs the ranges concurrently
+    ///   (RFC-0028)
+    /// - Streams and merges input keys across all sources (per range)
     /// - Applies merge and retention policies
     /// - Writes output SSTs up to `max_sst_size`, reporting periodic progress
     ///
@@ -433,30 +457,269 @@ impl TokioCompactionExecutorInner {
     /// - The destination [`SortedRun`] with all output SST handles.
     #[instrument(level = "debug", skip_all, fields(id = %args.id))]
     async fn execute_compaction_job(
-        &self,
+        self: &Arc<Self>,
         args: StartCompactionJobArgs,
     ) -> Result<SortedRun, SlateDBError> {
-        // Each job runs as a single merge over one (unbounded) range, so resume
-        // and progress reporting only ever look at the first subcompaction.
-        // Splitting a job into multiple ranges is not yet executed; guard the
-        // assumption so a future planner can't silently drop ranges here.
-        assert!(
-            args.subcompactions.len() <= 1,
-            "executor runs each job as a single merge; got {} subcompactions",
-            args.subcompactions.len()
-        );
         debug!("executing compaction [job_args={:?}]", args);
-        let mut all_iter = self.load_iterators(&args).await?;
-        let mut output_ssts = args.resume_output_ssts().to_vec();
+        // Load the manifest's sequence tracker once per job; every range shares
+        // it rather than re-reading the manifest.
+        let stored_manifest =
+            StoredManifest::load(self.manifest_store.clone(), self.clock.clone()).await?;
+        let sequence_tracker = Arc::new(stored_manifest.db_state().sequence_tracker.clone());
+
+        // Plan the job's ranges, then run them concurrently.
+        let subcompactions = self.plan_subcompactions(&args);
+        self.execute_subcompactions(args, subcompactions, sequence_tracker)
+            .await
+    }
+
+    /// Determines the subcompaction plan for a job (RFC-0028).
+    ///
+    /// ## Returns
+    /// - The persisted subcompactions when the job carries a plan: it is
+    ///   returned verbatim so output SSTs already recorded against its ranges
+    ///   stay valid.
+    /// - Otherwise a single subcompaction covering the whole (unbounded) key
+    ///   space.
+    fn plan_subcompactions(&self, args: &StartCompactionJobArgs) -> Vec<Subcompaction> {
+        if !args.subcompactions.is_empty() {
+            return args.subcompactions.clone();
+        }
+        vec![Subcompaction::new(BytesRange::unbounded())]
+    }
+
+    /// Executes a compaction job's subcompactions (RFC-0028), running every
+    /// range concurrently.
+    ///
+    /// The plan is reported (and therefore persisted by the orchestrator)
+    /// before any range output is recorded against it; per-range output SSTs
+    /// are then reported as they advance so an interrupted compaction can
+    /// resume at range granularity. Subcompactions carry no persisted status,
+    /// so every range is run: a range resumes from the output recorded against
+    /// it, and one that is already complete finds nothing left to merge and
+    /// finishes immediately. On the first range failure the remaining
+    /// subcompactions are aborted and the job fails; progress recorded by then
+    /// stays resumable.
+    async fn execute_subcompactions(
+        self: &Arc<Self>,
+        args: StartCompactionJobArgs,
+        mut subcompactions: Vec<Subcompaction>,
+        sequence_tracker: Arc<SequenceTracker>,
+    ) -> Result<SortedRun, SlateDBError> {
+        debug!(
+            "executing compaction with subcompactions [id={}, subcompactions={}]",
+            args.id,
+            subcompactions.len()
+        );
+
+        // Per-range bytes-processed, summed into the job's progress total. Each
+        // range folds its own resume offset into the values it reports (see
+        // `start_bytes_processed` in `run_subcompaction_merge`), so a range's
+        // latest event is its full cumulative contribution across attempts —
+        // including a range that resumes already-complete, which reports its
+        // full estimated size up front.
+        let mut bytes_processed_by_sub: Vec<u64> = vec![0; subcompactions.len()];
+
+        // For a fresh job, report the plan immediately so it is persisted
+        // before any range records output against it; bytes are genuinely zero
+        // at this point. A resumed job's plan is already persisted (it arrived
+        // in `args.subcompactions`), so reporting it here would only republish
+        // zero bytes processed before the ranges re-report their resumed
+        // progress — a momentary drop to zero. Skip it; the per-range progress
+        // emitted as each range starts carries the resumed totals instead.
+        if args.subcompactions.is_empty() {
+            self.send_compaction_progress(args.id, 0, subcompactions.clone());
+        }
+
+        let args = Arc::new(args);
+        let (sub_tx, mut sub_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut sub_tasks = Vec::new();
+        for (index, subcompaction) in subcompactions.iter().enumerate() {
+            // Each range runs as its own task, resuming from the output already
+            // recorded against it. A range whose output is already complete
+            // finds nothing left to merge and finishes immediately.
+            let this = self.clone();
+            let args = args.clone();
+            let range = subcompaction.range().clone();
+            let initial_output_ssts = subcompaction.output_ssts().clone();
+            let sequence_tracker = sequence_tracker.clone();
+            let event_tx = sub_tx.clone();
+            let finished_tx = sub_tx.clone();
+            let task = spawn_bg_task(
+                format!("subcompaction:{}:{}", args.compaction_id, index),
+                &self.handle,
+                move |result: &Result<Vec<SsTableHandle>, SlateDBError>| {
+                    // Allow send() because this channel is internal to the
+                    // parent job: the receiver is dropped only after the
+                    // parent has aborted (or collected) every subcompaction
+                    // task, so a failed send needs no handling.
+                    #[allow(clippy::disallowed_methods)]
+                    let _ = finished_tx.send(SubcompactionEvent::Finished {
+                        index,
+                        result: result.clone(),
+                    });
+                },
+                async move {
+                    let progress = move |bytes_processed: u64, output_ssts: &[SsTableHandle]| {
+                        // Allow send() for the same reason as the cleanup fn
+                        // above: a dropped receiver means the parent job is
+                        // aborting this task anyway.
+                        #[allow(clippy::disallowed_methods)]
+                        let _ = event_tx.send(SubcompactionEvent::Progress {
+                            index,
+                            bytes_processed,
+                            output_ssts: output_ssts.to_vec(),
+                        });
+                    };
+                    this.run_subcompaction_merge(
+                        &args,
+                        &range,
+                        initial_output_ssts,
+                        sequence_tracker,
+                        &progress,
+                    )
+                    .await
+                },
+            );
+            // Wrapping each task in an `AbortOnDropHandle` is what propagates a
+            // parent abort down to the children: if the parent compaction future
+            // is dropped — because the executor's `stop()` aborted it, or this
+            // fn returns early on a range error — `sub_tasks` drops with it and
+            // every still-running subcompaction is aborted at its await point.
+            // This is the mechanism that lets `stop()` tear down in-flight
+            // ranges rather than just the parent job.
+            sub_tasks.push(AbortOnDropHandle::new(task));
+        }
+        drop(sub_tx);
+
+        let mut completed = vec![false; subcompactions.len()];
+        let mut first_error: Option<SlateDBError> = None;
+        while !completed.iter().all(|done| *done) {
+            let Some(event) = sub_rx.recv().await else {
+                break;
+            };
+            match event {
+                SubcompactionEvent::Progress {
+                    index,
+                    bytes_processed,
+                    output_ssts,
+                } => {
+                    // Each range reports monotonically increasing bytes (its
+                    // resume offset is already folded in), so store the latest.
+                    bytes_processed_by_sub[index] = bytes_processed;
+                    subcompactions[index].set_output_ssts(output_ssts);
+                    let total_bytes = bytes_processed_by_sub.iter().sum();
+                    self.send_compaction_progress(args.id, total_bytes, subcompactions.clone());
+                }
+                SubcompactionEvent::Finished { index, result } => match result {
+                    Ok(output_ssts) => {
+                        subcompactions[index].set_output_ssts(output_ssts);
+                        completed[index] = true;
+                        let total_bytes = bytes_processed_by_sub.iter().sum();
+                        self.send_compaction_progress(args.id, total_bytes, subcompactions.clone());
+                    }
+                    Err(e) => {
+                        first_error = Some(e);
+                        break;
+                    }
+                },
+            }
+        }
+        // Abort any subcompactions still running after a failure, and wait
+        // for them to wind down so the job stops writing to the object store
+        // before it is reported failed. On success every task has already
+        // completed, so this returns immediately.
+        sub_tasks.iter().for_each(|task| task.abort());
+        let _ = join_all(sub_tasks).await;
+
+        if let Some(e) = first_error {
+            return Err(e);
+        }
+        if !completed.iter().all(|done| *done) {
+            // The event channel closed before every subcompaction reported a
+            // successful result; treat the job as failed so it can be
+            // rescheduled.
+            return Err(SlateDBError::CompactorExecutorFailed);
+        }
+
+        // A sorted run requires its SSTs to be in ascending, non-overlapping
+        // key order. Concatenating the ranges' output in plan order satisfies
+        // that only when the ranges themselves are ascending and disjoint.
+        // Verify it before committing the run rather than silently producing a
+        // corrupt one: adjacent output SSTs must not overlap by boundary key.
+        // The check is cheap because the boundary keys are already in memory.
+        let output_ssts: Vec<&SsTableHandle> = subcompactions
+            .iter()
+            .flat_map(|sub| sub.output_ssts().iter())
+            .collect();
+        let ascending = output_ssts.windows(2).all(|pair| {
+            match (&pair[0].info.last_entry, &pair[1].info.first_entry) {
+                (Some(prev_last), Some(next_first)) => prev_last <= next_first,
+                _ => true,
+            }
+        });
+        if !ascending {
+            error!(
+                "subcompaction output SSTs are not in ascending, non-overlapping key order \
+                 [id={}]",
+                args.id
+            );
+            return Err(SlateDBError::CompactorExecutorFailed);
+        }
+        Ok(SortedRun {
+            id: args.destination,
+            sst_views: output_ssts
+                .into_iter()
+                .map(|sst| {
+                    let id = self.rand.rng().gen_ulid(self.clock.as_ref());
+                    SsTableView::new(id, sst.clone())
+                })
+                .collect(),
+        })
+    }
+
+    /// Runs the merge for one key range of a compaction job and returns the
+    /// output SSTs, including any `initial_output_ssts` written by a previous
+    /// attempt. This is the shared execution path for whole compactions (an
+    /// unbounded range) and subcompactions (RFC-0028).
+    async fn run_subcompaction_merge(
+        &self,
+        args: &StartCompactionJobArgs,
+        range: &BytesRange,
+        initial_output_ssts: Vec<SsTableHandle>,
+        sequence_tracker: Arc<SequenceTracker>,
+        progress: &(dyn Fn(u64, &[SsTableHandle]) + Send + Sync),
+    ) -> Result<Vec<SsTableHandle>, SlateDBError> {
+        let mut output_ssts = initial_output_ssts;
+        let mut all_iter = self
+            .load_iterators(args, range, &output_ssts, sequence_tracker)
+            .await?;
         let mut current_writer = self.table_store.table_writer(SsTableId::Compacted(
             self.rand.rng().gen_ulid(self.clock.as_ref()),
         ));
         let mut bytes_written = 0usize;
-        let mut last_progress_report = self.clock.now();
-        // Estimate bytes processed before the resume point, if any.
+        // Estimate bytes processed within this range before the resume point,
+        // if any. For an unbounded range this is the estimate of everything
+        // before the resume key; for a subcompaction range the bytes before
+        // the range's start key are excluded since they belong to sibling
+        // ranges.
         let start_bytes_processed = all_iter.start().map_or(0, |(k, _s)| {
-            estimate_bytes_before_key(args.sorted_runs.as_slice(), k)
+            let before_key = estimate_bytes_before_key(args.sorted_runs.as_slice(), k);
+            let before_range = match range.start_bound() {
+                Bound::Included(s) | Bound::Excluded(s) => {
+                    estimate_bytes_before_key(args.sorted_runs.as_slice(), s)
+                }
+                Bound::Unbounded => 0,
+            };
+            before_key.saturating_sub(before_range)
         });
+
+        // Report the resume point up front so a resumed range surfaces the bytes
+        // already processed in prior attempts immediately. A range that resumes
+        // already-complete reports its full estimated size here (its resume
+        // cursor sits at the range's last key) and never enters the loop below.
+        progress(start_bytes_processed, &output_ssts);
+        let mut last_progress_report = self.clock.now();
 
         // At most one SST close runs in the background at a time (depth-1
         // pipeline). While a finished SST flushes to the object store we keep
@@ -475,7 +738,7 @@ impl TokioCompactionExecutorInner {
             if let Some(pending) = pending_close.take_if(|p| p.is_finished()) {
                 self.collect_close(pending, &mut output_ssts).await?;
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
-                self.send_compaction_progress(args.id, total_bytes, &output_ssts);
+                progress(total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();
             }
 
@@ -483,7 +746,7 @@ impl TokioCompactionExecutorInner {
                 self.clock.now().signed_duration_since(last_progress_report);
             if duration_since_last_report > TimeDelta::seconds(1) {
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
-                self.send_compaction_progress(args.id, total_bytes, &output_ssts);
+                progress(total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();
             }
 
@@ -511,7 +774,7 @@ impl TokioCompactionExecutorInner {
                 )));
                 bytes_written = 0;
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
-                self.send_compaction_progress(args.id, total_bytes, &output_ssts);
+                progress(total_bytes, &output_ssts);
                 last_progress_report = self.clock.now();
             }
         }
@@ -528,16 +791,7 @@ impl TokioCompactionExecutorInner {
             output_ssts.push(sst);
         }
 
-        Ok(SortedRun {
-            id: args.destination,
-            sst_views: output_ssts
-                .into_iter()
-                .map(|sst| {
-                    let id = self.rand.rng().gen_ulid(self.clock.as_ref());
-                    SsTableView::new(id, sst)
-                })
-                .collect(),
-        })
+        Ok(output_ssts)
     }
 
     /// Starts a background task to run the compaction job.
@@ -1177,7 +1431,31 @@ mod tests {
 
         // Verify the resumed iterator yields all remaining rows, starting immediately
         // after the persisted prefix and continuing in sorted order.
-        let mut iter = executor.inner.load_iterators(&job_args).await.unwrap();
+        let full_range = BytesRange::unbounded();
+        let resume_output_ssts = job_args
+            .subcompactions
+            .first()
+            .map(|s| s.output_ssts().clone())
+            .unwrap_or_default();
+        let sequence_tracker = {
+            let stored_manifest = StoredManifest::load(
+                executor.inner.manifest_store.clone(),
+                executor.inner.clock.clone(),
+            )
+            .await
+            .unwrap();
+            Arc::new(stored_manifest.db_state().sequence_tracker.clone())
+        };
+        let mut iter = executor
+            .inner
+            .load_iterators(
+                &job_args,
+                &full_range,
+                &resume_output_ssts,
+                sequence_tracker,
+            )
+            .await
+            .unwrap();
         let mut resumed_entries = Vec::new();
         while let Some(entry) = iter.next().await.unwrap() {
             resumed_entries.push(entry);
@@ -1410,6 +1688,569 @@ mod tests {
 
             });
         });
+    }
+
+    /// Reads every entry out of a sorted run's output SSTs, in order, so two
+    /// runs can be compared for byte-identical merged output.
+    async fn read_run_entries(table_store: &Arc<TableStore>, run: &SortedRun) -> Vec<RowEntry> {
+        let mut entries = Vec::new();
+        for sst in &run.sst_views {
+            let mut iter = SstIterator::new(
+                SstView::Borrowed(sst, BytesRange::from(..)),
+                table_store.clone(),
+                SstIteratorOptions::default(),
+            )
+            .unwrap();
+            iter.init().await.unwrap();
+            while let Some(entry) = iter.next().await.unwrap() {
+                entries.push(entry);
+            }
+        }
+        entries
+    }
+
+    /// Four contiguous ranges that partition the `key00000`..`key00399`
+    /// keyspace, used to drive the executor's parallel path with an explicit
+    /// plan (the planner itself only emits a single range).
+    fn four_ranges() -> Vec<Subcompaction> {
+        vec![
+            Subcompaction::new(BytesRange::from_slice(..b"key00100".as_slice())),
+            Subcompaction::new(BytesRange::from_slice(
+                b"key00100".as_slice()..b"key00200".as_slice(),
+            )),
+            Subcompaction::new(BytesRange::from_slice(
+                b"key00200".as_slice()..b"key00300".as_slice(),
+            )),
+            Subcompaction::new(BytesRange::from_slice(b"key00300".as_slice()..)),
+        ]
+    }
+
+    /// Output SST size the subcompaction tests run with: small enough that each
+    /// range rolls several SSTs.
+    const SUBCOMPACTION_SST_SIZE: usize = 512;
+
+    /// Builds value rows `key{i:05} -> {value_prefix}-{i}` with sequence
+    /// `seq_base + i`, for `i` in `range` taken every `step`.
+    fn rows(
+        range: std::ops::Range<u64>,
+        step: usize,
+        value_prefix: &str,
+        seq_base: u64,
+    ) -> Vec<RowEntry> {
+        range
+            .step_by(step)
+            .map(|i| {
+                RowEntry::new_value(
+                    format!("key{i:05}").as_bytes(),
+                    format!("{value_prefix}-{i}").as_bytes(),
+                    seq_base + i,
+                )
+            })
+            .collect()
+    }
+
+    /// A [`StartCompactionJobArgs`] over `sst_views`/`sorted_runs` running the
+    /// given `subcompactions` plan, with the defaults the subcompaction tests
+    /// share (destination 0, retaining everything, not the last run).
+    fn job(
+        sst_views: Vec<SsTableView>,
+        sorted_runs: Vec<SortedRun>,
+        subcompactions: Vec<Subcompaction>,
+    ) -> StartCompactionJobArgs {
+        StartCompactionJobArgs {
+            id: Ulid::new(),
+            compaction_id: Ulid::new(),
+            destination: 0,
+            sst_views,
+            sorted_runs,
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+            subcompactions,
+        }
+    }
+
+    /// Builds a fresh-DB table store (small block size, so ranges roll several
+    /// SSTs) and an executor wired to [`SUBCOMPACTION_SST_SIZE`], optionally
+    /// with a compaction-filter supplier. Returns the executor, its table
+    /// store, and the worker-message receiver.
+    async fn subcompaction_env(
+        path: &str,
+        #[cfg(feature = "compaction_filters")] filter: Option<Arc<dyn CompactionFilterSupplier>>,
+    ) -> (
+        TokioCompactionExecutor,
+        Arc<TableStore>,
+        async_channel::Receiver<WorkerMessage>,
+    ) {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let root_path = Path::from(path);
+        let clock = Arc::new(DefaultSystemClock::new());
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            SsTableFormat {
+                block_size: 256,
+                ..SsTableFormat::default()
+            },
+            root_path.clone(),
+            None,
+        ));
+        let manifest_store = Arc::new(ManifestStore::new(&root_path, object_store.clone()));
+        StoredManifest::create_new_db(manifest_store.clone(), ManifestCore::new(), clock.clone())
+            .await
+            .unwrap();
+        let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
+        let executor = TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
+            handle: tokio::runtime::Handle::current(),
+            options: Arc::new(CompactionWorkerOptions {
+                max_sst_size: SUBCOMPACTION_SST_SIZE,
+                ..CompactionWorkerOptions::default()
+            }),
+            worker_tx: tx,
+            table_store: table_store.clone(),
+            rand: Arc::new(DbRand::new(100u64)),
+            stats: {
+                let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+                Arc::new(CompactionStats::new(&recorder))
+            },
+            clock,
+            manifest_store,
+            merge_operator: None,
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: filter,
+        });
+        (executor, table_store, rx)
+    }
+
+    /// The overlapping multi-source inputs the split tests share: two L0s and
+    /// two sorted runs over `key00000`..`key00399`, each spanning several SSTs.
+    async fn split_inputs(table_store: &Arc<TableStore>) -> (Vec<SsTableView>, Vec<SortedRun>) {
+        let mut sst_views = Vec::new();
+        for entries in [
+            rows(0..400, 2, "l0a", 10_000),
+            rows(1..400, 2, "l0b", 20_000),
+        ] {
+            let ssts = write_ssts(table_store, &entries, SUBCOMPACTION_SST_SIZE).await;
+            sst_views.extend(ssts.into_iter().map(SsTableView::identity));
+        }
+        let sorted_runs = build_sorted_runs(
+            table_store,
+            &[
+                vec![rows(0..400, 1, "sra", 1)],
+                vec![rows(0..400, 5, "srb", 5_000)],
+            ],
+            SUBCOMPACTION_SST_SIZE,
+        )
+        .await;
+        (sst_views, sorted_runs)
+    }
+
+    /// Drains the non-empty subcompaction snapshots reported on `rx`.
+    fn collect_snapshots(rx: &async_channel::Receiver<WorkerMessage>) -> Vec<Vec<Subcompaction>> {
+        let mut snapshots = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let WorkerMessage::CompactionJobProgress { subcompactions, .. } = msg {
+                if !subcompactions.is_empty() {
+                    snapshots.push(subcompactions);
+                }
+            }
+        }
+        snapshots
+    }
+
+    /// A compaction run as parallel subcompactions produces exactly the same
+    /// merged entries as a single-threaded merge. The split run chunks the
+    /// output into different SSTs (each range rolls its own, so sizes, count,
+    /// and boundaries differ), but the logical content is identical: every
+    /// key's full set of versions falls in one range, so retention and
+    /// merge-operator decisions are made per key regardless of where the range
+    /// boundaries land.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_match_single_merge_when_split_into_subcompactions() {
+        let (executor, table_store, _rx) = subcompaction_env(
+            "testdb-split-equivalence",
+            #[cfg(feature = "compaction_filters")]
+            None,
+        )
+        .await;
+        let (sst_views, sorted_runs) = split_inputs(&table_store).await;
+
+        // when: the inputs run as a single merge (planner falls back to one
+        // range), then split into four explicit parallel ranges.
+        let single = executor
+            .inner
+            .execute_compaction_job(job(sst_views.clone(), sorted_runs.clone(), vec![]))
+            .await
+            .unwrap();
+        let expected_entries = read_run_entries(&table_store, &single).await;
+        assert!(!expected_entries.is_empty());
+        let split = executor
+            .inner
+            .execute_compaction_job(job(sst_views, sorted_runs, four_ranges()))
+            .await
+            .unwrap();
+
+        // then: the flattened entries are identical.
+        assert_eq!(
+            read_run_entries(&table_store, &split).await,
+            expected_entries
+        );
+    }
+
+    /// Each progress report carries a persistable snapshot of the whole plan:
+    /// the range set is stable across reports, and the final snapshot accounts
+    /// for every output SST the run is built from.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_report_a_stable_persistable_subcompaction_plan() {
+        let (executor, table_store, rx) = subcompaction_env(
+            "testdb-split-plan",
+            #[cfg(feature = "compaction_filters")]
+            None,
+        )
+        .await;
+        let (sst_views, sorted_runs) = split_inputs(&table_store).await;
+
+        // when: the job runs split into four ranges.
+        let split = executor
+            .inner
+            .execute_compaction_job(job(sst_views, sorted_runs, four_ranges()))
+            .await
+            .unwrap();
+
+        // then: every snapshot reports the same four-range plan, and the last
+        // one accounts for every output SST in the run.
+        let snapshots = collect_snapshots(&rx);
+        assert!(!snapshots.is_empty(), "expected subcompaction snapshots");
+        assert!(snapshots.iter().all(|s| s.len() == 4));
+        let final_output: usize = snapshots
+            .last()
+            .unwrap()
+            .iter()
+            .map(|s| s.output_ssts().len())
+            .sum();
+        assert_eq!(
+            final_output,
+            split.sst_views.len(),
+            "final snapshot should capture every output SST"
+        );
+    }
+
+    /// Resuming from any persisted snapshot — the bare plan, a mid-flight
+    /// state, or the fully-complete state — converges to the same merged output
+    /// and reuses the output SSTs already recorded against each range. Resuming
+    /// a completed compaction does no merge work but still reports its full
+    /// processed size rather than regressing to zero.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_resume_from_any_snapshot() {
+        let (executor, table_store, rx) = subcompaction_env(
+            "testdb-split-resume",
+            #[cfg(feature = "compaction_filters")]
+            None,
+        )
+        .await;
+        let (sst_views, sorted_runs) = split_inputs(&table_store).await;
+
+        // given: a completed split run and the snapshots reported during it.
+        let baseline_run = executor
+            .inner
+            .execute_compaction_job(job(sst_views.clone(), sorted_runs.clone(), four_ranges()))
+            .await
+            .unwrap();
+        let baseline_entries = read_run_entries(&table_store, &baseline_run).await;
+        let snapshots = collect_snapshots(&rx);
+        assert!(
+            snapshots.len() >= 2,
+            "expected several snapshots to resume from"
+        );
+
+        // when/then: resuming from the bare plan, a mid-flight snapshot, and the
+        // fully-complete snapshot each converges to the baseline output and
+        // reuses the SSTs already recorded against each range.
+        for index in [0, snapshots.len() / 2, snapshots.len() - 1] {
+            let snapshot = snapshots[index].clone();
+            // Drain buffered messages so we observe only this resume's progress.
+            while rx.try_recv().is_ok() {}
+            let resumed = executor
+                .inner
+                .execute_compaction_job(job(
+                    sst_views.clone(),
+                    sorted_runs.clone(),
+                    snapshot.clone(),
+                ))
+                .await
+                .unwrap();
+            let mut resume_bytes = Vec::new();
+            while let Ok(msg) = rx.try_recv() {
+                if let WorkerMessage::CompactionJobProgress {
+                    bytes_processed, ..
+                } = msg
+                {
+                    resume_bytes.push(bytes_processed);
+                }
+            }
+            assert_eq!(
+                read_run_entries(&table_store, &resumed).await,
+                baseline_entries,
+                "resume from snapshot {index} diverged"
+            );
+            for sst in snapshot.iter().flat_map(|s| s.output_ssts()) {
+                assert!(
+                    resumed.sst_views.iter().any(|v| v.sst.id == sst.id),
+                    "previously recorded subcompaction output SST was not reused"
+                );
+            }
+
+            // The fully-complete snapshot must do no merge work — the run is
+            // rebuilt purely from recorded output — yet still report its full
+            // processed size, never regressing to zero.
+            if index == snapshots.len() - 1 {
+                let recorded: usize = snapshot.iter().map(|s| s.output_ssts().len()).sum();
+                assert_eq!(
+                    resumed.sst_views.len(),
+                    recorded,
+                    "resuming a completed compaction must not produce new SSTs"
+                );
+                assert!(
+                    !resume_bytes.is_empty() && resume_bytes.iter().all(|&b| b > 0),
+                    "resuming a completed compaction must never report zero bytes, got {resume_bytes:?}"
+                );
+            }
+        }
+    }
+
+    /// When one subcompaction fails, the job must abort its sibling ranges and
+    /// report the failure (rather than hanging on them or committing partial
+    /// output). A compaction filter errors only on keys in the upper part of
+    /// the keyspace, so only the range covering those keys fails while lower
+    /// ranges run normally.
+    #[cfg(feature = "compaction_filters")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_fail_job_when_a_subcompaction_fails() {
+        use crate::compaction_filter::{
+            CompactionFilter, CompactionFilterDecision, CompactionFilterError,
+            CompactionFilterSupplier, CompactionJobContext,
+        };
+
+        struct FailUpperRangeFilter;
+
+        #[async_trait::async_trait]
+        impl CompactionFilter for FailUpperRangeFilter {
+            async fn filter(
+                &mut self,
+                entry: &RowEntry,
+            ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+                if entry.key.as_ref() >= b"key00300".as_slice() {
+                    Err(CompactionFilterError::FilterError(
+                        "injected failure".into(),
+                    ))
+                } else {
+                    Ok(CompactionFilterDecision::Keep)
+                }
+            }
+
+            async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
+                Ok(())
+            }
+        }
+
+        struct FailUpperRangeFilterSupplier;
+
+        #[async_trait::async_trait]
+        impl CompactionFilterSupplier for FailUpperRangeFilterSupplier {
+            async fn create_compaction_filter(
+                &self,
+                _context: &CompactionJobContext,
+            ) -> Result<Box<dyn CompactionFilter>, CompactionFilterError> {
+                Ok(Box::new(FailUpperRangeFilter))
+            }
+        }
+
+        // given: input spanning the whole keyspace, run as four explicit ranges
+        // where only the top range trips the failing filter.
+        let (executor, table_store, _rx) = subcompaction_env(
+            "testdb-subcompaction-failure",
+            Some(Arc::new(FailUpperRangeFilterSupplier)),
+        )
+        .await;
+        let sorted_runs = build_sorted_runs(
+            &table_store,
+            &[vec![rows(0..400, 1, "v", 1)]],
+            SUBCOMPACTION_SST_SIZE,
+        )
+        .await;
+
+        // when: the split job runs.
+        let result = tokio::time::timeout(
+            Duration::from_secs(10),
+            executor
+                .inner
+                .execute_compaction_job(job(vec![], sorted_runs, four_ranges())),
+        )
+        .await
+        // then: it fails promptly rather than hanging on the aborted siblings.
+        .expect("job should fail promptly rather than hang on aborted siblings");
+
+        let err = result.expect_err("job with a failing subcompaction should fail");
+        assert!(
+            matches!(err, SlateDBError::CompactionFilterError(_)),
+            "expected CompactionFilterError, got: {err:?}"
+        );
+    }
+
+    /// Stopping the executor must abort in-flight subcompactions, not just the
+    /// parent job. A compaction filter that never returns holds every range's
+    /// merge open and is dropped (releasing a shared counter) only when its
+    /// task future is dropped — so once the counter confirms the split job is
+    /// in flight, `stop()` must drive it back to zero.
+    #[cfg(feature = "compaction_filters")]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_abort_in_flight_subcompactions_on_stop() {
+        use crate::compaction_filter::{
+            CompactionFilter, CompactionFilterDecision, CompactionFilterError,
+            CompactionFilterSupplier, CompactionJobContext,
+        };
+        use std::sync::atomic::{AtomicI64, Ordering};
+
+        // Each range's merge suspends on its first row and never resumes; the
+        // filter counts itself as running on entry and uncounts on drop, so the
+        // shared counter mirrors the number of in-flight subcompactions even
+        // without a metric.
+        struct BlockForeverFilter {
+            running: Arc<AtomicI64>,
+            counted: bool,
+        }
+
+        impl Drop for BlockForeverFilter {
+            fn drop(&mut self) {
+                if self.counted {
+                    self.running.fetch_sub(1, Ordering::SeqCst);
+                }
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl CompactionFilter for BlockForeverFilter {
+            async fn filter(
+                &mut self,
+                _entry: &RowEntry,
+            ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+                if !self.counted {
+                    self.counted = true;
+                    self.running.fetch_add(1, Ordering::SeqCst);
+                }
+                std::future::pending::<Result<CompactionFilterDecision, CompactionFilterError>>()
+                    .await
+            }
+
+            async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
+                Ok(())
+            }
+        }
+
+        struct BlockForeverFilterSupplier {
+            running: Arc<AtomicI64>,
+        }
+
+        #[async_trait::async_trait]
+        impl CompactionFilterSupplier for BlockForeverFilterSupplier {
+            async fn create_compaction_filter(
+                &self,
+                _context: &CompactionJobContext,
+            ) -> Result<Box<dyn CompactionFilter>, CompactionFilterError> {
+                Ok(Box::new(BlockForeverFilter {
+                    running: self.running.clone(),
+                    counted: false,
+                }))
+            }
+        }
+
+        // Polls the shared running counter until `pred` holds, failing the test
+        // if it never does within the timeout.
+        async fn await_running(
+            running: &Arc<AtomicI64>,
+            pred: impl Fn(i64) -> bool,
+            what: &str,
+        ) -> i64 {
+            tokio::time::timeout(Duration::from_secs(10), async {
+                loop {
+                    let n = running.load(Ordering::SeqCst);
+                    if pred(n) {
+                        return n;
+                    }
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+        }
+
+        // given: a split compaction running in the background (started via the
+        // real path so its task lands in the map stop() drains), held open by a
+        // filter that blocks forever and decrements `running` on drop.
+        let running = Arc::new(AtomicI64::new(0));
+        let (executor, table_store, _rx) = subcompaction_env(
+            "testdb-stop-aborts-subcompactions",
+            Some(Arc::new(BlockForeverFilterSupplier {
+                running: running.clone(),
+            })),
+        )
+        .await;
+        let sorted_runs = build_sorted_runs(
+            &table_store,
+            &[vec![rows(0..400, 1, "v", 1)]],
+            SUBCOMPACTION_SST_SIZE,
+        )
+        .await;
+        executor
+            .inner
+            .start_compaction_job(job(vec![], sorted_runs, four_ranges()));
+
+        let in_flight = await_running(&running, |n| n >= 2, "subcompactions to start").await;
+        assert!(in_flight >= 2, "expected a split job, got {in_flight}");
+
+        // when: the executor is stopped.
+        executor.inner.stop();
+
+        // then: every in-flight subcompaction is aborted and its filter dropped.
+        let after = await_running(&running, |n| n == 0, "subcompactions to abort").await;
+        assert_eq!(after, 0);
+    }
+
+    /// The planner plans a single unbounded-range subcompaction for a fresh
+    /// job, and resumes a persisted multi-range plan verbatim so the output
+    /// already recorded against its ranges stays valid.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_resume_persisted_plan_or_plan_single_unbounded_range() {
+        // given: an executor and a fresh job with no persisted plan.
+        let ctx = TestContextBuilder::new("testdb-no-replan").build().await;
+        let args = StartCompactionJobArgs {
+            id: Ulid::new(),
+            compaction_id: Ulid::new(),
+            destination: 0,
+            sst_views: vec![],
+            sorted_runs: vec![],
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+            subcompactions: vec![],
+        };
+
+        // when/then: a fresh job plans a single unbounded-range subcompaction.
+        let planned = ctx.executor.inner.plan_subcompactions(&args);
+        assert_eq!(planned.len(), 1);
+        assert_eq!(planned[0].range(), &BytesRange::unbounded());
+
+        // given: a job carrying a persisted multi-range plan.
+        let persisted = vec![
+            Subcompaction::new(BytesRange::from_slice(..b"m".as_slice())),
+            Subcompaction::new(BytesRange::from_slice(b"m".as_slice()..)),
+        ];
+        let args = StartCompactionJobArgs {
+            subcompactions: persisted.clone(),
+            ..args
+        };
+
+        // when/then: the persisted plan is returned verbatim.
+        assert_eq!(ctx.executor.inner.plan_subcompactions(&args), persisted);
     }
 
     /// A blocked SST `close()` (the object-store flush of a finished output SST)

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -103,6 +103,9 @@ pub(crate) enum SlateDBError {
     #[error("segment extractor produced an empty prefix for key {key:?}")]
     EmptySegmentPrefix { key: Bytes },
 
+    #[error("compaction executor failed")]
+    CompactorExecutorFailed,
+
     #[error(
         "invalid clock tick, must be monotonic. last_tick=`{last_tick}`, next_tick=`{next_tick}`"
     )]
@@ -656,6 +659,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::CloneIncorrectFinalCheckpoint { .. } => Error::data(msg),
 
             // Internal errors
+            SlateDBError::CompactorExecutorFailed => Error::internal(msg),
             #[cfg(feature = "compaction_filters")]
             SlateDBError::CompactionFilterError(_) => Error::internal(msg),
             SlateDBError::SeekKeyOutOfKeyRange { .. } => Error::internal(msg),


### PR DESCRIPTION
## Summary

Replace the single-merge compaction executor with one that runs a compaction's subcompactions concurrently, each over a disjoint key range, with range-level resume and fail-fast. It still does not split subcompactions, just scheduling one. The next PR will introduce the splitting heuristic. 

See #1777 for a full implementation. 

## Changes

The strategy is to spin off a new task for each subcompaction, and they communicate progress over a tx/rx channel.

## Notes for Reviewers



## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
