### PR TITLE
docs: remove extra space from note block declaration

### DIFF
--- a/website/src/content/docs/docs/design/overview.mdx
+++ b/website/src/content/docs/docs/design/overview.mdx
@@ -153,7 +153,7 @@ SSTable 2:
 
 Now a read for `key56` will only need to search the first SSTable. Readers need only check the key range of each SSTable (stored in memory) to determine if it might contain the key. The unpartitioned tables, are called _level 0 (L0)_ SSTables. The partitioned tables are called _sorted runs (SRs)_. L0 SSTables are part of the write path, as we saw above. Sorted runs are generated through a background compaction process.
 
-::: note
+:::note
 
 Sorted runs are a logical construct. The files written to disk are the sorted run's SSTables. The manifest (which we'll see in a moment) contains the mapping from a sorted run ID to its SSTables.
 


### PR DESCRIPTION
## Summary

Literally a one-character fix for how the note block is rendered. It was raised a couple of weeks ago in the opendata discord as well ([link](https://discord.com/channels/1450884405219561628/1450884406750216346/1513072016201220106)). I forgot about it until I was going through the site today.

My smallest SlateDB PR so far, and one that doesn't involve Rust 😄

Before:
<img width="762" height="183" alt="Screenshot 2026-06-19 at 10 46 42 AM" src="https://github.com/user-attachments/assets/4c144a99-b94a-4a52-8096-fa09a8dff725" />

After:
<img width="759" height="171" alt="Screenshot 2026-06-19 at 10 47 58 AM" src="https://github.com/user-attachments/assets/970fbb65-dece-42cd-86ef-79f063a5faaf" />

## Notes for Reviewers

Asked my AI agent to scan other places in `website/src/content/docs` to find any more malformed syntax issues. It came up with nothing.
 
## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
