### PR TITLE
ci: add TableStoreKind to subcompaction test helper

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -1795,6 +1795,7 @@ mod tests {
             },
             root_path.clone(),
             None,
+            TableStoreKind::Compactor,
         ));
         let manifest_store = Arc::new(ManifestStore::new(&root_path, object_store.clone()));
         StoredManifest::create_new_db(manifest_store.clone(), ManifestCore::new(), clock.clone())


### PR DESCRIPTION
## Summary

`TableStore::new` in `subcompaction_env` was missing `TableStoreKind`, causing ci clippy and tests to fail after [1820](https://github.com/slatedb/slatedb/pull/1820) was merged.

## Changes

Add `TableStoreKind::Compactor` to the test helper method.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
