### PR TITLE
Remove OpenDAL environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,7 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -528,12 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,15 +561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -735,9 +720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -1385,21 +1368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,49 +1692,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jiff"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "js-sys",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "wasm-bindgen",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
 
 [[package]]
 name = "jobserver"
@@ -2102,9 +2027,9 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.39.4",
+ "quick-xml",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest",
  "ring",
  "rustls-pki-types",
  "serde",
@@ -2117,23 +2042,6 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
-]
-
-[[package]]
-name = "object_store_opendal"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08298874eee5935c95bcaa393148834f9c53d904461ca15584a041d8a1c907c2"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "mea",
- "object_store",
- "opendal",
- "pin-project",
- "tokio",
 ]
 
 [[package]]
@@ -2153,43 +2061,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "opendal"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
-dependencies = [
- "opendal-core",
-]
-
-[[package]]
-name = "opendal-core"
-version = "0.56.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "futures",
- "http",
- "http-body",
- "jiff",
- "log",
- "md-5",
- "mea",
- "percent-encoding",
- "quick-xml 0.38.4",
- "reqsign-core",
- "reqwest 0.13.3",
- "serde",
- "serde_json",
- "tokio",
- "url",
- "uuid",
- "web-time",
-]
 
 [[package]]
 name = "openssl-probe"
@@ -2370,15 +2241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,16 +2378,6 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "quick-xml"
@@ -2742,28 +2594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "reqsign-core"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10302cf0a7d7e7352ba211fc92c3c5bebf1286153e49cc5aa87348078a8e102"
-dependencies = [
- "anyhow",
- "base64",
- "bytes",
- "form_urlencoded",
- "futures",
- "hex",
- "hmac",
- "http",
- "jiff",
- "log",
- "percent-encoding",
- "sha1",
- "sha2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2801,39 +2631,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "sync_wrapper",
- "tokio",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3159,28 +2957,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3261,8 +3037,6 @@ dependencies = [
  "lz4_flex",
  "moka",
  "object_store",
- "object_store_opendal",
- "opendal",
  "ouroboros",
  "parking_lot",
  "pprof",
@@ -4325,19 +4099,6 @@ name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,6 @@ lru = "0.18"
 lz4_flex = "0.11.5"
 moka = "0.12.8"
 object_store = "0.13.2"
-object_store_opendal = "0.56.0"
-opendal = { version = "0.56.0", default-features = false }
 ouroboros = "0.18"
 parking_lot = "0.12.4"
 pyo3 = "0.25.1"

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -35,8 +35,6 @@ lru = { workspace = true }
 lz4_flex = { workspace = true, optional = true }
 moka = { workspace = true, features = ["future"], optional = true }
 object_store = { workspace = true }
-object_store_opendal = { workspace = true, optional = true }
-opendal = { workspace = true, optional = true }
 ouroboros = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
@@ -97,7 +95,6 @@ azure = ["object_store/azure"]
 bencher = ["aws", "azure", "wal_disable", "foyer"]
 compression = ["snappy"]
 gcp = ["object_store/gcp"]
-opendal = ["dep:opendal", "dep:object_store_opendal"]
 snappy = ["dep:snap"]
 zlib = ["dep:flate2"]
 lz4 = ["dep:lz4_flex"]
@@ -116,7 +113,6 @@ all = [
     "azure",
     "compression",
     "gcp",
-    "opendal",
     "snappy",
     "zlib",
     "lz4",

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -727,7 +727,6 @@ fn get_env_variable(name: &str) -> Result<String, SlateDBError> {
 /// | Memory | `memory` | [load_memory] |
 /// | AWS | `aws` | [load_aws] |
 /// | Azure | `azure` | [load_azure] |
-/// | OpenDAL | `opendal` | [load_opendal] |
 pub fn load_object_store_from_env(
     env_file: Option<String>,
 ) -> Result<Arc<dyn ObjectStore>, crate::Error> {
@@ -740,8 +739,6 @@ pub fn load_object_store_from_env(
         "aws" => load_aws(),
         #[cfg(feature = "azure")]
         "azure" => load_azure(),
-        #[cfg(feature = "opendal")]
-        "opendal" => load_opendal(),
         invalid_value => Err(SlateDBError::InvalidEnvironmentVariable {
             key: "CLOUD_PROVIDER".to_string(),
             value: Some(invalid_value.to_string()),
@@ -803,60 +800,6 @@ pub fn load_azure() -> Result<Arc<dyn ObjectStore>, crate::Error> {
     })?) as Arc<dyn ObjectStore>)
 }
 
-/// Loads an OpenDAL Object store instance.
-///
-/// | Env Variable | Doc | Required |
-/// |--------------|-----|----------|
-/// | OPENDAL_SCHEME | The OpenDAL scheme to use | Yes |
-/// | OPENDAL_* | The OpenDAL configuration | Yes |
-/// full list of schemes: https://docs.rs/opendal/latest/opendal/services/index.html
-/// for example, to use s3-compatible storage, you can set:
-/// ```bash
-/// OPENDAL_SCHEME=s3
-/// OPENDAL_ENDPOINT=http://localhost:9000
-/// OPENDAL_ACCESS_KEY_ID=minioadmin
-/// OPENDAL_SECRET_ACCESS_KEY=minioadmin
-/// OPENDAL_BUCKET=test
-/// OPENDAL_REGION=us-east-1
-/// OPENDAL_ROOT=/tmp
-/// ```
-/// full list of config: https://docs.rs/opendal/latest/opendal/services/s3/config/struct.S3Config.html
-/// for example, to use oss, you can set:
-/// ```bash
-/// OPENDAL_SCHEME=oss
-/// OPENDAL_ENDPOINT=http://oss-cn-shanghai.aliyuncs.com
-/// OPENDAL_ACCESS_KEY_ID=your-access-key-id
-/// OPENDAL_ACCESS_KEY_SECRET=your-access-key-secret
-/// OPENDAL_BUCKET=your-bucket-name
-/// OPENDAL_ROOT=/your/root/path
-/// ```
-/// full list of config: https://docs.rs/opendal/latest/opendal/services/oss/config/struct.OssConfig.html
-#[cfg(feature = "opendal")]
-pub fn load_opendal() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    use opendal::Operator;
-    use std::collections::HashMap;
-
-    let scheme_value = get_env_variable("OPENDAL_SCHEME")?;
-    let iter = env::vars()
-        .filter_map(|(k, v)| k.strip_prefix("OPENDAL_").map(|k| (k.to_lowercase(), v)))
-        .collect::<HashMap<String, String>>();
-
-    let op = Operator::via_iter(&scheme_value, iter).map_err(|error| {
-        if error.kind() == opendal::ErrorKind::Unsupported {
-            SlateDBError::InvalidEnvironmentVariable {
-                key: "OPENDAL_SCHEME".to_string(),
-                value: Some(scheme_value.clone()),
-            }
-        } else {
-            SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
-                store: "OpenDAL",
-                source: Box::new(error),
-            }))
-        }
-    })?;
-    Ok(Arc::new(object_store_opendal::OpendalStore::new(op)) as Arc<dyn ObjectStore>)
-}
-
 #[cfg(test)]
 mod tests {
     use crate::admin::{load_object_store_from_env, AdminBuilder};
@@ -905,23 +848,6 @@ mod tests {
             let store = r.expect("expected memory object store");
             assert_eq!(store.to_string(), "InMemory");
 
-            Ok(())
-        });
-    }
-
-    #[cfg(feature = "opendal")]
-    #[test]
-    fn test_load_opendal_invalid_scheme_maps_to_invalid_environment_variable() {
-        figment::Jail::expect_with(|jail| {
-            jail.set_env("OPENDAL_SCHEME", "not-a-scheme");
-
-            let err = super::load_opendal().expect_err("expected invalid OpenDAL scheme");
-
-            assert_eq!(err.kind(), ErrorKind::Invalid);
-            assert_eq!(
-                err.to_string(),
-                "Invalid error: invalid environment variable OPENDAL_SCHEME value `not-a-scheme`"
-            );
             Ok(())
         });
     }


### PR DESCRIPTION
## Summary

OpenDAL takes a long time to upgrade its dependencies. It slowed down our 0.13 object_store upgrade and is now in the way for the 0.14 upgrade. We only depend on OpenDAL in order to provide a convenience function that creates an OpenDAL object_store bridge. I'm removing support for this.

Users may still use OpenDAL as they see fit. They'll just need to create the OpenDAL object themselves.

In the past, we have discussed moving _more_ into OpenDAL's ecosystem (#1104, #1403). This PR does remove a direct dependency on OpenDAL, but does not preclude us from reintroducing it or migrating to OpenDAL later. It's merely fixing an immediate need we have.

It appears OSS still doesn't work with `object_store`: https://github.com/apache/arrow-rs-object-store/issues/416. Now that we use `If-Match` for boundary files, we might also need to add some changes for `PutMode::Update` as well. For OSS users, they should use OpenDAL's `object_store_opendal::OpendalStore::new(op)) as Arc<dyn ObjectStore>` to provide SlateDB with an object_store compatible OpenDAL shim.

cc @flaneur2020

## Changes

- Removes `load_opendal` and related environment variable.

## Notes for Reviewers

None

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
