### PR TITLE
feat(compaction): subcompaction planning heuristic (RFC-0028) [4/N]

### DIFF
--- a/rfcs/0028-subcompactions.md
+++ b/rfcs/0028-subcompactions.md
@@ -440,7 +440,7 @@ Selection](#boundary-selection-heuristic) keeps this as a coarse fallback (one
 As some evidence that the cost of index-based planning is not prohibitive, 
 a 16GB compaction had the following time breakdowns for the subcompaciton phase
 (ran on a `cg8in.8xlarge`) where planning takes only about 3% of the total time
-after parellelizing it 12 ways:
+after splitting it 12 ways:
 ```
 ┌───────────────────────────────────┬────────┬──────────┬─────────┬─────────┬────────────┐
 │                run                │ total  │ manifest │  plan   │  merge  │ planning % │

--- a/rfcs/0028-subcompactions.md
+++ b/rfcs/0028-subcompactions.md
@@ -117,10 +117,10 @@ four SSTs.
 generate more SSTs than required, with multiple having a size less than the max
 SST configuration.
 
-**Note 2**: the heuristic proposed later in this RFC actually prevents this specific
-example from happening because it chooses a non-SST boundary for the split. Splitting
-SSTs, however, is still possible with this RFC's approach when merging multiple SRs,
-so I used this example to illustrate that.
+**Note 2**: the heuristic proposed later in this RFC can produce a split like this
+one because it places boundaries at SST *block* boundaries, not just between SSTs.
+It would not cut at an arbitrary key `k`, though — it snaps the boundary to the
+nearest block boundary inside SST(92).
 
 ### Execution Lifecycle
 
@@ -190,9 +190,10 @@ run_subcompaction(spec, sub):
 
 It's worth noting that the main coordinator is still responsible for submitting
 the compaction, but the worker is responsible for computing the subcompaction
-plan (splits). This allows future optimizations where the subcompaction planner can pull
-information like SST indexes to improve the split algorithm without affecting the
-cache on the active serving node in distributed compaction.
+plan (splits). The planner reads the input SST indexes to choose split points
+(see [Boundary Selection](#boundary-selection-heuristic)); doing this on the
+worker rather than the coordinator keeps those index reads off the active
+serving node's cache in distributed compaction.
 
 ### Persistence & Schema
 
@@ -229,41 +230,56 @@ role of keeping old `.compactions` files around long enough to compute that wate
 
 ### Boundary Selection (Heuristic)
 
-The goal of the boundary selection is to make the sub-compactions roughly equally sized
-without spending too much time figuring this out (i.e. only by reading the manifest).
+The goal of boundary selection is to split a compaction into roughly equally
+sized sub-ranges, measured in bytes. 
 
-For v0 of subcompactions, we'll only consider SST boundaries as potential split points
-since the first/last keys are available directly in the manifest alongside the size
-estimates of various SSTs. The algorithm for determining splits is:
+The boundary selection algorithm uses candidates that consist of "anchor points"
+within individual SSTs. These points are sampled from the SST index (as opposed
+to using every block offset as a potential anchor point) to reduce the number
+of candidates.
+
+We then collect the sizes between anchor points until they exceed the threshold
+we want for a single subcompaction and mark those as the boundary range.
 
 ```
-// imagine three SSTs with ranges [a-k],[c-m],[f-z], then the candidates are
-// [a, c, f, k, m, z] and the candidate intervals are [(a,c), (c,f), (f,k),
-// (k,m), (m,z)]
-candidate_keys = union of input SST/view starts and ends
-intervals = adjacent candidate key ranges
+// Per input SST, read its index and sample it down to at most
+// MAX_ANCHORS_PER_SST anchors: (key, approx_bytes)
+anchors = merge_by_key(sst.index.sampled_anchors(MAX_ANCHORS_PER_SST) for sst in inputs)
 
-for interval in intervals:
-  interval.weight = sum size_estimate(sst) for every input sst overlapping interval
+target = max(total_input_bytes / max_subcompactions, max_sst_size)
+if target >= total_input_bytes:
+  return [(-∞, +∞)]
 
-// if the full interval weights are 600MB, and we want three subcompactions
-// then the target range would cover 200MB each so we sum the intervals until
-// we get close to the candidate and select that as the range
-target = sum(interval.weight) / desired_subcompactions
+boundaries = []
+threshold = target
+cumulative = 0
+for (key, approx_bytes) in anchors:
+  cumulative += approx_bytes
+  // the anchor that tips the running total past the next threshold ends the
+  // current range and starts the next; a running threshold avoids drift
+  if cumulative > threshold and len(boundaries) < max_subcompactions - 1:
+    boundaries.append(key)
+    threshold += target
 
-for interval in intervals:
-  accumulate interval.weight
-  when accumulated >= target:
-    emit boundary at interval end
-    reset toward next target  
+return covering_ranges(boundaries)         // (-∞,b1),[b1,b2),...,[bk,+∞)
 ```
+
+When `max_subcompactions <= 1`, or the inputs are smaller than `max_sst_size`,
+or no anchor ever crosses the threshold, the sweep emits no boundaries and the
+compaction runs as a single unbounded range.
 
 ### Configuration
 
-- `max_subcompactions` configures the desired number of subcompactions for a compaction, with
-  any number `<=1` disabling subcompactions. Default `4`.
-- `min_subcompaction_input_bytes` prevents small subcompaction jobs from running, which can
-  cause the creation of fragmented SSTs. Defaults to `2 x max_sst_size`. 
+- `max_subcompactions` configures the maximum number of subcompactions for a compaction, with
+  any number `<=1` disabling subcompactions. Default `4`. The planner targets ranges of
+  `max(total_input_bytes / max_subcompactions, max_sst_size)`, so a compaction smaller than
+  `max_subcompactions × max_sst_size` is split into fewer (or zero) ranges rather than
+  fragmented into undersized SSTs.
+
+There is deliberately no separate minimum-input knob: the `max_sst_size` floor baked into the
+target subsumes it (each subcompaction covers at least one output SST's worth of input). This
+mirrors RocksDB, which floors its target at `MaxFileSizeForLevel` rather than exposing a
+configurable minimum.
 
 We could optionally introduce `max_concurrent_subcompactions` to allow scheduling more
 subcompactions than we run concurrently actively, but until we decide to integrate this
@@ -384,11 +400,12 @@ with Fizzbee, but I don't think it's necessary.
 
 ## Rollout
 
-I opted to default to set `max_subcompactions = 4` by default instead of
-off-by-default because I think it's a pretty foundational feature for large
-compaction jobs. Note that this departs from prior art. RocksDB ships with it
-disabled (`max_subcompactions = 1`) but they also do not ship with a
-`min_subcompaction_input_bytes`. 
+I opted to default `max_subcompactions = 4` instead of off-by-default because I
+think it's a pretty foundational feature for large compaction jobs. Note that
+this departs from prior art: RocksDB ships with it disabled
+(`max_subcompactions = 1`). Like RocksDB, we expose no dedicated minimum-size
+knob since the per-range `max_sst_size` floor (RocksDB's `MaxFileSizeForLevel`)
+keeps small compactions from fragmenting.
 
 See the compatibility section for why this is safe to rollout in one go.
 
@@ -408,10 +425,18 @@ still one indivisible unit of work on one core, and no amount of
 cross-compaction concurrency speeds it up. Subcompactions parallelize *within*
 that unit, which is the only approach that addresses big SR compactions.
 
-**Index Metadata Split Algorithms.** Deferred. The idea here is to use the index
-metadata on SSTs to determine where we should be splitting instead of the rough
-heuristic that's outlined in this RFC. It's probably worth doing, but I've
-deferred details of that for a v2 implementation.
+**Manifest-only boundaries.** Rejected. An earlier draft restricted split
+points to the per-SST first/last keys in the manifest, avoiding index reads
+entirely. It is cheaper to plan, but does not work for compactions where data
+is skewed within the SST boundaries. The index-based heuristic in [Boundary
+Selection](#boundary-selection-heuristic) keeps this as a coarse fallback (one
+"block" per SST) for inputs whose indexes we choose not to read.
+
+**Sub-block split precision.** Deferred. Boundary selection splits at SST block
+granularity (~4 KiB), which is already fine enough for roughly-equal ranges.
+Going finer — splitting within a block at restart points, or sampling actual
+keys to balance skewed value sizes — is possible but not worth the added I/O and
+complexity now; deferred to a later iteration.
 
 **Parallelizing block construction within a single range.** Deferred/Partial
 Rejection. This is a valid alternative to the RFC in that it allows you to have

--- a/rfcs/0028-subcompactions.md
+++ b/rfcs/0028-subcompactions.md
@@ -246,7 +246,11 @@ we want for a single subcompaction and mark those as the boundary range.
 // MAX_ANCHORS_PER_SST anchors: (key, approx_bytes)
 anchors = merge_by_key(sst.index.sampled_anchors(MAX_ANCHORS_PER_SST) for sst in inputs)
 
-target = max(total_input_bytes / max_subcompactions, max_sst_size)
+// floor each range at the largest single input SST's estimated size, so a
+// subcompaction is never smaller than the biggest source SST
+min_range_bytes = max(sst.estimate_size() for sst in inputs)
+
+target = max(total_input_bytes / max_subcompactions, min_range_bytes)
 if target >= total_input_bytes:
   return [(-∞, +∞)]
 
@@ -264,22 +268,22 @@ for (key, approx_bytes) in anchors:
 return covering_ranges(boundaries)         // (-∞,b1),[b1,b2),...,[bk,+∞)
 ```
 
-When `max_subcompactions <= 1`, or the inputs are smaller than `max_sst_size`,
-or no anchor ever crosses the threshold, the sweep emits no boundaries and the
-compaction runs as a single unbounded range.
+When `max_subcompactions <= 1`, or the largest input SST already covers the whole
+compaction (so the floor meets the total), or no anchor ever crosses the
+threshold, the sweep emits no boundaries and the compaction runs as a single
+unbounded range.
 
 ### Configuration
 
 - `max_subcompactions` configures the maximum number of subcompactions for a compaction, with
   any number `<=1` disabling subcompactions. Default `4`. The planner targets ranges of
-  `max(total_input_bytes / max_subcompactions, max_sst_size)`, so a compaction smaller than
-  `max_subcompactions × max_sst_size` is split into fewer (or zero) ranges rather than
+  `max(total_input_bytes / max_subcompactions, max_input_sst_bytes)`, where `max_input_sst_bytes`
+  is the largest single input SST's estimated on-disk size. A compaction whose largest input
+  SST already accounts for most of the total is split into fewer (or zero) ranges rather than
   fragmented into undersized SSTs.
 
-There is deliberately no separate minimum-input knob: the `max_sst_size` floor baked into the
-target subsumes it (each subcompaction covers at least one output SST's worth of input). This
-mirrors RocksDB, which floors its target at `MaxFileSizeForLevel` rather than exposing a
-configurable minimum.
+There is deliberately no separate minimum-input knob: the floor baked into the subcompaction
+to make sure the output SSTs are no smaller than the largest input SST.
 
 We could optionally introduce `max_concurrent_subcompactions` to allow scheduling more
 subcompactions than we run concurrently actively, but until we decide to integrate this
@@ -404,8 +408,9 @@ I opted to default `max_subcompactions = 4` instead of off-by-default because I
 think it's a pretty foundational feature for large compaction jobs. Note that
 this departs from prior art: RocksDB ships with it disabled
 (`max_subcompactions = 1`). Like RocksDB, we expose no dedicated minimum-size
-knob since the per-range `max_sst_size` floor (RocksDB's `MaxFileSizeForLevel`)
-keeps small compactions from fragmenting.
+knob — the per-range floor (the largest input SST's worth of data) keeps small
+compactions from fragmenting, playing the role RocksDB's `MaxFileSizeForLevel`
+plays for it.
 
 See the compatibility section for why this is safe to rollout in one go.
 
@@ -431,6 +436,16 @@ entirely. It is cheaper to plan, but does not work for compactions where data
 is skewed within the SST boundaries. The index-based heuristic in [Boundary
 Selection](#boundary-selection-heuristic) keeps this as a coarse fallback (one
 "block" per SST) for inputs whose indexes we choose not to read.
+
+As some evidence, a 16GB compaction had the following time breakdowns for the
+subcompaciton phase (ran on a `cg8in.8xlarge`):
+```
+┌───────────────────────────────────┬────────┬──────────┬─────────┬─────────┬────────────┐
+│                run                │ total  │ manifest │  plan   │  merge  │ planning % │
+├───────────────────────────────────┼────────┼──────────┼─────────┼─────────┼────────────┤
+│ tiled sub=12 (zstd)               │ 20.2 s │ 50 ms    │ ~0.55 s │ ~19.5 s │ ~3%        │
+└───────────────────────────────────┴────────┴──────────┴─────────┴─────────┴────────────┘
+```
 
 **Sub-block split precision.** Deferred. Boundary selection splits at SST block
 granularity (~4 KiB), which is already fine enough for roughly-equal ranges.

--- a/rfcs/0028-subcompactions.md
+++ b/rfcs/0028-subcompactions.md
@@ -437,11 +437,15 @@ is skewed within the SST boundaries. The index-based heuristic in [Boundary
 Selection](#boundary-selection-heuristic) keeps this as a coarse fallback (one
 "block" per SST) for inputs whose indexes we choose not to read.
 
-As some evidence, a 16GB compaction had the following time breakdowns for the
-subcompaciton phase (ran on a `cg8in.8xlarge`):
+As some evidence that the cost of index-based planning is not prohibitive, 
+a 16GB compaction had the following time breakdowns for the subcompaciton phase
+(ran on a `cg8in.8xlarge`) where planning takes only about 3% of the total time
+after parellelizing it 12 ways:
 ```
 ┌───────────────────────────────────┬────────┬──────────┬─────────┬─────────┬────────────┐
 │                run                │ total  │ manifest │  plan   │  merge  │ planning % │
+├───────────────────────────────────┼────────┼──────────┼─────────┼─────────┼────────────┤
+│ tiled sub=1 (uncompressed)        │ 157 s  │ 50 ms    │ 0       │ ~157 s  │ ~0%        │
 ├───────────────────────────────────┼────────┼──────────┼─────────┼─────────┼────────────┤
 │ tiled sub=12 (zstd)               │ 20.2 s │ 50 ms    │ ~0.55 s │ ~19.5 s │ ~3%        │
 └───────────────────────────────────┴────────┴──────────┴─────────┴─────────┴────────────┘

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -112,6 +112,15 @@ pub(crate) enum WorkerMessage {
         bytes_processed: u64,
         ctx: CompactionContext,
     },
+    /// Liveness-only heartbeat from the [`CompactionExecutor`], emitted while a
+    /// job is still planning (reading input indexes) and so has no progress to
+    /// report yet. Refreshes `last_heartbeat_ms` without touching the persisted
+    /// context, so a slow planning step on a healthy worker is not mistaken for
+    /// a dead one and reclaimed mid-plan.
+    CompactionJobHeartbeat {
+        /// The job id to refresh liveness for.
+        id: Ulid,
+    },
     /// Ticker-triggered message to poll `.compactions` for claimable jobs.
     PollCompactions,
 }
@@ -592,6 +601,26 @@ impl CompactionWorkerHandler {
         Ok(())
     }
 
+    /// Handles a liveness-only heartbeat emitted while a job is still planning,
+    /// before it produces any progress (see
+    /// [`WorkerMessage::CompactionJobHeartbeat`]). Refreshes `last_heartbeat_ms`
+    /// without touching the persisted context, and advances the job's
+    /// `last_hb_ms` on a confirmed write so the bytes-trigger throttle stays
+    /// consistent. A skipped write (entry gone / ownership lost) is a no-op, so
+    /// this never resurrects a job that was already reclaimed mid-plan.
+    async fn handle_planning_heartbeat(&mut self, id: Ulid) -> Result<(), SlateDBError> {
+        if let Some(hb_ms) = self.write_heartbeat(id, None).await? {
+            if let Some(state) = self.job_progress.get_mut(&id) {
+                state.last_hb_ms = hb_ms;
+            }
+            debug!(
+                "planning heartbeat [worker_id={}, id={}, now_ms={}]",
+                self.worker_id, id, hb_ms
+            );
+        }
+        Ok(())
+    }
+
     fn build_job_args(
         compaction: &Compaction,
         db_state: &ManifestCore,
@@ -801,6 +830,9 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
                 ctx,
             } => {
                 self.handle_progress(id, bytes_processed, ctx).await?;
+            }
+            WorkerMessage::CompactionJobHeartbeat { id } => {
+                self.handle_planning_heartbeat(id).await?;
             }
         }
         Ok(())

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -521,18 +521,54 @@ impl TokioCompactionExecutorInner {
         args: StartCompactionJobArgs,
     ) -> Result<SortedRun, SlateDBError> {
         debug!("executing compaction [job_args={:?}]", args);
-        // Load the manifest's sequence tracker once per job; every range shares
-        // it rather than re-reading the manifest.
+        let id = args.id;
+        let destination = args.destination;
+
+        // Planning (manifest load + input-index reads) runs before
+        // `execute_compaction_job` emits its first progress event, so it would
+        // otherwise go un-heartbeated. On a cold object store with very wide
+        // input it can exceed `worker_heartbeat_timeout`, letting the
+        // coordinator reclaim a healthy job mid-plan and livelock on
+        // re-planning. Emit a liveness-only heartbeat on the
+        // `heartbeat_min_interval` cadence while planning is in flight; planning
+        // that finishes before the first tick (the common case) sends nothing.
+        let plan = self.load_manifest_and_plan(args);
+        tokio::pin!(plan);
+        let (sequence_tracker, planned) = loop {
+            tokio::select! {
+                biased;
+                res = &mut plan => break res?,
+                _ = self.clock.sleep(self.options.heartbeat_min_interval) => {
+                    if self
+                        .worker_tx
+                        .try_send(WorkerMessage::CompactionJobHeartbeat { id })
+                        .is_err()
+                    {
+                        debug!(
+                            "failed to send planning heartbeat (likely DB shutdown) [id={}]",
+                            id
+                        );
+                    }
+                }
+            }
+        };
+
+        self.execute_compaction_job(id, destination, planned, sequence_tracker)
+            .await
+    }
+
+    /// Loads the manifest's shared sequence tracker and plans the job's ranges
+    /// (RFC-0028). Every range shares the one sequence tracker rather than
+    /// re-reading the manifest.
+    async fn load_manifest_and_plan(
+        &self,
+        args: StartCompactionJobArgs,
+    ) -> Result<(Arc<SequenceTracker>, PlannedCompaction), SlateDBError> {
         let stored_manifest =
             StoredManifest::load(self.manifest_store.clone(), self.clock.clone()).await?;
         let sequence_tracker = Arc::new(stored_manifest.db_state().sequence_tracker.clone());
-
-        // Plan the job's ranges, then run them concurrently.
-        let id = args.id;
-        let destination = args.destination;
         let planned = self.plan_compaction_job(args).await?;
-        self.execute_compaction_job(id, destination, planned, sequence_tracker)
-            .await
+        Ok((sequence_tracker, planned))
     }
 
     /// Plans the subcompaction ranges for a fresh job (RFC-0028).
@@ -554,7 +590,6 @@ impl TokioCompactionExecutorInner {
             &args.l0_sst_views,
             &args.sorted_runs,
             self.options.max_subcompactions,
-            self.options.max_sst_size as u64,
             self.options.max_fetch_tasks,
         )
         .await?;
@@ -2386,7 +2421,7 @@ mod tests {
         let (l0_sst_views, sorted_runs) = split_inputs(&table_store).await;
 
         // given: a fresh job (no resume context) whose total input far exceeds
-        // the 512-byte max_sst_size floor.
+        // the per-source floor (the largest input SST's worth of bytes).
         let args = StartCompactionJobArgs {
             id: Ulid::new(),
             compaction_id: Ulid::new(),
@@ -2580,6 +2615,135 @@ mod tests {
         }
         let expected: Vec<Bytes> = entries.iter().map(|e| e.key.clone()).collect();
         assert_eq!(read_back, expected);
+    }
+
+    /// Planning (manifest load + input-index reads) runs before the executor
+    /// emits its first progress event. On a cold object store with wide input
+    /// it can outlast `worker_heartbeat_timeout`, so the executor must emit a
+    /// liveness heartbeat while planning is in flight or a healthy job gets
+    /// reclaimed mid-plan. Simulate the stall with a gated object store and
+    /// assert a planning heartbeat lands before any progress.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_heartbeat_while_planning_index_reads_block() {
+        // given: the table store reads/writes through a gated object store, but
+        // the manifest store uses the ungated inner store — so we can stall the
+        // planner's input-index reads while the manifest load still completes. A
+        // short heartbeat interval makes the planning heartbeat observable.
+        let handle = tokio::runtime::Handle::current();
+        let options = Arc::new(CompactionWorkerOptions {
+            max_sst_size: SUBCOMPACTION_SST_SIZE,
+            heartbeat_min_interval: Duration::from_millis(20),
+            ..CompactionWorkerOptions::default()
+        });
+        let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated = Arc::new(GatedObjectStore::new(inner.clone()));
+        let gated_store: Arc<dyn ObjectStore> = gated.clone();
+        let root_path = Path::from("testdb-plan-heartbeat");
+        let clock = Arc::new(DefaultSystemClock::new());
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(gated_store.clone(), None),
+            SsTableFormat {
+                block_size: 256,
+                ..SsTableFormat::default()
+            },
+            root_path.clone(),
+            None,
+            TableStoreKind::Compactor,
+        ));
+        let manifest_store = Arc::new(ManifestStore::new(&root_path, inner.clone()));
+        StoredManifest::create_new_db(manifest_store.clone(), ManifestCore::new(), clock.clone())
+            .await
+            .unwrap();
+
+        let executor = TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
+            handle,
+            options,
+            worker_tx: tx,
+            table_store: table_store.clone(),
+            rand: Arc::new(DbRand::new(100u64)),
+            stats: {
+                let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+                Arc::new(CompactionStats::new(&recorder))
+            },
+            worker_stats: WorkerStats::noop(),
+            clock,
+            manifest_store,
+            merge_operator: None,
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: None,
+        });
+
+        // given: multi-SST input (written with the read gate open).
+        let (l0_sst_views, sorted_runs) = split_inputs(&table_store).await;
+
+        // given: block object-store reads so the planner's index reads stall.
+        // Baseline existing read arrivals so we can wait for the next one.
+        let setup_gets = gated.get_opts_gate.arrivals();
+        gated.get_opts_gate.close();
+
+        // when: a *fresh* job (ctx = None, so it must plan) starts.
+        let id = Ulid::new();
+        executor.start_compaction_job(StartCompactionJobArgs {
+            id,
+            compaction_id: Ulid::new(),
+            destination: 0,
+            l0_sst_views,
+            sorted_runs,
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+            ctx: None,
+        });
+
+        // then: planning parks on a blocked index read (the manifest load, on the
+        // ungated store, already succeeded) ...
+        tokio::time::timeout(
+            Duration::from_secs(30),
+            gated.get_opts_gate.wait_for_arrivals(setup_gets + 1),
+        )
+        .await
+        .expect("planning should reach the blocked read gate");
+
+        // ... and while it is parked the executor emits a planning heartbeat for
+        // this job, with no progress/finished yet (planning produced no plan).
+        let heartbeated = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                match rx.recv().await.unwrap() {
+                    WorkerMessage::CompactionJobHeartbeat { id: hb_id } => {
+                        assert_eq!(hb_id, id, "heartbeat carried the wrong job id");
+                        break;
+                    }
+                    WorkerMessage::CompactionJobProgress { .. } => {
+                        panic!("progress emitted before planning completed")
+                    }
+                    WorkerMessage::CompactionJobFinished { .. } => {
+                        panic!("job finished while planning reads were blocked")
+                    }
+                    WorkerMessage::PollCompactions => {}
+                }
+            }
+        })
+        .await;
+        assert!(
+            heartbeated.is_ok(),
+            "expected a planning heartbeat while input-index reads were blocked"
+        );
+
+        // when: reads are unblocked, the job plans and runs to completion.
+        gated.get_opts_gate.release();
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                if let WorkerMessage::CompactionJobFinished { result, .. } =
+                    rx.recv().await.unwrap()
+                {
+                    return result;
+                }
+            }
+        })
+        .await
+        .expect("job should finish after reads are unblocked")
+        .expect("compaction should succeed");
     }
 
     /// Test context for compaction executor tests.

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -33,7 +33,7 @@ use crate::retention_iterator::RetentionIterator;
 use crate::seq_tracker::SequenceTracker;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
-use crate::subcompaction::Subcompaction;
+use crate::subcompaction::{plan_subcompaction_ranges, Subcompaction};
 use crate::tablestore::TableStore;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::DbRand;
@@ -470,10 +470,16 @@ impl TokioCompactionExecutorInner {
         Ok(())
     }
 
-    fn plan_compaction_job(&self, args: StartCompactionJobArgs) -> PlannedCompaction {
+    async fn plan_compaction_job(
+        &self,
+        args: StartCompactionJobArgs,
+    ) -> Result<PlannedCompaction, SlateDBError> {
         let ctx = match args.ctx {
             Some(ctx) => ctx,
-            None => CompactionContext::new(self.plan_subcompactions(&args), args.retention_min_seq),
+            None => CompactionContext::new(
+                self.plan_subcompactions(&args).await?,
+                args.retention_min_seq,
+            ),
         };
         assert!(!ctx.subcompactions().is_empty());
         let subcompaction_args = ctx
@@ -492,10 +498,10 @@ impl TokioCompactionExecutorInner {
                 output_ssts: s.output_ssts().clone(),
             })
             .collect::<Vec<_>>();
-        PlannedCompaction {
+        Ok(PlannedCompaction {
             ctx,
             subcompaction_args,
-        }
+        })
     }
 
     /// Executes a single compaction job and returns the resulting context.
@@ -524,21 +530,35 @@ impl TokioCompactionExecutorInner {
         // Plan the job's ranges, then run them concurrently.
         let id = args.id;
         let destination = args.destination;
-        let planned = self.plan_compaction_job(args);
+        let planned = self.plan_compaction_job(args).await?;
         self.execute_compaction_job(id, destination, planned, sequence_tracker)
             .await
     }
 
-    /// Determines the subcompaction plan for a job (RFC-0028).
+    /// Plans the subcompaction ranges for a fresh job (RFC-0028).
+    ///
+    /// Only called when the job carries no resume context: a job that is
+    /// resuming reuses its persisted [`CompactionContext`] verbatim (see
+    /// [`Self::plan_compaction_job`]). Reads the input SST indexes to choose
+    /// split points (see [`plan_subcompaction_ranges`]), so this is fallible.
     ///
     /// ## Returns
-    /// - The persisted subcompactions when the job carries a plan: it is
-    ///   returned verbatim so output SSTs already recorded against its ranges
-    ///   stay valid.
-    /// - Otherwise a single subcompaction covering the whole (unbounded) key
-    ///   space.
-    fn plan_subcompactions(&self, _args: &StartCompactionJobArgs) -> Vec<Subcompaction> {
-        vec![Subcompaction::new(BytesRange::unbounded())]
+    /// - The planned ranges or a single unbounded range when
+    ///   subcompactions are disabled
+    async fn plan_subcompactions(
+        &self,
+        args: &StartCompactionJobArgs,
+    ) -> Result<Vec<Subcompaction>, SlateDBError> {
+        let ranges = plan_subcompaction_ranges(
+            &self.table_store,
+            &args.l0_sst_views,
+            &args.sorted_runs,
+            self.options.max_subcompactions,
+            self.options.max_sst_size as u64,
+            self.options.max_fetch_tasks,
+        )
+        .await?;
+        Ok(ranges.into_iter().map(Subcompaction::new).collect())
     }
 
     /// Executes a compaction job's subcompactions (RFC-0028), running every
@@ -2323,8 +2343,13 @@ mod tests {
             ctx: None,
         };
 
-        // when/then: a fresh job plans a single unbounded-range subcompaction.
-        let planned = ctx.executor.inner.plan_compaction_job(args.clone());
+        // when/then: a fresh job with no inputs plans a single unbounded range.
+        let planned = ctx
+            .executor
+            .inner
+            .plan_compaction_job(args.clone())
+            .await
+            .unwrap();
         assert_eq!(planned.ctx.subcompactions().len(), 1);
         assert_eq!(
             planned.ctx.subcompactions()[0].range(),
@@ -2342,8 +2367,45 @@ mod tests {
         };
 
         // when/then: the persisted plan is returned verbatim.
-        let planned = ctx.executor.inner.plan_compaction_job(args);
+        let planned = ctx.executor.inner.plan_compaction_job(args).await.unwrap();
         assert_eq!(planned.ctx.subcompactions(), &persisted);
+    }
+
+    /// The planner reads the real input SST indexes and splits a sizable
+    /// multi-source compaction into several ranges (RFC-0028) when given no
+    /// resume context. This exercises the index-sampling path end to end,
+    /// unlike the tests that supply an explicit plan.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_plan_split_from_sst_indexes() {
+        let (executor, table_store, _rx) = subcompaction_env(
+            "testdb-plan-from-indexes",
+            #[cfg(feature = "compaction_filters")]
+            None,
+        )
+        .await;
+        let (l0_sst_views, sorted_runs) = split_inputs(&table_store).await;
+
+        // given: a fresh job (no resume context) whose total input far exceeds
+        // the 512-byte max_sst_size floor.
+        let args = StartCompactionJobArgs {
+            id: Ulid::new(),
+            compaction_id: Ulid::new(),
+            destination: 0,
+            l0_sst_views,
+            sorted_runs,
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+            ctx: None,
+        };
+
+        // when: planning the job.
+        let planned = executor.inner.plan_compaction_job(args).await.unwrap();
+
+        // then: it splits into multiple ranges, capped at max_subcompactions.
+        let n = planned.ctx.subcompactions().len();
+        assert!(n > 1, "expected an index-driven split, got {n} range(s)");
+        assert!(n <= 4, "must not exceed max_subcompactions");
     }
 
     /// A blocked SST `close()` (the object-store flush of a finished output SST)

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1220,6 +1220,21 @@ pub struct CompactionWorkerOptions {
     /// ahead of the cursor.
     pub bytes_to_fetch: usize,
 
+    /// The maximum number of subcompactions to split a single compaction into
+    /// (RFC-0028). Each subcompaction covers a disjoint sub-range of the key
+    /// space and executes concurrently with its siblings, so a single large
+    /// compaction can use multiple cores. Any value `<= 1` disables
+    /// subcompactions. The default is 4.
+    ///
+    /// The planner targets sub-ranges of
+    /// `max(total_input_bytes / max_subcompactions, max_sst_size)`, so a
+    /// compaction smaller than `max_subcompactions * max_sst_size` is split
+    /// into fewer (or zero) ranges rather than fragmented into undersized
+    /// SSTs. There is deliberately no separate minimum-size knob; the
+    /// [`max_sst_size`](CompactionWorkerOptions::max_sst_size) floor subsumes
+    /// it.
+    pub max_subcompactions: usize,
+
     /// Optional metrics reporting level for standalone compaction workers.
     /// Defaults to [`MetricLevel::default`] when unset.
     pub metric_level: Option<MetricLevel>,
@@ -1237,6 +1252,7 @@ impl Default for CompactionWorkerOptions {
             max_sst_size: 256 * 1024 * 1024,
             max_fetch_tasks: 4,
             bytes_to_fetch: 2 * 1024 * 1024,
+            max_subcompactions: 4,
             metric_level: None,
         }
     }

--- a/slatedb/src/subcompaction.rs
+++ b/slatedb/src/subcompaction.rs
@@ -1,12 +1,26 @@
-//! # Subcompaction Data Model
+//! # Subcompactions
 //!
 //! In-memory record of a subcompaction (RFC-0028): a compaction over a
-//! sub-range of a parent compaction's key space. See [`Subcompaction`].
+//! sub-range of a parent compaction's key space (see [`Subcompaction`]), plus
+//! the boundary-selection planner ([`plan_subcompaction_ranges`]) that decides
+//! how to split a logical compaction into those sub-ranges.
+//!
+//! The overall approach mirrors RocksDB's subcompaction boundary selection; see
+//! `ApproximateKeyAnchors` and `GenSubcompactionBoundaries` in RocksDB's
+//! `db/compaction/compaction_job.cc`.
 
+use std::ops::Bound::{self, Excluded, Included, Unbounded};
+use std::sync::Arc;
+
+use bytes::Bytes;
+use futures::stream::{self, StreamExt, TryStreamExt};
 use serde::Serialize;
 
 use crate::bytes_range::BytesRange;
-use crate::db_state::SsTableHandle;
+use crate::db_state::{SortedRun, SsTableHandle, SsTableView};
+use crate::error::SlateDBError;
+use crate::flatbuffer_types::SsTableIndexOwned;
+use crate::tablestore::TableStore;
 
 /// A compaction over a sub-range of the parent compaction's key space
 /// (RFC-0028).
@@ -52,14 +66,350 @@ impl Subcompaction {
         &self.output_ssts
     }
 
-    /// Sets the output SSTs produced by this subcompaction.
-    // Consumed by the subcompaction executor in a follow-up RFC-0028 PR; this
-    // PR only introduces the data model and its extend-only contract.
+    /// Sets the output SSTs produced by this subcompaction, enforcing the
+    /// extend-only contract: the new list must start with the previous one,
+    /// since the executor only ever appends as a range produces more SSTs.
     pub(crate) fn set_output_ssts(&mut self, output_ssts: Vec<SsTableHandle>) {
         assert!(
             output_ssts.starts_with(self.output_ssts.as_slice()),
             "new subcompaction output SSTs must always extend previous output SSTs"
         );
         self.output_ssts = output_ssts;
+    }
+}
+
+/// The maximum number of anchors sampled from a single SST's block index.
+///
+/// Capping anchors per SST bounds the planner's candidate set no matter how many
+/// blocks an SST has (a 256 MiB SST with 4 KiB blocks has ~65k blocks), so a
+/// wide compaction yields tens of thousands of candidates rather than tens of
+/// millions.
+const MAX_ANCHORS_PER_SST: usize = 128;
+
+/// Plans the key ranges to split a compaction into subcompactions (RFC-0028).
+///
+/// Reads each input SST's block index, samples it into at most
+/// [`MAX_ANCHORS_PER_SST`] weighted anchors, and places boundaries at the keys
+/// that fall on the byte-weight quantiles of the merged anchor stream (see
+/// [`select_boundaries`]). Index reads run concurrently, bounded by
+/// `max_fetch_tasks`, and warm the same block cache the merge will later use.
+///
+/// ## Returns
+/// - Ranges in ascending key order that are non-overlapping and together cover
+///   the entire key space. A single unbounded range means the compaction should
+///   run unsplit (subcompactions disabled, inputs too small, or no usable split
+///   point).
+pub(crate) async fn plan_subcompaction_ranges(
+    table_store: &Arc<TableStore>,
+    sst_views: &[SsTableView],
+    sorted_runs: &[SortedRun],
+    max_subcompactions: usize,
+    max_sst_size: u64,
+    max_fetch_tasks: usize,
+) -> Result<Vec<BytesRange>, SlateDBError> {
+    if max_subcompactions <= 1 {
+        return Ok(vec![BytesRange::unbounded()]);
+    }
+
+    // Collect owned input handles up front. Each read future then owns its
+    // handle and an `Arc<TableStore>` clone rather than borrowing the input
+    // slices, which keeps the enclosing (spawned) compaction future `Send`.
+    let handles: Vec<SsTableHandle> = sst_views
+        .iter()
+        .map(|view| view.sst.clone())
+        .chain(
+            sorted_runs
+                .iter()
+                .flat_map(|sr| sr.sst_views.iter().map(|view| view.sst.clone())),
+        )
+        .collect();
+
+    // Read and sample every input SST's index concurrently (bounded by
+    // `max_fetch_tasks`). Each SST yields at most MAX_ANCHORS_PER_SST anchors,
+    // so the merged candidate set stays bounded regardless of total data size.
+    let anchors: Vec<(Bytes, u64)> = stream::iter(handles)
+        .map(|handle| {
+            let table_store = table_store.clone();
+            async move {
+                let index = table_store.read_index(&handle, true).await?;
+                // `filter_offset` marks the end of the data-block region: the
+                // filter, index, and stats blocks all follow it, and when the
+                // SST has no filter it aliases `index_offset`. Using
+                // `index_offset` here would charge the filter block's bytes to
+                // the last anchor, skewing boundaries toward high keys (or
+                // pushing a near-floor compaction over the `max_sst_size` line).
+                Ok::<_, SlateDBError>(sample_anchors(
+                    &index,
+                    handle.info.filter_offset,
+                    MAX_ANCHORS_PER_SST,
+                ))
+            }
+        })
+        .buffer_unordered(max_fetch_tasks.max(1))
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    Ok(select_boundaries(anchors, max_subcompactions, max_sst_size))
+}
+
+/// Selects covering key ranges from weighted anchors so each range carries a
+/// roughly equal share of the input bytes (RFC-0028).
+///
+/// The target range size is `max(total_bytes / max_subcompactions, max_sst_size)`:
+/// the `max_sst_size` floor keeps each subcompaction to at least one output
+/// SST's worth of input, so a small compaction is split into fewer (or zero)
+/// ranges rather than fragmented. Anchors are swept in key order, and a
+/// boundary opens a new range at the first anchor once the running total of the
+/// ranges already closed reaches the next threshold; a running threshold (rather
+/// than a per-range reset) keeps rounding error from accumulating.
+///
+/// ## Returns
+/// - Ranges in ascending key order, non-overlapping and covering the whole key
+///   space. A single unbounded range means the compaction should run unsplit.
+fn select_boundaries(
+    mut anchors: Vec<(Bytes, u64)>,
+    max_subcompactions: usize,
+    max_sst_size: u64,
+) -> Vec<BytesRange> {
+    if max_subcompactions <= 1 {
+        return vec![BytesRange::unbounded()];
+    }
+
+    let total: u64 = anchors.iter().map(|(_, bytes)| bytes).sum();
+    let target = (total / max_subcompactions as u64).max(max_sst_size);
+    // Too small to split: a single range already fits within the target.
+    if target == 0 || target >= total {
+        return vec![BytesRange::unbounded()];
+    }
+
+    // Anchors from different SSTs interleave; sort into one key-ordered stream.
+    anchors.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // `cumulative` is the bytes in the ranges already closed (everything strictly
+    // before the current anchor). When it reaches the next threshold, the current
+    // anchor's key opens a new range, so the anchor — and its weight — belongs to
+    // that new range.
+    let mut boundaries: Vec<Bytes> = Vec::new();
+    let mut threshold = target;
+    let mut cumulative = 0u64;
+    for (key, bytes) in anchors {
+        let distinct = match boundaries.last() {
+            // Skip a key equal to the previous boundary: anchors from
+            // overlapping SSTs can share a key, and emitting it twice would
+            // create an empty range. The next distinct key still lands close to
+            // the target.
+            Some(last) => key > *last,
+            None => true,
+        };
+        if cumulative >= threshold && boundaries.len() < max_subcompactions - 1 && distinct {
+            boundaries.push(key);
+            threshold += target;
+        }
+        cumulative += bytes;
+    }
+
+    if boundaries.is_empty() {
+        return vec![BytesRange::unbounded()];
+    }
+
+    // Build covering ranges: (-inf, b1), [b1, b2), ..., [bk, +inf).
+    let mut ranges = Vec::with_capacity(boundaries.len() + 1);
+    let mut start: Bound<Bytes> = Unbounded;
+    for boundary in boundaries {
+        ranges.push(BytesRange::new(start, Excluded(boundary.clone())));
+        start = Included(boundary);
+    }
+    ranges.push(BytesRange::new(start, Unbounded));
+    ranges
+}
+
+/// Samples an SST's block index into at most `max_anchors` weighted anchors,
+/// each `(block first key, bytes the anchor represents)`.
+///
+/// A block's on-disk size is the gap between its offset and the next block's;
+/// the last block runs to `data_end_offset`, the end of the data-block region
+/// (the filter, index, and stats blocks follow it). When the SST has more
+/// blocks than `max_anchors`, adjacent blocks are grouped so the anchor count
+/// stays bounded: the group's key is its first block's first key and its weight
+/// is the summed size of the grouped blocks.
+fn sample_anchors(
+    index: &SsTableIndexOwned,
+    data_end_offset: u64,
+    max_anchors: usize,
+) -> Vec<(Bytes, u64)> {
+    let borrowed = index.borrow();
+    let blocks = borrowed.block_meta();
+    let num_blocks = blocks.len();
+    if num_blocks == 0 {
+        return Vec::new();
+    }
+
+    // End offset of block `i`: the next block's offset, or `data_end_offset`
+    // for the last block (the filter/index blocks immediately follow the data).
+    let block_end = |i: usize| -> u64 {
+        if i + 1 < num_blocks {
+            blocks.get(i + 1).offset()
+        } else {
+            data_end_offset
+        }
+    };
+
+    let max_anchors = max_anchors.max(1);
+    let stride = num_blocks.div_ceil(max_anchors);
+    let mut anchors = Vec::with_capacity(num_blocks.div_ceil(stride));
+    let mut block = 0;
+    while block < num_blocks {
+        let first = blocks.get(block);
+        let key = Bytes::copy_from_slice(first.first_key().bytes());
+        let group_end = (block + stride).min(num_blocks);
+        // Blocks are contiguous, so the group's size is the gap from its first
+        // block's offset to its last block's end offset.
+        let bytes = block_end(group_end - 1).saturating_sub(first.offset());
+        anchors.push((key, bytes));
+        block = group_end;
+    }
+    anchors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ops::RangeBounds;
+
+    /// A key for keyspace position `i`, fixed-width so byte order matches `i`.
+    fn k(i: u64) -> Bytes {
+        Bytes::copy_from_slice(format!("k{i:010}").as_bytes())
+    }
+
+    fn assert_covering_ranges(ranges: &[BytesRange]) {
+        assert!(!ranges.is_empty());
+        assert_eq!(RangeBounds::start_bound(ranges.first().unwrap()), Unbounded);
+        assert_eq!(RangeBounds::end_bound(ranges.last().unwrap()), Unbounded);
+        // Boundaries are pushed in strictly increasing key order, so every range
+        // spans distinct keys. Assert it directly: an empty range would mean two
+        // boundaries collapsed onto one key (a duplicated split point).
+        for range in ranges {
+            assert!(range.non_empty(), "range must be non-empty: {range:?}");
+        }
+        for pair in ranges.windows(2) {
+            let Excluded(prev_end) = pair[0].end_bound() else {
+                panic!("non-terminal ranges must have excluded end bounds");
+            };
+            let Included(next_start) = pair[1].start_bound() else {
+                panic!("non-initial ranges must have included start bounds");
+            };
+            assert_eq!(prev_end, next_start, "adjacent ranges must be contiguous");
+        }
+    }
+
+    #[test]
+    fn test_should_not_split_when_subcompactions_disabled() {
+        // given: anchors worth splitting, but subcompactions disabled (max == 1)
+        let anchors = vec![(k(0), 100), (k(100), 100)];
+
+        // when: boundaries are selected
+        let ranges = select_boundaries(anchors, 1, 1);
+
+        // then: the compaction runs unsplit
+        assert_eq!(ranges, vec![BytesRange::unbounded()]);
+    }
+
+    #[test]
+    fn test_should_not_split_inputs_below_max_sst_size() {
+        // given: 200 bytes of input but a 1000-byte max_sst_size floor
+        let anchors = vec![(k(0), 100), (k(100), 100)];
+
+        // when: boundaries are selected with the floor above the total size
+        let ranges = select_boundaries(anchors, 4, 1000);
+
+        // then: the compaction stays whole rather than fragmenting
+        assert_eq!(ranges, vec![BytesRange::unbounded()]);
+    }
+
+    #[test]
+    fn test_should_split_evenly_weighted_anchors() {
+        // given: four equal anchors at distinct keys (target = 400 / 4 = 100)
+        let anchors = vec![(k(0), 100), (k(10), 100), (k(20), 100), (k(30), 100)];
+
+        // when: boundaries are selected for four subcompactions
+        let ranges = select_boundaries(anchors, 4, 1);
+
+        // then: each later anchor opens a new range at k(10), k(20), k(30)
+        assert_covering_ranges(&ranges);
+        assert_eq!(ranges.len(), 4);
+        assert_eq!(ranges[0].end_bound(), Excluded(&k(10)));
+        assert_eq!(ranges[1].end_bound(), Excluded(&k(20)));
+        assert_eq!(ranges[2].end_bound(), Excluded(&k(30)));
+    }
+
+    #[test]
+    fn test_should_cap_splits_at_max_subcompactions() {
+        // given: many anchors, far more than the subcompaction cap
+        let anchors: Vec<(Bytes, u64)> = (0..100).map(|i| (k(i), 100)).collect();
+
+        // when: boundaries are selected with a cap of four
+        let ranges = select_boundaries(anchors, 4, 1);
+
+        // then: the split never exceeds max_subcompactions ranges
+        assert_covering_ranges(&ranges);
+        assert_eq!(ranges.len(), 4, "must not exceed max_subcompactions ranges");
+    }
+
+    #[test]
+    fn test_should_isolate_heavy_region() {
+        // given: a heavy front anchor carrying half the bytes (target = 1040 / 2 = 520)
+        let anchors = vec![
+            (k(0), 1000),
+            (k(10), 10),
+            (k(20), 10),
+            (k(30), 10),
+            (k(40), 10),
+        ];
+
+        // when: boundaries are selected for two subcompactions
+        let ranges = select_boundaries(anchors, 2, 1);
+
+        // then: the heavy anchor alone exceeds the target, so it gets its own range
+        assert_covering_ranges(&ranges);
+        assert_eq!(ranges.len(), 2);
+        assert_eq!(ranges[0].end_bound(), Excluded(&k(10)));
+    }
+
+    #[test]
+    fn test_should_not_split_single_anchor() {
+        // given: a single anchor (e.g. a single-block SST) below the floor
+        let anchors = vec![(k(0), 1000)];
+
+        // when: boundaries are selected
+        let ranges = select_boundaries(anchors, 4, 1000);
+
+        // then: the SST stays whole
+        assert_eq!(ranges, vec![BytesRange::unbounded()]);
+    }
+
+    #[test]
+    fn test_should_handle_duplicate_keys_without_empty_ranges() {
+        // given: overlapping SSTs contributing anchors at the same keys
+        let anchors = vec![
+            (k(0), 500),
+            (k(0), 500),
+            (k(10), 500),
+            (k(10), 500),
+            (k(20), 500),
+            (k(20), 500),
+        ];
+
+        // when: boundaries are selected
+        let ranges = select_boundaries(anchors, 4, 1);
+
+        // then: it splits without ever emitting two boundaries at one key.
+        // assert_covering_ranges checks every range is non-empty, so a
+        // duplicated split point (which would also panic BytesRange::new) fails
+        // here explicitly.
+        assert_covering_ranges(&ranges);
+        assert!(ranges.len() > 1);
     }
 }

--- a/slatedb/src/subcompaction.rs
+++ b/slatedb/src/subcompaction.rs
@@ -87,13 +87,11 @@ impl Subcompaction {
 /// millions.
 const MAX_ANCHORS_PER_SST: usize = 128;
 
-/// Plans the key ranges to split a compaction into subcompactions (RFC-0028).
-///
-/// Reads each input SST's block index, samples it into at most
-/// [`MAX_ANCHORS_PER_SST`] weighted anchors, and places boundaries at the keys
-/// that fall on the byte-weight quantiles of the merged anchor stream (see
-/// [`select_boundaries`]). Index reads run concurrently, bounded by
-/// `max_fetch_tasks`, and warm the same block cache the merge will later use.
+/// Hard ceiling for front-loaded planner index reads.
+const MAX_PLANNING_INDEX_READS: usize = 64;
+
+/// Plans the key ranges to split a compaction into subcompactions (see RFC-0028
+/// for a description on the algorithm).
 ///
 /// ## Returns
 /// - Ranges in ascending key order that are non-overlapping and together cover
@@ -138,13 +136,11 @@ pub(crate) async fn plan_subcompaction_ranges(
         .max()
         .unwrap_or(0);
 
-    // Read and sample every input SST's index concurrently (bounded by
-    // `max_fetch_tasks` x number of sources). Each SST yields at most
-    // MAX_ANCHORS_PER_SST anchors, so the merged candidate set stays bounded
-    // regardless of total data size. Floor at 1: with no inputs `views` is
-    // empty and `buffer_unordered(0)` never polls its source stream, so it
-    // would hang instead of completing with zero anchors.
-    let concurrency = (views.len() * max_fetch_tasks.max(1)).max(1);
+    // Mimic the parallelism that the executor has when executing the compaction
+    // itself (which would use one iterator per input L0 + input SR)
+    let sources = (sst_views.len() + sorted_runs.len()).max(1);
+    let concurrency = (sources * max_fetch_tasks.max(1)).min(MAX_PLANNING_INDEX_READS);
+
     let anchors: Vec<(Bytes, u64)> = stream::iter(views)
         .map(|view| {
             let table_store = table_store.clone();
@@ -210,6 +206,7 @@ fn select_boundaries(
 
     // Anchors from different SSTs interleave; sort into one key-ordered stream.
     anchors.sort_by(|a, b| a.0.cmp(&b.0));
+    let first_key = anchors[0].0.clone();
 
     // `cumulative` is the bytes in the ranges already closed (everything strictly
     // before the current anchor). When it reaches the next threshold, the current
@@ -225,7 +222,10 @@ fn select_boundaries(
             // create an empty range. The next distinct key still lands close to
             // the target.
             Some(last) => key > *last,
-            None => true,
+            // No boundary yet: the first one must clear `min_key`, else the
+            // leading range is empty. Overlapping inputs can stack enough weight
+            // on the smallest key to cross the threshold while still on it.
+            None => key > first_key,
         };
         if cumulative >= threshold && boundaries.len() < max_subcompactions - 1 && distinct {
             boundaries.push(key);
@@ -497,6 +497,30 @@ mod tests {
 
         // then: the SST stays whole
         assert_eq!(ranges, vec![BytesRange::unbounded()]);
+    }
+
+    #[test]
+    fn test_should_not_emit_boundary_on_smallest_key() {
+        // given: three overlapping SSTs all anchored at the smallest key k(0),
+        // each below the target (500) but together crossing it. cumulative
+        // reaches the threshold while still sitting on k(0).
+        let anchors = vec![
+            (k(0), 400),
+            (k(0), 400),
+            (k(0), 400),
+            (k(10), 400),
+            (k(20), 400),
+        ];
+
+        // when: boundaries are selected for four subcompactions
+        let ranges = select_boundaries(anchors, 4, 1);
+
+        // then: no boundary lands on k(0), so the leading range is never empty.
+        // The data concentrated at k(0) can't be split below it, so it yields
+        // three covering ranges rather than a wasted (-inf, k(0)) slot.
+        assert_covering_ranges(&ranges);
+        assert_eq!(ranges[0].end_bound(), Excluded(&k(10)));
+        assert!(ranges.len() > 1);
     }
 
     #[test]

--- a/slatedb/src/subcompaction.rs
+++ b/slatedb/src/subcompaction.rs
@@ -10,6 +10,7 @@
 //! `db/compaction/compaction_job.cc`.
 
 use std::ops::Bound::{self, Excluded, Included, Unbounded};
+use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -104,64 +105,86 @@ pub(crate) async fn plan_subcompaction_ranges(
     sst_views: &[SsTableView],
     sorted_runs: &[SortedRun],
     max_subcompactions: usize,
-    max_sst_size: u64,
     max_fetch_tasks: usize,
 ) -> Result<Vec<BytesRange>, SlateDBError> {
     if max_subcompactions <= 1 {
         return Ok(vec![BytesRange::unbounded()]);
     }
 
-    // Collect owned input handles up front. Each read future then owns its
-    // handle and an `Arc<TableStore>` clone rather than borrowing the input
-    // slices, which keeps the enclosing (spawned) compaction future `Send`.
-    let handles: Vec<SsTableHandle> = sst_views
+    // Collect owned input views up front. Each read future then owns its view
+    // (handle + projection) and an `Arc<TableStore>` clone rather than borrowing
+    // the input slices, which keeps the enclosing (spawned) compaction future
+    // `Send`. Keeping the full view (not just `view.sst`) lets sampling clip
+    // anchors to the view's effective range, so a projected input contributes
+    // only its visible keys and bytes (see `sample_anchors`).
+    let views: Vec<SsTableView> = sst_views
         .iter()
-        .map(|view| view.sst.clone())
+        .cloned()
         .chain(
             sorted_runs
                 .iter()
-                .flat_map(|sr| sr.sst_views.iter().map(|view| view.sst.clone())),
+                .flat_map(|sr| sr.sst_views.iter().cloned()),
         )
         .collect();
 
+    // Floor each range at the largest input SST's estimated on-disk size, so a
+    // subcompaction is never smaller than the biggest source SST. Tying the
+    // floor to the inputs' granularity rather than the output `max_sst_size`
+    // lets shallow compactions (e.g. L0, whose inputs are far below
+    // `max_sst_size`) split rather than always running unsplit.
+    let min_range_bytes = views
+        .iter()
+        .map(|view| view.estimate_size())
+        .max()
+        .unwrap_or(0);
+
     // Read and sample every input SST's index concurrently (bounded by
-    // `max_fetch_tasks`). Each SST yields at most MAX_ANCHORS_PER_SST anchors,
-    // so the merged candidate set stays bounded regardless of total data size.
-    let anchors: Vec<(Bytes, u64)> = stream::iter(handles)
-        .map(|handle| {
+    // `max_fetch_tasks` x number of sources). Each SST yields at most
+    // MAX_ANCHORS_PER_SST anchors, so the merged candidate set stays bounded
+    // regardless of total data size. Floor at 1: with no inputs `views` is
+    // empty and `buffer_unordered(0)` never polls its source stream, so it
+    // would hang instead of completing with zero anchors.
+    let concurrency = (views.len() * max_fetch_tasks.max(1)).max(1);
+    let anchors: Vec<(Bytes, u64)> = stream::iter(views)
+        .map(|view| {
             let table_store = table_store.clone();
             async move {
-                let index = table_store.read_index(&handle, true).await?;
+                let index = table_store.read_index(&view.sst, true).await?;
                 // `filter_offset` marks the end of the data-block region: the
                 // filter, index, and stats blocks all follow it, and when the
                 // SST has no filter it aliases `index_offset`. Using
                 // `index_offset` here would charge the filter block's bytes to
                 // the last anchor, skewing boundaries toward high keys (or
-                // pushing a near-floor compaction over the `max_sst_size` line).
+                // pushing a near-floor compaction over the split threshold).
                 Ok::<_, SlateDBError>(sample_anchors(
                     &index,
-                    handle.info.filter_offset,
+                    view.sst.info.filter_offset,
                     MAX_ANCHORS_PER_SST,
+                    view.compacted_effective_range(),
                 ))
             }
         })
-        .buffer_unordered(max_fetch_tasks.max(1))
+        .buffer_unordered(concurrency)
         .try_collect::<Vec<_>>()
         .await?
         .into_iter()
         .flatten()
         .collect();
 
-    Ok(select_boundaries(anchors, max_subcompactions, max_sst_size))
+    Ok(select_boundaries(
+        anchors,
+        max_subcompactions,
+        min_range_bytes,
+    ))
 }
 
 /// Selects covering key ranges from weighted anchors so each range carries a
 /// roughly equal share of the input bytes (RFC-0028).
 ///
-/// The target range size is `max(total_bytes / max_subcompactions, max_sst_size)`:
-/// the `max_sst_size` floor keeps each subcompaction to at least one output
-/// SST's worth of input, so a small compaction is split into fewer (or zero)
-/// ranges rather than fragmented. Anchors are swept in key order, and a
+/// The target range size is `max(total_bytes / max_subcompactions, min_range_bytes)`:
+/// the `min_range_bytes` floor keeps each subcompaction to at least the largest
+/// input SST's worth of input, so a small compaction is split into fewer (or
+/// zero) ranges rather than fragmented. Anchors are swept in key order, and a
 /// boundary opens a new range at the first anchor once the running total of the
 /// ranges already closed reaches the next threshold; a running threshold (rather
 /// than a per-range reset) keeps rounding error from accumulating.
@@ -172,14 +195,14 @@ pub(crate) async fn plan_subcompaction_ranges(
 fn select_boundaries(
     mut anchors: Vec<(Bytes, u64)>,
     max_subcompactions: usize,
-    max_sst_size: u64,
+    min_range_bytes: u64,
 ) -> Vec<BytesRange> {
     if max_subcompactions <= 1 {
         return vec![BytesRange::unbounded()];
     }
 
     let total: u64 = anchors.iter().map(|(_, bytes)| bytes).sum();
-    let target = (total / max_subcompactions as u64).max(max_sst_size);
+    let target = (total / max_subcompactions as u64).max(min_range_bytes);
     // Too small to split: a single range already fits within the target.
     if target == 0 || target >= total {
         return vec![BytesRange::unbounded()];
@@ -206,6 +229,10 @@ fn select_boundaries(
         };
         if cumulative >= threshold && boundaries.len() < max_subcompactions - 1 && distinct {
             boundaries.push(key);
+            // Advance to the next absolute quantile (`+= target`), not
+            // `cumulative + target`: `cumulative` has overshot the threshold by
+            // up to one anchor, and resetting from it would fold that overshoot
+            // into every later threshold, compounding the drift across boundaries.
             threshold += target;
         }
         cumulative += bytes;
@@ -227,7 +254,8 @@ fn select_boundaries(
 }
 
 /// Samples an SST's block index into at most `max_anchors` weighted anchors,
-/// each `(block first key, bytes the anchor represents)`.
+/// each `(block first key, bytes the anchor represents)`, restricted to the
+/// view's `effective_range`.
 ///
 /// A block's on-disk size is the gap between its offset and the next block's;
 /// the last block runs to `data_end_offset`, the end of the data-block region
@@ -235,10 +263,19 @@ fn select_boundaries(
 /// blocks than `max_anchors`, adjacent blocks are grouped so the anchor count
 /// stays bounded: the group's key is its first block's first key and its weight
 /// is the summed size of the grouped blocks.
+///
+/// Anchors whose key falls outside `effective_range` are dropped, so a projected
+/// input (a view with a narrower `visible_range`) only contributes boundaries
+/// and bytes for its visible keys — otherwise the planner could split on keys or
+/// byte totals the compaction never sees, yielding empty or undersized
+/// subcompactions. Filtering happens at the grouped-anchor granularity, so a
+/// group straddling a projection edge is kept or dropped wholesale; the residual
+/// edge error is at most one group, consistent with the byte-quantile heuristic.
 fn sample_anchors(
     index: &SsTableIndexOwned,
     data_end_offset: u64,
     max_anchors: usize,
+    effective_range: &BytesRange,
 ) -> Vec<(Bytes, u64)> {
     let borrowed = index.borrow();
     let blocks = borrowed.block_meta();
@@ -268,7 +305,9 @@ fn sample_anchors(
         // Blocks are contiguous, so the group's size is the gap from its first
         // block's offset to its last block's end offset.
         let bytes = block_end(group_end - 1).saturating_sub(first.offset());
-        anchors.push((key, bytes));
+        if effective_range.contains(&key) {
+            anchors.push((key, bytes));
+        }
         block = group_end;
     }
     anchors
@@ -282,6 +321,36 @@ mod tests {
     /// A key for keyspace position `i`, fixed-width so byte order matches `i`.
     fn k(i: u64) -> Bytes {
         Bytes::copy_from_slice(format!("k{i:010}").as_bytes())
+    }
+
+    /// Builds an `SsTableIndexOwned` from `(first_key, offset)` block entries,
+    /// matching the flatbuffer layout the SST writer produces, so
+    /// `sample_anchors` can be exercised directly.
+    fn build_index(blocks: &[(Bytes, u64)]) -> SsTableIndexOwned {
+        use crate::flatbuffer_types::{BlockMeta, BlockMetaArgs, SsTableIndex, SsTableIndexArgs};
+        let mut fbb = flatbuffers::FlatBufferBuilder::new();
+        let metas: Vec<_> = blocks
+            .iter()
+            .map(|(key, offset)| {
+                let first_key = fbb.create_vector(key);
+                BlockMeta::create(
+                    &mut fbb,
+                    &BlockMetaArgs {
+                        offset: *offset,
+                        first_key: Some(first_key),
+                    },
+                )
+            })
+            .collect();
+        let vector = fbb.create_vector(&metas);
+        let index = SsTableIndex::create(
+            &mut fbb,
+            &SsTableIndexArgs {
+                block_meta: Some(vector),
+            },
+        );
+        fbb.finish(index, None);
+        SsTableIndexOwned::new(Bytes::copy_from_slice(fbb.finished_data())).unwrap()
     }
 
     fn assert_covering_ranges(ranges: &[BytesRange]) {
@@ -318,8 +387,8 @@ mod tests {
     }
 
     #[test]
-    fn test_should_not_split_inputs_below_max_sst_size() {
-        // given: 200 bytes of input but a 1000-byte max_sst_size floor
+    fn test_should_not_split_inputs_below_floor() {
+        // given: 200 bytes of input but a 1000-byte floor
         let anchors = vec![(k(0), 100), (k(100), 100)];
 
         // when: boundaries are selected with the floor above the total size
@@ -343,6 +412,46 @@ mod tests {
         assert_eq!(ranges[0].end_bound(), Excluded(&k(10)));
         assert_eq!(ranges[1].end_bound(), Excluded(&k(20)));
         assert_eq!(ranges[2].end_bound(), Excluded(&k(30)));
+    }
+
+    #[test]
+    fn test_should_divide_evenly_with_many_anchors_per_subcompaction() {
+        // given: 16 equal anchors (total 160) and a floor (25) well below the
+        // keyspace, so the floor never binds and each subcompaction spans
+        // several anchors (target = 160 / 4 = 40, four anchors apiece)
+        let anchors: Vec<(Bytes, u64)> = (0..16).map(|i| (k(i), 10)).collect();
+
+        // when: boundaries are selected for four subcompactions
+        let ranges = select_boundaries(anchors, 4, 25);
+
+        // then: the keyspace divides into four even ranges at the 40/80/120-byte
+        // quantiles (k(4), k(8), k(12)) rather than fragmenting at the floor
+        assert_covering_ranges(&ranges);
+        assert_eq!(ranges.len(), 4);
+        assert_eq!(ranges[0].end_bound(), Excluded(&k(4)));
+        assert_eq!(ranges[1].end_bound(), Excluded(&k(8)));
+        assert_eq!(ranges[2].end_bound(), Excluded(&k(12)));
+    }
+
+    #[test]
+    fn test_should_split_into_fewer_ranges_when_floor_binds() {
+        // given: 8 anchors (total 400) with a floor (100) above the even-split
+        // size (400 / 8 = 50) but still below the total. The floor binds and
+        // raises the target to 100, so each range must carry a full input SST's
+        // worth of data.
+        let anchors: Vec<(Bytes, u64)> = (0..8).map(|i| (k(i), 50)).collect();
+
+        // when: boundaries are selected for eight subcompactions
+        let ranges = select_boundaries(anchors, 8, 100);
+
+        // then: the floor coarsens the split to total / floor = 4 ranges (each
+        // 100 bytes) rather than the requested 8 — it still splits (unlike the
+        // floor >= total case), just into fewer, larger ranges.
+        assert_covering_ranges(&ranges);
+        assert_eq!(ranges.len(), 4);
+        assert_eq!(ranges[0].end_bound(), Excluded(&k(2)));
+        assert_eq!(ranges[1].end_bound(), Excluded(&k(4)));
+        assert_eq!(ranges[2].end_bound(), Excluded(&k(6)));
     }
 
     #[test]
@@ -411,5 +520,35 @@ mod tests {
         // here explicitly.
         assert_covering_ranges(&ranges);
         assert!(ranges.len() > 1);
+    }
+
+    #[test]
+    fn test_sample_anchors_keeps_all_blocks_without_projection() {
+        // given: a 4-block index spanning k(0)..k(30), 100 bytes per block
+        let index = build_index(&[(k(0), 0), (k(10), 100), (k(20), 200), (k(30), 300)]);
+
+        // when: sampling with an unbounded effective range (no projection)
+        let anchors = sample_anchors(&index, 400, MAX_ANCHORS_PER_SST, &BytesRange::unbounded());
+
+        // then: every block becomes an anchor weighted by its on-disk size
+        assert_eq!(
+            anchors,
+            vec![(k(0), 100), (k(10), 100), (k(20), 100), (k(30), 100)]
+        );
+    }
+
+    #[test]
+    fn test_sample_anchors_clips_to_projected_effective_range() {
+        // given: the same 4-block index, but a projection that hides the first
+        // and last blocks (effective_range = the view's visible keys)
+        let index = build_index(&[(k(0), 0), (k(10), 100), (k(20), 200), (k(30), 300)]);
+        let effective_range = BytesRange::new(Included(k(10)), Excluded(k(30)));
+
+        // when: sampling the projected view
+        let anchors = sample_anchors(&index, 400, MAX_ANCHORS_PER_SST, &effective_range);
+
+        // then: only the visible blocks contribute anchors and bytes, so the
+        // planner never splits on keys or byte totals the compaction can't see.
+        assert_eq!(anchors, vec![(k(10), 100), (k(20), 100)]);
     }
 }


### PR DESCRIPTION
## Summary

This change introduces the subcompaction splitting algorithm and some changes to the RFC to make the heuristic more appropriate for overlapping ranges. Instead of splitting only on SST boundaries, we now select "anchor points" based on the SST index so that we can select points that are within a single SST, up to some limit.

See #1749 

## Changes

- RFC-0028 updated with new anchor algorithm (based on RocksDB)
- Compaction planning now plans multiple subcompactions

## Notes for Reviewers

After giving this some thought, I'm not convinced there's too much we can do to help L0-only compactions (e.g. 4 L0s -> 1 SR). This is because the default minimum input size for a subcomapction is the max sst size, which is (by default) 4x the l0 sst size (256MB and 64MB respectively). That means unless you compact >4 SSTs, you won't even leverage subcompactions at all.

This will be quite helpful if we're merging L0s and an SR into a new SR (e.g. leveled-like compaction). It's still mostly there for extremely large compactions (e.g. for the bottom tier).

## Benchmark

16GB compaction on a very beefy node (`c8in.8xlarge: 32 CPUs, 50 Gbps network`):

```
  ┌─────┬──────────┬─────────┬────────────┬─────────┬──────┐
  │ sub │ total ms │ speedup │ efficiency │ rx MB/s │ CPU% │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 1   │ 157,010  │ 1.0×    │ —          │ 114     │ 2%   │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 4   │ 37,350   │ 4.21×   │ 105%       │ 497     │ 8%   │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 8   │ 20,490   │ 7.66×   │ 96%        │ 925     │ 16%  │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 12  │ 13,990   │ 11.2×   │ 93%        │ 1383    │ 25%  │
  └─────┴──────────┴─────────┴────────────┴─────────┴──────┘
```


## Benchmark History Log

<details>
<summary>
 Expand to see full benchmark history
</summary>

I ran a naive benchmark on 16x 1GB SSTs to show the difference. It uses https://github.com/agavra/slatedb/tree/subcompaction-dst-bench which I will push as the last PR in the stack once this is merged.

```
  ┌────────────────────┬────────┬─────────┐
  │ max_subcompactions │  mean  │ speedup │
  ├────────────────────┼────────┼─────────┤
  │ 1                  │ 58.4 s │ 1.0×    │
  ├────────────────────┼────────┼─────────┤
  │ 4                  │ 24.3 s │ 2.40×   │
  ├────────────────────┼────────┼─────────┤
  │ 8                  │ 23.7 s │ 2.46×   │
  └────────────────────┴────────┴─────────┘
```

### Update 1: Network Bottleneck

Looks like we were hitting the burst limits on the `c7.2xlarge` instance I was running it on:
```
  - The ENA bw_in/out_allowance_exceeded counters fire in the millions on every 
  parallel run. That's the instance literally being shaped for exceeding its 
  network allowance. Combined rx+tx at sub=8 ≈ 14.6 Gbps (~7.7 in / ~6.9 out), 
  far above the c7i.2xlarge ~3.1 Gbps sustained baseline — it's running on 
  burst and getting throttled.
```

### Update 2: `c7gn.2xlarge`

Currently running on a 25Gbps network optimized machine to see if we can push it further for speedup ratios.

Looks like now I don't hit network throttles but CPU is also a bottleneck, so I need both faster machines and beefier netowrks. Trying again with a `c8in.8xlarge` temporarily.

```

  ┌─────┬───────────────────────────────────────────────┬───────────────────────────────────────────┐
  │ sub │       c7i.2xlarge (3.1 Gbps base, x86)        │    c7gn.2xlarge (25 Gbps base, arm64)     │
  ├─────┼───────────────────────────────────────────────┼───────────────────────────────────────────┤
  │ 1   │ 50.2 s · rx 358 MB/s · cpu 27% · bw_exc ~1.9M │ 67.7 s · rx 267 MB/s · cpu 21% · bw_exc 0 │
  ├─────┼───────────────────────────────────────────────┼───────────────────────────────────────────┤
  │ 8   │ 21.1 s · rx 960 · cpu 85% · bw_exc ~4.1M      │ 19.4 s · rx 1051 · cpu 80% · bw_exc ~0    │
  ├─────┼───────────────────────────────────────────────┼───────────────────────────────────────────┤


  ┌────────────────────┬─────────────────────────────┬─────────┬───────────────────────────────┬─────────┐
  │ max_subcompactions │ c7i.2xlarge (3.1 Gbps, x86) │ speedup │ c7gn.2xlarge (25 Gbps, arm64) │ speedup │
  ├────────────────────┼─────────────────────────────┼─────────┼───────────────────────────────┼─────────┤
  │ 1                  │ 50,150 ms                   │ 1.00×   │ 67,690 ms                     │ 1.00×   │
  ├────────────────────┼─────────────────────────────┼─────────┼───────────────────────────────┼─────────┤
  │ 8                  │ 21,130 ms                   │ 2.37×   │ 19,400 ms                     │ 3.49×   │
  ├────────────────────┼─────────────────────────────┼─────────┼───────────────────────────────┼─────────┤
```

I think there may have also been some memory pressure. 

### Update 3: `c8in.8xlarge`

Just tossing a very large machine at this to see where we get. Looks like this allows us to push it further, so there definitely was some hardware bottleneck earlier:

```
  c8in.8xlarge (32 vCPU, 50 Gbps), sub ∈ {1,4,8,12}

  ┌─────┬────────┬──────────────────┬─────────┬──────┬───────────┐
  │ sub │   ms   │ speedup vs sub=1 │ rx MB/s │ CPU% │ bw_in_exc │
  ├─────┼────────┼──────────────────┼─────────┼──────┼───────────┤
  │ 1   │ 53,090 │ 1.00×            │ 340     │ 6%   │ 0         │
  ├─────┼────────┼──────────────────┼─────────┼──────┼───────────┤
  │ 4   │ 16,440 │ 3.23×            │ 1166    │ 21%  │ 0         │
  ├─────┼────────┼──────────────────┼─────────┼──────┼───────────┤
  │ 8   │ 10,770 │ 4.93×            │ 1888    │ 34%  │ ~85k      │
  ├─────┼────────┼──────────────────┼─────────┼──────┼───────────┤
  │ 12  │ 9,320  │ 5.70×            │ 2312    │ 47%  │ ~330k     │
  └─────┴────────┴──────────────────┴─────────┴──────┴───────────┘
```

### Update 4: Tiling

Built to look like a real LSM compaction:
  - 12 "base" SSTs, each owning a separate, non-overlapping slice of the key range (a sorted run cut into pieces).
  - 4 "update" SSTs, each spanning the whole key range (the recent changes layered on top).
  - Net effect: any given key lives in ~5 of the 16 files (its one base slice + the 4 updates).

This helps us improve the subcompaction efficiency compared to the original fully overlapping 16x 1GB SSTs

```
  ┌─────┬──────────┬─────────┬────────────┬─────────┬──────┐
  │ sub │ total ms │ speedup │ efficiency │ rx MB/s │ CPU% │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 1   │ 157,010  │ 1.0×    │ —          │ 114     │ 2%   │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 4   │ 37,350   │ 4.21×   │ 105%       │ 497     │ 8%   │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 8   │ 20,490   │ 7.66×   │ 96%        │ 925     │ 16%  │
  ├─────┼──────────┼─────────┼────────────┼─────────┼──────┤
  │ 12  │ 13,990   │ 11.2×   │ 93%        │ 1383    │ 25%  │
  └─────┴──────────┴─────────┴────────────┴─────────┴──────┘
```
</details>

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
