### PR TITLE
test(dst): calibrate deterministic simulation runs

### DIFF
--- a/slatedb-dst/src/scenarios.rs
+++ b/slatedb-dst/src/scenarios.rs
@@ -214,6 +214,7 @@ fn run_seed_once(
         // explicit memtable flushes will trigger real compaction during the run.
         settings.l0_sst_size_bytes = 1024;
         settings.l0_max_ssts = 4;
+        settings.max_unflushed_bytes = 64 * 1024;
         settings.manifest_poll_interval = Duration::from_millis(10);
         // Disable since we're using the standalone compactor actor.
         settings.compactor_options = None;

--- a/slatedb-dst/tests/determinism.rs
+++ b/slatedb-dst/tests/determinism.rs
@@ -24,7 +24,7 @@ type TestResult<T> = Result<T, TestError>;
 
 #[rstest]
 #[cfg_attr(not(slow), case::regular(4, 200))]
-#[cfg_attr(slow, case::slow(2, 10_000))]
+#[cfg_attr(slow, case::slow(2, 4_000_000))]
 fn test_dst_is_deterministic(
     #[case] simulations: u32,
     #[case] shutdown_at_ms: i64,

--- a/slatedb-dst/tests/segments.rs
+++ b/slatedb-dst/tests/segments.rs
@@ -32,7 +32,7 @@ type TestResult<T> = Result<T, TestError>;
 
 #[rstest]
 #[cfg_attr(not(slow), case::regular(4, 200))]
-#[cfg_attr(slow, case::slow(2, 10_000))]
+#[cfg_attr(slow, case::slow(2, 2_400_000))]
 fn test_dst_segments_is_deterministic(
     #[case] simulations: u32,
     #[case] shutdown_at_ms: i64,


### PR DESCRIPTION
## Summary

Caps DST `max_unflushed_bytes` at 64KiB so tiny-L0 scenarios do not build a huge close-time flush backlog. Also retunes the slow determinism and segment runs to about 10 minutes locally.

## Changes

- Set DST `max_unflushed_bytes` directly to `64 * 1024`
- Bump slow determinism to `4_000_000ms`
- Bump slow segment determinism to `2_400_000ms`

## Notes for Reviewers

Validated with `cargo fmt`, targeted regular DST tests, and slow determinism/segment nextest runs.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant