### PR TITLE
lower metric verbosity for duplicate metric registrations

### DIFF
--- a/slatedb-common/src/metrics.rs
+++ b/slatedb-common/src/metrics.rs
@@ -448,6 +448,7 @@ impl HistogramFn for DefaultHistogram {
 }
 
 // Metadata for a registered metric in the default recorder.
+#[derive(Debug)]
 enum DefaultMetricHandle {
     Counter(Arc<DefaultCounter>),
     Gauge(Arc<DefaultGauge>),
@@ -490,7 +491,7 @@ impl DefaultMetricsRecorder {
             .iter()
             .find(|e| e.name == name && e.labels == labels);
         if entry.is_some() {
-            log::warn!("duplicate metric registration: name={name}, labels={labels:?}");
+            log::debug!("duplicate metric registration: name={name}, labels={labels:?}");
         }
         entry
     }
@@ -554,6 +555,12 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         if let Some(entry) = Self::find_duplicate(&entries, name, &canonical) {
             if let DefaultMetricHandle::Counter(ref h) = entry.handle {
                 return h.clone();
+            } else {
+                log::warn!(
+                    "duplicate metric registration with different type: name={}, labels={:?}, existing_type={:?}, expected_type=Counter",
+                    name,
+                    labels,
+                    entry.handle);
             }
         }
         let handle = Arc::new(DefaultCounter {
@@ -579,6 +586,12 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         if let Some(entry) = Self::find_duplicate(&entries, name, &canonical) {
             if let DefaultMetricHandle::Gauge(ref h) = entry.handle {
                 return h.clone();
+            } else {
+                log::warn!(
+                    "duplicate metric registration with different type: name={}, labels={:?}, existing_type={:?}, expected_type=Gauge",
+                    name,
+                    labels,
+                    entry.handle);
             }
         }
         let handle = Arc::new(DefaultGauge {
@@ -604,6 +617,12 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         if let Some(entry) = Self::find_duplicate(&entries, name, &canonical) {
             if let DefaultMetricHandle::UpDownCounter(ref h) = entry.handle {
                 return h.clone();
+            } else {
+                log::warn!(
+                    "duplicate metric registration with different type: name={}, labels={:?}, existing_type={:?}, expected_type=UpDownCounter",
+                    name,
+                    labels,
+                    entry.handle);
             }
         }
         let handle = Arc::new(DefaultUpDownCounter {
@@ -630,6 +649,12 @@ impl MetricsRecorder for DefaultMetricsRecorder {
         if let Some(entry) = Self::find_duplicate(&entries, name, &canonical) {
             if let DefaultMetricHandle::Histogram(ref h) = entry.handle {
                 return h.clone();
+            } else {
+                log::warn!(
+                    "duplicate metric registration with different type: name={}, labels={:?}, existing_type={:?}, expected_type=Histogram",
+                    name,
+                    labels,
+                    entry.handle);
             }
         }
         let handle = Arc::new(DefaultHistogram::new(boundaries));


### PR DESCRIPTION
## Summary

@Barre started seeing this recently:

```
2026-06-24T13:30:17.215257Z  WARN slatedb_common::metrics: duplicate metric registration: name=slatedb.compactor.worker_last_heartbeat_ms, labels=[("worker_id", "01KVWWGXZ63MFP8AKGC7CMME91")]
```

>   Root cause: CompactorEventHandler::update_distributed_compaction_metrics caches worker_last_heartbeat_ms gauge handles by worker_id, but then drops handles for workers that no longer own an in-flight job. The default recorder keeps the registered metric series anyway. When the same worker later claims another job, the compactor tries to register the same (metric, worker_id) again, and DefaultMetricsRecorder warns but returns the existing handle.

We have a few options on how we can fix this:

1. Turn down the verbosity in the logging and allow the compactor to continue re-registering workers
2. Add some form of "remove" to metrics recorders so we can remove metrics when we want to drop them. This came up in another discussion recently as well.
3. Don't prune the metrics to only workers that own jobs. This could grow unbounded, but in reality will be as large as the number of worker ULIDs that are generated. Could get large over time if workers are restarted repeatedly, but seems unlikely to go into the billions.

I opted for (1) in this PR.

## Changes

- debug log when a duplicate metric is registered
- warn when a duplicate metric is registered with a different type

## Notes for Reviewers

This does not address another issue in metrics.rs: if a user re-registers a metric and it's not the same type, we currently seem to insert a new metric with the same name. The current fn's are infallible, so not sure what to do there.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
