### PR TITLE
fix submit-compaction clap arg group

### DIFF
--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -234,7 +234,7 @@ pub(crate) enum CliCommands {
     /// Submit a compaction request.
     #[command(group(
         ArgGroup::new("compaction_request")
-            .args(["full", "spec"])
+            .args(["request"])
             .required(true)
     ))]
     SubmitCompaction {


### PR DESCRIPTION
## Summary

(Codex generated this while I was working on something else trying to trigger a full compaction)

Fixes the `slatedb-cli submit-compaction` clap argument group so it references the real `--request` argument instead of nonexistent `full` / `spec` argument ids.

## Root cause

`SubmitCompaction` declared a required `ArgGroup` containing `full` and `spec`, but the command only exposes `request: CompactionRequest`. Clap validates group members when building the command, so even `submit-compaction --help` panicked before argument parsing.

## Impact

`submit-compaction --help` now renders normally, and invoking `submit-compaction` without `--request` returns a normal clap missing-argument error.

## Validation

```sh
cargo run -p slatedb-cli -- -p /tmp/slatedb-check submit-compaction --help
cargo run -p slatedb-cli -- -p /tmp/slatedb-check submit-compaction
```