### PR TITLE
fix: merge_remote_compactions should accept stale terminal/compacted entries

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -875,25 +875,33 @@ impl CompactorState {
             merged.insert(compaction.id(), compaction.clone());
         }
 
-        // For compactions not in local state (Vacant), only accept `Submitted`. This
-        // is the only state the coordinator hasn't authored yet (external submissions,
-        // admin tools, reloaded `.compactions`). All later states (`Scheduled`,
-        // `Running`, `Compacted`, `Completed`, `Failed`) are downstream of the
-        // coordinator having seen the entry as `Submitted` and promoted it to
-        // `Scheduled`, so a Vacant entry in any of those states is anomalous and
-        // logged.
+        // For compactions not in local state (Vacant), accept new submissions and
+        // retained terminal entries. On a write conflict, the retry path reloads and
+        // merges the persisted `.compactions` object before writing again. At that
+        // point, local state may already have completed a newer compaction and pruned
+        // the previous terminal entry, while persisted state still contains that older
+        // Completed/Failed entry. Treat it as retained history and let the combined
+        // retain pass choose the newest terminal entry. Active states beyond Submitted
+        // are different: the coordinator must have seen those entries before workers
+        // can claim, run, or compact them, so a vacant Scheduled/Running/Compacted
+        // entry is anomalous.
         for compaction in remote_compactions.value.iter() {
             match merged.entry(compaction.id()) {
-                Entry::Vacant(v) => {
-                    if !matches!(compaction.status(), CompactionStatus::Submitted) {
+                Entry::Vacant(v) => match compaction.status() {
+                    CompactionStatus::Submitted
+                    | CompactionStatus::Completed
+                    | CompactionStatus::Failed => {
+                        v.insert(compaction.clone());
+                    }
+                    CompactionStatus::Scheduled
+                    | CompactionStatus::Running
+                    | CompactionStatus::Compacted => {
                         error!(
-                            "skipping remote compaction with unexpected (non-Submitted) status [compaction={:?}]",
+                            "skipping remote active compaction absent from local state [compaction={:?}]",
                             compaction,
                         );
-                        continue;
                     }
-                    v.insert(compaction.clone());
-                }
+                },
                 Entry::Occupied(mut o) => {
                     if o.get()
                         .status

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -281,7 +281,7 @@ impl CompactionStatus {
     /// State transitions made by CompactionWorker that should be accepted into local state
     /// during [`CompactorState::merge_remote_compactions`]
     ///
-    /// For known compactions (Occupied), accept these remote transitions:
+    /// For known active compactions (Occupied), accept these remote transitions:
     ///   - `Compacted`: the worker's signal that execution finished; the
     ///     coordinator must commit the output SSTs to the manifest.
     ///   - `Scheduled → Running`: a worker has claimed the job; adopt the
@@ -297,15 +297,21 @@ impl CompactionStatus {
     ///   - `Running -> Running`: should accept heartbeat updates when heartbeats
     ///     land for a job that is already in local state
     ///
+    /// Terminal local states are not overwritten by a remote `Compacted` entry.
+    /// The coordinator writes the manifest before `.compactions`, so local
+    /// `Completed`/`Failed` can be ahead of a stale persisted `Compacted` result.
+    ///
     /// All other remote updates are ignored.
     fn should_adopt_state_transition(&self, updated_status: CompactionStatus) -> bool {
         match self {
+            Self::Submitted => matches!(updated_status, Self::Compacted),
             Self::Scheduled => matches!(updated_status, Self::Running | Self::Compacted),
             Self::Running => matches!(
                 updated_status,
                 Self::Scheduled | Self::Running | Self::Compacted
             ),
-            _ => matches!(updated_status, Self::Compacted),
+            Self::Compacted => matches!(updated_status, Self::Compacted),
+            Self::Completed | Self::Failed => false,
         }
     }
 }
@@ -875,27 +881,25 @@ impl CompactorState {
             merged.insert(compaction.id(), compaction.clone());
         }
 
-        // For compactions not in local state (Vacant), accept new submissions and
-        // retained terminal entries. On a write conflict, the retry path reloads and
-        // merges the persisted `.compactions` object before writing again. At that
-        // point, local state may already have completed a newer compaction and pruned
-        // the previous terminal entry, while persisted state still contains that older
-        // Completed/Failed entry. Treat it as retained history and let the combined
-        // retain pass choose the newest terminal entry. Active states beyond Submitted
-        // are different: the coordinator must have seen those entries before workers
-        // can claim, run, or compact them, so a vacant Scheduled/Running/Compacted
-        // entry is anomalous.
+        // For compactions not in local state (Vacant), accept new submissions,
+        // worker-completed results, and retained terminal entries. On a write
+        // conflict, the retry path reloads and merges the persisted `.compactions`
+        // object before writing again. At that point, local state may already have
+        // committed or pruned an entry while persisted state still contains an older
+        // Compacted/Completed/Failed view. Insert those entries and let the commit
+        // path or combined retain pass resolve them. Scheduled/Running are different:
+        // they carry no finished output and require prior coordinator ownership, so
+        // seeing them absent from local state remains anomalous.
         for compaction in remote_compactions.value.iter() {
             match merged.entry(compaction.id()) {
                 Entry::Vacant(v) => match compaction.status() {
                     CompactionStatus::Submitted
+                    | CompactionStatus::Compacted
                     | CompactionStatus::Completed
                     | CompactionStatus::Failed => {
                         v.insert(compaction.clone());
                     }
-                    CompactionStatus::Scheduled
-                    | CompactionStatus::Running
-                    | CompactionStatus::Compacted => {
+                    CompactionStatus::Scheduled | CompactionStatus::Running => {
                         error!(
                             "skipping remote active compaction absent from local state [compaction={:?}]",
                             compaction,

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -886,10 +886,12 @@ impl CompactorState {
         // conflict, the retry path reloads and merges the persisted `.compactions`
         // object before writing again. At that point, local state may already have
         // committed or pruned an entry while persisted state still contains an older
-        // Compacted/Completed/Failed view. Insert those entries and let the commit
-        // path or combined retain pass resolve them. Scheduled/Running are different:
-        // they carry no finished output and require prior coordinator ownership, so
-        // seeing them absent from local state remains anomalous.
+        // Compacted/Completed/Failed view. Insert those entries, let the commit path
+        // resolve stale Compacted entries via `validate_compaction`, and let the compactions
+        // write path resolve stale terminal entries via `retain_active_and_last_finished`.
+        //
+        // Scheduled/Running are different: they carry no finished output and require prior
+        // coordinator ownership, so seeing them absent from local state remains anomalous.
         for compaction in remote_compactions.value.iter() {
             match merged.entry(compaction.id()) {
                 Entry::Vacant(v) => match compaction.status() {


### PR DESCRIPTION
## Summary

@Barre was seeing errors when running distributed compaction where there was a compaction in a terminal state held remotely that the coordinator did not have in it's local view. This can happen when `write_compactions_safely` fails to write a new `.compactions` file due to sequenced write conflict (e.g. conflict with a worker heartbeat or admin tool). On retrying this write, the coordinator attempts to merge remote compactions again, and it's last retained terminal compaction may already differ from what is held remotely. 


### Update

@Barre also started seeing errors where remote compacted entries were seen as Vacant by the coordinator and skipped during merge. I had codex help me trace how this happens and it looks right to me.

This trace starts from the CommitCompacted ticker handler:

  1. `load_compactions()`  calls `merge_remote_compactions()`. slatedb/src/compactor.rs:555

  2. `commit_compacted_entries()` collects all Compacted entries, so one commit pass can handle multiple worker results. slatedb/src/compactor.rs:868

  3. It loops over that whole batch and finishes each compaction in memory. slatedb/src/compactor.rs:878

  4. `finish_compaction()` applies each result to the in-memory manifest and marks that compaction Completed. slatedb/src/compactor_state.rs:1113

  5. Marking the compaction Completed goes through update_compaction(), which immediately runs retention. slatedb/src/compactor_state.rs:1030

  6. Retention keeps active compactions plus only the newest terminal compaction, so an older just-completed compaction can be removed from local state if a newer terminal compaction exists. slatedb/src/compactor_state.rs:759

  7. Only after the whole batch is processed does the coordinator persist state. slatedb/src/compactor.rs:912

  8. Persistence writes the manifest first, then .compactions. slatedb/src/compactor_state_protocols.rs:326

  9. If the .compactions write conflicts, the retry path reloads and merges persisted .compactions again. slatedb/src/compactor_state_protocols.rs:308

Net result: local state may have already completed and pruned compaction A, while persisted .compactions still says A = Compacted, so merge sees A as vacant locally and Compacted remotely.



## Changes
Merge all terminal compactions found in the remote object store and allow `retain_active_and_last_finished()` to decide which one the coordinator should keep in its local view.

Merge remote Compacted entries and let the next `commit_compacted_entries()` call mark it terminal via `validate_compaction()`  compactor.rs:880

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
