### PR TITLE
Add merge operator to admin builder

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -32,6 +32,7 @@ use ulid::Ulid;
 use uuid::Uuid;
 
 pub use crate::db::builder::AdminBuilder;
+use crate::merge_operator::MergeOperatorType;
 use slatedb_txn_obj::TransactionalObject;
 
 /// An Admin struct for SlateDB administration operations.
@@ -51,6 +52,7 @@ pub struct Admin {
     #[cfg(feature = "compaction_filters")]
     pub(crate) compaction_filter_supplier:
         Option<Arc<dyn crate::compaction_filter::CompactionFilterSupplier>>,
+    pub(crate) merge_operator: Option<MergeOperatorType>,
 }
 
 impl Admin {
@@ -377,6 +379,10 @@ impl Admin {
         #[cfg(feature = "compaction_filters")]
         if let Some(supplier) = &self.compaction_filter_supplier {
             builder = builder.with_compaction_filter_supplier(supplier.clone());
+        }
+
+        if let Some(merge_operator) = &self.merge_operator {
+            builder = builder.with_merge_operator(merge_operator.clone());
         }
 
         let compactor = builder.build();
@@ -808,7 +814,7 @@ mod tests {
     use crate::config::{CompactionWorkerOptions, CompactorOptions, GarbageCollectorOptions};
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
-    use crate::test_utils::FlakyObjectStore;
+    use crate::test_utils::{FlakyObjectStore, StringConcatMergeOperator};
     use crate::ErrorKind;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -1282,6 +1288,16 @@ mod tests {
             .build();
 
         assert!(admin.compaction_filter_supplier.is_some());
+    }
+
+    #[test]
+    fn test_admin_builder_with_merge_operator() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let admin = AdminBuilder::new("/tmp/test_merge_operator", object_store)
+            .with_merge_operator(Arc::new(StringConcatMergeOperator))
+            .build();
+
+        assert!(admin.merge_operator.is_some());
     }
 
     #[tokio::test]

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -51,7 +51,6 @@ pub struct Admin {
     #[cfg(feature = "compaction_filters")]
     pub(crate) compaction_filter_supplier:
         Option<Arc<dyn crate::compaction_filter::CompactionFilterSupplier>>,
-    pub(crate) compactor_builder: Option<crate::CompactorBuilder<Path>>,
 }
 
 impl Admin {
@@ -366,19 +365,14 @@ impl Admin {
         cancellation_token: CancellationToken,
         options: crate::config::CompactorOptions,
     ) -> Result<(), crate::Error> {
-        let builder = match self.compactor_builder.as_ref() {
-            Some(builder) => builder.clone(),
-            None => crate::CompactorBuilder::new(
-                self.path.clone(),
-                self.object_stores.store_of(ObjectStoreType::Main).clone(),
-            ),
-        };
-
         #[allow(unused_mut)]
-        let mut builder = builder
-            .with_options(options)
-            .with_system_clock(self.system_clock.clone())
-            .with_seed(self.rand.rng().next_u64());
+        let mut builder = crate::CompactorBuilder::new(
+            self.path.clone(),
+            self.object_stores.store_of(ObjectStoreType::Main).clone(),
+        )
+        .with_options(options)
+        .with_system_clock(self.system_clock.clone())
+        .with_seed(self.rand.rng().next_u64());
 
         #[cfg(feature = "compaction_filters")]
         if let Some(supplier) = &self.compaction_filter_supplier {

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -51,6 +51,7 @@ pub struct Admin {
     #[cfg(feature = "compaction_filters")]
     pub(crate) compaction_filter_supplier:
         Option<Arc<dyn crate::compaction_filter::CompactionFilterSupplier>>,
+    pub(crate) compactor_builder: Option<crate::CompactorBuilder<Path>>,
 }
 
 impl Admin {
@@ -365,14 +366,19 @@ impl Admin {
         cancellation_token: CancellationToken,
         options: crate::config::CompactorOptions,
     ) -> Result<(), crate::Error> {
+        let builder = match self.compactor_builder.as_ref() {
+            Some(builder) => builder.clone(),
+            None => crate::CompactorBuilder::new(
+                self.path.clone(),
+                self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            ),
+        };
+
         #[allow(unused_mut)]
-        let mut builder = crate::CompactorBuilder::new(
-            self.path.clone(),
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        )
-        .with_options(options)
-        .with_system_clock(self.system_clock.clone())
-        .with_seed(self.rand.rng().next_u64());
+        let mut builder = builder
+            .with_options(options)
+            .with_system_clock(self.system_clock.clone())
+            .with_seed(self.rand.rng().next_u64());
 
         #[cfg(feature = "compaction_filters")]
         if let Some(supplier) = &self.compaction_filter_supplier {

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -762,6 +762,7 @@ pub struct AdminBuilder<P: Into<Path>> {
     rand: Arc<DbRand>,
     #[cfg(feature = "compaction_filters")]
     compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
+    merge_operator: Option<MergeOperatorType>,
 }
 
 impl<P: Into<Path>> AdminBuilder<P> {
@@ -775,6 +776,7 @@ impl<P: Into<Path>> AdminBuilder<P> {
             rand: Arc::new(DbRand::default()),
             #[cfg(feature = "compaction_filters")]
             compaction_filter_supplier: None,
+            merge_operator: None,
         }
     }
 
@@ -813,6 +815,12 @@ impl<P: Into<Path>> AdminBuilder<P> {
         self
     }
 
+    /// Sets the merge operator to use when running a compactor.
+    pub fn with_merge_operator(mut self, merge_operator: MergeOperatorType) -> Self {
+        self.merge_operator = Some(merge_operator);
+        self
+    }
+
     /// Builds and returns an Admin instance.
     pub fn build(self) -> Admin {
         // No retrying object stores here, since we don't want to retry admin operations
@@ -823,6 +831,7 @@ impl<P: Into<Path>> AdminBuilder<P> {
             rand: self.rand,
             #[cfg(feature = "compaction_filters")]
             compaction_filter_supplier: self.compaction_filter_supplier,
+            merge_operator: self.merge_operator,
         }
     }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -762,7 +762,6 @@ pub struct AdminBuilder<P: Into<Path>> {
     rand: Arc<DbRand>,
     #[cfg(feature = "compaction_filters")]
     compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
-    compactor_builder: Option<CompactorBuilder<P>>,
 }
 
 impl<P: Into<Path>> AdminBuilder<P> {
@@ -776,7 +775,6 @@ impl<P: Into<Path>> AdminBuilder<P> {
             rand: Arc::new(DbRand::default()),
             #[cfg(feature = "compaction_filters")]
             compaction_filter_supplier: None,
-            compactor_builder: None,
         }
     }
 
@@ -815,11 +813,6 @@ impl<P: Into<Path>> AdminBuilder<P> {
         self
     }
 
-    pub fn with_compactor_builder(mut self, compactor_builder: CompactorBuilder<P>) -> Self {
-        self.compactor_builder = Some(compactor_builder);
-        self
-    }
-
     /// Builds and returns an Admin instance.
     pub fn build(self) -> Admin {
         // No retrying object stores here, since we don't want to retry admin operations
@@ -830,9 +823,6 @@ impl<P: Into<Path>> AdminBuilder<P> {
             rand: self.rand,
             #[cfg(feature = "compaction_filters")]
             compaction_filter_supplier: self.compaction_filter_supplier,
-            compactor_builder: self
-                .compactor_builder
-                .map(|builder| builder.into_path_builder()),
         }
     }
 }
@@ -1017,7 +1007,6 @@ pub(crate) struct CompactorHandlers {
 /// Builder for creating new Compactor instances.
 ///
 /// This provides a fluent API for configuring a Compactor object.
-#[derive(Clone)]
 pub struct CompactorBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -762,6 +762,7 @@ pub struct AdminBuilder<P: Into<Path>> {
     rand: Arc<DbRand>,
     #[cfg(feature = "compaction_filters")]
     compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
+    compactor_builder: Option<CompactorBuilder<P>>,
 }
 
 impl<P: Into<Path>> AdminBuilder<P> {
@@ -775,6 +776,7 @@ impl<P: Into<Path>> AdminBuilder<P> {
             rand: Arc::new(DbRand::default()),
             #[cfg(feature = "compaction_filters")]
             compaction_filter_supplier: None,
+            compactor_builder: None,
         }
     }
 
@@ -813,6 +815,11 @@ impl<P: Into<Path>> AdminBuilder<P> {
         self
     }
 
+    pub fn with_compactor_builder(mut self, compactor_builder: CompactorBuilder<P>) -> Self {
+        self.compactor_builder = Some(compactor_builder);
+        self
+    }
+
     /// Builds and returns an Admin instance.
     pub fn build(self) -> Admin {
         // No retrying object stores here, since we don't want to retry admin operations
@@ -823,6 +830,9 @@ impl<P: Into<Path>> AdminBuilder<P> {
             rand: self.rand,
             #[cfg(feature = "compaction_filters")]
             compaction_filter_supplier: self.compaction_filter_supplier,
+            compactor_builder: self
+                .compactor_builder
+                .map(|builder| builder.into_path_builder()),
         }
     }
 }
@@ -1007,6 +1017,7 @@ pub(crate) struct CompactorHandlers {
 /// Builder for creating new Compactor instances.
 ///
 /// This provides a fluent API for configuring a Compactor object.
+#[derive(Clone)]
 pub struct CompactorBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,


### PR DESCRIPTION
## Summary

Adds the merge operator to the admin builder. The merge operator is needed by the compactor builder to construct a compactor when `run_compactor()` is called on the admin. Without the merge operator the compactor will fail to compact databases that contain merges.

Closes https://github.com/slatedb/slatedb/issues/1832

## Changes
- adds merge operator to admin builder
- adds merge operator to admin
- passes merge operator to compactor builder
- adds a unit test

## Notes for Reviewers

nothing

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
