### PR TITLE
[bindings] add unit tests for new admin checkpoint methods

### DIFF
--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -1965,6 +1965,476 @@ func TestAdminClone(t *testing.T) {
 	}
 }
 
+func TestAdminCreateDetachedCheckpointWithoutOptions(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	options := slatedb.CheckpointOptions{
+		LifetimeMs: nil,
+		Source:     nil,
+		Name:       nil,
+	}
+	result, err := admin.CreateDetachedCheckpoint(options)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(): %v", err)
+	}
+
+	if result.Id == "" {
+		t.Fatal("CreateDetachedCheckpoint(): got empty id")
+	}
+	if result.ManifestId == 0 {
+		t.Fatal("CreateDetachedCheckpoint(): got ManifestId = 0")
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 1 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 1", len(checkpoints))
+	}
+	if checkpoints[0].Id != result.Id {
+		t.Fatalf("checkpoint id: got %q, want %q", checkpoints[0].Id, result.Id)
+	}
+	if checkpoints[0].ManifestId != result.ManifestId {
+		t.Fatalf("checkpoint manifest_id: got %d, want %d", checkpoints[0].ManifestId, result.ManifestId)
+	}
+	if checkpoints[0].Name != nil {
+		t.Fatalf("checkpoint name: got %v, want nil", *checkpoints[0].Name)
+	}
+	if checkpoints[0].ExpireTimeSecs != nil {
+		t.Fatalf("checkpoint expire_time_secs: got %v, want nil", *checkpoints[0].ExpireTimeSecs)
+	}
+}
+
+func TestAdminCreateDetachedCheckpointWithLifetime(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	lifetimeMs := uint64(60_000)
+	options := slatedb.CheckpointOptions{
+		LifetimeMs: &lifetimeMs,
+		Source:     nil,
+		Name:       nil,
+	}
+	result, err := admin.CreateDetachedCheckpoint(options)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(): %v", err)
+	}
+
+	if result.Id == "" {
+		t.Fatal("CreateDetachedCheckpoint(): got empty id")
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 1 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 1", len(checkpoints))
+	}
+
+	checkpoint := checkpoints[0]
+	if checkpoint.Id != result.Id {
+		t.Fatalf("checkpoint id: got %q, want %q", checkpoint.Id, result.Id)
+	}
+	if checkpoint.ExpireTimeSecs == nil {
+		t.Fatal("checkpoint expire_time_secs: got nil, want non-nil")
+	}
+	if *checkpoint.ExpireTimeSecs <= checkpoint.CreateTimeSecs {
+		t.Fatalf("checkpoint expire_time_secs: got %d, want > %d", *checkpoint.ExpireTimeSecs, checkpoint.CreateTimeSecs)
+	}
+
+	expectedExpireSecs := checkpoint.CreateTimeSecs + int64(lifetimeMs/1000)
+	delta := *checkpoint.ExpireTimeSecs - expectedExpireSecs
+	if delta < -2 || delta > 2 {
+		t.Fatalf("checkpoint expire_time_secs: got %d, want approximately %d", *checkpoint.ExpireTimeSecs, expectedExpireSecs)
+	}
+}
+
+func TestAdminCreateDetachedCheckpointWithName(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	checkpointName := "backup-2026-06-25"
+	options := slatedb.CheckpointOptions{
+		LifetimeMs: nil,
+		Source:     nil,
+		Name:       &checkpointName,
+	}
+	result, err := admin.CreateDetachedCheckpoint(options)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(): %v", err)
+	}
+
+	if result.Id == "" {
+		t.Fatal("CreateDetachedCheckpoint(): got empty id")
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 1 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 1", len(checkpoints))
+	}
+	if checkpoints[0].Id != result.Id {
+		t.Fatalf("checkpoint id: got %q, want %q", checkpoints[0].Id, result.Id)
+	}
+	if checkpoints[0].Name == nil || *checkpoints[0].Name != checkpointName {
+		t.Fatalf("checkpoint name: got %v, want %q", checkpoints[0].Name, checkpointName)
+	}
+
+	filteredByName, err := admin.ListCheckpoints(&checkpointName)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(name): %v", err)
+	}
+	if len(filteredByName) != 1 {
+		t.Fatalf("ListCheckpoints(name): got %d checkpoints, want 1", len(filteredByName))
+	}
+	if filteredByName[0].Id != result.Id {
+		t.Fatalf("filtered checkpoint id: got %q, want %q", filteredByName[0].Id, result.Id)
+	}
+
+	otherName := "other-name"
+	filteredOther, err := admin.ListCheckpoints(&otherName)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(other-name): %v", err)
+	}
+	if len(filteredOther) != 0 {
+		t.Fatalf("ListCheckpoints(other-name): got %d checkpoints, want 0", len(filteredOther))
+	}
+}
+
+func TestAdminCreateDetachedCheckpointFromSource(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	firstCheckpointName := "first-checkpoint"
+	firstOptions := slatedb.CheckpointOptions{
+		LifetimeMs: nil,
+		Source:     nil,
+		Name:       &firstCheckpointName,
+	}
+	firstResult, err := admin.CreateDetachedCheckpoint(firstOptions)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(first): %v", err)
+	}
+
+	secondCheckpointName := "second-checkpoint"
+	lifetimeMs := uint64(120_000)
+	secondOptions := slatedb.CheckpointOptions{
+		LifetimeMs: &lifetimeMs,
+		Source:     &firstResult.Id,
+		Name:       &secondCheckpointName,
+	}
+	secondResult, err := admin.CreateDetachedCheckpoint(secondOptions)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(second): %v", err)
+	}
+
+	if secondResult.Id == "" {
+		t.Fatal("CreateDetachedCheckpoint(second): got empty id")
+	}
+	if secondResult.ManifestId != firstResult.ManifestId {
+		t.Fatalf("second checkpoint manifest_id: got %d, want %d", secondResult.ManifestId, firstResult.ManifestId)
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 2 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 2", len(checkpoints))
+	}
+}
+
+func TestAdminRefreshCheckpointUpdatesLifetime(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	initialLifetimeMs := uint64(30_000)
+	checkpointName := "refresh-test"
+	options := slatedb.CheckpointOptions{
+		LifetimeMs: &initialLifetimeMs,
+		Source:     nil,
+		Name:       &checkpointName,
+	}
+	result, err := admin.CreateDetachedCheckpoint(options)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(): %v", err)
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	initial := checkpoints[0]
+	if initial.ExpireTimeSecs == nil {
+		t.Fatal("initial checkpoint expire_time_secs: got nil")
+	}
+	initialExpireTime := *initial.ExpireTimeSecs
+
+	time.Sleep(1 * time.Second)
+
+	newLifetimeMs := uint64(90_000)
+	if err := admin.RefreshCheckpoint(result.Id, &newLifetimeMs); err != nil {
+		t.Fatalf("RefreshCheckpoint(): %v", err)
+	}
+
+	updatedCheckpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil) after refresh: %v", err)
+	}
+	refreshed := updatedCheckpoints[0]
+	if refreshed.ExpireTimeSecs == nil {
+		t.Fatal("refreshed checkpoint expire_time_secs: got nil")
+	}
+	if *refreshed.ExpireTimeSecs <= initialExpireTime {
+		t.Fatalf("refreshed expire_time_secs: got %d, want > %d", *refreshed.ExpireTimeSecs, initialExpireTime)
+	}
+}
+
+func TestAdminRefreshCheckpointWithoutLifetime(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	options := slatedb.CheckpointOptions{
+		LifetimeMs: nil,
+		Source:     nil,
+		Name:       nil,
+	}
+	result, err := admin.CreateDetachedCheckpoint(options)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(): %v", err)
+	}
+
+	if err := admin.RefreshCheckpoint(result.Id, nil); err != nil {
+		t.Fatalf("RefreshCheckpoint(nil lifetime): %v", err)
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 1 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 1", len(checkpoints))
+	}
+	if checkpoints[0].Id != result.Id {
+		t.Fatalf("checkpoint id: got %q, want %q", checkpoints[0].Id, result.Id)
+	}
+}
+
+func TestAdminRefreshCheckpointWithInvalidIdFails(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	lifetimeMs := uint64(60_000)
+	err := admin.RefreshCheckpoint("invalid-uuid", &lifetimeMs)
+	if !errors.Is(err, slatedb.ErrErrorInvalid) {
+		t.Fatalf("RefreshCheckpoint(invalid-uuid): got %v, want invalid error", err)
+	}
+	var invalidErr *slatedb.ErrorInvalid
+	if !errors.As(err, &invalidErr) {
+		t.Fatalf("RefreshCheckpoint(invalid-uuid): expected *ErrorInvalid, got %T", err)
+	}
+	if !strings.Contains(invalidErr.Message, "invalid checkpoint_id") {
+		t.Fatalf("RefreshCheckpoint(invalid-uuid): message = %q, want substring %q", invalidErr.Message, "invalid checkpoint_id")
+	}
+}
+
+func TestAdminDeleteCheckpointRemovesCheckpoint(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	checkpointName := "delete-test"
+	options := slatedb.CheckpointOptions{
+		LifetimeMs: nil,
+		Source:     nil,
+		Name:       &checkpointName,
+	}
+	result, err := admin.CreateDetachedCheckpoint(options)
+	if err != nil {
+		t.Fatalf("CreateDetachedCheckpoint(): %v", err)
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 1 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 1", len(checkpoints))
+	}
+	if checkpoints[0].Id != result.Id {
+		t.Fatalf("checkpoint id: got %q, want %q", checkpoints[0].Id, result.Id)
+	}
+
+	if err := admin.DeleteCheckpoint(result.Id); err != nil {
+		t.Fatalf("DeleteCheckpoint(): %v", err)
+	}
+
+	waitUntil(t, 60*time.Second, 25*time.Millisecond, func() (bool, error) {
+		remaining, err := admin.ListCheckpoints(nil)
+		if err != nil {
+			return false, err
+		}
+		return len(remaining) == 0, nil
+	})
+}
+
+func TestAdminDeleteCheckpointWithInvalidIdFails(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	err := admin.DeleteCheckpoint("invalid-uuid")
+	if !errors.Is(err, slatedb.ErrErrorInvalid) {
+		t.Fatalf("DeleteCheckpoint(invalid-uuid): got %v, want invalid error", err)
+	}
+	var invalidErr *slatedb.ErrorInvalid
+	if !errors.As(err, &invalidErr) {
+		t.Fatalf("DeleteCheckpoint(invalid-uuid): expected *ErrorInvalid, got %T", err)
+	}
+	if !strings.Contains(invalidErr.Message, "invalid checkpoint_id") {
+		t.Fatalf("DeleteCheckpoint(invalid-uuid): message = %q, want substring %q", invalidErr.Message, "invalid checkpoint_id")
+	}
+}
+
+func TestAdminDeleteMultipleCheckpoints(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key1"), []byte("value1")); err != nil {
+		t.Fatalf("Put(key1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	var results []slatedb.CheckpointCreateResult
+	for i := 1; i <= 3; i++ {
+		name := fmt.Sprintf("checkpoint-%d", i)
+		options := slatedb.CheckpointOptions{
+			LifetimeMs: nil,
+			Source:     nil,
+			Name:       &name,
+		}
+		result, err := admin.CreateDetachedCheckpoint(options)
+		if err != nil {
+			t.Fatalf("CreateDetachedCheckpoint(%d): %v", i, err)
+		}
+		results = append(results, result)
+	}
+
+	checkpoints, err := admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil): %v", err)
+	}
+	if len(checkpoints) != 3 {
+		t.Fatalf("ListCheckpoints(nil): got %d checkpoints, want 3", len(checkpoints))
+	}
+
+	if err := admin.DeleteCheckpoint(results[0].Id); err != nil {
+		t.Fatalf("DeleteCheckpoint(first): %v", err)
+	}
+	checkpoints, err = admin.ListCheckpoints(nil)
+	if err != nil {
+		t.Fatalf("ListCheckpoints(nil) after first delete: %v", err)
+	}
+	for _, c := range checkpoints {
+		if c.Id == results[0].Id {
+			t.Fatalf("found deleted checkpoint %q", results[0].Id)
+		}
+	}
+
+	if err := admin.DeleteCheckpoint(results[1].Id); err != nil {
+		t.Fatalf("DeleteCheckpoint(second): %v", err)
+	}
+	if err := admin.DeleteCheckpoint(results[2].Id); err != nil {
+		t.Fatalf("DeleteCheckpoint(third): %v", err)
+	}
+
+	waitUntil(t, 60*time.Second, 25*time.Millisecond, func() (bool, error) {
+		remaining, err := admin.ListCheckpoints(nil)
+		if err != nil {
+			return false, err
+		}
+		return len(remaining) == 0, nil
+	})
+}
+
 func TestWalReaderEmptyStore(t *testing.T) {
 	store := newMemoryStore(t)
 	reader := openTestWalReader(t, store)

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
@@ -234,4 +234,293 @@ class SlateDbAdminTest {
             assertTrue(invalidTimestamp.getMessage().contains("invalid timestamp seconds"));
         }
     }
+
+    @Test
+    void adminCreateDetachedCheckpointWithoutOptions() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-create");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            CheckpointOptions options = new CheckpointOptions(null, null, null);
+            CheckpointCreateResult result = TestSupport.await(admin.createDetachedCheckpoint(options));
+
+            assertNotNull(result);
+            assertFalse(result.id().isEmpty());
+            assertTrue(result.manifestId() > 0L);
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(1, checkpoints.size());
+            assertEquals(result.id(), checkpoints.get(0).id());
+            assertEquals(result.manifestId(), checkpoints.get(0).manifestId());
+            assertNull(checkpoints.get(0).name());
+            assertNull(checkpoints.get(0).expireTimeSecs());
+        }
+    }
+
+    @Test
+    void adminCreateDetachedCheckpointWithLifetime() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-lifetime");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            long lifetimeMs = 60_000L;
+            CheckpointOptions options = new CheckpointOptions(lifetimeMs, null, null);
+            CheckpointCreateResult result = TestSupport.await(admin.createDetachedCheckpoint(options));
+
+            assertNotNull(result);
+            assertFalse(result.id().isEmpty());
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(1, checkpoints.size());
+            Checkpoint checkpoint = checkpoints.get(0);
+            assertEquals(result.id(), checkpoint.id());
+            assertNotNull(checkpoint.expireTimeSecs());
+            assertTrue(checkpoint.expireTimeSecs() > checkpoint.createTimeSecs());
+
+            long expectedExpireSecs = checkpoint.createTimeSecs() + (lifetimeMs / 1000);
+            long delta = Math.abs(checkpoint.expireTimeSecs() - expectedExpireSecs);
+            assertTrue(delta <= 2, "Expire time should be approximately create time + lifetime");
+        }
+    }
+
+    @Test
+    void adminCreateDetachedCheckpointWithName() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-name");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            String checkpointName = "backup-2026-06-25";
+            CheckpointOptions options = new CheckpointOptions(null, null, checkpointName);
+            CheckpointCreateResult result = TestSupport.await(admin.createDetachedCheckpoint(options));
+
+            assertNotNull(result);
+            assertFalse(result.id().isEmpty());
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(1, checkpoints.size());
+            assertEquals(result.id(), checkpoints.get(0).id());
+            assertEquals(checkpointName, checkpoints.get(0).name());
+
+            List<Checkpoint> filteredByName = TestSupport.await(admin.listCheckpoints(checkpointName));
+            assertEquals(1, filteredByName.size());
+            assertEquals(result.id(), filteredByName.get(0).id());
+
+            List<Checkpoint> filteredOther = TestSupport.await(admin.listCheckpoints("other-name"));
+            assertEquals(0, filteredOther.size());
+        }
+    }
+
+    @Test
+    void adminCreateDetachedCheckpointFromSource() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-source");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            CheckpointOptions firstOptions = new CheckpointOptions(null, null, "first-checkpoint");
+            CheckpointCreateResult firstResult = TestSupport.await(admin.createDetachedCheckpoint(firstOptions));
+
+            CheckpointOptions secondOptions = new CheckpointOptions(120_000L, firstResult.id(), "second-checkpoint");
+            CheckpointCreateResult secondResult = TestSupport.await(admin.createDetachedCheckpoint(secondOptions));
+
+            assertNotNull(secondResult);
+            assertFalse(secondResult.id().isEmpty());
+            assertEquals(firstResult.manifestId(), secondResult.manifestId());
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(2, checkpoints.size());
+        }
+    }
+
+    @Test
+    void adminRefreshCheckpointUpdatesLifetime() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-refresh");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            long initialLifetimeMs = 30_000L;
+            CheckpointOptions options = new CheckpointOptions(initialLifetimeMs, null, "refresh-test");
+            CheckpointCreateResult result = TestSupport.await(admin.createDetachedCheckpoint(options));
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            Checkpoint initial = checkpoints.get(0);
+            Long initialExpireTime = initial.expireTimeSecs();
+            assertNotNull(initialExpireTime);
+
+            Thread.sleep(1000);
+
+            long newLifetimeMs = 90_000L;
+            TestSupport.await(admin.refreshCheckpoint(result.id(), newLifetimeMs));
+
+            checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            Checkpoint refreshed = checkpoints.get(0);
+            assertNotNull(refreshed.expireTimeSecs());
+            assertTrue(refreshed.expireTimeSecs() > initialExpireTime,
+                    "Refreshed expire time should be later than initial");
+        }
+    }
+
+    @Test
+    void adminRefreshCheckpointWithoutLifetime() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-refresh-no-lifetime");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            CheckpointOptions options = new CheckpointOptions(null, null, null);
+            CheckpointCreateResult result = TestSupport.await(admin.createDetachedCheckpoint(options));
+
+            TestSupport.await(admin.refreshCheckpoint(result.id(), null));
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(1, checkpoints.size());
+            assertEquals(result.id(), checkpoints.get(0).id());
+        }
+    }
+
+    @Test
+    void adminRefreshCheckpointWithInvalidIdFails() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-refresh-invalid");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            Error.Invalid error = TestSupport.awaitFailure(
+                    Error.Invalid.class,
+                    admin.refreshCheckpoint("invalid-uuid", 60_000L));
+            assertTrue(error.getMessage().contains("invalid checkpoint_id"));
+        }
+    }
+
+    @Test
+    void adminDeleteCheckpointRemovesCheckpoint() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-delete");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            CheckpointOptions options = new CheckpointOptions(null, null, "delete-test");
+            CheckpointCreateResult result = TestSupport.await(admin.createDetachedCheckpoint(options));
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(1, checkpoints.size());
+            assertEquals(result.id(), checkpoints.get(0).id());
+
+            TestSupport.await(admin.deleteCheckpoint(result.id()));
+
+            TestSupport.waitUntil(
+                    TestSupport.WAIT_TIMEOUT,
+                    TestSupport.WAIT_STEP,
+                    () -> TestSupport.await(admin.listCheckpoints(null)).isEmpty());
+        }
+    }
+
+    @Test
+    void adminDeleteCheckpointWithInvalidIdFails() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-delete-invalid");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            Error.Invalid error = TestSupport.awaitFailure(
+                    Error.Invalid.class,
+                    admin.deleteCheckpoint("invalid-uuid"));
+            assertTrue(error.getMessage().contains("invalid checkpoint_id"));
+        }
+    }
+
+    @Test
+    void adminDeleteMultipleCheckpoints() throws Exception {
+        String path = TestSupport.uniquePath("admin-checkpoint-delete-multiple");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key1"), TestSupport.bytes("value1")));
+            TestSupport.await(db.flushWithOptions(new FlushOptions(FlushType.MEM_TABLE)));
+
+            CheckpointCreateResult first = TestSupport.await(admin.createDetachedCheckpoint(
+                    new CheckpointOptions(null, null, "checkpoint-1")));
+            CheckpointCreateResult second = TestSupport.await(admin.createDetachedCheckpoint(
+                    new CheckpointOptions(null, null, "checkpoint-2")));
+            CheckpointCreateResult third = TestSupport.await(admin.createDetachedCheckpoint(
+                    new CheckpointOptions(null, null, "checkpoint-3")));
+
+            List<Checkpoint> checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertEquals(3, checkpoints.size());
+
+            TestSupport.await(admin.deleteCheckpoint(first.id()));
+            checkpoints = TestSupport.await(admin.listCheckpoints(null));
+            assertTrue(checkpoints.stream().noneMatch(c -> c.id().equals(first.id())));
+
+            TestSupport.await(admin.deleteCheckpoint(second.id()));
+            TestSupport.await(admin.deleteCheckpoint(third.id()));
+
+            TestSupport.waitUntil(
+                    TestSupport.WAIT_TIMEOUT,
+                    TestSupport.WAIT_STEP,
+                    () -> TestSupport.await(admin.listCheckpoints(null)).isEmpty());
+        }
+    }
 }

--- a/bindings/node/tests/admin.test.mjs
+++ b/bindings/node/tests/admin.test.mjs
@@ -246,3 +246,288 @@ test("admin sequence lookups use persisted tracker", async (t) => {
   );
   assert.match(invalidTimestamp.message, /invalid timestamp seconds/);
 });
+
+test("admin create detached checkpoint without options", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-create");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const options = {
+    lifetime_ms: undefined,
+    source: undefined,
+    name: undefined,
+  };
+  const result = await admin.create_detached_checkpoint(options);
+
+  assert.notEqual(result, undefined);
+  assert.notEqual(result.id, "");
+  assert.ok(BigInt(result.manifest_id) > 0n);
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 1);
+  assert.equal(checkpoints[0].id, result.id);
+  assert.equal(BigInt(checkpoints[0].manifest_id), BigInt(result.manifest_id));
+  assert.equal(checkpoints[0].name, undefined);
+  assert.equal(checkpoints[0].expire_time_secs, undefined);
+});
+
+test("admin create detached checkpoint with lifetime", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-lifetime");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const lifetimeMs = 60_000n;
+  const options = {
+    lifetime_ms: lifetimeMs,
+    source: undefined,
+    name: undefined,
+  };
+  const result = await admin.create_detached_checkpoint(options);
+
+  assert.notEqual(result, undefined);
+  assert.notEqual(result.id, "");
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 1);
+  const checkpoint = checkpoints[0];
+  assert.equal(checkpoint.id, result.id);
+  assert.notEqual(checkpoint.expire_time_secs, undefined);
+  assert.ok(BigInt(checkpoint.expire_time_secs) > BigInt(checkpoint.create_time_secs));
+
+  const expectedExpireSecs = BigInt(checkpoint.create_time_secs) + (lifetimeMs / 1000n);
+  const delta = BigInt(checkpoint.expire_time_secs) - expectedExpireSecs;
+  assert.ok(delta >= -2n && delta <= 2n, "Expire time should be approximately create time + lifetime");
+});
+
+test("admin create detached checkpoint with name", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-name");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const checkpointName = "backup-2026-06-25";
+  const options = {
+    lifetime_ms: undefined,
+    source: undefined,
+    name: checkpointName,
+  };
+  const result = await admin.create_detached_checkpoint(options);
+
+  assert.notEqual(result, undefined);
+  assert.notEqual(result.id, "");
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 1);
+  assert.equal(checkpoints[0].id, result.id);
+  assert.equal(checkpoints[0].name, checkpointName);
+
+  const filteredByName = await admin.list_checkpoints(checkpointName);
+  assert.equal(filteredByName.length, 1);
+  assert.equal(filteredByName[0].id, result.id);
+
+  const filteredOther = await admin.list_checkpoints("other-name");
+  assert.equal(filteredOther.length, 0);
+});
+
+test("admin create detached checkpoint from source", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-source");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const firstOptions = {
+    lifetime_ms: undefined,
+    source: undefined,
+    name: "first-checkpoint",
+  };
+  const firstResult = await admin.create_detached_checkpoint(firstOptions);
+
+  const secondOptions = {
+    lifetime_ms: 120_000n,
+    source: firstResult.id,
+    name: "second-checkpoint",
+  };
+  const secondResult = await admin.create_detached_checkpoint(secondOptions);
+
+  assert.notEqual(secondResult, undefined);
+  assert.notEqual(secondResult.id, "");
+  assert.equal(BigInt(secondResult.manifest_id), BigInt(firstResult.manifest_id));
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 2);
+});
+
+test("admin refresh checkpoint updates lifetime", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-refresh");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const initialLifetimeMs = 30_000n;
+  const options = {
+    lifetime_ms: initialLifetimeMs,
+    source: undefined,
+    name: "refresh-test",
+  };
+  const result = await admin.create_detached_checkpoint(options);
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  const initial = checkpoints[0];
+  const initialExpireTime = BigInt(initial.expire_time_secs);
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  const newLifetimeMs = 90_000n;
+  await admin.refresh_checkpoint(result.id, newLifetimeMs);
+
+  const updatedCheckpoints = await admin.list_checkpoints(undefined);
+  const refreshed = updatedCheckpoints[0];
+  assert.notEqual(refreshed.expire_time_secs, undefined);
+  assert.ok(
+    BigInt(refreshed.expire_time_secs) > initialExpireTime,
+    "Refreshed expire time should be later than initial"
+  );
+});
+
+test("admin refresh checkpoint without lifetime", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-refresh-no-lifetime");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const options = {
+    lifetime_ms: undefined,
+    source: undefined,
+    name: undefined,
+  };
+  const result = await admin.create_detached_checkpoint(options);
+
+  await admin.refresh_checkpoint(result.id, undefined);
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 1);
+  assert.equal(checkpoints[0].id, result.id);
+});
+
+test("admin refresh checkpoint with invalid id fails", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-refresh-invalid");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const error = await expectInvalid(() => admin.refresh_checkpoint("invalid-uuid", 60_000n));
+  assert.match(error.message, /invalid checkpoint_id/);
+});
+
+test("admin delete checkpoint removes checkpoint", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-delete");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const options = {
+    lifetime_ms: undefined,
+    source: undefined,
+    name: "delete-test",
+  };
+  const result = await admin.create_detached_checkpoint(options);
+
+  const checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 1);
+  assert.equal(checkpoints[0].id, result.id);
+
+  await admin.delete_checkpoint(result.id);
+
+  await waitUntil(async () => {
+    return (await admin.list_checkpoints(undefined)).length === 0;
+  });
+});
+
+test("admin delete checkpoint with invalid id fails", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-delete-invalid");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const error = await expectInvalid(() => admin.delete_checkpoint("invalid-uuid"));
+  assert.match(error.message, /invalid checkpoint_id/);
+});
+
+test("admin delete multiple checkpoints", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-checkpoint-delete-multiple");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key1"), bytes("value1"));
+  await db.flush_with_options({ flush_type: FlushType.MemTable });
+
+  const first = await admin.create_detached_checkpoint({
+    lifetime_ms: undefined,
+    source: undefined,
+    name: "checkpoint-1",
+  });
+  const second = await admin.create_detached_checkpoint({
+    lifetime_ms: undefined,
+    source: undefined,
+    name: "checkpoint-2",
+  });
+  const third = await admin.create_detached_checkpoint({
+    lifetime_ms: undefined,
+    source: undefined,
+    name: "checkpoint-3",
+  });
+
+  let checkpoints = await admin.list_checkpoints(undefined);
+  assert.equal(checkpoints.length, 3);
+
+  await admin.delete_checkpoint(first.id);
+  checkpoints = await admin.list_checkpoints(undefined);
+  assert.ok(checkpoints.every((c) => c.id !== first.id));
+
+  await admin.delete_checkpoint(second.id);
+  await admin.delete_checkpoint(third.id);
+
+  await waitUntil(async () => {
+    return (await admin.list_checkpoints(undefined)).length === 0;
+  });
+});

--- a/bindings/python/tests/test_admin.py
+++ b/bindings/python/tests/test_admin.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import time
 
 import pytest
 
 from conftest import new_memory_store, open_db, open_reader, unique_path, wait_until
-from slatedb.uniffi import AdminBuilder, DbBuilder, Error, FlushOptions, FlushType, CloneSourceSpec
+from slatedb.uniffi import AdminBuilder, DbBuilder, Error, FlushOptions, FlushType, CloneSourceSpec, CheckpointOptions
 
 MAX_I64 = 9_223_372_036_854_775_807
 MAX_U64 = 18_446_744_073_709_551_615
@@ -199,3 +200,258 @@ async def test_admin_clone() -> None:
     async with open_db(store, path=clone_path) as db:
         for i in range(3):
             assert await db.get(f"k{i}".encode("utf-8")) == f"v{i}".encode("utf-8")
+
+
+@pytest.mark.asyncio
+async def test_admin_create_detached_checkpoint_without_options() -> None:
+    path = unique_path("admin-checkpoint-create")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        options = CheckpointOptions(lifetime_ms=None, source=None, name=None)
+        result = await admin.create_detached_checkpoint(options)
+
+        assert result is not None
+        assert result.id
+        assert result.manifest_id > 0
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 1
+        assert checkpoints[0].id == result.id
+        assert checkpoints[0].manifest_id == result.manifest_id
+        assert checkpoints[0].name is None
+        assert checkpoints[0].expire_time_secs is None
+
+
+@pytest.mark.asyncio
+async def test_admin_create_detached_checkpoint_with_lifetime() -> None:
+    path = unique_path("admin-checkpoint-lifetime")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        lifetime_ms = 60_000
+        options = CheckpointOptions(lifetime_ms=lifetime_ms, source=None, name=None)
+        result = await admin.create_detached_checkpoint(options)
+
+        assert result is not None
+        assert result.id
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 1
+        checkpoint = checkpoints[0]
+        assert checkpoint.id == result.id
+        assert checkpoint.expire_time_secs is not None
+        assert checkpoint.expire_time_secs > checkpoint.create_time_secs
+
+        expected_expire_secs = checkpoint.create_time_secs + (lifetime_ms // 1000)
+        delta = abs(checkpoint.expire_time_secs - expected_expire_secs)
+        assert delta <= 2, "Expire time should be approximately create time + lifetime"
+
+
+@pytest.mark.asyncio
+async def test_admin_create_detached_checkpoint_with_name() -> None:
+    path = unique_path("admin-checkpoint-name")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        checkpoint_name = "backup-2026-06-25"
+        options = CheckpointOptions(lifetime_ms=None, source=None, name=checkpoint_name)
+        result = await admin.create_detached_checkpoint(options)
+
+        assert result is not None
+        assert result.id
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 1
+        assert checkpoints[0].id == result.id
+        assert checkpoints[0].name == checkpoint_name
+
+        filtered_by_name = await admin.list_checkpoints(checkpoint_name)
+        assert len(filtered_by_name) == 1
+        assert filtered_by_name[0].id == result.id
+
+        filtered_other = await admin.list_checkpoints("other-name")
+        assert len(filtered_other) == 0
+
+
+@pytest.mark.asyncio
+async def test_admin_create_detached_checkpoint_from_source() -> None:
+    path = unique_path("admin-checkpoint-source")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        first_options = CheckpointOptions(lifetime_ms=None, source=None, name="first-checkpoint")
+        first_result = await admin.create_detached_checkpoint(first_options)
+
+        second_options = CheckpointOptions(
+            lifetime_ms=120_000, source=first_result.id, name="second-checkpoint"
+        )
+        second_result = await admin.create_detached_checkpoint(second_options)
+
+        assert second_result is not None
+        assert second_result.id
+        assert second_result.manifest_id == first_result.manifest_id
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 2
+
+
+@pytest.mark.asyncio
+async def test_admin_refresh_checkpoint_updates_lifetime() -> None:
+    path = unique_path("admin-checkpoint-refresh")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        initial_lifetime_ms = 30_000
+        options = CheckpointOptions(
+            lifetime_ms=initial_lifetime_ms, source=None, name="refresh-test"
+        )
+        result = await admin.create_detached_checkpoint(options)
+
+        checkpoints = await admin.list_checkpoints(None)
+        initial = checkpoints[0]
+        initial_expire_time = initial.expire_time_secs
+        assert initial_expire_time is not None
+
+        await asyncio.sleep(1)
+
+        new_lifetime_ms = 90_000
+        await admin.refresh_checkpoint(result.id, new_lifetime_ms)
+
+        updated_checkpoints = await admin.list_checkpoints(None)
+        refreshed = updated_checkpoints[0]
+        assert refreshed.expire_time_secs is not None
+        assert (
+            refreshed.expire_time_secs > initial_expire_time
+        ), "Refreshed expire time should be later than initial"
+
+
+@pytest.mark.asyncio
+async def test_admin_refresh_checkpoint_without_lifetime() -> None:
+    path = unique_path("admin-checkpoint-refresh-no-lifetime")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        options = CheckpointOptions(lifetime_ms=None, source=None, name=None)
+        result = await admin.create_detached_checkpoint(options)
+
+        await admin.refresh_checkpoint(result.id, None)
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 1
+        assert checkpoints[0].id == result.id
+
+
+@pytest.mark.asyncio
+async def test_admin_refresh_checkpoint_with_invalid_id_fails() -> None:
+    path = unique_path("admin-checkpoint-refresh-invalid")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        with pytest.raises(Error.Invalid) as error:
+            await admin.refresh_checkpoint("invalid-uuid", 60_000)
+        assert "invalid checkpoint_id" in error.value.message
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_checkpoint_removes_checkpoint() -> None:
+    path = unique_path("admin-checkpoint-delete")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        options = CheckpointOptions(lifetime_ms=None, source=None, name="delete-test")
+        result = await admin.create_detached_checkpoint(options)
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 1
+        assert checkpoints[0].id == result.id
+
+        await admin.delete_checkpoint(result.id)
+
+        async def checkpoints_cleared() -> bool:
+            return await admin.list_checkpoints(None) == []
+
+        await wait_until(checkpoints_cleared)
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_checkpoint_with_invalid_id_fails() -> None:
+    path = unique_path("admin-checkpoint-delete-invalid")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        with pytest.raises(Error.Invalid) as error:
+            await admin.delete_checkpoint("invalid-uuid")
+        assert "invalid checkpoint_id" in error.value.message
+
+
+@pytest.mark.asyncio
+async def test_admin_delete_multiple_checkpoints() -> None:
+    path = unique_path("admin-checkpoint-delete-multiple")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key1", b"value1")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        first = await admin.create_detached_checkpoint(
+            CheckpointOptions(lifetime_ms=None, source=None, name="checkpoint-1")
+        )
+        second = await admin.create_detached_checkpoint(
+            CheckpointOptions(lifetime_ms=None, source=None, name="checkpoint-2")
+        )
+        third = await admin.create_detached_checkpoint(
+            CheckpointOptions(lifetime_ms=None, source=None, name="checkpoint-3")
+        )
+
+        checkpoints = await admin.list_checkpoints(None)
+        assert len(checkpoints) == 3
+
+        await admin.delete_checkpoint(first.id)
+        checkpoints = await admin.list_checkpoints(None)
+        assert all(c.id != first.id for c in checkpoints)
+
+        await admin.delete_checkpoint(second.id)
+        await admin.delete_checkpoint(third.id)
+
+        async def checkpoints_cleared() -> bool:
+            return await admin.list_checkpoints(None) == []
+
+        await wait_until(checkpoints_cleared)


### PR DESCRIPTION
## Summary

Just adding unit tests for new admin checkpoint methods. I forgot to include unit tests in the original PR.

## Changes

Unit tests for go, node, python, and java bindings.

## Notes for Reviewers

n/a

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
