### PR TITLE
[codex] Fix Python aarch64 manylinux wheel build

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -45,8 +45,9 @@ jobs:
           AR_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-ar
           RANLIB_aarch64_unknown_linux_gnu: aarch64-unknown-linux-gnu-ranlib
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-unknown-linux-gnu-gcc
-          # ensure the ARM assembler defines __ARM_ARCH
-          CFLAGS_aarch64_unknown_linux_gnu: "-march=armv8-a -D__ARM_ARCH=8"
+          # ensure the ARM assembler defines __ARM_ARCH; manylinux2014's
+          # aarch64 sysroot is missing the Linux UAPI AT_HWCAP2 definition.
+          CFLAGS_aarch64_unknown_linux_gnu: "-march=armv8-a -D__ARM_ARCH=8 -DAT_HWCAP2=26"
         with:
           working-directory: ./bindings/python
           target: ${{ matrix.platform.target }}


### PR DESCRIPTION
## Summary

Fix the Python release workflow's `linux (ubuntu-22.04, aarch64)` wheel build. After the `object_store` 0.14 upgrade, the Python bindings pull in `aws-lc-sys`, which fails to compile in the `manylinux2014-cross:aarch64` sysroot because `AT_HWCAP2` is missing from the headers. Linux UAPI defines `AT_HWCAP2` as `26`, so this adds that definition to the existing aarch64 CFLAGS while keeping the `manylinux2014` compatibility baseline.

## Changes

- Add `-DAT_HWCAP2=26` to `CFLAGS_aarch64_unknown_linux_gnu` in the Python release workflow.
- Document why the define is needed for the manylinux2014 aarch64 sysroot.

## Notes for Reviewers

Focus review on the `Build wheels` step for the Linux aarch64 Python release job. The full validation is rerunning `Publish Release (Python)`; locally I verified the workflow YAML parses and the diff has no whitespace errors.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏