### PR TITLE
Format bytes in International System of Units (SI)

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -893,8 +893,8 @@ impl FsCacheEvictorInner {
             if self.cache_size_bytes.load(Ordering::Relaxed) > target_size {
                 warn!(
                     "cache_size_bytes still exceeds max_cache_size_bytes but no more entries can be evicted(cache_size_bytes={}, max_cache_size_bytes={})",
-                    self.cache_size_bytes.load(Ordering::Relaxed),
-                    self.max_cache_size_bytes
+                    format_bytes_si(self.cache_size_bytes.load(Ordering::Relaxed)),
+                    format_bytes_si(self.max_cache_size_bytes as u64)
                 );
             }
             return 0;

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -86,7 +86,7 @@ use crate::manifest::ManifestCore;
 use crate::merge_operator::MergeOperatorType;
 use crate::subcompaction::Subcompaction;
 use crate::tablestore::TableStore;
-use crate::utils::IdGenerator;
+use crate::utils::{format_bytes_si, IdGenerator};
 #[cfg(feature = "compaction_filters")]
 use crate::CompactionFilterSupplier;
 use slatedb_common::clock::SystemClock;
@@ -584,7 +584,7 @@ impl CompactionWorkerHandler {
                 "progress heartbeat [worker_id={}, id={}, bytes={}, output_ssts={}, new_output_ssts={}]",
                 self.worker_id,
                 id,
-                bytes_processed,
+                format_bytes_si(bytes_processed),
                 new_sst_count,
                 new_sst_count.saturating_sub(prev_sst_count)
             );

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -73,6 +73,7 @@
 use crate::{
     db_cache::{CacheLoader, CachedEntry, CachedKey, DbCache},
     error::SlateDBError,
+    utils::format_bytes_si,
 };
 use async_trait::async_trait;
 use log::info;
@@ -133,8 +134,8 @@ impl DbCache for FoyerHybridCache {
         let memory_bytes = self.inner.memory().usage();
         info!(
             "foyer hybrid cache: closing \
-             (flushing {:.2} MB from memory to disk)",
-            memory_bytes as f64 / (1024.0 * 1024.0)
+             (flushing {} from memory to disk)",
+            format_bytes_si(memory_bytes as u64)
         );
         let result = self
             .inner


### PR DESCRIPTION
## Summary

We lost SI-style byte formatting in logs in 0.14. This re-adds it. I had Codex take a pass looking for such cases.