### PR TITLE
Reclaim jobs a worker is already running

### DIFF
--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -371,10 +371,10 @@ impl CompactionWorkerHandler {
                 } else if self.job_progress.contains_key(&c.id()) {
                     // It's possible this worker tries to claim a job that it's already running.
                     // This can happen if coordinator hasn't seen this worker's heartbeat yet,
-                    // and transitions the job back to `Submitted`. This worker can reclaim the
+                    // and transitions the job back to `Scheduled`. This worker can reclaim the
                     // job (which it does in the dirty_compactions insert, below), but should
                     // not dispatch it to the executor again. To prevent this, we skip jobs
-                    // that are already in `active_jobs`.
+                    // that are already in `job_progress`.
                     to_reclaim.push(c.clone());
                 } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
@@ -387,9 +387,9 @@ impl CompactionWorkerHandler {
                     );
                 }
             }
-            if to_claim.is_empty() {
+            if to_claim.is_empty() && to_reclaim.is_empty() {
                 debug!(
-                    "No claimable compactions; skipping .compactions CAS write and executor dispatch [worker_id={}]",
+                    "No claimable or reclaimable compactions; skipping .compactions CAS write and executor dispatch [worker_id={}]",
                     self.worker_id
                 );
                 return Ok(());
@@ -414,6 +414,9 @@ impl CompactionWorkerHandler {
                 Err(e) => return Err(e),
             }
         };
+        if claimed.is_empty() {
+            return Ok(());
+        }
 
         // Build job args against a manifest read *after* the claim CAS. The
         // coordinator writes the manifest before `.compactions` (see
@@ -1022,6 +1025,10 @@ mod tests {
         async fn seed_scheduled_compaction(&self, id: Ulid, sources: Vec<SourceId>) {
             let spec = CompactionSpec::new(sources, 0);
             let compaction = Compaction::new(id, spec).with_status(CompactionStatus::Scheduled);
+            self.write_compaction(compaction).await;
+        }
+
+        async fn write_compaction(&self, compaction: Compaction) {
             let mut stored = StoredCompactions::try_load(self.compactions_store.clone())
                 .await
                 .unwrap()
@@ -1064,6 +1071,90 @@ mod tests {
 
         // And the worker tracks the job locally.
         assert!(fx.handler.job_progress.contains_key(&id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_reclaims_already_running_scheduled_compaction_without_redispatch() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert_eq!(fx.executor.jobs().len(), 1);
+
+        // Simulate the coordinator reclaiming the job after missing this
+        // worker's heartbeat, while the local executor attempt is still active.
+        let reclaimed = fx
+            .read_compaction(id)
+            .await
+            .expect("compaction missing")
+            .with_status(CompactionStatus::Scheduled)
+            .with_worker(None);
+        fx.write_compaction(reclaimed).await;
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Running);
+        assert_eq!(
+            c.worker().expect("worker spec missing").worker_id,
+            fx.worker_id
+        );
+        assert_eq!(
+            fx.executor.jobs().len(),
+            1,
+            "already-running reclaim must not dispatch a duplicate job"
+        );
+        assert!(fx.handler.job_progress.contains_key(&id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_reclaims_already_running_compaction_at_capacity() {
+        let options = CompactionWorkerOptions {
+            max_concurrent_compactions: 1,
+            ..CompactionWorkerOptions::default()
+        };
+        let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+        let mut fx = WorkerFixture::new_with_clock("worker-A", clock, options).await;
+        let active_id = Ulid::from_parts(1, 0);
+        let pending_id = Ulid::from_parts(2, 0);
+        fx.seed_scheduled_compaction(active_id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert_eq!(fx.executor.jobs().len(), 1);
+        assert_eq!(fx.handler.capacity(), 0);
+
+        let reclaimed = fx
+            .read_compaction(active_id)
+            .await
+            .expect("compaction missing")
+            .with_status(CompactionStatus::Scheduled)
+            .with_worker(None);
+        fx.write_compaction(reclaimed).await;
+        fx.seed_scheduled_compaction(pending_id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let active = fx
+            .read_compaction(active_id)
+            .await
+            .expect("active compaction missing");
+        assert_eq!(active.status(), CompactionStatus::Running);
+        assert_eq!(
+            active.worker().expect("worker spec missing").worker_id,
+            fx.worker_id
+        );
+
+        let pending = fx
+            .read_compaction(pending_id)
+            .await
+            .expect("pending compaction missing");
+        assert_eq!(pending.status(), CompactionStatus::Scheduled);
+        assert!(pending.worker().is_none());
+        assert_eq!(fx.executor.jobs().len(), 1);
+        assert_eq!(fx.handler.job_progress.len(), 1);
+        assert!(fx.handler.job_progress.contains_key(&active_id));
     }
 
     #[tokio::test]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -75,7 +75,9 @@ use crate::compactor_executor::{
     CompactionExecutor, StartCompactionJobArgs, TokioCompactionExecutor,
     TokioCompactionExecutorOptions,
 };
-use crate::compactor_state::{Compaction, CompactionContext, CompactionStatus, WorkerSpec};
+use crate::compactor_state::{
+    Compaction, CompactionContext, CompactionSpec, CompactionStatus, WorkerSpec,
+};
 use crate::config::CompactionWorkerOptions;
 use crate::db_state::SortedRun;
 use crate::dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef};
@@ -181,6 +183,8 @@ impl CompactionWorker {
 /// Per-job state used to detect when the per-range subcompaction progress has
 /// advanced and when the bytes threshold has been crossed.
 struct JobProgressState {
+    /// Spec this worker claimed for the active executor attempt.
+    spec: CompactionSpec,
     /// Total bytes processed as of the last bytes-based heartbeat write.
     last_hb_bytes: u64,
     /// Wall-clock timestamp (ms) of this job's most recent heartbeat write
@@ -419,6 +423,7 @@ impl CompactionWorkerHandler {
                     self.job_progress.insert(
                         compaction.id(),
                         JobProgressState {
+                            spec: compaction.spec().clone(),
                             last_hb_bytes: 0,
                             last_hb_ms: self.clock.now().timestamp_millis() as u64,
                             last_hb_ctx: compaction.ctx().cloned(),
@@ -459,6 +464,17 @@ impl CompactionWorkerHandler {
         compaction_id: Ulid,
         ctx: Option<CompactionContext>,
     ) -> Result<Option<u64>, SlateDBError> {
+        let Some(claimed_spec) = self
+            .job_progress
+            .get(&compaction_id)
+            .map(|state| state.spec.clone())
+        else {
+            debug!(
+                "heartbeat: no local progress state for compaction [worker_id={}, compaction_id={}]; skipping",
+                self.worker_id, compaction_id
+            );
+            return Ok(None);
+        };
         loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
@@ -479,9 +495,16 @@ impl CompactionWorkerHandler {
                 );
                 return Ok(None);
             }
+            if existing.spec() != &claimed_spec {
+                error!(
+                    "heartbeat: compaction spec changed since claim [worker_id={}, compaction_id={}]; skipping",
+                    self.worker_id, compaction_id
+                );
+                return Ok(None);
+            }
             let now_ms = self.clock.now().timestamp_millis() as u64;
-            let new_spec = WorkerSpec::new(self.worker_id.clone(), now_ms);
-            let mut updated_compaction = existing.with_worker(Some(new_spec));
+            let new_worker = WorkerSpec::new(self.worker_id.clone(), now_ms);
+            let mut updated_compaction = existing.with_worker(Some(new_worker));
             if let Some(ctx) = ctx.clone() {
                 updated_compaction.set_ctx(Some(ctx));
             }
@@ -1143,6 +1166,7 @@ mod tests {
             (
                 id3,
                 JobProgressState {
+                    spec: CompactionSpec::new(vec![], 0),
                     last_hb_bytes: 0,
                     last_hb_ms: 0,
                     last_hb_ctx: None,
@@ -1151,6 +1175,7 @@ mod tests {
             (
                 id1,
                 JobProgressState {
+                    spec: CompactionSpec::new(vec![], 0),
                     last_hb_bytes: 0,
                     last_hb_ms: 0,
                     last_hb_ctx: None,
@@ -1159,6 +1184,7 @@ mod tests {
             (
                 id2,
                 JobProgressState {
+                    spec: CompactionSpec::new(vec![], 0),
                     last_hb_bytes: 0,
                     last_hb_ms: 0,
                     last_hb_ctx: None,
@@ -1190,6 +1216,46 @@ mod tests {
         assert!(fx.handler.job_progress.is_empty());
         // No job was dispatched to the executor either.
         assert!(fx.executor.jobs().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_worker_ignores_stale_progress_when_spec_changed() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let replacement_spec = CompactionSpec::new(vec![SourceId::SstView(fx.l0_view.id)], 1);
+        let persisted_ctx =
+            CompactionContext::new(vec![Subcompaction::new(BytesRange::unbounded())], Some(0));
+        let replacement = Compaction::new(id, replacement_spec.clone())
+            .with_status(CompactionStatus::Running)
+            .with_worker(Some(WorkerSpec::new(fx.worker_id.clone(), 12345)))
+            .with_ctx(Some(persisted_ctx.clone()));
+        let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut dirty = stored.prepare_dirty().unwrap();
+        dirty.value.insert(replacement);
+        stored.update(dirty).await.unwrap();
+
+        // This is stale progress from the original executor attempt. Without
+        // the claimed-spec check, writing it into the replacement compaction
+        // would panic because the persisted plan has a different shape.
+        let stale_ctx = CompactionContext::new(
+            vec![
+                Subcompaction::new(BytesRange::unbounded()),
+                Subcompaction::new(BytesRange::unbounded()),
+            ],
+            Some(0),
+        );
+        fx.handler.handle_progress(id, 1, stale_ctx).await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.spec(), &replacement_spec);
+        assert_eq!(c.ctx(), Some(&persisted_ctx));
     }
 
     #[tokio::test(start_paused = true)]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -59,8 +59,7 @@
 //! The coordinator emits complementary metrics (`jobs_claimed`, `jobs_reclaimed`,
 //! `worker_last_heartbeat_ms`) on its own recorder.
 
-use std::collections::BTreeSet;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -211,10 +210,6 @@ pub(crate) struct CompactionWorkerHandler {
     manifest_store: Arc<ManifestStore>,
     executor: Arc<dyn CompactionExecutor + Send + Sync>,
     clock: Arc<dyn SystemClock>,
-    /// Compactions currently being executed by this worker (claimed but not
-    /// yet `Compacted`). Used to gate capacity and to know what to reset on
-    /// graceful shutdown.
-    active_jobs: BTreeSet<Ulid>,
     /// Lazily-initialized handle for CAS reads/writes on `.compactions`. The
     /// coordinator creates the file on first run; the worker tolerates its
     /// absence on early ticks.
@@ -222,7 +217,8 @@ pub(crate) struct CompactionWorkerHandler {
     rand: Arc<DbRand>,
     fp_registry: Arc<FailPointRegistry>,
     /// Per-job heartbeat bookkeeping. Entry present iff the job is active.
-    job_progress: HashMap<Ulid, JobProgressState>,
+    /// Used to gate capacity and to know what to reset on graceful shutdown.
+    job_progress: BTreeMap<Ulid, JobProgressState>,
 }
 
 impl CompactionWorkerHandler {
@@ -243,11 +239,10 @@ impl CompactionWorkerHandler {
             manifest_store,
             executor,
             clock,
-            active_jobs: BTreeSet::new(),
             stored: None,
             rand,
             fp_registry,
-            job_progress: HashMap::new(),
+            job_progress: BTreeMap::new(),
         }
     }
 
@@ -334,7 +329,7 @@ impl CompactionWorkerHandler {
     fn capacity(&self) -> usize {
         self.options
             .max_concurrent_compactions
-            .saturating_sub(self.active_jobs.len())
+            .saturating_sub(self.job_progress.len())
     }
 
     /// Scans `.compactions` for `Scheduled` entries without a worker, claims up
@@ -421,7 +416,6 @@ impl CompactionWorkerHandler {
                         self.worker_id,
                         compaction.id()
                     );
-                    self.active_jobs.insert(compaction.id());
                     self.job_progress.insert(
                         compaction.id(),
                         JobProgressState {
@@ -741,7 +735,7 @@ impl CompactionWorkerHandler {
     /// Returns a claim to `Scheduled` so it can be re-attempted by any worker
     /// (used when execution fails or when the worker shuts down gracefully).
     async fn release_claim(&mut self, compaction_id: Ulid) -> Result<(), SlateDBError> {
-        self.active_jobs.remove(&compaction_id);
+        self.job_progress.remove(&compaction_id);
         let worker_id = self.worker_id.as_str();
         loop {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
@@ -782,7 +776,6 @@ impl CompactionWorkerHandler {
         id: Ulid,
         result: Result<SortedRun, SlateDBError>,
     ) -> Result<(), SlateDBError> {
-        self.active_jobs.remove(&id);
         self.job_progress.remove(&id);
         match result {
             Ok(sorted_run) => self.write_compacted(id, sorted_run).await?,
@@ -848,9 +841,8 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
         // heartbeat-timeout reclamation path. Stopping the executor runs each
         // in-flight task's cleanup, which decrements `running_compactions`.
         self.executor.stop();
-        self.job_progress.clear();
-        let claimed = std::mem::take(&mut self.active_jobs);
-        for id in claimed {
+        let claimed = std::mem::take(&mut self.job_progress);
+        for id in claimed.into_keys() {
             if let Err(e) = self.release_claim(id).await {
                 error!(
                     "failed to release claim on shutdown [worker_id={}, id={}, error={:?}]",
@@ -1035,7 +1027,7 @@ mod tests {
         assert_eq!(jobs[0].compaction_id, id);
 
         // And the worker tracks the job locally.
-        assert!(fx.handler.active_jobs.contains(&id));
+        assert!(fx.handler.job_progress.contains_key(&id));
     }
 
     #[tokio::test]
@@ -1062,7 +1054,7 @@ mod tests {
         assert_eq!(c.status(), CompactionStatus::Running);
         assert_eq!(c.worker().unwrap().worker_id, "worker-B");
         assert!(fx.executor.jobs().is_empty());
-        assert!(fx.handler.active_jobs.is_empty());
+        assert!(fx.handler.job_progress.is_empty());
     }
 
     #[tokio::test]
@@ -1098,8 +1090,8 @@ mod tests {
         assert_eq!(c.output_ssts()[0].id, output_handle.id);
         // worker_id is still attached (the coordinator clears it on commit).
         assert_eq!(c.worker().unwrap().worker_id, fx.worker_id);
-        // Active set is drained on finish.
-        assert!(!fx.handler.active_jobs.contains(&id));
+        // Progress bookkeeping is drained on finish.
+        assert!(!fx.handler.job_progress.contains_key(&id));
     }
 
     #[tokio::test]
@@ -1119,7 +1111,7 @@ mod tests {
         let c = fx.read_compaction(id).await.expect("compaction missing");
         assert_eq!(c.status(), CompactionStatus::Scheduled);
         assert!(c.worker().is_none());
-        assert!(!fx.handler.active_jobs.contains(&id));
+        assert!(!fx.handler.job_progress.contains_key(&id));
     }
 
     #[tokio::test]
@@ -1129,7 +1121,7 @@ mod tests {
         fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
             .await;
         fx.handler.poll_and_claim().await.unwrap();
-        assert_eq!(fx.handler.active_jobs.len(), 1);
+        assert_eq!(fx.handler.job_progress.len(), 1);
 
         // cleanup mirrors graceful shutdown.
         let empty: BoxStream<'_, WorkerMessage> = futures::stream::empty().boxed();
@@ -1138,7 +1130,7 @@ mod tests {
         let c = fx.read_compaction(id).await.expect("compaction missing");
         assert_eq!(c.status(), CompactionStatus::Scheduled);
         assert!(c.worker().is_none());
-        assert!(fx.handler.active_jobs.is_empty());
+        assert!(fx.handler.job_progress.is_empty());
     }
 
     #[test]
@@ -1147,8 +1139,33 @@ mod tests {
         let id2 = Ulid::from_parts(2, 0);
         let id3 = Ulid::from_parts(3, 0);
 
-        let active_jobs = BTreeSet::from([id3, id1, id2]);
-        let release_order = active_jobs.into_iter().collect::<Vec<_>>();
+        let job_progress = BTreeMap::from([
+            (
+                id3,
+                JobProgressState {
+                    last_hb_bytes: 0,
+                    last_hb_ms: 0,
+                    last_hb_ctx: None,
+                },
+            ),
+            (
+                id1,
+                JobProgressState {
+                    last_hb_bytes: 0,
+                    last_hb_ms: 0,
+                    last_hb_ctx: None,
+                },
+            ),
+            (
+                id2,
+                JobProgressState {
+                    last_hb_bytes: 0,
+                    last_hb_ms: 0,
+                    last_hb_ctx: None,
+                },
+            ),
+        ]);
+        let release_order = job_progress.into_keys().collect::<Vec<_>>();
 
         assert_eq!(release_order, vec![id1, id2, id3]);
     }
@@ -1170,7 +1187,7 @@ mod tests {
         assert_eq!(c.status(), CompactionStatus::Scheduled);
         assert!(c.worker().is_none());
         // No active job retained.
-        assert!(fx.handler.active_jobs.is_empty());
+        assert!(fx.handler.job_progress.is_empty());
         // No job was dispatched to the executor either.
         assert!(fx.executor.jobs().is_empty());
     }

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -369,6 +369,12 @@ impl CompactionWorkerHandler {
                         c.spec(),
                     );
                 } else if self.job_progress.contains_key(&c.id()) {
+                    // It's possible this worker tries to claim a job that it's already running.
+                    // This can happen if coordinator hasn't seen this worker's heartbeat yet,
+                    // and transitions the job back to `Submitted`. This worker can reclaim the
+                    // job (which it does in the dirty_compactions insert, below), but should
+                    // not dispatch it to the executor again. To prevent this, we skip jobs
+                    // that are already in `active_jobs`.
                     to_reclaim.push(c.clone());
                 } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -368,14 +368,37 @@ impl CompactionWorkerHandler {
                         c.id(),
                         c.spec(),
                     );
-                } else if self.job_progress.contains_key(&c.id()) {
+                } else if let Some(state) = self.job_progress.get(&c.id()) {
                     // It's possible this worker tries to claim a job that it's already running.
                     // This can happen if coordinator hasn't seen this worker's heartbeat yet,
                     // and transitions the job back to `Scheduled`. This worker can reclaim the
                     // job (which it does in the dirty_compactions insert, below), but should
-                    // not dispatch it to the executor again. To prevent this, we skip jobs
-                    // that are already in `job_progress`.
-                    to_reclaim.push(c.clone());
+                    // not dispatch it to the executor again. To prevent this, we separate the
+                    // reclaim jobs in `to_reclaim`, which updates the compaction entry to
+                    // `Running` but does not dispatch it to the executor. We also validate that
+                    // the spec and retention_min_seq match the local job state, for safety (these
+                    // should never differ).
+                    let compaction_retention_min_seq =
+                        c.ctx().and_then(CompactionContext::retention_min_seq);
+                    let local_retention_min_seq = state
+                        .last_hb_ctx
+                        .as_ref()
+                        .and_then(CompactionContext::retention_min_seq);
+                    if c.spec() == &state.spec
+                        && compaction_retention_min_seq == local_retention_min_seq
+                    {
+                        to_reclaim.push(c.clone());
+                    } else {
+                        error!(
+                            "should never happen: skipping already-running compaction reclaim because persisted state doesn't match local job [worker_id={}, id={}, compaction_spec={:?}, local_spec={:?}, compaction_retention_min_seq={:?}, local_retention_min_seq={:?}]",
+                            self.worker_id,
+                            c.id(),
+                            c.spec(),
+                            state.spec,
+                            compaction_retention_min_seq,
+                            local_retention_min_seq,
+                        );
+                    }
                 } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
                 } else {
@@ -387,6 +410,7 @@ impl CompactionWorkerHandler {
                     );
                 }
             }
+
             if to_claim.is_empty() && to_reclaim.is_empty() {
                 debug!(
                     "No claimable or reclaimable compactions; skipping .compactions CAS write and executor dispatch [worker_id={}]",
@@ -405,6 +429,7 @@ impl CompactionWorkerHandler {
                         .with_worker(Some(worker_spec.clone())),
                 );
             }
+
             match stored.update(dirty_compactions).await {
                 Ok(()) => break to_claim,
                 Err(e) if e.is_sequenced_write_conflict() => {
@@ -1155,6 +1180,67 @@ mod tests {
         assert_eq!(fx.executor.jobs().len(), 1);
         assert_eq!(fx.handler.job_progress.len(), 1);
         assert!(fx.handler.job_progress.contains_key(&active_id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_does_not_reclaim_already_running_compaction_with_changed_spec() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let replacement_spec = CompactionSpec::new(vec![SourceId::SstView(fx.l0_view.id)], 1);
+        fx.write_compaction(
+            Compaction::new(id, replacement_spec.clone()).with_status(CompactionStatus::Scheduled),
+        )
+        .await;
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Scheduled);
+        assert_eq!(c.spec(), &replacement_spec);
+        assert!(c.worker().is_none());
+        assert_eq!(fx.executor.jobs().len(), 1);
+        assert!(fx.handler.job_progress.contains_key(&id));
+    }
+
+    #[tokio::test]
+    async fn test_worker_does_not_reclaim_already_running_compaction_with_changed_retention() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let local_ctx =
+            CompactionContext::new(vec![Subcompaction::new(BytesRange::unbounded())], Some(0));
+        fx.handler.handle_progress(id, 0, local_ctx).await.unwrap();
+
+        let spec = fx
+            .read_compaction(id)
+            .await
+            .expect("compaction missing")
+            .spec()
+            .clone();
+        let replacement_ctx =
+            CompactionContext::new(vec![Subcompaction::new(BytesRange::unbounded())], Some(1));
+        fx.write_compaction(
+            Compaction::new(id, spec)
+                .with_status(CompactionStatus::Scheduled)
+                .with_ctx(Some(replacement_ctx.clone())),
+        )
+        .await;
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Scheduled);
+        assert_eq!(c.ctx(), Some(&replacement_ctx));
+        assert!(c.worker().is_none());
+        assert_eq!(fx.executor.jobs().len(), 1);
+        assert!(fx.handler.job_progress.contains_key(&id));
     }
 
     #[tokio::test]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -342,10 +342,6 @@ impl CompactionWorkerHandler {
     /// Claims that fail validation are released back to `Scheduled`.
     async fn poll_and_claim(&mut self) -> Result<(), SlateDBError> {
         let capacity = self.capacity();
-        if capacity == 0 {
-            return Ok(());
-        }
-
         // CAS loop: read latest, identify candidates, attempt write.
         // Candidates are filtered on their spec alone here; validating the
         // spec's sources against the manifest happens after the claim
@@ -355,23 +351,34 @@ impl CompactionWorkerHandler {
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
             let mut dirty_compactions = stored.prepare_dirty()?;
-
             let mut to_claim: Vec<Compaction> = Vec::new();
+            let mut to_reclaim: Vec<Compaction> = Vec::new();
+
             for c in dirty_compactions
                 .value
                 .iter_with_status(&[CompactionStatus::Scheduled])
                 .filter(|c| c.worker().is_none())
             {
-                if to_claim.len() >= capacity {
-                    break;
-                }
                 // Drain specs are coordinator-local, and a tiered spec without
                 // a destination can never be executed; neither can become
                 // valid later, so skip them rather than claim and release.
-                if !c.spec().is_drain() && c.spec().destination().is_some() {
+                if c.spec().is_drain() || c.spec().destination().is_none() {
+                    warn!(
+                        "skipping unrunnable compaction spec [id={}, spec={:?}]",
+                        c.id(),
+                        c.spec(),
+                    );
+                } else if self.job_progress.contains_key(&c.id()) {
+                    to_reclaim.push(c.clone());
+                } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
                 } else {
-                    warn!("skipping unrunnable compaction spec [id={}]", c.id());
+                    debug!(
+                        "skipping compaction claim due to capacity limit [worker_id={}, id={}, capacity={}]",
+                        self.worker_id,
+                        c.id(),
+                        capacity
+                    );
                 }
             }
             if to_claim.is_empty() {
@@ -385,7 +392,7 @@ impl CompactionWorkerHandler {
             let heartbeat_ms = self.clock.now().timestamp_millis() as u64;
             let worker_spec = WorkerSpec::new(self.worker_id.clone(), heartbeat_ms);
 
-            for c in &to_claim {
+            for c in to_claim.iter().chain(to_reclaim.iter()) {
                 dirty_compactions.value.insert(
                     c.clone()
                         .with_status(CompactionStatus::Running)


### PR DESCRIPTION
## Summary

The compactor coordinator can time out a running compaction job and move it from `Running` back to `Submitted`. The worker, meanwhile, doesn't know it's been timed out. It can poll the `.compactions` file later, looking for new jobs to run. When it does so, it can see the job it's already running (that's been timed out) as `Submitted`. It currently tries to claim this job _again_ and dispatch it. That results in a double dispatch, which triggers a panic.

This PR updates the logic so that the worker reclaims the job (marks it as `Running` again with is `WorkerSpec`), but doesn't double dispatch. Instead, it lets the old job continue to run to completion.

Fixes #1850

## Changes

- Removed `active_jobs` since it's a dupe of `job_progress` now.
- Added `CompactionSpec` to job_progress so we can verify the spec/retention seq when reclaiming a job.
- Reclaim already-running jobs (`Scheduled` in `.compactions`, but in `self.job_progress`), but don't dispatch them to the executor.
- Validate already-running jobs have identical `CompactionSpec`s and `retention_min_seq`s for paranoia.

## Notes for Reviewers

Review in commit order.

There's a bit of a gotcha here:

> When an executor task stalls but the worker event loop keeps polling, the coordinator will reset the job to Scheduled; this branch treats any local job_progress entry as safe to reclaim and later writes a fresh WorkerSpec without restarting the job. That lets a non-heartbeating compaction repeatedly renew its own lease and prevents another worker from taking it over, defeating the per-job heartbeat timeout.

IMO, this is OK. There are a few outcomes in this scenario:

1. The job is still running, but slow. If so, it'll make some progress and time out again--giving other workers a change to claim it.
2. The job is dead for some reason. `handle_finished` will transition the job to `Failed` later.

If there are no other workers, it's a bit of a no-op anyway.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
