### PR TITLE
Improve GC logging

### DIFF
--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -383,9 +383,17 @@ impl GarbageCollector {
     #[instrument(level = "debug", skip_all, fields(resource = task.resource()))]
     async fn run_gc_task<T: GcTask + std::fmt::Debug>(&self, task: &T) {
         if let Err(e) = self.remove_expired_checkpoints().await {
-            error!("error removing expired checkpoints [error={}]", e);
+            error!(
+                "error removing expired checkpoints [resource={}, error={:?}]",
+                task.resource(),
+                e,
+            );
         } else if let Err(e) = task.collect(self.system_clock.now()).await {
-            error!("error collecting compacted garbage [error={}]", e);
+            error!(
+                "error collecting garbage [resource={}, error={:?}]",
+                task.resource(),
+                e,
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

@Barre reported on AWS, seeing:

```
2026-06-26T19:55:36.898814Z ERROR slatedb::garbage_collector: error collecting compacted garbage [error=object store error]
2026-06-26T19:55:36.901602Z  INFO slatedb::compactor: in-flight compaction [compaction=[seg=b"chunk"] ["10", "7", "3", "1"] -> SR(1)]
2026-06-26T19:55:36.901616Z  INFO slatedb::compactor: in-flight compaction [compaction=[seg=b"chunk"] ["l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0", "l0"] -> SR(13)]
2026-06-26T19:55:36.904677Z ERROR slatedb::garbage_collector: error collecting compacted garbage [error=object store error]
2026-06-26T19:55:36.918259Z  INFO zerofs::cli::server: .nbd directory already exists
```

The GC error log line is rather useless. This PR adds more details so we can see what's going on.

## Changes

- Use debug for GC log lines and print task resource name rather than always hard coding `compacted`.