### PR TITLE
Stop executing compaction job if it's no longer owned

### DIFF
--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -896,17 +896,23 @@ mod tests {
     /// worker handler can be exercised without spinning up actual SST writers.
     struct NoopExecutor {
         jobs: Mutex<Vec<StartCompactionJobArgs>>,
+        stopped_jobs: Mutex<Vec<Ulid>>,
     }
 
     impl NoopExecutor {
         fn new() -> Self {
             Self {
                 jobs: Mutex::new(Vec::new()),
+                stopped_jobs: Mutex::new(Vec::new()),
             }
         }
 
         fn jobs(&self) -> Vec<StartCompactionJobArgs> {
             self.jobs.lock().clone()
+        }
+
+        fn stopped_jobs(&self) -> Vec<Ulid> {
+            self.stopped_jobs.lock().clone()
         }
     }
 
@@ -914,8 +920,9 @@ mod tests {
         fn start_compaction_job(&self, args: StartCompactionJobArgs) {
             self.jobs.lock().push(args);
         }
-        fn stop_compaction_job(&self, _id: Ulid) -> bool {
-            false
+        fn stop_compaction_job(&self, id: Ulid) -> bool {
+            self.stopped_jobs.lock().push(id);
+            true
         }
         fn stop(&self) {}
     }
@@ -1074,6 +1081,97 @@ mod tests {
         assert_eq!(c.worker().unwrap().worker_id, "worker-B");
         assert!(fx.executor.jobs().is_empty());
         assert!(fx.handler.active_jobs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_worker_skips_rescheduled_job_already_active_locally() {
+        let mut fx = WorkerFixture::new_with_clock(
+            "worker-A",
+            Arc::new(DefaultSystemClock::new()),
+            CompactionWorkerOptions {
+                max_concurrent_compactions: 1,
+                ..CompactionWorkerOptions::default()
+            },
+        )
+        .await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert_eq!(fx.executor.jobs().len(), 1);
+        assert!(fx.handler.active_jobs.contains(&id));
+
+        // Simulate the coordinator reclaiming this worker's still-running job:
+        // the persisted entry is Scheduled again while the local executor still
+        // has it active. The worker should not re-claim or stop it here; the
+        // heartbeat path handles ownership loss.
+        let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        stored.refresh().await.unwrap();
+        let mut dirty = stored.prepare_dirty().unwrap();
+        let rescheduled = dirty
+            .value
+            .get(&id)
+            .cloned()
+            .expect("claimed compaction missing")
+            .with_status(CompactionStatus::Scheduled)
+            .with_worker(None);
+        dirty.value.insert(rescheduled);
+        stored.update(dirty).await.unwrap();
+
+        fx.handler.poll_and_claim().await.unwrap();
+
+        assert_eq!(
+            fx.executor.jobs().len(),
+            1,
+            "worker must not dispatch a duplicate execution"
+        );
+        assert!(
+            fx.executor.stopped_jobs().is_empty(),
+            "polling should not stop the active job"
+        );
+        assert!(fx.handler.active_jobs.contains(&id));
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Scheduled);
+        assert!(c.worker().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_worker_stops_active_job_when_heartbeat_loses_ownership() {
+        let mut fx = WorkerFixture::new("worker-A").await;
+        let id = Ulid::from_parts(1, 0);
+        fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert!(fx.handler.active_jobs.contains(&id));
+
+        // Simulate another worker taking ownership before this worker's next
+        // heartbeat. The heartbeat must not rewrite the entry; it should just
+        // request local execution stop.
+        let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        stored.refresh().await.unwrap();
+        let mut dirty = stored.prepare_dirty().unwrap();
+        let stolen = dirty
+            .value
+            .get(&id)
+            .cloned()
+            .expect("claimed compaction missing")
+            .with_worker(Some(WorkerSpec::new("worker-B".to_string(), 12345)));
+        dirty.value.insert(stolen);
+        stored.update(dirty).await.unwrap();
+
+        fx.handler.handle_planning_heartbeat(id).await.unwrap();
+
+        assert_eq!(fx.executor.stopped_jobs(), vec![id]);
+        let c = fx.read_compaction(id).await.expect("compaction missing");
+        assert_eq!(c.status(), CompactionStatus::Running);
+        assert_eq!(c.worker().unwrap().worker_id, "worker-B");
+        assert_eq!(c.worker().unwrap().last_heartbeat_ms, 12345);
     }
 
     #[tokio::test]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -845,8 +845,8 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
     ) -> Result<(), SlateDBError> {
         // Stop accepting new work, then release any active claims so other
         // workers can pick them up immediately rather than waiting for the
-        // heartbeat-timeout reclamation path. Stopping the executor runs each
-        // in-flight task's cleanup, which decrements `running_compactions`.
+        // heartbeat-timeout reclamation path. Stopping the executor also
+        // decrements `running_compactions` for cancelled tasks.
         self.executor.stop();
         self.job_progress.clear();
         let claimed = std::mem::take(&mut self.active_jobs);
@@ -905,6 +905,9 @@ mod tests {
     impl CompactionExecutor for NoopExecutor {
         fn start_compaction_job(&self, args: StartCompactionJobArgs) {
             self.jobs.lock().push(args);
+        }
+        fn stop_compaction_job(&self, _id: Ulid) -> bool {
+            false
         }
         fn stop(&self) {}
     }

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -379,8 +379,7 @@ impl CompactionWorkerHandler {
                     );
                 } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
-                } else {
-                }
+                } 
             }
             if to_claim.is_empty() {
                 debug!(

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -379,7 +379,7 @@ impl CompactionWorkerHandler {
                     );
                 } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
-                } 
+                }
             }
             if to_claim.is_empty() {
                 debug!(
@@ -490,6 +490,8 @@ impl CompactionWorkerHandler {
                     compaction_id
                 );
                 self.executor.stop_compaction_job(compaction_id);
+                self.active_jobs.remove(&compaction_id);
+                self.job_progress.remove(&compaction_id);
                 return Ok(None);
             }
             let now_ms = self.clock.now().timestamp_millis() as u64;
@@ -1139,16 +1141,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_worker_stops_active_job_when_heartbeat_loses_ownership() {
-        let mut fx = WorkerFixture::new("worker-A").await;
+        let mut fx = WorkerFixture::new_with_clock(
+            "worker-A",
+            Arc::new(DefaultSystemClock::new()),
+            CompactionWorkerOptions {
+                max_concurrent_compactions: 1,
+                ..CompactionWorkerOptions::default()
+            },
+        )
+        .await;
         let id = Ulid::from_parts(1, 0);
         fx.seed_scheduled_compaction(id, vec![SourceId::SstView(fx.l0_view.id)])
             .await;
         fx.handler.poll_and_claim().await.unwrap();
         assert!(fx.handler.active_jobs.contains(&id));
+        assert!(fx.handler.job_progress.contains_key(&id));
 
         // Simulate another worker taking ownership before this worker's next
         // heartbeat. The heartbeat must not rewrite the entry; it should just
-        // request local execution stop.
+        // request local execution stop and clear local capacity bookkeeping.
         let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
             .await
             .unwrap()
@@ -1167,10 +1178,23 @@ mod tests {
         fx.handler.handle_planning_heartbeat(id).await.unwrap();
 
         assert_eq!(fx.executor.stopped_jobs(), vec![id]);
+        assert!(!fx.handler.active_jobs.contains(&id));
+        assert!(!fx.handler.job_progress.contains_key(&id));
         let c = fx.read_compaction(id).await.expect("compaction missing");
         assert_eq!(c.status(), CompactionStatus::Running);
         assert_eq!(c.worker().unwrap().worker_id, "worker-B");
         assert_eq!(c.worker().unwrap().last_heartbeat_ms, 12345);
+
+        let next_id = Ulid::from_parts(2, 0);
+        fx.seed_scheduled_compaction(next_id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+
+        let jobs = fx.executor.jobs();
+        assert_eq!(jobs.len(), 2);
+        assert_eq!(jobs[1].compaction_id, next_id);
+        assert!(fx.handler.active_jobs.contains(&next_id));
+        assert!(fx.handler.job_progress.contains_key(&next_id));
     }
 
     #[tokio::test]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -343,9 +343,6 @@ impl CompactionWorkerHandler {
     /// Claims that fail validation are released back to `Scheduled`.
     async fn poll_and_claim(&mut self) -> Result<(), SlateDBError> {
         let capacity = self.capacity();
-        if capacity == 0 {
-            return Ok(());
-        }
 
         // CAS loop: read latest, identify candidates, attempt write.
         // Candidates are filtered on their spec alone here; validating the
@@ -363,16 +360,26 @@ impl CompactionWorkerHandler {
                 .iter_with_status(&[CompactionStatus::Scheduled])
                 .filter(|c| c.worker().is_none())
             {
-                if to_claim.len() >= capacity {
-                    break;
-                }
-                // Drain specs are coordinator-local, and a tiered spec without
-                // a destination can never be executed; neither can become
-                // valid later, so skip them rather than claim and release.
-                if !c.spec().is_drain() && c.spec().destination().is_some() {
+                if c.spec().is_drain() || c.spec().destination().is_none() {
+                    // Drain specs are coordinator-local, and a tiered spec without
+                    // a destination can never be executed; neither can become
+                    // valid later, so skip them rather than claim and release.
+                    warn!("skipping unrunnable compaction spec [id={}]", c.id());
+                } else if self.active_jobs.contains(&c.id()) {
+                    // It's possible this worker tries to claim a job that it's already running.
+                    // This can happen if coordinator hasn't seen this worker's heartbeat yet,
+                    // and transitions the job back to `Scheduled`. We don't attempt to reclaim
+                    // the job since its context might have diverged or this worker might be
+                    // misbehaving. Instead, we allow the worker's next heartbeat to see it no
+                    // longer owns the job and stop the local execution.
+                    debug!(
+                        "skipping this compactor is running but doesn't own [worker_id={}, id={}]",
+                        self.worker_id,
+                        c.id()
+                    );
+                } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
                 } else {
-                    warn!("skipping unrunnable compaction spec [id={}]", c.id());
                 }
             }
             if to_claim.is_empty() {
@@ -479,10 +486,11 @@ impl CompactionWorkerHandler {
             };
             if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str()) {
                 debug!(
-                    "heartbeat: no longer owner of compaction [worker_id={} compaction_id={}]; skipping",
+                    "heartbeat: no longer owner of compaction, stopping execution [worker_id={} compaction_id={}]; skipping",
                     self.worker_id,
                     compaction_id
                 );
+                self.executor.stop_compaction_job(compaction_id);
                 return Ok(None);
             }
             let now_ms = self.clock.now().timestamp_millis() as u64;

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -370,12 +370,18 @@ impl CompactionWorkerHandler {
                     // This can happen if coordinator hasn't seen this worker's heartbeat yet,
                     // and transitions the job back to `Scheduled`. We don't attempt to reclaim
                     // the job since its context might have diverged or this worker might be
-                    // misbehaving. Instead, we allow the worker's next heartbeat to see it no
-                    // longer owns the job and stop the local execution.
+                    // misbehaving. Instead, stop the local execution so a subsequent poll can
+                    // claim only after local bookkeeping has been cleared.
                     debug!(
                         "skipping this compactor is running but doesn't own [worker_id={}, id={}]",
                         self.worker_id,
                         c.id()
+                    );
+                    Self::stop_compaction_job(
+                        &self.executor,
+                        &mut self.active_jobs,
+                        &mut self.job_progress,
+                        c.id(),
                     );
                 } else if to_claim.len() < capacity {
                     to_claim.push(c.clone());
@@ -489,9 +495,12 @@ impl CompactionWorkerHandler {
                     self.worker_id,
                     compaction_id
                 );
-                self.executor.stop_compaction_job(compaction_id);
-                self.active_jobs.remove(&compaction_id);
-                self.job_progress.remove(&compaction_id);
+                Self::stop_compaction_job(
+                    &self.executor,
+                    &mut self.active_jobs,
+                    &mut self.job_progress,
+                    compaction_id,
+                );
                 return Ok(None);
             }
             let now_ms = self.clock.now().timestamp_millis() as u64;
@@ -745,6 +754,24 @@ impl CompactionWorkerHandler {
                 Err(e) => return Err(e),
             }
         }
+    }
+
+    // Stops a compaction job that is currently executing on this worker, removing
+    // it from the active jobs and progress bookkeeping. This is used when a
+    // job is no longer owned by this worker (e.g., it was reclaimed by the
+    // coordinator due to a heartbeat timeout). The function returns without waiting
+    // for the executor to finish stopping the job.
+    //
+    // To release ownership of a job, use `release_claim` instead.
+    fn stop_compaction_job(
+        executor: &Arc<dyn CompactionExecutor + Send + Sync>,
+        active_jobs: &mut BTreeSet<Ulid>,
+        job_progress: &mut HashMap<Ulid, JobProgressState>,
+        compaction_id: Ulid,
+    ) {
+        executor.stop_compaction_job(compaction_id);
+        active_jobs.remove(&compaction_id);
+        job_progress.remove(&compaction_id);
     }
 
     /// Returns a claim to `Scheduled` so it can be re-attempted by any worker
@@ -1085,7 +1112,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_worker_skips_rescheduled_job_already_active_locally() {
+    async fn test_worker_stops_rescheduled_job_already_active_locally_on_poll() {
         let mut fx = WorkerFixture::new_with_clock(
             "worker-A",
             Arc::new(DefaultSystemClock::new()),
@@ -1104,8 +1131,8 @@ mod tests {
 
         // Simulate the coordinator reclaiming this worker's still-running job:
         // the persisted entry is Scheduled again while the local executor still
-        // has it active. The worker should not re-claim or stop it here; the
-        // heartbeat path handles ownership loss.
+        // has it active. The worker should not re-claim it in the same poll,
+        // but it should stop local execution and clear local bookkeeping.
         let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
             .await
             .unwrap()
@@ -1129,11 +1156,9 @@ mod tests {
             1,
             "worker must not dispatch a duplicate execution"
         );
-        assert!(
-            fx.executor.stopped_jobs().is_empty(),
-            "polling should not stop the active job"
-        );
-        assert!(fx.handler.active_jobs.contains(&id));
+        assert_eq!(fx.executor.stopped_jobs(), vec![id]);
+        assert!(!fx.handler.active_jobs.contains(&id));
+        assert!(!fx.handler.job_progress.contains_key(&id));
         let c = fx.read_compaction(id).await.expect("compaction missing");
         assert_eq!(c.status(), CompactionStatus::Scheduled);
         assert!(c.worker().is_none());

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -204,7 +204,14 @@ pub(crate) trait CompactionExecutor {
     /// Starts executing a compaction job asynchronously.
     fn start_compaction_job(&self, compaction: StartCompactionJobArgs);
 
-    /// Stops the executor and cancels any in-flight tasks, waiting for them to finish.
+    /// Requests that an executing compaction job stop.
+    ///
+    /// Returns true if the job was active and a stop was requested. This does
+    /// not wait for the task to finish winding down.
+    #[allow(dead_code)]
+    fn stop_compaction_job(&self, id: Ulid) -> bool;
+
+    /// Stops the executor and requests cancellation of any in-flight tasks.
     fn stop(&self);
 }
 
@@ -264,12 +271,17 @@ impl CompactionExecutor for TokioCompactionExecutor {
         self.inner.start_compaction_job(compaction);
     }
 
+    fn stop_compaction_job(&self, id: Ulid) -> bool {
+        self.inner.stop_compaction_job(id)
+    }
+
     fn stop(&self) {
         self.inner.stop()
     }
 }
 
 struct TokioCompactionTask {
+    destination: u32,
     task: JoinHandle<Result<SortedRun, SlateDBError>>,
 }
 
@@ -293,7 +305,7 @@ pub(crate) struct TokioCompactionExecutorInner {
     handle: tokio::runtime::Handle,
     worker_tx: async_channel::Sender<WorkerMessage>,
     table_store: Arc<TableStore>,
-    tasks: Arc<Mutex<BTreeMap<u32, TokioCompactionTask>>>,
+    tasks: Arc<Mutex<BTreeMap<Ulid, TokioCompactionTask>>>,
     rand: Arc<DbRand>,
     stats: Arc<CompactionStats>,
     worker_stats: WorkerStats,
@@ -920,11 +932,11 @@ impl TokioCompactionExecutorInner {
         if self.is_stopped.load(atomic::Ordering::SeqCst) {
             return;
         }
-        let dst = args.destination;
-        self.worker_stats.running_compactions.increment(1);
-        assert!(!tasks.contains_key(&dst));
-
         let id = args.id;
+        let dst = args.destination;
+        assert!(!tasks.contains_key(&id));
+        assert!(!tasks.values().any(|task| task.destination == dst));
+        self.worker_stats.running_compactions.increment(1);
 
         // TODO(sujeetsawala): Add compaction plan to object store with InProgress status
 
@@ -934,11 +946,18 @@ impl TokioCompactionExecutorInner {
             "compactor_executor".to_string(),
             &self.handle,
             move |result| {
-                let result = result.clone();
-                {
+                let removed = {
                     let mut tasks = this_cleanup.tasks.lock();
-                    tasks.remove(&dst);
+                    tasks.remove(&id).is_some()
+                };
+
+                // If the task was already removed (e.g., by `stop_compaction_job`), don't
+                // send a completion message or update metrics.
+                if !removed {
+                    return;
                 }
+
+                let result = result.clone();
                 // Allow send() because we are treating the executor like an external
                 // component. They can do what they want. If the send fails (e.g., during
                 // DB shutdown), we log it and continue with cleanup.
@@ -956,40 +975,81 @@ impl TokioCompactionExecutorInner {
             },
             async move { this.plan_and_execute_compaction_job(args).await },
         );
-        tasks.insert(dst, TokioCompactionTask { task });
+        tasks.insert(
+            id,
+            TokioCompactionTask {
+                destination: dst,
+                task,
+            },
+        );
     }
 
-    /// Cancels all active compaction tasks and waits for their termination.
-    fn stop(&self) {
-        // Drain all tasks and abort them, then release tasks lock so
-        // the cleanup function in spawn_bg_task (above) can take the
-        // lock and remove the task from the map.
-        let task_handles = {
+    /// Requests cancellation of one active compaction job.
+    #[allow(dead_code)]
+    fn stop_compaction_job(&self, id: Ulid) -> bool {
+        let task = {
             let mut tasks = self.tasks.lock();
-            // BTreeMap keeps abort/join order stable by destination. HashMap
-            // iteration order is randomized, which can feed the DST runtime a
-            // process-dependent shutdown order.
-            let mut task_handles = Vec::with_capacity(tasks.len());
-            while let Some((_, task)) = tasks.pop_first() {
-                task.task.abort();
-                task_handles.push(task.task);
-            }
-            task_handles
+            tasks.remove(&id)
+        };
+        let Some(task) = task else {
+            return false;
         };
 
+        task.task.abort();
+        self.worker_stats.running_compactions.increment(-1);
+        self.spawn_task_termination_logger(vec![(id, task.task)]);
+        true
+    }
+
+    fn spawn_task_termination_logger(
+        &self,
+        task_handles: Vec<(Ulid, JoinHandle<Result<SortedRun, SlateDBError>>)>,
+    ) {
+        if task_handles.is_empty() {
+            return;
+        }
         let wait_for_task_termination = async move {
-            let results = join_all(task_handles).await;
-            for result in results {
+            let results = join_all(
+                task_handles
+                    .into_iter()
+                    .map(|(id, task)| async move { (id, task.await) }),
+            )
+            .await;
+            for (id, result) in results {
                 match result {
                     Err(e) if !e.is_cancelled() => {
-                        error!("shutdown error in compaction task [error={:?}]", e);
+                        error!(
+                            "compaction job failed to stop cleanly [id={}, error={:?}]",
+                            id, e
+                        );
                     }
                     _ => {}
                 }
             }
         };
-
         self.handle.spawn(wait_for_task_termination);
+    }
+
+    /// Requests cancellation of all active compaction tasks.
+    fn stop(&self) {
+        // Drain all tasks and abort them, then release tasks lock. Draining
+        // takes ownership of cancellation accounting, so task cleanup skips
+        // completion messages and metric updates for these jobs.
+        let task_handles = {
+            let mut tasks = self.tasks.lock();
+            // BTreeMap keeps abort/join order stable by job id. HashMap
+            // iteration order is randomized, which can feed the DST runtime a
+            // process-dependent shutdown order.
+            let mut task_handles = Vec::with_capacity(tasks.len());
+            while let Some((id, task)) = tasks.pop_first() {
+                task.task.abort();
+                self.worker_stats.running_compactions.increment(-1);
+                task_handles.push((id, task.task));
+            }
+            task_handles
+        };
+
+        self.spawn_task_termination_logger(task_handles);
         self.is_stopped.store(true, atomic::Ordering::SeqCst);
     }
 }
@@ -2449,6 +2509,139 @@ mod tests {
     /// still makes progress (emits a progress message) while that flush is in
     /// flight. Before `close()` was pipelined off the loop, the loop would be
     /// parked inside `close()` and emit nothing until the flush completed.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_stop_single_compaction_job_without_stopping_executor() {
+        // given: an executor writing through a gated object store, with a tiny
+        // max_sst_size so the first compaction parks while flushing output.
+        let handle = tokio::runtime::Handle::current();
+        let options = Arc::new(CompactionWorkerOptions {
+            max_sst_size: 1,
+            ..CompactionWorkerOptions::default()
+        });
+        let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated = Arc::new(GatedObjectStore::new(inner));
+        let object_store: Arc<dyn ObjectStore> = gated.clone();
+        let root_path = Path::from("testdb-stop-single-job");
+        let clock = Arc::new(DefaultSystemClock::new());
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store.clone(), None),
+            SsTableFormat {
+                block_size: 64,
+                ..SsTableFormat::default()
+            },
+            root_path.clone(),
+            None,
+            TableStoreKind::Compactor,
+        ));
+        let manifest_store = Arc::new(ManifestStore::new(&root_path, object_store.clone()));
+        StoredManifest::create_new_db(manifest_store.clone(), ManifestCore::new(), clock.clone())
+            .await
+            .unwrap();
+
+        let executor = TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
+            handle,
+            options,
+            worker_tx: tx,
+            table_store: table_store.clone(),
+            rand: Arc::new(DbRand::new(100u64)),
+            stats: {
+                let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+                Arc::new(CompactionStats::new(&recorder))
+            },
+            worker_stats: WorkerStats::noop(),
+            clock,
+            manifest_store,
+            merge_operator: None,
+            #[cfg(feature = "compaction_filters")]
+            compaction_filter_supplier: None,
+        });
+
+        let entries: Vec<RowEntry> = (0u64..64)
+            .map(|i| {
+                RowEntry::new_value(
+                    format!("key{i:04}").as_bytes(),
+                    format!("val{i:04}").as_bytes(),
+                    i + 1,
+                )
+            })
+            .collect();
+        let input_ssts = write_sst(&table_store, &entries, usize::MAX).await;
+        let l0_sst_views: Vec<SsTableView> =
+            input_ssts.into_iter().map(SsTableView::identity).collect();
+
+        let setup_puts = gated.put_opts_gate.arrivals();
+        gated.put_opts_gate.close();
+
+        // when: the first job runs and reaches a blocked output flush.
+        let stopped_id = Ulid::new();
+        executor.start_compaction_job(StartCompactionJobArgs {
+            id: stopped_id,
+            compaction_id: stopped_id,
+            destination: 0,
+            l0_sst_views: l0_sst_views.clone(),
+            sorted_runs: vec![],
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+            ctx: Some(CompactionContext::new(
+                vec![Subcompaction::new(BytesRange::unbounded())],
+                Some(0),
+            )),
+        });
+        tokio::time::timeout(
+            Duration::from_secs(5),
+            gated.put_opts_gate.wait_for_arrivals(setup_puts + 1),
+        )
+        .await
+        .expect("a close() should reach the blocked put gate");
+        assert!(executor.inner.tasks.lock().contains_key(&stopped_id));
+
+        // then: stopping that job clears executor bookkeeping immediately.
+        assert!(executor.stop_compaction_job(stopped_id));
+        assert!(executor.inner.tasks.lock().is_empty());
+        assert!(!executor.stop_compaction_job(stopped_id));
+
+        // when: the gate is reopened and a second job is started on the same
+        // executor and destination.
+        gated.put_opts_gate.release();
+        let second_id = Ulid::new();
+        executor.start_compaction_job(StartCompactionJobArgs {
+            id: second_id,
+            compaction_id: second_id,
+            destination: 0,
+            l0_sst_views,
+            sorted_runs: vec![],
+            compaction_clock_tick: 0,
+            is_dest_last_run: false,
+            retention_min_seq: Some(0),
+            ctx: Some(CompactionContext::new(
+                vec![Subcompaction::new(BytesRange::unbounded())],
+                Some(0),
+            )),
+        });
+
+        // then: the second job completes, and the stopped job never reports a
+        // completion after cancellation won ownership of task accounting.
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match rx.recv().await.unwrap() {
+                    WorkerMessage::CompactionJobFinished { id, result } => {
+                        assert_ne!(id, stopped_id, "stopped job reported completion");
+                        if id == second_id {
+                            return result;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("second job should finish after the gate is released")
+        .expect("second compaction should succeed");
+        assert!(executor.inner.tasks.lock().is_empty());
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn should_keep_processing_while_sst_flush_is_blocked() {
         // given: an executor writing through a gated object store, with a tiny

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -2624,7 +2624,9 @@ mod tests {
         // completion after cancellation won ownership of task accounting.
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
-                if let WorkerMessage::CompactionJobFinished { id, result } = rx.recv().await.unwrap() {
+                if let WorkerMessage::CompactionJobFinished { id, result } =
+                    rx.recv().await.unwrap()
+                {
                     assert_ne!(id, stopped_id, "stopped job reported completion");
                     if id == second_id {
                         return result;

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -2624,14 +2624,11 @@ mod tests {
         // completion after cancellation won ownership of task accounting.
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
-                match rx.recv().await.unwrap() {
-                    WorkerMessage::CompactionJobFinished { id, result } => {
-                        assert_ne!(id, stopped_id, "stopped job reported completion");
-                        if id == second_id {
-                            return result;
-                        }
+                if let WorkerMessage::CompactionJobFinished { id, result } = rx.recv().await.unwrap() {
+                    assert_ne!(id, stopped_id, "stopped job reported completion");
+                    if id == second_id {
+                        return result;
                     }
-                    _ => {}
                 }
             }
         })

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -208,7 +208,6 @@ pub(crate) trait CompactionExecutor {
     ///
     /// Returns true if the job was active and a stop was requested. This does
     /// not wait for the task to finish winding down.
-    #[allow(dead_code)]
     fn stop_compaction_job(&self, id: Ulid) -> bool;
 
     /// Stops the executor and requests cancellation of any in-flight tasks.

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -937,8 +937,6 @@ impl TokioCompactionExecutorInner {
         assert!(!tasks.values().any(|task| task.destination == dst));
         self.worker_stats.running_compactions.increment(1);
 
-        // TODO(sujeetsawala): Add compaction plan to object store with InProgress status
-
         let this = self.clone();
         let this_cleanup = self.clone();
         let task = spawn_bg_task(


### PR DESCRIPTION
## Summary

Fix compaction worker behavior when a running job is reclaimed by another worker or owned by no worker. The worker now stops local execution once it discovers it no longer owns a job and clears local bookkeeping.

The PR also avoids attempting to claim a `Scheduled` job that it's already running. This can happen if the coordinator moved the job back to `Scheduled`. The worker can see the job, and attempt to claim it even though it's already running a stale version of the job. We now skip such compactions. On subsequent heartbeat, the worker will halt the job and clear its state. If the job is still `Scheduled` on a subsequent poll_and_claim, the worker can reclaim it and resume.

Fixes #1850
Closes #1854

## Changes

- Add `CompactionExecutor::stop_compaction_job` for cancelling a single active compaction without stopping the whole executor.
- Track executor tasks by compaction job id instead of destination. We still check that destination is unique, though.
- Stop and clear local job state when heartbeat detects ownership loss.
- Avoid claiming a scheduled job that this worker is already running locally; the heartbeat path handles cleanup.
- Add tests covering local active-job rescheduling, heartbeat ownership loss, and single-job executor cancellation.

## Notes for Reviewers

Review can be done in commit order.

See #1853 and #1854 for previous attempts that tried to reclaim the job rather than halting the local execution. See [this discord](https://discord.com/channels/1232385660460204122/1520251104754143413) for info on why we chose to halt the job instead.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
