### PR TITLE
fix wal replay point propagation by serializing flush on writer task

### DIFF
--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -376,6 +376,7 @@ impl DbInner {
 
     /// Request a memtable freeze from the writer task. Sends a
     /// [`BatchWriterMessage::Flush`] to the writer event loop and waits for it to complete.
+    #[instrument(level = "trace", skip_all, err(level = tracing::Level::DEBUG))]
     pub(crate) async fn request_batch_writer_flush(
         &self,
         freeze_memtable: bool,

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -37,7 +37,7 @@ use tracing::instrument;
 use std::collections::BTreeSet;
 
 use bytes::Bytes;
-
+use parking_lot::RwLockWriteGuard;
 use crate::config::WriteOptions;
 use crate::db_transaction::DbTransaction;
 use crate::dispatcher::MessageHandler;
@@ -46,6 +46,8 @@ use crate::types::RowEntry;
 use crate::utils::WatchableOnceCellReader;
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
 use slatedb_common::clock::SystemClock;
+use crate::db_state::DbState;
+use tokio::sync::oneshot;
 
 pub(crate) const WRITE_BATCH_TASK_NAME: &str = "writer";
 
@@ -57,23 +59,43 @@ pub(crate) type WriteBatchResult = Result<
     SlateDBError,
 >;
 
-pub(crate) struct WriteBatchMessage {
+/// A message processed by the batch writer event loop.
+pub(crate) enum BatchWriterMessage {
+    /// Apply a write batch to the WAL and memtable. This may trigger freezing the memtable.
+    WriteBatch(WriteBatchRequest),
+    /// Flush the wal if enabled, and optionally freeze the current active memtable.
+    Flush(BatchWriterFlush),
+}
+
+pub(crate) struct BatchWriterFlush {
+    freeze_memtable: bool,
+    done: oneshot::Sender<Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError>>,
+}
+
+pub(crate) struct WriteBatchRequest {
     pub(crate) batch: WriteBatch,
     pub(crate) options: WriteOptions,
-    pub(crate) done: tokio::sync::oneshot::Sender<WriteBatchResult>,
+    pub(crate) done: oneshot::Sender<WriteBatchResult>,
     /// Holds the committing transaction once it is enqueued, ownership
     /// transfers from the caller to the writer. `None` for
     /// non-transactional writes. Fix for #1732.
     pub(crate) txn: Option<DbTransaction>,
 }
 
-impl std::fmt::Debug for WriteBatchMessage {
+impl std::fmt::Debug for BatchWriterMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let WriteBatchMessage { batch, options, .. } = self;
-        f.debug_struct("WriteBatch")
-            .field("batch", batch)
-            .field("options", options)
-            .finish()
+        match self {
+            BatchWriterMessage::WriteBatch(WriteBatchRequest { batch, options, .. }) => f
+                .debug_struct("WriteBatch")
+                .field("batch", batch)
+                .field("options", options)
+                .finish(),
+            BatchWriterMessage::Flush (BatchWriterFlush { freeze_memtable, .. }) => {
+                f.debug_struct("Flush")
+                    .field("freeze_memtable", freeze_memtable)
+                    .finish()
+            }
+        }
     }
 }
 
@@ -92,42 +114,69 @@ impl WriteBatchEventHandler {
 }
 
 #[async_trait]
-impl MessageHandler<WriteBatchMessage> for WriteBatchEventHandler {
-    async fn handle(&mut self, message: WriteBatchMessage) -> Result<(), SlateDBError> {
-        let WriteBatchMessage {
-            batch,
-            options,
-            done,
-            txn,
-        } = message;
-        let result = self
-            .db_inner
-            .write_batch(batch, &options, txn.as_ref())
-            .await;
-        // if this is the first write and the WAL is disabled, make sure users are flushing
-        // their memtables in a timely manner.
-        if self.is_first_write && !self.db_inner.wal_enabled && options.await_durable {
-            if let Ok((_, this_watcher)) = &result {
-                let this_watcher = this_watcher.clone();
-                let this_clock = self.db_inner.system_clock.clone();
-                tokio::spawn(async move {
-                    monitor_first_write(this_watcher, this_clock).await;
-                });
+impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
+    async fn handle(&mut self, message: BatchWriterMessage) -> Result<(), SlateDBError> {
+        match message {
+            BatchWriterMessage::WriteBatch(WriteBatchRequest {
+                batch,
+                options,
+                done,
+                txn,
+            }) => {
+                let result = self
+                    .db_inner
+                    .write_batch(batch, &options, txn.as_ref())
+                    .await;
+                // if this is the first write and the WAL is disabled, make sure users are flushing
+                // their memtables in a timely manner.
+                if self.is_first_write && !self.db_inner.wal_enabled && options.await_durable {
+                    if let Ok((_, this_watcher)) = &result {
+                        let this_watcher = this_watcher.clone();
+                        let this_clock = self.db_inner.system_clock.clone();
+                        tokio::spawn(async move {
+                            monitor_first_write(this_watcher, this_clock).await;
+                        });
+                    }
+                }
+                self.is_first_write = false;
+                _ = done.send(result);
+                Ok(())
+            }
+            // Run the freeze on the writer thread so it is totally ordered with
+            // write batches: it cannot land between a batch's WAL append and its
+            // memtable apply. The freeze resolves `replay_after_wal_id` from the
+            // WAL buffer here, where it is guaranteed consistent with the memtable.
+            BatchWriterMessage::Flush(flush_msg) => {
+                let BatchWriterFlush {
+                    freeze_memtable,
+                    done
+                } = flush_msg;
+                let result = self.db_inner.flush_batch_writer(freeze_memtable);
+                let _ = done.send(result);
+                Ok(())
             }
         }
-        self.is_first_write = false;
-        _ = done.send(result);
-        Ok(())
     }
 
     async fn cleanup(
         &mut self,
-        mut messages: BoxStream<'async_trait, WriteBatchMessage>,
+        mut messages: BoxStream<'async_trait, BatchWriterMessage>,
         result: Result<(), SlateDBError>,
     ) -> Result<(), SlateDBError> {
         let error = result.clone().err().unwrap_or(SlateDBError::Closed);
         while let Some(msg) = messages.next().await {
-            let _ = msg.done.send(Err(error.clone()));
+            match msg {
+                BatchWriterMessage::WriteBatch(req) => {
+                    let _ = req.done.send(Err(error.clone()));
+                }
+                BatchWriterMessage::Flush(flush_msg) => {
+                    let BatchWriterFlush {
+                        freeze_memtable: _,
+                        done
+                    } = flush_msg;
+                    let _ = done.send(Err(error.clone()));
+                }
+            }
         }
         Ok(())
     }
@@ -202,16 +251,6 @@ impl DbInner {
             self.wal_buffer.maybe_trigger_flush()?;
             // TODO: handle sync here, if sync is enabled, we can call `flush` here. let's put this
             // in another Pull Request.
-            // Test-only sync point: the batch is now durable-able (appended to the
-            // WAL and flushable) but has NOT been applied to the memtable yet. A
-            // test pauses here to let a concurrent freeze/flush advance
-            // `replay_after_wal_id` past this batch's WAL before the entry lands in
-            // the memtable, exercising the write-loss race.
-            fail_point!(
-                Arc::clone(&self.fp_registry),
-                "write-batch-before-memtable-apply",
-                |_| { Err(SlateDBError::from(std::io::Error::other("oops"))) }
-            );
             self.write_entries_to_memtable(entries, touched_segments);
             wal_watcher
         } else {
@@ -265,6 +304,83 @@ impl DbInner {
         Ok((write_handle, durable_watcher))
     }
 
+    fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {
+        let replay_after_wal_id = self.wal_buffer.recent_flushed_wal_id();
+        let mut guard = self.state.write();
+        let meta = guard.memtable().metadata();
+
+        let last_freeze_wal_id = guard
+            .state()
+            .imm_memtable
+            .front()
+            .map(|imm| imm.recent_flushed_wal_id())
+            .unwrap_or(guard.state().core().replay_after_wal_id);
+
+        let l0_sst_size_est = self
+            .table_store
+            .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
+
+        let wal_id_gap = replay_after_wal_id
+            .checked_sub(last_freeze_wal_id)
+            .ok_or_else(|| SlateDBError::InvalidDBState)?;
+
+        if wal_id_gap < self.settings.max_wal_flushes_before_l0_flush
+            && l0_sst_size_est < self.settings.l0_sst_size_bytes
+        {
+            return Ok(());
+        }
+        self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
+        Ok(())
+    }
+
+    fn flush_batch_writer(&self, freeze_memtable: bool) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
+        let flush_rx = if self.wal_enabled {
+            self.wal_buffer.flush()?
+        } else {
+            let (flush_tx, flush_rx) = oneshot::channel();
+            flush_tx.send(Ok(())).expect("unexpected oneshot send failure");
+            flush_rx
+        };
+        if freeze_memtable {
+            // Note that this likely won't reflect the result of the above flush call as we don't
+            // block until the flush completes. That's fine, as any earlier wal is still a safe
+            // replay point.
+            let replay_after_wal_id = self.wal_buffer.recent_flushed_wal_id();
+            let mut guard = self.state.write();
+            self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
+        }
+        Ok(flush_rx)
+    }
+
+    // TODO: this is only pub(crate) because currently the replay logic resides in db_common. We
+    //       should consolidate replay and the write path into one module and make this private
+    pub(crate) fn freeze_current_memtable_with_state_guard(
+        &self,
+        guard: &mut RwLockWriteGuard<'_, DbState>,
+        replay_after_wal_id: u64,
+    ) {
+        if guard.memtable().is_empty() {
+            return;
+        }
+
+        guard.freeze_memtable(replay_after_wal_id);
+        let _ = self.memtable_flusher().notify_memtable_frozen();
+    }
+
+    /// Request a memtable freeze from the writer task. Sends a
+    /// [`BatchWriterMessage::Flush`] to the writer event loop and waits for it to complete.
+    pub(crate) async fn request_batch_writer_flush(&self, freeze_memtable: bool) -> Result<(), SlateDBError> {
+        let (done, rx) = tokio::sync::oneshot::channel();
+        self.write_notifier
+            .send(BatchWriterMessage::Flush(
+                BatchWriterFlush {
+                    freeze_memtable,
+                    done
+                }
+            ))?;
+        rx.await??.await?
+    }
+
     /// RFC-0024 route-consistency check. Verifies that `batch_prefixes`,
     /// added to the union of every prefix the writer already knows
     /// about (manifest segments, in-flight imms, the active memtable),
@@ -279,7 +395,7 @@ impl DbInner {
     ///
     /// Read-only and runs before any durable side-effect, so a
     /// rejection leaves no trace.
-    pub(crate) fn validate_segment_antichain(
+    fn validate_segment_antichain(
         &self,
         batch_prefixes: &BTreeSet<Bytes>,
     ) -> Result<(), SlateDBError> {
@@ -399,17 +515,17 @@ mod tests {
         batch: WriteBatch,
         options: WriteOptions,
     ) -> (
-        WriteBatchMessage,
+        BatchWriterMessage,
         tokio::sync::oneshot::Receiver<WriteBatchResult>,
     ) {
         let (done, rx) = tokio::sync::oneshot::channel();
         (
-            WriteBatchMessage {
+            BatchWriterMessage::WriteBatch(WriteBatchRequest {
                 batch,
                 options,
                 done,
                 txn: None,
-            },
+            }),
             rx,
         )
     }

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -202,6 +202,16 @@ impl DbInner {
             self.wal_buffer.maybe_trigger_flush()?;
             // TODO: handle sync here, if sync is enabled, we can call `flush` here. let's put this
             // in another Pull Request.
+            // Test-only sync point: the batch is now durable-able (appended to the
+            // WAL and flushable) but has NOT been applied to the memtable yet. A
+            // test pauses here to let a concurrent freeze/flush advance
+            // `replay_after_wal_id` past this batch's WAL before the entry lands in
+            // the memtable, exercising the write-loss race.
+            fail_point!(
+                Arc::clone(&self.fp_registry),
+                "write-batch-before-memtable-apply",
+                |_| { Err(SlateDBError::from(std::io::Error::other("oops"))) }
+            );
             self.write_entries_to_memtable(entries, touched_segments);
             wal_watcher
         } else {

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -36,17 +36,17 @@ use tracing::instrument;
 
 use std::collections::BTreeSet;
 
-use bytes::Bytes;
-use parking_lot::RwLockWriteGuard;
 use crate::config::WriteOptions;
+use crate::db_state::DbState;
 use crate::db_transaction::DbTransaction;
 use crate::dispatcher::MessageHandler;
 use crate::mem_table::KVTable;
 use crate::types::RowEntry;
 use crate::utils::WatchableOnceCellReader;
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
+use bytes::Bytes;
+use parking_lot::RwLockWriteGuard;
 use slatedb_common::clock::SystemClock;
-use crate::db_state::DbState;
 use tokio::sync::oneshot;
 
 pub(crate) const WRITE_BATCH_TASK_NAME: &str = "writer";
@@ -60,6 +60,7 @@ pub(crate) type WriteBatchResult = Result<
 >;
 
 /// A message processed by the batch writer event loop.
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum BatchWriterMessage {
     /// Apply a write batch to the WAL and memtable. This may trigger freezing the memtable.
     WriteBatch(WriteBatchRequest),
@@ -68,7 +69,11 @@ pub(crate) enum BatchWriterMessage {
 }
 
 pub(crate) struct BatchWriterFlush {
+    /// If true, then also freeze the current active memtable.
     freeze_memtable: bool,
+    /// Sends a message when the writer has processed the flush message. On successful receipt
+    /// of a message, the caller should wait on the received Receiver to get the result of the
+    /// wal flush.
     done: oneshot::Sender<Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError>>,
 }
 
@@ -90,11 +95,12 @@ impl std::fmt::Debug for BatchWriterMessage {
                 .field("batch", batch)
                 .field("options", options)
                 .finish(),
-            BatchWriterMessage::Flush (BatchWriterFlush { freeze_memtable, .. }) => {
-                f.debug_struct("Flush")
-                    .field("freeze_memtable", freeze_memtable)
-                    .finish()
-            }
+            BatchWriterMessage::Flush(BatchWriterFlush {
+                freeze_memtable, ..
+            }) => f
+                .debug_struct("Flush")
+                .field("freeze_memtable", freeze_memtable)
+                .finish(),
         }
     }
 }
@@ -142,14 +148,10 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 _ = done.send(result);
                 Ok(())
             }
-            // Run the freeze on the writer thread so it is totally ordered with
-            // write batches: it cannot land between a batch's WAL append and its
-            // memtable apply. The freeze resolves `replay_after_wal_id` from the
-            // WAL buffer here, where it is guaranteed consistent with the memtable.
             BatchWriterMessage::Flush(flush_msg) => {
                 let BatchWriterFlush {
                     freeze_memtable,
-                    done
+                    done,
                 } = flush_msg;
                 let result = self.db_inner.flush_batch_writer(freeze_memtable);
                 let _ = done.send(result);
@@ -172,7 +174,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 BatchWriterMessage::Flush(flush_msg) => {
                     let BatchWriterFlush {
                         freeze_memtable: _,
-                        done
+                        done,
                     } = flush_msg;
                     let _ = done.send(Err(error.clone()));
                 }
@@ -333,12 +335,17 @@ impl DbInner {
         Ok(())
     }
 
-    fn flush_batch_writer(&self, freeze_memtable: bool) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
+    fn flush_batch_writer(
+        &self,
+        freeze_memtable: bool,
+    ) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
         let flush_rx = if self.wal_enabled {
             self.wal_buffer.flush()?
         } else {
             let (flush_tx, flush_rx) = oneshot::channel();
-            flush_tx.send(Ok(())).expect("unexpected oneshot send failure");
+            flush_tx
+                .send(Ok(()))
+                .expect("unexpected oneshot send failure");
             flush_rx
         };
         if freeze_memtable {
@@ -369,15 +376,16 @@ impl DbInner {
 
     /// Request a memtable freeze from the writer task. Sends a
     /// [`BatchWriterMessage::Flush`] to the writer event loop and waits for it to complete.
-    pub(crate) async fn request_batch_writer_flush(&self, freeze_memtable: bool) -> Result<(), SlateDBError> {
+    pub(crate) async fn request_batch_writer_flush(
+        &self,
+        freeze_memtable: bool,
+    ) -> Result<(), SlateDBError> {
         let (done, rx) = tokio::sync::oneshot::channel();
         self.write_notifier
-            .send(BatchWriterMessage::Flush(
-                BatchWriterFlush {
-                    freeze_memtable,
-                    done
-                }
-            ))?;
+            .send(BatchWriterMessage::Flush(BatchWriterFlush {
+                freeze_memtable,
+                done,
+            }))?;
         rx.await??.await?
     }
 

--- a/slatedb/src/checkpoint.rs
+++ b/slatedb/src/checkpoint.rs
@@ -34,10 +34,7 @@ impl Db {
     ) -> Result<CheckpointCreateResult, crate::Error> {
         let target = match scope {
             CheckpointScope::All => {
-                if self.inner.wal_enabled {
-                    self.inner.flush_wals().await?;
-                }
-                self.inner.freeze_current_memtable()?;
+                self.inner.request_batch_writer_flush(true).await?;
                 FlushTarget::All
             }
             CheckpointScope::Durable => FlushTarget::CurrentDurable,

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -5946,6 +5946,175 @@ mod tests {
         reader.close().await.unwrap();
     }
 
+    // Reproduces a lost-write race: a batch is acked durable (its WAL is
+    // flushed) yet is dropped on restart, because a concurrent memtable
+    // freeze/flush advances `replay_after_wal_id` past the batch's WAL *before*
+    // the batch is applied to the memtable.
+    //
+    // Timeline (W = the racing write batch):
+    //   1. The write task appends W to the WAL (making it flushable) and then
+    //      pauses, via failpoint, *before* applying W to the memtable.
+    //   2. A concurrent flush (e.g. an explicit `flush()`/`create_checkpoint`)
+    //      flushes the WAL -- advancing recent_flushed_wal_id to cover W and
+    //      acking W as durable -- and then freezes+flushes the memtable. The
+    //      frozen memtable does NOT contain W, yet it is stamped with
+    //      recent_flushed_wal_id, so the persisted manifest advances
+    //      replay_after_wal_id past W's WAL.
+    //   3. The write task resumes and applies W to the *new* memtable; the write
+    //      completes and is reported durable.
+    //   4. Crash + restart: replay begins after W's WAL, so W is gone.
+    //
+    // The final assertion (W survives restart) FAILS on the buggy code,
+    // demonstrating the data loss.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_write_lost_when_freeze_races_wal_flush() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_write_loss_race");
+
+        // Disable automatic flushing so the test drives the race deterministically:
+        // no flush timer (flush_interval = None) and a large size threshold so a
+        // couple of tiny writes never trigger a size-based WAL flush or memtable
+        // freeze on their own.
+        let mut options = test_db_options(0, 64 * 1024 * 1024, None);
+        options.flush_interval = None;
+
+        let db = Db::builder(path.clone(), object_store.clone())
+            .with_settings(options)
+            .with_fp_registry(fp_registry.clone())
+            .build()
+            .await
+            .unwrap();
+
+        let key_base = b"base";
+        let val_base = b"base-value";
+        let key_w = b"lost";
+        let val_w = b"lost-value";
+
+        let non_durable = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+        let durable = WriteOptions {
+            await_durable: true,
+            ..Default::default()
+        };
+
+        // Baseline write: leaves the active memtable non-empty (but WITHOUT W) so
+        // the freeze during the race produces a real immutable memtable to flush.
+        // Flush its WAL so the durable WAL boundary is settled before W is issued.
+        db.put_with_options(key_base, val_base, &PutOptions::default(), &non_durable)
+            .await
+            .unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::Wal,
+        })
+        .await
+        .unwrap();
+        let wal_boundary_before_w = db.inner.wal_buffer.recent_flushed_wal_id();
+
+        // Park the write task after it appends W to the WAL but before it applies
+        // W to the memtable.
+        fail_parallel::cfg(
+            fp_registry.clone(),
+            "write-batch-before-memtable-apply",
+            "pause",
+        )
+        .unwrap();
+
+        // Issue W on a background task; it blocks until we lift the pause.
+        let db_writer = db.clone();
+        let join = tokio::spawn(async move {
+            db_writer
+                .put_with_options(key_w, val_w, &PutOptions::default(), &durable)
+                .await
+        });
+
+        // W is being parked at the failpoint, after it is appended to the WAL but
+        // before it is applied to the memtable. Drive WAL flushes until the
+        // durable WAL boundary advances past its pre-W value. That boundary --
+        // recent_flushed_wal_id, the same value copied into replay_after_wal_id --
+        // only moves when a WAL SST is flushed, so once it advances we know W's
+        // append was captured in a flushed WAL (and W is acked durable). A
+        // FlushType::Wal flush is a no-op until W has actually been appended.
+        let mut wal_id_covering_w = wal_boundary_before_w;
+        for _ in 0..3000 {
+            db.flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+            let flushed = db.inner.wal_buffer.recent_flushed_wal_id();
+            if flushed > wal_boundary_before_w {
+                wal_id_covering_w = flushed;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            wal_id_covering_w > wal_boundary_before_w,
+            "timed out waiting for W's WAL to be flushed"
+        );
+
+        // Now freeze + flush the memtable through the PUBLIC flush API. The frozen
+        // memtable holds key_base but NOT W, yet it is stamped with
+        // recent_flushed_wal_id, so the manifest's replay boundary is advanced to
+        // (and including) W's WAL. (The WAL flush this performs internally is a
+        // no-op -- W's WAL was already flushed above.) This freeze-after-WAL-flush
+        // is the exact sequence `flush_with_options(MemTable)` and
+        // `create_checkpoint(All)` run concurrently with writes.
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        let replay_after = db.inner.state.read().state().core().replay_after_wal_id;
+        assert_eq!(
+            replay_after, wal_id_covering_w,
+            "replay boundary was advanced to (and including) the WAL that holds W"
+        );
+
+        // Resume the write task: W lands in the new memtable and the write
+        // completes -- and is acked durable.
+        fail_parallel::cfg(
+            fp_registry.clone(),
+            "write-batch-before-memtable-apply",
+            "off",
+        )
+        .unwrap();
+        join.await.unwrap().expect("W was acked durable");
+
+        // --- Crash + restart. Do NOT close `db` -- closing would flush the live
+        // memtable and persist W, masking the bug. Reopen on the same store and
+        // let it replay from the manifest. ---
+        let mut reopen_options = test_db_options(0, 64 * 1024 * 1024, None);
+        reopen_options.flush_interval = None;
+        let reopened = Db::builder(path.clone(), object_store.clone())
+            .with_settings(reopen_options)
+            .build()
+            .await
+            .unwrap();
+
+        // key_base survived: it was flushed to L0.
+        assert_eq!(
+            reopened.get(key_base).await.unwrap(),
+            Some(Bytes::copy_from_slice(val_base)),
+            "key_base should survive restart via L0"
+        );
+
+        // W was acked durable but is gone after restart: replay skipped its WAL.
+        // This assertion FAILS on the buggy code, reproducing the lost write.
+        assert_eq!(
+            reopened.get(key_w).await.unwrap(),
+            Some(Bytes::copy_from_slice(val_w)),
+            "acked-durable write W must survive restart, but it was lost: the \
+             memtable freeze advanced replay_after_wal_id past W's WAL before W \
+             was applied to the memtable"
+        );
+
+        reopened.close().await.unwrap();
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_should_recover_imm_from_wal_after_flush_error() {
         let fp_registry = Arc::new(FailPointRegistry::new());

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -42,7 +42,7 @@ use parking_lot::RwLock;
 use std::time::Duration;
 
 use crate::batch::WriteBatch;
-use crate::batch_write::{WriteBatchMessage, WRITE_BATCH_TASK_NAME};
+use crate::batch_write::{BatchWriterMessage, WriteBatchRequest, WRITE_BATCH_TASK_NAME};
 use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
@@ -89,7 +89,7 @@ pub(crate) struct DbInner {
     pub(crate) settings: Settings,
     pub(crate) table_store: Arc<TableStore>,
     pub(crate) memtable_flusher: Arc<MemtableFlusher>,
-    pub(crate) write_notifier: SafeSender<WriteBatchMessage>,
+    pub(crate) write_notifier: SafeSender<BatchWriterMessage>,
     pub(crate) db_stats: DbStats,
     /// Kept alive so the underlying `MetricsRecorder` is not dropped while
     /// metric handles in `DbStats` (and other stats structs) are still in use.
@@ -129,7 +129,7 @@ impl DbInner {
         table_store: Arc<TableStore>,
         manifest: DirtyObject<Manifest>,
         memtable_flusher: Arc<MemtableFlusher>,
-        write_notifier: SafeSender<WriteBatchMessage>,
+        write_notifier: SafeSender<BatchWriterMessage>,
         recorder: MetricsRecorderHelper,
         fp_registry: Arc<FailPointRegistry>,
         merge_operator: Option<crate::merge_operator::MergeOperatorType>,
@@ -295,12 +295,12 @@ impl DbInner {
         }
 
         let (tx, rx) = tokio::sync::oneshot::channel();
-        let batch_msg = WriteBatchMessage {
+        let batch_msg = BatchWriterMessage::WriteBatch(WriteBatchRequest {
             batch,
             options: options.clone(),
             done: tx,
             txn,
-        };
+        });
 
         self.maybe_apply_backpressure().await?;
         self.write_notifier.send(batch_msg)?;
@@ -421,11 +421,6 @@ impl DbInner {
         Ok(())
     }
 
-    pub(crate) async fn flush_wals(&self) -> Result<u64, SlateDBError> {
-        self.wal_buffer.flush().await?;
-        Ok(self.wal_buffer.recent_flushed_wal_id())
-    }
-
     async fn flush_imm_memtables(&self, target: FlushTarget) -> Result<FlushResult, SlateDBError> {
         self.memtable_flusher().flush(target).await
     }
@@ -434,7 +429,9 @@ impl DbInner {
         &self,
         target: FlushTarget,
     ) -> Result<FlushResult, SlateDBError> {
-        self.freeze_current_memtable()?;
+        // flush the batch writer to freeze the active memtable and flush all WALs to unblock
+        // memtable flush
+        self.request_batch_writer_flush(true).await?;
         self.flush_imm_memtables(target).await
     }
 
@@ -467,16 +464,12 @@ impl DbInner {
         }
         match options.flush_type {
             FlushType::Wal => {
-                if self.wal_enabled {
-                    self.flush_wals().await.map(|_| ())
-                } else {
-                    Err(SlateDBError::WalDisabled)
+                if !self.wal_enabled {
+                    return Err(SlateDBError::WalDisabled);
                 }
+                self.request_batch_writer_flush(false).await
             }
             FlushType::MemTable => {
-                if self.wal_enabled {
-                    self.flush_wals().await?;
-                }
                 self.flush_memtables(FlushTarget::All).await.map(|_| ())
             }
         }
@@ -4879,7 +4872,6 @@ mod tests {
         let flush_handle = {
             let inner = Arc::clone(&db.inner);
             tokio::spawn(async move {
-                inner.flush_wals().await?;
                 inner.flush_memtables(FlushTarget::All).await
             })
         };
@@ -5944,175 +5936,6 @@ mod tests {
 
         db.close().await.unwrap();
         reader.close().await.unwrap();
-    }
-
-    // Reproduces a lost-write race: a batch is acked durable (its WAL is
-    // flushed) yet is dropped on restart, because a concurrent memtable
-    // freeze/flush advances `replay_after_wal_id` past the batch's WAL *before*
-    // the batch is applied to the memtable.
-    //
-    // Timeline (W = the racing write batch):
-    //   1. The write task appends W to the WAL (making it flushable) and then
-    //      pauses, via failpoint, *before* applying W to the memtable.
-    //   2. A concurrent flush (e.g. an explicit `flush()`/`create_checkpoint`)
-    //      flushes the WAL -- advancing recent_flushed_wal_id to cover W and
-    //      acking W as durable -- and then freezes+flushes the memtable. The
-    //      frozen memtable does NOT contain W, yet it is stamped with
-    //      recent_flushed_wal_id, so the persisted manifest advances
-    //      replay_after_wal_id past W's WAL.
-    //   3. The write task resumes and applies W to the *new* memtable; the write
-    //      completes and is reported durable.
-    //   4. Crash + restart: replay begins after W's WAL, so W is gone.
-    //
-    // The final assertion (W survives restart) FAILS on the buggy code,
-    // demonstrating the data loss.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn test_write_lost_when_freeze_races_wal_flush() {
-        let fp_registry = Arc::new(FailPointRegistry::new());
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let path = Path::from("/tmp/test_write_loss_race");
-
-        // Disable automatic flushing so the test drives the race deterministically:
-        // no flush timer (flush_interval = None) and a large size threshold so a
-        // couple of tiny writes never trigger a size-based WAL flush or memtable
-        // freeze on their own.
-        let mut options = test_db_options(0, 64 * 1024 * 1024, None);
-        options.flush_interval = None;
-
-        let db = Db::builder(path.clone(), object_store.clone())
-            .with_settings(options)
-            .with_fp_registry(fp_registry.clone())
-            .build()
-            .await
-            .unwrap();
-
-        let key_base = b"base";
-        let val_base = b"base-value";
-        let key_w = b"lost";
-        let val_w = b"lost-value";
-
-        let non_durable = WriteOptions {
-            await_durable: false,
-            ..Default::default()
-        };
-        let durable = WriteOptions {
-            await_durable: true,
-            ..Default::default()
-        };
-
-        // Baseline write: leaves the active memtable non-empty (but WITHOUT W) so
-        // the freeze during the race produces a real immutable memtable to flush.
-        // Flush its WAL so the durable WAL boundary is settled before W is issued.
-        db.put_with_options(key_base, val_base, &PutOptions::default(), &non_durable)
-            .await
-            .unwrap();
-        db.flush_with_options(FlushOptions {
-            flush_type: FlushType::Wal,
-        })
-        .await
-        .unwrap();
-        let wal_boundary_before_w = db.inner.wal_buffer.recent_flushed_wal_id();
-
-        // Park the write task after it appends W to the WAL but before it applies
-        // W to the memtable.
-        fail_parallel::cfg(
-            fp_registry.clone(),
-            "write-batch-before-memtable-apply",
-            "pause",
-        )
-        .unwrap();
-
-        // Issue W on a background task; it blocks until we lift the pause.
-        let db_writer = db.clone();
-        let join = tokio::spawn(async move {
-            db_writer
-                .put_with_options(key_w, val_w, &PutOptions::default(), &durable)
-                .await
-        });
-
-        // W is being parked at the failpoint, after it is appended to the WAL but
-        // before it is applied to the memtable. Drive WAL flushes until the
-        // durable WAL boundary advances past its pre-W value. That boundary --
-        // recent_flushed_wal_id, the same value copied into replay_after_wal_id --
-        // only moves when a WAL SST is flushed, so once it advances we know W's
-        // append was captured in a flushed WAL (and W is acked durable). A
-        // FlushType::Wal flush is a no-op until W has actually been appended.
-        let mut wal_id_covering_w = wal_boundary_before_w;
-        for _ in 0..3000 {
-            db.flush_with_options(FlushOptions {
-                flush_type: FlushType::Wal,
-            })
-            .await
-            .unwrap();
-            let flushed = db.inner.wal_buffer.recent_flushed_wal_id();
-            if flushed > wal_boundary_before_w {
-                wal_id_covering_w = flushed;
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(10)).await;
-        }
-        assert!(
-            wal_id_covering_w > wal_boundary_before_w,
-            "timed out waiting for W's WAL to be flushed"
-        );
-
-        // Now freeze + flush the memtable through the PUBLIC flush API. The frozen
-        // memtable holds key_base but NOT W, yet it is stamped with
-        // recent_flushed_wal_id, so the manifest's replay boundary is advanced to
-        // (and including) W's WAL. (The WAL flush this performs internally is a
-        // no-op -- W's WAL was already flushed above.) This freeze-after-WAL-flush
-        // is the exact sequence `flush_with_options(MemTable)` and
-        // `create_checkpoint(All)` run concurrently with writes.
-        db.flush_with_options(FlushOptions {
-            flush_type: FlushType::MemTable,
-        })
-        .await
-        .unwrap();
-        let replay_after = db.inner.state.read().state().core().replay_after_wal_id;
-        assert_eq!(
-            replay_after, wal_id_covering_w,
-            "replay boundary was advanced to (and including) the WAL that holds W"
-        );
-
-        // Resume the write task: W lands in the new memtable and the write
-        // completes -- and is acked durable.
-        fail_parallel::cfg(
-            fp_registry.clone(),
-            "write-batch-before-memtable-apply",
-            "off",
-        )
-        .unwrap();
-        join.await.unwrap().expect("W was acked durable");
-
-        // --- Crash + restart. Do NOT close `db` -- closing would flush the live
-        // memtable and persist W, masking the bug. Reopen on the same store and
-        // let it replay from the manifest. ---
-        let mut reopen_options = test_db_options(0, 64 * 1024 * 1024, None);
-        reopen_options.flush_interval = None;
-        let reopened = Db::builder(path.clone(), object_store.clone())
-            .with_settings(reopen_options)
-            .build()
-            .await
-            .unwrap();
-
-        // key_base survived: it was flushed to L0.
-        assert_eq!(
-            reopened.get(key_base).await.unwrap(),
-            Some(Bytes::copy_from_slice(val_base)),
-            "key_base should survive restart via L0"
-        );
-
-        // W was acked durable but is gone after restart: replay skipped its WAL.
-        // This assertion FAILS on the buggy code, reproducing the lost write.
-        assert_eq!(
-            reopened.get(key_w).await.unwrap(),
-            Some(Bytes::copy_from_slice(val_w)),
-            "acked-durable write W must survive restart, but it was lost: the \
-             memtable freeze advanced replay_after_wal_id past W's WAL before W \
-             was applied to the memtable"
-        );
-
-        reopened.close().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -469,9 +469,7 @@ impl DbInner {
                 }
                 self.request_batch_writer_flush(false).await
             }
-            FlushType::MemTable => {
-                self.flush_memtables(FlushTarget::All).await.map(|_| ())
-            }
+            FlushType::MemTable => self.flush_memtables(FlushTarget::All).await.map(|_| ()),
         }
     }
 
@@ -4871,9 +4869,7 @@ mod tests {
         // flusher is paused at the failpoint above.
         let flush_handle = {
             let inner = Arc::clone(&db.inner);
-            tokio::spawn(async move {
-                inner.flush_memtables(FlushTarget::All).await
-            })
+            tokio::spawn(async move { inner.flush_memtables(FlushTarget::All).await })
         };
 
         let mut wrote_l0_sst = false;

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -1,9 +1,6 @@
 use bytes::Bytes;
-use parking_lot::RwLockWriteGuard;
 
-use crate::batch_write::BatchWriterMessage;
 use crate::db::DbInner;
-use crate::db_state::DbState;
 use crate::error::SlateDBError;
 use crate::oracle::Oracle;
 use crate::prefix_extractor::{PrefixExtractor, PrefixTarget};

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use parking_lot::RwLockWriteGuard;
 
+use crate::batch_write::BatchWriterMessage;
 use crate::db::DbInner;
 use crate::db_state::DbState;
 use crate::error::SlateDBError;
@@ -28,55 +29,6 @@ pub(crate) fn extract_segment_prefix(
 }
 
 impl DbInner {
-    pub(crate) fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {
-        let wal_id = self.wal_buffer.recent_flushed_wal_id();
-        let mut guard = self.state.write();
-        let meta = guard.memtable().metadata();
-
-        let last_freeze_wal_id = guard
-            .state()
-            .imm_memtable
-            .front()
-            .map(|imm| imm.recent_flushed_wal_id())
-            .unwrap_or(guard.state().core().replay_after_wal_id);
-
-        let l0_sst_size_est = self
-            .table_store
-            .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
-
-        let wal_id_gap = wal_id
-            .checked_sub(last_freeze_wal_id)
-            .ok_or_else(|| SlateDBError::InvalidDBState)?;
-
-        if wal_id_gap < self.settings.max_wal_flushes_before_l0_flush
-            && l0_sst_size_est < self.settings.l0_sst_size_bytes
-        {
-            Ok(())
-        } else {
-            self.freeze_memtable(&mut guard, wal_id)
-        }
-    }
-
-    pub(crate) fn freeze_current_memtable(&self) -> Result<(), SlateDBError> {
-        let wal_id = self.wal_buffer.recent_flushed_wal_id();
-        let mut guard = self.state.write();
-        self.freeze_memtable(&mut guard, wal_id)
-    }
-
-    pub(crate) fn freeze_memtable(
-        &self,
-        guard: &mut RwLockWriteGuard<'_, DbState>,
-        wal_id: u64,
-    ) -> Result<(), SlateDBError> {
-        if guard.memtable().is_empty() {
-            return Ok(());
-        }
-
-        guard.freeze_memtable(wal_id);
-        let _ = self.memtable_flusher().notify_memtable_frozen();
-        Ok(())
-    }
-
     pub(crate) fn replay_memtable(
         &self,
         replayed_memtable: ReplayedMemtable,
@@ -88,7 +40,7 @@ impl DbInner {
         // durable WAL boundary is the WAL buffer's current boundary. Stamp the
         // frozen table with that boundary before advancing the buffer for the new
         // replayed memtable.
-        self.freeze_memtable(&mut guard, current_memtable_wal_id)?;
+        self.freeze_current_memtable_with_state_guard(&mut guard, current_memtable_wal_id);
 
         let last_wal = replayed_memtable.last_wal_id;
         guard.modify(|modifier| modifier.state.manifest.value.core.next_wal_sst_id = last_wal + 1);

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -721,7 +721,7 @@ impl DbState {
         &self.memtable
     }
 
-    pub(crate) fn freeze_memtable(&mut self, recent_flushed_wal_id: u64) {
+    pub(crate) fn freeze_memtable(&mut self, replay_after_wal_id: u64) {
         let old_memtable = std::mem::replace(&mut self.memtable, WritableKVTable::new());
         self.modify(|modifier| {
             modifier
@@ -729,7 +729,7 @@ impl DbState {
                 .imm_memtable
                 .push_front(Arc::new(ImmutableMemtable::new(
                     old_memtable,
-                    recent_flushed_wal_id,
+                    replay_after_wal_id,
                 )))
         });
     }

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -162,15 +162,15 @@ impl WritableKVTable {
 }
 
 pub(crate) struct ImmutableMemtable {
-    /// The recent flushed WAL ID when this IMM is freezed. This is used to determine the starting
-    /// position of WAL replay during recovery. After an IMM is flushed to L0, we do not need to
-    /// care about the earlier WALs which produced this IMM, all we need to know is the recent
-    /// WAL ID of the last L0 compacted.
+    /// A WAL ID for which it is guaranteed that all writes in the contained WAL object are present
+    /// in this memtable. This is used to determine a safe replay point when this IMM is flushed to
+    /// a new L0. On a restart, only WALs after this id may contain data that is not present in the
+    /// tree.
     ///
-    /// Please note that this recent flushed WAL ID might not exactly match the last WAL ID that
-    /// produced this IMM, we still need to take the last l0's `last_seq` to filter out the entries
-    /// that already contained in the last L0 SST.
-    recent_flushed_wal_id: u64,
+    /// Please note that this WAL ID might not exactly match the last WAL ID that produced this
+    /// IMM, so we still need to take the last l0's `last_seq` to filter out the entries that are
+    /// already contained in the last L0 SST.
+    replay_after_wal_id: u64,
     table: Arc<KVTable>,
     /// Notified when the memtable's SST has been uploaded to object storage.
     /// Used to release backpressure on writers when unflushed bytes are too high.
@@ -289,11 +289,11 @@ impl MemTableIterator {
 }
 
 impl ImmutableMemtable {
-    pub(crate) fn new(table: WritableKVTable, recent_flushed_wal_id: u64) -> Self {
+    pub(crate) fn new(table: WritableKVTable, replay_after_wal_id: u64) -> Self {
         let sequence_tracker = table.table.sequence_tracker_snapshot();
         Self {
             table: table.table,
-            recent_flushed_wal_id,
+            replay_after_wal_id,
             uploaded: WatchableOnceCell::new(),
             sequence_tracker,
         }
@@ -310,7 +310,7 @@ impl ImmutableMemtable {
     }
 
     pub(crate) fn recent_flushed_wal_id(&self) -> u64 {
-        self.recent_flushed_wal_id
+        self.replay_after_wal_id
     }
 
     pub(crate) async fn await_uploaded(&self) -> Result<(), SlateDBError> {
@@ -355,7 +355,7 @@ impl ImmutableMemtable {
             }
         }
         new_table.record_touched_segments(surviving_segments);
-        Ok(Self::new(new_table, self.recent_flushed_wal_id))
+        Ok(Self::new(new_table, self.replay_after_wal_id))
     }
 }
 

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -518,7 +518,7 @@ enum TrackedImmState {
 
 #[cfg(test)]
 mod tests {
-    use crate::batch_write::WriteBatchMessage;
+    use crate::batch_write::BatchWriterMessage;
     use crate::config::{CheckpointOptions, Settings};
     use crate::db::DbInner;
     use crate::db_state::{
@@ -602,7 +602,7 @@ mod tests {
         ));
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
-            SafeSender::<WriteBatchMessage>::unbounded_channel(status_manager.result_reader());
+            SafeSender::<BatchWriterMessage>::unbounded_channel(status_manager.result_reader());
         let inner = Arc::new(
             DbInner::new(
                 settings,

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -319,7 +319,9 @@ impl WalBufferManager {
         flush_tx.send(WalFlushWork { result_tx })
     }
 
-    pub(crate) fn flush(&self) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
+    pub(crate) fn flush(
+        &self,
+    ) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
         let (result_tx, result_rx) = oneshot::channel();
         self.send_flush_request(Some(result_tx))?;
         Ok(result_rx)

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -319,11 +319,10 @@ impl WalBufferManager {
         flush_tx.send(WalFlushWork { result_tx })
     }
 
-    #[instrument(level = "trace", skip_all, err(level = tracing::Level::DEBUG))]
-    pub(crate) async fn flush(&self) -> Result<(), SlateDBError> {
+    pub(crate) fn flush(&self) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
         let (result_tx, result_rx) = oneshot::channel();
         self.send_flush_request(Some(result_tx))?;
-        result_rx.await?
+        Ok(result_rx)
     }
 
     /// Returns the list of immutable WALs that need to be flushed.
@@ -895,7 +894,7 @@ mod tests {
         wal_buffer.append(std::slice::from_ref(&entry2)).unwrap();
 
         // Flush the buffer
-        wal_buffer.flush().await.unwrap();
+        wal_buffer.flush().unwrap().await.unwrap().unwrap();
 
         // Verify entries were written to storage
         let sst_iter_options = SstIteratorOptions {
@@ -951,7 +950,7 @@ mod tests {
             let seq = i + 1;
             let entry = make_entry(&format!("key{}", i), &format!("value{}", i), seq, None);
             wal_buffer.append(&[entry]).unwrap();
-            wal_buffer.flush().await.unwrap();
+            wal_buffer.flush().unwrap().await.unwrap().unwrap();
         }
         assert_eq!(wal_buffer.recent_flushed_wal_id(), 100);
         assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 100);
@@ -969,7 +968,7 @@ mod tests {
             let seq = i + 1;
             let entry = make_entry(&format!("key{}", i), &format!("value{}", i), seq, None);
             wal_buffer.append(&[entry]).unwrap();
-            wal_buffer.flush().await.unwrap();
+            wal_buffer.flush().unwrap().await.unwrap().unwrap();
         }
         wal_buffer.track_last_applied_seq(50);
         assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 50);
@@ -1004,7 +1003,7 @@ mod tests {
             lookup_metric(&recorder, crate::db_stats::WAL_BUFFER_FLUSH_REQUESTS).unwrap();
 
         // Explicitly flush to drain everything, including any partial current WAL.
-        wal_buffer.flush().await.unwrap();
+        wal_buffer.flush().unwrap().await.unwrap().unwrap();
 
         let actual_flushes = lookup_metric(&recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap();
 


### PR DESCRIPTION
## Summary

This patch fixes the following bug with propagating the wal replay point that can cause the db to lose data:
t1: write task appends a write W to WAL at wal ID 10, but hasn't written to memtable yet.
t2: wal ID 10 is flushed, so recent_flushed_wal_id=10
t3: db flush freezes/flushes memtable (doesn't have W) an sets replay_after_wal_id=10
t4: db hard fails (so W was never written to L0)
t5: db restarts but replay skips W

## Changes

The fix changes the flush path to go through the batch write task, so the batch write task owns the wal/memtable and makes all mutations once the db has been initialized (completed replay):
- changes `WriteBatchMessage` to an enum with WriteBatch and Flush variants.
- The Flush variant carries `BatchWriterFlush` which includes a `freeze_memtable: bool` field.
- The writer task handles the flush msg by first flushing initiating a flush of the wal and then freezing the memtable if requested.
- WAL flush now returns a `oneshot::Receiver` so the batch writer doesn't block on flush.
- the `Db::flush`/`Db::checkpoint` flush paths now go through the write task.

Also renames `recent_flushed_wal_id to replay_after_wal_id` throughout memtable flush path to better reflect the semantics of the field. The property we care about is that the field should carry a safe replay point.

## Notes for Reviewers

The first patch contains a test that repros the bug. The second patch has the fix and removes this test since it's not really possible to reproduce the same interleaving in the fixed version (since everything is serialized on the write task.

I considered 2 approaches to this problem and went with (1):
1. Treat it as an ownership problem - in the current code the wal buffer and memtable lifecycle are shared and multiple tasks can freeze the current memtable. It would be better if the batch-writer task owns the wal buffer and the memtable lifecycle. Modeling this properly for the wal is a bigger exercise, but this patch takes us a step in that direction. Once the db has started up, the batch-write task is the only thing that can mutate the wal/memtable and all other tasks send it a message to do so, and these fns are all private within batch_write.rs
2. Record the last flushed wal id in the memtable when writing, and use this when freezing rather than the value sampled from the wal when freezing. This solves the problem and is a bit simpler, but doesn't really fix what I think is a bigger structural issue of multiple tasks writing the wal/memtable.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
