### PR TITLE
Heartbeat in CompactorWorker

### DIFF
--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -24,20 +24,19 @@
 //! # Heartbeat and failure detection
 //!
 //! Workers emit heartbeats to prove liveness. A heartbeat is a CAS write that
-//! bumps `last_heartbeat_ms` in the worker's `.compactions` entry. Two triggers:
+//! bumps `last_heartbeat_ms` in the worker's `.compactions` entry. Three paths
+//! can refresh it:
 //!
-//! 1. **Bytes trigger**: when the cumulative bytes processed since the last
+//! 1. **Worker ticker**: every `heartbeat_min_interval`, the worker refreshes
+//!    liveness for every active job it still owns.
+//! 2. **Bytes trigger**: when the cumulative bytes processed since the last
 //!    bytes-based heartbeat exceeds `CompactionWorkerOptions::heartbeat_bytes`
 //!    *and* at least `heartbeat_min_interval` has elapsed since the last such
 //!    write, the worker emits a cheap heartbeat that just refreshes liveness.
-//! 2. **Subcompaction trigger**: whenever the per-range subcompaction progress
+//! 3. **Subcompaction trigger**: whenever the per-range subcompaction progress
 //!    (RFC-0028) advances — a range produces new output SSTs — the worker
 //!    writes a heartbeat carrying the latest progress report, so a reclaiming
 //!    worker can resume completed ranges.
-//!
-//! Both triggers are strictly per-job: a job that stops making progress stops
-//! heartbeating and is reclaimed independently of its siblings on the same
-//! worker, so a stalled job can be handed off to a less-loaded worker.
 //!
 //! The coordinator reclaims stale Running compactions whose
 //! `last_heartbeat_ms` is older than
@@ -111,17 +110,11 @@ pub(crate) enum WorkerMessage {
         bytes_processed: u64,
         ctx: CompactionContext,
     },
-    /// Liveness-only heartbeat from the [`CompactionExecutor`], emitted while a
-    /// job is still planning (reading input indexes) and so has no progress to
-    /// report yet. Refreshes `last_heartbeat_ms` without touching the persisted
-    /// context, so a slow planning step on a healthy worker is not mistaken for
-    /// a dead one and reclaimed mid-plan.
-    CompactionJobHeartbeat {
-        /// The job id to refresh liveness for.
-        id: Ulid,
-    },
     /// Ticker-triggered message to poll `.compactions` for claimable jobs.
     PollCompactions,
+    /// Ticker-triggered message to refresh liveness for all jobs this worker
+    /// currently owns.
+    HeartbeatOwnedJobs,
 }
 
 /// Stateless executor of compaction jobs claimed from `.compactions`.
@@ -534,10 +527,10 @@ impl CompactionWorkerHandler {
         // `write_heartbeat`; state is advanced afterwards only on a confirmed
         // durable write.
         //
-        // Bytes-trigger liveness is tied to *this job's own* progress: both the
+        // Bytes-trigger writes are tied to *this job's own* progress: both the
         // threshold (`last_hb_bytes`) and the throttle (`last_hb_ms`) are
-        // per-job, so a job that stops making byte progress stops heartbeating
-        // and is reclaimed even while its siblings on this worker stay busy.
+        // per-job. The worker-level heartbeat ticker handles liveness for
+        // active jobs that are temporarily not reporting byte progress.
         let now_ms = self.clock.now().timestamp_millis() as u64;
         let (bytes_trigger, ctx_changed, prev_sst_count) = {
             let Some(state) = self.job_progress.get(&id) else {
@@ -598,26 +591,6 @@ impl CompactionWorkerHandler {
                     |_| { Err(SlateDBError::Fenced) }
                 );
             }
-        }
-        Ok(())
-    }
-
-    /// Handles a liveness-only heartbeat emitted while a job is still planning,
-    /// before it produces any progress (see
-    /// [`WorkerMessage::CompactionJobHeartbeat`]). Refreshes `last_heartbeat_ms`
-    /// without touching the persisted context, and advances the job's
-    /// `last_hb_ms` on a confirmed write so the bytes-trigger throttle stays
-    /// consistent. A skipped write (entry gone / ownership lost) is a no-op, so
-    /// this never resurrects a job that was already reclaimed mid-plan.
-    async fn handle_planning_heartbeat(&mut self, id: Ulid) -> Result<(), SlateDBError> {
-        if let Some(hb_ms) = self.write_heartbeat(id, None).await? {
-            if let Some(state) = self.job_progress.get_mut(&id) {
-                state.last_hb_ms = hb_ms;
-            }
-            debug!(
-                "planning heartbeat [worker_id={}, id={}, now_ms={}]",
-                self.worker_id, id, hb_ms
-            );
         }
         Ok(())
     }
@@ -693,6 +666,72 @@ impl CompactionWorkerHandler {
         args: StartCompactionJobArgs,
     ) {
         executor.start_compaction_job(args);
+    }
+
+    /// Refreshes liveness for every active job this worker still owns. The
+    /// heartbeat-only write preserves compaction status, context, and output
+    /// progress, and only updates `worker.last_heartbeat_ms`.
+    async fn heartbeat_owned_jobs(&mut self) -> Result<(), SlateDBError> {
+        if self.job_progress.is_empty() {
+            return Ok(());
+        }
+
+        let ids: Vec<Ulid> = self.job_progress.keys().copied().collect();
+        loop {
+            let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
+            stored.refresh().await?;
+            let mut dirty = stored.prepare_dirty()?;
+            let now_ms = self.clock.now().timestamp_millis() as u64;
+            let worker_spec = WorkerSpec::new(self.worker_id.clone(), now_ms);
+            let mut heartbeated = Vec::with_capacity(ids.len());
+            let mut lost = Vec::new();
+
+            for id in &ids {
+                let Some(existing) = dirty.value.get(id).cloned() else {
+                    lost.push(*id);
+                    continue;
+                };
+                if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str())
+                {
+                    lost.push(*id);
+                    continue;
+                }
+
+                dirty
+                    .value
+                    .insert(existing.with_worker(Some(worker_spec.clone())));
+                heartbeated.push(*id);
+            }
+
+            if heartbeated.is_empty() {
+                for id in lost {
+                    Self::stop_compaction_job(&self.executor, &mut self.job_progress, id);
+                }
+                return Ok(());
+            }
+
+            match stored.update(dirty).await {
+                Ok(()) => {
+                    for id in lost {
+                        Self::stop_compaction_job(&self.executor, &mut self.job_progress, id);
+                    }
+                    for id in &heartbeated {
+                        if let Some(state) = self.job_progress.get_mut(id) {
+                            state.last_hb_ms = now_ms;
+                        }
+                    }
+                    debug!(
+                        "worker heartbeat refreshed owned compactions [worker_id={}, count={}, now_ms={}]",
+                        self.worker_id,
+                        heartbeated.len(),
+                        now_ms
+                    );
+                    return Ok(());
+                }
+                Err(e) if e.is_sequenced_write_conflict() => continue,
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     /// Writes `Compacted` (with the produced output recorded on the job's
@@ -817,11 +856,17 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
         // synchronize on the same read cadence. Each poll waits a random
         // duration centered on `compactions_poll_interval` (the interval plus or
         // minus half), so the mean poll rate is unchanged.
-        vec![MessageTickerDef::new(
-            self.options.compactions_poll_interval,
-            Box::new(|| WorkerMessage::PollCompactions),
-        )
-        .with_jitter(0.5, self.rand.clone())]
+        vec![
+            MessageTickerDef::new(
+                self.options.compactions_poll_interval,
+                Box::new(|| WorkerMessage::PollCompactions),
+            )
+            .with_jitter(0.5, self.rand.clone()),
+            MessageTickerDef::new(
+                self.options.heartbeat_min_interval,
+                Box::new(|| WorkerMessage::HeartbeatOwnedJobs),
+            ),
+        ]
     }
 
     async fn handle(&mut self, message: WorkerMessage) -> Result<(), SlateDBError> {
@@ -836,6 +881,9 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
             WorkerMessage::PollCompactions => {
                 self.poll_and_claim().await?;
             }
+            WorkerMessage::HeartbeatOwnedJobs => {
+                self.heartbeat_owned_jobs().await?;
+            }
             WorkerMessage::CompactionJobFinished { id, result } => {
                 self.handle_finished(id, result).await?;
             }
@@ -845,9 +893,6 @@ impl MessageHandler<WorkerMessage> for CompactionWorkerHandler {
                 ctx,
             } => {
                 self.handle_progress(id, bytes_processed, ctx).await?;
-            }
-            WorkerMessage::CompactionJobHeartbeat { id } => {
-                self.handle_planning_heartbeat(id).await?;
             }
         }
         Ok(())
@@ -1176,7 +1221,7 @@ mod tests {
         dirty.value.insert(stolen);
         stored.update(dirty).await.unwrap();
 
-        fx.handler.handle_planning_heartbeat(id).await.unwrap();
+        fx.handler.heartbeat_owned_jobs().await.unwrap();
 
         assert_eq!(fx.executor.stopped_jobs(), vec![id]);
         assert!(!fx.handler.job_progress.contains_key(&id));
@@ -1360,6 +1405,126 @@ mod tests {
                 ..SsTableInfo::default()
             },
         )
+    }
+
+    #[tokio::test]
+    async fn test_worker_heartbeat_ticker_refreshes_all_owned_jobs() {
+        let mock_clock = Arc::new(MockSystemClock::new());
+        mock_clock.set(1000);
+        let options = CompactionWorkerOptions {
+            max_concurrent_compactions: 2,
+            heartbeat_min_interval: Duration::from_millis(1),
+            ..CompactionWorkerOptions::default()
+        };
+        let clock: Arc<dyn SystemClock> = mock_clock.clone();
+        let mut fx = WorkerFixture::new_with_clock("worker-hb-all", clock, options).await;
+
+        let id1 = Ulid::from_parts(1, 0);
+        let id2 = Ulid::from_parts(2, 0);
+        fx.seed_scheduled_compaction(id1, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.seed_scheduled_compaction(id2, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert_eq!(fx.handler.job_progress.len(), 2);
+
+        let sst = fake_output_handle(Ulid::from_parts(9000, 0));
+        let ctx = CompactionContext::new(
+            vec![Subcompaction::new(BytesRange::unbounded()).with_output_ssts(vec![sst])],
+            Some(7),
+        );
+        fx.handler
+            .handle_progress(id1, 123, ctx.clone())
+            .await
+            .unwrap();
+        let before_id1 = fx
+            .read_compaction(id1)
+            .await
+            .expect("compaction missing")
+            .worker()
+            .expect("worker missing")
+            .last_heartbeat_ms;
+        let before_id2 = fx
+            .read_compaction(id2)
+            .await
+            .expect("compaction missing")
+            .worker()
+            .expect("worker missing")
+            .last_heartbeat_ms;
+
+        mock_clock.advance(Duration::from_secs(5)).await;
+        fx.handler.heartbeat_owned_jobs().await.unwrap();
+
+        let c1 = fx.read_compaction(id1).await.expect("compaction missing");
+        let c2 = fx.read_compaction(id2).await.expect("compaction missing");
+        let hb1 = c1.worker().expect("worker missing").last_heartbeat_ms;
+        let hb2 = c2.worker().expect("worker missing").last_heartbeat_ms;
+
+        assert_eq!(c1.status(), CompactionStatus::Running);
+        assert_eq!(c1.ctx(), Some(&ctx));
+        assert!(c1.output_ssts().is_empty());
+        assert!(hb1 > before_id1);
+        assert!(hb2 > before_id2);
+        assert_eq!(fx.handler.job_progress.get(&id1).unwrap().last_hb_ms, hb1);
+        assert_eq!(fx.handler.job_progress.get(&id2).unwrap().last_hb_ms, hb2);
+    }
+
+    #[tokio::test]
+    async fn test_worker_heartbeat_ticker_stops_lost_jobs_and_refreshes_remaining_jobs() {
+        let mock_clock = Arc::new(MockSystemClock::new());
+        mock_clock.set(1000);
+        let options = CompactionWorkerOptions {
+            max_concurrent_compactions: 2,
+            heartbeat_min_interval: Duration::from_millis(1),
+            ..CompactionWorkerOptions::default()
+        };
+        let clock: Arc<dyn SystemClock> = mock_clock.clone();
+        let mut fx = WorkerFixture::new_with_clock("worker-hb-lost", clock, options).await;
+
+        let lost_id = Ulid::from_parts(1, 0);
+        let kept_id = Ulid::from_parts(2, 0);
+        fx.seed_scheduled_compaction(lost_id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.seed_scheduled_compaction(kept_id, vec![SourceId::SstView(fx.l0_view.id)])
+            .await;
+        fx.handler.poll_and_claim().await.unwrap();
+        assert_eq!(fx.handler.job_progress.len(), 2);
+
+        let mut stored = StoredCompactions::try_load(fx.compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        stored.refresh().await.unwrap();
+        let mut dirty = stored.prepare_dirty().unwrap();
+        let stolen = dirty
+            .value
+            .get(&lost_id)
+            .cloned()
+            .expect("claimed compaction missing")
+            .with_worker(Some(WorkerSpec::new("worker-B".to_string(), 12345)));
+        dirty.value.insert(stolen);
+        stored.update(dirty).await.unwrap();
+
+        mock_clock.advance(Duration::from_secs(5)).await;
+        fx.handler.heartbeat_owned_jobs().await.unwrap();
+
+        assert_eq!(fx.executor.stopped_jobs(), vec![lost_id]);
+        assert!(!fx.handler.job_progress.contains_key(&lost_id));
+        assert!(fx.handler.job_progress.contains_key(&kept_id));
+
+        let lost = fx
+            .read_compaction(lost_id)
+            .await
+            .expect("compaction missing");
+        assert_eq!(lost.worker().unwrap().worker_id, "worker-B");
+        assert_eq!(lost.worker().unwrap().last_heartbeat_ms, 12345);
+
+        let kept = fx
+            .read_compaction(kept_id)
+            .await
+            .expect("compaction missing");
+        assert_eq!(kept.worker().unwrap().worker_id, fx.worker_id);
+        assert!(kept.worker().unwrap().last_heartbeat_ms > 1000);
     }
 
     /// When the bytes-processed counter crosses `heartbeat_bytes` and enough

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -672,49 +672,52 @@ impl CompactionWorkerHandler {
     /// heartbeat-only write preserves compaction status, context, and output
     /// progress, and only updates `worker.last_heartbeat_ms`.
     async fn heartbeat_owned_jobs(&mut self) -> Result<(), SlateDBError> {
-        if self.job_progress.is_empty() {
-            return Ok(());
-        }
-
-        let ids: Vec<Ulid> = self.job_progress.keys().copied().collect();
         loop {
+            let ids: Vec<Ulid> = self.job_progress.keys().copied().collect();
+            if ids.is_empty() {
+                return Ok(());
+            }
+
             let stored = self.stored.as_mut().expect(Self::EXPECT_LOADED);
             stored.refresh().await?;
             let mut dirty = stored.prepare_dirty()?;
             let now_ms = self.clock.now().timestamp_millis() as u64;
             let worker_spec = WorkerSpec::new(self.worker_id.clone(), now_ms);
             let mut heartbeated = Vec::with_capacity(ids.len());
-            let mut lost = Vec::new();
 
-            for id in &ids {
-                let Some(existing) = dirty.value.get(id).cloned() else {
-                    lost.push(*id);
+            for id in ids {
+                let Some(existing) = dirty.value.get(&id).cloned() else {
+                    debug!(
+                        "heartbeat: compaction entry missing [worker_id={}, compaction_id={}]; stopping execution",
+                        self.worker_id,
+                        id
+                    );
+                    Self::stop_compaction_job(&self.executor, &mut self.job_progress, id);
                     continue;
                 };
                 if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str())
                 {
-                    lost.push(*id);
+                    debug!(
+                        "heartbeat: lost ownership [worker_id={}, compaction_id={}]; stopping execution",
+                        self.worker_id,
+                        id
+                    );
+                    Self::stop_compaction_job(&self.executor, &mut self.job_progress, id);
                     continue;
                 }
 
                 dirty
                     .value
                     .insert(existing.with_worker(Some(worker_spec.clone())));
-                heartbeated.push(*id);
+                heartbeated.push(id);
             }
 
             if heartbeated.is_empty() {
-                for id in lost {
-                    Self::stop_compaction_job(&self.executor, &mut self.job_progress, id);
-                }
                 return Ok(());
             }
 
             match stored.update(dirty).await {
                 Ok(()) => {
-                    for id in lost {
-                        Self::stop_compaction_job(&self.executor, &mut self.job_progress, id);
-                    }
                     for id in &heartbeated {
                         if let Some(state) = self.job_progress.get_mut(id) {
                             state.last_hb_ms = now_ms;

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -932,9 +932,14 @@ mod tests {
     use crate::bytes_range::BytesRange;
     use crate::compactor_state::{Compaction, CompactionSpec, SourceId};
     use crate::db_state::{SsTableHandle, SsTableId, SsTableInfo, SsTableView};
-    use crate::format::sst::SST_FORMAT_VERSION_LATEST;
+    use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
     use crate::manifest::store::StoredManifest;
     use crate::manifest::ManifestCore;
+    use crate::object_stores::ObjectStores;
+    use crate::tablestore::{TableStore, TableStoreKind};
+    use crate::test_utils::{build_sorted_runs, write_ssts, GatedObjectStore};
+    use crate::types::RowEntry;
+    use crate::utils::WatchableOnceCell;
     use bytes::Bytes;
     use futures::stream::StreamExt;
     use object_store::memory::InMemory;
@@ -1470,6 +1475,190 @@ mod tests {
         assert!(hb2 > before_id2);
         assert_eq!(fx.handler.job_progress.get(&id1).unwrap().last_hb_ms, hb1);
         assert_eq!(fx.handler.job_progress.get(&id2).unwrap().last_hb_ms, hb2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_worker_heartbeat_ticker_refreshes_job_while_planning_reads_block() {
+        // given: real compaction input SSTs behind a gated table store, while
+        // manifest and `.compactions` reads/writes use the ungated inner store.
+        let clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+        let planning_heartbeat_sst_size = 512;
+        let options = Arc::new(CompactionWorkerOptions {
+            max_concurrent_compactions: 1,
+            compactions_poll_interval: Duration::from_millis(5),
+            heartbeat_min_interval: Duration::from_millis(5),
+            max_sst_size: planning_heartbeat_sst_size,
+            ..CompactionWorkerOptions::default()
+        });
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated = Arc::new(GatedObjectStore::new(inner.clone()));
+        let gated_store: Arc<dyn ObjectStore> = gated.clone();
+        let root_path = Path::from("testdb-worker-planning-heartbeat");
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(gated_store, None),
+            SsTableFormat {
+                block_size: 256,
+                ..SsTableFormat::default()
+            },
+            root_path.clone(),
+            None,
+            TableStoreKind::Compactor,
+        ));
+        let manifest_store = Arc::new(ManifestStore::new(&root_path, inner.clone()));
+        let compactions_store = Arc::new(CompactionsStore::new(&root_path, inner.clone()));
+        // Build a few L0 SSTs and a single sorted run to seed the manifest.
+        let rows = |range: std::ops::Range<u64>,
+                    step: usize,
+                    value_prefix: &str,
+                    seq_base: u64|
+         -> Vec<RowEntry> {
+            range
+                .step_by(step)
+                .map(|i| {
+                    RowEntry::new_value(
+                        format!("key{i:05}").as_bytes(),
+                        format!("{value_prefix}-{i}").as_bytes(),
+                        seq_base + i,
+                    )
+                })
+                .collect()
+        };
+        let mut l0_sst_views = Vec::new();
+        for entries in [
+            rows(0..160, 2, "l0a", 10_000),
+            rows(1..160, 2, "l0b", 20_000),
+        ] {
+            let ssts = write_ssts(&table_store, &entries, planning_heartbeat_sst_size).await;
+            l0_sst_views.extend(ssts.into_iter().map(SsTableView::identity));
+        }
+        let sorted_runs = build_sorted_runs(
+            &table_store,
+            &[vec![rows(0..160, 1, "sr", 1)]],
+            planning_heartbeat_sst_size,
+        )
+        .await;
+        let mut core = ManifestCore::new();
+        {
+            let tree = Arc::make_mut(&mut core.tree);
+            tree.l0.extend(l0_sst_views.clone());
+            tree.compacted = sorted_runs.clone();
+        }
+        StoredManifest::create_new_db(manifest_store.clone(), core, clock.clone())
+            .await
+            .unwrap();
+        StoredCompactions::create(compactions_store.clone(), 0)
+            .await
+            .unwrap();
+        // Wire up the executor and handler.
+        let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
+        let executor: Arc<dyn CompactionExecutor + Send + Sync> = Arc::new(
+            TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
+                handle: tokio::runtime::Handle::current(),
+                options: options.clone(),
+                worker_tx: tx,
+                table_store: table_store.clone(),
+                rand: Arc::new(DbRand::new(100u64)),
+                stats: {
+                    let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
+                    Arc::new(CompactionStats::new(&recorder))
+                },
+                worker_stats: WorkerStats::noop(),
+                clock: clock.clone(),
+                manifest_store: manifest_store.clone(),
+                merge_operator: None,
+                #[cfg(feature = "compaction_filters")]
+                compaction_filter_supplier: None,
+            }),
+        );
+        let handler = CompactionWorkerHandler::new(
+            "worker-plan-hb".to_string(),
+            options.clone(),
+            compactions_store.clone(),
+            manifest_store,
+            executor.clone(),
+            clock.clone(),
+            Arc::new(DbRand::new(0)),
+            Arc::new(FailPointRegistry::new()),
+        );
+        let id = Ulid::from_parts(42, 0);
+        let sources = l0_sst_views
+            .iter()
+            .map(|sst| SourceId::SstView(sst.id))
+            .chain(sorted_runs.iter().map(|sr| SourceId::SortedRun(sr.id)))
+            .collect();
+        let compaction = Compaction::new(id, CompactionSpec::new(sources, 0))
+            .with_status(CompactionStatus::Scheduled);
+        let mut stored = StoredCompactions::try_load(compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut dirty = stored.prepare_dirty().unwrap();
+        dirty.value.insert(compaction);
+        stored.update(dirty).await.unwrap();
+
+        let task_executor = Arc::new(MessageHandlerExecutor::new(
+            Arc::new(WatchableOnceCell::new()),
+            clock,
+        ));
+        task_executor
+            .add_handler(
+                COMPACTION_WORKER_TASK_NAME.to_string(),
+                Box::new(handler),
+                rx,
+                &tokio::runtime::Handle::current(),
+            )
+            .unwrap();
+        let worker = CompactionWorker::new(task_executor);
+
+        // when: the worker's poll ticker claims the job and executor planning
+        // blocks on the first SST index read.
+        let setup_gets = gated.get_opts_gate.arrivals();
+        gated.get_opts_gate.close();
+        worker.start().unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(30),
+            gated.get_opts_gate.wait_for_arrivals(setup_gets + 1),
+        )
+        .await
+        .expect("planning should reach the blocked read gate");
+
+        let before = compactions_store
+            .read_latest_compactions()
+            .await
+            .unwrap()
+            .compactions
+            .get(&id)
+            .expect("compaction missing")
+            .worker()
+            .expect("worker missing")
+            .last_heartbeat_ms;
+
+        // then: the worker-level heartbeat ticker refreshes the persisted
+        // liveness timestamp without requiring executor progress.
+        let after = tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                let compaction = compactions_store
+                    .read_latest_compactions()
+                    .await
+                    .unwrap()
+                    .compactions
+                    .get(&id)
+                    .expect("compaction missing")
+                    .clone();
+                if compaction.worker().unwrap().last_heartbeat_ms > before {
+                    break compaction;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("worker heartbeat ticker should refresh planning job");
+        assert_eq!(after.status(), CompactionStatus::Running);
+        assert_eq!(after.ctx(), None);
+        assert!(after.worker().unwrap().last_heartbeat_ms > before);
+
+        worker.stop().await.unwrap();
+        gated.get_opts_gate.release();
     }
 
     #[tokio::test]

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -697,7 +697,7 @@ impl CompactionWorkerHandler {
                 };
                 if existing.worker().map(|w| w.worker_id.as_str()) != Some(self.worker_id.as_str())
                 {
-                    debug!(
+                    info!(
                         "heartbeat: lost ownership [worker_id={}, compaction_id={}]; stopping execution",
                         self.worker_id,
                         id

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -535,34 +535,11 @@ impl TokioCompactionExecutorInner {
         let id = args.id;
         let destination = args.destination;
 
-        // Planning (manifest load + input-index reads) runs before
-        // `execute_compaction_job` emits its first progress event, so it would
-        // otherwise go un-heartbeated. On a cold object store with very wide
-        // input it can exceed `worker_heartbeat_timeout`, letting the
-        // coordinator reclaim a healthy job mid-plan and livelock on
-        // re-planning. Emit a liveness-only heartbeat on the
-        // `heartbeat_min_interval` cadence while planning is in flight; planning
-        // that finishes before the first tick (the common case) sends nothing.
-        let plan = self.load_manifest_and_plan(args);
-        tokio::pin!(plan);
-        let (sequence_tracker, planned) = loop {
-            tokio::select! {
-                biased;
-                res = &mut plan => break res?,
-                _ = self.clock.sleep(self.options.heartbeat_min_interval) => {
-                    if self
-                        .worker_tx
-                        .try_send(WorkerMessage::CompactionJobHeartbeat { id })
-                        .is_err()
-                    {
-                        debug!(
-                            "failed to send planning heartbeat (likely DB shutdown) [id={}]",
-                            id
-                        );
-                    }
-                }
-            }
-        };
+        // Worker liveness is refreshed by the compaction worker's own heartbeat
+        // ticker while planning is in flight. The executor only reports
+        // progress when it has compaction context that may need to be persisted
+        // for resume.
+        let (sequence_tracker, planned) = self.load_manifest_and_plan(args).await?;
 
         self.execute_compaction_job(id, destination, planned, sequence_tracker)
             .await
@@ -834,8 +811,8 @@ impl TokioCompactionExecutorInner {
 
         // Cadence for the time-based progress send below. Caps sends at 1s (the
         // pre-distributed-compaction default), but never coarser than the
-        // worker's `heartbeat_min_interval`, since the worker can only heartbeat
-        // when the executor sends (see `handle_progress`).
+        // worker's `heartbeat_min_interval`, so progress heartbeats still use
+        // the worker's configured write throttle.
         let progress_interval = TimeDelta::from_std(
             self.options
                 .heartbeat_min_interval
@@ -2804,135 +2781,6 @@ mod tests {
         }
         let expected: Vec<Bytes> = entries.iter().map(|e| e.key.clone()).collect();
         assert_eq!(read_back, expected);
-    }
-
-    /// Planning (manifest load + input-index reads) runs before the executor
-    /// emits its first progress event. On a cold object store with wide input
-    /// it can outlast `worker_heartbeat_timeout`, so the executor must emit a
-    /// liveness heartbeat while planning is in flight or a healthy job gets
-    /// reclaimed mid-plan. Simulate the stall with a gated object store and
-    /// assert a planning heartbeat lands before any progress.
-    #[tokio::test(flavor = "multi_thread")]
-    async fn should_heartbeat_while_planning_index_reads_block() {
-        // given: the table store reads/writes through a gated object store, but
-        // the manifest store uses the ungated inner store — so we can stall the
-        // planner's input-index reads while the manifest load still completes. A
-        // short heartbeat interval makes the planning heartbeat observable.
-        let handle = tokio::runtime::Handle::current();
-        let options = Arc::new(CompactionWorkerOptions {
-            max_sst_size: SUBCOMPACTION_SST_SIZE,
-            heartbeat_min_interval: Duration::from_millis(20),
-            ..CompactionWorkerOptions::default()
-        });
-        let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
-        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let gated = Arc::new(GatedObjectStore::new(inner.clone()));
-        let gated_store: Arc<dyn ObjectStore> = gated.clone();
-        let root_path = Path::from("testdb-plan-heartbeat");
-        let clock = Arc::new(DefaultSystemClock::new());
-        let table_store = Arc::new(TableStore::new(
-            ObjectStores::new(gated_store.clone(), None),
-            SsTableFormat {
-                block_size: 256,
-                ..SsTableFormat::default()
-            },
-            root_path.clone(),
-            None,
-            TableStoreKind::Compactor,
-        ));
-        let manifest_store = Arc::new(ManifestStore::new(&root_path, inner.clone()));
-        StoredManifest::create_new_db(manifest_store.clone(), ManifestCore::new(), clock.clone())
-            .await
-            .unwrap();
-
-        let executor = TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
-            handle,
-            options,
-            worker_tx: tx,
-            table_store: table_store.clone(),
-            rand: Arc::new(DbRand::new(100u64)),
-            stats: {
-                let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
-                Arc::new(CompactionStats::new(&recorder))
-            },
-            worker_stats: WorkerStats::noop(),
-            clock,
-            manifest_store,
-            merge_operator: None,
-            #[cfg(feature = "compaction_filters")]
-            compaction_filter_supplier: None,
-        });
-
-        // given: multi-SST input (written with the read gate open).
-        let (l0_sst_views, sorted_runs) = split_inputs(&table_store).await;
-
-        // given: block object-store reads so the planner's index reads stall.
-        // Baseline existing read arrivals so we can wait for the next one.
-        let setup_gets = gated.get_opts_gate.arrivals();
-        gated.get_opts_gate.close();
-
-        // when: a *fresh* job (ctx = None, so it must plan) starts.
-        let id = Ulid::new();
-        executor.start_compaction_job(StartCompactionJobArgs {
-            id,
-            compaction_id: Ulid::new(),
-            destination: 0,
-            l0_sst_views,
-            sorted_runs,
-            compaction_clock_tick: 0,
-            is_dest_last_run: false,
-            retention_min_seq: Some(0),
-            ctx: None,
-        });
-
-        // then: planning parks on a blocked index read (the manifest load, on the
-        // ungated store, already succeeded) ...
-        tokio::time::timeout(
-            Duration::from_secs(30),
-            gated.get_opts_gate.wait_for_arrivals(setup_gets + 1),
-        )
-        .await
-        .expect("planning should reach the blocked read gate");
-
-        // ... and while it is parked the executor emits a planning heartbeat for
-        // this job, with no progress/finished yet (planning produced no plan).
-        let heartbeated = tokio::time::timeout(Duration::from_secs(30), async {
-            loop {
-                match rx.recv().await.unwrap() {
-                    WorkerMessage::CompactionJobHeartbeat { id: hb_id } => {
-                        assert_eq!(hb_id, id, "heartbeat carried the wrong job id");
-                        break;
-                    }
-                    WorkerMessage::CompactionJobProgress { .. } => {
-                        panic!("progress emitted before planning completed")
-                    }
-                    WorkerMessage::CompactionJobFinished { .. } => {
-                        panic!("job finished while planning reads were blocked")
-                    }
-                    WorkerMessage::PollCompactions => {}
-                }
-            }
-        })
-        .await;
-        assert!(
-            heartbeated.is_ok(),
-            "expected a planning heartbeat while input-index reads were blocked"
-        );
-
-        // when: reads are unblocked, the job plans and runs to completion.
-        gated.get_opts_gate.release();
-        tokio::time::timeout(Duration::from_secs(30), async {
-            loop {
-                if let WorkerMessage::CompactionJobFinished { result, .. } =
-                    rx.recv().await.unwrap()
-                {
-                    return result;
-                }
-            }
-        })
-        .await
-        .expect("job should finish after reads are unblocked")
-        .expect("compaction should succeed");
     }
 
     /// Test context for compaction executor tests.


### PR DESCRIPTION
## Summary

This PR adds a compactor worker heartbeat ticker. It's triggered independent of byte/SST output progress; it simply signals the worker process is still alive. We're moving away from byte-based triggers as it's causing timeouts during initialization (before byte-progress reporting happens).

Fixes #1862

## Changes

- Add `HeartbeatOwnedJobs` ticker and remove `CompactionJobHeartbeat` message from executor
- Remove `handle_planning_heartbeat` in executor since we are heartbeating on a timer now

## Notes for Reviewers

This is the first PR in this series. I plan to remove the per-byte reporting in a subsequent PR.

Question for reviewers: do we want to rename `heartbeat_min_interval` to `heartbeat_interval`? It is currently being used for both the periodic ticker interval and as a cap to prevent job progress from triggering too many updates.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
