### PR TITLE
cleanup durable clock tick bookkeeping

### DIFF
--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -34,7 +34,6 @@ use std::{
 #[allow(dead_code)] // unused during DST
 pub(crate) struct MonotonicClock {
     pub(crate) last_tick: AtomicI64,
-    pub(crate) last_durable_tick: AtomicI64,
     delegate: Arc<dyn SystemClock>,
 }
 
@@ -43,16 +42,11 @@ impl MonotonicClock {
         Self {
             delegate,
             last_tick: AtomicI64::new(init_tick),
-            last_durable_tick: AtomicI64::new(init_tick),
         }
     }
 
     pub(crate) fn set_last_tick(&self, tick: i64) -> Result<i64, SlateDBError> {
         self.enforce_monotonic(tick)
-    }
-
-    pub(crate) fn fetch_max_last_durable_tick(&self, tick: i64) -> i64 {
-        self.last_durable_tick.fetch_max(tick, Ordering::SeqCst)
     }
 
     #[cfg_attr(dst, allow(dead_code))]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -179,7 +179,6 @@ impl DbInner {
             recent_flushed_wal_id,
             oracle.clone(),
             table_store.clone(),
-            mono_clock.clone(),
             settings.l0_sst_size_bytes,
             settings.flush_interval,
         ));
@@ -274,7 +273,7 @@ impl DbInner {
     }
 
     #[allow(unused_variables)]
-    pub(crate) fn wal_enabled_in_options(settings: &Settings) -> bool {
+    fn wal_enabled_in_options(settings: &Settings) -> bool {
         #[cfg(feature = "wal_disable")]
         return settings.wal_enabled;
         #[cfg(not(feature = "wal_disable"))]

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -146,7 +146,6 @@ impl DbInner {
     pub(crate) async fn upload_sst(
         &self,
         id: &db_state::SsTableId,
-        imm_table: Arc<KVTable>,
         encoded_sst: &EncodedSsTable,
         write_cache: bool,
     ) -> Result<SsTableHandle, SlateDBError> {
@@ -154,10 +153,6 @@ impl DbInner {
             .table_store
             .write_sst(id, encoded_sst, write_cache)
             .await?;
-
-        self.mono_clock
-            .fetch_max_last_durable_tick(imm_table.last_tick());
-
         Ok(handle)
     }
 
@@ -183,9 +178,7 @@ impl DbInner {
             let id = db_state::SsTableId::Compacted(
                 self.rand.rng().gen_ulid(self.system_clock.as_ref()),
             );
-            let handle = self
-                .upload_sst(&id, imm_table.clone(), &sst.encoded, write_cache)
-                .await?;
+            let handle = self.upload_sst(&id, &sst.encoded, write_cache).await?;
             handles.push(handle);
         }
         Ok(handles)
@@ -845,11 +838,7 @@ mod tests {
         ];
         for (sst, entries) in ssts.into_iter().zip(expected.into_iter()) {
             let id = SsTableId::Compacted(Ulid::new());
-            let handle = db
-                .inner
-                .upload_sst(&id, table.table().clone(), &sst.encoded, false)
-                .await
-                .unwrap();
+            let handle = db.inner.upload_sst(&id, &sst.encoded, false).await.unwrap();
             verify_sst(&db, &handle, &entries).await;
         }
         db.close().await.unwrap();

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -1803,10 +1803,7 @@ mod tests {
             let id = crate::db_state::SsTableId::Compacted(
                 inner.rand.rng().gen_ulid(inner.system_clock.as_ref()),
             );
-            let sst_handle = inner
-                .upload_sst(&id, imm_memtable.table(), &encoded_sst, false)
-                .await
-                .unwrap();
+            let sst_handle = inner.upload_sst(&id, &encoded_sst, false).await.unwrap();
             segments.push(SegmentedSstHandle {
                 prefix: Bytes::copy_from_slice(prefix),
                 sst_handle,

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -197,12 +197,9 @@ impl UploadHandler {
         // uploads that already landed before the abort are left for the
         // garbage collector to reclaim, since the worker allocates ids
         // internally and they are not visible here for explicit cleanup.
-        let segments = futures::future::try_join_all(
-            built
-                .iter()
-                .map(|sst| self.upload_segment_sst(&job.imm_memtable, sst)),
-        )
-        .await?;
+        let segments =
+            futures::future::try_join_all(built.iter().map(|sst| self.upload_segment_sst(sst)))
+                .await?;
 
         Ok(UploadedMemtable {
             imm_memtable: Arc::clone(&job.imm_memtable),
@@ -217,18 +214,13 @@ impl UploadHandler {
     /// memtable.
     async fn upload_segment_sst(
         &self,
-        imm_memtable: &Arc<ImmutableMemtable>,
         sst: &EncodedSegmentSst,
     ) -> Result<SegmentedSstHandle, SlateDBError> {
         let sst_id =
             SsTableId::Compacted(self.db.rand.rng().gen_ulid(self.db.system_clock.as_ref()));
         let written_bytes = sst.encoded.remaining_len() as u64;
         loop {
-            match self
-                .db
-                .upload_sst(&sst_id, imm_memtable.table(), &sst.encoded, true)
-                .await
-            {
+            match self.db.upload_sst(&sst_id, &sst.encoded, true).await {
                 Ok(sst_handle) => {
                     self.db.db_stats.l0_flush_bytes.increment(written_bytes);
                     return Ok(SegmentedSstHandle {

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -9,7 +9,6 @@ use log::{error, trace};
 use tokio::{runtime::Handle, sync::oneshot};
 use tracing::instrument;
 
-use crate::clock::MonotonicClock;
 use crate::db_state::SsTableId;
 use crate::db_stats::DbStats;
 use crate::db_status::ClosedResultWriter;
@@ -52,7 +51,6 @@ pub(crate) struct WalBufferManager {
     wal_id_incrementor: Arc<dyn WalIdStore + Send + Sync>,
     status_manager: crate::db_status::DbStatusManager,
     db_stats: DbStats,
-    mono_clock: Arc<MonotonicClock>,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
     max_flush_interval: Option<Duration>,
@@ -98,8 +96,6 @@ struct WalBuffer {
     entries: VecDeque<RowEntry>,
     /// watcher to await durability
     durable: WatchableOnceCell<Result<(), SlateDBError>>,
-    /// this corresponds to the timestamp of the most recent addition to this WAL buffer
-    last_tick: i64,
     /// the sequence number of the most recent addition to this WAL buffer
     last_seq: u64,
     /// size of the entries that has been added to the WAL buffer in bytes
@@ -120,7 +116,6 @@ impl WalBufferManager {
         recent_flushed_wal_id: u64,
         oracle: Arc<DbOracle>,
         table_store: Arc<TableStore>,
-        mono_clock: Arc<MonotonicClock>,
         max_wal_bytes_size: usize,
         max_flush_interval: Option<Duration>,
     ) -> Self {
@@ -142,7 +137,6 @@ impl WalBufferManager {
             status_manager,
             db_stats,
             table_store,
-            mono_clock,
             max_wal_bytes_size,
             max_flush_interval,
             last_flush_requested_epoch: AtomicU64::new(0),
@@ -380,7 +374,7 @@ impl WalBufferManager {
         self.db_stats.wal_buffer_flushes.increment(1);
 
         let mut sst_builder = self.table_store.wal_table_builder();
-        let (mut iter, last_tick) = (wal.iter(), wal.last_tick());
+        let mut iter = wal.iter();
         while let Some(entry) = iter.next() {
             sst_builder.add(entry).await?;
         }
@@ -391,8 +385,6 @@ impl WalBufferManager {
             .write_sst(&SsTableId::Wal(wal_id), &encoded_sst, false)
             .await?;
         self.db_stats.wal_flush_bytes.increment(written_bytes);
-
-        self.mono_clock.fetch_max_last_durable_tick(last_tick);
         Ok(())
     }
 
@@ -476,16 +468,12 @@ impl WalBuffer {
         Self {
             entries: VecDeque::new(),
             durable: WatchableOnceCell::new(),
-            last_tick: i64::MIN,
             last_seq: 0,
             entries_size: 0,
         }
     }
 
     fn append(&mut self, entry: RowEntry) {
-        if let Some(ts) = entry.create_ts {
-            self.last_tick = ts;
-        }
         self.last_seq = entry.seq;
         self.entries_size += entry.estimated_size();
         self.entries.push_back(entry);
@@ -534,11 +522,6 @@ impl WalBuffer {
         } else {
             Some(self.last_seq)
         }
-    }
-
-    /// Returns the last tick (timestamp) written to this buffer.
-    fn last_tick(&self) -> i64 {
-        self.last_tick
     }
 }
 
@@ -620,7 +603,6 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clock::MonotonicClock;
     use crate::db_status::DbStatusManager;
     use crate::format::sst::SsTableFormat;
     use crate::iter::RowEntryIterator;
@@ -658,7 +640,6 @@ mod tests {
         assert_eq!(buffer.len(), 0);
         assert_eq!(buffer.size(), 0);
         assert_eq!(buffer.last_seq(), None);
-        assert_eq!(buffer.last_tick(), i64::MIN);
     }
 
     #[test]
@@ -673,7 +654,6 @@ mod tests {
         assert_eq!(buffer.len(), 1);
         assert_eq!(buffer.size(), expected_size);
         assert_eq!(buffer.last_seq(), Some(42));
-        assert_eq!(buffer.last_tick(), 1000);
     }
 
     #[test]
@@ -698,7 +678,6 @@ mod tests {
         assert_eq!(buffer.len(), 4);
         assert_eq!(buffer.size(), size1 + size2 + size3 + size4);
         assert_eq!(buffer.last_seq(), Some(40));
-        assert_eq!(buffer.last_tick(), 300);
     }
 
     #[tokio::test]
@@ -855,7 +834,6 @@ mod tests {
             TableStoreKind::Main,
         ));
         let test_clock = Arc::new(MockSystemClock::new());
-        let mono_clock = Arc::new(MonotonicClock::new(test_clock.clone(), 0));
         let system_clock = Arc::new(DefaultSystemClock::new());
         let status_manager = DbStatusManager::new(0);
         let oracle = Arc::new(DbOracle::new(0, 0, 0, status_manager.clone()));
@@ -869,7 +847,6 @@ mod tests {
             0, // recent_flushed_wal_id
             oracle,
             table_store.clone(),
-            mono_clock,
             1000,                 // max_wal_bytes_size
             Some(flush_interval), // max_flush_interval
         ));


### PR DESCRIPTION

## Summary

cleans up bookkeeping of the last durable clock tick

## Changes

https://github.com/slatedb/slatedb/pull/1387 removed read-time ttl filtering. The only reason for bookkeeping the last durable clock tick was to retain a valid timestamp when filtering reads at the Remote durability level, so we don't need this anymore.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
