### PR TITLE
Change DST runner to ubuntu-latest

### DIFF
--- a/.github/workflows/dst-hourly.yaml
+++ b/.github/workflows/dst-hourly.yaml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   deterministic-simulation-test:
-    runs-on: warp-ubuntu-latest-x64-16x
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Realized DST is running on Warpbuild right now. I'd like to try it on a GH runner since they're free.