### PR TITLE
Drop compacted L0s by recorded SST id, not a positional watermark

### DIFF
--- a/schemas/manifest.fbs
+++ b/schemas/manifest.fbs
@@ -148,6 +148,11 @@ table ManifestV2 {
     // (RFC-0024). Persisted so the writer can detect accidental reconfiguration
     // on startup. Absent when no extractor is configured.
     segment_extractor_name: string;
+
+    // SST ids of top-level L0s that have been folded into a sorted run. See
+    // `Segment.compacted_l0_ids`; this is the same set for the compatibility
+    // `prefix=""` tree. Appended last for vtable stability; optional.
+    compacted_l0_ids: [Ulid];
 }
 
 // Per-segment LSM state. Structurally mirrors the top-level `l0` / `compacted` /
@@ -167,6 +172,12 @@ table Segment {
     // Sorted runs for this segment, ordered by descending id (list position
     // encodes read precedence within the segment).
     compacted: [SortedRunV2] (required);
+
+    // SST ids of L0s folded into a sorted run in this segment. The writer's merge drops
+    // exactly these (matched by stable SST id, not instance-local view id), so a stale
+    // watermark across a takeover cannot drop a still-uncompacted L0. Appended last
+    // (vtable-stable); optional, defaults to empty.
+    compacted_l0_ids: [Ulid];
 }
 
 table WriterCheckpoint {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -3716,6 +3716,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: Bytes::from_static(b"seg"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 l0: VecDeque::from(vec![segment_l0.clone()]),
                 compacted: vec![segment_sr.clone()],
                 ..LsmTreeState::default()
@@ -4187,6 +4188,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: Bytes::from_static(b"key"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -4343,6 +4345,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"a/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -4359,6 +4362,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"b/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -4436,6 +4440,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"l0only/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
@@ -4450,6 +4455,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"none/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -5367,6 +5373,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![make_view(l0_view)]),
@@ -5412,6 +5419,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![make_view(l0_view)]),
@@ -5455,6 +5463,7 @@ mod tests {
             .segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![make_view(l0_view)]),
@@ -5553,6 +5562,7 @@ mod tests {
         let make_segment = |prefix: Bytes, l0_view_id: Ulid| Segment {
             prefix,
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![SsTableView::identity(SsTableHandle::new(
@@ -5653,6 +5663,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -5698,6 +5709,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -5761,6 +5773,7 @@ mod tests {
             .segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![make_view(l0_3), make_view(l0_2), make_view(l0_1)]),

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -1049,7 +1049,7 @@ impl CompactorState {
                 .destination()
                 .expect("finish_compaction with output SR called on a non-tiered spec");
             let segment = spec.segment().clone();
-            // reconstruct l0
+            // The L0 view ids this compaction folds in.
             let compaction_l0s: HashSet<Ulid> = spec
                 .sources()
                 .iter()
@@ -1080,6 +1080,15 @@ impl CompactorState {
                 return;
             };
 
+            // Resolve the folded L0s to their SST ids while l0 is still intact. The writer
+            // merge drops by SST id, not view id: a view id is local to one writer/compactor
+            // instance, but the SST id is the shared physical identity that survives takeover.
+            let compacted_sst_ids: Vec<Ulid> = tree
+                .l0
+                .iter()
+                .filter(|l0| compaction_l0s.contains(&l0.id))
+                .map(|l0| l0.sst.id.unwrap_compacted_id())
+                .collect();
             let new_l0: VecDeque<SsTableView> = tree
                 .l0
                 .iter()
@@ -1114,6 +1123,7 @@ impl CompactorState {
             }
             tree.l0 = new_l0;
             tree.compacted = new_compacted;
+            tree.record_compacted_l0_ids(compacted_sst_ids);
             self.manifest.value.core = db_state;
             self.manifest.value.prune_external_sst_ids();
             self.update_compaction(&compaction_id, |c| {
@@ -1196,8 +1206,17 @@ impl CompactorState {
             tree.last_compacted_l0_sst_id = Some(view.sst.id.unwrap_compacted_id());
         }
 
+        // Resolve to SST ids (the takeover-stable identity the writer merge matches on)
+        // before the retain drops the views.
+        let drained_sst_ids: Vec<Ulid> = tree
+            .l0
+            .iter()
+            .filter(|view| drained_l0_ids.contains(&view.id))
+            .map(|view| view.sst.id.unwrap_compacted_id())
+            .collect();
         tree.l0.retain(|view| !drained_l0_ids.contains(&view.id));
         tree.compacted.retain(|sr| !drained_sr_ids.contains(&sr.id));
+        tree.record_compacted_l0_ids(drained_sst_ids);
 
         self.manifest.value.core = db_state;
         self.manifest.value.prune_external_sst_ids();
@@ -1871,6 +1890,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=11/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![v_b.clone()]),
@@ -1880,6 +1900,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![v_a.clone()]),
@@ -1928,6 +1949,7 @@ mod tests {
         let writer_v0 = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![v1.clone()]),
@@ -1941,6 +1963,7 @@ mod tests {
         let compactor_post_drain = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![v1.sst.id.unwrap_compacted_id()],
                 last_compacted_l0_sst_view_id: Some(v1.id),
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -2123,6 +2146,7 @@ mod tests {
         let segment = Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -2176,6 +2200,7 @@ mod tests {
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -2228,6 +2253,7 @@ mod tests {
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -2296,6 +2322,7 @@ mod tests {
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![l0_b.clone(), l0_a.clone()]),
@@ -2332,6 +2359,7 @@ mod tests {
             Segment {
                 prefix: prefix_a.clone(),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![l0_a.clone()]),
@@ -2341,6 +2369,7 @@ mod tests {
             Segment {
                 prefix: prefix_b.clone(),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![l0_b.clone()]),
@@ -2374,6 +2403,7 @@ mod tests {
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![l0.clone()]),
@@ -2429,6 +2459,7 @@ mod tests {
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![l0_newer.clone(), l0_older.clone()]),
@@ -2480,6 +2511,7 @@ mod tests {
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![l0_late.clone(), l0_observed.clone()]),

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2921,6 +2921,7 @@ mod tests {
                 Segment {
                     prefix: Bytes::from_static(b"hour=12/"),
                     tree: Arc::new(LsmTreeState {
+                        compacted_l0_ids: vec![],
                         last_compacted_l0_sst_view_id: None,
                         last_compacted_l0_sst_id: None,
                         l0: VecDeque::new(),
@@ -2930,6 +2931,7 @@ mod tests {
                 Segment {
                     prefix: Bytes::from_static(b"hour=13/"),
                     tree: Arc::new(LsmTreeState {
+                        compacted_l0_ids: vec![],
                         last_compacted_l0_sst_view_id: None,
                         last_compacted_l0_sst_id: None,
                         l0: VecDeque::new(),

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -2746,6 +2746,7 @@ mod tests {
         }
         fn tree_l0(views: Vec<SsTableView>) -> LsmTreeState {
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(views),
@@ -2793,6 +2794,7 @@ mod tests {
         latest.segments = vec![segment_with(
             b"hour=12/",
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![view(1)]),
@@ -2812,6 +2814,7 @@ mod tests {
         latest.segments = vec![segment_with(
             b"hour=12/",
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: Some(ulid::Ulid::from_parts(99, 0)),
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -865,15 +865,14 @@ mod tests {
         // given:
         let mut db_state = DbState::new(new_dirty_manifest());
         add_l0s_to_dbstate(&mut db_state, 4);
-        // mimic the compactor popping off l0s
+        // mimic the compactor compacting the oldest l0: pop it, advance the watermark, and
+        // record its SST id in the compacted set the writer merge drops by.
         let mut compactor_state = new_dirty_manifest();
         compactor_state.value.core = db_state.state.core().clone();
-        let last_compacted = Arc::make_mut(&mut compactor_state.value.core.tree)
-            .l0
-            .pop_back()
-            .unwrap();
-        Arc::make_mut(&mut compactor_state.value.core.tree).last_compacted_l0_sst_view_id =
-            Some(last_compacted.id);
+        let tree = Arc::make_mut(&mut compactor_state.value.core.tree);
+        let last_compacted = tree.l0.pop_back().unwrap();
+        tree.last_compacted_l0_sst_view_id = Some(last_compacted.id);
+        tree.record_compacted_l0_ids([last_compacted.sst.id.unwrap_compacted_id()]);
 
         // when:
         db_state.merge_remote_manifest(compactor_state.clone());
@@ -922,6 +921,55 @@ mod tests {
     }
 
     #[test]
+    fn merge_must_not_drop_uncompacted_l0_after_watermark() {
+        fn view(seq: u64) -> SsTableView {
+            let ulid = ulid::Ulid::from_parts(seq, 0);
+            SsTableView::identity(SsTableHandle::new(
+                SsTableId::Compacted(ulid),
+                SST_FORMAT_VERSION_LATEST,
+                SsTableInfo::default(),
+            ))
+        }
+        // merge_writer_and_compactor's position-based trim drops every writer L0 from the
+        // watermark onward, ASSUMING the l0 list is in flush order so the watermark marks
+        // the compacted boundary. Across an HA takeover the writer's deque is rebuilt and
+        // that order diverges: an L0 the compactor KEPT uncompacted (still listed in
+        // compactor.l0) can land positioned after the watermark, and the position trim
+        // drops it -> a durably-committed write is lost. The merge must rescue it because
+        // the compactor still lists it as live.
+        let watermark_l0 = view(1); // compacted -> recorded as last_compacted_l0_sst_view_id
+        let kept_l0 = view(2); // kept uncompacted by the compactor; must survive the merge
+
+        // Writer L0 deque in DIVERGED order: the compacted watermark L0 ahead of the kept
+        // L0 (in flush order the newer kept L0 would precede the watermark).
+        let mut db_state = DbState::new(new_dirty_manifest());
+        db_state.modify(|m| {
+            Arc::make_mut(&mut m.state.manifest.value.core.tree).l0 =
+                VecDeque::from(vec![watermark_l0.clone(), kept_l0.clone()]);
+        });
+
+        // Compactor-authored remote: it compacted watermark_l0 (setting the watermark) and
+        // KEPT kept_l0 uncompacted, so kept_l0 is still listed in its l0.
+        let mut compactor = new_dirty_manifest();
+        compactor.value.core = db_state.state.core().clone();
+        {
+            let tree = Arc::make_mut(&mut compactor.value.core.tree);
+            tree.l0 = VecDeque::from(vec![kept_l0.clone()]);
+            tree.last_compacted_l0_sst_view_id = Some(watermark_l0.id);
+        }
+
+        db_state.merge_remote_manifest(compactor);
+
+        let merged: Vec<_> = db_state.state.core().tree.l0.iter().map(|v| v.id).collect();
+        assert!(
+            merged.contains(&kept_l0.id),
+            "merge dropped the kept, uncompacted L0 {} (positioned after the watermark) -> lost write; merged l0 = {:?}",
+            kept_l0.id,
+            merged
+        );
+    }
+
+    #[test]
     fn test_should_keep_local_segments_on_merge() {
         fn view(seq: u64) -> SsTableView {
             let ulid = ulid::Ulid::from_parts(seq, 0);
@@ -941,6 +989,7 @@ mod tests {
             core.segments = vec![Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![v1.clone()]),
@@ -995,6 +1044,7 @@ mod tests {
             core.segments = vec![Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![v2.clone(), v1.clone()]),
@@ -1009,6 +1059,7 @@ mod tests {
         remote_state.value.core.segments = vec![Segment {
             prefix: Bytes::from_static(b"hour=12/"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![v1.sst.id.unwrap_compacted_id()],
                 last_compacted_l0_sst_view_id: Some(v1.id),
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -332,6 +332,8 @@ impl FlatBufferManifestCodec {
                 last_compacted_l0_sst_id: l0_last_compacted,
                 l0,
                 compacted,
+                // V1 has no explicit compacted-l0-id set.
+                compacted_l0_ids: Vec::new(),
             }),
             // Segmentation is V2-only. V1 manifests are always unsegmented.
             segments: vec![],
@@ -386,6 +388,10 @@ impl FlatBufferManifestCodec {
             manifest.last_compacted_l0_sst_view_id(),
             manifest.l0(),
             manifest.compacted(),
+            manifest
+                .compacted_l0_ids()
+                .map(|v| v.iter().map(|id| id.ulid()).collect())
+                .unwrap_or_default(),
             &sst_lookup,
         )?;
         let mut segments = manifest
@@ -496,6 +502,10 @@ impl FlatBufferManifestCodec {
             fb_segment.last_compacted_l0_sst_view_id(),
             fb_segment.l0(),
             fb_segment.compacted(),
+            fb_segment
+                .compacted_l0_ids()
+                .map(|v| v.iter().map(|id| id.ulid()).collect())
+                .unwrap_or_default(),
             sst_lookup,
         )?;
         Ok(Segment {
@@ -511,6 +521,7 @@ impl FlatBufferManifestCodec {
         last_compacted_l0_sst_view_id: Option<FbUlid>,
         l0: flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTableView<'_>>>,
         compacted: flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SortedRunV2<'_>>>,
+        compacted_l0_ids: Vec<Ulid>,
         sst_lookup: &std::collections::HashMap<Ulid, SsTableHandle>,
     ) -> Result<LsmTreeState, Box<dyn std::error::Error + Send + Sync>> {
         let last_compacted_l0_sst_view_id = last_compacted_l0_sst_view_id.map(|id| id.ulid());
@@ -526,6 +537,7 @@ impl FlatBufferManifestCodec {
             last_compacted_l0_sst_id: None,
             l0,
             compacted,
+            compacted_l0_ids,
         })
     }
 
@@ -544,7 +556,12 @@ impl FlatBufferManifestCodec {
     /// Whether `manifest` carries state that V1 cannot represent:
     /// a configured segment extractor, or any named segment.
     fn requires_v2(manifest: &Manifest) -> bool {
-        manifest.core.segment_extractor_name.is_some() || !manifest.core.segments.is_empty()
+        // `compacted_l0_ids` only exists on the V2 wire shape, so a manifest that carries it
+        // must encode as V2 or the set is silently dropped on persist (then the writer-side
+        // merge can no longer drop those L0s). Segments imply V2 already and so carry theirs.
+        manifest.core.segment_extractor_name.is_some()
+            || !manifest.core.segments.is_empty()
+            || !manifest.core.tree.compacted_l0_ids.is_empty()
     }
 }
 
@@ -771,6 +788,7 @@ struct LsmTreeV2Offsets<'b> {
     l0: WIPOffset<Vector<'b, ForwardsUOffset<CompactedSsTableView<'b>>>>,
     last_compacted_l0_sst_view_id: Option<WIPOffset<FbUlid<'b>>>,
     compacted: WIPOffset<Vector<'b, ForwardsUOffset<SortedRunV2<'b>>>>,
+    compacted_l0_ids: Option<WIPOffset<Vector<'b, ForwardsUOffset<FbUlid<'b>>>>>,
 }
 
 impl<'b> DbFlatBufferBuilder<'b> {
@@ -986,6 +1004,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 last_compacted_l0_sst_view_id: tree.last_compacted_l0_sst_view_id,
                 l0: Some(tree.l0),
                 compacted: Some(tree.compacted),
+                compacted_l0_ids: tree.compacted_l0_ids,
             },
         )
     }
@@ -1001,10 +1020,13 @@ impl<'b> DbFlatBufferBuilder<'b> {
             .as_ref()
             .map(|ulid| self.add_compacted_sst_id(ulid));
         let compacted = self.add_sorted_runs_v2(&tree.compacted);
+        let compacted_l0_ids = (!tree.compacted_l0_ids.is_empty())
+            .then(|| self.add_ulids(tree.compacted_l0_ids.iter()));
         LsmTreeV2Offsets {
             l0,
             last_compacted_l0_sst_view_id,
             compacted,
+            compacted_l0_ids,
         }
     }
 
@@ -1351,6 +1373,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 ssts: Some(ssts),
                 l0: Some(tree.l0),
                 compacted: Some(tree.compacted),
+                compacted_l0_ids: tree.compacted_l0_ids,
                 last_l0_clock_tick: core.last_l0_clock_tick,
                 checkpoints: Some(checkpoints),
                 last_l0_seq: core.last_l0_seq,
@@ -1923,6 +1946,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=11/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -1935,6 +1959,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![new_sst_view(), new_sst_view()]),

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -718,6 +718,7 @@ mod tests {
         let segment_sr = view_at(3);
         let manifest = manifest_with(
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![unsegmented_l0.clone()]),
@@ -726,6 +727,7 @@ mod tests {
             vec![Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![segment_l0.clone()]),
@@ -751,6 +753,7 @@ mod tests {
         // Segment L0 newer than unsegmented L0; barrier should reflect it.
         let manifest = manifest_with(
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![view_at(1_000)]),
@@ -759,6 +762,7 @@ mod tests {
             vec![Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![view_at(5_000)]),
@@ -781,6 +785,7 @@ mod tests {
             vec![Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: Some(ulid_at(7_000)),
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -800,6 +805,7 @@ mod tests {
         // Mix of an unsegmented watermark and a newer segment L0.
         let manifest = manifest_with(
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: Some(ulid_at(2_000)),
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -808,6 +814,7 @@ mod tests {
             vec![Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![view_at(9_000)]),

--- a/slatedb/src/generated/root_generated.rs
+++ b/slatedb/src/generated/root_generated.rs
@@ -4237,6 +4237,7 @@ impl<'a> ManifestV2<'a> {
   pub const VT_SEQUENCE_TRACKER: flatbuffers::VOffsetT = 34;
   pub const VT_SEGMENTS: flatbuffers::VOffsetT = 36;
   pub const VT_SEGMENT_EXTRACTOR_NAME: flatbuffers::VOffsetT = 38;
+  pub const VT_COMPACTED_L0_IDS: flatbuffers::VOffsetT = 40;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -4256,6 +4257,7 @@ impl<'a> ManifestV2<'a> {
     builder.add_compactor_epoch(args.compactor_epoch);
     builder.add_writer_epoch(args.writer_epoch);
     builder.add_manifest_id(args.manifest_id);
+    if let Some(x) = args.compacted_l0_ids { builder.add_compacted_l0_ids(x); }
     if let Some(x) = args.segment_extractor_name { builder.add_segment_extractor_name(x); }
     if let Some(x) = args.segments { builder.add_segments(x); }
     if let Some(x) = args.sequence_tracker { builder.add_sequence_tracker(x); }
@@ -4396,6 +4398,13 @@ impl<'a> ManifestV2<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<&str>>(ManifestV2::VT_SEGMENT_EXTRACTOR_NAME, None)}
   }
+  #[inline]
+  pub fn compacted_l0_ids(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid>>>>(ManifestV2::VT_COMPACTED_L0_IDS, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for ManifestV2<'_> {
@@ -4423,6 +4432,7 @@ impl flatbuffers::Verifiable for ManifestV2<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, u8>>>("sequence_tracker", Self::VT_SEQUENCE_TRACKER, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Segment>>>>("segments", Self::VT_SEGMENTS, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<&str>>("segment_extractor_name", Self::VT_SEGMENT_EXTRACTOR_NAME, false)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("compacted_l0_ids", Self::VT_COMPACTED_L0_IDS, false)?
      .finish();
     Ok(())
   }
@@ -4446,6 +4456,7 @@ pub struct ManifestV2Args<'a> {
     pub sequence_tracker: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, u8>>>,
     pub segments: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Segment<'a>>>>>,
     pub segment_extractor_name: Option<flatbuffers::WIPOffset<&'a str>>,
+    pub compacted_l0_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
 }
 impl<'a> Default for ManifestV2Args<'a> {
   #[inline]
@@ -4469,6 +4480,7 @@ impl<'a> Default for ManifestV2Args<'a> {
       sequence_tracker: None,
       segments: None,
       segment_extractor_name: None,
+      compacted_l0_ids: None,
     }
   }
 }
@@ -4551,6 +4563,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> ManifestV2Builder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_SEGMENT_EXTRACTOR_NAME, segment_extractor_name);
   }
   #[inline]
+  pub fn add_compacted_l0_ids(&mut self, compacted_l0_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Ulid<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(ManifestV2::VT_COMPACTED_L0_IDS, compacted_l0_ids);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> ManifestV2Builder<'a, 'b, A> {
     let start = _fbb.start_table();
     ManifestV2Builder {
@@ -4590,6 +4606,7 @@ impl core::fmt::Debug for ManifestV2<'_> {
       ds.field("sequence_tracker", &self.sequence_tracker());
       ds.field("segments", &self.segments());
       ds.field("segment_extractor_name", &self.segment_extractor_name());
+      ds.field("compacted_l0_ids", &self.compacted_l0_ids());
       ds.finish()
   }
 }
@@ -4613,6 +4630,7 @@ impl<'a> Segment<'a> {
   pub const VT_LAST_COMPACTED_L0_SST_VIEW_ID: flatbuffers::VOffsetT = 6;
   pub const VT_L0: flatbuffers::VOffsetT = 8;
   pub const VT_COMPACTED: flatbuffers::VOffsetT = 10;
+  pub const VT_COMPACTED_L0_IDS: flatbuffers::VOffsetT = 12;
 
   #[inline]
   pub unsafe fn init_from_table(table: flatbuffers::Table<'a>) -> Self {
@@ -4624,6 +4642,7 @@ impl<'a> Segment<'a> {
     args: &'args SegmentArgs<'args>
   ) -> flatbuffers::WIPOffset<Segment<'bldr>> {
     let mut builder = SegmentBuilder::new(_fbb);
+    if let Some(x) = args.compacted_l0_ids { builder.add_compacted_l0_ids(x); }
     if let Some(x) = args.compacted { builder.add_compacted(x); }
     if let Some(x) = args.l0 { builder.add_l0(x); }
     if let Some(x) = args.last_compacted_l0_sst_view_id { builder.add_last_compacted_l0_sst_view_id(x); }
@@ -4660,6 +4679,13 @@ impl<'a> Segment<'a> {
     // which contains a valid value in this slot
     unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunV2>>>>(Segment::VT_COMPACTED, None).unwrap()}
   }
+  #[inline]
+  pub fn compacted_l0_ids(&self) -> Option<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>> {
+    // Safety:
+    // Created from valid Table for this object
+    // which contains a valid value in this slot
+    unsafe { self._tab.get::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid>>>>(Segment::VT_COMPACTED_L0_IDS, None)}
+  }
 }
 
 impl flatbuffers::Verifiable for Segment<'_> {
@@ -4673,6 +4699,7 @@ impl flatbuffers::Verifiable for Segment<'_> {
      .visit_field::<flatbuffers::ForwardsUOffset<Ulid>>("last_compacted_l0_sst_view_id", Self::VT_LAST_COMPACTED_L0_SST_VIEW_ID, false)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<CompactedSsTableView>>>>("l0", Self::VT_L0, true)?
      .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<SortedRunV2>>>>("compacted", Self::VT_COMPACTED, true)?
+     .visit_field::<flatbuffers::ForwardsUOffset<flatbuffers::Vector<'_, flatbuffers::ForwardsUOffset<Ulid>>>>("compacted_l0_ids", Self::VT_COMPACTED_L0_IDS, false)?
      .finish();
     Ok(())
   }
@@ -4682,6 +4709,7 @@ pub struct SegmentArgs<'a> {
     pub last_compacted_l0_sst_view_id: Option<flatbuffers::WIPOffset<Ulid<'a>>>,
     pub l0: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<CompactedSsTableView<'a>>>>>,
     pub compacted: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<SortedRunV2<'a>>>>>,
+    pub compacted_l0_ids: Option<flatbuffers::WIPOffset<flatbuffers::Vector<'a, flatbuffers::ForwardsUOffset<Ulid<'a>>>>>,
 }
 impl<'a> Default for SegmentArgs<'a> {
   #[inline]
@@ -4691,6 +4719,7 @@ impl<'a> Default for SegmentArgs<'a> {
       last_compacted_l0_sst_view_id: None,
       l0: None, // required field
       compacted: None, // required field
+      compacted_l0_ids: None,
     }
   }
 }
@@ -4717,6 +4746,10 @@ impl<'a: 'b, 'b, A: flatbuffers::Allocator + 'a> SegmentBuilder<'a, 'b, A> {
     self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Segment::VT_COMPACTED, compacted);
   }
   #[inline]
+  pub fn add_compacted_l0_ids(&mut self, compacted_l0_ids: flatbuffers::WIPOffset<flatbuffers::Vector<'b , flatbuffers::ForwardsUOffset<Ulid<'b >>>>) {
+    self.fbb_.push_slot_always::<flatbuffers::WIPOffset<_>>(Segment::VT_COMPACTED_L0_IDS, compacted_l0_ids);
+  }
+  #[inline]
   pub fn new(_fbb: &'b mut flatbuffers::FlatBufferBuilder<'a, A>) -> SegmentBuilder<'a, 'b, A> {
     let start = _fbb.start_table();
     SegmentBuilder {
@@ -4741,6 +4774,7 @@ impl core::fmt::Debug for Segment<'_> {
       ds.field("last_compacted_l0_sst_view_id", &self.last_compacted_l0_sst_view_id());
       ds.field("l0", &self.l0());
       ds.field("compacted", &self.compacted());
+      ds.field("compacted_l0_ids", &self.compacted_l0_ids());
       ds.finish()
   }
 }

--- a/slatedb/src/manifest/invariants.rs
+++ b/slatedb/src/manifest/invariants.rs
@@ -226,6 +226,7 @@ mod tests {
         current_core.segments.push(Segment {
             prefix: bytes::Bytes::from_static(b"seg"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 l0: VecDeque::from(vec![l0_view(400, 0)]),
                 ..LsmTreeState::default()
             }),
@@ -238,6 +239,7 @@ mod tests {
         dirty_core.segments.push(Segment {
             prefix: bytes::Bytes::from_static(b"seg"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 l0: VecDeque::from(vec![l0_view(400, 0)]),
                 ..LsmTreeState::default()
             }),

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -39,6 +39,12 @@ pub(crate) struct LsmTreeState {
 
     /// A list of the sorted runs that are valid to read in the `compacted` folder.
     pub compacted: Vec<SortedRun>,
+
+    /// SST ids of L0s folded into a sorted run. The writer-side merge drops exactly these
+    /// (matched by stable SST id, not instance-local view id), so a stale watermark across a
+    /// takeover cannot drop a still-uncompacted L0. Bounded; see
+    /// [`Self::record_compacted_l0_ids`].
+    pub compacted_l0_ids: Vec<ulid::Ulid>,
 }
 
 impl LsmTreeState {
@@ -78,48 +84,43 @@ impl LsmTreeState {
                 .sum::<usize>()
     }
 
+    /// Record L0 view ids folded into a sorted run, so the writer-side merge drops exactly
+    /// these. Bounded; over-pruning only risks a benign duplicate (the L0's data is also in
+    /// the run), never a loss.
+    pub(crate) fn record_compacted_l0_ids(&mut self, ids: impl IntoIterator<Item = ulid::Ulid>) {
+        const MAX_COMPACTED_L0_IDS: usize = 4096;
+        self.compacted_l0_ids.extend(ids);
+        if self.compacted_l0_ids.len() > MAX_COMPACTED_L0_IDS {
+            let excess = self.compacted_l0_ids.len() - MAX_COMPACTED_L0_IDS;
+            self.compacted_l0_ids.drain(0..excess);
+        }
+    }
+
     /// Canonical merge of a single LSM tree, called by both
     /// [`Self::merge_from_writer`] and [`Self::merge_from_compactor`]. The
     /// writer owns L0 and the compactor owns compacted runs / markers, so the
     /// merge keeps each side's authoritative state and drops L0 entries the
     /// compactor has already absorbed.
     pub(crate) fn merge_writer_and_compactor(writer: &Self, compactor: &Self) -> Self {
-        let last_compacted_view = compactor.last_compacted_l0_sst_view_id;
-        let last_compacted_sst = compactor.last_compacted_l0_sst_id;
-        // todo: this is brittle. we are relying on the l0 list always being
-        //       updated in an expected order. We should instead encode the
-        //       ordering in the l0 SST IDs and assert that it follows the
-        //       order.
-        let l0: VecDeque<SsTableView> =
-            if last_compacted_view.is_some() || last_compacted_sst.is_some() {
-                writer
-                    .l0
-                    .iter()
-                    .cloned()
-                    .take_while(|view| {
-                        // Match by view ID first (V2 manifests), then fall back
-                        // to SST ID (V1).
-                        if let Some(id) = last_compacted_view {
-                            if view.id == id {
-                                return false;
-                            }
-                        }
-                        if let Some(id) = last_compacted_sst {
-                            if view.sst.id.unwrap_compacted_id() == id {
-                                return false;
-                            }
-                        }
-                        true
-                    })
-                    .collect()
-            } else {
-                writer.l0.clone()
-            };
+        // Drop exactly the L0s the compactor recorded as compacted, matched by SST id (the
+        // stable physical identity — view ids are not shared across the writer and compactor
+        // instances). Inferring the set from the writer's deque order or the `last_compacted`
+        // watermark instead breaks across a takeover, where both go stale and still-durable,
+        // uncompacted L0s get dropped.
+        let compacted_ssts: std::collections::HashSet<ulid::Ulid> =
+            compactor.compacted_l0_ids.iter().copied().collect();
+        let l0: VecDeque<SsTableView> = writer
+            .l0
+            .iter()
+            .filter(|view| !compacted_ssts.contains(&view.sst.id.unwrap_compacted_id()))
+            .cloned()
+            .collect();
         Self {
-            last_compacted_l0_sst_view_id: last_compacted_view,
-            last_compacted_l0_sst_id: last_compacted_sst,
+            last_compacted_l0_sst_view_id: compactor.last_compacted_l0_sst_view_id,
+            last_compacted_l0_sst_id: compactor.last_compacted_l0_sst_id,
             l0,
             compacted: compactor.compacted.clone(),
+            compacted_l0_ids: compactor.compacted_l0_ids.clone(),
         }
     }
 }
@@ -2003,9 +2004,10 @@ mod tests {
 
     #[test]
     fn test_lsm_tree_merge_invariants() {
-        // Build a writer L0 with `n` views whose view IDs and SST IDs are all
-        // distinct, so we can tell V2 (view-id) and V1 (sst-id) marker
-        // matching apart.
+        // The merge drops exactly the writer L0s whose SST id the compactor recorded in
+        // `compacted_l0_ids`, keeps the rest in order, and carries the compactor's markers,
+        // sorted runs, and compacted-id set through unchanged. View id and SST id differ per
+        // entry so a regression to view-id matching would mismatch and fail.
         fn build_writer_l0(n: usize) -> VecDeque<SsTableView> {
             (0..n)
                 .map(|i| {
@@ -2023,38 +2025,19 @@ mod tests {
 
         proptest!(|(
             n in 1usize..10,
-            // 0 = no marker, 1 = V2 (view id) only, 2 = V1 (sst id) only, 3 = both
-            marker_kind in 0u8..4,
-            // Resolved against [0, n] below: index `n` means "marker doesn't
-            // match any L0 entry," exercising the no-trim path even with a
-            // marker present.
-            cutoff_idx_raw in 0usize..32,
+            // Per-position flag: did the compactor fold this L0 into a run?
+            compacted_mask in proptest::collection::vec(proptest::bool::ANY, 0..10),
         )| {
             let writer_l0 = build_writer_l0(n);
-            let cutoff_idx = cutoff_idx_raw % (n + 1);
-
-            let (last_view, last_sst) = if marker_kind == 0 {
-                (None, None)
-            } else if cutoff_idx == n {
-                // Marker that doesn't match any entry.
-                let nonmatch = Ulid::from_parts(u64::MAX, 0);
-                match marker_kind {
-                    1 => (Some(nonmatch), None),
-                    2 => (None, Some(nonmatch)),
-                    _ => (Some(nonmatch), Some(nonmatch)),
-                }
-            } else {
-                let target = &writer_l0[cutoff_idx];
-                let view_id = target.id;
-                let sst_id = target.sst.id.unwrap_compacted_id();
-                match marker_kind {
-                    1 => (Some(view_id), None),
-                    2 => (None, Some(sst_id)),
-                    _ => (Some(view_id), Some(sst_id)),
-                }
-            };
+            let compacted_l0_ids: Vec<Ulid> = writer_l0
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| *compacted_mask.get(*i).unwrap_or(&false))
+                .map(|(_, v)| v.sst.id.unwrap_compacted_id())
+                .collect();
 
             let writer = LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: writer_l0.clone(),
@@ -2062,29 +2045,30 @@ mod tests {
             };
             let compactor_compacted = vec![SortedRun { id: 42, sst_views: vec![] }];
             let compactor = LsmTreeState {
-                last_compacted_l0_sst_view_id: last_view,
-                last_compacted_l0_sst_id: last_sst,
+                compacted_l0_ids: compacted_l0_ids.clone(),
+                last_compacted_l0_sst_view_id: writer_l0.back().map(|v| v.id),
+                last_compacted_l0_sst_id: writer_l0.back().map(|v| v.sst.id.unwrap_compacted_id()),
                 l0: VecDeque::new(),
                 compacted: compactor_compacted.clone(),
             };
 
             let merged = writer.merge_from_compactor(&compactor);
 
-            // Effective trim point: cutoff_idx if a matching marker is set,
-            // otherwise n (everything passes through).
-            let effective_cutoff = if marker_kind == 0 || cutoff_idx == n {
-                n
-            } else {
-                cutoff_idx
-            };
-            let expected_l0: Vec<_> = writer_l0.iter().take(effective_cutoff).cloned().collect();
+            let dropped: std::collections::HashSet<Ulid> =
+                compacted_l0_ids.iter().copied().collect();
+            let expected_l0: Vec<_> = writer_l0
+                .iter()
+                .filter(|v| !dropped.contains(&v.sst.id.unwrap_compacted_id()))
+                .cloned()
+                .collect();
             let actual_l0: Vec<_> = merged.l0.iter().cloned().collect();
             assert_eq!(actual_l0, expected_l0);
 
-            // Markers and compacted are taken from the compactor unchanged.
-            assert_eq!(merged.last_compacted_l0_sst_view_id, last_view);
-            assert_eq!(merged.last_compacted_l0_sst_id, last_sst);
+            // Markers, compacted runs, and the compacted-id set come from the compactor.
+            assert_eq!(merged.last_compacted_l0_sst_view_id, compactor.last_compacted_l0_sst_view_id);
+            assert_eq!(merged.last_compacted_l0_sst_id, compactor.last_compacted_l0_sst_id);
             assert_eq!(merged.compacted, compactor_compacted);
+            assert_eq!(merged.compacted_l0_ids, compacted_l0_ids);
 
             // The two wrappers must agree for any (writer, compactor) pair —
             // catches accidental arg-swapping in the wrappers.
@@ -2111,6 +2095,7 @@ mod tests {
                 SsTableInfo::default(),
             );
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![SsTableView::new(view_id, handle)]),
@@ -2119,6 +2104,7 @@ mod tests {
         }
         fn marker_tree(seed: u64) -> LsmTreeState {
             LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: Some(Ulid::from_parts(seed, 0)),
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
@@ -2400,6 +2386,7 @@ mod tests {
                         Segment {
                             prefix,
                             tree: Arc::new(LsmTreeState {
+                                compacted_l0_ids: vec![],
                                 last_compacted_l0_sst_view_id: None,
                                 last_compacted_l0_sst_id: None,
                                 l0: VecDeque::from(vec![view]),
@@ -2436,12 +2423,18 @@ mod tests {
                     if count == 0 {
                         return;
                     }
-                    let newest = tree.l0[0].id;
-                    let sr_views: Vec<_> = (0..count).map(|i| tree.l0[i].clone()).collect();
-                    for _ in 0..count {
-                        tree.l0.pop_front();
-                    }
-                    tree.last_compacted_l0_sst_view_id = Some(newest);
+                    // Compact the oldest `count` L0s (the tail; l0 is newest-first), as
+                    // production does. The watermark advances to the newest of the compacted
+                    // range, so it stays monotonic across successive compactions.
+                    let start = tree.l0.len() - count;
+                    let newest_compacted = tree.l0[start].id;
+                    let sr_views: Vec<_> =
+                        (start..tree.l0.len()).map(|i| tree.l0[i].clone()).collect();
+                    tree.l0.truncate(start);
+                    tree.last_compacted_l0_sst_view_id = Some(newest_compacted);
+                    tree.record_compacted_l0_ids(
+                        sr_views.iter().map(|v| v.sst.id.unwrap_compacted_id()),
+                    );
                     self.next_sr_id += 1;
                     tree.compacted.insert(
                         0,
@@ -2465,8 +2458,11 @@ mod tests {
                     if let Some(newest) = tree.l0.front() {
                         tree.last_compacted_l0_sst_view_id = Some(newest.id);
                     }
+                    let drained: Vec<Ulid> =
+                        tree.l0.iter().map(|v| v.sst.id.unwrap_compacted_id()).collect();
                     tree.l0.clear();
                     tree.compacted.clear();
+                    tree.record_compacted_l0_ids(drained);
                 }
             }
 
@@ -2504,7 +2500,7 @@ mod tests {
                 self.check_no_l0_resurrection();
                 self.check_l0_provenance();
                 self.check_l0_unique_across_segments();
-                self.check_watermark_trim();
+                self.check_compacted_l0s_dropped();
                 self.check_watermark_monotonic();
                 self.check_l0_not_in_l0_and_sr_simultaneously();
             }
@@ -2577,21 +2573,20 @@ mod tests {
                 }
             }
 
-            // Within a segment, no L0 in the L0 list may have an ID at
-            // or below the segment's watermark — those are supposed to
-            // be trimmed by the merge.
-            fn check_watermark_trim(&self) {
+            // No L0 whose SST id the compactor recorded as compacted may
+            // survive in a segment's L0 list — the merge drops exactly
+            // those.
+            fn check_compacted_l0s_dropped(&self) {
                 for seg in &self.store {
-                    if let Some(wm) = seg.tree.last_compacted_l0_sst_view_id {
-                        for view in &seg.tree.l0 {
-                            assert!(
-                                view.id > wm,
-                                "L0 {} survived in segment {:?} but watermark is {}",
-                                view.id,
-                                seg.prefix,
-                                wm
-                            );
-                        }
+                    let compacted: std::collections::HashSet<Ulid> =
+                        seg.tree.compacted_l0_ids.iter().copied().collect();
+                    for view in &seg.tree.l0 {
+                        assert!(
+                            !compacted.contains(&view.sst.id.unwrap_compacted_id()),
+                            "L0 {} survived in segment {:?} but its SST id is recorded compacted",
+                            view.id,
+                            seg.prefix,
+                        );
                     }
                 }
             }
@@ -3196,6 +3191,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: Bytes::from_static(b"seg/"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![create_sst_view(segment_l0, b"seg/a")]),
@@ -3424,6 +3420,7 @@ mod tests {
         super::Segment {
             prefix: Bytes::copy_from_slice(prefix),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![SsTableView::new(view_id, handle)]),
@@ -3657,6 +3654,7 @@ mod tests {
         core.segments = vec![Segment {
             prefix: Bytes::copy_from_slice(prefix),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![SsTableView::new_projected(
@@ -3756,6 +3754,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=11/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -3765,6 +3764,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -3870,6 +3870,7 @@ mod tests {
         m1.core.segments.push(Segment {
             prefix: Bytes::from_static(b"hour=99/"),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: Some(Ulid::new()),
                 last_compacted_l0_sst_id: Some(Ulid::new()),
                 l0: VecDeque::new(),
@@ -3934,6 +3935,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(prefix),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![SsTableView::new_projected(
@@ -4113,6 +4115,7 @@ mod tests {
             core.segments = vec![Segment {
                 prefix: Bytes::from_static(b"foo/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![SsTableView::new_projected(
@@ -4138,6 +4141,7 @@ mod tests {
             core.segments = vec![Segment {
                 prefix: Bytes::from_static(b"foo/bar/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![SsTableView::new_projected(
@@ -4375,6 +4379,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=11/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![SsTableView::new_projected(
@@ -4409,6 +4414,7 @@ mod tests {
             Segment {
                 prefix: Bytes::from_static(b"hour=12/"),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
@@ -4538,6 +4544,7 @@ mod tests {
                 Segment {
                     prefix: Bytes::copy_from_slice(p),
                     tree: Arc::new(LsmTreeState {
+                        compacted_l0_ids: vec![],
                         last_compacted_l0_sst_view_id: None,
                         last_compacted_l0_sst_id: None,
                         l0: VecDeque::from(vec![SsTableView::new_projected(

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -769,6 +769,7 @@ mod tests {
             modifier.state.manifest.value.core.segments = vec![Segment {
                 prefix: Bytes::copy_from_slice(prefix),
                 tree: Arc::new(LsmTreeState {
+                    compacted_l0_ids: vec![],
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0,

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -982,6 +982,7 @@ mod tests {
         ManifestCore {
             initialized: true,
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0,
@@ -1022,6 +1023,7 @@ mod tests {
         Segment {
             prefix: Bytes::copy_from_slice(prefix),
             tree: Arc::new(LsmTreeState {
+                compacted_l0_ids: vec![],
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0,


### PR DESCRIPTION
## Summary

merge_writer_and_compactor trimmed the writer's L0 list positionally at the compactor's watermark, assuming the deque stays in flush order. Across a takeover that order diverges, so durably-committed but still-uncompacted L0s past the watermark were dropped, silently losing acknowledged writes.

## Changes

- Record the exact set of compacted L0 SST ids on the lsm tree when a compaction (or drain) finishes (new manifest field compacted_l0_ids) and have the merge drop only those. SST id is the stable physical identity; view ids are local to a single writer or compactor instance and do not match across a takeover. A non-empty set forces v2 manifest encoding so the field survives persistence on non-segmented databases.
- Protocol and merge tests are updated to the membership contract; the protocol simulator now compacts oldest-first, matching production.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
