### PR TITLE
Remove `CompactionExecutor` byte-based heartbeating

### DIFF
--- a/rfcs/0025-distributed-compaction.md
+++ b/rfcs/0025-distributed-compaction.md
@@ -156,7 +156,7 @@ max_sst_size = 268435456
 
 #### Workers
 
-Workers use `CompactorWorkerOptions` instead of `CompactorOptions`. The primary settings are:
+Workers use `CompactionWorkerOptions` instead of `CompactorOptions`. The primary settings are:
 
 ```rust
 pub struct CompactionWorkerOptions {
@@ -165,9 +165,6 @@ pub struct CompactionWorkerOptions {
 
   // How often a worker checks `.compactions` for new jobs.
   pub compactions_poll_interval: Duration,
-
-  // How many bytes a worker must process before emitting a heartbeat.
-  pub heartbeat_bytes: u64,
 
   // Minimum wall-clock time between heartbeat writes.
   pub heartbeat_min_interval: Duration,
@@ -186,9 +183,7 @@ pub struct CompactionWorkerOptions {
 
 - `compactions_poll_interval` is used for polling frequency. To prevent workers from synchronizing on `.compactions` reads, the poll ticker jitters each wait: instead of waiting exactly `compactions_poll_interval`, each tick waits a random duration picked uniformly between `compactions_poll_interval/2` and `3 * compactions_poll_interval/2` (the interval plus or minus half). Because the range is centered on `compactions_poll_interval`, each worker still polls once per `compactions_poll_interval` on average. Jitter is a feature of the shared task dispatcher (defaulting to off) that the worker enables for its poll ticker; the randomized wait happens inside the ticker rather than in the message handler, so waiting on it never blocks the worker from processing job-progress or job-finished messages. It requires no user configuration.
 
-- `heartbeat_bytes` is used to tie heartbeats to compaction progress and gives the coordinator a liveness guarantee. A worker that falls behind this rate will be reclaimed and its job handed off, regardless of whether its event loop is still alive.
-
-- `heartbeat_min_interval` suppresses heartbeats triggered by `heartbeat_bytes` when processing is fast and should be set well below the coordinator's `worker_heartbeat_timeout`.
+- `heartbeat_min_interval` controls the worker ticker that refreshes liveness for active jobs and should be set well below the coordinator's `worker_heartbeat_timeout`.
 
 New `CompactionWorkerBuilder` entrypoint for `CompactionWorker` processes:
 
@@ -196,7 +191,6 @@ New `CompactionWorkerBuilder` entrypoint for `CompactionWorker` processes:
 let options = CompactionWorkerOptions {
     max_concurrent_compactions: 2,
     compactions_poll_interval: Duration::from_secs(1),
-    heartbeat_bytes: 100_000,
     heartbeat_min_interval: Duration::from_secs(10),
 };
 
@@ -244,11 +238,11 @@ Workers claim up to `max_concurrent_compactions` jobs at a time, limiting the nu
 
 **Heartbeat Protocol** (worker):
 
-1. On each output SST write, piggyback `last_heartbeat_ms = now()` onto the RFC-0013 progress-persistence write to `.compactions`.
-2. Additionally, after every `heartbeat_bytes` bytes processed: if `now() - last_heartbeat_ms >= heartbeat_min_interval_ms`, write updated `.compactions` with `last_heartbeat_ms = now()` for all `Running` jobs owned by this worker. This ties liveness directly to compaction throughput. A degraded machine that is alive but slow will miss the threshold and be reclaimed.
+1. Every `heartbeat_min_interval`, write updated `.compactions` with `last_heartbeat_ms = now()` for all `Running` jobs owned by this worker.
+2. When the compaction context changes, including the initial plan or new output SST progress, persist the updated context and piggyback `last_heartbeat_ms = now()`.
 3. On `AlreadyExists`: re-read latest. If the compaction is now `Submitted` or claimed by another `worker_id`, the worker has lost the assignment: discard local state for that compaction, abort execution, and return to the poll/claim loop. Otherwise retry the write.
 
-Polls do not emit heartbeats. Liveness is driven entirely by compaction progress.
+Polls do not emit heartbeats. Liveness is driven by the worker heartbeat ticker; progress writes also refresh liveness when resumable state changes.
 
 **Failure Detection Protocol** (coordinator):
 
@@ -371,7 +365,6 @@ let worker = CompactionWorkerBuilder::new("db", object_store)
       CompactionWorkerOptions {
         max_concurrent_compactions: 2,
         compactions_poll_interval: Duration::from_secs(1),
-        heartbeat_bytes: 100_000,
         heartbeat_min_interval: Duration::from_secs(5),
       }
     )
@@ -424,8 +417,7 @@ let worker = CompactionWorkerBuilder::new("db", object_store)
       CompactionWorkerOptions {
         max_concurrent_compactions: 2,
         compactions_poll_interval: Duration::from_secs(1),
-        heartbeat_bytes: 100_000,
-        heartbeat_min_interval_ms: Duration::from_secs(5),
+        heartbeat_min_interval: Duration::from_secs(5),
       }
     )
     .build()

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -174,8 +174,6 @@ impl CompactionWorker {
 /// Per-job state used to detect when the per-range subcompaction progress has
 /// advanced and when the bytes threshold has been crossed.
 struct JobProgressState {
-    /// Total bytes processed as of the last bytes-based heartbeat write.
-    last_hb_bytes: u64,
     /// Wall-clock timestamp (ms) of this job's most recent heartbeat write
     /// (either trigger). Used to throttle the bytes trigger to at most one
     /// write per `heartbeat_min_interval`, independently of sibling jobs.
@@ -418,7 +416,6 @@ impl CompactionWorkerHandler {
                     self.job_progress.insert(
                         compaction.id(),
                         JobProgressState {
-                            last_hb_bytes: 0,
                             last_hb_ms: self.clock.now().timestamp_millis() as u64,
                             last_hb_ctx: compaction.ctx().cloned(),
                         },
@@ -531,20 +528,14 @@ impl CompactionWorkerHandler {
         // threshold (`last_hb_bytes`) and the throttle (`last_hb_ms`) are
         // per-job. The worker-level heartbeat ticker handles liveness for
         // active jobs that are temporarily not reporting byte progress.
-        let now_ms = self.clock.now().timestamp_millis() as u64;
-        let (bytes_trigger, ctx_changed, prev_sst_count) = {
+        let (ctx_changed, prev_sst_count) = {
             let Some(state) = self.job_progress.get(&id) else {
                 return Ok(());
             };
-            let bytes_trigger = bytes_processed.saturating_sub(state.last_hb_bytes)
-                >= self.options.heartbeat_bytes
-                && now_ms.saturating_sub(state.last_hb_ms)
-                    >= self.options.heartbeat_min_interval.as_millis() as u64;
             // Persist the full compaction context whenever it advances. This captures
             // both the initial plan/retention choice and later output progress.
             let ctx_changed = state.last_hb_ctx.as_ref() != Some(&ctx);
             (
-                bytes_trigger,
                 ctx_changed,
                 state
                     .last_hb_ctx
@@ -554,7 +545,7 @@ impl CompactionWorkerHandler {
             )
         };
 
-        if !bytes_trigger && !ctx_changed {
+        if !ctx_changed {
             return Ok(());
         }
 
@@ -572,7 +563,6 @@ impl CompactionWorkerHandler {
             if ctx_changed {
                 state.last_hb_ctx = Some(ctx);
             }
-            state.last_hb_bytes = bytes_processed;
             state.last_hb_ms = hb_ms;
             info!(
                 "progress heartbeat [worker_id={}, id={}, bytes={}, output_ssts={}, new_output_ssts={}]",
@@ -1335,7 +1325,6 @@ mod tests {
             (
                 id3,
                 JobProgressState {
-                    last_hb_bytes: 0,
                     last_hb_ms: 0,
                     last_hb_ctx: None,
                 },
@@ -1343,7 +1332,6 @@ mod tests {
             (
                 id1,
                 JobProgressState {
-                    last_hb_bytes: 0,
                     last_hb_ms: 0,
                     last_hb_ctx: None,
                 },
@@ -1351,7 +1339,6 @@ mod tests {
             (
                 id2,
                 JobProgressState {
-                    last_hb_bytes: 0,
                     last_hb_ms: 0,
                     last_hb_ctx: None,
                 },
@@ -1733,7 +1720,6 @@ mod tests {
         let mock_clock = Arc::new(MockSystemClock::new());
         mock_clock.set(1000);
         let options = CompactionWorkerOptions {
-            heartbeat_bytes: 1,
             heartbeat_min_interval: Duration::from_millis(1),
             ..CompactionWorkerOptions::default()
         };
@@ -1790,7 +1776,6 @@ mod tests {
         let mock_clock = Arc::new(MockSystemClock::new());
         mock_clock.set(1000);
         let options = CompactionWorkerOptions {
-            heartbeat_bytes: u64::MAX,
             ..CompactionWorkerOptions::default()
         };
         let clock: Arc<dyn SystemClock> = mock_clock.clone();

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -24,17 +24,13 @@
 //! # Heartbeat and failure detection
 //!
 //! Workers emit heartbeats to prove liveness. A heartbeat is a CAS write that
-//! bumps `last_heartbeat_ms` in the worker's `.compactions` entry. Three paths
+//! bumps `last_heartbeat_ms` in the worker's `.compactions` entry. Two paths
 //! can refresh it:
 //!
 //! 1. **Worker ticker**: every `heartbeat_min_interval`, the worker refreshes
 //!    liveness for every active job it still owns.
-//! 2. **Bytes trigger**: when the cumulative bytes processed since the last
-//!    bytes-based heartbeat exceeds `CompactionWorkerOptions::heartbeat_bytes`
-//!    *and* at least `heartbeat_min_interval` has elapsed since the last such
-//!    write, the worker emits a cheap heartbeat that just refreshes liveness.
-//! 3. **Subcompaction trigger**: whenever the per-range subcompaction progress
-//!    (RFC-0028) advances — a range produces new output SSTs — the worker
+//! 2. **Progress trigger**: whenever the compaction context advances - the
+//!    executor plans the job or a range produces new output SSTs - the worker
 //!    writes a heartbeat carrying the latest progress report, so a reclaiming
 //!    worker can resume completed ranges.
 //!
@@ -102,12 +98,13 @@ pub(crate) enum WorkerMessage {
         /// Output SR on success, or the compaction error.
         result: Result<SortedRun, SlateDBError>,
     },
-    /// Periodic progress update from the [`CompactionExecutor`].
+    /// Progress update from the [`CompactionExecutor`].
     CompactionJobProgress {
         /// The job id associated with this progress report.
         id: Ulid,
         /// The total number of bytes processed so far (estimate).
         bytes_processed: u64,
+        /// The current compaction context, which may carry new output SSTs.
         ctx: CompactionContext,
     },
     /// Ticker-triggered message to poll `.compactions` for claimable jobs.
@@ -171,12 +168,10 @@ impl CompactionWorker {
     }
 }
 
-/// Per-job state used to detect when the per-range subcompaction progress has
-/// advanced and when the bytes threshold has been crossed.
+/// Per-job state used to detect when executor progress carries new resumable
+/// compaction context.
 struct JobProgressState {
-    /// Wall-clock timestamp (ms) of this job's most recent heartbeat write
-    /// (either trigger). Used to throttle the bytes trigger to at most one
-    /// write per `heartbeat_min_interval`, independently of sibling jobs.
+    /// Wall-clock timestamp (ms) of this job's most recent heartbeat write.
     last_hb_ms: u64,
     /// Context as of the last heartbeat write that persisted it. Snapshots
     /// change only when the executor first plans the job or when a range's
@@ -497,37 +492,28 @@ impl CompactionWorkerHandler {
         }
     }
 
-    /// Handles a progress update from the executor. Triggers:
-    /// - A **bytes heartbeat** when cumulative bytes since the last bytes-hb
-    ///   exceeds `heartbeat_bytes` and `heartbeat_min_interval` has elapsed.
-    /// - A **subcompaction write** when the per-range subcompaction progress
-    ///   (RFC-0028) changed since the one last persisted, so a reclaiming
-    ///   worker can resume completed ranges. This bypasses the bytes throttle
-    ///   because progress changes only on range output transitions, not per
-    ///   byte.
+    /// Handles a progress update from the executor. Writes a heartbeat when the
+    /// compaction context changed since the one last persisted, so a reclaiming
+    /// worker can resume completed ranges.
     ///
     /// `bytes_processed` is *cumulative* per job (the running byte total), not
     /// a delta.
     ///
-    /// Per-job progress bookkeeping (`last_hb_bytes`, `last_hb_ms`, and
-    /// `last_hb_ctx`) is only advanced after `write_heartbeat`
-    /// confirms a durable write, so a skipped write (entry gone / ownership
-    /// lost) does not mark un-persisted progress as heartbeated.
+    /// Per-job progress bookkeeping (`last_hb_ms` and `last_hb_ctx`) is only
+    /// advanced after `write_heartbeat` confirms a durable write, so a skipped
+    /// write (entry gone / ownership lost) does not mark un-persisted progress
+    /// as heartbeated.
     async fn handle_progress(
         &mut self,
         id: Ulid,
         bytes_processed: u64,
         ctx: CompactionContext,
     ) -> Result<(), SlateDBError> {
-        // Compute both triggers from a single borrow, then bail if this job is
-        // unknown (stale progress message). The borrow ends before the async
-        // `write_heartbeat`; state is advanced afterwards only on a confirmed
-        // durable write.
-        //
-        // Bytes-trigger writes are tied to *this job's own* progress: both the
-        // threshold (`last_hb_bytes`) and the throttle (`last_hb_ms`) are
-        // per-job. The worker-level heartbeat ticker handles liveness for
-        // active jobs that are temporarily not reporting byte progress.
+        // Compute the context change from a single borrow, then bail if this
+        // job is unknown (stale progress message). The borrow ends before the
+        // async `write_heartbeat`; state is advanced afterwards only on a
+        // confirmed durable write. The worker-level heartbeat ticker handles
+        // liveness even when progress reports do not change resumable state.
         let (ctx_changed, prev_sst_count) = {
             let Some(state) = self.job_progress.get(&id) else {
                 return Ok(());
@@ -549,10 +535,8 @@ impl CompactionWorkerHandler {
             return Ok(());
         }
 
-        // Carry the compaction context only when it changed; a bytes-only
-        // heartbeat just refreshes liveness (`last_heartbeat_ms`). On a
-        // confirmed write, record the timestamp that was actually persisted so
-        // in-memory throttling stays consistent with the durable entry.
+        // On a confirmed write, record the timestamp that was actually
+        // persisted so in-memory state stays consistent with the durable entry.
         let new_sst_count = total_output_ssts(ctx.subcompactions());
         let new_ctx = ctx_changed.then(|| ctx.clone());
         if let Some(hb_ms) = self.write_heartbeat(id, new_ctx).await? {
@@ -1706,16 +1690,14 @@ mod tests {
         assert!(kept.worker().unwrap().last_heartbeat_ms > 1000);
     }
 
-    /// When the bytes-processed counter crosses `heartbeat_bytes` and enough
-    /// time has elapsed since the last bytes-based heartbeat, the worker must
-    /// write a heartbeat without touching the per-range subcompaction progress.
+    /// When the executor reports the initial planned context, the worker must
+    /// persist it without requiring per-range subcompaction progress.
     #[tokio::test]
-    async fn test_worker_emits_bytes_heartbeat_on_threshold() {
+    async fn test_worker_persists_initial_compaction_context() {
         use tokio::time::pause;
         pause();
 
-        // given: a claimed compaction and a worker whose bytes threshold is tiny
-        // (so any byte progress crosses it), with the clock advanced past the
+        // given: a claimed compaction with the clock advanced past the
         // heartbeat min-interval.
         let mock_clock = Arc::new(MockSystemClock::new());
         mock_clock.set(1000);
@@ -1731,8 +1713,8 @@ mod tests {
         fx.handler.poll_and_claim().await.unwrap();
         mock_clock.advance(Duration::from_secs(2)).await;
 
-        // when: progress reports bytes over the threshold and the executor's
-        // first planned context, but no output SSTs yet.
+        // when: progress reports the executor's first planned context, but no
+        // output SSTs yet.
         let ctx =
             CompactionContext::new(vec![Subcompaction::new(BytesRange::unbounded())], Some(0));
         fx.handler
@@ -1740,8 +1722,8 @@ mod tests {
             .await
             .unwrap();
 
-        // then: a heartbeat is written (last_heartbeat_ms bumped) but no
-        // per-range output progress is persisted.
+        // then: a heartbeat is written and the initial context is persisted,
+        // but no per-range output progress exists yet.
         let c = fx.read_compaction(id).await.expect("compaction missing");
         assert_eq!(c.status(), CompactionStatus::Running);
         let worker = c.worker().expect("worker spec missing");
@@ -1763,16 +1745,15 @@ mod tests {
 
     /// When the executor reports per-range subcompaction progress (RFC-0028),
     /// the worker must persist the progress to `.compactions` so a reclaiming
-    /// worker can resume — even when the bytes trigger did not fire. A later
-    /// report that extends a range's output SSTs must also be persisted.
+    /// worker can resume. A later report that extends a range's output SSTs
+    /// must also be persisted.
     #[tokio::test]
     async fn test_worker_persists_subcompaction_progress() {
         use tokio::time::pause;
         pause();
 
-        // given: a claimed compaction and a worker whose bytes trigger is
-        // disabled, so only a subcompaction progress report change drives a
-        // write.
+        // given: a claimed compaction where only a subcompaction progress
+        // report change drives a write.
         let mock_clock = Arc::new(MockSystemClock::new());
         mock_clock.set(1000);
         let options = CompactionWorkerOptions {
@@ -1786,7 +1767,7 @@ mod tests {
         fx.handler.poll_and_claim().await.unwrap();
         mock_clock.advance(Duration::from_secs(5)).await;
 
-        // when: progress carries a subcompaction (bytes trigger off).
+        // when: progress carries subcompaction output.
         let sst1 = fake_output_handle(Ulid::from_parts(9000, 0));
         let subcompactions =
             vec![Subcompaction::new(BytesRange::unbounded()).with_output_ssts(vec![sst1.clone()])];

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
 
 use bytes::Bytes;
-use chrono::TimeDelta;
 use futures::future::{join, join_all};
 use parking_lot::Mutex;
 use tokio::task::JoinHandle;
@@ -809,22 +808,11 @@ impl TokioCompactionExecutorInner {
             before_key.saturating_sub(before_range)
         });
 
-        // Cadence for the time-based progress send below. Caps sends at 1s (the
-        // pre-distributed-compaction default), but never coarser than the
-        // worker's `heartbeat_min_interval`, so progress heartbeats still use
-        // the worker's configured write throttle.
-        let progress_interval = TimeDelta::from_std(
-            self.options
-                .heartbeat_min_interval
-                .min(std::time::Duration::from_secs(1)),
-        )
-        .expect("clamped to <= 1s, which always fits in a TimeDelta");
         // Report the resume point up front so a resumed range surfaces the bytes
         // already processed in prior attempts immediately. A range that resumes
         // already-complete reports its full estimated size here (its resume
         // cursor sits at the range's last key) and never enters the loop below.
         progress(start_bytes_processed, &output_ssts);
-        let mut last_progress_report = self.clock.now();
 
         // At most one SST close runs in the background at a time (depth-1
         // pipeline). While a finished SST flushes to the object store we keep
@@ -844,15 +832,6 @@ impl TokioCompactionExecutorInner {
                 self.collect_close(pending, &mut output_ssts).await?;
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
                 progress(total_bytes, &output_ssts);
-                last_progress_report = self.clock.now();
-            }
-
-            let duration_since_last_report =
-                self.clock.now().signed_duration_since(last_progress_report);
-            if duration_since_last_report > progress_interval {
-                let total_bytes = start_bytes_processed + all_iter.bytes_processed();
-                progress(total_bytes, &output_ssts);
-                last_progress_report = self.clock.now();
             }
 
             if let Some(block_size) = current_writer.add(kv).await? {
@@ -880,7 +859,6 @@ impl TokioCompactionExecutorInner {
                 bytes_written = 0;
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
                 progress(total_bytes, &output_ssts);
-                last_progress_report = self.clock.now();
             }
         }
 

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -521,7 +521,7 @@ impl TokioCompactionExecutorInner {
     ///   (RFC-0028)
     /// - Streams and merges input keys across all sources (per range)
     /// - Applies merge and retention policies
-    /// - Writes output SSTs up to `max_sst_size`, reporting periodic progress
+    /// - Writes output SSTs up to `max_sst_size`, reporting resumable progress
     ///
     /// ## Returns
     /// - The compaction context with all output SST handles.

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1192,9 +1192,6 @@ pub struct CompactionWorkerOptions {
     #[serde(serialize_with = "serialize_duration")]
     pub compactions_poll_interval: Duration,
 
-    /// How many bytes a worker must process before emitting a heartbeat.
-    pub heartbeat_bytes: u64,
-
     /// Minimum wall-clock time between heartbeat writes.
     #[serde(deserialize_with = "deserialize_duration")]
     #[serde(serialize_with = "serialize_duration")]
@@ -1263,7 +1260,6 @@ impl Default for CompactionWorkerOptions {
         Self {
             max_concurrent_compactions: 4,
             compactions_poll_interval: Duration::from_secs(5),
-            heartbeat_bytes: 5_242_880,
             heartbeat_min_interval: Duration::from_secs(5),
             max_sst_size: 256 * 1024 * 1024,
             max_fetch_tasks: 4,


### PR DESCRIPTION
## Summary

In the initial distributed compaction RFC, I pushed for a byte-based heartbeat. The idea was that the executor should heartbeat after it's made a least a fixed amount of byte progress (e.g. 10 megs of compaction progress) even if it hasn't output an SST lately. I suggested this instead of a simple ticker-based heartbeat; I was concerned about brownouts where the worker would continue heartbeating but make no actual progress.

In practice, this approach has proven to be more trouble than it's worth. In  #1864, I re-introduced a simple heartbeat-based approach; the worker heartbeats on a fixed interval. Now that we have that, we don't need the byte-based approach anymore. This PR removes it.

## Changes

- Remove `config.rs` `heartbeat_bytes` (backwards incompatible). No longer needed.
- Remove `JobProgressState:: last_hb_bytes`. No longer needed.
- Update logic, tests, and docs to reflect these changes.

## Notes for Reviewers

There is still some cruft I want to get rid of. The next step will be to remove compaction context-based triggers (i.e. triggering on new SST output). I plan to move us to an entirely time-based heartbeat. As new SSTs are added, they'll reside in `JobProgressState` and will get reported on the next heartbeat tick. This will make for a very simple mental model: your exposure to lost compaction work is bounded to the heartbeat interval; that's it.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
