### PR TITLE
Allow users to specify DST seeds to make replay easier

### DIFF
--- a/.github/workflows/dst-hourly.yaml
+++ b/.github/workflows/dst-hourly.yaml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   deterministic-simulation-test:
     runs-on: ubuntu-latest
+    # Hard backstop for the whole job. The "Run DST Tests" step below sets a
+    # shorter timeout so an overrun is reported as a step *failure* (which sends
+    # a notification) rather than a job-level cancellation (which does not).
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +25,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gdb
       - name: Run DST Tests
+        # Time out the run itself, below the job-level timeout above. A step
+        # timeout marks the step (and job) as failed, so the usual GitHub
+        # failure notification fires. A job-level timeout would instead cancel
+        # the run, and GitHub does not notify on cancellations.
+        timeout-minutes: 55
         run: cargo nextest run -p slatedb-dst --all-features --profile dst-nightly --no-capture
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"

--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -383,6 +383,9 @@ Other helpers expose the pieces separately:
   `GarbageCollectorOptions`
 - `utils::build_toxic(rand, root_path, index)`: randomized deterministic
   `Toxic` values for object-store fault injection
+- `utils::dst_seeds(default_count)`: the seeds a DST test should run — the
+  comma-separated list from `SLATEDB_DST_SEEDS` when set, otherwise
+  `default_count` random seeds
 
 Because these values are derived from supplied RNGs, they expand scenario
 coverage without sacrificing reproducibility.
@@ -417,3 +420,21 @@ If you want both in one pass, run the DST-gated command for the package:
 ```bash
 RUSTFLAGS="--cfg dst --cfg tokio_unstable" cargo test -p slatedb-dst
 ```
+
+### Reproducing a failed run
+
+Every DST test logs the seeds it runs (e.g. `dst bank seed: ...` or
+`dst determinism seed [core=0, seed=...]`). To re-run a test with specific
+seeds instead of fresh random ones, set `SLATEDB_DST_SEEDS` to a
+comma-separated list of seeds:
+
+```bash
+SLATEDB_DST_SEEDS=17689751483034105621 \
+RUSTFLAGS="--cfg dst --cfg tokio_unstable" \
+cargo test -p slatedb-dst --test determinism
+```
+
+The scenario tests (`determinism`, `segments`) run one OS thread per listed
+seed; the `bank` test runs the listed seeds serially. The variable applies to
+every DST test in the invocation, so target one test binary with
+`--test <name>` when reproducing a single failure.

--- a/slatedb-dst/src/scenarios.rs
+++ b/slatedb-dst/src/scenarios.rs
@@ -37,7 +37,7 @@ use crate::actors::{
     CompactorActor, CompactorActorOptions, FlusherActor, ShutdownActor, WorkloadActor,
     WorkloadActorOptions, WorkloadMergeOperator,
 };
-use crate::utils::{build_settings, build_settings_compactor, build_toxic};
+use crate::utils::{build_settings, build_settings_compactor, build_toxic, dst_seeds};
 use crate::{DeterministicLocalFilesystem, Harness};
 
 type ScenarioError = Box<dyn std::error::Error + Send + Sync>;
@@ -45,12 +45,13 @@ type ScenarioResult<T> = Result<T, ScenarioError>;
 
 /// Configuration for a deterministic SlateDB scenario test.
 ///
-/// The scenario fans out one random seed per available CPU core, runs
-/// those seed groups on separate OS threads, and within each thread
-/// replays the seeded scenario `simulations` times in serial. Every
-/// replay must leave the harness in the same observable state (next root
-/// RNG value + current mock-clock time); a divergence indicates a
-/// non-deterministic code path in the harness or SlateDB.
+/// The scenario fans out one random seed per available CPU core (or the
+/// seeds listed in [`crate::utils::DST_SEEDS_ENV`]), runs those seed
+/// groups on separate OS threads, and within each thread replays the
+/// seeded scenario `simulations` times in serial. Every replay must
+/// leave the harness in the same observable state (next root RNG value +
+/// current mock-clock time); a divergence indicates a non-deterministic
+/// code path in the harness or SlateDB.
 pub struct DeterministicScenario {
     /// Logical name used for the harness label and tempdir path prefix.
     pub name: &'static str,
@@ -69,7 +70,8 @@ pub struct DeterministicScenario {
 impl DeterministicScenario {
     /// Runs the scenario across all available CPU cores in parallel.
     ///
-    /// Creates one random seed per available CPU core, then runs those seed
+    /// Creates one random seed per available CPU core (or takes the seeds
+    /// listed in [`crate::utils::DST_SEEDS_ENV`]), then runs those seed
     /// groups concurrently on separate OS threads. Each thread owns one seed
     /// and executes that seed repeatedly in serial, so the determinism
     /// assertion is still made by comparing multiple runs of the same seed
@@ -85,7 +87,7 @@ impl DeterministicScenario {
         let num_cores = std::thread::available_parallelism()
             .map(|p| p.get())
             .unwrap_or(1);
-        let seeds: Vec<u64> = (0..num_cores).map(|_| rand::random::<u64>()).collect();
+        let seeds = dst_seeds(num_cores)?;
 
         let handles = seeds
             .into_iter()

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -283,6 +283,51 @@ pub fn build_toxic(rand: &DbRand, root_path: &str, index: usize) -> Toxic {
     }
 }
 
+/// Environment variable holding a comma-separated list of `u64` seeds that
+/// overrides random seed generation for DST tests.
+pub const DST_SEEDS_ENV: &str = "SLATEDB_DST_SEEDS";
+
+/// Returns the seeds a DST test should run.
+///
+/// When [`DST_SEEDS_ENV`] is set, parses it as a comma-separated list of
+/// `u64` seeds so a failed run can be reproduced with the seeds it logged.
+/// Otherwise returns `default_count` random seeds.
+pub fn dst_seeds(default_count: usize) -> std::io::Result<Vec<u64>> {
+    match std::env::var(DST_SEEDS_ENV) {
+        Ok(raw) => parse_seeds(&raw),
+        Err(std::env::VarError::NotPresent) => {
+            Ok((0..default_count).map(|_| rand::random::<u64>()).collect())
+        }
+        Err(err) => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("invalid {DST_SEEDS_ENV}: {err}"),
+        )),
+    }
+}
+
+fn parse_seeds(raw: &str) -> std::io::Result<Vec<u64>> {
+    let seeds = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            value.parse::<u64>().map_err(|err| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("invalid seed {value:?} in {DST_SEEDS_ENV}: {err}"),
+                )
+            })
+        })
+        .collect::<std::io::Result<Vec<u64>>>()?;
+    if seeds.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("{DST_SEEDS_ENV} must contain at least one seed"),
+        ));
+    }
+    Ok(seeds)
+}
+
 // A flag so we only initialize logging once.
 static INIT_LOGGING: Once = Once::new();
 

--- a/slatedb-dst/tests/bank.rs
+++ b/slatedb-dst/tests/bank.rs
@@ -18,7 +18,9 @@ use slatedb_dst::{
         SuppressFenced, TransferActor, TransferMode,
     },
     failing_object_store::ToxicKind,
-    utils::{build_reader_options, build_settings, build_settings_compactor, build_toxic},
+    utils::{
+        build_reader_options, build_settings, build_settings_compactor, build_toxic, dst_seeds,
+    },
     DeterministicLocalFilesystem, Harness, StartupCtx,
 };
 use tempfile::TempDir;
@@ -29,7 +31,13 @@ use tempfile::TempDir;
 fn test_dst_bank_with_toxics(
     #[case] shutdown_at_ms: i64,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let seed = rand::random::<u64>();
+    for seed in dst_seeds(1)? {
+        run_bank(seed, shutdown_at_ms)?;
+    }
+    Ok(())
+}
+
+fn run_bank(seed: u64, shutdown_at_ms: i64) -> Result<(), Box<dyn std::error::Error>> {
     info!("dst bank seed: {seed}");
     let tempdir = TempDir::new()?;
     let main_dir = tempdir.path().join("main");


### PR DESCRIPTION
## Summary

Whenever I want to recreate a failed DST, I need to inject the previous seeds into the test. I'm adding a `SLATEDB_DST_SEEDS` environment variable that makes this easier.

I also set a 55m timeout for DST so I get actual job failure notifications when it times out. The workflow was timing out silently because it treats the job as "canceled".