### PR TITLE
[k/N] wal refactor: reorganize wal buffer so its owned by batch writer

### DIFF
--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -43,6 +43,7 @@ use crate::dispatcher::MessageHandler;
 use crate::mem_table::KVTable;
 use crate::types::RowEntry;
 use crate::utils::WatchableOnceCellReader;
+use crate::wal_buffer::WalBufferManager;
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
 use bytes::Bytes;
 use parking_lot::RwLockWriteGuard;
@@ -108,13 +109,15 @@ impl std::fmt::Debug for BatchWriterMessage {
 pub(crate) struct WriteBatchEventHandler {
     db_inner: Arc<DbInner>,
     is_first_write: bool,
+    wal_buffer: Arc<WalBufferManager>,
 }
 
 impl WriteBatchEventHandler {
-    pub(crate) fn new(db_inner: Arc<DbInner>) -> Self {
+    pub(crate) fn new(db_inner: Arc<DbInner>, wal_buffer: Arc<WalBufferManager>) -> Self {
         Self {
             db_inner,
             is_first_write: true,
+            wal_buffer,
         }
     }
 }
@@ -131,7 +134,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
             }) => {
                 let result = self
                     .db_inner
-                    .write_batch(batch, &options, txn.as_ref())
+                    .write_batch(batch, &options, txn.as_ref(), self.wal_buffer.as_ref())
                     .await;
                 // if this is the first write and the WAL is disabled, make sure users are flushing
                 // their memtables in a timely manner.
@@ -153,7 +156,9 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                     freeze_memtable,
                     done,
                 } = flush_msg;
-                let result = self.db_inner.flush_batch_writer(freeze_memtable);
+                let result = self
+                    .db_inner
+                    .flush_batch_writer(freeze_memtable, self.wal_buffer.as_ref());
                 let _ = done.send(result);
                 Ok(())
             }
@@ -192,6 +197,7 @@ impl DbInner {
         batch: WriteBatch,
         options: &WriteOptions,
         txn: Option<&DbTransaction>,
+        wal_buffer: &WalBufferManager,
     ) -> WriteBatchResult {
         let _options = options;
         #[cfg(not(dst))]
@@ -249,8 +255,8 @@ impl DbInner {
             // would violate the guarantee that batches are written atomically. We do
             // this by appending the entire entry batch in a single call to the WAL buffer,
             // which holds a write lock during the append.
-            let wal_watcher = self.wal_buffer.append(&entries)?;
-            self.wal_buffer.maybe_trigger_flush()?;
+            let wal_watcher = wal_buffer.append(&entries)?;
+            wal_buffer.maybe_trigger_flush()?;
             // TODO: handle sync here, if sync is enabled, we can call `flush` here. let's put this
             // in another Pull Request.
             self.write_entries_to_memtable(entries, touched_segments);
@@ -265,7 +271,7 @@ impl DbInner {
 
         // update the last_applied_seq to wal buffer. if a chunk of WAL entries are applied to the memtable
         // and flushed to the remote storage, WAL buffer manager will recycle these WAL entries.
-        self.wal_buffer.track_last_applied_seq(commit_seq);
+        wal_buffer.track_last_applied_seq(commit_seq);
 
         // insert a fail point to make it easier to test the case where the last_committed_seq is not updated.
         // this is useful for testing the case where the reader is not able to see the writes.
@@ -299,15 +305,18 @@ impl DbInner {
         self.record_memtable_sequence(commit_seq);
 
         // maybe freeze the memtable.
-        self.maybe_freeze_current_memtable()?;
+        self.maybe_freeze_current_memtable(wal_buffer)?;
 
         let write_handle = WriteHandle::new(commit_seq, now);
 
         Ok((write_handle, durable_watcher))
     }
 
-    fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {
-        let replay_after_wal_id = self.wal_buffer.recent_flushed_wal_id();
+    fn maybe_freeze_current_memtable(
+        &self,
+        wal_buffer: &WalBufferManager,
+    ) -> Result<(), SlateDBError> {
+        let replay_after_wal_id = wal_buffer.recent_flushed_wal_id();
         let mut guard = self.state.write();
         let meta = guard.memtable().metadata();
 
@@ -338,9 +347,10 @@ impl DbInner {
     fn flush_batch_writer(
         &self,
         freeze_memtable: bool,
+        wal_buffer: &WalBufferManager,
     ) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
         let flush_rx = if self.wal_enabled {
-            self.wal_buffer.flush()?
+            wal_buffer.flush()?
         } else {
             let (flush_tx, flush_rx) = oneshot::channel();
             flush_tx
@@ -352,7 +362,7 @@ impl DbInner {
             // Note that this likely won't reflect the result of the above flush call as we don't
             // block until the flush completes. That's fine, as any earlier wal is still a safe
             // replay point.
-            let replay_after_wal_id = self.wal_buffer.recent_flushed_wal_id();
+            let replay_after_wal_id = wal_buffer.status().last_flushed_wal_id;
             let mut guard = self.state.write();
             self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
         }
@@ -548,8 +558,16 @@ mod tests {
         )
         .await
         .unwrap();
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            db.inner.status_manager.clone(),
+            &db.inner.recorder,
+            0,
+            db.inner.table_store.clone(),
+            1024,
+            None,
+        ));
 
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone());
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
         assert!(handler.is_first_write);
 
         let mut batch = WriteBatch::new();
@@ -569,8 +587,16 @@ mod tests {
         let db = Db::open("/tmp/test_user_defined_seqnum", object_store)
             .await
             .unwrap();
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            db.inner.status_manager.clone(),
+            &db.inner.recorder,
+            0,
+            db.inner.table_store.clone(),
+            1024,
+            None,
+        ));
 
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone());
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
 
         // Write with a user-defined seqnum
         let mut batch = WriteBatch::new();
@@ -604,8 +630,16 @@ mod tests {
         )
         .await
         .unwrap();
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            db.inner.status_manager.clone(),
+            &db.inner.recorder,
+            0,
+            db.inner.table_store.clone(),
+            1024,
+            None,
+        ));
 
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone());
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
 
         // First, do a normal write to advance the oracle
         let mut batch = WriteBatch::new();

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -316,7 +316,7 @@ impl DbInner {
         &self,
         wal_buffer: &WalBufferManager,
     ) -> Result<(), SlateDBError> {
-        let replay_after_wal_id = wal_buffer.recent_flushed_wal_id();
+        let replay_after_wal_id = wal_buffer.last_flushed_wal_id();
         let mut guard = self.state.write();
         let meta = guard.memtable().metadata();
 
@@ -362,7 +362,7 @@ impl DbInner {
             // Note that this likely won't reflect the result of the above flush call as we don't
             // block until the flush completes. That's fine, as any earlier wal is still a safe
             // replay point.
-            let replay_after_wal_id = wal_buffer.status().last_flushed_wal_id;
+            let replay_after_wal_id = wal_buffer.last_flushed_wal_id();
             let mut guard = self.state.write();
             self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
         }

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -5867,7 +5867,7 @@ mod tests {
                 let db_state = db.inner.state.read();
                 let cow_db_state = db_state.state();
                 (
-                    db.inner.wal_buffer.is_empty(),
+                    db.inner.wal_observer.status().buffered_wal_entries_count == 0,
                     db_state.memtable().is_empty() && cow_db_state.imm_memtable.is_empty(),
                     db_state.state().core().clone(),
                 )

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -374,7 +374,7 @@ impl DbInner {
 
                 let await_flush_wal = self
                     .wal_observer
-                    .wait_until_memory_released(wal_status.estimated_bytes);
+                    .wait_until_wal_released(wal_status.last_purged_wal_id);
 
                 let timeout_fut = self.system_clock.sleep(Duration::from_secs(30));
                 let await_closed = async {
@@ -2095,11 +2095,9 @@ impl DbWalObserver {
     }
 
     /// Waits until the wal's estimated memory usage drops below some threshold
-    async fn wait_until_memory_released(
-        &self,
-        limit_bytes: usize,
-    ) -> Result<(), SlateDBError> {
-        self.wait_on_condition(|status| status.estimated_bytes < limit_bytes).await
+    async fn wait_until_wal_released(&self, last_purged_wal_id: u64) -> Result<(), SlateDBError> {
+        self.wait_on_condition(|status| status.last_purged_wal_id > last_purged_wal_id)
+            .await
     }
 }
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -70,7 +70,7 @@ use crate::tablestore::TableStore;
 use crate::transaction_manager::TransactionManager;
 use crate::types::KeyValue;
 use crate::utils::{format_bytes_si, SafeSender};
-use crate::wal_buffer::{WalBufferManager, WAL_BUFFER_TASK_NAME};
+use crate::wal_buffer::{WalEvent, WalObserver, WalStatus, WAL_BUFFER_TASK_NAME};
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{DbCacheManagerOps, DbMetadataOps, DbReadOps, DbWriteOps};
 use slatedb_common::clock::SystemClock;
@@ -108,7 +108,7 @@ pub(crate) struct DbInner {
     pub(crate) reader: Reader,
     /// [`wal_buffer`] manages the in-memory WAL buffer, it manages the flushing
     /// of the WAL buffer to the remote storage.
-    pub(crate) wal_buffer: Arc<WalBufferManager>,
+    pub(crate) wal_observer: DbWalObserver,
     pub(crate) wal_enabled: bool,
     /// [`txn_manager`] tracks all the live transactions and related metadata.
     pub(crate) txn_manager: Arc<TransactionManager>,
@@ -130,6 +130,7 @@ impl DbInner {
         manifest: DirtyObject<Manifest>,
         memtable_flusher: Arc<MemtableFlusher>,
         write_notifier: SafeSender<BatchWriterMessage>,
+        wal_observer: WalObserver,
         recorder: MetricsRecorderHelper,
         fp_registry: Arc<FailPointRegistry>,
         merge_operator: Option<crate::merge_operator::MergeOperatorType>,
@@ -171,20 +172,9 @@ impl DbInner {
             merge_operator.clone(),
         );
 
-        let recent_flushed_wal_id = state.read().state().core().replay_after_wal_id;
-        let wal_buffer = Arc::new(WalBufferManager::new(
-            state.clone(),
-            status_manager.clone(),
-            db_stats.clone(),
-            recent_flushed_wal_id,
-            oracle.clone(),
-            table_store.clone(),
-            settings.l0_sst_size_bytes,
-            settings.flush_interval,
-        ));
-
         let txn_manager = Arc::new(TransactionManager::new(oracle.clone(), rand.clone()));
         let snapshot_manager = Arc::new(SnapshotManager::new(oracle.clone(), rand.clone()));
+        let wal_observer = DbWalObserver::new(wal_observer, oracle.clone(), state.clone());
 
         let db_inner = Self {
             state,
@@ -193,7 +183,7 @@ impl DbInner {
             oracle,
             wal_enabled,
             table_store,
-            wal_buffer,
+            wal_observer,
             write_notifier,
             db_stats,
             mono_clock,
@@ -319,8 +309,8 @@ impl DbInner {
     pub(crate) async fn maybe_apply_backpressure(&self) -> Result<(), SlateDBError> {
         loop {
             self.check_closed()?;
-            let (wal_size_bytes, imm_memtable_size_bytes) = {
-                let wal_size_bytes = self.wal_buffer.estimated_bytes()?;
+            let (wal_status, imm_memtable_size_bytes) = {
+                let wal_status = self.wal_observer.status();
                 let imm_memtable_size_bytes = {
                     let guard = self.state.read();
                     // Exclude active memtable to avoid a write lock.
@@ -337,9 +327,9 @@ impl DbInner {
                         })
                         .sum::<usize>()
                 };
-                (wal_size_bytes, imm_memtable_size_bytes)
+                (wal_status, imm_memtable_size_bytes)
             };
-            let total_mem_size_bytes = wal_size_bytes + imm_memtable_size_bytes;
+            let total_mem_size_bytes = wal_status.estimated_bytes + imm_memtable_size_bytes;
             self.db_stats
                 .total_mem_size_bytes
                 .set(total_mem_size_bytes as i64);
@@ -347,7 +337,7 @@ impl DbInner {
             trace!(
                 "checking backpressure [total_mem_size_bytes={}, wal_size_bytes={}, imm_memtable_size_bytes={}, max_unflushed_bytes={}]",
                 format_bytes_si(total_mem_size_bytes as u64),
-                format_bytes_si(wal_size_bytes as u64),
+                format_bytes_si(wal_status.estimated_bytes as u64),
                 format_bytes_si(imm_memtable_size_bytes as u64),
                 format_bytes_si(self.settings.max_unflushed_bytes as u64),
             );
@@ -357,7 +347,7 @@ impl DbInner {
                 warn!(
                     "unflushed memtable size exceeds max_unflushed_bytes. applying backpressure. [total_mem_size_bytes={}, wal_size_bytes={}, imm_memtable_size_bytes={}, max_unflushed_bytes={}]",
                     format_bytes_si(total_mem_size_bytes as u64),
-                    format_bytes_si(wal_size_bytes as u64),
+                    format_bytes_si(wal_status.estimated_bytes as u64),
                     format_bytes_si(imm_memtable_size_bytes as u64),
                     format_bytes_si(self.settings.max_unflushed_bytes as u64),
                 );
@@ -367,16 +357,11 @@ impl DbInner {
                     guard.state().imm_memtable.back().cloned()
                 };
 
-                let watcher_for_oldest_unflushed_wal =
-                    self.wal_buffer.watcher_for_oldest_unflushed_wal();
-
                 // There is a window of time after mem_size_bytes is larger than max_unflushed_bytes
                 // but before we get the memtable and wal table. During that time, if the memtable and/or
                 // wal table are fully flushed out, we should short circuit since the select! will always
                 // time out.
-                if maybe_oldest_unflushed_memtable.is_none()
-                    && watcher_for_oldest_unflushed_wal.is_none()
-                {
+                if maybe_oldest_unflushed_memtable.is_none() {
                     continue;
                 }
 
@@ -388,13 +373,9 @@ impl DbInner {
                     }
                 };
 
-                let await_flush_wal = async {
-                    if let Some(mut watcher) = watcher_for_oldest_unflushed_wal {
-                        watcher.await_value().await
-                    } else {
-                        std::future::pending().await
-                    }
-                };
+                let await_flush_wal = self
+                    .wal_observer
+                    .wait_until_flushed_past_durable_seq(wal_status.last_flushed_seq);
 
                 let timeout_fut = self.system_clock.sleep(Duration::from_secs(30));
                 let await_closed = async {
@@ -473,6 +454,14 @@ impl DbInner {
     }
 
     async fn replay_wal(&self, wal_id_range: Range<u64>) -> Result<(), SlateDBError> {
+        let mut current_memtable_wal_id = self
+            .state
+            .read()
+            .state()
+            .manifest
+            .value
+            .core
+            .replay_after_wal_id;
         let writer_epoch = self.state.read().state().manifest.value.writer_epoch;
         fail_point!(
             Arc::clone(&self.fp_registry),
@@ -556,7 +545,9 @@ impl DbInner {
             assert!(self.oracle.last_remote_persisted_seq() <= replayed_table.last_seq);
             self.oracle.advance_durable_seq(replayed_table.last_seq);
             self.maybe_apply_backpressure().await?;
-            self.replay_memtable(replayed_table)?;
+            let replayed_table_last_wal_id = replayed_table.last_wal_id;
+            self.replay_memtable(current_memtable_wal_id, replayed_table)?;
+            current_memtable_wal_id = replayed_table_last_wal_id;
         }
 
         let guard = self.state.read();
@@ -2059,6 +2050,67 @@ impl WriteHandle {
     }
 }
 
+/// Wraps [`WalObserver`] and injects a [`crate::wal_buffer::WalStatusListener`]
+/// that updates the oracle and manifest, and drives cross-task notifications about wal events
+/// via a [`tokio::sync::watch`] channel.
+#[derive(Clone)]
+pub(crate) struct DbWalObserver {
+    status_rx: tokio::sync::watch::Receiver<WalStatus>,
+    wrapped: WalObserver,
+}
+
+impl DbWalObserver {
+    fn new(wrapped: WalObserver, oracle: Arc<DbOracle>, db_state: Arc<RwLock<DbState>>) -> Self {
+        let (status_tx, status_rx) = tokio::sync::watch::channel(wrapped.status());
+        wrapped.subscribe(Arc::new(move |event| {
+            let status = match event {
+                WalEvent::WalFlushed(status) => status,
+                WalEvent::WalFrozen(status) => status,
+            };
+            if let Some(seq) = status.last_flushed_seq {
+                oracle.advance_durable_seq(seq);
+            }
+            let mut guard = db_state.write();
+            guard.set_next_wal_id(status.next_wal_id);
+            drop(guard);
+            let _ = status_tx.send(status);
+        }));
+        Self { status_rx, wrapped }
+    }
+
+    pub(crate) fn status(&self) -> WalStatus {
+        self.wrapped.status()
+    }
+
+    async fn wait_on_condition(
+        &self,
+        predicate: impl FnMut(&WalStatus) -> bool,
+    ) -> Result<(), SlateDBError> {
+        let mut status_rx = self.status_rx.clone();
+        status_rx
+            .wait_for(predicate)
+            .await
+            .map_err(|_| SlateDBError::Closed)?;
+        Ok(())
+    }
+
+    async fn wait_until_flushed_past_durable_seq(
+        &self,
+        seq: Option<u64>,
+    ) -> Result<(), SlateDBError> {
+        self.wait_on_condition(|status| {
+            let Some(seq) = seq else {
+                return status.last_flushed_seq.is_some();
+            };
+            let Some(flushed_seq) = status.last_flushed_seq else {
+                return false;
+            };
+            flushed_seq > seq
+        })
+        .await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3029,11 +3081,11 @@ mod tests {
             .unwrap();
 
         // a sanity check: the wal contains the most recent write
-        assert_ne!(kv_store.inner.wal_buffer.estimated_bytes().unwrap(), 0);
+        assert_ne!(kv_store.inner.wal_observer.status().estimated_bytes, 0);
 
         // and a flush() should clear it
         kv_store.flush().await.unwrap();
-        assert_eq!(kv_store.inner.wal_buffer.estimated_bytes().unwrap(), 0);
+        assert_eq!(kv_store.inner.wal_observer.status().estimated_bytes, 0);
     }
 
     #[tokio::test]
@@ -3066,18 +3118,40 @@ mod tests {
             .unwrap();
 
         // Sanity check: WAL has buffered entries before close.
-        assert_eq!(kv_store.inner.wal_buffer.buffered_wal_entries_count(), 1);
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
+            kv_store
+                .inner
+                .wal_observer
+                .status()
+                .buffered_wal_entries_count,
+            1
+        );
+        assert_eq!(
+            lookup_metric(
+                &metrics_recorder,
+                crate::wal_buffer::stats::WAL_BUFFER_FLUSHES
+            )
+            .unwrap(),
             0
         );
 
         kv_store.close().await.unwrap();
 
         // close() should trigger a flush when the db is open.
-        assert_eq!(kv_store.inner.wal_buffer.buffered_wal_entries_count(), 0);
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
+            kv_store
+                .inner
+                .wal_observer
+                .status()
+                .buffered_wal_entries_count,
+            0
+        );
+        assert_eq!(
+            lookup_metric(
+                &metrics_recorder,
+                crate::wal_buffer::stats::WAL_BUFFER_FLUSHES
+            )
+            .unwrap(),
             1
         );
     }
@@ -3125,9 +3199,13 @@ mod tests {
         .unwrap();
 
         // Sanity check: WAL has buffered entries before close.
-        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
+        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
+            lookup_metric(
+                &metrics_recorder,
+                crate::wal_buffer::stats::WAL_BUFFER_FLUSHES
+            )
+            .unwrap(),
             0
         );
 
@@ -3139,9 +3217,13 @@ mod tests {
         // close() should succeed but not flush when failed.
         db.close().await.unwrap();
 
-        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
+        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
+            lookup_metric(
+                &metrics_recorder,
+                crate::wal_buffer::stats::WAL_BUFFER_FLUSHES
+            )
+            .unwrap(),
             0
         );
         let status = db.status();
@@ -3176,17 +3258,25 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
+        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
+            lookup_metric(
+                &metrics_recorder,
+                crate::wal_buffer::stats::WAL_BUFFER_FLUSHES
+            )
+            .unwrap(),
             0
         );
 
         db.close().await.unwrap();
 
-        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 0);
+        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 0);
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap(),
+            lookup_metric(
+                &metrics_recorder,
+                crate::wal_buffer::stats::WAL_BUFFER_FLUSHES
+            )
+            .unwrap(),
             1
         );
         let status = db.status();
@@ -3356,13 +3446,15 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            lookup_metric(&metrics_recorder, crate::db_stats::WAL_FLUSH_BYTES).unwrap_or(0),
+            lookup_metric(&metrics_recorder, crate::wal_buffer::stats::WAL_FLUSH_BYTES)
+                .unwrap_or(0),
             0,
         );
 
         db.flush().await.unwrap();
 
-        let wal_bytes = lookup_metric(&metrics_recorder, crate::db_stats::WAL_FLUSH_BYTES).unwrap();
+        let wal_bytes =
+            lookup_metric(&metrics_recorder, crate::wal_buffer::stats::WAL_FLUSH_BYTES).unwrap();
         let memtable_bytes =
             lookup_metric(&metrics_recorder, crate::db_stats::MEMTABLE_WRITE_BYTES).unwrap();
         // WAL SST framing/footer makes the encoded payload at least as large as
@@ -4431,7 +4523,7 @@ mod tests {
         }
 
         // Verify WALs flushes.
-        let wal_id = kv_store.inner.wal_buffer.recent_flushed_wal_id();
+        let wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
         assert_eq!(wal_id, MAX_WAL_FLUSHES_BEFORE_L0_FLUSH); // account for the empty WAL written for fencing
 
         // Verify no memtable was frozen or L0 flush happened.
@@ -4594,7 +4686,7 @@ mod tests {
 
         // Verify that the WAL was also flushed since we guarantee
         // memtable data is persisted in the WAL prior to L0 flush.
-        let recent_flushed_wal_id = kv_store.inner.wal_buffer.recent_flushed_wal_id();
+        let recent_flushed_wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
         assert_eq!(recent_flushed_wal_id, 2);
 
         // Verify that the data is still accessible after flush
@@ -4658,7 +4750,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(kv_store.inner.wal_buffer.buffered_wal_entries_count(), 1);
+        assert_eq!(
+            kv_store
+                .inner
+                .wal_observer
+                .status()
+                .buffered_wal_entries_count,
+            1
+        );
 
         kv_store
             .flush_with_options(FlushOptions {
@@ -4667,7 +4766,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(kv_store.inner.wal_buffer.buffered_wal_entries_count(), 0);
+        assert_eq!(
+            kv_store
+                .inner
+                .wal_observer
+                .status()
+                .buffered_wal_entries_count,
+            0
+        );
 
         let wal_reader = WalReader::new(path, wal_object_store);
         let wal_files = wal_reader.list(..).await.unwrap();
@@ -4987,7 +5093,7 @@ mod tests {
             .unwrap();
 
         // Get initial WAL ID to verify flush occurred
-        let initial_wal_id = kv_store.inner.wal_buffer.recent_flushed_wal_id();
+        let initial_wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
 
         // Flush WAL using flush_with_options - this should succeed without error
         let flush_result = kv_store
@@ -5008,7 +5114,7 @@ mod tests {
 
         // Verify that the WAL buffer is in a consistent state after flush
         // The recent_flushed_wal_id should be at least as high as before
-        let final_wal_id = kv_store.inner.wal_buffer.recent_flushed_wal_id();
+        let final_wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
         assert!(
             final_wal_id >= initial_wal_id,
             "WAL ID should not decrease after flush"
@@ -5127,14 +5233,14 @@ mod tests {
             .unwrap();
 
         // Wait for put to end up in the WAL buffer
-        let this_wal_buffer = db.inner.wal_buffer.clone();
+        let this_wal_buffer = db.inner.wal_observer.clone();
         wait_for(Box::new(move || {
-            this_wal_buffer.buffered_wal_entries_count() > 0
+            this_wal_buffer.status().buffered_wal_entries_count > 0
         }))
         .await;
 
         // Verify that there is now 1 WAL entry in memory.
-        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
+        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
 
         // Put another WAL entry, which should trigger backpressure. Do this in a separate
         // task since the put() is blocked until the WAL is flushed, which isn't happening
@@ -5199,7 +5305,7 @@ mod tests {
         db.put_with_options(b"key1", &large_value, &PutOptions::default(), &write_opts)
             .await
             .unwrap();
-        assert_eq!(db.inner.wal_buffer.buffered_wal_entries_count(), 1);
+        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
 
         // Start backpressure on a cloned inner handle. This parks the task on
         // the same wait path used by writers before they enqueue a batch.
@@ -5956,7 +6062,7 @@ mod tests {
         let value1 = [b'b'; 96];
         let result = db.put(&key1, &value1).await;
         assert!(result.is_ok(), "Failed to write key1");
-        assert_eq!(db.inner.wal_buffer.recent_flushed_wal_id(), 2);
+        assert_eq!(db.inner.wal_observer.status().last_flushed_wal_id, 2);
 
         // Let background flush attempts fail while WAL durability preserves recovery.
         // expect to fail as l0 upload is blocked
@@ -9679,7 +9785,7 @@ mod tests {
         // then:
         let estimated = lookup_metric(
             &metrics_recorder,
-            crate::db_stats::WAL_BUFFER_ESTIMATED_BYTES,
+            crate::wal_buffer::stats::WAL_BUFFER_ESTIMATED_BYTES,
         );
         assert!(
             estimated.is_some_and(|v| v > 0),
@@ -9835,11 +9941,11 @@ mod tests {
                 .await
                 .unwrap();
             if i == 0 {
-                first_l0_flushed_wal_id = source.inner.wal_buffer.recent_flushed_wal_id();
+                first_l0_flushed_wal_id = source.inner.wal_observer.status().last_flushed_wal_id;
             }
             l0_flushed_seq = write.seqnum();
         }
-        let l0_flushed_boundary_wal_id = source.inner.wal_buffer.recent_flushed_wal_id();
+        let l0_flushed_boundary_wal_id = source.inner.wal_observer.status().last_flushed_wal_id;
         assert!(l0_flushed_boundary_wal_id > first_l0_flushed_wal_id);
 
         // Write several smaller records, each flushed into a separate WAL. On
@@ -9863,7 +9969,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let final_source_wal_id = source.inner.wal_buffer.recent_flushed_wal_id();
+        let final_source_wal_id = source.inner.wal_observer.status().last_flushed_wal_id;
         assert!(final_source_wal_id >= l0_flushed_boundary_wal_id + 2);
 
         // Recover with a much smaller replay target so WAL replay splits into

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -358,9 +358,8 @@ impl DbInner {
                 };
 
                 // There is a window of time after mem_size_bytes is larger than max_unflushed_bytes
-                // but before we get the memtable and wal table. During that time, if the memtable and/or
-                // wal table are fully flushed out, we should short circuit since the select! will always
-                // time out.
+                // but before we get the memtable. During that time, if the memtable is fully
+                // flushed out, we should short circuit to avoid blocking indefinitely.
                 if maybe_oldest_unflushed_memtable.is_none() {
                     continue;
                 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2094,7 +2094,7 @@ impl DbWalObserver {
         Ok(())
     }
 
-    /// Waits until the wal's estimated memory usage drops below some threshold
+    /// Waits until the wal a given wal id is released by the wal writer
     async fn wait_until_wal_released(&self, last_purged_wal_id: u64) -> Result<(), SlateDBError> {
         self.wait_on_condition(|status| status.last_purged_wal_id > last_purged_wal_id)
             .await

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -106,8 +106,8 @@ pub(crate) struct DbInner {
     pub(crate) oracle: Arc<DbOracle>,
     pub(crate) flush_merge_operator: Option<MergeOperatorType>,
     pub(crate) reader: Reader,
-    /// [`wal_buffer`] manages the in-memory WAL buffer, it manages the flushing
-    /// of the WAL buffer to the remote storage.
+    /// [`wal_observer`] inspects the status of WAL buffer. The WAL buffer itself is owned by
+    /// the batch write task.
     pub(crate) wal_observer: DbWalObserver,
     pub(crate) wal_enabled: bool,
     /// [`txn_manager`] tracks all the live transactions and related metadata.
@@ -360,7 +360,7 @@ impl DbInner {
                 // There is a window of time after mem_size_bytes is larger than max_unflushed_bytes
                 // but before we get the memtable. During that time, if the memtable is fully
                 // flushed out, we should short circuit to avoid blocking indefinitely.
-                if maybe_oldest_unflushed_memtable.is_none() {
+                if maybe_oldest_unflushed_memtable.is_none() && wal_status.estimated_bytes == 0 {
                     continue;
                 }
 
@@ -374,7 +374,7 @@ impl DbInner {
 
                 let await_flush_wal = self
                     .wal_observer
-                    .wait_until_flushed_past_durable_seq(wal_status.last_flushed_seq);
+                    .wait_until_memory_released(wal_status.estimated_bytes);
 
                 let timeout_fut = self.system_clock.sleep(Duration::from_secs(30));
                 let await_closed = async {
@@ -2065,6 +2065,7 @@ impl DbWalObserver {
             let status = match event {
                 WalEvent::WalFlushed(status) => status,
                 WalEvent::WalFrozen(status) => status,
+                WalEvent::MemoryReleased(status) => status,
             };
             if let Some(seq) = status.last_flushed_seq {
                 oracle.advance_durable_seq(seq);
@@ -2093,20 +2094,12 @@ impl DbWalObserver {
         Ok(())
     }
 
-    async fn wait_until_flushed_past_durable_seq(
+    /// Waits until the wal's estimated memory usage drops below some threshold
+    async fn wait_until_memory_released(
         &self,
-        seq: Option<u64>,
+        limit_bytes: usize,
     ) -> Result<(), SlateDBError> {
-        self.wait_on_condition(|status| {
-            let Some(seq) = seq else {
-                return status.last_flushed_seq.is_some();
-            };
-            let Some(flushed_seq) = status.last_flushed_seq else {
-                return false;
-            };
-            flushed_seq > seq
-        })
-        .await
+        self.wait_on_condition(|status| status.estimated_bytes < limit_bytes).await
     }
 }
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -161,6 +161,7 @@ use crate::store_provider::DefaultStoreProvider;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
 use crate::utils::WatchableOnceCell;
+use crate::wal_buffer::WalBufferManager;
 use slatedb_common::clock::DefaultSystemClock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorder;
@@ -581,6 +582,16 @@ impl<P: Into<Path>> DbBuilder<P> {
             BTreeSet::new(),
         );
 
+        let recent_flushed_wal_id = replay_range.end - 1;
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            status_manager.clone(),
+            &recorder,
+            recent_flushed_wal_id,
+            table_store.clone(),
+            self.settings.l0_sst_size_bytes,
+            self.settings.flush_interval,
+        ));
+
         // Setup communication channels wired to the shared closed state.
         let reader = status_manager.result_reader();
         let (write_tx, write_rx) = SafeSender::unbounded_channel(reader);
@@ -596,6 +607,7 @@ impl<P: Into<Path>> DbBuilder<P> {
                 manifest_dirty,
                 Arc::clone(&memtable_flusher),
                 write_tx,
+                wal_buffer.observer(),
                 recorder.clone(),
                 self.fp_registry.clone(),
                 self.merge_operator.clone(),
@@ -612,11 +624,11 @@ impl<P: Into<Path>> DbBuilder<P> {
             system_clock.clone(),
         ));
         if inner.wal_enabled {
-            inner.wal_buffer.init(task_executor.clone()).await?;
+            wal_buffer.init(task_executor.clone()).await?;
         };
         task_executor.add_handler(
             WRITE_BATCH_TASK_NAME.to_string(),
-            Box::new(WriteBatchEventHandler::new(inner.clone())),
+            Box::new(WriteBatchEventHandler::new(inner.clone(), wal_buffer)),
             write_rx,
             &tokio_handle,
         )?;

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -28,9 +28,9 @@ pub(crate) fn extract_segment_prefix(
 impl DbInner {
     pub(crate) fn replay_memtable(
         &self,
+        current_memtable_wal_id: u64,
         replayed_memtable: ReplayedMemtable,
     ) -> Result<(), SlateDBError> {
-        let current_memtable_wal_id = self.wal_buffer.recent_flushed_wal_id();
         let mut guard = self.state.write();
 
         // The active memtable was installed by the previous replay step, so its
@@ -55,7 +55,6 @@ impl DbInner {
 
         // replace the memtable
         guard.replace_memtable(replayed_memtable.table);
-        self.wal_buffer.advance_recent_flushed_wal_id(last_wal);
         let dirty_manifest = guard.state().manifest.clone();
         drop(guard);
         self.status_manager.report_manifest(dirty_manifest.into());

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -4,7 +4,6 @@ use crate::error::SlateDBError;
 use crate::manifest::{Manifest, ManifestCore};
 use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
 use crate::reader::DbStateReader;
-use crate::wal_id::WalIdStore;
 use bytes::Bytes;
 use serde::Serialize;
 use slatedb_txn_obj::DirtyObject;
@@ -734,6 +733,13 @@ impl DbState {
         });
     }
 
+    pub(crate) fn set_next_wal_id(&mut self, next_wal_id: u64) {
+        self.modify(|modifier| {
+            assert!(next_wal_id >= modifier.state.manifest.value.core.next_wal_sst_id);
+            modifier.state.manifest.value.core.next_wal_sst_id = next_wal_id;
+        })
+    }
+
     pub(crate) fn replace_memtable(&mut self, memtable: WritableKVTable) {
         assert!(self.memtable.is_empty());
         let _ = std::mem::replace(&mut self.memtable, memtable);
@@ -792,22 +798,6 @@ impl<'a> StateModifier<'a> {
 
     fn finish(self) {
         self.db_state.state = Arc::new(self.state);
-    }
-}
-
-impl WalIdStore for parking_lot::RwLock<DbState> {
-    /// increment the next wal id, and return the previous value.
-    fn next_wal_id(&self) -> u64 {
-        let mut state = self.write();
-
-        // not sure why, but it doesn't compile without the return
-        // statement -- probably some generic inference bug
-        #[allow(clippy::needless_return)]
-        return state.modify(|modifier| {
-            let next_wal_id = modifier.state.manifest.value.core.next_wal_sst_id;
-            modifier.state.manifest.value.core.next_wal_sst_id += 1;
-            next_wal_id
-        });
     }
 }
 

--- a/slatedb/src/db_stats.rs
+++ b/slatedb/src/db_stats.rs
@@ -23,9 +23,6 @@ pub const L0_STALL_TYPE_LABEL: &str = "type";
 pub const L0_STALL_TYPE_NUM_SSTS: &str = "num_ssts";
 pub const L0_STALL_TYPE_NUM_SSTS_PER_KEY: &str = "num_ssts_per_key";
 pub const IMMUTABLE_MEMTABLE_FLUSHES: &str = db_stat_name!("immutable_memtable_flushes");
-pub const WAL_BUFFER_FLUSHES: &str = db_stat_name!("wal_buffer_flushes");
-pub const WAL_BUFFER_FLUSH_REQUESTS: &str = db_stat_name!("wal_buffer_flush_requests");
-pub const WAL_BUFFER_ESTIMATED_BYTES: &str = db_stat_name!("wal_buffer_estimated_bytes");
 pub const TOTAL_MEM_SIZE_BYTES: &str = db_stat_name!("total_mem_size_bytes");
 pub const L0_SST_COUNT: &str = db_stat_name!("l0_sst_count");
 pub const SEGMENT_MAX_L0_SST_COUNT: &str = db_stat_name!("segment_max_l0_sst_count");
@@ -39,7 +36,6 @@ pub const SST_FILTER_NEGATIVE_COUNT: &str = db_stat_name!("sst_filter_negative_c
 ///   write_amp = (`WAL_FLUSH_BYTES` + `L0_FLUSH_BYTES` + `compactor::stats::BYTES_COMPACTED`)
 ///               / `MEMTABLE_WRITE_BYTES`
 pub const MEMTABLE_WRITE_BYTES: &str = db_stat_name!("memtable_write_bytes");
-pub const WAL_FLUSH_BYTES: &str = db_stat_name!("wal_flush_bytes");
 
 /// Label key distinguishing filter metrics for point lookups from those for
 /// prefix scans. Value is one of [`FILTER_KIND_POINT`] or
@@ -50,9 +46,6 @@ pub const FILTER_KIND_PREFIX: &str = "prefix";
 
 pub(crate) struct DbStatsInner {
     pub(crate) immutable_memtable_flushes: Arc<dyn CounterFn>,
-    pub(crate) wal_buffer_estimated_bytes: Arc<dyn GaugeFn>,
-    pub(crate) wal_buffer_flushes: Arc<dyn CounterFn>,
-    pub(crate) wal_buffer_flush_requests: Arc<dyn CounterFn>,
     pub(crate) sst_filter_point_false_positives: Arc<dyn CounterFn>,
     pub(crate) sst_filter_point_positives: Arc<dyn CounterFn>,
     pub(crate) sst_filter_point_negatives: Arc<dyn CounterFn>,
@@ -74,7 +67,6 @@ pub(crate) struct DbStatsInner {
     pub(crate) merge_operator_read_operands: Arc<dyn CounterFn>,
     pub(crate) merge_operator_flush_operands: Arc<dyn CounterFn>,
     pub(crate) memtable_write_bytes: Arc<dyn CounterFn>,
-    pub(crate) wal_flush_bytes: Arc<dyn CounterFn>,
 }
 
 #[derive(Clone)]
@@ -95,9 +87,6 @@ impl DbStats {
     pub(crate) fn new(recorder: &MetricsRecorderHelper) -> DbStats {
         let inner = DbStatsInner {
             immutable_memtable_flushes: recorder.counter(IMMUTABLE_MEMTABLE_FLUSHES).register(),
-            wal_buffer_estimated_bytes: recorder.gauge(WAL_BUFFER_ESTIMATED_BYTES).register(),
-            wal_buffer_flushes: recorder.counter(WAL_BUFFER_FLUSHES).register(),
-            wal_buffer_flush_requests: recorder.counter(WAL_BUFFER_FLUSH_REQUESTS).register(),
             sst_filter_point_false_positives: recorder
                 .counter(SST_FILTER_FALSE_POSITIVE_COUNT)
                 .labels(&[(FILTER_KIND_LABEL, FILTER_KIND_POINT)])
@@ -160,7 +149,6 @@ impl DbStats {
                 .description(MERGE_OPERATOR_OPERANDS_DESCRIPTION)
                 .register(),
             memtable_write_bytes: recorder.counter(MEMTABLE_WRITE_BYTES).register(),
-            wal_flush_bytes: recorder.counter(WAL_FLUSH_BYTES).register(),
         };
         DbStats {
             inner: Arc::new(inner),

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -75,6 +75,7 @@ pub use sst_stats::{BlockStats, SstStats};
 pub use transaction_manager::IsolationLevel;
 pub use types::KeyValue;
 pub use types::{RowEntry, ValueDeletable};
+pub use wal_buffer::stats as wal_buffer_stats;
 pub use wal_reader::{WalFile, WalFileIterator, WalReader};
 
 pub mod admin;
@@ -171,7 +172,6 @@ mod utils;
 mod fence;
 mod wal;
 mod wal_buffer;
-mod wal_id;
 mod wal_reader;
 mod wal_replay;
 

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -880,6 +880,7 @@ mod tests {
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::types::RowEntry;
     use crate::utils::WatchableOnceCell;
+    use crate::wal_buffer::WalBufferManager;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -887,7 +888,7 @@ mod tests {
     use object_store::ObjectStore;
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::clock::SystemClock;
-    use slatedb_common::metrics::MetricsRecorderHelper;
+    use slatedb_common::metrics::{DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper};
     use slatedb_common::DbRand;
     use std::sync::Arc;
     use std::time::Duration;
@@ -1040,6 +1041,16 @@ mod tests {
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
             crate::utils::SafeSender::unbounded_channel(status_manager.result_reader());
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(recorder, MetricLevel::Info);
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            status_manager.clone(),
+            &helper,
+            0,
+            table_store.clone(),
+            1024,
+            None,
+        ));
         let inner = Arc::new(
             DbInner::new(
                 settings.clone(),
@@ -1051,6 +1062,7 @@ mod tests {
                     &WatchableOnceCell::new(),
                 )),
                 write_tx,
+                wal_buffer.observer(),
                 db_metrics,
                 fp_registry,
                 None,

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -539,6 +539,7 @@ mod tests {
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::types::RowEntry;
     use crate::utils::{SafeSender, WatchableOnceCell};
+    use crate::wal_buffer::WalBufferManager;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -603,6 +604,16 @@ mod tests {
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
             SafeSender::<BatchWriterMessage>::unbounded_channel(status_manager.result_reader());
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(recorder, MetricLevel::Info);
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            status_manager.clone(),
+            &helper,
+            0,
+            table_store.clone(),
+            1024,
+            None,
+        ));
         let inner = Arc::new(
             DbInner::new(
                 settings,
@@ -612,6 +623,7 @@ mod tests {
                 stored_manifest.prepare_dirty().unwrap(),
                 Arc::new(MemtableFlusher::new(&status_manager)),
                 write_tx,
+                wal_buffer.observer(),
                 db_metrics,
                 fp_registry,
                 None,

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -290,13 +290,14 @@ mod tests {
     use crate::test_utils::FixedThreeBytePrefixExtractor;
     use crate::types::{RowEntry, ValueDeletable};
     use crate::utils::WatchableOnceCell;
+    use crate::wal_buffer::WalBufferManager;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
-    use slatedb_common::metrics::MetricsRecorderHelper;
+    use slatedb_common::metrics::{DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper};
     use slatedb_common::DbRand;
     use std::sync::Arc;
     use std::time::Duration;
@@ -339,6 +340,16 @@ mod tests {
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
             crate::utils::SafeSender::unbounded_channel(status_manager.result_reader());
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let helper = MetricsRecorderHelper::new(recorder, MetricLevel::Info);
+        let wal_buffer = Arc::new(WalBufferManager::new(
+            status_manager.clone(),
+            &helper,
+            0,
+            table_store.clone(),
+            1024,
+            None,
+        ));
         Arc::new(
             DbInner::new(
                 settings,
@@ -350,6 +361,7 @@ mod tests {
                     &status_manager,
                 )),
                 write_tx,
+                wal_buffer.observer(),
                 db_metrics,
                 fp_registry,
                 None,

--- a/slatedb/src/oracle.rs
+++ b/slatedb/src/oracle.rs
@@ -61,12 +61,6 @@ impl DbOracle {
         self.last_durable_seq.fetch_max(seq, SeqCst);
         self.status_reporter.report_durable_seq(seq);
     }
-
-    #[cfg(test)]
-    pub(crate) fn set_durable_seq_unsafe(&self, value: u64) {
-        self.last_durable_seq.store(value, SeqCst);
-        self.status_reporter.report_durable_seq(value);
-    }
 }
 
 impl Oracle for DbOracle {

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -80,6 +80,8 @@ struct WalBufferManagerInner {
     last_flushed_wal_id: u64,
     /// The last seq that was flushed to the WAL. This value will be None until the first flush.
     last_flushed_seq: Option<u64>,
+    /// The last wal id that was deallocated from the buffer
+    last_purged_wal_id: u64,
     /// A listener to which the wal sends events. Currently the only event is a wal file flush.
     listener: Option<WalStatusListener>,
 }
@@ -127,6 +129,7 @@ impl WalBufferManager {
             last_applied_seq: None,
             flush_epoch: 1,
             last_flushed_wal_id,
+            last_purged_wal_id: last_flushed_wal_id,
             next_wal_id: last_flushed_wal_id + 1,
             last_flushed_seq: None,
             flush_tx: None,
@@ -336,6 +339,11 @@ impl WalBufferManager {
         }
 
         self.maybe_release_immutable_wals();
+        let status = self.status();
+        let listener = self.inner.read().listener.clone();
+        if let Some(l) = listener {
+            (*l)(WalEvent::MemoryReleased(status))
+        }
 
         Ok(())
     }
@@ -391,6 +399,7 @@ impl WalBufferManager {
             inner.last_applied_seq = Some(seq);
         }
         self.maybe_release_immutable_wals();
+        // don't notify here - notifications should only be issued from the flush task
     }
 
     /// Recycle the immutable WALs that are flushed to the remote storage.
@@ -423,14 +432,14 @@ impl WalBufferManager {
                 "draining immutable wals [releaseable_count={}]",
                 releaseable_count
             );
-            inner.immutable_wals.drain(..releaseable_count);
-        }
-
-        let status = inner.status(&self.table_store);
-        let listener = inner.listener.clone();
-        drop(inner);
-        if let Some(l) = listener {
-            (*l)(WalEvent::MemoryReleased(status))
+            let last_purged = inner
+                .immutable_wals
+                .drain(..releaseable_count)
+                .map(|(id, _wal)| id)
+                .max();
+            if let Some(last_purged) = last_purged {
+                inner.last_purged_wal_id = last_purged;
+            }
         }
     }
 
@@ -472,6 +481,7 @@ impl WalBufferManagerInner {
             next_wal_id: self.next_wal_id,
             last_flushed_wal_id: self.last_flushed_wal_id,
             last_flushed_seq: self.last_flushed_seq,
+            last_purged_wal_id: self.last_purged_wal_id,
             buffered_wal_entries_count,
         }
     }
@@ -624,8 +634,10 @@ pub(crate) struct WalObserver {
 pub(crate) struct WalStatus {
     pub(crate) estimated_bytes: usize,
     pub(crate) next_wal_id: u64,
+    #[allow(dead_code)]
     pub(crate) last_flushed_wal_id: u64,
     pub(crate) last_flushed_seq: Option<u64>,
+    pub(crate) last_purged_wal_id: u64,
     #[allow(dead_code)]
     pub(crate) buffered_wal_entries_count: usize,
 }

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -3,25 +3,24 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use async_trait::async_trait;
-use futures::{stream::BoxStream, StreamExt};
-use log::{error, trace};
-use tokio::{runtime::Handle, sync::oneshot};
-use tracing::instrument;
-
 use crate::db_state::SsTableId;
-use crate::db_stats::DbStats;
 use crate::db_status::ClosedResultWriter;
 use crate::dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef};
 use crate::error::SlateDBError;
-use crate::oracle::{DbOracle, Oracle};
 use crate::tablestore::TableStore;
 use crate::types::RowEntry;
 use crate::utils::SafeSender;
 use crate::utils::{format_bytes_si, WatchableOnceCell, WatchableOnceCellReader};
-use crate::wal_id::WalIdStore;
+use async_trait::async_trait;
+use futures::{stream::BoxStream, StreamExt};
+use log::{error, trace};
+use slatedb_common::metrics::MetricsRecorderHelper;
+use tokio::{runtime::Handle, sync::oneshot};
+use tracing::instrument;
 
 pub(crate) const WAL_BUFFER_TASK_NAME: &str = "wal_writer";
+
+pub(crate) type WalStatusListener = Arc<dyn Fn(WalEvent) + Send + Sync + 'static>;
 
 /// [`WalBufferManager`] buffers write operations in memory before flushing them to persistent storage.
 /// The flush operation only targets Remote storage right now, later we can add an option to flush to local
@@ -48,9 +47,8 @@ pub(crate) const WAL_BUFFER_TASK_NAME: &str = "wal_writer";
 ///   operations. The manager becomes unusable after encountering a fatal error.
 pub(crate) struct WalBufferManager {
     inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
-    wal_id_incrementor: Arc<dyn WalIdStore + Send + Sync>,
     status_manager: crate::db_status::DbStatusManager,
-    db_stats: DbStats,
+    stats: stats::WalBufferStats,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
     max_flush_interval: Option<Duration>,
@@ -72,14 +70,18 @@ struct WalBufferManagerInner {
     /// Whenever a WAL is applied to Memtable and successfully flushed to remote storage,
     /// the immutable wal can be recycled in memory.
     last_applied_seq: Option<u64>,
+    /// The next wal id that will be generated
+    next_wal_id: u64,
     /// Monotonically increasing epoch incremented each time the current WAL is
     /// frozen. Used with `last_flush_requested_epoch` to deduplicate size-triggered
     /// flush requests.
     flush_epoch: u64,
-    /// The flusher will update the recent_flushed_wal_id and last_flushed_seq when the flush is done.
-    recent_flushed_wal_id: u64,
-    /// The oracle to track the last flushed sequence number.
-    oracle: Arc<DbOracle>,
+    /// The flusher will update the last_flushed_wal_id and last_flushed_seq when the flush is done.
+    last_flushed_wal_id: u64,
+    /// The last seq that was flushed to the WAL. This value will be None until the first flush.
+    last_flushed_seq: Option<u64>,
+    /// A listener to which the wal sends events. Currently the only event is a wal file flush.
+    listener: Option<WalStatusListener>,
 }
 
 /// Stores entries to the write-ahead log (WAL) in memory.
@@ -110,11 +112,9 @@ struct WalBufferIterator {
 
 impl WalBufferManager {
     pub(crate) fn new(
-        wal_id_incrementor: Arc<dyn WalIdStore + Send + Sync>,
         status_manager: crate::db_status::DbStatusManager,
-        db_stats: DbStats,
-        recent_flushed_wal_id: u64,
-        oracle: Arc<DbOracle>,
+        recorder: &MetricsRecorderHelper,
+        last_flushed_wal_id: u64,
         table_store: Arc<TableStore>,
         max_wal_bytes_size: usize,
         max_flush_interval: Option<Duration>,
@@ -126,16 +126,17 @@ impl WalBufferManager {
             immutable_wals,
             last_applied_seq: None,
             flush_epoch: 1,
-            recent_flushed_wal_id,
+            last_flushed_wal_id,
+            next_wal_id: last_flushed_wal_id + 1,
+            last_flushed_seq: None,
             flush_tx: None,
             task_executor: None,
-            oracle,
+            listener: None,
         };
         Self {
             inner: Arc::new(parking_lot::RwLock::new(inner)),
-            wal_id_incrementor,
             status_manager,
-            db_stats,
+            stats: stats::WalBufferStats::new(recorder),
             table_store,
             max_wal_bytes_size,
             max_flush_interval,
@@ -143,6 +144,7 @@ impl WalBufferManager {
         }
     }
 
+    // todo: consider consolidating with new
     pub(crate) async fn init(
         self: &Arc<Self>,
         task_executor: Arc<MessageHandlerExecutor>,
@@ -171,53 +173,21 @@ impl WalBufferManager {
         result
     }
 
-    #[cfg(test)]
-    pub(crate) fn buffered_wal_entries_count(&self) -> usize {
-        let guard = self.inner.read();
-        let flushing_wal_entries_count = guard
-            .immutable_wals
-            .iter()
-            .map(|(_, wal)| wal.len())
-            .sum::<usize>();
-        guard.current_wal.len() + flushing_wal_entries_count
-    }
-
     pub(crate) fn recent_flushed_wal_id(&self) -> u64 {
         let inner = self.inner.read();
-        inner.recent_flushed_wal_id
+        inner.last_flushed_wal_id
     }
 
-    /// Advance `recent_flushed_wal_id` to at least `wal_id`.
-    pub(crate) fn advance_recent_flushed_wal_id(&self, wal_id: u64) {
+    fn subscribe(&self, listener: WalStatusListener) {
+        // TODO: consider extending to multiple listeners
         let mut inner = self.inner.write();
-        if wal_id > inner.recent_flushed_wal_id {
-            inner.recent_flushed_wal_id = wal_id;
-        }
+        assert!(inner.listener.is_none());
+        inner.listener = Some(listener);
     }
 
-    #[cfg(test)] // used in compactor.rs
-    pub(crate) fn is_empty(&self) -> bool {
+    pub(crate) fn status(&self) -> WalStatus {
         let inner = self.inner.read();
-        inner.current_wal.is_empty() && inner.immutable_wals.is_empty()
-    }
-
-    /// Returns the total size of all unflushed WALs in bytes.
-    pub(crate) fn estimated_bytes(&self) -> Result<usize, SlateDBError> {
-        let inner = self.inner.read();
-        let current_wal_size = self
-            .table_store
-            .estimate_encoded_size_wal(inner.current_wal.len(), inner.current_wal.size());
-
-        let imm_wal_size = inner
-            .immutable_wals
-            .iter()
-            .map(|(_, wal)| {
-                self.table_store
-                    .estimate_encoded_size_wal(wal.len(), wal.size())
-            })
-            .sum::<usize>();
-
-        Ok(current_wal_size + imm_wal_size)
+        inner.status(&self.table_store)
     }
 
     /// Append row entries to the current WAL. Returns a watcher for durability notification.
@@ -274,27 +244,16 @@ impl WalBufferManager {
             }
         }
 
-        let estimated_bytes = self.estimated_bytes()?;
-        self.db_stats
-            .wal_buffer_estimated_bytes
-            .set(estimated_bytes as i64);
+        let status = self.status();
+        self.stats
+            .estimated_bytes
+            .set(status.estimated_bytes as i64);
         Ok(durable_watcher)
     }
 
-    /// Returns a watcher to await durability of the oldest unflushed WAL.
-    /// If there are immutable WALs, it returns a watcher for the oldest immutable WAL.
-    /// Otherwise, it returns a watcher for the current WAL if it's not empty.
-    /// Returns None if there are no unflushed WALs.
-    pub(crate) fn watcher_for_oldest_unflushed_wal(
-        &self,
-    ) -> Option<WatchableOnceCellReader<Result<(), SlateDBError>>> {
-        let guard = self.inner.read();
-        if let Some((_, wal)) = guard.immutable_wals.front() {
-            Some(wal.durable_watcher())
-        } else if !guard.current_wal.is_empty() {
-            Some(guard.current_wal.durable_watcher())
-        } else {
-            None
+    pub(crate) fn observer(self: &Arc<Self>) -> WalObserver {
+        WalObserver {
+            wal_buffer: self.clone(),
         }
     }
 
@@ -303,7 +262,7 @@ impl WalBufferManager {
         &self,
         result_tx: Option<oneshot::Sender<Result<(), SlateDBError>>>,
     ) -> Result<(), SlateDBError> {
-        self.db_stats.wal_buffer_flush_requests.increment(1);
+        self.stats.flush_requests.increment(1);
         let flush_tx = self
             .inner
             .read()
@@ -327,7 +286,7 @@ impl WalBufferManager {
         let inner = self.inner.read();
         let mut flushing_wals = Vec::new();
         for (wal_id, wal) in inner.immutable_wals.iter() {
-            if *wal_id > inner.recent_flushed_wal_id {
+            if *wal_id > inner.last_flushed_wal_id {
                 flushing_wals.push((*wal_id, wal.clone()));
             }
         }
@@ -354,15 +313,25 @@ impl WalBufferManager {
             }
 
             // increment the last flushed wal id, and last flushed seq
-            {
+            let (status, listener) = {
                 let mut inner = self.inner.write();
-                inner.recent_flushed_wal_id = *wal_id;
+                inner.last_flushed_wal_id = *wal_id;
                 if let Some(seq) = wal.last_seq() {
-                    inner.oracle.advance_durable_seq(seq);
+                    if let Some(last_flushed_seq) = inner.last_flushed_seq {
+                        assert!(seq >= last_flushed_seq);
+                    }
+                    inner.last_flushed_seq = Some(seq);
                 }
-            }
+                let status = inner.status(&self.table_store);
+                let listener = inner.listener.clone();
+                (status, listener)
+            };
 
+            // TODO: we probably want to release immutable wals first for the backpressure check
             // notify durable only when the flush is successful.
+            if let Some(l) = listener {
+                (*l)(WalEvent::WalFlushed(status))
+            }
             wal.notify_durable(result.clone());
         }
 
@@ -371,7 +340,7 @@ impl WalBufferManager {
     }
 
     async fn do_flush_one_wal(&self, wal_id: u64, wal: Arc<WalBuffer>) -> Result<(), SlateDBError> {
-        self.db_stats.wal_buffer_flushes.increment(1);
+        self.stats.flushes.increment(1);
 
         let mut sst_builder = self.table_store.wal_table_builder();
         let mut iter = wal.iter();
@@ -384,7 +353,7 @@ impl WalBufferManager {
         self.table_store
             .write_sst(&SsTableId::Wal(wal_id), &encoded_sst, false)
             .await?;
-        self.db_stats.wal_flush_bytes.increment(written_bytes);
+        self.stats.flush_bytes.increment(written_bytes);
         Ok(())
     }
 
@@ -394,13 +363,20 @@ impl WalBufferManager {
             return Ok(());
         }
 
-        let next_wal_id = self.wal_id_incrementor.next_wal_id();
         let mut inner = self.inner.write();
+        let next_wal_id = inner.next_wal_id;
+        inner.next_wal_id += 1;
         let current_wal = std::mem::replace(&mut inner.current_wal, WalBuffer::new());
         inner.flush_epoch += 1;
         inner
             .immutable_wals
             .push_back((next_wal_id, Arc::new(current_wal)));
+        let status = inner.status(&self.table_store);
+        let listener = inner.listener.clone();
+        drop(inner);
+        if let Some(l) = listener {
+            (*l)(WalEvent::WalFrozen(status))
+        }
         Ok(())
     }
 
@@ -425,13 +401,14 @@ impl WalBufferManager {
             None => return,
         };
 
-        let last_flushed_seq = inner.oracle.last_remote_persisted_seq();
+        let last_flushed_seq = inner.last_flushed_seq;
 
         let mut releaseable_count = 0;
         for (_, wal) in inner.immutable_wals.iter() {
             if wal
                 .last_seq()
-                .map(|seq| seq <= last_applied_seq && seq <= last_flushed_seq)
+                // TODO: check me (make sure seq starts at 1)
+                .map(|seq| seq <= last_applied_seq && seq <= last_flushed_seq.unwrap_or(0))
                 .unwrap_or(false)
             {
                 releaseable_count += 1;
@@ -459,6 +436,36 @@ impl WalBufferManager {
                 .expect("task executor should be initialized")
         };
         task_executor.shutdown_task(WAL_BUFFER_TASK_NAME).await
+    }
+}
+
+impl WalBufferManagerInner {
+    /// Returns the total size of all unflushed WALs in bytes.
+    fn estimated_bytes(&self, table_store: &TableStore) -> usize {
+        let current_wal_size =
+            table_store.estimate_encoded_size_wal(self.current_wal.len(), self.current_wal.size());
+        let imm_wal_size = self
+            .immutable_wals
+            .iter()
+            .map(|(_, wal)| table_store.estimate_encoded_size_wal(wal.len(), wal.size()))
+            .sum::<usize>();
+        current_wal_size + imm_wal_size
+    }
+
+    fn status(&self, table_store: &TableStore) -> WalStatus {
+        let flushing_wal_entries_count = self
+            .immutable_wals
+            .iter()
+            .map(|(_, wal)| wal.len())
+            .sum::<usize>();
+        let buffered_wal_entries_count = self.current_wal.len() + flushing_wal_entries_count;
+        WalStatus {
+            estimated_bytes: self.estimated_bytes(table_store),
+            next_wal_id: self.next_wal_id,
+            last_flushed_wal_id: self.last_flushed_wal_id,
+            last_flushed_seq: self.last_flushed_seq,
+            buffered_wal_entries_count,
+        }
     }
 }
 
@@ -600,6 +607,71 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
     }
 }
 
+/// Interface for getting information about the current state of the Wal
+#[derive(Clone)]
+pub(crate) struct WalObserver {
+    wal_buffer: Arc<WalBufferManager>,
+}
+
+pub(crate) struct WalStatus {
+    pub(crate) estimated_bytes: usize,
+    pub(crate) next_wal_id: u64,
+    pub(crate) last_flushed_wal_id: u64,
+    pub(crate) last_flushed_seq: Option<u64>,
+    #[allow(dead_code)]
+    pub(crate) buffered_wal_entries_count: usize,
+}
+
+pub(crate) enum WalEvent {
+    WalFrozen(WalStatus),
+    WalFlushed(WalStatus),
+}
+
+impl WalObserver {
+    /// Gets information about the Wal buffer's current state
+    pub(crate) fn status(&self) -> WalStatus {
+        self.wal_buffer.status()
+    }
+
+    pub(crate) fn subscribe(&self, listener: WalStatusListener) {
+        self.wal_buffer.subscribe(listener);
+    }
+}
+
+pub mod stats {
+    use slatedb_common::metrics::{CounterFn, GaugeFn, MetricsRecorderHelper};
+    use std::sync::Arc;
+
+    macro_rules! wal_stat_name {
+        ($suffix:expr) => {
+            concat!("slatedb.wal.", $suffix)
+        };
+    }
+
+    pub const WAL_BUFFER_FLUSHES: &str = wal_stat_name!("wal_buffer_flushes");
+    pub const WAL_BUFFER_FLUSH_REQUESTS: &str = wal_stat_name!("wal_buffer_flush_requests");
+    pub const WAL_BUFFER_ESTIMATED_BYTES: &str = wal_stat_name!("wal_buffer_estimated_bytes");
+    pub const WAL_FLUSH_BYTES: &str = wal_stat_name!("wal_flush_bytes");
+
+    pub(super) struct WalBufferStats {
+        pub(super) estimated_bytes: Arc<dyn GaugeFn>,
+        pub(super) flushes: Arc<dyn CounterFn>,
+        pub(super) flush_requests: Arc<dyn CounterFn>,
+        pub(super) flush_bytes: Arc<dyn CounterFn>,
+    }
+
+    impl WalBufferStats {
+        pub(super) fn new(recorder: &MetricsRecorderHelper) -> Self {
+            Self {
+                estimated_bytes: recorder.gauge(WAL_BUFFER_ESTIMATED_BYTES).register(),
+                flushes: recorder.counter(WAL_BUFFER_FLUSHES).register(),
+                flush_requests: recorder.counter(WAL_BUFFER_FLUSH_REQUESTS).register(),
+                flush_bytes: recorder.counter(WAL_FLUSH_BYTES).register(),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -608,6 +680,7 @@ mod tests {
     use crate::iter::RowEntryIterator;
     use crate::manifest::SsTableView;
     use crate::object_stores::ObjectStores;
+    use crate::oracle::DbOracle;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::types::{RowEntry, ValueDeletable};
@@ -618,7 +691,6 @@ mod tests {
         lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper,
     };
     use slatedb_common::MockSystemClock;
-    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -793,21 +865,10 @@ mod tests {
         assert!(buffer.size() > 100_000);
     }
 
-    struct MockWalIdStore {
-        next_id: AtomicU64,
-    }
-
-    impl WalIdStore for MockWalIdStore {
-        fn next_wal_id(&self) -> u64 {
-            self.next_id.fetch_add(1, Ordering::SeqCst)
-        }
-    }
-
     async fn setup_wal_buffer() -> (
         Arc<WalBufferManager>,
         Arc<TableStore>,
         Arc<MockSystemClock>,
-        DbStats,
         Arc<DefaultMetricsRecorder>,
     ) {
         setup_wal_buffer_with_flush_interval(Duration::from_millis(10)).await
@@ -819,12 +880,8 @@ mod tests {
         Arc<WalBufferManager>,
         Arc<TableStore>,
         Arc<MockSystemClock>,
-        DbStats,
         Arc<DefaultMetricsRecorder>,
     ) {
-        let wal_id_store: Arc<dyn WalIdStore + Send + Sync> = Arc::new(MockWalIdStore {
-            next_id: AtomicU64::new(1),
-        });
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(object_store, None),
@@ -839,17 +896,20 @@ mod tests {
         let oracle = Arc::new(DbOracle::new(0, 0, 0, status_manager.clone()));
         let recorder = Arc::new(DefaultMetricsRecorder::new());
         let helper = MetricsRecorderHelper::new(recorder.clone(), MetricLevel::default());
-        let db_stats = DbStats::new(&helper);
         let wal_buffer = Arc::new(WalBufferManager::new(
-            wal_id_store,
             status_manager.clone(),
-            db_stats.clone(),
+            &helper,
             0, // recent_flushed_wal_id
-            oracle,
             table_store.clone(),
             1000,                 // max_wal_bytes_size
             Some(flush_interval), // max_flush_interval
         ));
+        wal_buffer.subscribe(Arc::new(move |status| {
+            let WalEvent::WalFlushed(status) = status else {
+                return;
+            };
+            oracle.advance_durable_seq(status.last_flushed_seq.unwrap_or(0))
+        }));
         let task_executor = Arc::new(MessageHandlerExecutor::new(
             Arc::new(status_manager),
             system_clock.clone(),
@@ -858,12 +918,12 @@ mod tests {
         task_executor
             .monitor_on(&Handle::current())
             .expect("failed to monitor executor");
-        (wal_buffer, table_store, test_clock, db_stats, recorder)
+        (wal_buffer, table_store, test_clock, recorder)
     }
 
     #[tokio::test]
     async fn test_basic_append_and_flush_operations() {
-        let (wal_buffer, table_store, _, _, _) = setup_wal_buffer().await;
+        let (wal_buffer, table_store, _, _) = setup_wal_buffer().await;
 
         // Append some entries
         let entry1 = make_entry("key1", "value1", 1, None);
@@ -905,11 +965,11 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_size_based_flush_triggering() {
-        let (wal_buffer, _, _, _, _) = setup_wal_buffer_with_flush_interval(Duration::MAX).await;
+        let (wal_buffer, _, _, _) = setup_wal_buffer_with_flush_interval(Duration::MAX).await;
 
         // Append entries until we exceed the size threshold
         let mut seq = 1;
-        while wal_buffer.estimated_bytes().unwrap() < wal_buffer.max_wal_bytes_size {
+        while wal_buffer.status().estimated_bytes < wal_buffer.max_wal_bytes_size {
             let entry = make_entry(&format!("key{}", seq), &format!("value{}", seq), seq, None);
             wal_buffer.append(&[entry]).unwrap();
             seq += 1;
@@ -922,7 +982,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_immutable_wal_reclaim() {
-        let (wal_buffer, _, _, _, _) = setup_wal_buffer().await;
+        let (wal_buffer, _, _, _) = setup_wal_buffer().await;
 
         // Append entries to create multiple WALs
         for i in 0..100 {
@@ -940,7 +1000,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_immutable_wal_reclaim_with_flush_check() {
-        let (wal_buffer, _, _, _, _) = setup_wal_buffer().await;
+        let (wal_buffer, _, _, _) = setup_wal_buffer().await;
 
         // Append entries to create multiple WALs
         for i in 0..100 {
@@ -955,8 +1015,8 @@ mod tests {
 
         // set flush seq to 80, and track last applied seq to 90, it should release 20 wals
         {
-            let inner = wal_buffer.inner.write();
-            inner.oracle.set_durable_seq_unsafe(80);
+            let mut inner = wal_buffer.inner.write();
+            inner.last_flushed_seq = Some(80);
         }
         wal_buffer.track_last_applied_seq(90);
         assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 20);
@@ -964,7 +1024,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_maybe_trigger_flush_spams_flush_requests() {
-        let (wal_buffer, _, _, _db_stats, recorder) =
+        let (wal_buffer, _, _, recorder) =
             setup_wal_buffer_with_flush_interval(Duration::MAX).await;
 
         // Simulate many writers each appending a small entry and calling
@@ -979,12 +1039,12 @@ mod tests {
         }
 
         let size_triggered_requests =
-            lookup_metric(&recorder, crate::db_stats::WAL_BUFFER_FLUSH_REQUESTS).unwrap();
+            lookup_metric(&recorder, stats::WAL_BUFFER_FLUSH_REQUESTS).unwrap();
 
         // Explicitly flush to drain everything, including any partial current WAL.
         wal_buffer.flush().unwrap().await.unwrap().unwrap();
 
-        let actual_flushes = lookup_metric(&recorder, crate::db_stats::WAL_BUFFER_FLUSHES).unwrap();
+        let actual_flushes = lookup_metric(&recorder, stats::WAL_BUFFER_FLUSHES).unwrap();
 
         // With the flush_requested flag, the number of size-triggered requests
         // should be bounded by the number of WALs, not by the number of writes.

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -631,6 +631,7 @@ pub(crate) struct WalObserver {
     wal_buffer: Arc<WalBufferManager>,
 }
 
+#[derive(Debug, Clone)]
 pub(crate) struct WalStatus {
     pub(crate) estimated_bytes: usize,
     pub(crate) next_wal_id: u64,
@@ -642,6 +643,7 @@ pub(crate) struct WalStatus {
     pub(crate) buffered_wal_entries_count: usize,
 }
 
+#[derive(Debug, Clone)]
 pub(crate) enum WalEvent {
     WalFrozen(WalStatus),
     WalFlushed(WalStatus),
@@ -712,7 +714,7 @@ mod tests {
         lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper,
     };
     use slatedb_common::MockSystemClock;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     fn make_entry(key: &str, value: &str, seq: u64, create_ts: Option<i64>) -> RowEntry {
@@ -903,6 +905,21 @@ mod tests {
         Arc<MockSystemClock>,
         Arc<DefaultMetricsRecorder>,
     ) {
+       setup_wal_buffer_with_args(
+           flush_interval,
+           Arc::new(|_status| {})
+       ).await
+    }
+
+    async fn setup_wal_buffer_with_args(
+        flush_interval: Duration,
+        listener: WalStatusListener,
+    ) -> (
+        Arc<WalBufferManager>,
+        Arc<TableStore>,
+        Arc<MockSystemClock>,
+        Arc<DefaultMetricsRecorder>,
+    ) {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(object_store, None),
@@ -926,6 +943,7 @@ mod tests {
             Some(flush_interval), // max_flush_interval
         ));
         wal_buffer.subscribe(Arc::new(move |status| {
+            (*listener)(status.clone());
             let WalEvent::WalFlushed(status) = status else {
                 return;
             };
@@ -1081,5 +1099,77 @@ mod tests {
             size_triggered_requests,
             actual_flushes,
         );
+    }
+
+    fn recording_listener() -> (WalStatusListener, Arc<Mutex<Vec<WalEvent>>>) {
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = events.clone();
+        let listener = Arc::new(move |event| {
+            recorder.lock().unwrap().push(event);
+        });
+        (listener, events)
+    }
+
+    #[tokio::test]
+    async fn test_listener_notified_when_flush_task_flushes_wal() {
+        // given:
+        let (listener, events) = recording_listener();
+        let (wal_buffer, _, _, _) = setup_wal_buffer_with_args(Duration::MAX, listener).await;
+
+        // when: Append an entry and explicitly flush it, driving the background flush task.
+        wal_buffer
+            .append(&[make_entry("key1", "value1", 1, None)])
+            .unwrap();
+        wal_buffer.flush().unwrap().await.unwrap().unwrap();
+
+        // then: the listener should have been notified that wal 1 was flushed.
+        let recorded = events.lock().unwrap().clone();
+        let mut flushed: Vec<_> = recorded
+            .iter()
+            .filter_map(|e| {
+                if let WalEvent::WalFlushed(status) = e {
+                    Some(status)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(flushed.len(), 1);
+        let status = flushed.pop().unwrap();
+        assert_eq!(status.last_flushed_wal_id, 1);
+        assert_eq!(status.last_flushed_seq, Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_listener_notified_when_flush_task_releases_wal() {
+        // given:
+        let (listener, events) = recording_listener();
+        let (wal_buffer, _, _, _) = setup_wal_buffer_with_args(Duration::MAX, listener).await;
+        wal_buffer.track_last_applied_seq(10);
+
+        // when:
+        wal_buffer
+            .append(&[make_entry("key1", "value1", 1, None)])
+            .unwrap();
+        wal_buffer.flush().unwrap().await.unwrap().unwrap();
+        // The flush should have released the immutable wal from memory.
+        assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 0);
+
+        // The listener should have been notified that wal 1 was purged.
+        // then: the listener should have been notified that wal 1 was flushed.
+        let recorded = events.lock().unwrap().clone();
+        let mut flushed: Vec<_> = recorded
+            .iter()
+            .filter_map(|e| {
+                if let WalEvent::MemoryReleased(status) = e {
+                    Some(status)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(flushed.len(), 1);
+        let status = flushed.pop().unwrap();
+        assert_eq!(status.last_purged_wal_id, 1);
     }
 }

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -173,7 +173,7 @@ impl WalBufferManager {
         result
     }
 
-    pub(crate) fn recent_flushed_wal_id(&self) -> u64 {
+    pub(crate) fn last_flushed_wal_id(&self) -> u64 {
         let inner = self.inner.read();
         inner.last_flushed_wal_id
     }
@@ -336,6 +336,7 @@ impl WalBufferManager {
         }
 
         self.maybe_release_immutable_wals();
+
         Ok(())
     }
 
@@ -423,6 +424,13 @@ impl WalBufferManager {
                 releaseable_count
             );
             inner.immutable_wals.drain(..releaseable_count);
+        }
+
+        let status = inner.status(&self.table_store);
+        let listener = inner.listener.clone();
+        drop(inner);
+        if let Some(l) = listener {
+            (*l)(WalEvent::MemoryReleased(status))
         }
     }
 
@@ -625,6 +633,7 @@ pub(crate) struct WalStatus {
 pub(crate) enum WalEvent {
     WalFrozen(WalStatus),
     WalFlushed(WalStatus),
+    MemoryReleased(WalStatus),
 }
 
 impl WalObserver {
@@ -977,7 +986,7 @@ mod tests {
         let mut reader = wal_buffer.maybe_trigger_flush().unwrap();
         reader.await_value().await.unwrap();
 
-        assert_eq!(wal_buffer.recent_flushed_wal_id(), 1);
+        assert_eq!(wal_buffer.last_flushed_wal_id(), 1);
     }
 
     #[tokio::test]
@@ -991,7 +1000,7 @@ mod tests {
             wal_buffer.append(&[entry]).unwrap();
             wal_buffer.flush().unwrap().await.unwrap().unwrap();
         }
-        assert_eq!(wal_buffer.recent_flushed_wal_id(), 100);
+        assert_eq!(wal_buffer.last_flushed_wal_id(), 100);
         assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 100);
 
         wal_buffer.track_last_applied_seq(50);
@@ -1011,7 +1020,7 @@ mod tests {
         }
         wal_buffer.track_last_applied_seq(50);
         assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 50);
-        assert_eq!(wal_buffer.recent_flushed_wal_id(), 100);
+        assert_eq!(wal_buffer.last_flushed_wal_id(), 100);
 
         // set flush seq to 80, and track last applied seq to 90, it should release 20 wals
         {

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -631,22 +631,33 @@ pub(crate) struct WalObserver {
     wal_buffer: Arc<WalBufferManager>,
 }
 
+/// Describes the current status of the WAL
 #[derive(Debug, Clone)]
 pub(crate) struct WalStatus {
+    /// The estimated in-memory bytes used by the WAL to buffer unflushed writes.
     pub(crate) estimated_bytes: usize,
     pub(crate) next_wal_id: u64,
+    /// The id of the last WAL file that was durably flushed
     #[allow(dead_code)]
     pub(crate) last_flushed_wal_id: u64,
+    /// The last sequence number that was durably flushed
     pub(crate) last_flushed_seq: Option<u64>,
+    /// The last WAL file id whose memory was released
     pub(crate) last_purged_wal_id: u64,
+    /// The number of writes currently buffered
     #[allow(dead_code)]
     pub(crate) buffered_wal_entries_count: usize,
 }
 
+/// An event emitted by [`WalBufferManager`] to subscribers.
 #[derive(Debug, Clone)]
 pub(crate) enum WalEvent {
+    /// Emitted when the current buffer is frozen
     WalFrozen(WalStatus),
+    /// Emitted when a WAL file is durably flushed to storage. On receipt of this event, SlateDB
+    /// notifies write tasks blocked on [`crate::config::WriteOptions::await_durable`]
     WalFlushed(WalStatus),
+    /// Emitted when `WalBufferManager` releases buffer memory.
     MemoryReleased(WalStatus),
 }
 
@@ -905,10 +916,7 @@ mod tests {
         Arc<MockSystemClock>,
         Arc<DefaultMetricsRecorder>,
     ) {
-       setup_wal_buffer_with_args(
-           flush_interval,
-           Arc::new(|_status| {})
-       ).await
+        setup_wal_buffer_with_args(flush_interval, Arc::new(|_status| {})).await
     }
 
     async fn setup_wal_buffer_with_args(

--- a/slatedb/src/wal_id.rs
+++ b/slatedb/src/wal_id.rs
@@ -1,3 +1,0 @@
-pub(crate) trait WalIdStore: Send + Sync + 'static {
-    fn next_wal_id(&self) -> u64;
-}

--- a/website/src/content/docs/docs/operations/metrics.mdx
+++ b/website/src/content/docs/docs/operations/metrics.mdx
@@ -97,15 +97,20 @@ All metric names use dot-separated notation: `slatedb.<subsystem>.<metric>`.
 | `slatedb.db.backpressure_count` | counter | | Backpressure events |
 | `slatedb.db.l0_stall_count` | counter | `type`: num_ssts, num_ssts_per_key | L0 flush dispatch stalls by cause |
 | `slatedb.db.immutable_memtable_flushes` | counter | | Immutable memtable flushes |
-| `slatedb.db.wal_buffer_flushes` | counter | | WAL buffer flushes |
-| `slatedb.db.wal_buffer_flush_requests` | counter | | WAL buffer flush requests |
-| `slatedb.db.wal_buffer_estimated_bytes` | gauge | | Estimated WAL buffer size |
 | `slatedb.db.total_mem_size_bytes` | gauge | | Total memory usage |
 | `slatedb.db.l0_sst_count` | gauge | | L0 SST count summed across all segment trees |
 | `slatedb.db.segment_max_l0_sst_count` | gauge | | Maximum L0 SST count across all segments (useful for detecting backpressure on specific segments) |
 | `slatedb.db.sst_filter_false_positive_count` | counter | | Bloom filter false positives |
 | `slatedb.db.sst_filter_positive_count` | counter | | Bloom filter positives |
 | `slatedb.db.sst_filter_negative_count` | counter | | Bloom filter negatives |
+
+### Write-Ahead Log (WAL) (`slatedb.wal.*`)
+
+| Name | Type | Labels | Description |
+|------|------|--------|-------------|
+| `slatedb.wal.wal_buffer_flushes` | counter | | WAL buffer flushes |
+| `slatedb.wal.wal_buffer_flush_requests` | counter | | WAL buffer flush requests |
+| `slatedb.wal.wal_buffer_estimated_bytes` | gauge | | Estimated WAL buffer size |
 
 ### Block cache (`slatedb.db_cache.*`)
 


### PR DESCRIPTION
## Summary

Reorganizes `WalBufferManager` so its owned by the batch writer, and is more decoupled from the rest of slatedb (so it holds fewer refs to internal slate types). `DbInner` now only holds an observer that can inspect status. The batch writer task holds an `Arc<WalBufferManager>`. It's an `Arc` so it doesn't truly own it yet (this is deferred to another pr)

## Changes

- splits the `WalBufferManager` into `WalBufferManager` and `WalObserver`
- `WalBufferManager` has all the apis for appending/flushing the WAL, and is only held by the batch writer.
- `WalObserver` has an api to get a WalStatus which returns info about the current status of the Wal (freeze/flush watermarks, estimated size). It also has a subscribe api that allows the aller to attach a listener that's called back whenever a flush or freeze happens.
- Decouple `WalBufferManager` from most of the db's internals. Oracle and manifest updates are now propogated by the subscription mechanism.
- Changes the backpressure path to block on advancement of released wal buffers as reported in the status. Blocking is tied to the status that backpressure was computed against. This eliminates the race where a flush happens between deciding to block and resolving what to block on.
- Moves wal stats out of DbStats and into new stats module in `wal_buffer.rs`

## Notes for Reviewers

This patch should be small enough that you can review it in full. I went through a couple iterations with fable refining the backpressure mechanism. You can look at the last couple commits if you're curious.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
