### PR TITLE
[k/n] wal refactor: only update last seen wal id with flushed wals

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2064,14 +2064,13 @@ impl DbWalObserver {
         wrapped.subscribe(Arc::new(move |event| {
             let status = match event {
                 WalEvent::WalFlushed(status) => status,
-                WalEvent::WalFrozen(status) => status,
                 WalEvent::MemoryReleased(status) => status,
             };
             if let Some(seq) = status.last_flushed_seq {
                 oracle.advance_durable_seq(seq);
             }
             let mut guard = db_state.write();
-            guard.set_next_wal_id(status.next_wal_id);
+            guard.set_next_wal_id(status.last_flushed_wal_id + 1);
             drop(guard);
             let _ = status_tx.send(status);
         }));
@@ -5905,7 +5904,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_wal_id_last_seen_should_exist_even_if_wal_write_fails() {
+    async fn test_wal_id_last_seen_should_only_reflect_flushed_wals() {
         let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_kv_store";
@@ -5917,6 +5916,8 @@ mod tests {
                 .await
                 .unwrap(),
         );
+        // Trigger a WAL write and block until durable so WAL is written
+        db.put(b"foo", b"bar").await.unwrap();
 
         fail_parallel::cfg(fp_registry.clone(), "write-wal-sst-io-error", "panic").unwrap();
 
@@ -5947,10 +5948,8 @@ mod tests {
         // Get the latest manifest
         let manifest = manifest_store.read_latest_manifest().await.unwrap();
 
-        // It's possible that there exists buffered multiple wals in memory, so the next_wal_sst_id
-        // in manifest is greater than the next_wal_sst_id based on what's currently in the object
-        // store unless ALL the wals are flushed.
-        assert!(manifest.manifest.core.next_wal_sst_id > next_wal_sst_id);
+        // Assert that the manifest reflects only the flushed WAL
+        assert_eq!(manifest.manifest.core.next_wal_sst_id, next_wal_sst_id);
     }
 
     #[tokio::test]

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -472,7 +472,6 @@ impl WalBufferManagerInner {
         let buffered_wal_entries_count = self.current_wal.len() + flushing_wal_entries_count;
         WalStatus {
             estimated_bytes: self.estimated_bytes(table_store),
-            next_wal_id: self.next_wal_id,
             last_flushed_wal_id: self.last_flushed_wal_id,
             last_flushed_seq: self.last_flushed_seq,
             last_purged_wal_id: self.last_purged_wal_id,
@@ -630,9 +629,7 @@ pub(crate) struct WalObserver {
 pub(crate) struct WalStatus {
     /// The estimated in-memory bytes used by the WAL to buffer unflushed writes.
     pub(crate) estimated_bytes: usize,
-    pub(crate) next_wal_id: u64,
     /// The id of the last WAL file that was durably flushed
-    #[allow(dead_code)]
     pub(crate) last_flushed_wal_id: u64,
     /// The last sequence number that was durably flushed
     pub(crate) last_flushed_seq: Option<u64>,

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -380,12 +380,6 @@ impl WalBufferManager {
         inner
             .immutable_wals
             .push_back((next_wal_id, Arc::new(current_wal)));
-        let status = inner.status(&self.table_store);
-        let listener = inner.listener.clone();
-        drop(inner);
-        if let Some(l) = listener {
-            (*l)(WalEvent::WalFrozen(status))
-        }
         Ok(())
     }
 
@@ -652,8 +646,6 @@ pub(crate) struct WalStatus {
 /// An event emitted by [`WalBufferManager`] to subscribers.
 #[derive(Debug, Clone)]
 pub(crate) enum WalEvent {
-    /// Emitted when the current buffer is frozen
-    WalFrozen(WalStatus),
     /// Emitted when a WAL file is durably flushed to storage. On receipt of this event, SlateDB
     /// notifies write tasks blocked on [`crate::config::WriteOptions::await_durable`]
     WalFlushed(WalStatus),


### PR DESCRIPTION

## Summary

Changes how we manage the wal_id_last_seen in the manifest so that it only reflects WALs that are known to be flushed to the object store. Before this patch, it was recording the last frozen WAL id, which may not necessarily be flushed. There is no benefit to this - in fact it's actively harmful. wal_id_last_seen is only read by DbReader to resolve the end of the wal when loading a checkpoint. Since wal_id_last_seen reflects unflushed WALs, DbReader is not stable across repeated restarts using the same checkpoint since it tries to load a different range of WALs. We should ultimately fix this by associating a checkpoint with a sequence number, however even then the sequence number can only reflect what was durably stored at the time of the checkpoint, so again there is no benefit to using a higher wal id

## Notes for Reviewers

This is stacked on top of #1882 

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
