### PR TITLE
[k/N] wal refactor: reorganize WalBufferManager into separate handles that share inner

### DIFF
--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -109,11 +109,11 @@ impl std::fmt::Debug for BatchWriterMessage {
 pub(crate) struct WriteBatchEventHandler {
     db_inner: Arc<DbInner>,
     is_first_write: bool,
-    wal_buffer: Arc<WalBufferManager>,
+    wal_buffer: WalBufferManager,
 }
 
 impl WriteBatchEventHandler {
-    pub(crate) fn new(db_inner: Arc<DbInner>, wal_buffer: Arc<WalBufferManager>) -> Self {
+    pub(crate) fn new(db_inner: Arc<DbInner>, wal_buffer: WalBufferManager) -> Self {
         Self {
             db_inner,
             is_first_write: true,
@@ -134,7 +134,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
             }) => {
                 let result = self
                     .db_inner
-                    .write_batch(batch, &options, txn.as_ref(), self.wal_buffer.as_ref())
+                    .write_batch(batch, &options, txn.as_ref(), &self.wal_buffer)
                     .await;
                 // if this is the first write and the WAL is disabled, make sure users are flushing
                 // their memtables in a timely manner.
@@ -158,7 +158,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 } = flush_msg;
                 let result = self
                     .db_inner
-                    .flush_batch_writer(freeze_memtable, self.wal_buffer.as_ref());
+                    .flush_batch_writer(freeze_memtable, &self.wal_buffer);
                 let _ = done.send(result);
                 Ok(())
             }
@@ -558,14 +558,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let wal_buffer = Arc::new(WalBufferManager::new(
+        let wal_buffer = WalBufferManager::new(
             db.inner.status_manager.clone(),
             &db.inner.recorder,
             0,
             db.inner.table_store.clone(),
             1024,
             None,
-        ));
+        );
 
         let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
         assert!(handler.is_first_write);
@@ -587,14 +587,14 @@ mod tests {
         let db = Db::open("/tmp/test_user_defined_seqnum", object_store)
             .await
             .unwrap();
-        let wal_buffer = Arc::new(WalBufferManager::new(
+        let wal_buffer = WalBufferManager::new(
             db.inner.status_manager.clone(),
             &db.inner.recorder,
             0,
             db.inner.table_store.clone(),
             1024,
             None,
-        ));
+        );
 
         let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
 
@@ -630,14 +630,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let wal_buffer = Arc::new(WalBufferManager::new(
+        let wal_buffer = WalBufferManager::new(
             db.inner.status_manager.clone(),
             &db.inner.recorder,
             0,
             db.inner.table_store.clone(),
             1024,
             None,
-        ));
+        );
 
         let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -178,7 +178,7 @@ impl DbInner {
             wal_observer,
             oracle.clone(),
             state.clone(),
-            status_manager.result_reader()
+            status_manager.result_reader(),
         );
 
         let db_inner = Self {
@@ -2071,7 +2071,7 @@ impl DbWalObserver {
         wrapped: WalObserver,
         oracle: Arc<DbOracle>,
         db_state: Arc<RwLock<DbState>>,
-        closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>
+        closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     ) -> Self {
         let (status_tx, status_rx) = tokio::sync::watch::channel(wrapped.status());
         wrapped
@@ -2089,7 +2089,11 @@ impl DbWalObserver {
                 let _ = status_tx.send(status);
             }))
             .expect("failed to subscribe to wal");
-        Self { status_rx, closed_reader, wrapped }
+        Self {
+            status_rx,
+            closed_reader,
+            wrapped,
+        }
     }
 
     pub(crate) fn status(&self) -> WalStatus {
@@ -2101,10 +2105,7 @@ impl DbWalObserver {
         predicate: impl FnMut(&WalStatus) -> bool,
     ) -> Result<(), SlateDBError> {
         let mut status_rx = self.status_rx.clone();
-        let result = status_rx
-            .wait_for(predicate)
-            .await
-            .map(|_| ());
+        let result = status_rx.wait_for(predicate).await.map(|_| ());
         match result {
             Ok(_) => Ok(()),
             Err(_) => {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -37,7 +37,7 @@ use crate::dispatcher::MessageHandlerExecutor;
 use crate::garbage_collector::GC_TASK_NAME;
 use crate::transaction_manager::IsolationLevel;
 use crate::CloseReason;
-use log::{info, trace, warn};
+use log::{debug, info, trace, warn};
 use parking_lot::RwLock;
 use std::time::Duration;
 
@@ -69,7 +69,7 @@ use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
 use crate::transaction_manager::TransactionManager;
 use crate::types::KeyValue;
-use crate::utils::{format_bytes_si, SafeSender};
+use crate::utils::{format_bytes_si, SafeSender, WatchableOnceCellReader};
 use crate::wal_buffer::{WalEvent, WalObserver, WalStatus, WAL_BUFFER_TASK_NAME};
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{DbCacheManagerOps, DbMetadataOps, DbReadOps, DbWriteOps};
@@ -174,7 +174,12 @@ impl DbInner {
 
         let txn_manager = Arc::new(TransactionManager::new(oracle.clone(), rand.clone()));
         let snapshot_manager = Arc::new(SnapshotManager::new(oracle.clone(), rand.clone()));
-        let wal_observer = DbWalObserver::new(wal_observer, oracle.clone(), state.clone());
+        let wal_observer = DbWalObserver::new(
+            wal_observer,
+            oracle.clone(),
+            state.clone(),
+            status_manager.result_reader()
+        );
 
         let db_inner = Self {
             state,
@@ -386,9 +391,11 @@ impl DbInner {
                 };
 
                 tokio::select! {
+                    biased;
+
+                    result = await_closed => result?,
                     result = await_memtable_uploaded => result?,
                     result = await_flush_wal => result?,
-                    result = await_closed => result?,
                     _ = timeout_fut => {
                         warn!("backpressure timeout: waited 30s, no memtable/WAL flushed yet");
                     }
@@ -2055,11 +2062,17 @@ impl WriteHandle {
 #[derive(Clone)]
 pub(crate) struct DbWalObserver {
     status_rx: tokio::sync::watch::Receiver<WalStatus>,
+    closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     wrapped: WalObserver,
 }
 
 impl DbWalObserver {
-    fn new(wrapped: WalObserver, oracle: Arc<DbOracle>, db_state: Arc<RwLock<DbState>>) -> Self {
+    fn new(
+        wrapped: WalObserver,
+        oracle: Arc<DbOracle>,
+        db_state: Arc<RwLock<DbState>>,
+        closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>
+    ) -> Self {
         let (status_tx, status_rx) = tokio::sync::watch::channel(wrapped.status());
         wrapped
             .subscribe(Arc::new(move |event| {
@@ -2076,7 +2089,7 @@ impl DbWalObserver {
                 let _ = status_tx.send(status);
             }))
             .expect("failed to subscribe to wal");
-        Self { status_rx, wrapped }
+        Self { status_rx, closed_reader, wrapped }
     }
 
     pub(crate) fn status(&self) -> WalStatus {
@@ -2088,11 +2101,17 @@ impl DbWalObserver {
         predicate: impl FnMut(&WalStatus) -> bool,
     ) -> Result<(), SlateDBError> {
         let mut status_rx = self.status_rx.clone();
-        status_rx
+        let result = status_rx
             .wait_for(predicate)
             .await
-            .map_err(|_| SlateDBError::Closed)?;
-        Ok(())
+            .map(|_| ());
+        match result {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                debug!("wal listener tx dropped - wait on db close");
+                self.closed_reader.clone().await_value().await
+            }
+        }
     }
 
     /// Waits until the wal a given wal id is released by the wal writer

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2061,19 +2061,21 @@ pub(crate) struct DbWalObserver {
 impl DbWalObserver {
     fn new(wrapped: WalObserver, oracle: Arc<DbOracle>, db_state: Arc<RwLock<DbState>>) -> Self {
         let (status_tx, status_rx) = tokio::sync::watch::channel(wrapped.status());
-        wrapped.subscribe(Arc::new(move |event| {
-            let status = match event {
-                WalEvent::WalFlushed(status) => status,
-                WalEvent::MemoryReleased(status) => status,
-            };
-            if let Some(seq) = status.last_flushed_seq {
-                oracle.advance_durable_seq(seq);
-            }
-            let mut guard = db_state.write();
-            guard.set_next_wal_id(status.last_flushed_wal_id + 1);
-            drop(guard);
-            let _ = status_tx.send(status);
-        }));
+        wrapped
+            .subscribe(Arc::new(move |event| {
+                let status = match event {
+                    WalEvent::WalFlushed(status) => status,
+                    WalEvent::MemoryReleased(status) => status,
+                };
+                if let Some(seq) = status.last_flushed_seq {
+                    oracle.advance_durable_seq(seq);
+                }
+                let mut guard = db_state.write();
+                guard.set_next_wal_id(status.last_flushed_wal_id + 1);
+                drop(guard);
+                let _ = status_tx.send(status);
+            }))
+            .expect("failed to subscribe to wal");
         Self { status_rx, wrapped }
     }
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -588,14 +588,14 @@ impl<P: Into<Path>> DbBuilder<P> {
         );
 
         let recent_flushed_wal_id = replay_range.end - 1;
-        let wal_buffer = Arc::new(WalBufferManager::new(
+        let mut wal_buffer = WalBufferManager::new(
             status_manager.clone(),
             &recorder,
             recent_flushed_wal_id,
             table_store.clone(),
             self.settings.l0_sst_size_bytes,
             self.settings.flush_interval,
-        ));
+        );
 
         // Setup communication channels wired to the shared closed state.
         let reader = status_manager.result_reader();

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::fmt::{Debug, Formatter};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,6 +12,7 @@ use crate::tablestore::TableStore;
 use crate::types::RowEntry;
 use crate::utils::SafeSender;
 use crate::utils::{format_bytes_si, WatchableOnceCell, WatchableOnceCellReader};
+use crate::wal_buffer_stats::WalBufferStats;
 use async_trait::async_trait;
 use futures::{stream::BoxStream, StreamExt};
 use log::{error, trace};
@@ -47,8 +49,7 @@ pub(crate) type WalStatusListener = Arc<dyn Fn(WalEvent) + Send + Sync + 'static
 ///   operations. The manager becomes unusable after encountering a fatal error.
 pub(crate) struct WalBufferManager {
     inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
-    status_manager: crate::db_status::DbStatusManager,
-    stats: stats::WalBufferStats,
+    stats: Arc<WalBufferStats>,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
     max_flush_interval: Option<Duration>,
@@ -56,6 +57,12 @@ pub(crate) struct WalBufferManager {
     /// sent. Compared against `flush_epoch` in the inner struct to avoid sending
     /// redundant flush requests for the same WAL.
     last_flush_requested_epoch: AtomicU64,
+    /// The channel to send the flush work to the background worker.
+    flush_tx: SafeSender<WalFlushWork>,
+    /// The channel that the flush task waits on to receive work. Will be consumed by init
+    flush_rx: Option<async_channel::Receiver<WalFlushWork>>,
+    /// task executor for the background worker.
+    task_executor: Option<Arc<MessageHandlerExecutor>>,
 }
 
 struct WalBufferManagerInner {
@@ -63,10 +70,6 @@ struct WalBufferManagerInner {
     /// When the current WAL is ready to be flushed, it'll be moved to the `immutable_wals`.
     /// The flusher will try flush all the immutable wals to remote storage.
     immutable_wals: VecDeque<(u64, Arc<WalBuffer>)>,
-    /// The channel to send the flush work to the background worker.
-    flush_tx: Option<SafeSender<WalFlushWork>>,
-    /// task executor for the background worker.
-    task_executor: Option<Arc<MessageHandlerExecutor>>,
     /// Whenever a WAL is applied to Memtable and successfully flushed to remote storage,
     /// the immutable wal can be recycled in memory.
     last_applied_seq: Option<u64>,
@@ -82,8 +85,6 @@ struct WalBufferManagerInner {
     last_flushed_seq: Option<u64>,
     /// The last wal id that was deallocated from the buffer
     last_purged_wal_id: u64,
-    /// A listener to which the wal sends events. Currently the only event is a wal file flush.
-    listener: Option<WalStatusListener>,
 }
 
 /// Stores entries to the write-ahead log (WAL) in memory.
@@ -132,47 +133,45 @@ impl WalBufferManager {
             last_purged_wal_id: last_flushed_wal_id,
             next_wal_id: last_flushed_wal_id + 1,
             last_flushed_seq: None,
-            flush_tx: None,
-            task_executor: None,
-            listener: None,
         };
+        let (flush_tx, flush_rx) = SafeSender::unbounded_channel(status_manager.result_reader());
         Self {
             inner: Arc::new(parking_lot::RwLock::new(inner)),
-            status_manager,
-            stats: stats::WalBufferStats::new(recorder),
+            stats: Arc::new(WalBufferStats::new(recorder)),
             table_store,
             max_wal_bytes_size,
             max_flush_interval,
             last_flush_requested_epoch: AtomicU64::new(0),
+            flush_tx,
+            flush_rx: Some(flush_rx),
+            task_executor: None,
         }
     }
 
     // todo: consider consolidating with new
     pub(crate) async fn init(
-        self: &Arc<Self>,
+        &mut self,
         task_executor: Arc<MessageHandlerExecutor>,
     ) -> Result<(), SlateDBError> {
-        let (flush_tx, flush_rx) =
-            SafeSender::unbounded_channel(self.status_manager.result_reader());
-        {
-            let mut inner = self.inner.write();
-            inner.flush_tx = Some(flush_tx);
-        }
+        let Some(flush_rx) = self.flush_rx.take() else {
+            error!("WalBufferManager#init called multiple times");
+            return Err(SlateDBError::InvalidDBState);
+        };
+        assert!(self.task_executor.is_none());
         let wal_flush_handler = WalFlushHandler {
             max_flush_interval: self.max_flush_interval,
-            wal_buffer_manager: self.clone(),
+            inner: self.inner.clone(),
+            table_store: self.table_store.clone(),
+            stats: self.stats.clone(),
+            listener: None,
         };
-
         let result = task_executor.add_handler(
             WAL_BUFFER_TASK_NAME.to_string(),
             Box::new(wal_flush_handler),
             flush_rx,
             &Handle::current(),
         );
-        {
-            let mut inner = self.inner.write();
-            inner.task_executor = Some(task_executor);
-        }
+        self.task_executor = Some(task_executor);
         result
     }
 
@@ -181,31 +180,17 @@ impl WalBufferManager {
         inner.last_flushed_wal_id
     }
 
-    fn subscribe(&self, listener: WalStatusListener) {
-        // TODO: consider extending to multiple listeners
-        let mut inner = self.inner.write();
-        assert!(inner.listener.is_none());
-        inner.listener = Some(listener);
-    }
-
     pub(crate) fn status(&self) -> WalStatus {
-        let inner = self.inner.read();
-        inner.status(&self.table_store)
+        self.inner.read().status(&self.table_store)
     }
 
     /// Append row entries to the current WAL. Returns a watcher for durability notification.
-    /// TODO: validate the seq number is always increasing.
     pub(crate) fn append(
         &self,
         entries: &[RowEntry],
     ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
         // TODO: check if the wal buffer is in a fatal error state.
-
-        let mut inner = self.inner.write();
-        for entry in entries {
-            inner.current_wal.append(entry.clone());
-        }
-        Ok(inner.current_wal.durable_watcher())
+        self.inner.write().append(entries)
     }
 
     /// Check if we need to flush the wal with considering max_wal_size. the checking over `max_wal_size`
@@ -215,23 +200,12 @@ impl WalBufferManager {
     pub(crate) fn maybe_trigger_flush(
         &self,
     ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
-        // check the size of the current wal
         let (durable_watcher, need_flush, flush_epoch) = {
             let inner = self.inner.read();
-            let current_wal_size = self
-                .table_store
-                .estimate_encoded_size_wal(inner.current_wal.len(), inner.current_wal.size());
-            trace!(
-                "checking flush trigger [current_wal_size={}, max_wal_bytes_size={}]",
-                format_bytes_si(current_wal_size as u64),
-                format_bytes_si(self.max_wal_bytes_size as u64),
-            );
-            let need_flush = current_wal_size >= self.max_wal_bytes_size;
-            (
-                inner.current_wal.durable_watcher(),
-                need_flush,
-                inner.flush_epoch,
-            )
+            // checks the size of the current wal
+            let (need_flush, flush_epoch) =
+                inner.needs_flush(&self.table_store, self.max_wal_bytes_size);
+            (inner.current_wal.durable_watcher(), need_flush, flush_epoch)
         };
         if need_flush {
             // Only send a flush request if one hasn't already been sent for this epoch.
@@ -254,9 +228,11 @@ impl WalBufferManager {
         Ok(durable_watcher)
     }
 
-    pub(crate) fn observer(self: &Arc<Self>) -> WalObserver {
+    pub(crate) fn observer(&self) -> WalObserver {
         WalObserver {
-            wal_buffer: self.clone(),
+            inner: self.inner.clone(),
+            table_store: self.table_store.clone(),
+            flush_tx: self.flush_tx.clone(),
         }
     }
 
@@ -266,13 +242,7 @@ impl WalBufferManager {
         result_tx: Option<oneshot::Sender<Result<(), SlateDBError>>>,
     ) -> Result<(), SlateDBError> {
         self.stats.flush_requests.increment(1);
-        let flush_tx = self
-            .inner
-            .read()
-            .flush_tx
-            .clone()
-            .expect("flush_tx not initialized, please call init first.");
-        flush_tx.send(WalFlushWork { result_tx })
+        self.flush_tx.send(WalFlushWork::Flush { result_tx })
     }
 
     pub(crate) fn flush(
@@ -283,106 +253,6 @@ impl WalBufferManager {
         Ok(result_rx)
     }
 
-    /// Returns the list of immutable WALs that need to be flushed.
-    /// Used by the handler to determine which WALs to write to storage.
-    fn flushing_wals(&self) -> Vec<(u64, Arc<WalBuffer>)> {
-        let inner = self.inner.read();
-        let mut flushing_wals = Vec::new();
-        for (wal_id, wal) in inner.immutable_wals.iter() {
-            if *wal_id > inner.last_flushed_wal_id {
-                flushing_wals.push((*wal_id, wal.clone()));
-            }
-        }
-        flushing_wals
-    }
-
-    #[instrument(level = "trace", skip_all, err(level = tracing::Level::DEBUG))]
-    async fn do_flush(&self) -> Result<(), SlateDBError> {
-        self.freeze_current_wal()?;
-        let flushing_wals = self.flushing_wals();
-
-        if flushing_wals.is_empty() {
-            return Ok(());
-        }
-
-        for (wal_id, wal) in flushing_wals.iter() {
-            let result = self.do_flush_one_wal(*wal_id, wal.clone()).await;
-            if let Err(e) = &result {
-                // a WAL buffer can be retried to flush multiple times, but WatchableOnceCell is only set once.
-                // we do NOT call `wal.notify_durable` as soon as encountered any error here, but notify
-                // the error when we're sure enters fatal state in `do_cleanup`.
-                error!("failed to flush WAL [wal_id={}]", wal_id);
-                return Err(e.clone());
-            }
-
-            // increment the last flushed wal id, and last flushed seq
-            let (status, listener) = {
-                let mut inner = self.inner.write();
-                inner.last_flushed_wal_id = *wal_id;
-                if let Some(seq) = wal.last_seq() {
-                    if let Some(last_flushed_seq) = inner.last_flushed_seq {
-                        assert!(seq >= last_flushed_seq);
-                    }
-                    inner.last_flushed_seq = Some(seq);
-                }
-                let status = inner.status(&self.table_store);
-                let listener = inner.listener.clone();
-                (status, listener)
-            };
-
-            // TODO: we probably want to release immutable wals first for the backpressure check
-            // notify durable only when the flush is successful.
-            if let Some(l) = listener {
-                (*l)(WalEvent::WalFlushed(status))
-            }
-            wal.notify_durable(result.clone());
-        }
-
-        self.maybe_release_immutable_wals();
-        let status = self.status();
-        let listener = self.inner.read().listener.clone();
-        if let Some(l) = listener {
-            (*l)(WalEvent::MemoryReleased(status))
-        }
-
-        Ok(())
-    }
-
-    async fn do_flush_one_wal(&self, wal_id: u64, wal: Arc<WalBuffer>) -> Result<(), SlateDBError> {
-        self.stats.flushes.increment(1);
-
-        let mut sst_builder = self.table_store.wal_table_builder();
-        let mut iter = wal.iter();
-        while let Some(entry) = iter.next() {
-            sst_builder.add(entry).await?;
-        }
-
-        let encoded_sst = sst_builder.build().await?;
-        let written_bytes = encoded_sst.remaining_len() as u64;
-        self.table_store
-            .write_sst(&SsTableId::Wal(wal_id), &encoded_sst, false)
-            .await?;
-        self.stats.flush_bytes.increment(written_bytes);
-        Ok(())
-    }
-
-    fn freeze_current_wal(&self) -> Result<(), SlateDBError> {
-        let is_empty = self.inner.read().current_wal.is_empty();
-        if is_empty {
-            return Ok(());
-        }
-
-        let mut inner = self.inner.write();
-        let next_wal_id = inner.next_wal_id;
-        inner.next_wal_id += 1;
-        let current_wal = std::mem::replace(&mut inner.current_wal, WalBuffer::new());
-        inner.flush_epoch += 1;
-        inner
-            .immutable_wals
-            .push_back((next_wal_id, Arc::new(current_wal)));
-        Ok(())
-    }
-
     /// Track the last applied sequence number. It's called when some WAL entries are applied to the memtable.
     /// This information of the last applied seq is used to determine if the immutable wals can be recycled.
     ///
@@ -391,66 +261,57 @@ impl WalBufferManager {
         {
             let mut inner = self.inner.write();
             inner.last_applied_seq = Some(seq);
-        }
-        self.maybe_release_immutable_wals();
-        // don't notify here - notifications should only be issued from the flush task
-    }
-
-    /// Recycle the immutable WALs that are flushed to the remote storage.
-    fn maybe_release_immutable_wals(&self) {
-        let mut inner = self.inner.write();
-
-        let last_applied_seq = match inner.last_applied_seq {
-            Some(seq) => seq,
-            None => return,
-        };
-
-        let last_flushed_seq = inner.last_flushed_seq;
-
-        let mut releaseable_count = 0;
-        for (_, wal) in inner.immutable_wals.iter() {
-            if wal
-                .last_seq()
-                // TODO: check me (make sure seq starts at 1)
-                .map(|seq| seq <= last_applied_seq && seq <= last_flushed_seq.unwrap_or(0))
-                .unwrap_or(false)
-            {
-                releaseable_count += 1;
-            } else {
-                break;
-            }
-        }
-
-        if releaseable_count > 0 {
-            trace!(
-                "draining immutable wals [releaseable_count={}]",
-                releaseable_count
-            );
-            let last_purged = inner
-                .immutable_wals
-                .drain(..releaseable_count)
-                .map(|(id, _wal)| id)
-                .max();
-            if let Some(last_purged) = last_purged {
-                inner.last_purged_wal_id = last_purged;
-            }
+            inner.maybe_release_immutable_wals();
         }
     }
 
     #[allow(dead_code)]
     pub(crate) async fn close(&self) -> Result<(), SlateDBError> {
-        let task_executor = {
-            let inner = self.inner.read();
-            inner
-                .task_executor
-                .clone()
-                .expect("task executor should be initialized")
-        };
+        let task_executor = self
+            .task_executor
+            .as_ref()
+            .expect("task executor should be initialized");
         task_executor.shutdown_task(WAL_BUFFER_TASK_NAME).await
     }
 }
 
 impl WalBufferManagerInner {
+    fn append(
+        &mut self,
+        entries: &[RowEntry],
+    ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
+        // TODO: validate the seq number is always increasing.
+        for entry in entries {
+            self.current_wal.append(entry.clone());
+        }
+        Ok(self.current_wal.durable_watcher())
+    }
+
+    fn needs_flush(&self, table_store: &TableStore, max_wal_bytes_size: usize) -> (bool, u64) {
+        // check the size of the current wal
+        let current_wal_size =
+            table_store.estimate_encoded_size_wal(self.current_wal.len(), self.current_wal.size());
+        trace!(
+            "checking flush trigger [current_wal_size={}, max_wal_bytes_size={}]",
+            format_bytes_si(current_wal_size as u64),
+            format_bytes_si(max_wal_bytes_size as u64),
+        );
+        let need_flush = current_wal_size >= max_wal_bytes_size;
+        (need_flush, self.flush_epoch)
+    }
+
+    /// Returns the list of immutable WALs that need to be flushed.
+    /// Used by the handler to determine which WALs to write to storage.
+    fn flushing_wals(&self) -> Vec<(u64, Arc<WalBuffer>)> {
+        let mut flushing_wals = Vec::new();
+        for (wal_id, wal) in self.immutable_wals.iter() {
+            if *wal_id > self.last_flushed_wal_id {
+                flushing_wals.push((*wal_id, wal.clone()));
+            }
+        }
+        flushing_wals
+    }
+
     /// Returns the total size of all unflushed WALs in bytes.
     fn estimated_bytes(&self, table_store: &TableStore) -> usize {
         let current_wal_size =
@@ -473,10 +334,71 @@ impl WalBufferManagerInner {
         WalStatus {
             estimated_bytes: self.estimated_bytes(table_store),
             last_flushed_wal_id: self.last_flushed_wal_id,
-            last_flushed_seq: self.last_flushed_seq,
             last_purged_wal_id: self.last_purged_wal_id,
+            last_flushed_seq: self.last_flushed_seq,
             buffered_wal_entries_count,
         }
+    }
+
+    fn freeze_current_wal(&mut self) {
+        if self.current_wal.is_empty() {
+            return;
+        }
+        let next_wal_id = self.next_wal_id;
+        self.next_wal_id += 1;
+        let current_wal = std::mem::replace(&mut self.current_wal, WalBuffer::new());
+        self.flush_epoch += 1;
+        self.immutable_wals
+            .push_back((next_wal_id, Arc::new(current_wal)));
+    }
+
+    fn record_flushed_wal(&mut self, wal_id: u64, wal: &Arc<WalBuffer>) {
+        self.last_flushed_wal_id = wal_id;
+        if let Some(seq) = wal.last_seq() {
+            if let Some(last_flushed_seq) = self.last_flushed_seq {
+                assert!(seq >= last_flushed_seq);
+            }
+            self.last_flushed_seq = Some(seq);
+        }
+    }
+
+    fn maybe_release_immutable_wals(&mut self) -> usize {
+        let last_applied_seq = match self.last_applied_seq {
+            Some(seq) => seq,
+            None => return 0,
+        };
+
+        let last_flushed_seq = self.last_flushed_seq;
+
+        let mut releaseable_count = 0;
+        for (_, wal) in self.immutable_wals.iter() {
+            if wal
+                .last_seq()
+                // TODO: check me (make sure seq starts at 1)
+                .map(|seq| seq <= last_applied_seq && seq <= last_flushed_seq.unwrap_or(0))
+                .unwrap_or(false)
+            {
+                releaseable_count += 1;
+            } else {
+                break;
+            }
+        }
+
+        if releaseable_count > 0 {
+            trace!(
+                "draining immutable wals [releaseable_count={}]",
+                releaseable_count
+            );
+            let last_purged = self
+                .immutable_wals
+                .drain(..releaseable_count)
+                .map(|(id, _wal)| id)
+                .max();
+            if let Some(last_purged) = last_purged {
+                self.last_purged_wal_id = last_purged;
+            }
+        }
+        releaseable_count
     }
 }
 
@@ -558,14 +480,102 @@ impl WalBufferIterator {
     }
 }
 
-#[derive(Debug)]
-struct WalFlushWork {
-    result_tx: Option<oneshot::Sender<Result<(), SlateDBError>>>,
+enum WalFlushWork {
+    Flush {
+        result_tx: Option<oneshot::Sender<Result<(), SlateDBError>>>,
+    },
+    Subscribe {
+        listener: WalStatusListener,
+    },
+}
+
+impl Debug for WalFlushWork {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WalFlushWork::Flush { .. } => f.write_str("Flush"),
+            WalFlushWork::Subscribe { .. } => f.write_str("Subscribe"),
+        }
+    }
 }
 
 struct WalFlushHandler {
     max_flush_interval: Option<Duration>,
-    wal_buffer_manager: Arc<WalBufferManager>,
+    inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
+    table_store: Arc<TableStore>,
+    stats: Arc<WalBufferStats>,
+    listener: Option<WalStatusListener>,
+}
+
+impl WalFlushHandler {
+    #[instrument(level = "trace", skip_all, err(level = tracing::Level::DEBUG))]
+    async fn do_flush(&self) -> Result<(), SlateDBError> {
+        let flushing_wals = {
+            let mut inner = self.inner.write();
+            inner.freeze_current_wal();
+            inner.flushing_wals()
+        };
+
+        for (wal_id, wal) in flushing_wals.iter() {
+            let result = self.do_flush_one_wal(*wal_id, wal.clone()).await;
+            if let Err(e) = &result {
+                // a WAL buffer can be retried to flush multiple times, but WatchableOnceCell is only set once.
+                // we do NOT call `wal.notify_durable` as soon as encountered any error here, but notify
+                // the error when we're sure enters fatal state in `do_cleanup`.
+                error!("failed to flush WAL [wal_id={}]", wal_id);
+                return Err(e.clone());
+            }
+
+            // increment the last flushed wal id, and last flushed seq
+            let status = {
+                let mut inner = self.inner.write();
+                inner.record_flushed_wal(*wal_id, wal);
+                inner.status(&self.table_store)
+            };
+
+            self.notify_listener(WalEvent::WalFlushed(status));
+            wal.notify_durable(result.clone());
+        }
+
+        self.maybe_release_immutable_wals();
+
+        Ok(())
+    }
+
+    fn maybe_release_immutable_wals(&self) {
+        let (status, released_wals) = {
+            let mut inner = self.inner.write();
+            let released_wals = inner.maybe_release_immutable_wals();
+            let status = inner.status(&self.table_store);
+            (status, released_wals)
+        };
+        if released_wals > 0 {
+            self.notify_listener(WalEvent::MemoryReleased(status));
+        }
+    }
+
+    async fn do_flush_one_wal(&self, wal_id: u64, wal: Arc<WalBuffer>) -> Result<(), SlateDBError> {
+        self.stats.flushes.increment(1);
+
+        let mut sst_builder = self.table_store.wal_table_builder();
+        let mut iter = wal.iter();
+        while let Some(entry) = iter.next() {
+            sst_builder.add(entry).await?;
+        }
+
+        let encoded_sst = sst_builder.build().await?;
+        let written_bytes = encoded_sst.remaining_len() as u64;
+        self.table_store
+            .write_sst(&SsTableId::Wal(wal_id), &encoded_sst, false)
+            .await?;
+        self.stats.flush_bytes.increment(written_bytes);
+        Ok(())
+    }
+
+    fn notify_listener(&self, event: WalEvent) {
+        if let Some(l) = self.listener.as_ref() {
+            (*l)(event);
+        }
+    }
 }
 
 #[async_trait]
@@ -574,20 +584,29 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
         if let Some(max_flush_interval) = self.max_flush_interval {
             return vec![MessageTickerDef::new(
                 max_flush_interval,
-                Box::new(|| WalFlushWork { result_tx: None }),
+                Box::new(|| WalFlushWork::Flush { result_tx: None }),
             )];
         }
         vec![]
     }
 
     async fn handle(&mut self, message: WalFlushWork) -> Result<(), SlateDBError> {
-        let WalFlushWork { result_tx } = message;
-        if let Some(result_tx) = result_tx {
-            let result = self.wal_buffer_manager.do_flush().await;
-            let _ = result_tx.send(result.clone());
-            result
-        } else {
-            self.wal_buffer_manager.do_flush().await
+        match message {
+            WalFlushWork::Flush { result_tx } => {
+                if let Some(result_tx) = result_tx {
+                    let result = self.do_flush().await;
+                    let _ = result_tx.send(result.clone());
+                    result
+                } else {
+                    self.do_flush().await
+                }
+            }
+            WalFlushWork::Subscribe { listener } => {
+                // TODO: support multiple listeners. For now, the db listener is the only one
+                assert!(self.listener.is_none());
+                self.listener = Some(listener);
+                Ok(())
+            }
         }
     }
 
@@ -599,18 +618,25 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
         let error = result.err().unwrap_or(SlateDBError::Closed);
 
         // drain remaining messages
-        while let Some(WalFlushWork { result_tx }) = messages.next().await {
-            if let Some(result_tx) = result_tx {
-                let _ = result_tx.send(Err(error.clone()));
+        while let Some(msg) = messages.next().await {
+            match msg {
+                WalFlushWork::Flush { result_tx } => {
+                    if let Some(result_tx) = result_tx {
+                        let _ = result_tx.send(Err(error.clone()));
+                    }
+                }
+                WalFlushWork::Subscribe { listener: _ } => {}
             }
         }
 
         // notify all the flushing wals to be finished with fatal error or shutdown
         // error. we need ensure all the wal tables finally get notified. freeze current
         // WAL to notify writers in the subsequent flushing_wals loop.
-        self.wal_buffer_manager.freeze_current_wal()?;
-
-        let flushing_wals = self.wal_buffer_manager.flushing_wals();
+        let flushing_wals = {
+            let mut inner = self.inner.write();
+            inner.freeze_current_wal();
+            inner.flushing_wals()
+        };
         for (_, wal) in flushing_wals.iter() {
             wal.notify_durable(Err(error.clone()));
         }
@@ -621,7 +647,9 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
 /// Interface for getting information about the current state of the Wal
 #[derive(Clone)]
 pub(crate) struct WalObserver {
-    wal_buffer: Arc<WalBufferManager>,
+    inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
+    table_store: Arc<TableStore>,
+    flush_tx: SafeSender<WalFlushWork>,
 }
 
 /// Describes the current status of the WAL
@@ -653,11 +681,13 @@ pub(crate) enum WalEvent {
 impl WalObserver {
     /// Gets information about the Wal buffer's current state
     pub(crate) fn status(&self) -> WalStatus {
-        self.wal_buffer.status()
+        self.inner.read().status(self.table_store.as_ref())
     }
 
-    pub(crate) fn subscribe(&self, listener: WalStatusListener) {
-        self.wal_buffer.subscribe(listener);
+    pub(crate) fn subscribe(&self, listener: WalStatusListener) -> Result<(), SlateDBError> {
+        self.flush_tx
+            .send(WalFlushWork::Subscribe { listener })
+            .map_err(|_err| SlateDBError::Closed)
     }
 }
 
@@ -889,7 +919,7 @@ mod tests {
     }
 
     async fn setup_wal_buffer() -> (
-        Arc<WalBufferManager>,
+        WalBufferManager,
         Arc<TableStore>,
         Arc<MockSystemClock>,
         Arc<DefaultMetricsRecorder>,
@@ -900,7 +930,7 @@ mod tests {
     async fn setup_wal_buffer_with_flush_interval(
         flush_interval: Duration,
     ) -> (
-        Arc<WalBufferManager>,
+        WalBufferManager,
         Arc<TableStore>,
         Arc<MockSystemClock>,
         Arc<DefaultMetricsRecorder>,
@@ -912,7 +942,7 @@ mod tests {
         flush_interval: Duration,
         listener: WalStatusListener,
     ) -> (
-        Arc<WalBufferManager>,
+        WalBufferManager,
         Arc<TableStore>,
         Arc<MockSystemClock>,
         Arc<DefaultMetricsRecorder>,
@@ -931,21 +961,24 @@ mod tests {
         let oracle = Arc::new(DbOracle::new(0, 0, 0, status_manager.clone()));
         let recorder = Arc::new(DefaultMetricsRecorder::new());
         let helper = MetricsRecorderHelper::new(recorder.clone(), MetricLevel::default());
-        let wal_buffer = Arc::new(WalBufferManager::new(
+        let mut wal_buffer = WalBufferManager::new(
             status_manager.clone(),
             &helper,
             0, // recent_flushed_wal_id
             table_store.clone(),
             1000,                 // max_wal_bytes_size
             Some(flush_interval), // max_flush_interval
-        ));
-        wal_buffer.subscribe(Arc::new(move |status| {
-            (*listener)(status.clone());
-            let WalEvent::WalFlushed(status) = status else {
-                return;
-            };
-            oracle.advance_durable_seq(status.last_flushed_seq.unwrap_or(0))
-        }));
+        );
+        let observer = wal_buffer.observer();
+        observer
+            .subscribe(Arc::new(move |status| {
+                (*listener)(status.clone());
+                let WalEvent::WalFlushed(status) = status else {
+                    return;
+                };
+                oracle.advance_durable_seq(status.last_flushed_seq.unwrap_or(0))
+            }))
+            .unwrap();
         let task_executor = Arc::new(MessageHandlerExecutor::new(
             Arc::new(status_manager),
             system_clock.clone(),


### PR DESCRIPTION
## Summary/Changes

Reorganized WalBufferManager into distinct handles that share inner rather than sharing an Arc<WalBufferManager> everywhere. This clarifies the ownership model, isolates responsibilities of different components, and simplifies synchronization.
- WalBufferManager, WalFlushHandler, and WalObserver all hold Arc<RwLock<WalBufferManagerInner>>
- WalBufferManagerInner now defines more precise mutators/accessors for freezing the wal, recording the outputs of flushing, and releasing wals.
- WalBufferManager now only supports appending and requesting a flush
- batch write task holds WalBufferManager rather than Arc
- WalFlushHandler has the logic for executing the flush, and owns the notification mechanism


## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
