### PR TITLE
Tolerate key gaps in sorted runs during manifest projection

### DIFF
--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -155,8 +155,45 @@ impl SsTableView {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn with_visible_range(&self, visible_range: BytesRange) -> Self {
         Self::new_projected(self.id, self.sst.clone(), Some(visible_range))
+    }
+
+    /// The SST's physical key range, derived from its first/last entry. This is
+    /// the range that [`Self::new_projected`] intersects a visible range
+    /// against.
+    fn physical_range(&self) -> BytesRange {
+        match self.sst.info.first_entry.clone() {
+            Some(physical_first_entry) => {
+                let end_bound = match self.sst.info.last_entry.clone() {
+                    Some(physical_last_entry) => Included(physical_last_entry),
+                    None => Unbounded,
+                };
+                BytesRange::new(Included(physical_first_entry), end_bound)
+            }
+            None => unreachable!("SST always has a first entry."),
+        }
+    }
+
+    /// Like [`Self::with_visible_range`], but returns `None` instead of
+    /// panicking when `visible_range` does not overlap the SST's physical key
+    /// range.
+    ///
+    /// [`Self::compacted_intersection`] bounds a sorted-run SST's logical
+    /// coverage by the *next* SST's start key, which can extend past this SST's
+    /// physical last key. When a projection range falls entirely into the gap
+    /// between this SST's last physical key and the next SST's start key, the
+    /// SST owns the range logically but holds no physical keys in it: it
+    /// contributes nothing to the projection and is dropped rather than
+    /// constructing a view whose physical/visible intersection is empty.
+    pub(crate) fn try_with_visible_range(&self, visible_range: BytesRange) -> Option<Self> {
+        self.physical_range().intersect(&visible_range)?;
+        Some(Self::new_projected(
+            self.id,
+            self.sst.clone(),
+            Some(visible_range),
+        ))
     }
 
     /// The range of keys that are visible to the user.

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -1183,7 +1183,14 @@ impl Manifest {
             if let Some(intersection) =
                 current_handle.compacted_intersection(next_handle, projection_range)
             {
-                filtered_handles.push(current_handle.with_visible_range(intersection));
+                // `compacted_intersection` bounds a sorted-run SST's coverage by
+                // the next SST's start key, so `intersection` can fall into the
+                // gap beyond this SST's physical keys. `try_with_visible_range`
+                // drops the SST in that case instead of panicking on an empty
+                // physical/visible intersection.
+                if let Some(view) = current_handle.try_with_visible_range(intersection) {
+                    filtered_handles.push(view);
+                }
             }
         }
         filtered_handles
@@ -4445,6 +4452,72 @@ mod tests {
         );
         assert_eq!(projected.core.segments[0].tree.l0.len(), 1);
         assert_eq!(projected.core.segments[0].tree.compacted.len(), 1);
+    }
+
+    /// Build a single-sorted-run tree of two compacted SSTs with a key gap
+    /// between them: SST1 physically covers `[a, c]`, SST2 covers `[m, p]`,
+    /// so the keyspace `(c, m)` is owned by SST1 logically (up to SST2's start
+    /// key) but holds no physical keys in SST1.
+    fn manifest_with_two_sst_sorted_run_gap() -> Manifest {
+        let sst1 = SsTableId::Compacted(Ulid::new());
+        let sst2 = SsTableId::Compacted(Ulid::new());
+        let make = |id: SsTableId, first: &'static [u8], last: &'static [u8], vis: BytesRange| {
+            SsTableView::new_projected(
+                id.unwrap_compacted_id(),
+                SsTableHandle::new(
+                    id,
+                    SST_FORMAT_VERSION_LATEST,
+                    SsTableInfo {
+                        first_entry: Some(Bytes::from_static(first)),
+                        last_entry: Some(Bytes::from_static(last)),
+                        ..SsTableInfo::default()
+                    },
+                ),
+                Some(vis),
+            )
+        };
+        let mut core = ManifestCore::new();
+        Arc::make_mut(&mut core.tree).compacted.push(SortedRun {
+            id: 0,
+            sst_views: vec![
+                make(sst1, b"a", b"c", BytesRange::from_ref("a".."d")),
+                make(sst2, b"m", b"p", BytesRange::from_ref("m".."q")),
+            ],
+        });
+        Manifest::initial(core)
+    }
+
+    #[test]
+    fn test_projected_drops_sorted_run_sst_when_range_falls_in_key_gap() {
+        // Regression: a projection range that lands entirely in the gap between a sorted-run SST's
+        // last physical key and the next SST's start key must drop the SST, not panic.
+        // `compacted_intersection` bounds the SST by the next SST's start key (logical), so it
+        // reports overlap for `(c, m)`, but the SST has no physical keys there.
+        let manifest = manifest_with_two_sst_sorted_run_gap();
+
+        // ["e", "g") sits in the gap (c, m): both SSTs are physically disjoint
+        // from it, so the sorted run becomes empty and is dropped.
+        let projected = Manifest::projected(
+            &manifest,
+            &ProjectionConfig::from_global_range(BytesRange::from_ref("e".."g")),
+        )
+        .unwrap();
+        assert!(projected.core.tree.compacted.is_empty());
+    }
+
+    #[test]
+    fn test_projected_keeps_sorted_run_sst_overlapping_physical_keys() {
+        // Sanity check that the gap fix does not over-drop: a range that
+        // overlaps SST1's physical keys keeps it (with the SST projected).
+        let manifest = manifest_with_two_sst_sorted_run_gap();
+
+        let projected = Manifest::projected(
+            &manifest,
+            &ProjectionConfig::from_global_range(BytesRange::from_ref("b".."f")),
+        )
+        .unwrap();
+        assert_eq!(projected.core.tree.compacted.len(), 1);
+        assert_eq!(projected.core.tree.compacted[0].sst_views.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Manifest::projected` filters a sorted run's SSTs by intersecting the projection range with each SST's coverage via `compacted_intersection`, which bounds an SST's coverage by the *next* SST's start key rather than by its own last physical key. When the projection range falls entirely into the gap between an SST's last physical key and the next SST's start key, the SST owns the range logically but holds no physical keys in it, and `with_visible_range` panicked on the empty physical/visible intersection.

**Example:** with SST1 physically holding [a, c] and SST2 holding [m, p], SST1 is treated as logically owning everything up to m. If the projection range is, say, ["e", "g") — entirely inside the gap
(c, m) — compacted_intersection still reports an overlap for SST1, and the old code called with_visible_range, which panics because the visible range doesn't intersect the SST's physical keys.



Add `SsTableView::try_with_visible_range`, which returns `None` when the visible range does not overlap the SST's physical key range, and use it during projection to drop such SSTs instead of panicking.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
