### PR TITLE
[fix] : Add UnownedDbCache to fix FoyerHybridCache close behaviour

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -10771,7 +10771,132 @@ mod tests {
         let value_a_cached = reader_a.get(b"key1").await.unwrap();
         assert_eq!(value_a_cached, Some(Bytes::from("value_from_db_a")));
 
+        // Close reader_a; the shared cache must remain usable for reader_b.
+        reader_a.close().await.unwrap();
+
         let value_b_cached = reader_b.get(b"key1").await.unwrap();
         assert_eq!(value_b_cached, Some(Bytes::from("value_from_db_b")));
+
+        reader_b.close().await.unwrap();
+    }
+
+    #[cfg(feature = "foyer")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_close_does_not_kill_shared_hybrid_cache() {
+        use crate::db_cache::foyer_hybrid::FoyerHybridCache;
+        use crate::db_cache::{CachedEntry, CachedKey, DbCache};
+        use crate::db_state::SsTableId;
+        use crate::format::sst::BlockBuilder;
+        use foyer::{
+            BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCacheBuilder,
+            PsyncIoEngineConfig,
+        };
+
+        fn probe_entry() -> CachedEntry {
+            use rand::RngCore;
+            let mut rng = rand::rng();
+            let mut builder = BlockBuilder::new_latest(1024);
+            loop {
+                let mut k = vec![0u8; 32];
+                rng.fill_bytes(&mut k);
+                let mut v = vec![0u8; 128];
+                rng.fill_bytes(&mut v);
+                if builder.add_value(&k, &v, None, None) {
+                    break;
+                }
+            }
+            CachedEntry::with_block(Arc::new(builder.build().unwrap()))
+        }
+
+        async fn open_shared_cache(path: &std::path::Path) -> Arc<dyn DbCache> {
+            let hybrid = HybridCacheBuilder::new()
+                .with_name("shared_hybrid")
+                .memory(1024 * 1024)
+                .with_weighter(|_, v: &CachedEntry| v.size())
+                .storage()
+                .with_io_engine_config(PsyncIoEngineConfig::new())
+                .with_engine_config(
+                    BlockEngineConfig::new(
+                        FsDeviceBuilder::new(path)
+                            .with_capacity(4 * 1024 * 1024)
+                            .build()
+                            .unwrap(),
+                    )
+                    .with_block_size(64 * 1024),
+                )
+                .build()
+                .await
+                .unwrap();
+            Arc::new(FoyerHybridCache::new_with_cache(hybrid))
+        }
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let shared_cache = open_shared_cache(cache_dir.path()).await;
+
+        let object_store_a: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let object_store_b: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+
+        let db_a = Db::builder("/tmp/test_shared_hybrid_a", object_store_a)
+            .with_settings(test_db_options(0, 1024, None))
+            .with_db_cache(shared_cache.clone())
+            .build()
+            .await
+            .unwrap();
+        let db_b = Db::builder("/tmp/test_shared_hybrid_b", object_store_b)
+            .with_settings(test_db_options(0, 1024, None))
+            .with_db_cache(shared_cache.clone())
+            .build()
+            .await
+            .unwrap();
+
+        db_a.put(b"key1", b"value_from_db_a").await.unwrap();
+        db_a.flush().await.unwrap();
+        db_b.put(b"key1", b"value_from_db_b").await.unwrap();
+        db_b.flush().await.unwrap();
+
+        // Close db_a; the shared cache must remain usable for db_b.
+        db_a.close().await.unwrap();
+
+        // db_b reads still succeed (they can fall back to the object store)...
+        let value_b = db_b.get(b"key1").await.unwrap();
+        assert_eq!(value_b, Some(Bytes::from("value_from_db_b")));
+
+        // ...and entries cached on behalf of db_b after db_a closed should
+        // still persist across the caller's own graceful shutdown sequence
+        // (close all DBs, then close the cache we own) + cache reopen, exactly
+        // like `should_persist_blocks_to_disk_on_close` proves for a cache
+        // that nobody else closed. If db_a's close had closed the shared
+        // cache, these entries could never reach disk: the disk engine drops
+        // post-close writes and the final close below becomes a no-op.
+        let mut keys = Vec::new();
+        for b in 0u64..64 {
+            let k = CachedKey::from((SsTableId::Wal(u64::MAX - 2), b));
+            shared_cache.insert(k.clone(), probe_entry()).await;
+            keys.push(k);
+        }
+
+        db_b.close().await.unwrap();
+        // The caller owns the injected cache and closes it once all DBs are
+        // closed; this flushes the memory tier to disk.
+        shared_cache.close().await.unwrap();
+        drop(db_a);
+        drop(db_b);
+        drop(shared_cache);
+
+        let reopened = open_shared_cache(cache_dir.path()).await;
+        let mut found = 0;
+        for k in &keys {
+            if reopened.get_block(k).await.unwrap().is_some() {
+                found += 1;
+            }
+        }
+        assert_eq!(
+            found,
+            keys.len(),
+            "entries cached after another DB closed the shared cache were lost \
+             ({}/{} survived cache close + reopen)",
+            found,
+            keys.len()
+        );
     }
 }

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -138,7 +138,7 @@ use crate::config::{Settings, SstBlockSize};
 use crate::db::Db;
 use crate::db::DbInner;
 use crate::db_cache::SplitCache;
-use crate::db_cache::{DbCache, DbCacheWrapper};
+use crate::db_cache::{DbCache, DbCacheWrapper, UnownedDbCache};
 use crate::db_reader::DbReader;
 use crate::db_status::{ClosedResultWriter, DbStatusManager};
 use crate::dispatcher::MessageHandlerExecutor;
@@ -255,8 +255,14 @@ impl<P: Into<Path>> DbBuilder<P> {
     ///
     /// SlateDB uses a cache to efficiently store and retrieve blocks and SST metadata locally.
     /// [`slatedb::db_cache::SplitCache`] is used by default.
+    ///
+    /// A cache passed in here remains owned by the caller: it is safe to share it across
+    /// multiple `Db`/`DbReader` instances, and [`Db::close`](crate::Db::close) will *not*
+    /// close it. Call [`DbCache::close`] yourself after closing every database that uses it.
     pub fn with_db_cache(mut self, db_cache: Arc<dyn DbCache>) -> Self {
-        self.db_cache = Some(db_cache);
+        // Wrap so Db::close()/DbReader::close() can't close a cache the
+        // caller owns and may be sharing with other instances.
+        self.db_cache = Some(Arc::new(UnownedDbCache::new(db_cache)));
         self
     }
 
@@ -1489,8 +1495,15 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
     ///
     /// SlateDB uses a cache to efficiently store and retrieve blocks and SST metadata locally.
     /// [`slatedb::db_cache::SplitCache`] is used by default.
+    ///
+    /// A cache passed in here remains owned by the caller: it is safe to share it across
+    /// multiple `Db`/`DbReader` instances, and [`DbReader::close`](crate::DbReader::close)
+    /// will *not* close it. Call [`DbCache::close`] yourself after closing every database
+    /// that uses it.
     pub fn with_db_cache(mut self, db_cache: Arc<dyn DbCache>) -> Self {
-        self.db_cache = Some(db_cache);
+        // Wrap so Db::close()/DbReader::close() can't close a cache the
+        // caller owns and may be sharing with other instances.
+        self.db_cache = Some(Arc::new(UnownedDbCache::new(db_cache)));
         self
     }
 

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -163,6 +163,14 @@ pub trait DbCache: Send + Sync {
     /// Implementations backed by hybrid (memory + disk) caches should use
     /// this to ensure cached entries survive process restarts. The default
     /// implementation is a no-op.
+    ///
+    /// SlateDB only invokes this on caches it created itself (the default
+    /// cache built when none is configured). If you pass your own cache to
+    /// [`with_db_cache`](crate::db::builder::DbBuilder::with_db_cache), you
+    /// own it: close it yourself after closing every `Db` and `DbReader`
+    /// that uses it. This allows a single cache to be safely shared across
+    /// multiple databases without the first `close()` disabling it for the
+    /// others.
     async fn close(&self) -> Result<(), crate::Error> {
         Ok(())
     }
@@ -822,6 +830,94 @@ impl DbCache for DbCacheWrapper {
         let result = self.cache.fetch_stats(scoped_key, loader).await;
         self.record_fetch_outcome("stats", loader_ran.was_called(), &result);
         result
+    }
+}
+
+/// Wraps a user-provided [`DbCache`] so that [`DbCache::close`] becomes a no-op.
+///
+/// SlateDB does not own caches passed in via `with_db_cache`: the caller may be sharing one
+/// cache across several `Db`/`DbReader` instances, so the first `Db::close()` must not shut
+/// it down for the others. The caller closes the inner cache themselves once every instance
+/// using it is closed.
+///
+/// Note: every trait method must be forwarded explicitly, including the ones with default
+/// implementations. Falling back to a default here would silently replace the inner cache's
+/// behavior (e.g. foyer's dedup-aware `fetch_*`) for user-provided caches only.
+pub(crate) struct UnownedDbCache {
+    inner: Arc<dyn DbCache>,
+}
+
+impl UnownedDbCache {
+    pub(crate) fn new(inner: Arc<dyn DbCache>) -> Self {
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl DbCache for UnownedDbCache {
+    async fn get_block(&self, key: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+        self.inner.get_block(key).await
+    }
+
+    async fn get_index(&self, key: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+        self.inner.get_index(key).await
+    }
+
+    async fn get_filter(&self, key: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+        self.inner.get_filter(key).await
+    }
+
+    async fn get_stats(&self, key: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+        self.inner.get_stats(key).await
+    }
+
+    async fn insert(&self, key: CachedKey, value: CachedEntry) {
+        self.inner.insert(key, value).await
+    }
+
+    async fn remove(&self, key: &CachedKey) {
+        self.inner.remove(key).await
+    }
+
+    fn entry_count(&self) -> u64 {
+        self.inner.entry_count()
+    }
+
+    /// The point of this type: never propagate close to a cache we don't own.
+    async fn close(&self) -> Result<(), crate::Error> {
+        Ok(())
+    }
+
+    async fn fetch_block(
+        &self,
+        key: CachedKey,
+        loader: CacheLoader,
+    ) -> Result<CachedEntry, crate::Error> {
+        self.inner.fetch_block(key, loader).await
+    }
+
+    async fn fetch_index(
+        &self,
+        key: CachedKey,
+        loader: CacheLoader,
+    ) -> Result<CachedEntry, crate::Error> {
+        self.inner.fetch_index(key, loader).await
+    }
+
+    async fn fetch_filter(
+        &self,
+        key: CachedKey,
+        loader: CacheLoader,
+    ) -> Result<CachedEntry, crate::Error> {
+        self.inner.fetch_filter(key, loader).await
+    }
+
+    async fn fetch_stats(
+        &self,
+        key: CachedKey,
+        loader: CacheLoader,
+    ) -> Result<CachedEntry, crate::Error> {
+        self.inner.fetch_stats(key, loader).await
     }
 }
 
@@ -1487,5 +1583,115 @@ mod tests {
     #[fixture]
     async fn sst(sst_format: SsTableFormat) -> EncodedSsTable {
         build_test_sst(&sst_format, 1).await
+    }
+
+    /// Canary for `UnownedDbCache`'s delegation: every defaulted trait method must be
+    /// forwarded to the inner cache — except `close()`, which must be suppressed. If a
+    /// forwarding method is dropped (e.g. when a new defaulted method is added to
+    /// `DbCache`), the trait default runs against the wrapper instead of the inner
+    /// cache's override and this test fails.
+    #[tokio::test]
+    async fn test_unowned_cache_suppresses_close_and_forwards_overrides() {
+        use crate::db_cache::{CacheLoader, UnownedDbCache};
+        use crate::format::block::Block;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        fn build_block(key: &[u8]) -> Arc<Block> {
+            let mut builder = BlockBuilder::new_latest(4096);
+            assert!(builder.add(RowEntry::new_value(key, b"v", 0)).unwrap());
+            Arc::new(builder.build().unwrap())
+        }
+
+        /// A cache whose `fetch_*` overrides always return `marker` without running the
+        /// loader (like foyer's dedup-aware fetches). If the trait's default fetch runs
+        /// instead, the loader's entry comes back and the marker assertion fails.
+        struct ProbeCache {
+            close_called: AtomicBool,
+            marker: CachedEntry,
+        }
+
+        #[async_trait::async_trait]
+        impl DbCache for ProbeCache {
+            async fn get_block(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                Ok(None)
+            }
+            async fn get_index(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                Ok(None)
+            }
+            async fn get_filter(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                Ok(None)
+            }
+            async fn get_stats(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                Ok(None)
+            }
+            async fn insert(&self, _: CachedKey, _: CachedEntry) {}
+            async fn remove(&self, _: &CachedKey) {}
+            fn entry_count(&self) -> u64 {
+                0
+            }
+            async fn close(&self) -> Result<(), crate::Error> {
+                self.close_called.store(true, Ordering::SeqCst);
+                Ok(())
+            }
+            async fn fetch_block(
+                &self,
+                _: CachedKey,
+                _: CacheLoader,
+            ) -> Result<CachedEntry, crate::Error> {
+                Ok(self.marker.clone())
+            }
+            async fn fetch_index(
+                &self,
+                _: CachedKey,
+                _: CacheLoader,
+            ) -> Result<CachedEntry, crate::Error> {
+                Ok(self.marker.clone())
+            }
+            async fn fetch_filter(
+                &self,
+                _: CachedKey,
+                _: CacheLoader,
+            ) -> Result<CachedEntry, crate::Error> {
+                Ok(self.marker.clone())
+            }
+            async fn fetch_stats(
+                &self,
+                _: CachedKey,
+                _: CacheLoader,
+            ) -> Result<CachedEntry, crate::Error> {
+                Ok(self.marker.clone())
+            }
+        }
+
+        let marker_block = build_block(b"marker");
+        let probe = Arc::new(ProbeCache {
+            close_called: AtomicBool::new(false),
+            marker: CachedEntry::with_block(marker_block.clone()),
+        });
+        let unowned = UnownedDbCache::new(probe.clone());
+
+        let loader = || -> CacheLoader {
+            Box::new(|| Box::pin(async { Ok(CachedEntry::with_block(build_block(b"loader"))) }))
+        };
+        let key = || CachedKey::from((SST_ID, 0u64));
+
+        let fetched = [
+            unowned.fetch_block(key(), loader()).await.unwrap(),
+            unowned.fetch_index(key(), loader()).await.unwrap(),
+            unowned.fetch_filter(key(), loader()).await.unwrap(),
+            unowned.fetch_stats(key(), loader()).await.unwrap(),
+        ];
+        for entry in fetched {
+            assert!(
+                Arc::ptr_eq(&entry.block().unwrap(), &marker_block),
+                "fetch was not forwarded to the inner cache's override"
+            );
+        }
+
+        unowned.close().await.unwrap();
+        assert!(
+            !probe.close_called.load(Ordering::SeqCst),
+            "close() must not propagate to a cache slatedb does not own"
+        );
     }
 }

--- a/website/src/content/docs/docs/design/caching.mdx
+++ b/website/src/content/docs/docs/design/caching.mdx
@@ -43,6 +43,8 @@ For the object-store cache, sharing is straightforward. If multiple instances on
 
 The block cache is different. Both [`DbBuilder::with_db_cache`](https://docs.rs/slatedb/latest/slatedb/db/struct.DbBuilder.html#method.with_db_cache) and [`DbReaderBuilder::with_db_cache`](https://docs.rs/slatedb/latest/slatedb/db/struct.DbReaderBuilder.html#method.with_db_cache) let you pass in your own cache object, so you can choose to reuse the same process-local cache implementation across builders. For `Db`, that mainly gives you a shared memory or disk budget, not shared hits: SlateDB scopes each instance's entries so one `Db` does not read another `Db`'s cached blocks by accident. If your main goal is cross-instance warming, the object-store cache is the better fit.
 
+A cache you pass in stays owned by you: `Db::close()` and `DbReader::close()` never close it, so closing one instance does not affect the others sharing it. Once every instance using the cache is closed, call [`DbCache::close`](https://docs.rs/slatedb/latest/slatedb/db_cache/trait.DbCache.html#method.close) yourself so hybrid implementations can flush their memory tier to disk.
+
 For `DbReader`, treat a caller-managed block cache as an advanced optimization. It can make sense to keep one reader-side cache per database in a single process, but if you want a cache that is naturally shared between writers and readers, or across many short-lived instances, the object-store cache is the simpler mechanism to share.
 
 ## Tradeoffs

--- a/website/src/content/docs/docs/operations/foyer-cache.mdx
+++ b/website/src/content/docs/docs/operations/foyer-cache.mdx
@@ -122,9 +122,16 @@ If the process exits without calling `close()` (`SIGKILL`, panic, or dropping th
 without closing), the in-memory tier is lost. Only entries that Foyer wrote to disk during
 normal operation survive.
 
+A cache passed to `with_db_cache()` is owned by you, not by SlateDB: `Db::close()` and
+`DbReader::close()` will *not* close it. This makes it safe to share one cache across
+multiple databases — closing one database no longer shuts down the disk engine for the
+others. It also means the shutdown flush is your responsibility: call `DbCache::close()`
+on the cache yourself, after closing every `Db` and `DbReader` that uses it.
+
 :::caution
-Always call `Db::close()` or `DbReader::close()` before shutdown. Dropping without
-closing races with tokio runtime teardown and will lose in-memory cached entries.
+Always call `Db::close()` / `DbReader::close()` before shutdown, and then close the cache
+you passed in with `DbCache::close()`. Dropping without closing races with tokio runtime
+teardown and will lose in-memory cached entries.
 :::
 
 ## Monitoring


### PR DESCRIPTION
## Summary

Closing one `Db`/`DbReader` permanently disables a block cache shared with other instances in the same process.

Since #1550, `Db::close()` and `DbReader::close()` call `close()` on whatever cache was configured — including one passed in via `with_db_cache()`. For `FoyerHybridCache`, close is one-way: it shuts down foyer's disk engine and cannot be reopened. In a process with N databases sharing one cache (the pattern recommended in the caching docs for a shared memory/disk budget), the *first* database to close silently kills the disk tier for the remaining N-1: every subsequent disk write is dropped (`WARN cannot enqueue new entry after closed`), and DBs opened later inherit the same dead cache.

This PR applies standard ownership semantics: **SlateDB only closes caches it created**. A cache passed to `with_db_cache()` is borrowed — the caller necessarily still holds the `Arc` and closes it once, after closing every instance that uses it.

More context: https://discord.com/channels/1232385660460204122/1232385660946616433/1522604298083631287

## Changes

- Added `UnownedDbCache`, a `pub(crate)` decorator that forwards all `DbCache` methods to the inner cache except `close()`, which becomes a no-op. `with_db_cache()` (both builders) wraps the caller's cache in it; the builder-created default cache is unwrapped, so its close-on-shutdown behavior is unchanged.
- Regression test `test_close_does_not_kill_shared_hybrid_cache`: two `Db`s share one `FoyerHybridCache`, one closes, and entries cached afterwards must survive the caller's `cache.close()` + reopen. Deterministically red before the fix (0/64 entries survive), green after.
- Canary test asserting every defaulted trait method (`close`, `fetch_*`) is explicitly forwarded through `UnownedDbCache` — guards against a future trait method silently falling back to its default for user-provided caches only.
- Docs: `DbCache::close()` / `with_db_cache()` rustdoc, the caching design page, and the foyer operations page now state the contract: close your DBs, then close the cache you passed in.

## Notes for Reviewers

- **Breaking behavior change** for single-DB embedders who inject a hybrid cache and relied on `Db::close()` flushing it (#1550's original motivation): they must now call `cache.close()` themselves after closing the DB. One-line migration, and arguably more correct, the flush happens at actual shutdown rather than whenever the first `Db::close()` fires.
- The delegation in `UnownedDbCache` must stay exhaustive: falling back to a trait default would silently drop the inner cache's dedup-aware `fetch_*` (e.g. foyer's `get_or_fetch`). 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests)
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy`, and the test suite
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact (one extra dyn-dispatch hop per cache op for user-provided caches only; negligible next to the cache work itself)

Thank you for the review! 🙏