### PR TITLE
[codex] Split hourly DST tests

### DIFF
--- a/.github/workflows/dst-hourly.yaml
+++ b/.github/workflows/dst-hourly.yaml
@@ -10,11 +10,22 @@ permissions:
 
 jobs:
   deterministic-simulation-test:
+    name: deterministic-simulation-test (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: bank
+            test-filter: test_dst_bank_with_toxics
+          - name: determinism
+            test-filter: test_dst_is_deterministic
+          - name: segments
+            test-filter: test_dst_segments_is_deterministic
     # Hard backstop for the whole job. The "Run DST Tests" step below sets a
     # shorter timeout so an overrun is reported as a step *failure* (which sends
     # a notification) rather than a job-level cancellation (which does not).
-    timeout-minutes: 60
+    timeout-minutes: 65
     steps:
       - uses: actions/checkout@v4
       - uses: taiki-e/install-action@v2
@@ -29,8 +40,8 @@ jobs:
         # timeout marks the step (and job) as failed, so the usual GitHub
         # failure notification fires. A job-level timeout would instead cancel
         # the run, and GitHub does not notify on cancellations.
-        timeout-minutes: 55
-        run: cargo nextest run -p slatedb-dst --all-features --profile dst-nightly --no-capture
+        timeout-minutes: 60
+        run: cargo nextest run -p slatedb-dst --all-features --profile dst-nightly --no-capture ${{ matrix.test-filter }}
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
           RUST_LOG: "info"


### PR DESCRIPTION
Splits hourly DST into bank, determinism, and segments matrix jobs so each gets a 60-minute test step. Disables fail-fast so one slow test does not cancel the others.

Validation:
- git diff --check
- ruby YAML parse
- cargo nextest list for each matrix filter