### PR TITLE
Expose garbage collection in the language bindings via Admin.run_gc_once

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -509,6 +509,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once()
+		})
+		if checksum != 24128 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_adminbuilder_build()
 		})
 		if checksum != 46255 {
@@ -2173,6 +2182,9 @@ type AdminInterface interface {
 	ReadManifest(id *uint64) (*VersionedManifest, error)
 	// Refresh the lifetime of an existing checkpoint.
 	RefreshCheckpoint(id string, lifetimeMs *uint64) error
+	// Runs a single garbage collection pass in the foreground with the provided
+	// options. Directories whose options are `None` are skipped.
+	RunGcOnce(options GarbageCollectorOptions) error
 }
 
 // Administrative read/query handle for SlateDB.
@@ -2603,6 +2615,39 @@ func (_self *Admin) RefreshCheckpoint(id string, lifetimeMs *uint64) error {
 		func(_ struct{}) struct{} { return struct{}{} },
 		C.uniffi_slatedb_uniffi_fn_method_admin_refresh_checkpoint(
 			_pointer, FfiConverterStringINSTANCE.Lower(id), FfiConverterOptionalUint64INSTANCE.Lower(lifetimeMs)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
+}
+
+// Runs a single garbage collection pass in the foreground with the provided
+// options. Directories whose options are `None` are skipped.
+func (_self *Admin) RunGcOnce(options GarbageCollectorOptions) error {
+	_pointer := _self.ffiObject.incrementPointer("*Admin")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_admin_run_gc_once(
+			_pointer, FfiConverterGarbageCollectorOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
@@ -9344,6 +9389,181 @@ func (_ FfiDestroyerFoyerCacheOptions) Destroy(value FoyerCacheOptions) {
 	value.Destroy()
 }
 
+// Garbage collection options for a single directory (manifest, WAL, WAL fence,
+// compacted, or compactions).
+type GarbageCollectorDirectoryOptions struct {
+	// Interval between recurring garbage collector runs, in milliseconds. Only
+	// consulted by recurring garbage collection; `None` uses the default interval.
+	IntervalMs *uint64
+	// Minimum age a file must reach before it can be garbage collected, in milliseconds.
+	MinAgeMs uint64
+	// If true, log files that would be deleted without deleting them.
+	// Defaults to `false`: enabling a directory collects for real.
+	DryRun bool
+}
+
+func (r *GarbageCollectorDirectoryOptions) Destroy() {
+	FfiDestroyerOptionalUint64{}.Destroy(r.IntervalMs)
+	FfiDestroyerUint64{}.Destroy(r.MinAgeMs)
+	FfiDestroyerBool{}.Destroy(r.DryRun)
+}
+
+type FfiConverterGarbageCollectorDirectoryOptions struct{}
+
+var FfiConverterGarbageCollectorDirectoryOptionsINSTANCE = FfiConverterGarbageCollectorDirectoryOptions{}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Lift(rb RustBufferI) GarbageCollectorDirectoryOptions {
+	return LiftFromRustBuffer[GarbageCollectorDirectoryOptions](c, rb)
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Read(reader io.Reader) GarbageCollectorDirectoryOptions {
+	return GarbageCollectorDirectoryOptions{
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterBoolINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Lower(value GarbageCollectorDirectoryOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[GarbageCollectorDirectoryOptions](c, value)
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) LowerExternal(value GarbageCollectorDirectoryOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[GarbageCollectorDirectoryOptions](c, value))
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Write(writer io.Writer, value GarbageCollectorDirectoryOptions) {
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.IntervalMs)
+	FfiConverterUint64INSTANCE.Write(writer, value.MinAgeMs)
+	FfiConverterBoolINSTANCE.Write(writer, value.DryRun)
+}
+
+type FfiDestroyerGarbageCollectorDirectoryOptions struct{}
+
+func (_ FfiDestroyerGarbageCollectorDirectoryOptions) Destroy(value GarbageCollectorDirectoryOptions) {
+	value.Destroy()
+}
+
+// Options for the garbage collector. Each directory is garbage collected
+// independently; a `None` field disables garbage collection for that directory.
+//
+// Note: unlike the Rust `GarbageCollectorOptions::default()` (which enables all
+// directories, with WAL fence collection in dry-run mode), the default record is
+// a no-op — every directory must be enabled explicitly. In particular, enabling
+// `wal_fence_options` collects fence objects for real unless `dry_run` is set.
+type GarbageCollectorOptions struct {
+	// Garbage collection options for the manifest directory.
+	ManifestOptions *GarbageCollectorDirectoryOptions
+	// Garbage collection options for the WAL directory.
+	WalOptions *GarbageCollectorDirectoryOptions
+	// Garbage collection options for zero-byte WAL fence objects.
+	//
+	// WARNING: deleting fence objects too aggressively can cause data loss; use a
+	// `min_age_ms` longer than any writer is expected to run. See the Rust
+	// `GarbageCollectorOptions::wal_fence_options` docs for details.
+	WalFenceOptions *GarbageCollectorDirectoryOptions
+	// Garbage collection options for the compacted directory.
+	CompactedOptions *GarbageCollectorDirectoryOptions
+	// Garbage collection options for the compactions directory.
+	CompactionsOptions *GarbageCollectorDirectoryOptions
+	// Schedule options for detaching a clone from its parent database(s).
+	DetachOptions *GarbageCollectorScheduleOptions
+}
+
+func (r *GarbageCollectorOptions) Destroy() {
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.ManifestOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.WalOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.WalFenceOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactedOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactionsOptions)
+	FfiDestroyerOptionalGarbageCollectorScheduleOptions{}.Destroy(r.DetachOptions)
+}
+
+type FfiConverterGarbageCollectorOptions struct{}
+
+var FfiConverterGarbageCollectorOptionsINSTANCE = FfiConverterGarbageCollectorOptions{}
+
+func (c FfiConverterGarbageCollectorOptions) Lift(rb RustBufferI) GarbageCollectorOptions {
+	return LiftFromRustBuffer[GarbageCollectorOptions](c, rb)
+}
+
+func (c FfiConverterGarbageCollectorOptions) Read(reader io.Reader) GarbageCollectorOptions {
+	return GarbageCollectorOptions{
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGarbageCollectorOptions) Lower(value GarbageCollectorOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[GarbageCollectorOptions](c, value)
+}
+
+func (c FfiConverterGarbageCollectorOptions) LowerExternal(value GarbageCollectorOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[GarbageCollectorOptions](c, value))
+}
+
+func (c FfiConverterGarbageCollectorOptions) Write(writer io.Writer, value GarbageCollectorOptions) {
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.ManifestOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.WalOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.WalFenceOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactedOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactionsOptions)
+	FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Write(writer, value.DetachOptions)
+}
+
+type FfiDestroyerGarbageCollectorOptions struct{}
+
+func (_ FfiDestroyerGarbageCollectorOptions) Destroy(value GarbageCollectorOptions) {
+	value.Destroy()
+}
+
+// Schedule options for a garbage collector task that has no file-age threshold.
+type GarbageCollectorScheduleOptions struct {
+	// Interval between recurring runs, in milliseconds. Only consulted by
+	// recurring garbage collection; `None` uses the default interval.
+	IntervalMs *uint64
+}
+
+func (r *GarbageCollectorScheduleOptions) Destroy() {
+	FfiDestroyerOptionalUint64{}.Destroy(r.IntervalMs)
+}
+
+type FfiConverterGarbageCollectorScheduleOptions struct{}
+
+var FfiConverterGarbageCollectorScheduleOptionsINSTANCE = FfiConverterGarbageCollectorScheduleOptions{}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Lift(rb RustBufferI) GarbageCollectorScheduleOptions {
+	return LiftFromRustBuffer[GarbageCollectorScheduleOptions](c, rb)
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Read(reader io.Reader) GarbageCollectorScheduleOptions {
+	return GarbageCollectorScheduleOptions{
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Lower(value GarbageCollectorScheduleOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[GarbageCollectorScheduleOptions](c, value)
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) LowerExternal(value GarbageCollectorScheduleOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[GarbageCollectorScheduleOptions](c, value))
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Write(writer io.Writer, value GarbageCollectorScheduleOptions) {
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.IntervalMs)
+}
+
+type FfiDestroyerGarbageCollectorScheduleOptions struct{}
+
+func (_ FfiDestroyerGarbageCollectorScheduleOptions) Destroy(value GarbageCollectorScheduleOptions) {
+	value.Destroy()
+}
+
 // Histogram payload captured in a metric snapshot.
 type HistogramMetricValue struct {
 	// Total number of recorded observations.
@@ -12578,6 +12798,88 @@ type FfiDestroyerOptionalCompaction struct{}
 func (_ FfiDestroyerOptionalCompaction) Destroy(value *Compaction) {
 	if value != nil {
 		FfiDestroyerCompaction{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalGarbageCollectorDirectoryOptions struct{}
+
+var FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE = FfiConverterOptionalGarbageCollectorDirectoryOptions{}
+
+func (c FfiConverterOptionalGarbageCollectorDirectoryOptions) Lift(rb RustBufferI) *GarbageCollectorDirectoryOptions {
+	return LiftFromRustBuffer[*GarbageCollectorDirectoryOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalGarbageCollectorDirectoryOptions) Read(reader io.Reader) *GarbageCollectorDirectoryOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterGarbageCollectorDirectoryOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalGarbageCollectorDirectoryOptions) Lower(value *GarbageCollectorDirectoryOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*GarbageCollectorDirectoryOptions](c, value)
+}
+
+func (c FfiConverterOptionalGarbageCollectorDirectoryOptions) LowerExternal(value *GarbageCollectorDirectoryOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*GarbageCollectorDirectoryOptions](c, value))
+}
+
+func (_ FfiConverterOptionalGarbageCollectorDirectoryOptions) Write(writer io.Writer, value *GarbageCollectorDirectoryOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalGarbageCollectorDirectoryOptions struct{}
+
+func (_ FfiDestroyerOptionalGarbageCollectorDirectoryOptions) Destroy(value *GarbageCollectorDirectoryOptions) {
+	if value != nil {
+		FfiDestroyerGarbageCollectorDirectoryOptions{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalGarbageCollectorScheduleOptions struct{}
+
+var FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE = FfiConverterOptionalGarbageCollectorScheduleOptions{}
+
+func (c FfiConverterOptionalGarbageCollectorScheduleOptions) Lift(rb RustBufferI) *GarbageCollectorScheduleOptions {
+	return LiftFromRustBuffer[*GarbageCollectorScheduleOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalGarbageCollectorScheduleOptions) Read(reader io.Reader) *GarbageCollectorScheduleOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterGarbageCollectorScheduleOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalGarbageCollectorScheduleOptions) Lower(value *GarbageCollectorScheduleOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*GarbageCollectorScheduleOptions](c, value)
+}
+
+func (c FfiConverterOptionalGarbageCollectorScheduleOptions) LowerExternal(value *GarbageCollectorScheduleOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*GarbageCollectorScheduleOptions](c, value))
+}
+
+func (_ FfiConverterOptionalGarbageCollectorScheduleOptions) Write(writer io.Writer, value *GarbageCollectorScheduleOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterGarbageCollectorScheduleOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalGarbageCollectorScheduleOptions struct{}
+
+func (_ FfiDestroyerOptionalGarbageCollectorScheduleOptions) Destroy(value *GarbageCollectorScheduleOptions) {
+	if value != nil {
+		FfiDestroyerGarbageCollectorScheduleOptions{}.Destroy(*value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -689,6 +689,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_admin_read_manifest(uint64_t ptr, RustB
 uint64_t uniffi_slatedb_uniffi_fn_method_admin_refresh_checkpoint(uint64_t ptr, RustBuffer id, RustBuffer lifetime_ms
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_ADMIN_RUN_GC_ONCE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_ADMIN_RUN_GC_ONCE
+uint64_t uniffi_slatedb_uniffi_fn_method_admin_run_gc_once(uint64_t ptr, RustBuffer options
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_ADMINBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_ADMINBUILDER
 uint64_t uniffi_slatedb_uniffi_fn_clone_adminbuilder(uint64_t handle, RustCallStatus *out_status
@@ -2084,6 +2089,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_admin_read_manifest(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_REFRESH_CHECKPOINT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_REFRESH_CHECKPOINT
 uint16_t uniffi_slatedb_uniffi_checksum_method_admin_refresh_checkpoint(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
+uint16_t uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once(void
     
 );
 #endif

--- a/bindings/python/tests/test_admin.py
+++ b/bindings/python/tests/test_admin.py
@@ -6,7 +6,17 @@ import time
 import pytest
 
 from conftest import new_memory_store, open_db, open_reader, unique_path, wait_until
-from slatedb.uniffi import AdminBuilder, DbBuilder, Error, FlushOptions, FlushType, CloneSourceSpec, CheckpointOptions
+from slatedb.uniffi import (
+    AdminBuilder,
+    CheckpointOptions,
+    CloneSourceSpec,
+    DbBuilder,
+    Error,
+    FlushOptions,
+    FlushType,
+    GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions,
+)
 
 MAX_I64 = 9_223_372_036_854_775_807
 MAX_U64 = 18_446_744_073_709_551_615
@@ -455,3 +465,35 @@ async def test_admin_delete_multiple_checkpoints() -> None:
             return await admin.list_checkpoints(None) == []
 
         await wait_until(checkpoints_cleared)
+
+
+@pytest.mark.asyncio
+async def test_admin_run_gc_once_prunes_old_manifests() -> None:
+    path = unique_path("admin-gc")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        for i in range(3):
+            await db.put(f"key-{i}".encode(), b"value")
+            await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+    before = await admin.list_manifests(None, None)
+    assert len(before) > 1
+
+    # Every directory option defaults to None, so this pass has nothing to collect.
+    await admin.run_gc_once(GarbageCollectorOptions())
+    assert len(await admin.list_manifests(None, None)) == len(before)
+
+    # Manifest GC requires last_modified strictly older than min_age, so retry
+    # until the manifests age past min_age_ms=0.
+    async def manifests_pruned() -> bool:
+        await admin.run_gc_once(
+            GarbageCollectorOptions(manifest_options=GarbageCollectorDirectoryOptions(min_age_ms=0))
+        )
+        return len(await admin.list_manifests(None, None)) < len(before)
+
+    await wait_until(manifests_pruned)
+
+    after = await admin.list_manifests(None, None)
+    assert after[-1].id == before[-1].id

--- a/bindings/uniffi/src/admin.rs
+++ b/bindings/uniffi/src/admin.rs
@@ -1,5 +1,5 @@
 use crate::builder::CloneBuilder;
-use crate::config::CheckpointOptions;
+use crate::config::{CheckpointOptions, GarbageCollectorOptions};
 use crate::error::{Error, SlateDbError};
 use crate::types::{
     try_checkpoint_id_from_str, Checkpoint, CheckpointCreateResult, CloneSourceSpec, Compaction,
@@ -152,6 +152,15 @@ impl Admin {
     pub async fn delete_checkpoint(&self, id: String) -> Result<(), crate::Error> {
         self.inner
             .delete_checkpoint(try_checkpoint_id_from_str(&id)?)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Runs a single garbage collection pass in the foreground with the provided
+    /// options. Directories whose options are `None` are skipped.
+    pub async fn run_gc_once(&self, options: GarbageCollectorOptions) -> Result<(), Error> {
+        self.inner
+            .run_gc_once(options.into())
             .await
             .map_err(Into::into)
     }

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -374,3 +374,93 @@ impl TryFrom<&CheckpointOptions> for slatedb::config::CheckpointOptions {
         })
     }
 }
+
+/// Garbage collection options for a single directory (manifest, WAL, WAL fence,
+/// compacted, or compactions).
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GarbageCollectorDirectoryOptions {
+    /// Interval between recurring garbage collector runs, in milliseconds. Only
+    /// consulted by recurring garbage collection; `None` uses the default interval.
+    #[uniffi(default = None)]
+    pub interval_ms: Option<u64>,
+    /// Minimum age a file must reach before it can be garbage collected, in milliseconds.
+    pub min_age_ms: u64,
+    /// If true, log files that would be deleted without deleting them.
+    /// Defaults to `false`: enabling a directory collects for real.
+    #[uniffi(default = false)]
+    pub dry_run: bool,
+}
+
+impl From<GarbageCollectorDirectoryOptions> for slatedb::config::GarbageCollectorDirectoryOptions {
+    fn from(value: GarbageCollectorDirectoryOptions) -> Self {
+        slatedb::config::GarbageCollectorDirectoryOptions {
+            interval: value.interval_ms.map(Duration::from_millis),
+            min_age: Duration::from_millis(value.min_age_ms),
+            dry_run: value.dry_run,
+        }
+    }
+}
+
+/// Schedule options for a garbage collector task that has no file-age threshold.
+#[derive(Clone, Debug, Default, uniffi::Record)]
+pub struct GarbageCollectorScheduleOptions {
+    /// Interval between recurring runs, in milliseconds. Only consulted by
+    /// recurring garbage collection; `None` uses the default interval.
+    #[uniffi(default = None)]
+    pub interval_ms: Option<u64>,
+}
+
+impl From<GarbageCollectorScheduleOptions> for slatedb::config::GarbageCollectorScheduleOptions {
+    fn from(value: GarbageCollectorScheduleOptions) -> Self {
+        slatedb::config::GarbageCollectorScheduleOptions {
+            interval: value.interval_ms.map(Duration::from_millis),
+        }
+    }
+}
+
+/// Options for the garbage collector. Each directory is garbage collected
+/// independently; a `None` field disables garbage collection for that directory.
+///
+/// Note: unlike the Rust `GarbageCollectorOptions::default()` (which enables all
+/// directories, with WAL fence collection in dry-run mode), the default record is
+/// a no-op — every directory must be enabled explicitly. In particular, enabling
+/// `wal_fence_options` collects fence objects for real unless `dry_run` is set.
+#[derive(Clone, Debug, Default, uniffi::Record)]
+pub struct GarbageCollectorOptions {
+    /// Garbage collection options for the manifest directory.
+    #[uniffi(default = None)]
+    pub manifest_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Garbage collection options for the WAL directory.
+    #[uniffi(default = None)]
+    pub wal_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Garbage collection options for zero-byte WAL fence objects.
+    ///
+    /// WARNING: deleting fence objects too aggressively can cause data loss; use a
+    /// `min_age_ms` longer than any writer is expected to run. See the Rust
+    /// `GarbageCollectorOptions::wal_fence_options` docs for details.
+    #[uniffi(default = None)]
+    pub wal_fence_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Garbage collection options for the compacted directory.
+    #[uniffi(default = None)]
+    pub compacted_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Garbage collection options for the compactions directory.
+    #[uniffi(default = None)]
+    pub compactions_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Schedule options for detaching a clone from its parent database(s).
+    #[uniffi(default = None)]
+    pub detach_options: Option<GarbageCollectorScheduleOptions>,
+}
+
+impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions {
+    fn from(value: GarbageCollectorOptions) -> Self {
+        slatedb::config::GarbageCollectorOptions {
+            manifest_options: value.manifest_options.map(Into::into),
+            wal_options: value.wal_options.map(Into::into),
+            wal_fence_options: value.wal_fence_options.map(Into::into),
+            compacted_options: value.compacted_options.map(Into::into),
+            compactions_options: value.compactions_options.map(Into::into),
+            detach_options: value.detach_options.map(Into::into),
+            metric_level: None,
+        }
+    }
+}

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -23,8 +23,10 @@ mod write_batch;
 pub use admin::Admin;
 pub use builder::{AdminBuilder, CloneBuilder, DbBuilder, DbReaderBuilder};
 pub use config::{
-    DurabilityLevel, FlushOptions, FlushType, IsolationLevel, IterationOrder, MergeOptions,
-    PutOptions, ReadOptions, ReaderOptions, ScanOptions, SstBlockSize, Ttl, WriteOptions,
+    DurabilityLevel, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions, GarbageCollectorScheduleOptions, IsolationLevel, IterationOrder,
+    MergeOptions, PutOptions, ReadOptions, ReaderOptions, ScanOptions, SstBlockSize, Ttl,
+    WriteOptions,
 };
 pub use db::Db;
 pub use db_reader::DbReader;


### PR DESCRIPTION
## Summary

The bindings currently have no way to run garbage collection: `Admin::run_gc_once` exists in Rust but is not exported through UniFFI. This is a real operational gap for reader-only deployments — `DbReader` checkpoint refreshes mint a new manifest on every poll, the embedded GC only runs on a writer `Db` handle, so a read-hot/write-cold database accumulates manifests without bound (we hit ~28k manifests per database on GCS, degrading reader opens to minutes). See #1892 for the full context.

This PR exposes a one-shot GC pass on the uniffi `Admin` so bindings users can schedule GC out-of-band from their own services.

## Changes

- Add `uniffi::Record` mirrors for `GarbageCollectorOptions`, `GarbageCollectorDirectoryOptions`, and `GarbageCollectorScheduleOptions` in `bindings/uniffi/src/config.rs`, following the existing `CheckpointOptions`/`ReaderOptions` conventions (`Duration` → `*_ms: u64`, `Option<Duration>` → `Option<u64>`, infallible `From` conversions). All directory options default to `None` (= that directory is skipped), mirroring the core semantics.
- `metric_level` is intentionally not exposed (`MetricLevel` has no uniffi mirror today); the conversion sets it to `None`.
- Add `Admin::run_gc_once(options)` to `bindings/uniffi/src/admin.rs`. One-shot only — the looping `run_gc`/`run_gc_with_options` take a `CancellationToken`, which has no uniffi surface; callers can loop `run_gc_once` on their own schedule.
- Re-export the new records from `bindings/uniffi/src/lib.rs`.
- Regenerated Go bindings (`bindings/go/uniffi/slatedb.{go,h}`) via `./scripts/generate-go-uniffi.sh` — purely additive generated code for the new records and method.
- Python test `test_admin_run_gc_once_prunes_old_manifests`: builds several manifests, verifies an all-`None` options pass is a no-op, then verifies a `manifest_options(min_age_ms=0)` pass prunes everything but the latest manifest.

## Notes for Reviewers

- The record/conversion code is deliberately pattern-matched to `CheckpointOptions`/`ReaderOptions` in the same file.
- Nothing changes for existing binding APIs; this is purely additive.

Disclosure per CONTRIBUTING: this PR was largely generated with Claude Code (model: Claude Fable 5). I reviewed and understand the changes, and ran a local review pass before submitting.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests)
- [x] Linked related issue(s): #1892
- [x] Self-reviewed the diff
- [x] Tests added/updated and passing locally (`pytest bindings/python/tests/test_admin.py` — 17 passed)
- [x] Ran `cargo fmt`, `cargo clippy --all-targets`, and the Python binding build (`maturin develop --extras test`) + `ruff check`; `go test ./...` passes in `bindings/go` against the regenerated bindings
- [x] No breaking changes (additive only)
- [x] Performance impact: none (new API surface only)

