### PR TITLE
Add `run_gc_once` to bindings

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -509,6 +509,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once()
+		})
+		if checksum != 14634 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_adminbuilder_build()
 		})
 		if checksum != 46255 {
@@ -2173,6 +2182,10 @@ type AdminInterface interface {
 	ReadManifest(id *uint64) (*VersionedManifest, error)
 	// Refresh the lifetime of an existing checkpoint.
 	RefreshCheckpoint(id string, lifetimeMs *uint64) error
+	// Runs the garbage collector once with the provided options.
+	//
+	// When `options` is `None`, SlateDB's default garbage collector options are used.
+	RunGcOnce(options *GarbageCollectorOptions) error
 }
 
 // Administrative read/query handle for SlateDB.
@@ -2603,6 +2616,40 @@ func (_self *Admin) RefreshCheckpoint(id string, lifetimeMs *uint64) error {
 		func(_ struct{}) struct{} { return struct{}{} },
 		C.uniffi_slatedb_uniffi_fn_method_admin_refresh_checkpoint(
 			_pointer, FfiConverterStringINSTANCE.Lower(id), FfiConverterOptionalUint64INSTANCE.Lower(lifetimeMs)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
+}
+
+// Runs the garbage collector once with the provided options.
+//
+// When `options` is `None`, SlateDB's default garbage collector options are used.
+func (_self *Admin) RunGcOnce(options *GarbageCollectorOptions) error {
+	_pointer := _self.ffiObject.incrementPointer("*Admin")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_admin_run_gc_once(
+			_pointer, FfiConverterOptionalGarbageCollectorOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
@@ -9344,6 +9391,172 @@ func (_ FfiDestroyerFoyerCacheOptions) Destroy(value FoyerCacheOptions) {
 	value.Destroy()
 }
 
+// Garbage collector options for one age-thresholded directory.
+type GarbageCollectorDirectoryOptions struct {
+	// How often recurring garbage collection runs, in milliseconds.
+	//
+	// Ignored by [`crate::Admin::run_gc_once`], but preserved so the same option
+	// shape matches SlateDB's core garbage collector configuration.
+	IntervalMs *uint64
+	// Minimum file age before it can be garbage collected, in milliseconds.
+	MinAgeMs uint64
+	// Whether to log files that would be deleted without deleting them.
+	DryRun bool
+}
+
+func (r *GarbageCollectorDirectoryOptions) Destroy() {
+	FfiDestroyerOptionalUint64{}.Destroy(r.IntervalMs)
+	FfiDestroyerUint64{}.Destroy(r.MinAgeMs)
+	FfiDestroyerBool{}.Destroy(r.DryRun)
+}
+
+type FfiConverterGarbageCollectorDirectoryOptions struct{}
+
+var FfiConverterGarbageCollectorDirectoryOptionsINSTANCE = FfiConverterGarbageCollectorDirectoryOptions{}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Lift(rb RustBufferI) GarbageCollectorDirectoryOptions {
+	return LiftFromRustBuffer[GarbageCollectorDirectoryOptions](c, rb)
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Read(reader io.Reader) GarbageCollectorDirectoryOptions {
+	return GarbageCollectorDirectoryOptions{
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterBoolINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Lower(value GarbageCollectorDirectoryOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[GarbageCollectorDirectoryOptions](c, value)
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) LowerExternal(value GarbageCollectorDirectoryOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[GarbageCollectorDirectoryOptions](c, value))
+}
+
+func (c FfiConverterGarbageCollectorDirectoryOptions) Write(writer io.Writer, value GarbageCollectorDirectoryOptions) {
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.IntervalMs)
+	FfiConverterUint64INSTANCE.Write(writer, value.MinAgeMs)
+	FfiConverterBoolINSTANCE.Write(writer, value.DryRun)
+}
+
+type FfiDestroyerGarbageCollectorDirectoryOptions struct{}
+
+func (_ FfiDestroyerGarbageCollectorDirectoryOptions) Destroy(value GarbageCollectorDirectoryOptions) {
+	value.Destroy()
+}
+
+// Options controlling which garbage collector tasks run.
+type GarbageCollectorOptions struct {
+	// Options for manifest files. `None` disables manifest garbage collection.
+	ManifestOptions *GarbageCollectorDirectoryOptions
+	// Options for WAL SST files. `None` disables WAL garbage collection.
+	WalOptions *GarbageCollectorDirectoryOptions
+	// Options for zero-byte WAL fence objects. `None` disables WAL fence garbage collection.
+	WalFenceOptions *GarbageCollectorDirectoryOptions
+	// Options for compacted SST files. `None` disables compacted SST garbage collection.
+	CompactedOptions *GarbageCollectorDirectoryOptions
+	// Options for compactor job state files. `None` disables compactions garbage collection.
+	CompactionsOptions *GarbageCollectorDirectoryOptions
+	// Options for detaching clone references. `None` disables detach garbage collection.
+	DetachOptions *GarbageCollectorScheduleOptions
+}
+
+func (r *GarbageCollectorOptions) Destroy() {
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.ManifestOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.WalOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.WalFenceOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactedOptions)
+	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactionsOptions)
+	FfiDestroyerOptionalGarbageCollectorScheduleOptions{}.Destroy(r.DetachOptions)
+}
+
+type FfiConverterGarbageCollectorOptions struct{}
+
+var FfiConverterGarbageCollectorOptionsINSTANCE = FfiConverterGarbageCollectorOptions{}
+
+func (c FfiConverterGarbageCollectorOptions) Lift(rb RustBufferI) GarbageCollectorOptions {
+	return LiftFromRustBuffer[GarbageCollectorOptions](c, rb)
+}
+
+func (c FfiConverterGarbageCollectorOptions) Read(reader io.Reader) GarbageCollectorOptions {
+	return GarbageCollectorOptions{
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
+		FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGarbageCollectorOptions) Lower(value GarbageCollectorOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[GarbageCollectorOptions](c, value)
+}
+
+func (c FfiConverterGarbageCollectorOptions) LowerExternal(value GarbageCollectorOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[GarbageCollectorOptions](c, value))
+}
+
+func (c FfiConverterGarbageCollectorOptions) Write(writer io.Writer, value GarbageCollectorOptions) {
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.ManifestOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.WalOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.WalFenceOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactedOptions)
+	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactionsOptions)
+	FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Write(writer, value.DetachOptions)
+}
+
+type FfiDestroyerGarbageCollectorOptions struct{}
+
+func (_ FfiDestroyerGarbageCollectorOptions) Destroy(value GarbageCollectorOptions) {
+	value.Destroy()
+}
+
+// Schedule options for a garbage collector task without a file-age threshold.
+type GarbageCollectorScheduleOptions struct {
+	// How often recurring garbage collection runs, in milliseconds.
+	//
+	// Ignored by [`crate::Admin::run_gc_once`].
+	IntervalMs *uint64
+}
+
+func (r *GarbageCollectorScheduleOptions) Destroy() {
+	FfiDestroyerOptionalUint64{}.Destroy(r.IntervalMs)
+}
+
+type FfiConverterGarbageCollectorScheduleOptions struct{}
+
+var FfiConverterGarbageCollectorScheduleOptionsINSTANCE = FfiConverterGarbageCollectorScheduleOptions{}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Lift(rb RustBufferI) GarbageCollectorScheduleOptions {
+	return LiftFromRustBuffer[GarbageCollectorScheduleOptions](c, rb)
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Read(reader io.Reader) GarbageCollectorScheduleOptions {
+	return GarbageCollectorScheduleOptions{
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Lower(value GarbageCollectorScheduleOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[GarbageCollectorScheduleOptions](c, value)
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) LowerExternal(value GarbageCollectorScheduleOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[GarbageCollectorScheduleOptions](c, value))
+}
+
+func (c FfiConverterGarbageCollectorScheduleOptions) Write(writer io.Writer, value GarbageCollectorScheduleOptions) {
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.IntervalMs)
+}
+
+type FfiDestroyerGarbageCollectorScheduleOptions struct{}
+
+func (_ FfiDestroyerGarbageCollectorScheduleOptions) Destroy(value GarbageCollectorScheduleOptions) {
+	value.Destroy()
+}
+
 // Histogram payload captured in a metric snapshot.
 type HistogramMetricValue struct {
 	// Total number of recorded observations.
@@ -12578,6 +12791,129 @@ type FfiDestroyerOptionalCompaction struct{}
 func (_ FfiDestroyerOptionalCompaction) Destroy(value *Compaction) {
 	if value != nil {
 		FfiDestroyerCompaction{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalGarbageCollectorDirectoryOptions struct{}
+
+var FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE = FfiConverterOptionalGarbageCollectorDirectoryOptions{}
+
+func (c FfiConverterOptionalGarbageCollectorDirectoryOptions) Lift(rb RustBufferI) *GarbageCollectorDirectoryOptions {
+	return LiftFromRustBuffer[*GarbageCollectorDirectoryOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalGarbageCollectorDirectoryOptions) Read(reader io.Reader) *GarbageCollectorDirectoryOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterGarbageCollectorDirectoryOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalGarbageCollectorDirectoryOptions) Lower(value *GarbageCollectorDirectoryOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*GarbageCollectorDirectoryOptions](c, value)
+}
+
+func (c FfiConverterOptionalGarbageCollectorDirectoryOptions) LowerExternal(value *GarbageCollectorDirectoryOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*GarbageCollectorDirectoryOptions](c, value))
+}
+
+func (_ FfiConverterOptionalGarbageCollectorDirectoryOptions) Write(writer io.Writer, value *GarbageCollectorDirectoryOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalGarbageCollectorDirectoryOptions struct{}
+
+func (_ FfiDestroyerOptionalGarbageCollectorDirectoryOptions) Destroy(value *GarbageCollectorDirectoryOptions) {
+	if value != nil {
+		FfiDestroyerGarbageCollectorDirectoryOptions{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalGarbageCollectorOptions struct{}
+
+var FfiConverterOptionalGarbageCollectorOptionsINSTANCE = FfiConverterOptionalGarbageCollectorOptions{}
+
+func (c FfiConverterOptionalGarbageCollectorOptions) Lift(rb RustBufferI) *GarbageCollectorOptions {
+	return LiftFromRustBuffer[*GarbageCollectorOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalGarbageCollectorOptions) Read(reader io.Reader) *GarbageCollectorOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterGarbageCollectorOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalGarbageCollectorOptions) Lower(value *GarbageCollectorOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*GarbageCollectorOptions](c, value)
+}
+
+func (c FfiConverterOptionalGarbageCollectorOptions) LowerExternal(value *GarbageCollectorOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*GarbageCollectorOptions](c, value))
+}
+
+func (_ FfiConverterOptionalGarbageCollectorOptions) Write(writer io.Writer, value *GarbageCollectorOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterGarbageCollectorOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalGarbageCollectorOptions struct{}
+
+func (_ FfiDestroyerOptionalGarbageCollectorOptions) Destroy(value *GarbageCollectorOptions) {
+	if value != nil {
+		FfiDestroyerGarbageCollectorOptions{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalGarbageCollectorScheduleOptions struct{}
+
+var FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE = FfiConverterOptionalGarbageCollectorScheduleOptions{}
+
+func (c FfiConverterOptionalGarbageCollectorScheduleOptions) Lift(rb RustBufferI) *GarbageCollectorScheduleOptions {
+	return LiftFromRustBuffer[*GarbageCollectorScheduleOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalGarbageCollectorScheduleOptions) Read(reader io.Reader) *GarbageCollectorScheduleOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterGarbageCollectorScheduleOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalGarbageCollectorScheduleOptions) Lower(value *GarbageCollectorScheduleOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*GarbageCollectorScheduleOptions](c, value)
+}
+
+func (c FfiConverterOptionalGarbageCollectorScheduleOptions) LowerExternal(value *GarbageCollectorScheduleOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*GarbageCollectorScheduleOptions](c, value))
+}
+
+func (_ FfiConverterOptionalGarbageCollectorScheduleOptions) Write(writer io.Writer, value *GarbageCollectorScheduleOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterGarbageCollectorScheduleOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalGarbageCollectorScheduleOptions struct{}
+
+func (_ FfiDestroyerOptionalGarbageCollectorScheduleOptions) Destroy(value *GarbageCollectorScheduleOptions) {
+	if value != nil {
+		FfiDestroyerGarbageCollectorScheduleOptions{}.Destroy(*value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -689,6 +689,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_admin_read_manifest(uint64_t ptr, RustB
 uint64_t uniffi_slatedb_uniffi_fn_method_admin_refresh_checkpoint(uint64_t ptr, RustBuffer id, RustBuffer lifetime_ms
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_ADMIN_RUN_GC_ONCE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_ADMIN_RUN_GC_ONCE
+uint64_t uniffi_slatedb_uniffi_fn_method_admin_run_gc_once(uint64_t ptr, RustBuffer options
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_ADMINBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_ADMINBUILDER
 uint64_t uniffi_slatedb_uniffi_fn_clone_adminbuilder(uint64_t handle, RustCallStatus *out_status
@@ -2085,6 +2090,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_admin_read_manifest(void
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_REFRESH_CHECKPOINT
 uint16_t uniffi_slatedb_uniffi_checksum_method_admin_refresh_checkpoint(void
     
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
+uint16_t uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once(void
+
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMINBUILDER_BUILD

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -2095,7 +2095,7 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_admin_refresh_checkpoint(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
 uint16_t uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once(void
-
+    
 );
 #endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMINBUILDER_BUILD

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -1888,6 +1888,41 @@ func TestAdminQueries(t *testing.T) {
 	}
 }
 
+func TestAdminRunGcOnce(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, nil)
+
+	if _, err := dbHandle.db.Put([]byte("key"), []byte("value")); err != nil {
+		t.Fatalf("Put(key): %v", err)
+	}
+	if err := dbHandle.db.Flush(); err != nil {
+		t.Fatalf("Flush(): %v", err)
+	}
+
+	if err := admin.RunGcOnce(nil); err != nil {
+		t.Fatalf("RunGcOnce(nil): %v", err)
+	}
+
+	directoryOptions := &slatedb.GarbageCollectorDirectoryOptions{
+		IntervalMs: nil,
+		MinAgeMs:   0,
+		DryRun:     true,
+	}
+	options := &slatedb.GarbageCollectorOptions{
+		ManifestOptions:    nil,
+		WalOptions:         directoryOptions,
+		WalFenceOptions:    directoryOptions,
+		CompactedOptions:   nil,
+		CompactionsOptions: nil,
+		DetachOptions:      &slatedb.GarbageCollectorScheduleOptions{IntervalMs: nil},
+	}
+
+	if err := admin.RunGcOnce(options); err != nil {
+		t.Fatalf("RunGcOnce(custom): %v", err)
+	}
+}
+
 func TestAdminClone(t *testing.T) {
 	store := newMemoryStore(t)
 

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
@@ -158,6 +158,38 @@ class SlateDbAdminTest {
     }
 
     @Test
+    void adminRunGcOnceAcceptsDefaultAndCustomOptions() throws Exception {
+        String path = TestSupport.uniquePath("admin-run-gc-once");
+
+        try (ObjectStore store = TestSupport.newMemoryStore();
+                TestSupport.ManagedDb dbHandle = TestSupport.openDb(path, store, null);
+                AdminBuilder adminBuilder = new AdminBuilder(path, store);
+                Admin admin = adminBuilder.build()) {
+            Db db = dbHandle.db();
+
+            TestSupport.await(db.put(TestSupport.bytes("key"), TestSupport.bytes("value")));
+            TestSupport.await(db.flush());
+
+            TestSupport.await(admin.runGcOnce(null));
+
+            GarbageCollectorDirectoryOptions directoryOptions =
+                    new GarbageCollectorDirectoryOptions(null, 0L, true);
+            GarbageCollectorScheduleOptions scheduleOptions =
+                    new GarbageCollectorScheduleOptions(null);
+            GarbageCollectorOptions options =
+                    new GarbageCollectorOptions(
+                            null,
+                            directoryOptions,
+                            directoryOptions,
+                            null,
+                            null,
+                            scheduleOptions);
+
+            TestSupport.await(admin.runGcOnce(options));
+        }
+    }
+
+    @Test
     void adminCheckpointListingTracksReaderLifecycle() throws Exception {
         String path = TestSupport.uniquePath("admin-checkpoints");
 

--- a/bindings/node/tests/admin.test.mjs
+++ b/bindings/node/tests/admin.test.mjs
@@ -138,6 +138,33 @@ test("admin compaction queries handle empty store and invalid ids", async (t) =>
   assert.match(invalidCompactionId.message, /invalid compaction_id ULID/);
 });
 
+test("admin run_gc_once accepts default and custom options", async (t) => {
+  const cleanup = createCleanup(t);
+  const path = uniquePath("admin-run-gc-once");
+  const store = cleanup.track(newMemoryStore());
+  const admin = openAdmin(store, { path, cleanup });
+  const db = await openDb(store, { path, cleanup });
+
+  await db.put(bytes("key"), bytes("value"));
+  await db.flush();
+
+  await admin.run_gc_once(undefined);
+
+  const directoryOptions = {
+    interval_ms: undefined,
+    min_age_ms: 0n,
+    dry_run: true,
+  };
+  await admin.run_gc_once({
+    manifest_options: undefined,
+    wal_options: directoryOptions,
+    wal_fence_options: directoryOptions,
+    compacted_options: undefined,
+    compactions_options: undefined,
+    detach_options: { interval_ms: undefined },
+  });
+});
+
 test("admin checkpoint listing tracks reader lifecycle", async (t) => {
   const cleanup = createCleanup(t);
   const path = uniquePath("admin-checkpoints");

--- a/bindings/python/tests/test_admin.py
+++ b/bindings/python/tests/test_admin.py
@@ -6,7 +6,18 @@ import time
 import pytest
 
 from conftest import new_memory_store, open_db, open_reader, unique_path, wait_until
-from slatedb.uniffi import AdminBuilder, DbBuilder, Error, FlushOptions, FlushType, CloneSourceSpec, CheckpointOptions
+from slatedb.uniffi import (
+    AdminBuilder,
+    CheckpointOptions,
+    CloneSourceSpec,
+    DbBuilder,
+    Error,
+    FlushOptions,
+    FlushType,
+    GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions,
+    GarbageCollectorScheduleOptions,
+)
 
 MAX_I64 = 9_223_372_036_854_775_807
 MAX_U64 = 18_446_744_073_709_551_615
@@ -106,6 +117,36 @@ async def test_admin_compaction_queries_handle_empty_store_and_invalid_ids() -> 
     with pytest.raises(Error.Invalid) as invalid_compaction_id:
         await admin.read_compaction("not-a-ulid", None)
     assert "invalid compaction_id ULID" in invalid_compaction_id.value.message
+
+
+@pytest.mark.asyncio
+async def test_admin_run_gc_once_accepts_default_and_custom_options() -> None:
+    path = unique_path("admin-run-gc-once")
+    store = new_memory_store()
+    admin = AdminBuilder(path, store).build()
+
+    async with open_db(store, path=path) as db:
+        await db.put(b"key", b"value")
+        await db.flush()
+
+        await admin.run_gc_once(None)
+
+        directory_options = GarbageCollectorDirectoryOptions(
+            interval_ms=None,
+            min_age_ms=0,
+            dry_run=True,
+        )
+        schedule_options = GarbageCollectorScheduleOptions(interval_ms=None)
+        options = GarbageCollectorOptions(
+            manifest_options=None,
+            wal_options=directory_options,
+            wal_fence_options=directory_options,
+            compacted_options=None,
+            compactions_options=None,
+            detach_options=schedule_options,
+        )
+
+        await admin.run_gc_once(options)
 
 
 @pytest.mark.asyncio

--- a/bindings/uniffi/src/admin.rs
+++ b/bindings/uniffi/src/admin.rs
@@ -1,5 +1,5 @@
 use crate::builder::CloneBuilder;
-use crate::config::CheckpointOptions;
+use crate::config::{CheckpointOptions, GarbageCollectorOptions};
 use crate::error::{Error, SlateDbError};
 use crate::types::{
     try_checkpoint_id_from_str, Checkpoint, CheckpointCreateResult, CloneSourceSpec, Compaction,
@@ -94,6 +94,17 @@ impl Admin {
     ) -> Result<Vec<Checkpoint>, Error> {
         let checkpoints = self.inner.list_checkpoints(name_filter.as_deref()).await?;
         Ok(checkpoints.iter().map(Checkpoint::from).collect())
+    }
+
+    /// Runs the garbage collector once with the provided options.
+    ///
+    /// When `options` is `None`, SlateDB's default garbage collector options are used.
+    pub async fn run_gc_once(&self, options: Option<GarbageCollectorOptions>) -> Result<(), Error> {
+        let options = options.map_or_else(
+            slatedb::config::GarbageCollectorOptions::default,
+            Into::into,
+        );
+        self.inner.run_gc_once(options).await.map_err(Into::into)
     }
 
     /// Looks up a timestamp for the provided sequence number.

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -340,6 +340,138 @@ impl From<FlushOptions> for slatedb::config::FlushOptions {
     }
 }
 
+/// Garbage collector options for one age-thresholded directory.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GarbageCollectorDirectoryOptions {
+    /// How often recurring garbage collection runs, in milliseconds.
+    ///
+    /// Ignored by [`crate::Admin::run_gc_once`], but preserved so the same option
+    /// shape matches SlateDB's core garbage collector configuration.
+    #[uniffi(default = None)]
+    pub interval_ms: Option<u64>,
+    /// Minimum file age before it can be garbage collected, in milliseconds.
+    pub min_age_ms: u64,
+    /// Whether to log files that would be deleted without deleting them.
+    pub dry_run: bool,
+}
+
+impl Default for GarbageCollectorDirectoryOptions {
+    fn default() -> Self {
+        let core = slatedb::config::GarbageCollectorDirectoryOptions::default();
+        Self {
+            interval_ms: core.interval.map(|duration| duration.as_millis() as u64),
+            min_age_ms: core.min_age.as_millis() as u64,
+            dry_run: core.dry_run,
+        }
+    }
+}
+
+impl From<GarbageCollectorDirectoryOptions> for slatedb::config::GarbageCollectorDirectoryOptions {
+    fn from(value: GarbageCollectorDirectoryOptions) -> Self {
+        Self {
+            interval: value.interval_ms.map(Duration::from_millis),
+            min_age: Duration::from_millis(value.min_age_ms),
+            dry_run: value.dry_run,
+        }
+    }
+}
+
+/// Schedule options for a garbage collector task without a file-age threshold.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GarbageCollectorScheduleOptions {
+    /// How often recurring garbage collection runs, in milliseconds.
+    ///
+    /// Ignored by [`crate::Admin::run_gc_once`].
+    #[uniffi(default = None)]
+    pub interval_ms: Option<u64>,
+}
+
+impl Default for GarbageCollectorScheduleOptions {
+    fn default() -> Self {
+        let core = slatedb::config::GarbageCollectorScheduleOptions::default();
+        Self {
+            interval_ms: core.interval.map(|duration| duration.as_millis() as u64),
+        }
+    }
+}
+
+impl From<GarbageCollectorScheduleOptions> for slatedb::config::GarbageCollectorScheduleOptions {
+    fn from(value: GarbageCollectorScheduleOptions) -> Self {
+        Self {
+            interval: value.interval_ms.map(Duration::from_millis),
+        }
+    }
+}
+
+/// Options controlling which garbage collector tasks run.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct GarbageCollectorOptions {
+    /// Options for manifest files. `None` disables manifest garbage collection.
+    #[uniffi(default = None)]
+    pub manifest_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Options for WAL SST files. `None` disables WAL garbage collection.
+    #[uniffi(default = None)]
+    pub wal_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Options for zero-byte WAL fence objects. `None` disables WAL fence garbage collection.
+    #[uniffi(default = None)]
+    pub wal_fence_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Options for compacted SST files. `None` disables compacted SST garbage collection.
+    #[uniffi(default = None)]
+    pub compacted_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Options for compactor job state files. `None` disables compactions garbage collection.
+    #[uniffi(default = None)]
+    pub compactions_options: Option<GarbageCollectorDirectoryOptions>,
+    /// Options for detaching clone references. `None` disables detach garbage collection.
+    #[uniffi(default = None)]
+    pub detach_options: Option<GarbageCollectorScheduleOptions>,
+}
+
+impl Default for GarbageCollectorOptions {
+    fn default() -> Self {
+        let core = slatedb::config::GarbageCollectorOptions::default();
+        Self {
+            manifest_options: core.manifest_options.map(Into::into),
+            wal_options: core.wal_options.map(Into::into),
+            wal_fence_options: core.wal_fence_options.map(Into::into),
+            compacted_options: core.compacted_options.map(Into::into),
+            compactions_options: core.compactions_options.map(Into::into),
+            detach_options: core.detach_options.map(Into::into),
+        }
+    }
+}
+
+impl From<slatedb::config::GarbageCollectorDirectoryOptions> for GarbageCollectorDirectoryOptions {
+    fn from(value: slatedb::config::GarbageCollectorDirectoryOptions) -> Self {
+        Self {
+            interval_ms: value.interval.map(|duration| duration.as_millis() as u64),
+            min_age_ms: value.min_age.as_millis() as u64,
+            dry_run: value.dry_run,
+        }
+    }
+}
+
+impl From<slatedb::config::GarbageCollectorScheduleOptions> for GarbageCollectorScheduleOptions {
+    fn from(value: slatedb::config::GarbageCollectorScheduleOptions) -> Self {
+        Self {
+            interval_ms: value.interval.map(|duration| duration.as_millis() as u64),
+        }
+    }
+}
+
+impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions {
+    fn from(value: GarbageCollectorOptions) -> Self {
+        Self {
+            manifest_options: value.manifest_options.map(Into::into),
+            wal_options: value.wal_options.map(Into::into),
+            wal_fence_options: value.wal_fence_options.map(Into::into),
+            compacted_options: value.compacted_options.map(Into::into),
+            compactions_options: value.compactions_options.map(Into::into),
+            detach_options: value.detach_options.map(Into::into),
+            metric_level: None,
+        }
+    }
+}
+
 /// Specify options to provide when creating a checkpoint.
 #[derive(Clone, Debug, PartialEq, Eq, uniffi::Record, Default)]
 pub struct CheckpointOptions {

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -23,8 +23,10 @@ mod write_batch;
 pub use admin::Admin;
 pub use builder::{AdminBuilder, CloneBuilder, DbBuilder, DbReaderBuilder};
 pub use config::{
-    DurabilityLevel, FlushOptions, FlushType, IsolationLevel, IterationOrder, MergeOptions,
-    PutOptions, ReadOptions, ReaderOptions, ScanOptions, SstBlockSize, Ttl, WriteOptions,
+    DurabilityLevel, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions, GarbageCollectorScheduleOptions, IsolationLevel, IterationOrder,
+    MergeOptions, PutOptions, ReadOptions, ReaderOptions, ScanOptions, SstBlockSize, Ttl,
+    WriteOptions,
 };
 pub use db::Db;
 pub use db_reader::DbReader;


### PR DESCRIPTION
## Summary

Adds `run_gc_once` to UniFFI bindings and related tests.

Closes #1893

## Changes

- Update UniFFI
- Add tests

## Notes for Reviewers

Vibed.