### PR TITLE
add docs and uniffi bindings for segments

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -518,6 +518,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_admin_submit_compaction()
+		})
+		if checksum != 20337 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_admin_submit_compaction: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_adminbuilder_build()
 		})
 		if checksum != 46255 {
@@ -2186,6 +2195,12 @@ type AdminInterface interface {
 	//
 	// When `options` is `None`, SlateDB's default garbage collector options are used.
 	RunGcOnce(options *GarbageCollectorOptions) error
+	// Generate a compaction from a spec and submit it.
+	//
+	// ## Returns
+	// - `Ok(Compaction)`: The submitted compaction.
+	// - `Err`: If there was an error during submission or reading the submitted compaction.
+	SubmitCompaction(spec CompactionSpec) (Compaction, error)
 }
 
 // Administrative read/query handle for SlateDB.
@@ -2665,6 +2680,46 @@ func (_self *Admin) RunGcOnce(options *GarbageCollectorOptions) error {
 	}
 
 	return err
+}
+
+// Generate a compaction from a spec and submit it.
+//
+// ## Returns
+// - `Ok(Compaction)`: The submitted compaction.
+// - `Err`: If there was an error during submission or reading the submitted compaction.
+func (_self *Admin) SubmitCompaction(spec CompactionSpec) (Compaction, error) {
+	_pointer := _self.ffiObject.incrementPointer("*Admin")
+	defer _self.ffiObject.decrementPointer()
+	res, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_rust_buffer(handle, status)
+			return GoRustBuffer{
+				inner: res,
+			}
+		},
+		// liftFn
+		func(ffi RustBufferI) Compaction {
+			return FfiConverterCompactionINSTANCE.Lift(ffi)
+		},
+		C.uniffi_slatedb_uniffi_fn_method_admin_submit_compaction(
+			_pointer, FfiConverterCompactionSpecINSTANCE.Lower(spec)),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_rust_buffer(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_rust_buffer(handle)
+		},
+	)
+
+	if err == nil {
+		return res, nil
+	}
+
+	return res, err
 }
 func (object *Admin) Destroy() {
 	runtime.SetFinalizer(object, nil)
@@ -9087,64 +9142,6 @@ func (_ FfiDestroyerCompaction) Destroy(value Compaction) {
 	value.Destroy()
 }
 
-// Immutable compaction specification.
-type CompactionSpec struct {
-	// Ordered compaction sources.
-	Sources []SourceId
-	// Destination sorted run ID. `None` for drain-segment specs, which
-	// produce no new sorted run.
-	Destination *uint32
-	// Whether any input source is an L0 SST view.
-	HasL0Sources bool
-	// Whether any input source is a sorted run.
-	HasSrSources bool
-}
-
-func (r *CompactionSpec) Destroy() {
-	FfiDestroyerSequenceSourceId{}.Destroy(r.Sources)
-	FfiDestroyerOptionalUint32{}.Destroy(r.Destination)
-	FfiDestroyerBool{}.Destroy(r.HasL0Sources)
-	FfiDestroyerBool{}.Destroy(r.HasSrSources)
-}
-
-type FfiConverterCompactionSpec struct{}
-
-var FfiConverterCompactionSpecINSTANCE = FfiConverterCompactionSpec{}
-
-func (c FfiConverterCompactionSpec) Lift(rb RustBufferI) CompactionSpec {
-	return LiftFromRustBuffer[CompactionSpec](c, rb)
-}
-
-func (c FfiConverterCompactionSpec) Read(reader io.Reader) CompactionSpec {
-	return CompactionSpec{
-		FfiConverterSequenceSourceIdINSTANCE.Read(reader),
-		FfiConverterOptionalUint32INSTANCE.Read(reader),
-		FfiConverterBoolINSTANCE.Read(reader),
-		FfiConverterBoolINSTANCE.Read(reader),
-	}
-}
-
-func (c FfiConverterCompactionSpec) Lower(value CompactionSpec) C.RustBuffer {
-	return LowerIntoRustBuffer[CompactionSpec](c, value)
-}
-
-func (c FfiConverterCompactionSpec) LowerExternal(value CompactionSpec) ExternalCRustBuffer {
-	return RustBufferFromC(LowerIntoRustBuffer[CompactionSpec](c, value))
-}
-
-func (c FfiConverterCompactionSpec) Write(writer io.Writer, value CompactionSpec) {
-	FfiConverterSequenceSourceIdINSTANCE.Write(writer, value.Sources)
-	FfiConverterOptionalUint32INSTANCE.Write(writer, value.Destination)
-	FfiConverterBoolINSTANCE.Write(writer, value.HasL0Sources)
-	FfiConverterBoolINSTANCE.Write(writer, value.HasSrSources)
-}
-
-type FfiDestroyerCompactionSpec struct{}
-
-func (_ FfiDestroyerCompactionSpec) Destroy(value CompactionSpec) {
-	value.Destroy()
-}
-
 // Read-only compactor state view.
 type CompactorStateView struct {
 	// Latest compactions file, if present.
@@ -10418,6 +10415,64 @@ func (_ FfiDestroyerScanOptions) Destroy(value ScanOptions) {
 	value.Destroy()
 }
 
+// Per-segment LSM state (RFC-0024). Each named segment carries its own L0
+// SSTs and sorted runs, compacted and retired independently of the root tree.
+type Segment struct {
+	// Segment prefix.
+	Prefix []byte
+	// Last compacted L0 SST view ID for this segment, if any.
+	LastCompactedL0SstViewId *string
+	// Current L0 SST views in this segment.
+	L0 []SsTableView
+	// Current compacted sorted runs in this segment.
+	Compacted []SortedRun
+}
+
+func (r *Segment) Destroy() {
+	FfiDestroyerBytes{}.Destroy(r.Prefix)
+	FfiDestroyerOptionalString{}.Destroy(r.LastCompactedL0SstViewId)
+	FfiDestroyerSequenceSsTableView{}.Destroy(r.L0)
+	FfiDestroyerSequenceSortedRun{}.Destroy(r.Compacted)
+}
+
+type FfiConverterSegment struct{}
+
+var FfiConverterSegmentINSTANCE = FfiConverterSegment{}
+
+func (c FfiConverterSegment) Lift(rb RustBufferI) Segment {
+	return LiftFromRustBuffer[Segment](c, rb)
+}
+
+func (c FfiConverterSegment) Read(reader io.Reader) Segment {
+	return Segment{
+		FfiConverterBytesINSTANCE.Read(reader),
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterSequenceSsTableViewINSTANCE.Read(reader),
+		FfiConverterSequenceSortedRunINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterSegment) Lower(value Segment) C.RustBuffer {
+	return LowerIntoRustBuffer[Segment](c, value)
+}
+
+func (c FfiConverterSegment) LowerExternal(value Segment) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[Segment](c, value))
+}
+
+func (c FfiConverterSegment) Write(writer io.Writer, value Segment) {
+	FfiConverterBytesINSTANCE.Write(writer, value.Prefix)
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.LastCompactedL0SstViewId)
+	FfiConverterSequenceSsTableViewINSTANCE.Write(writer, value.L0)
+	FfiConverterSequenceSortedRunINSTANCE.Write(writer, value.Compacted)
+}
+
+type FfiDestroyerSegment struct{}
+
+func (_ FfiDestroyerSegment) Destroy(value Segment) {
+	value.Destroy()
+}
+
 // A segment (RFC-0024), identified by the key prefix it owns; the segment
 // spans the key interval `[prefix, prefix++)`.
 type SegmentPrefix struct {
@@ -10782,10 +10837,12 @@ type VersionedManifest struct {
 	LastCompactedL0SstViewId *string
 	// Last compacted L0 SST ID, if any.
 	LastCompactedL0SstId *string
-	// Current L0 SST views.
+	// Current L0 SST views (root `prefix=""` tree).
 	L0 []SsTableView
-	// Current compacted sorted runs.
+	// Current compacted sorted runs (root `prefix=""` tree).
 	Compacted []SortedRun
+	// Per-segment LSM state for named (non-empty-prefix) segments.
+	Segments []Segment
 	// Next WAL SST ID to assign.
 	NextWalSstId uint64
 	// WAL replay watermark.
@@ -10812,6 +10869,7 @@ func (r *VersionedManifest) Destroy() {
 	FfiDestroyerOptionalString{}.Destroy(r.LastCompactedL0SstId)
 	FfiDestroyerSequenceSsTableView{}.Destroy(r.L0)
 	FfiDestroyerSequenceSortedRun{}.Destroy(r.Compacted)
+	FfiDestroyerSequenceSegment{}.Destroy(r.Segments)
 	FfiDestroyerUint64{}.Destroy(r.NextWalSstId)
 	FfiDestroyerUint64{}.Destroy(r.ReplayAfterWalId)
 	FfiDestroyerInt64{}.Destroy(r.LastL0ClockTick)
@@ -10840,6 +10898,7 @@ func (c FfiConverterVersionedManifest) Read(reader io.Reader) VersionedManifest 
 		FfiConverterOptionalStringINSTANCE.Read(reader),
 		FfiConverterSequenceSsTableViewINSTANCE.Read(reader),
 		FfiConverterSequenceSortedRunINSTANCE.Read(reader),
+		FfiConverterSequenceSegmentINSTANCE.Read(reader),
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterInt64INSTANCE.Read(reader),
@@ -10868,6 +10927,7 @@ func (c FfiConverterVersionedManifest) Write(writer io.Writer, value VersionedMa
 	FfiConverterOptionalStringINSTANCE.Write(writer, value.LastCompactedL0SstId)
 	FfiConverterSequenceSsTableViewINSTANCE.Write(writer, value.L0)
 	FfiConverterSequenceSortedRunINSTANCE.Write(writer, value.Compacted)
+	FfiConverterSequenceSegmentINSTANCE.Write(writer, value.Segments)
 	FfiConverterUint64INSTANCE.Write(writer, value.NextWalSstId)
 	FfiConverterUint64INSTANCE.Write(writer, value.ReplayAfterWalId)
 	FfiConverterInt64INSTANCE.Write(writer, value.LastL0ClockTick)
@@ -11105,6 +11165,95 @@ func (FfiConverterCloseReason) Write(writer io.Writer, value CloseReason) {
 type FfiDestroyerCloseReason struct{}
 
 func (_ FfiDestroyerCloseReason) Destroy(value CloseReason) {
+}
+
+// Immutable compaction specification. Mirrors the core `CompactionSpec`:
+// either a tiered merge into a destination sorted run, or a segment drain.
+type CompactionSpec interface {
+	Destroy()
+}
+
+// Tiered merge: read `sources` and write a single output sorted run with
+// id `destination`. An empty `segment` targets the root (`prefix=""`) tree.
+type CompactionSpecTiered struct {
+	Segment     []byte
+	Sources     []SourceId
+	Destination uint32
+}
+
+func (e CompactionSpecTiered) Destroy() {
+	FfiDestroyerBytes{}.Destroy(e.Segment)
+	FfiDestroyerSequenceSourceId{}.Destroy(e.Sources)
+	FfiDestroyerUint32{}.Destroy(e.Destination)
+}
+
+// Segment drain (retention): retire `segment` by detaching the listed
+// `sources` (its L0 SSTs and sorted runs). Produces no new sorted run.
+type CompactionSpecDrainSegment struct {
+	Segment []byte
+	Sources []SourceId
+}
+
+func (e CompactionSpecDrainSegment) Destroy() {
+	FfiDestroyerBytes{}.Destroy(e.Segment)
+	FfiDestroyerSequenceSourceId{}.Destroy(e.Sources)
+}
+
+type FfiConverterCompactionSpec struct{}
+
+var FfiConverterCompactionSpecINSTANCE = FfiConverterCompactionSpec{}
+
+func (c FfiConverterCompactionSpec) Lift(rb RustBufferI) CompactionSpec {
+	return LiftFromRustBuffer[CompactionSpec](c, rb)
+}
+
+func (c FfiConverterCompactionSpec) Lower(value CompactionSpec) C.RustBuffer {
+	return LowerIntoRustBuffer[CompactionSpec](c, value)
+}
+
+func (c FfiConverterCompactionSpec) LowerExternal(value CompactionSpec) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[CompactionSpec](c, value))
+}
+func (FfiConverterCompactionSpec) Read(reader io.Reader) CompactionSpec {
+	id := readInt32(reader)
+	switch id {
+	case 1:
+		return CompactionSpecTiered{
+			FfiConverterBytesINSTANCE.Read(reader),
+			FfiConverterSequenceSourceIdINSTANCE.Read(reader),
+			FfiConverterUint32INSTANCE.Read(reader),
+		}
+	case 2:
+		return CompactionSpecDrainSegment{
+			FfiConverterBytesINSTANCE.Read(reader),
+			FfiConverterSequenceSourceIdINSTANCE.Read(reader),
+		}
+	default:
+		panic(fmt.Sprintf("invalid enum value %v in FfiConverterCompactionSpec.Read()", id))
+	}
+}
+
+func (FfiConverterCompactionSpec) Write(writer io.Writer, value CompactionSpec) {
+	switch variant_value := value.(type) {
+	case CompactionSpecTiered:
+		writeInt32(writer, 1)
+		FfiConverterBytesINSTANCE.Write(writer, variant_value.Segment)
+		FfiConverterSequenceSourceIdINSTANCE.Write(writer, variant_value.Sources)
+		FfiConverterUint32INSTANCE.Write(writer, variant_value.Destination)
+	case CompactionSpecDrainSegment:
+		writeInt32(writer, 2)
+		FfiConverterBytesINSTANCE.Write(writer, variant_value.Segment)
+		FfiConverterSequenceSourceIdINSTANCE.Write(writer, variant_value.Sources)
+	default:
+		_ = variant_value
+		panic(fmt.Sprintf("invalid enum value `%v` in FfiConverterCompactionSpec.Write", value))
+	}
+}
+
+type FfiDestroyerCompactionSpec struct{}
+
+func (_ FfiDestroyerCompactionSpec) Destroy(value CompactionSpec) {
+	value.Destroy()
 }
 
 // Compaction lifecycle state.
@@ -13835,6 +13984,53 @@ type FfiDestroyerSequenceMetricLabel struct{}
 func (FfiDestroyerSequenceMetricLabel) Destroy(sequence []MetricLabel) {
 	for _, value := range sequence {
 		FfiDestroyerMetricLabel{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceSegment struct{}
+
+var FfiConverterSequenceSegmentINSTANCE = FfiConverterSequenceSegment{}
+
+func (c FfiConverterSequenceSegment) Lift(rb RustBufferI) []Segment {
+	return LiftFromRustBuffer[[]Segment](c, rb)
+}
+
+func (c FfiConverterSequenceSegment) Read(reader io.Reader) []Segment {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]Segment, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterSegmentINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceSegment) Lower(value []Segment) C.RustBuffer {
+	return LowerIntoRustBuffer[[]Segment](c, value)
+}
+
+func (c FfiConverterSequenceSegment) LowerExternal(value []Segment) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[[]Segment](c, value))
+}
+
+func (c FfiConverterSequenceSegment) Write(writer io.Writer, value []Segment) {
+	if len(value) > math.MaxInt32 {
+		panic("[]Segment is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterSegmentINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceSegment struct{}
+
+func (FfiDestroyerSequenceSegment) Destroy(sequence []Segment) {
+	for _, value := range sequence {
+		FfiDestroyerSegment{}.Destroy(value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -694,6 +694,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_admin_refresh_checkpoint(uint64_t ptr, 
 uint64_t uniffi_slatedb_uniffi_fn_method_admin_run_gc_once(uint64_t ptr, RustBuffer options
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_ADMIN_SUBMIT_COMPACTION
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_ADMIN_SUBMIT_COMPACTION
+uint64_t uniffi_slatedb_uniffi_fn_method_admin_submit_compaction(uint64_t ptr, RustBuffer spec
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_ADMINBUILDER
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_CLONE_ADMINBUILDER
 uint64_t uniffi_slatedb_uniffi_fn_clone_adminbuilder(uint64_t handle, RustCallStatus *out_status
@@ -2095,6 +2100,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_admin_refresh_checkpoint(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_RUN_GC_ONCE
 uint16_t uniffi_slatedb_uniffi_checksum_method_admin_run_gc_once(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_SUBMIT_COMPACTION
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_ADMIN_SUBMIT_COMPACTION
+uint16_t uniffi_slatedb_uniffi_checksum_method_admin_submit_compaction(void
     
 );
 #endif

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -60,6 +60,21 @@ func newMemoryStore(t *testing.T) *slatedb.ObjectStore {
 	return store
 }
 
+// newLocalStore returns a local-filesystem object store rooted at `/` together
+// with a fresh temp-directory DB path relative to that root. SlateDB requires
+// the resolved store to have an empty path, so the directory is carried as the
+// path passed to the builders rather than baked into the store URL.
+func newLocalStore(t *testing.T) (*slatedb.ObjectStore, string) {
+	t.Helper()
+
+	store, err := slatedb.ObjectStoreResolve("file:///")
+	if err != nil {
+		t.Fatalf("ObjectStoreResolve(file:///): %v", err)
+	}
+	t.Cleanup(store.Destroy)
+	return store, strings.TrimPrefix(t.TempDir(), "/")
+}
+
 func openTestDB(t *testing.T, store *slatedb.ObjectStore, configure func(*testing.T, *slatedb.DbBuilder)) *testDB {
 	t.Helper()
 
@@ -2162,6 +2177,174 @@ func TestAdminCreateDetachedCheckpointWithName(t *testing.T) {
 	}
 	if len(filteredOther) != 0 {
 		t.Fatalf("ListCheckpoints(other-name): got %d checkpoints, want 0", len(filteredOther))
+	}
+}
+
+func TestAdminDrainSegment(t *testing.T) {
+	store := newMemoryStore(t)
+	admin := openTestAdmin(t, store, nil)
+	dbHandle := openTestDB(t, store, func(t *testing.T, builder *slatedb.DbBuilder) {
+		t.Helper()
+		if err := builder.WithSegmentExtractor(fixedThreeByteSegmentExtractor{}); err != nil {
+			t.Fatalf("WithSegmentExtractor(): %v", err)
+		}
+	})
+
+	// Write to two segments and flush so they land in the manifest as L0.
+	if _, err := dbHandle.db.Put([]byte("aaa-1"), []byte("value")); err != nil {
+		t.Fatalf("Put(aaa-1): %v", err)
+	}
+	if _, err := dbHandle.db.Put([]byte("bbb-1"), []byte("value")); err != nil {
+		t.Fatalf("Put(bbb-1): %v", err)
+	}
+	if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	// Locate the "aaa" segment in the manifest and enumerate its sources.
+	view, err := admin.ReadCompactorStateView()
+	if err != nil {
+		t.Fatalf("ReadCompactorStateView(): %v", err)
+	}
+	sources := collectSegmentSources(view.Manifest.Segments, []byte("aaa"))
+	if len(sources) == 0 {
+		t.Fatal("segment aaa: got 0 sources, want its L0 SSTs")
+	}
+
+	// Submitting a drain spec retires the segment.
+	compaction, err := admin.SubmitCompaction(slatedb.CompactionSpecDrainSegment{
+		Segment: []byte("aaa"),
+		Sources: sources,
+	})
+	if err != nil {
+		t.Fatalf("SubmitCompaction(drain aaa): %v", err)
+	}
+	spec, ok := compaction.Spec.(slatedb.CompactionSpecDrainSegment)
+	if !ok {
+		t.Fatalf("submitted spec: got %T, want CompactionSpecDrainSegment", compaction.Spec)
+	}
+	if !bytes.Equal(spec.Segment, []byte("aaa")) {
+		t.Fatalf("drain spec segment: got %q, want %q", spec.Segment, "aaa")
+	}
+	if len(spec.Sources) != len(sources) {
+		t.Fatalf("drain spec sources: got %d, want %d", len(spec.Sources), len(sources))
+	}
+}
+
+// collectSegmentSources returns every L0 SST and sorted run of the segment with
+// the given prefix as drain/compaction sources.
+func collectSegmentSources(segments []slatedb.Segment, prefix []byte) []slatedb.SourceId {
+	var sources []slatedb.SourceId
+	for i := range segments {
+		if !bytes.Equal(segments[i].Prefix, prefix) {
+			continue
+		}
+		for _, v := range segments[i].L0 {
+			sources = append(sources, slatedb.SourceIdSstView{Field0: v.Id})
+		}
+		for _, r := range segments[i].Compacted {
+			sources = append(sources, slatedb.SourceIdSortedRun{Field0: r.Id})
+		}
+	}
+	return sources
+}
+
+// segmentDrained reports whether the segment with the given prefix has been
+// retired: either absent from the manifest, or reduced to an empty drain marker.
+func segmentDrained(segments []slatedb.Segment, prefix []byte) bool {
+	for i := range segments {
+		if bytes.Equal(segments[i].Prefix, prefix) {
+			return len(segments[i].L0) == 0 && len(segments[i].Compacted) == 0
+		}
+	}
+	return true
+}
+
+// TestAdminDrainSegmentEndToEnd exercises the full drain lifecycle against a
+// local-filesystem object store: write two segments, submit a drain for one,
+// and let the embedded compactor retire it while the other is left intact.
+func TestAdminDrainSegmentEndToEnd(t *testing.T) {
+	store, dbPath := newLocalStore(t)
+
+	// Writer with a segment extractor and a fast compactor poll so the
+	// submitted drain is executed promptly by the embedded compactor.
+	dbBuilder := slatedb.NewDbBuilder(dbPath, store)
+	defer dbBuilder.Destroy()
+	if err := dbBuilder.WithSegmentExtractor(fixedThreeByteSegmentExtractor{}); err != nil {
+		t.Fatalf("WithSegmentExtractor(): %v", err)
+	}
+	settings := slatedb.SettingsDefault()
+	defer settings.Destroy()
+	if err := settings.Set("compactor_options.poll_interval", `"200ms"`); err != nil {
+		t.Fatalf("Set(compactor_options.poll_interval): %v", err)
+	}
+	if err := dbBuilder.WithSettings(settings); err != nil {
+		t.Fatalf("WithSettings(): %v", err)
+	}
+	db, err := dbBuilder.Build()
+	if err != nil {
+		t.Fatalf("DbBuilder.Build(): %v", err)
+	}
+	defer func() {
+		if err := db.Shutdown(); err != nil {
+			t.Errorf("Shutdown(): %v", err)
+		}
+		db.Destroy()
+	}()
+
+	// Two segments, flushed to L0 so they are visible in the manifest.
+	if _, err := db.Put([]byte("aaa-1"), []byte("value")); err != nil {
+		t.Fatalf("Put(aaa-1): %v", err)
+	}
+	if _, err := db.Put([]byte("bbb-1"), []byte("value")); err != nil {
+		t.Fatalf("Put(bbb-1): %v", err)
+	}
+	if err := db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+		t.Fatalf("FlushWithOptions(MemTable): %v", err)
+	}
+
+	adminBuilder := slatedb.NewAdminBuilder(dbPath, store)
+	defer adminBuilder.Destroy()
+	admin, err := adminBuilder.Build()
+	if err != nil {
+		t.Fatalf("AdminBuilder.Build(): %v", err)
+	}
+	defer admin.Destroy()
+
+	// Build the drain from the segment's current L0s and sorted runs.
+	view, err := admin.ReadCompactorStateView()
+	if err != nil {
+		t.Fatalf("ReadCompactorStateView(): %v", err)
+	}
+	sources := collectSegmentSources(view.Manifest.Segments, []byte("aaa"))
+	if len(sources) == 0 {
+		t.Fatal("segment aaa: got 0 sources before drain")
+	}
+	if _, err := admin.SubmitCompaction(slatedb.CompactionSpecDrainSegment{
+		Segment: []byte("aaa"),
+		Sources: sources,
+	}); err != nil {
+		t.Fatalf("SubmitCompaction(drain aaa): %v", err)
+	}
+
+	// The embedded compactor picks up the drain and retires "aaa". Poll the
+	// manifest until it is drained, and confirm "bbb" is left intact.
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		view, err := admin.ReadCompactorStateView()
+		if err != nil {
+			t.Fatalf("ReadCompactorStateView(): %v", err)
+		}
+		if segmentDrained(view.Manifest.Segments, []byte("aaa")) {
+			if len(collectSegmentSources(view.Manifest.Segments, []byte("bbb"))) == 0 {
+				t.Fatal("segment bbb was retired by a drain targeting aaa")
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for segment aaa to drain")
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/bindings/uniffi/src/admin.rs
+++ b/bindings/uniffi/src/admin.rs
@@ -3,7 +3,7 @@ use crate::config::{CheckpointOptions, GarbageCollectorOptions};
 use crate::error::{Error, SlateDbError};
 use crate::types::{
     try_checkpoint_id_from_str, Checkpoint, CheckpointCreateResult, CloneSourceSpec, Compaction,
-    CompactorStateView, VersionedCompactions, VersionedManifest,
+    CompactionSpec, CompactorStateView, VersionedCompactions, VersionedManifest,
 };
 use chrono::{DateTime, Utc};
 use std::ops::Bound;
@@ -74,6 +74,16 @@ impl Admin {
     pub async fn read_compactor_state_view(&self) -> Result<CompactorStateView, Error> {
         let view = self.inner.read_compactor_state_view().await?;
         Ok((&view).into())
+    }
+
+    /// Generate a compaction from a spec and submit it.
+    ///
+    /// ## Returns
+    /// - `Ok(Compaction)`: The submitted compaction.
+    /// - `Err`: If there was an error during submission or reading the submitted compaction.
+    pub async fn submit_compaction(&self, spec: CompactionSpec) -> Result<Compaction, Error> {
+        let compaction = self.inner.submit_compaction((&spec).try_into()?).await?;
+        Ok(Compaction::from(&compaction))
     }
 
     /// Lists compactions files inside the half-open ID range `[from, to)`.

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -48,7 +48,7 @@ pub use settings::Settings;
 pub use types::{
     CacheTarget, Checkpoint, CloneSourceSpec, Compaction, CompactionSpec, CompactionStatus,
     CompactorStateView, CompressionCodec, DbStatus, ExternalDb, FilterFormat,
-    IdentifiedObjectMetadata, KeyRange, KeyValue, ObjectMetadata, RowEntry, RowEntryKind,
+    IdentifiedObjectMetadata, KeyRange, KeyValue, ObjectMetadata, RowEntry, RowEntryKind, Segment,
     SegmentPrefix, SortedRun, SourceId, SsTableHandle, SsTableId, SsTableInfo, SsTableView,
     SstType, VersionedCompactions, VersionedManifest, WriteHandle,
 };

--- a/bindings/uniffi/src/types.rs
+++ b/bindings/uniffi/src/types.rs
@@ -8,9 +8,9 @@ use slatedb::compactor::{
 };
 use slatedb::config::CompressionCodec as CoreCompressionCodec;
 use slatedb::manifest::{
-    ExternalDb as CoreExternalDb, SortedRun as CoreSortedRun, SsTableHandle as CoreSsTableHandle,
-    SsTableId as CoreSsTableId, SsTableInfo as CoreSsTableInfo, SsTableView as CoreSsTableView,
-    VersionedManifest as CoreVersionedManifest,
+    ExternalDb as CoreExternalDb, Segment as CoreSegment, SortedRun as CoreSortedRun,
+    SsTableHandle as CoreSsTableHandle, SsTableId as CoreSsTableId, SsTableInfo as CoreSsTableInfo,
+    SsTableView as CoreSsTableView, VersionedManifest as CoreVersionedManifest,
 };
 use slatedb::CacheTarget as CoreCacheTarget;
 use slatedb::ValueDeletable;
@@ -276,10 +276,12 @@ pub struct VersionedManifest {
     pub last_compacted_l0_sst_view_id: Option<String>,
     /// Last compacted L0 SST ID, if any.
     pub last_compacted_l0_sst_id: Option<String>,
-    /// Current L0 SST views.
+    /// Current L0 SST views (root `prefix=""` tree).
     pub l0: Vec<SsTableView>,
-    /// Current compacted sorted runs.
+    /// Current compacted sorted runs (root `prefix=""` tree).
     pub compacted: Vec<SortedRun>,
+    /// Per-segment LSM state for named (non-empty-prefix) segments.
+    pub segments: Vec<Segment>,
     /// Next WAL SST ID to assign.
     pub next_wal_sst_id: u64,
     /// WAL replay watermark.
@@ -310,6 +312,7 @@ impl From<&CoreVersionedManifest> for VersionedManifest {
             last_compacted_l0_sst_id: value.last_compacted_l0_sst_id().map(|id| id.to_string()),
             l0: value.l0().iter().map(SsTableView::from).collect(),
             compacted: value.compacted().iter().map(SortedRun::from).collect(),
+            segments: value.segments().iter().map(Segment::from).collect(),
             next_wal_sst_id: value.next_wal_sst_id(),
             replay_after_wal_id: value.replay_after_wal_id(),
             last_l0_clock_tick: value.last_l0_clock_tick(),
@@ -317,6 +320,33 @@ impl From<&CoreVersionedManifest> for VersionedManifest {
             recent_snapshot_min_seq: value.recent_snapshot_min_seq(),
             checkpoints: value.checkpoints().iter().map(Checkpoint::from).collect(),
             wal_object_store_uri: value.wal_object_store_uri().map(str::to_owned),
+        }
+    }
+}
+
+/// Per-segment LSM state (RFC-0024). Each named segment carries its own L0
+/// SSTs and sorted runs, compacted and retired independently of the root tree.
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]
+pub struct Segment {
+    /// Segment prefix.
+    pub prefix: Vec<u8>,
+    /// Last compacted L0 SST view ID for this segment, if any.
+    pub last_compacted_l0_sst_view_id: Option<String>,
+    /// Current L0 SST views in this segment.
+    pub l0: Vec<SsTableView>,
+    /// Current compacted sorted runs in this segment.
+    pub compacted: Vec<SortedRun>,
+}
+
+impl From<&CoreSegment> for Segment {
+    fn from(value: &CoreSegment) -> Self {
+        Self {
+            prefix: value.prefix().to_vec(),
+            last_compacted_l0_sst_view_id: value
+                .last_compacted_l0_sst_view_id()
+                .map(|id| id.to_string()),
+            l0: value.l0().iter().map(SsTableView::from).collect(),
+            compacted: value.compacted().iter().map(SortedRun::from).collect(),
         }
     }
 }
@@ -435,29 +465,80 @@ impl From<&CoreSourceId> for SourceId {
     }
 }
 
-/// Immutable compaction specification.
-#[derive(Clone, Debug, PartialEq, Eq, uniffi::Record)]
-pub struct CompactionSpec {
-    /// Ordered compaction sources.
-    pub sources: Vec<SourceId>,
-    /// Destination sorted run ID. `None` for drain-segment specs, which
-    /// produce no new sorted run.
-    pub destination: Option<u32>,
-    /// Whether any input source is an L0 SST view.
-    pub has_l0_sources: bool,
-    /// Whether any input source is a sorted run.
-    pub has_sr_sources: bool,
+impl TryFrom<&SourceId> for CoreSourceId {
+    type Error = Error;
+
+    fn try_from(value: &SourceId) -> Result<Self, Self::Error> {
+        Ok(match value {
+            SourceId::SortedRun(id) => CoreSourceId::SortedRun(*id),
+            SourceId::SstView(id) => CoreSourceId::SstView(
+                Ulid::from_string(id)
+                    .map_err(|source| SlateDbError::InvalidSsTableId { source })?,
+            ),
+        })
+    }
+}
+
+/// Immutable compaction specification. Mirrors the core `CompactionSpec`:
+/// either a tiered merge into a destination sorted run, or a segment drain.
+#[derive(Clone, Debug, PartialEq, Eq, uniffi::Enum)]
+pub enum CompactionSpec {
+    /// Tiered merge: read `sources` and write a single output sorted run with
+    /// id `destination`. An empty `segment` targets the root (`prefix=""`) tree.
+    Tiered {
+        segment: Vec<u8>,
+        sources: Vec<SourceId>,
+        destination: u32,
+    },
+    /// Segment drain (retention): retire `segment` by detaching the listed
+    /// `sources` (its L0 SSTs and sorted runs). Produces no new sorted run.
+    DrainSegment {
+        segment: Vec<u8>,
+        sources: Vec<SourceId>,
+    },
 }
 
 impl From<&CoreCompactionSpec> for CompactionSpec {
     fn from(value: &CoreCompactionSpec) -> Self {
-        Self {
-            sources: value.sources().iter().map(SourceId::from).collect(),
-            destination: value.destination(),
-            has_l0_sources: value.has_l0_sources(),
-            has_sr_sources: value.has_sr_sources(),
+        let segment = value.segment().to_vec();
+        let sources = value.sources().iter().map(SourceId::from).collect();
+        match value.destination() {
+            Some(destination) => CompactionSpec::Tiered {
+                segment,
+                sources,
+                destination,
+            },
+            None => CompactionSpec::DrainSegment { segment, sources },
         }
     }
+}
+
+impl TryFrom<&CompactionSpec> for CoreCompactionSpec {
+    type Error = Error;
+
+    fn try_from(value: &CompactionSpec) -> Result<Self, Self::Error> {
+        match value {
+            CompactionSpec::Tiered {
+                segment,
+                sources,
+                destination,
+            } => Ok(CoreCompactionSpec::for_segment(
+                Bytes::from(segment.clone()),
+                try_convert_sources(sources)?,
+                *destination,
+            )),
+            CompactionSpec::DrainSegment { segment, sources } => {
+                Ok(CoreCompactionSpec::drain_segment(
+                    Bytes::from(segment.clone()),
+                    try_convert_sources(sources)?,
+                ))
+            }
+        }
+    }
+}
+
+fn try_convert_sources(sources: &[SourceId]) -> Result<Vec<CoreSourceId>, Error> {
+    sources.iter().map(CoreSourceId::try_from).collect()
 }
 
 /// Canonical compaction record.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -225,6 +225,10 @@ export default defineConfig({
 							link: '/docs/design/compaction/',
 						},
 						{
+							label: 'Segmented Compaction',
+							link: '/docs/design/segmented-compaction/',
+						},
+						{
 							label: 'Merge Operators',
 							link: '/docs/design/merge-operators/',
 						},

--- a/website/src/content/docs/docs/design/compaction.mdx
+++ b/website/src/content/docs/docs/design/compaction.mdx
@@ -28,3 +28,7 @@ The Executor does the actual work of compacting sorted runs by sort-merging them
 sorted run. It implements the [`CompactionExecutor`] trait. Currently, the only implementation
 is the [`TokioCompactionExecutor`](https://github.com/slatedb/slatedb/blob/main/slatedb/src/compactor_executor.rs),
 which runs compaction on a local tokio runtime.
+
+To split data with different read/write profiles into independent LSM trees — each with its own
+compaction policy — and to retire whole key ranges cheaply, see
+[Segmented Compaction](/docs/design/segmented-compaction).

--- a/website/src/content/docs/docs/design/segmented-compaction.mdx
+++ b/website/src/content/docs/docs/design/segmented-compaction.mdx
@@ -1,0 +1,303 @@
+---
+title: Segmented Compaction
+description: Split a dataset into independent LSM trees, each with its own compaction and retention policy
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+Segmented compaction splits a database into independent LSM trees keyed by a
+prefix.  Segments let each tree independenly configure compaction policy to
+match its access pattern needs, and let a whole segment be dropped cheaply
+once it ages out. All segments share a WAL and writes across segments can
+be done transactionally/atomically.
+
+A [`PrefixExtractor`](https://docs.rs/slatedb/latest/slatedb/trait.PrefixExtractor.html)
+derives a segment prefix from each key, and each segment becomes its own
+logical LSM tree. Because segments own disjoint key ranges, they are compacted
+and retired independently, and reads/scans automatically prune to the segments
+overlapping the query.
+
+Common fits:
+
+- **Timeseries / append-ordered data**: one segment per time bucket or log
+  segment; old segments
+  freeze and age out as a unit.
+- **Metadata/data separation**: isolate a churny, frequently-read metadata
+  keyspace from bulky, write-once data so each gets its own compaction and
+  caching policy.
+- **Column-family-like isolation**: give small, frequently-overwritten
+  structures an aggressive policy while slow-moving data uses a
+  low-write-amplification one.
+
+See [RFC 0024](/rfcs/0024-segment-oriented-compaction) for the full design.
+
+## Enabling segments
+
+Configure an extractor at creation with
+[`DbBuilder::with_segment_extractor`](https://docs.rs/slatedb/latest/slatedb/struct.DbBuilder.html#method.with_segment_extractor).
+The application encodes segment boundaries in the key (e.g. an hour bucket, a log segment id);
+the extractor returns the prefix length that identifies the segment. The example below routes
+every key to the segment named by its first three bytes.
+
+<Tabs syncKey="lang">
+  <TabItem label="Rust">
+    ```rust
+    use std::sync::Arc;
+    use slatedb::{Db, PrefixExtractor, PrefixTarget};
+
+    struct FixedThreeByteExtractor;
+
+    impl PrefixExtractor for FixedThreeByteExtractor {
+        fn name(&self) -> &str { "fixed_three_byte" }
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let (PrefixTarget::Point(key) | PrefixTarget::Prefix(key)) = target;
+            (key.len() >= 3).then_some(3)
+        }
+    }
+
+    let db = Db::builder(path, object_store)
+        .with_segment_extractor(Arc::new(FixedThreeByteExtractor))
+        .build()
+        .await?;
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    type fixedThreeByteExtractor struct{}
+
+    func (fixedThreeByteExtractor) Name() string { return "fixed_three_byte" }
+
+    func (fixedThreeByteExtractor) PrefixLen(target slatedb.PrefixTarget) *uint64 {
+        var key []byte
+        switch t := target.(type) {
+        case slatedb.PrefixTargetPoint:
+            key = t.Key
+        case slatedb.PrefixTargetPrefix:
+            key = t.Prefix
+        }
+        if len(key) < 3 {
+            return nil
+        }
+        n := uint64(3)
+        return &n
+    }
+
+    builder := slatedb.NewDbBuilder("example-db", store)
+    if err := builder.WithSegmentExtractor(fixedThreeByteExtractor{}); err != nil {
+        panic(err)
+    }
+    db, err := builder.Build()
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import io.slatedb.uniffi.PrefixExtractor;
+    import io.slatedb.uniffi.PrefixTarget;
+
+    class FixedThreeByteExtractor implements PrefixExtractor {
+        @Override
+        public String name() {
+            return "fixed_three_byte";
+        }
+
+        @Override
+        public Long prefixLen(PrefixTarget target) {
+            byte[] key =
+                    switch (target) {
+                        case PrefixTarget.Point point -> point.key();
+                        case PrefixTarget.Prefix prefix -> prefix.prefix();
+                    };
+            return key.length < 3 ? null : 3L;
+        }
+    }
+
+    DbBuilder builder = new DbBuilder("demo-db", store);
+    builder.withSegmentExtractor(new FixedThreeByteExtractor());
+    Db db = builder.build().get();
+    ```
+  </TabItem>
+  <TabItem label="Node.js">
+    ```js
+    import { DbBuilder } from "@slatedb/uniffi";
+
+    class FixedThreeByteExtractor {
+      name() {
+        return "fixed_three_byte";
+      }
+
+      prefix_len(target) {
+        const key = target.tag === "Point" ? target.key : target.prefix;
+        return key.length < 3 ? undefined : 3;
+      }
+    }
+
+    const builder = new DbBuilder("demo-db", store);
+    builder.with_segment_extractor(new FixedThreeByteExtractor());
+    const db = await builder.build();
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from slatedb.uniffi import DbBuilder, PrefixExtractor, PrefixTarget
+
+
+    class FixedThreeByteExtractor(PrefixExtractor):
+        def name(self) -> str:
+            return "fixed_three_byte"
+
+        def prefix_len(self, target: PrefixTarget) -> int | None:
+            key = target.key if target.is_point() else target.prefix
+            return None if len(key) < 3 else 3
+
+
+    builder = DbBuilder("demo-db", store)
+    builder.with_segment_extractor(FixedThreeByteExtractor())
+    db = await builder.build()
+    ```
+  </TabItem>
+</Tabs>
+
+:::caution
+The extractor is fixed for the life of the database. Its `name()` is persisted
+in the manifest; opening with a different (or newly-added/removed) extractor
+fails. 
+:::
+
+List the segments that currently exist (in the manifest or in memtables) with
+[`DbStatus::list_segments()`](https://docs.rs/slatedb/latest/slatedb/struct.DbStatus.html#method.list_segments).
+
+## How it compacts
+
+Each segment is compacted on its own schedule. The default size-tiered
+[`CompactionScheduler`](/docs/design/compaction) applies per segment, and
+compactions in different segments are parallel-safe (disjoint keys, no
+cross-segment ordering). Embed a semantic hint in the prefix (e.g. a time
+bucket) and a custom scheduler can vary policy per segment.
+
+:::note
+Writing to N segments at once produces up to N× the L0 objects (smaller each);
+the WAL is shared, so it is unaffected. Most data models keep one active
+segment, so this rarely bites in practice.
+:::
+
+## Deleting Segments Wholesale
+
+The default scheduler never drops data; segment retention is the application's
+job. To retire a whole segment, schedule a `CompactionSpec::drain_segment`
+compaction. Unlike a merge, a drain reads and rewrites nothing. Instead it
+detaches the segment's L0s and sorted runs from the manifest, leaving a drain
+marker (`l0=[]`, `compacted=[]`) that the writer prunes, after which the
+garbage collector reclaims the files.
+
+A drain is a `CompactionSpec::drain_segment` submitted through
+[`Admin.submit_compaction`](https://docs.rs/slatedb/latest/slatedb/admin/struct.Admin.html), built
+from the segment's L0 SSTs and sorted runs read from `read_compactor_state_view`. Every binding
+mirrors this API:
+
+<Tabs syncKey="lang">
+  <TabItem label="Rust">
+    ```rust
+    use bytes::Bytes;
+    use slatedb::admin::Admin;
+    use slatedb::compactor::{CompactionSpec, SourceId};
+
+    let admin = Admin::builder(path, object_store).build();
+    let view = admin.read_compactor_state_view().await?;
+
+    let segment = Bytes::from_static(b"hour=10/");
+    if let Some(seg) = view.manifest().segment(&segment) {
+        // Drain every L0 SST and sorted run currently visible in the segment.
+        let sources: Vec<SourceId> = seg
+            .l0()
+            .iter()
+            .map(|v| SourceId::SstView(v.id))
+            .chain(seg.compacted().iter().map(|sr| SourceId::SortedRun(sr.id)))
+            .collect();
+        admin.submit_compaction(CompactionSpec::drain_segment(segment, sources)).await?;
+    }
+    ```
+  </TabItem>
+  <TabItem label="Go">
+    ```go
+    admin, err := slatedb.NewAdminBuilder("example-db", store).Build()
+    if err != nil {
+        panic(err)
+    }
+    view, err := admin.ReadCompactorStateView()
+    if err != nil {
+        panic(err)
+    }
+
+    var sources []slatedb.SourceId
+    for _, seg := range view.Manifest.Segments {
+        if !bytes.Equal(seg.Prefix, []byte("hour=10/")) {
+            continue
+        }
+        for _, v := range seg.L0 {
+            sources = append(sources, slatedb.SourceIdSstView{Field0: v.Id})
+        }
+        for _, r := range seg.Compacted {
+            sources = append(sources, slatedb.SourceIdSortedRun{Field0: r.Id})
+        }
+    }
+    _, err = admin.SubmitCompaction(slatedb.CompactionSpecDrainSegment{
+        Segment: []byte("hour=10/"),
+        Sources: sources,
+    })
+    ```
+  </TabItem>
+  <TabItem label="Java">
+    ```java
+    import io.slatedb.uniffi.*;
+    import java.util.ArrayList;
+    import java.util.Arrays;
+    import java.util.List;
+
+    Admin admin = new AdminBuilder("demo-db", store).build();
+    var view = admin.readCompactorStateView().get();
+
+    byte[] prefix = "hour=10/".getBytes();
+    List<SourceId> sources = new ArrayList<>();
+    for (Segment seg : view.manifest().segments()) {
+        if (!Arrays.equals(seg.prefix(), prefix)) continue;
+        seg.l0().forEach(v -> sources.add(new SourceId.SstView(v.id())));
+        seg.compacted().forEach(r -> sources.add(new SourceId.SortedRun(r.id())));
+    }
+    admin.submitCompaction(new CompactionSpec.DrainSegment(prefix, sources)).get();
+    ```
+  </TabItem>
+  <TabItem label="Node.js">
+    ```js
+    import { AdminBuilder, CompactionSpec, SourceId } from "@slatedb/uniffi";
+
+    const admin = new AdminBuilder("demo-db", store).build();
+    const view = await admin.read_compactor_state_view();
+
+    const prefix = Buffer.from("hour=10/");
+    const seg = view.manifest.segments.find((s) => prefix.equals(Buffer.from(s.prefix)));
+    const sources = [
+      ...seg.l0.map((v) => SourceId.SstView(v.id)),
+      ...seg.compacted.map((r) => SourceId.SortedRun(r.id)),
+    ];
+    await admin.submit_compaction(CompactionSpec.DrainSegment(seg.prefix, sources));
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    from slatedb.uniffi import AdminBuilder, CompactionSpec, SourceId
+
+    admin = AdminBuilder("demo-db", store).build()
+    view = await admin.read_compactor_state_view()
+
+    seg = next(s for s in view.manifest.segments if s.prefix == b"hour=10/")
+    sources = [SourceId.SST_VIEW(v.id) for v in seg.l0]
+    sources += [SourceId.SORTED_RUN(r.id) for r in seg.compacted]
+    await admin.submit_compaction(CompactionSpec.DRAIN_SEGMENT(segment=seg.prefix, sources=sources))
+    ```
+  </TabItem>
+</Tabs>
+
+To retire segments automatically (e.g. by a TTL), implement
+[`CompactionScheduler`](https://docs.rs/slatedb/latest/slatedb/compactor/trait.CompactionScheduler.html)
+and return `drain_segment` specs from `propose`, wired in with
+`CompactorBuilder::with_scheduler_supplier`.

--- a/website/src/content/docs/docs/design/segmented-compaction.mdx
+++ b/website/src/content/docs/docs/design/segmented-compaction.mdx
@@ -6,7 +6,7 @@ description: Split a dataset into independent LSM trees, each with its own compa
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Segmented compaction splits a database into independent LSM trees keyed by a
-prefix.  Segments let each tree independenly configure compaction policy to
+prefix.  Segments let each tree independently configure compaction policy to
 match its access pattern needs, and let a whole segment be dropped cheaply
 once it ages out. All segments share a WAL and writes across segments can
 be done transactionally/atomically.


### PR DESCRIPTION
## Summary

1. added docs about segmented compaction
2. added uniffi bindings for `submit_compaction`
3. added uniffi binding to create `CompactionSpec`

## Changes

See above, only interesting thing is that i had to expose a bit more stuff to make constructing a `DrainCompactionSpec` possible to construct

## Notes for Reviewers



## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
