### PR TITLE
Add GCS support to CLI

### DIFF
--- a/slatedb-cli/Cargo.toml
+++ b/slatedb-cli/Cargo.toml
@@ -14,7 +14,15 @@ clap = { workspace = true, features = ["derive"] }
 humantime = { workspace = true }
 object_store = { workspace = true }
 serde_json = { workspace = true }
-slatedb = { workspace = true }
+slatedb = { workspace = true, features = [
+    "aws",
+    "azure",
+    "gcp",
+    "snappy",
+    "zlib",
+    "lz4",
+    "zstd",
+] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tokio-util = { workspace = true, default-features = false, features = ["rt"] }
 tracing = { workspace = true, features = ["log"] }

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -733,6 +733,7 @@ fn get_env_variable(name: &str) -> Result<String, SlateDBError> {
 /// | Memory | `memory` | [load_memory] |
 /// | AWS | `aws` | [load_aws] |
 /// | Azure | `azure` | [load_azure] |
+/// | GCP | `gcp` | [load_gcp] |
 pub fn load_object_store_from_env(
     env_file: Option<String>,
 ) -> Result<Arc<dyn ObjectStore>, crate::Error> {
@@ -745,6 +746,8 @@ pub fn load_object_store_from_env(
         "aws" => load_aws(),
         #[cfg(feature = "azure")]
         "azure" => load_azure(),
+        #[cfg(feature = "gcp")]
+        "gcp" => load_gcp(),
         invalid_value => Err(SlateDBError::InvalidEnvironmentVariable {
             key: "CLOUD_PROVIDER".to_string(),
             value: Some(invalid_value.to_string()),
@@ -801,6 +804,21 @@ pub fn load_azure() -> Result<Arc<dyn ObjectStore>, crate::Error> {
     Ok(Arc::new(builder.build().map_err(|error| {
         SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
             store: "MicrosoftAzure",
+            source: Box::new(error),
+        }))
+    })?) as Arc<dyn ObjectStore>)
+}
+
+/// Loads a Google Cloud Storage object store instance. The environment variables
+/// consumed are the same as those supported by [`GoogleCloudStorageBuilder::from_env`].
+/// Refer to the builder documentation for the full list and meaning of supported variables:
+/// <https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html#method.with_config>
+#[cfg(feature = "gcp")]
+pub fn load_gcp() -> Result<Arc<dyn ObjectStore>, crate::Error> {
+    let builder = object_store::gcp::GoogleCloudStorageBuilder::from_env();
+    Ok(Arc::new(builder.build().map_err(|error| {
+        SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
+            store: "GoogleCloudStorage",
             source: Box::new(error),
         }))
     })?) as Arc<dyn ObjectStore>)


### PR DESCRIPTION
## Summary

Addresses #1892's issue:

> The CLI isn't a practical escape hatch for us: there are no prebuilt binaries, and load_object_store_from_env has no GCS provider (local|memory|aws|azure only), so running slatedb-cli run-garbage-collection against GCS requires patching and distributing a custom binary. (The bindings' ObjectStore.resolve("gs://…") path works fine — it goes through object_store::parse_url_opts.)

## Changes

- Add proper features to `slatedb-cli` for compression and object stores
- Adds a `load_gcp` to `admin.rs`
