### PR TITLE
Resolve external SSTs in DbReader so zero-copy clones are readable

### DIFF
--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -491,6 +491,7 @@ mod tests {
     };
     use crate::db::builder::CloneSourceSpec;
     use crate::db::Db;
+    use crate::db_reader::DbReader;
     use crate::db_state::SsTableId;
     use crate::error::SlateDBError;
     use crate::iter::IterationOrder;
@@ -511,6 +512,7 @@ mod tests {
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::DbRand;
     use slatedb_common::SystemClock;
+    use slatedb_txn_obj::TransactionalObject;
     use std::collections::BTreeMap;
     use std::ops::Bound;
     use std::ops::RangeBounds;
@@ -584,6 +586,150 @@ mod tests {
         test_utils::assert_ranged_db_scan(&table, .., IterationOrder::Ascending, &mut db_iter)
             .await;
         clone_db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_read_clone_with_db_reader() {
+        let mut rng = rng::new_test_rng(None);
+        let table = sample::table(&mut rng, 5000, 10);
+
+        let object_store = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_parent");
+        let clone_path = Path::from("/tmp/test_clone");
+
+        let parent_db = Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap();
+        test_utils::seed_database(&parent_db, &table, false)
+            .await
+            .unwrap();
+        parent_db.flush().await.unwrap();
+        // Flush the memtable so the parent's data lives in L0 SSTs, which the
+        // clone references as external SSTs instead of replaying WALs.
+        parent_db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+        parent_db.close().await.unwrap();
+
+        create_clone(
+            clone_path.clone(),
+            parent_path.clone(),
+            object_store.clone(),
+            object_store.clone(),
+            None,
+            Arc::new(FailPointRegistry::new()),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+        )
+        .await
+        .unwrap();
+
+        // Sanity check that reads must resolve parent-resident SSTs.
+        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_manifest = clone_manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest;
+        assert!(!clone_manifest.external_ssts().is_empty());
+
+        let reader = DbReader::builder(clone_path.clone(), object_store.clone())
+            .build()
+            .await
+            .unwrap();
+        let mut db_iter = reader.scan(..).await.unwrap();
+        test_utils::assert_ranged_db_scan(&table, .., IterationOrder::Ascending, &mut db_iter)
+            .await;
+        reader.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_read_clone_with_db_reader_from_checkpoint_with_pruned_external_ssts() {
+        let mut rng = rng::new_test_rng(None);
+        let table = sample::table(&mut rng, 5000, 10);
+
+        let object_store = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_parent");
+        let clone_path = Path::from("/tmp/test_clone");
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+        let rand = Arc::new(DbRand::default());
+
+        let parent_db = Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap();
+        test_utils::seed_database(&parent_db, &table, false)
+            .await
+            .unwrap();
+        parent_db.flush().await.unwrap();
+        parent_db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+        parent_db.close().await.unwrap();
+
+        create_clone(
+            clone_path.clone(),
+            parent_path.clone(),
+            object_store.clone(),
+            object_store.clone(),
+            None,
+            Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
+            rand.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Pin a checkpoint to the clone's current manifest, which references
+        // the parent's SSTs externally.
+        let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let mut clone_sm = StoredManifest::load(clone_manifest_store.clone(), system_clock.clone())
+            .await
+            .unwrap();
+        let checkpoint_id = rand.rng().gen_uuid();
+        clone_sm
+            .write_checkpoint(checkpoint_id, &CheckpointOptions::default())
+            .await
+            .unwrap();
+
+        // Simulate a post-checkpoint compaction that re-localized all external
+        // SSTs and pruned their ids from the latest manifest. The checkpoint's
+        // manifest still references them.
+        clone_sm
+            .maybe_apply_update(|sr| {
+                let mut dirty = sr.prepare_dirty()?;
+                dirty
+                    .value
+                    .external_dbs
+                    .iter_mut()
+                    .for_each(|external_db| external_db.sst_ids.clear());
+                Ok(Some(dirty))
+            })
+            .await
+            .unwrap();
+        let latest_manifest = clone_manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest;
+        assert!(latest_manifest.external_ssts().is_empty());
+
+        // A reader pinned to the checkpoint must resolve the external SSTs
+        // referenced by the checkpoint's manifest.
+        let reader = DbReader::builder(clone_path.clone(), object_store.clone())
+            .with_checkpoint_id(checkpoint_id)
+            .build()
+            .await
+            .unwrap();
+        let mut db_iter = reader.scan(..).await.unwrap();
+        test_utils::assert_ranged_db_scan(&table, .., IterationOrder::Ascending, &mut db_iter)
+            .await;
+        reader.close().await.unwrap();
     }
 
     #[tokio::test]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1750,17 +1750,14 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
         // the latest manifest), and the latest manifest otherwise.
         let external_ssts = match (&latest_manifest, self.checkpoint_id) {
             (Some(latest_stored_manifest), Some(checkpoint_id)) => {
-                match latest_stored_manifest
+                let checkpoint = latest_stored_manifest
                     .db_state()
                     .find_checkpoint(checkpoint_id)
-                {
-                    Some(checkpoint) => manifest_store
-                        .read_manifest(checkpoint.manifest_id)
-                        .await?
-                        .external_ssts(),
-                    // A missing checkpoint is diagnosed in open_internal.
-                    None => HashMap::new(),
-                }
+                    .ok_or(SlateDBError::CheckpointMissing(checkpoint_id))?;
+                manifest_store
+                    .read_manifest(checkpoint.manifest_id)
+                    .await?
+                    .external_ssts()
             }
             (Some(latest_stored_manifest), None) => {
                 latest_stored_manifest.manifest().external_ssts()

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -1744,6 +1744,30 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
                 .validate_wal_object_store_uri(wal_object_store_uri.as_deref())?;
         }
 
+        // Resolve external SSTs against the manifest the reader will actually
+        // read from: the pinned checkpoint's manifest when a checkpoint id is
+        // given (compaction may have pruned re-localized external SSTs from
+        // the latest manifest), and the latest manifest otherwise.
+        let external_ssts = match (&latest_manifest, self.checkpoint_id) {
+            (Some(latest_stored_manifest), Some(checkpoint_id)) => {
+                match latest_stored_manifest
+                    .db_state()
+                    .find_checkpoint(checkpoint_id)
+                {
+                    Some(checkpoint) => manifest_store
+                        .read_manifest(checkpoint.manifest_id)
+                        .await?
+                        .external_ssts(),
+                    // A missing checkpoint is diagnosed in open_internal.
+                    None => HashMap::new(),
+                }
+            }
+            (Some(latest_stored_manifest), None) => {
+                latest_stored_manifest.manifest().external_ssts()
+            }
+            (None, _) => HashMap::new(),
+        };
+
         let wrapped_cache = self.db_cache.as_ref().map(|c| {
             Arc::new(DbCacheWrapper::new(
                 c.clone(),
@@ -1757,10 +1781,12 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             block_transformer: self.block_transformer,
             ..SsTableFormat::default()
         };
-        let table_store = Arc::new(TableStore::new(
+        let path_resolver = PathResolver::new_with_external_ssts(path.clone(), external_ssts);
+        let table_store = Arc::new(TableStore::new_with_fp_registry(
             ObjectStores::new(object_store, retrying_wal_object_store),
             sst_format,
-            path.clone(),
+            path_resolver,
+            Arc::new(FailPointRegistry::new()),
             wrapped_cache,
             TableStoreKind::Reader,
         ));


### PR DESCRIPTION
This PR is 100% AI-generated (Claude Code, model: Fable 5). I've reviewed the diff and understand the approach; deep SlateDB-internals feedback is beyond me, so extra scrutiny is welcome.

Fixes slatedb/slatedb#1902

Supersedes #1904, which was auto-closed when its stacked base branch was deleted after #1905 merged. This is the same commit rebased onto `main`, plus one change addressing @criccomini's review comment there (see "Changes" below).

## Summary

`DbReader` cannot read parent-resident data in a zero-copy clone. The clone's manifest references the parent's SSTs via `external_dbs`, and the writer path resolves them correctly — `Db`'s builder threads `manifest.external_ssts()` into its `TableStore`'s `PathResolver`. `DbReader`, however, built its `TableStore` with a `PathResolver` rooted only at the clone's own path, so every parent-resident SST was looked up under the clone's root and came back `NotFound`. A freshly cloned DB was fully readable through `Db` but unreadable through `DbReader` until compaction happened to re-localize the referenced SSTs.

This PR threads the manifest's external SSTs into the `DbReader` path, mirroring what `Db`'s builder already does.

## Changes

- `DbReaderBuilder::build` builds the reader's `TableStore` with `PathResolver::new_with_external_ssts` instead of a plain clone-rooted resolver — the same pattern `DbBuilder` uses.
- The external SSTs are sourced from the manifest the reader will actually read from — *either/or*, per @criccomini's review on #1904 (the earlier revision unioned both):
  - **Checkpoint-pinned reader** (`with_checkpoint_id`): the checkpoint's manifest. Its external set can exceed latest's, because compaction may have since pruned re-localized SSTs from the latest manifest (`prune_external_sst_ids`).
  - **Non-pinned reader**: the latest manifest (which `build` already loads for WAL-URI validation).
- Regression tests in `slatedb/src/clone.rs`:
  - `should_read_clone_with_db_reader`: seeds a parent, flushes its memtable to L0, zero-copy clones it, asserts the clone manifest references external SSTs, then scans the clone through `DbReader`. Fails before the fix with `NotFound { path: "tmp/test_clone/compacted/<ulid>.sst" }` (the parent-resident SST resolved under the clone's root) and passes after.
  - `should_read_clone_with_db_reader_from_checkpoint_with_pruned_external_ssts`: additionally pins a checkpoint on the clone, simulates a post-checkpoint compaction pruning all external SST ids from the latest manifest, and scans through a checkpoint-pinned `DbReader`. Fails if external SSTs are sourced from the latest manifest only.

## Notes for Reviewers

- Why either/or is sufficient (verified against every production writer of `external_dbs`):
  - A checkpoint-pinned reader never spawns the manifest poller and skips WAL replay — its state is built exactly once from `read_manifest(checkpoint.manifest_id)`, so the checkpoint's manifest is the only source of SSTs it can ever touch.
  - A non-pinned reader captures the latest manifest's set at open. The poller only re-establishes checkpoints against *newer* manifests, and a DB's external-SST set is written once at clone creation and only ever shrinks afterwards (`prune_external_sst_ids` in the compactor, entry removal in detach-GC), so the open-time set is a superset of anything a later manifest can reference; stale extra entries are never consulted for SSTs the state no longer references.
- A missing checkpoint fails `build` immediately with `CheckpointMissing`, matching `DbReaderInner::get_or_create_checkpoint`. This also closes the window where a checkpoint created between the builder's manifest read and `open_internal`'s re-read would open a reader with an incomplete path resolver.
- `DbReader`'s disk-cache preloader (`preload_cache`) was already external-aware — this change makes the read path consistent with it.
- A standalone reproduction against the published 0.14.1 crate (Db reads 500/500 keys of a fresh clone, DbReader reads 0/500) is in the linked issue.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes (none — internal-only change)
- [x] Considered performance impact; added notes or benchmarks if relevant (for checkpoint readers, one extra manifest read at reader open; no per-read cost)
