### PR TITLE
[1908] Wire RetryingObjectStore into Admin and Clone paths

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -14,6 +14,7 @@ use crate::manifest::VersionedManifest;
 use slatedb_common::clock::SystemClock;
 
 use crate::object_stores::{ObjectStoreType, ObjectStores};
+use crate::retrying_object_store::RetryingObjectStore;
 use crate::seq_tracker::FindOption;
 use crate::utils::IdGenerator;
 use bytes::Bytes;
@@ -68,10 +69,7 @@ impl Admin {
         &self,
         maybe_id: Option<u64>,
     ) -> Result<Option<VersionedManifest>, crate::Error> {
-        let manifest_store = ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        );
+        let manifest_store = self.manifest_store();
         let manifest = if let Some(id) = maybe_id {
             manifest_store
                 .try_read_manifest(id)
@@ -96,10 +94,7 @@ impl Admin {
         &self,
         range: R,
     ) -> Result<Vec<VersionedManifest>, crate::Error> {
-        let manifest_store = ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        );
+        let manifest_store = self.manifest_store();
         let manifest_metadata = manifest_store
             .list_manifests(range)
             .await
@@ -183,10 +178,7 @@ impl Admin {
 
     /// Returns a read-only view of the current compactor state.
     pub async fn read_compactor_state_view(&self) -> Result<CompactorStateView, crate::Error> {
-        let manifest_store = Arc::new(ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        ));
+        let manifest_store = Arc::new(self.manifest_store());
         let compactions_store = Arc::new(self.compactions_store());
         let reader = CompactorStateReader::new(&manifest_store, &compactions_store);
         reader.read_view().await.map_err(crate::Error::from)
@@ -249,10 +241,7 @@ impl Admin {
         &self,
         name_filter: Option<&str>,
     ) -> Result<Vec<Checkpoint>, crate::Error> {
-        let manifest_store = ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        );
+        let manifest_store = self.manifest_store();
         let manifest = manifest_store
             .read_latest_manifest()
             .await
@@ -495,10 +484,7 @@ impl Admin {
         &self,
         options: &CheckpointOptions,
     ) -> Result<CheckpointCreateResult, crate::Error> {
-        let manifest_store = Arc::new(ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        ));
+        let manifest_store = Arc::new(self.manifest_store());
         let mut stored_manifest =
             StoredManifest::load(manifest_store, self.system_clock.clone()).await?;
 
@@ -526,10 +512,7 @@ impl Admin {
         id: Uuid,
         lifetime: Option<Duration>,
     ) -> Result<(), crate::Error> {
-        let manifest_store = Arc::new(ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        ));
+        let manifest_store = Arc::new(self.manifest_store());
         let mut stored_manifest =
             StoredManifest::load(manifest_store, self.system_clock.clone()).await?;
         stored_manifest
@@ -553,10 +536,7 @@ impl Admin {
 
     /// Deletes the checkpoint with the specified id.
     pub async fn delete_checkpoint(&self, id: Uuid) -> Result<(), crate::Error> {
-        let manifest_store = Arc::new(ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        ));
+        let manifest_store = Arc::new(self.manifest_store());
         let mut stored_manifest =
             StoredManifest::load(manifest_store, self.system_clock.clone()).await?;
         stored_manifest
@@ -621,18 +601,26 @@ impl Admin {
         Ok(manifest.core().sequence_tracker.find_seq(ts, opt))
     }
 
+    /// Wraps the configured object store of the given type in a
+    /// [`RetryingObjectStore`] so that admin operations retry transient object
+    /// store failures with exponential backoff. Retrying is safe here because
+    /// `RetryingObjectStore` verifies conditional puts via a ULID written to
+    /// object metadata, so an ambiguous failure after a successful write is
+    /// detected rather than surfaced as a spurious error.
+    fn retrying_store(&self, store_type: ObjectStoreType) -> Arc<dyn ObjectStore> {
+        Arc::new(RetryingObjectStore::new(
+            self.object_stores.store_of(store_type).clone(),
+            self.rand.clone(),
+            self.system_clock.clone(),
+        ))
+    }
+
     fn manifest_store(&self) -> ManifestStore {
-        ManifestStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        )
+        ManifestStore::new(&self.path, self.retrying_store(ObjectStoreType::Main))
     }
 
     fn compactions_store(&self) -> CompactionsStore {
-        CompactionsStore::new(
-            &self.path,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
-        )
+        CompactionsStore::new(&self.path, self.retrying_store(ObjectStoreType::Main))
     }
 
     /// Clone a database using a builder pattern. If no db already exists at the specified path,
@@ -677,9 +665,9 @@ impl Admin {
         CloneBuilder::new(
             self.path.clone(),
             source,
-            self.object_stores.store_of(ObjectStoreType::Main).clone(),
+            self.retrying_store(ObjectStoreType::Main),
         )
-        .with_wal_object_store(self.object_stores.store_of(ObjectStoreType::Wal).clone())
+        .with_wal_object_store(self.retrying_store(ObjectStoreType::Wal))
     }
 
     /// Creates a new builder for an admin client at the given path.
@@ -829,7 +817,9 @@ mod tests {
     use crate::admin::{load_object_store_from_env, AdminBuilder};
     use crate::compactions_store::{CompactionsStore, StoredCompactions};
     use crate::compactor_state::{Compaction, CompactionSpec, CompactionStatus, SourceId};
-    use crate::config::{CompactionWorkerOptions, CompactorOptions, GarbageCollectorOptions};
+    use crate::config::{
+        CheckpointOptions, CompactionWorkerOptions, CompactorOptions, GarbageCollectorOptions,
+    };
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
     use crate::test_utils::{FlakyObjectStore, StringConcatMergeOperator};
@@ -1075,19 +1065,70 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_admin_list_manifests_list_failure_maps_to_unavailable() {
+    async fn test_admin_list_manifests_retries_transient_failure() {
+        // Admin operations wrap the object store in a RetryingObjectStore, so a
+        // transient list failure should be retried rather than surfaced.
         let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let object_store: Arc<dyn ObjectStore> =
-            Arc::new(FlakyObjectStore::new(inner, 0).with_list_failures(1, 0));
-        let path = Path::from("/tmp/test_admin_list_manifests_list_failure");
-        let admin = AdminBuilder::new(path, object_store).build();
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_list_failures(1, 0));
+        let path = Path::from("/tmp/test_admin_list_manifests_retries_transient_failure");
+        let admin = AdminBuilder::new(path, flaky.clone()).build();
 
-        let err = admin
+        let manifests = admin
             .list_manifests(..)
             .await
-            .expect_err("expected list failure");
+            .expect("list should succeed after retrying the transient failure");
+
+        assert!(manifests.is_empty());
+        // 1 transient failure + 1 successful retry.
+        assert_eq!(flaky.list_attempts(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_admin_create_detached_checkpoint_retries_transient_put() {
+        // A transient put failure during checkpoint creation should be retried
+        // by the RetryingObjectStore rather than failing the operation.
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_admin_create_detached_checkpoint_retries_transient_put");
+        let db = crate::Db::open(path.clone(), inner.clone()).await.unwrap();
+        db.put(b"key", b"value").await.unwrap();
+        db.close().await.unwrap();
+
+        // Fail the first put_opts, which the retrying store should transparently retry.
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 1));
+        let admin = AdminBuilder::new(path, flaky.clone()).build();
+
+        admin
+            .create_detached_checkpoint(&CheckpointOptions::default())
+            .await
+            .expect("checkpoint should succeed after retrying the transient put");
+
+        assert!(flaky.put_attempts() >= 2);
+    }
+
+    #[tokio::test]
+    async fn test_admin_terminal_object_store_error_maps_to_unavailable() {
+        // The retry layer retries transient errors forever, so it never exhausts
+        // and surfaces a transient failure. A terminal (non-retryable) error,
+        // however, must still pass through the retry wrapper and map to
+        // ErrorKind::Unavailable rather than being swallowed. A conditional put
+        // that always fails with Precondition is such a terminal error.
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_admin_terminal_object_store_error_maps_to_unavailable");
+        let db = crate::Db::open(path.clone(), inner.clone()).await.unwrap();
+        db.put(b"key", b"value").await.unwrap();
+        db.close().await.unwrap();
+
+        let failing = Arc::new(FlakyObjectStore::new(inner, 0).with_put_precondition_always());
+        let admin = AdminBuilder::new(path, failing.clone()).build();
+
+        let err = admin
+            .create_detached_checkpoint(&CheckpointOptions::default())
+            .await
+            .expect_err("expected terminal precondition failure to surface");
 
         assert_eq!(err.kind(), ErrorKind::Unavailable);
+        // Terminal error: attempted exactly once, no retries.
+        assert_eq!(failing.put_attempts(), 1);
     }
 
     #[tokio::test]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -846,7 +846,11 @@ impl<P: Into<Path>> AdminBuilder<P> {
 
     /// Builds and returns an Admin instance.
     pub fn build(self) -> Admin {
-        // No retrying object stores here, since we don't want to retry admin operations
+        // Store the raw object stores here. Admin wraps them in a
+        // `RetryingObjectStore` per-operation (see `Admin::retrying_store`)
+        // rather than at build time, because several admin operations delegate
+        // to sub-builders (compactor/GC) that add their own retry layer, and
+        // wrapping here would double-wrap them.
         Admin {
             path: self.path.into(),
             object_stores: ObjectStores::new(self.main_object_store, self.wal_object_store),


### PR DESCRIPTION
## Summary

What is being changed and why?

Fixes https://github.com/slatedb/slatedb/issues/1908

## Changes

Wire RetryingObjectStore into the Admin and Clone paths, always-on (not opt-in), so admin operations behave consistently with the other paths. RetryingObjectStore's ULID-in-metadata verification already makes conditional puts safe to retry after an ambiguous failure, so this is safe for the non-idempotent manifest writes too.

Scope: wrap the object stores used directly by the Admin methods (manifest/compactions stores) and by the clone builder. Leave the methods that delegate to the compactor/GC sub-builders alone, since those already add their own retry layer.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

- As a follow up I would like to wire metrics into the Admin path.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
