### PR TITLE
Allow users to disable boundary files in GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,6 +3358,7 @@ dependencies = [
  "object_store",
  "parking_lot",
  "slatedb-common",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -9457,6 +9457,9 @@ type GarbageCollectorOptions struct {
 	CompactionsOptions *GarbageCollectorDirectoryOptions
 	// Options for detaching clone references. `None` disables detach garbage collection.
 	DetachOptions *GarbageCollectorScheduleOptions
+	// Whether GC should delete eligible manifest/compactions metadata without advancing boundary
+	// files.
+	DisableBoundaryFiles bool
 }
 
 func (r *GarbageCollectorOptions) Destroy() {
@@ -9466,6 +9469,7 @@ func (r *GarbageCollectorOptions) Destroy() {
 	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactedOptions)
 	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactionsOptions)
 	FfiDestroyerOptionalGarbageCollectorScheduleOptions{}.Destroy(r.DetachOptions)
+	FfiDestroyerBool{}.Destroy(r.DisableBoundaryFiles)
 }
 
 type FfiConverterGarbageCollectorOptions struct{}
@@ -9484,6 +9488,7 @@ func (c FfiConverterGarbageCollectorOptions) Read(reader io.Reader) GarbageColle
 		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
 		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
 		FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Read(reader),
+		FfiConverterBoolINSTANCE.Read(reader),
 	}
 }
 
@@ -9502,6 +9507,7 @@ func (c FfiConverterGarbageCollectorOptions) Write(writer io.Writer, value Garba
 	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactedOptions)
 	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactionsOptions)
 	FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Write(writer, value.DetachOptions)
+	FfiConverterBoolINSTANCE.Write(writer, value.DisableBoundaryFiles)
 }
 
 type FfiDestroyerGarbageCollectorOptions struct{}

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -1925,12 +1925,13 @@ func TestAdminRunGcOnce(t *testing.T) {
 		DryRun:     true,
 	}
 	options := &slatedb.GarbageCollectorOptions{
-		ManifestOptions:    nil,
-		WalOptions:         directoryOptions,
-		WalFenceOptions:    directoryOptions,
-		CompactedOptions:   nil,
-		CompactionsOptions: nil,
-		DetachOptions:      &slatedb.GarbageCollectorScheduleOptions{IntervalMs: nil},
+		ManifestOptions:      nil,
+		WalOptions:           directoryOptions,
+		WalFenceOptions:      directoryOptions,
+		CompactedOptions:     nil,
+		CompactionsOptions:   nil,
+		DetachOptions:        &slatedb.GarbageCollectorScheduleOptions{IntervalMs: nil},
+		DisableBoundaryFiles: true,
 	}
 
 	if err := admin.RunGcOnce(options); err != nil {

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
@@ -183,7 +183,8 @@ class SlateDbAdminTest {
                             directoryOptions,
                             null,
                             null,
-                            scheduleOptions);
+                            scheduleOptions,
+                            true);
 
             TestSupport.await(admin.runGcOnce(options));
         }

--- a/bindings/node/tests/admin.test.mjs
+++ b/bindings/node/tests/admin.test.mjs
@@ -162,6 +162,7 @@ test("admin run_gc_once accepts default and custom options", async (t) => {
     compacted_options: undefined,
     compactions_options: undefined,
     detach_options: { interval_ms: undefined },
+    disable_boundary_files: true,
   });
 });
 

--- a/bindings/python/tests/test_admin.py
+++ b/bindings/python/tests/test_admin.py
@@ -144,6 +144,7 @@ async def test_admin_run_gc_once_accepts_default_and_custom_options() -> None:
             compacted_options=None,
             compactions_options=None,
             detach_options=schedule_options,
+            disable_boundary_files=True,
         )
 
         await admin.run_gc_once(options)

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -424,6 +424,10 @@ pub struct GarbageCollectorOptions {
     /// Options for detaching clone references. `None` disables detach garbage collection.
     #[uniffi(default = None)]
     pub detach_options: Option<GarbageCollectorScheduleOptions>,
+    /// Whether GC should delete eligible manifest/compactions metadata without advancing boundary
+    /// files.
+    #[uniffi(default = false)]
+    pub disable_boundary_files: bool,
 }
 
 impl Default for GarbageCollectorOptions {
@@ -436,6 +440,7 @@ impl Default for GarbageCollectorOptions {
             compacted_options: core.compacted_options.map(Into::into),
             compactions_options: core.compactions_options.map(Into::into),
             detach_options: core.detach_options.map(Into::into),
+            disable_boundary_files: !core.boundary_files_enabled,
         }
     }
 }
@@ -468,7 +473,32 @@ impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions 
             compactions_options: value.compactions_options.map(Into::into),
             detach_options: value.detach_options.map(Into::into),
             metric_level: None,
+            boundary_files_enabled: !value.disable_boundary_files,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GarbageCollectorOptions;
+
+    #[test]
+    fn boundary_files_are_enabled_by_default() {
+        let gc: slatedb::config::GarbageCollectorOptions =
+            GarbageCollectorOptions::default().into();
+
+        assert!(gc.boundary_files_enabled);
+    }
+
+    #[test]
+    fn boundary_files_can_be_disabled() {
+        let gc: slatedb::config::GarbageCollectorOptions = GarbageCollectorOptions {
+            disable_boundary_files: true,
+            ..GarbageCollectorOptions::default()
+        }
+        .into();
+
+        assert!(!gc.boundary_files_enabled);
     }
 }
 

--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -195,6 +195,10 @@ pub(crate) enum CliCommands {
         #[arg(short, long)]
         #[clap(value_parser = humantime::parse_duration)]
         min_age: Duration,
+
+        /// Delete eligible metadata without advancing boundary files.
+        #[arg(long, default_value_t = false)]
+        disable_boundary_files: bool,
     },
 
     /// Runs the compactor coordinator until interrupted (Ctrl-C).
@@ -311,6 +315,10 @@ pub(crate) enum CliCommands {
         /// the period is how often to attempt a GC
         #[arg(long, value_parser = parse_gc_schedule)]
         compactions: Option<GcSchedule>,
+
+        /// Delete eligible metadata without advancing boundary files.
+        #[arg(long, default_value_t = false)]
+        disable_boundary_files: bool,
     },
 }
 
@@ -454,9 +462,14 @@ mod tests {
         .unwrap();
 
         match args.command {
-            CliCommands::RunGarbageCollection { resource, min_age } => {
+            CliCommands::RunGarbageCollection {
+                resource,
+                min_age,
+                disable_boundary_files,
+            } => {
                 assert!(matches!(resource, GcResource::WalFence));
                 assert_eq!(min_age, Duration::from_secs(60));
+                assert!(!disable_boundary_files);
             }
             command => panic!("unexpected command: {command:?}"),
         }

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -67,9 +67,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         CliCommands::DeleteCheckpoint { id } => exec_delete_checkpoint(&admin, id).await?,
         CliCommands::ListCheckpoints { name } => exec_list_checkpoints(&admin, name).await?,
-        CliCommands::RunGarbageCollection { resource, min_age } => {
-            exec_gc_once(&admin, resource, min_age).await?
-        }
+        CliCommands::RunGarbageCollection {
+            resource,
+            min_age,
+            disable_boundary_files,
+        } => exec_gc_once(&admin, resource, min_age, !disable_boundary_files).await?,
         CliCommands::RunCompactor { no_embedded_worker } => {
             admin
                 .run_compactor_with_options(
@@ -112,6 +114,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             wal_fence,
             compacted,
             compactions,
+            disable_boundary_files,
         } => {
             schedule_gc(
                 &admin,
@@ -120,6 +123,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 wal_fence,
                 compacted,
                 compactions,
+                !disable_boundary_files,
                 cancellation_token.clone(),
             )
             .await?
@@ -290,6 +294,7 @@ async fn exec_gc_once(
     admin: &Admin,
     resource: GcResource,
     min_age: Duration,
+    boundary_files_enabled: bool,
 ) -> Result<(), Box<dyn Error>> {
     fn create_gc_dir_opts(min_age: Duration) -> Option<GarbageCollectorDirectoryOptions> {
         Some(GarbageCollectorDirectoryOptions {
@@ -307,6 +312,7 @@ async fn exec_gc_once(
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled,
         },
         GcResource::Wal => GarbageCollectorOptions {
             manifest_options: None,
@@ -316,6 +322,7 @@ async fn exec_gc_once(
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled,
         },
         GcResource::WalFence => GarbageCollectorOptions {
             manifest_options: None,
@@ -325,6 +332,7 @@ async fn exec_gc_once(
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled,
         },
         GcResource::Compacted => GarbageCollectorOptions {
             manifest_options: None,
@@ -334,6 +342,7 @@ async fn exec_gc_once(
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled,
         },
         GcResource::Compactions => GarbageCollectorOptions {
             manifest_options: None,
@@ -343,12 +352,14 @@ async fn exec_gc_once(
             compactions_options: create_gc_dir_opts(min_age),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled,
         },
     };
     admin.run_gc_once(gc_opts).await?;
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn schedule_gc(
     admin: &Admin,
     manifest_schedule: Option<GcSchedule>,
@@ -356,6 +367,7 @@ async fn schedule_gc(
     wal_fence_schedule: Option<GcSchedule>,
     compacted_schedule: Option<GcSchedule>,
     compactions_schedule: Option<GcSchedule>,
+    boundary_files_enabled: bool,
     cancellation_token: CancellationToken,
 ) -> Result<(), Box<dyn Error>> {
     fn create_gc_dir_opts(schedule: GcSchedule) -> Option<GarbageCollectorDirectoryOptions> {
@@ -373,6 +385,7 @@ async fn schedule_gc(
         compactions_options: compactions_schedule.and_then(create_gc_dir_opts),
         detach_options: None,
         metric_level: None,
+        boundary_files_enabled,
     };
 
     admin

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -157,6 +157,7 @@ pub fn build_settings_gc(rng: &mut impl Rng) -> GarbageCollectorOptions {
             interval: Some(rng.random_range(Duration::from_millis(1)..Duration::from_secs(600))),
         }),
         metric_level: None,
+        boundary_files_enabled: true,
     }
 }
 

--- a/slatedb-txn-obj/Cargo.toml
+++ b/slatedb-txn-obj/Cargo.toml
@@ -22,4 +22,5 @@ thiserror = { workspace = true }
 test-util = []
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -437,6 +437,7 @@ mod tests {
     use chrono::Utc;
     use futures::stream::{self, BoxStream};
     use futures::StreamExt;
+    use object_store::local::LocalFileSystem;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{
@@ -681,6 +682,45 @@ mod tests {
             ObjectStoreBoundaryObject::new(&Path::from("/root"), object_store, "manifest");
 
         boundary.check(MonotonicId::new(1)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_boundary_check_supports_local_filesystem_conditional_get() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let object_store: Arc<dyn ObjectStore> = Arc::new(
+            LocalFileSystem::new_with_prefix(tempdir.path()).expect("create local object store"),
+        );
+        let root = Path::from("root");
+        let boundary_path = root.clone().join("gc").join("manifest.boundary");
+        object_store
+            .put(&boundary_path, PutPayload::from("2"))
+            .await
+            .unwrap();
+        let boundary = ObjectStoreBoundaryObject::new(&root, object_store.clone(), "manifest");
+
+        // The first check reads and caches the boundary and its filesystem ETag.
+        boundary.check(MonotonicId::new(3)).await.unwrap();
+        assert!(boundary
+            .cache
+            .lock()
+            .as_ref()
+            .and_then(|(_, version)| version.e_tag.as_ref())
+            .is_some());
+
+        // The second check sends GET If-None-Match. LocalFileSystem returns NotModified,
+        // which the boundary implementation must handle by reusing its cache.
+        boundary.check(MonotonicId::new(3)).await.unwrap();
+
+        // Replace the file directly rather than calling BoundaryObject::advance, since
+        // LocalFileSystem does not support PutMode::Update. The stale ETag should cause
+        // the next check to read and enforce the new boundary.
+        object_store
+            .put(&boundary_path, PutPayload::from("4"))
+            .await
+            .unwrap();
+        let err = boundary.check(MonotonicId::new(3)).await.unwrap_err();
+        assert!(matches!(err, TransactionalObjectError::ObjectVersionExists));
+        boundary.check(MonotonicId::new(5)).await.unwrap();
     }
 
     #[tokio::test]

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -210,6 +210,10 @@ use crate::error::SlateDBError;
 
 use crate::garbage_collector::{DEFAULT_INTERVAL, DEFAULT_MIN_AGE};
 
+fn default_boundary_files_enabled() -> bool {
+    true
+}
+
 /// Enum representing different levels of cache preloading on startup
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
 pub enum PreloadLevel {
@@ -1431,6 +1435,13 @@ pub struct GarbageCollectorOptions {
     /// a garbage collector is owned by a [`Settings`] configured DB, unset means
     /// inherit [`Settings::metric_level`].
     pub metric_level: Option<MetricLevel>,
+
+    /// Whether manifest and compactions boundary files are advanced before deletion.
+    ///
+    /// When disabled, garbage collection still deletes eligible metadata but does not update the
+    /// durable boundary. Every garbage collector for the database must use the same policy.
+    #[serde(default = "default_boundary_files_enabled")]
+    pub boundary_files_enabled: bool,
 }
 
 impl GarbageCollectorOptions {
@@ -1531,6 +1542,7 @@ impl Default for GarbageCollectorOptions {
             compactions_options: Some(GarbageCollectorDirectoryOptions::default()),
             detach_options: Some(GarbageCollectorScheduleOptions::default()),
             metric_level: None,
+            boundary_files_enabled: true,
         }
     }
 }
@@ -1692,6 +1704,24 @@ mod tests {
     fn test_db_options_default_metric_level() {
         let options = Settings::default();
         assert_eq!(MetricLevel::default(), options.metric_level);
+    }
+
+    #[test]
+    fn test_gc_boundary_files_are_enabled_by_default_when_omitted() {
+        fn without_boundary_setting<T: Serialize>(value: T) -> serde_json::Value {
+            let mut value = serde_json::to_value(value).unwrap();
+            value
+                .as_object_mut()
+                .unwrap()
+                .remove("boundary_files_enabled");
+            value
+        }
+
+        let gc: GarbageCollectorOptions =
+            serde_json::from_value(without_boundary_setting(GarbageCollectorOptions::default()))
+                .unwrap();
+
+        assert!(gc.boundary_files_enabled);
     }
 
     #[test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -7794,6 +7794,7 @@ mod tests {
             }),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
 
         let gc = GarbageCollectorBuilder::new(path.clone(), object_store.clone())

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -309,6 +309,7 @@ mod tests {
                 compactions_options: None,
                 detach_options: None,
                 metric_level: None,
+                boundary_files_enabled: true,
             };
             let gc = GarbageCollector::new(
                 self.manifest_store.clone(),

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -278,6 +278,7 @@ impl GarbageCollector {
                 stats.clone(),
                 compactions_options,
                 gc_filter.clone(),
+                options.boundary_files_enabled,
             )
         });
         let manifest_gc_task = options.manifest_options.map(|manifest_options| {
@@ -286,6 +287,7 @@ impl GarbageCollector {
                 stats.clone(),
                 manifest_options,
                 gc_filter.clone(),
+                options.boundary_files_enabled,
             )
         });
         let detach_gc_task = options.detach_options.map(|detach_options| {
@@ -1167,6 +1169,7 @@ mod tests {
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let gc = GarbageCollector::new(
             manifest_store.clone(),
@@ -1233,6 +1236,7 @@ mod tests {
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let recorder = Arc::new(DefaultMetricsRecorder::new());
         let helper = MetricsRecorderHelper::new(recorder.clone(), Default::default());
@@ -1298,6 +1302,7 @@ mod tests {
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let gc = GarbageCollector::new(
             manifest_store.clone(),
@@ -1376,6 +1381,7 @@ mod tests {
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let gc = GarbageCollector::new(
             manifest_store.clone(),
@@ -1830,6 +1836,7 @@ mod tests {
             }),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
 
         let gc = GarbageCollector::new(
@@ -1905,6 +1912,7 @@ mod tests {
             }),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
 
         let mut gc = GarbageCollector::new(
@@ -1975,6 +1983,7 @@ mod tests {
             }),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
 
         let gc = GarbageCollector::new(
@@ -2024,6 +2033,7 @@ mod tests {
             }),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
 
         let mut gc = GarbageCollector::new(
@@ -2077,6 +2087,7 @@ mod tests {
             }),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
 
         let gc = GarbageCollector::new(
@@ -2407,6 +2418,7 @@ mod tests {
             compactions_options: Some(options),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let recorder = MetricsRecorderHelper::noop();
         let gc = GarbageCollector::new(
@@ -2505,6 +2517,7 @@ mod tests {
             compactions_options: None,
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let recorder = Arc::new(DefaultMetricsRecorder::new());
         let helper = MetricsRecorderHelper::new(recorder.clone(), Default::default());
@@ -2638,6 +2651,7 @@ mod tests {
             compactions_options: Some(dry_run_options),
             detach_options: None,
             metric_level: None,
+            boundary_files_enabled: true,
         };
         let recorder = MetricsRecorderHelper::noop();
         let gc = GarbageCollector::new(

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -36,12 +36,14 @@ pub(crate) struct CompactionsGcTask {
     stats: Arc<GcStats>,
     compactions_options: GarbageCollectorDirectoryOptions,
     gc_filter: Option<Arc<dyn GcFilter>>,
+    boundary_files_enabled: bool,
 }
 
 impl std::fmt::Debug for CompactionsGcTask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CompactionsGcTask")
             .field("compactions_options", &self.compactions_options)
+            .field("boundary_files_enabled", &self.boundary_files_enabled)
             .finish()
     }
 }
@@ -52,12 +54,14 @@ impl CompactionsGcTask {
         stats: Arc<GcStats>,
         compactions_options: GarbageCollectorDirectoryOptions,
         gc_filter: Option<Arc<dyn GcFilter>>,
+        boundary_files_enabled: bool,
     ) -> Self {
         Self {
             compactions_store,
             stats,
             compactions_options,
             gc_filter,
+            boundary_files_enabled,
         }
     }
 
@@ -87,12 +91,14 @@ impl GcTask for CompactionsGcTask {
 
         // Advance the boundary to the latest compactions file selected by the GC model. The
         // optional GC filter only gates the final deletion pass.
-        if let Some(boundary) = compactions_to_delete
-            .iter()
-            .map(|compactions_metadata| compactions_metadata.id)
-            .max()
-        {
-            self.compactions_store.advance_boundary(boundary).await?;
+        if self.boundary_files_enabled {
+            if let Some(boundary) = compactions_to_delete
+                .iter()
+                .map(|compactions_metadata| compactions_metadata.id)
+                .max()
+            {
+                self.compactions_store.advance_boundary(boundary).await?;
+            }
         }
         let compactions_to_delete =
             retain_allowed_by_gc_filter(&self.gc_filter, compactions_to_delete).await;
@@ -186,6 +192,7 @@ mod tests {
                 dry_run: false,
             },
             None,
+            true,
         );
         task.collect(Utc::now() + TimeDelta::hours(1))
             .await
@@ -200,6 +207,60 @@ mod tests {
             .unwrap();
         assert_eq!("2", std::str::from_utf8(&raw_boundary).unwrap());
 
+        let compactions = compactions_store.list_compactions(..).await.unwrap();
+        assert_eq!(
+            vec![3],
+            compactions
+                .iter()
+                .map(|compactions| compactions.id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_without_boundary_advancement_deletes_and_preserves_boundary() {
+        let object_store = Arc::new(InMemory::new());
+        let compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from("/root"),
+            object_store.clone(),
+        ));
+        let mut stored_compactions = StoredCompactions::create(compactions_store.clone(), 0)
+            .await
+            .unwrap();
+        stored_compactions
+            .update(stored_compactions.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        compactions_store.advance_boundary(1).await.unwrap();
+        stored_compactions
+            .update(stored_compactions.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+
+        let recorder = MetricsRecorderHelper::noop();
+        let task = CompactionsGcTask::new(
+            compactions_store.clone(),
+            Arc::new(GcStats::new(&recorder)),
+            GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(1),
+                interval: None,
+                dry_run: false,
+            },
+            None,
+            false,
+        );
+        task.collect(Utc::now() + TimeDelta::hours(1))
+            .await
+            .unwrap();
+
+        let raw_boundary = object_store
+            .get(&Path::from("/root/gc/compactions.boundary"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert_eq!("1", std::str::from_utf8(&raw_boundary).unwrap());
         let compactions = compactions_store.list_compactions(..).await.unwrap();
         assert_eq!(
             vec![3],
@@ -239,6 +300,7 @@ mod tests {
                 dry_run: false,
             },
             Some(Arc::new(DenyAllGcFilter) as Arc<dyn GcFilter>),
+            true,
         );
         task.collect(Utc::now() + TimeDelta::hours(1))
             .await

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -16,12 +16,14 @@ pub(crate) struct ManifestGcTask {
     stats: Arc<GcStats>,
     manifest_options: GarbageCollectorDirectoryOptions,
     gc_filter: Option<Arc<dyn GcFilter>>,
+    boundary_files_enabled: bool,
 }
 
 impl std::fmt::Debug for ManifestGcTask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ManifestGcTask")
             .field("manifest_options", &self.manifest_options)
+            .field("boundary_files_enabled", &self.boundary_files_enabled)
             .finish()
     }
 }
@@ -32,12 +34,14 @@ impl ManifestGcTask {
         stats: Arc<GcStats>,
         manifest_options: GarbageCollectorDirectoryOptions,
         gc_filter: Option<Arc<dyn GcFilter>>,
+        boundary_files_enabled: bool,
     ) -> Self {
         ManifestGcTask {
             manifest_store,
             stats,
             manifest_options,
             gc_filter,
+            boundary_files_enabled,
         }
     }
 
@@ -83,12 +87,14 @@ impl GcTask for ManifestGcTask {
 
         // Advance the boundary to the latest manifest selected by the GC model. The optional GC
         // filter only gates the final deletion pass.
-        if let Some(boundary) = manifests_to_delete
-            .iter()
-            .map(|manifest_metadata| manifest_metadata.id)
-            .max()
-        {
-            self.manifest_store.advance_boundary(boundary).await?;
+        if self.boundary_files_enabled {
+            if let Some(boundary) = manifests_to_delete
+                .iter()
+                .map(|manifest_metadata| manifest_metadata.id)
+                .max()
+            {
+                self.manifest_store.advance_boundary(boundary).await?;
+            }
         }
         let manifests_to_delete =
             retain_allowed_by_gc_filter(&self.gc_filter, manifests_to_delete).await;
@@ -189,6 +195,7 @@ mod tests {
                 dry_run: false,
             },
             None,
+            true,
         );
         task.collect(Utc::now() + TimeDelta::hours(1))
             .await
@@ -203,6 +210,61 @@ mod tests {
             .unwrap();
         assert_eq!("2", std::str::from_utf8(&raw_boundary).unwrap());
 
+        let manifests = manifest_store.list_manifests(..).await.unwrap();
+        assert_eq!(
+            vec![3],
+            manifests
+                .iter()
+                .map(|manifest| manifest.id)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_without_boundary_advancement_deletes_without_creating_boundary() {
+        let object_store = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from("/root"),
+            object_store.clone(),
+        ));
+        let mut stored_manifest = StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+        stored_manifest
+            .update(stored_manifest.prepare_dirty().unwrap())
+            .await
+            .unwrap();
+
+        let recorder = MetricsRecorderHelper::noop();
+        let task = ManifestGcTask::new(
+            manifest_store.clone(),
+            Arc::new(GcStats::new(&recorder)),
+            GarbageCollectorDirectoryOptions {
+                min_age: Duration::from_secs(1),
+                interval: None,
+                dry_run: false,
+            },
+            None,
+            false,
+        );
+        task.collect(Utc::now() + TimeDelta::hours(1))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            object_store
+                .get(&Path::from("/root/gc/manifest.boundary"))
+                .await,
+            Err(object_store::Error::NotFound { .. })
+        ));
         let manifests = manifest_store.list_manifests(..).await.unwrap();
         assert_eq!(
             vec![3],
@@ -246,6 +308,7 @@ mod tests {
                 dry_run: false,
             },
             Some(Arc::new(DenyAllGcFilter) as Arc<dyn GcFilter>),
+            true,
         );
         task.collect(Utc::now() + TimeDelta::hours(1))
             .await

--- a/website/src/content/docs/docs/design/files.mdx
+++ b/website/src/content/docs/docs/design/files.mdx
@@ -70,3 +70,9 @@ The `gc` directory contains boundary files used for garbage collection coordinat
 Each boundary file stores a single unsigned 64-bit integer representing an inclusive high-watermark. A boundary value `B` means that object IDs `<= B` are eligible for deletion. Before the garbage collector deletes old sequenced metadata files, it advances the namespace boundary. After a writer creates a sequenced metadata file, it checks the boundary before returning success. If the created ID is at or behind the boundary, the write is treated as failed.
 
 Boundary files use conditional updates (ETag-based) to ensure monotonic advancement and prevent concurrent GC processes from interfering with each other. They provide a persistent marker that allows garbage collectors to safely delete objects below the boundary without risking deletion of still-referenced data.
+
+Garbage collectors advance boundary files by default. This can be disabled through
+`GarbageCollectorOptions`; eligible metadata is still deleted, but the durable boundary is not
+advanced. Metadata writers always check any existing boundary. All garbage collectors for a
+database must use a compatible policy, and the metadata `min_age` settings must be long enough to
+outlive stale processes when boundary advancement is disabled.

--- a/website/src/content/docs/docs/design/gc.mdx
+++ b/website/src/content/docs/docs/design/gc.mdx
@@ -9,6 +9,20 @@ The garbage collector has a configurable minimum age and interval for each file 
 
 Each garbage collection directory type supports a `dry_run` option. When enabled, the collector logs files that would be deleted without actually deleting them. This is useful for testing or verifying garbage collection behavior before enabling actual deletion.
 
+## Boundary files
+
+Before deleting old manifest or compactions metadata, SlateDB normally advances a durable boundary
+file. Metadata writers check that boundary after creating a new version, which prevents a stale
+writer from successfully publishing metadata that GC has already passed.
+
+Boundary advancement can be disabled with
+`GarbageCollectorOptions::boundary_files_enabled`. This supports object stores without conditional
+overwrite (`If-Match`) while allowing GC to continue deleting eligible metadata. Metadata readers
+and writers still check any existing boundary; on a new database, no boundary file is created while
+all garbage collectors use this mode. Disabling advancement removes the stale-writer fail-safe, so
+every garbage collector must use a compatible setting and the manifest and compactions `min_age`
+values must exceed the maximum lifetime of a stale process.
+
 ## Filtering Deletion Candidates
 
 SlateDB supports custom filtering of garbage collection candidates through the `GcFilter` trait. This allows users to intercept files before deletion and approve or reject them based on custom logic.

--- a/website/src/content/docs/docs/operations/cli.mdx
+++ b/website/src/content/docs/docs/operations/cli.mdx
@@ -76,6 +76,11 @@ slatedb --env-file .env --path <db-path> schedule-garbage-collection \
 
 The scheduled process runs until interrupted (Ctrl-C), then shuts down gracefully.
 
+Pass `--disable-boundary-files` to `run-garbage-collection` or
+`schedule-garbage-collection` to delete eligible manifest and compactions metadata without
+advancing boundary files. Use the same setting for every garbage collector operating on the
+database.
+
 :::note
 
 The garbage collector expects the database to already exist (a manifest must be present). If you're creating a new database, open it once before starting the garbage collector.

--- a/website/src/content/docs/docs/operations/configuration.mdx
+++ b/website/src/content/docs/docs/operations/configuration.mdx
@@ -67,6 +67,17 @@ default is `Info`; set it to `Debug` to enable debug-level metrics when using a
 metrics recorder. See [Metric levels](/docs/operations/metrics/#metric-levels) for more
 information.
 
+## Garbage-collection boundary files
+
+`GarbageCollectorOptions::boundary_files_enabled` controls whether manifest and compactions garbage
+collection advances durable boundary files before deleting eligible metadata. Boundary advancement
+is enabled by default. Set it to `false` for object stores that do not support conditional overwrite
+(`If-Match`), and use the same setting for every garbage collector operating on the database.
+
+Metadata readers and writers always honor existing boundary files. Without boundary advancement,
+configure manifest and compactions garbage collection `min_age` values longer than any stale writer
+or compactor can remain alive.
+
 ## Reconfiguring Object Stores
 
 Reconfiguring an object store only changes how SlateDB reaches storage. It does not migrate data between stores for you. The new `ObjectStore` must still have the existing database contents for the database path.

--- a/website/src/content/docs/docs/tutorials/standalone-garbage-collector.mdx
+++ b/website/src/content/docs/docs/tutorials/standalone-garbage-collector.mdx
@@ -52,6 +52,12 @@ You can also embed the garbage collector in your own process using `GarbageColle
 
 With `GarbageCollectorOptions::default()`, garbage collection runs every 60 seconds and uses a 5 minute minimum age for managed directories. WAL fence deletion stays in dry-run mode by default.
 
+To delete manifest and compactions metadata without advancing boundary files, set
+`GarbageCollectorOptions::boundary_files_enabled` to `false` on every garbage collector for the
+database. Metadata readers and writers continue to honor any existing boundary. Increase the
+manifest and compactions `min_age` values beyond the longest time a stale process could remain
+alive before using this mode.
+
 :::note
 
 The standalone garbage collector expects the database to already exist (a manifest must be present).


### PR DESCRIPTION
## Summary

Not all filesystems support `If-Match`. I introduced a dependency on this feature when I added GC boundary files:

https://github.com/slatedb/slatedb/blob/main/rfcs/0026-garbage-collector-boundary.md

This PR exposes a `boundary_files_enabled` GC option, which allows users to disable the feature in the GC. When `false`, the garbage collector will not call `advance_boundary` for `.manifest` and `.compactions`.

Closes #1818

## Changes

- Add `boundary_files_enabled` in config.rs
- Update GC to skip boundary advances
- Update docs and bindings

## Notes for Reviewers

This PR has a few subtleties:

1. If the boundary is disabled, the manifest/compaction writers still GET with `If-None-Match` using an ETag.
2. If a DB already has a boundary file, it'll still be visible and used by the writers.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
