### PR TITLE
Optimize DST binary

### DIFF
--- a/.github/workflows/dst-hourly.yaml
+++ b/.github/workflows/dst-hourly.yaml
@@ -41,7 +41,7 @@ jobs:
         # failure notification fires. A job-level timeout would instead cancel
         # the run, and GitHub does not notify on cancellations.
         timeout-minutes: 60
-        run: cargo nextest run -p slatedb-dst --all-features --profile dst-nightly --no-capture ${{ matrix.test-filter }}
+        run: cargo nextest run -p slatedb-dst --all-features --cargo-profile dst --profile dst-nightly --no-capture ${{ matrix.test-filter }}
         env:
           RUSTFLAGS: "--cfg dst --cfg tokio_unstable --cfg slow"
           RUST_LOG: "info"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ readme = "README.md"
 [profile.bench]
 lto = true
 
+[profile.dst]
+inherits = "test"
+opt-level = 2
+debug-assertions = true
+overflow-checks = true
+
 [workspace.dependencies]
 
 # dependencies


### PR DESCRIPTION
## Summary

The DST bank job recently timed out. It's just slow sometimes. Rather than reducing coverage or time, I'm trying to see if speeding up the binary will help. 🤞 If not, I'll look at reducing toxics or decreasing steps.

## Changes

- Add a DST test binary profile for nextest and use it