### PR TITLE
extract gc deletion into maybe_delete methods

### DIFF
--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -64,6 +64,41 @@ impl CompactionsGcTask {
     fn compactions_min_age(&self) -> chrono::Duration {
         chrono::Duration::from_std(self.compactions_options.min_age).expect("invalid duration")
     }
+
+    /// Deletes the given compactions files from the compactions store.
+    ///
+    /// In case of dryrun, the actual deletion doesn't happen.
+    async fn maybe_delete_compactions(&self, compactions_ids: Vec<u64>) {
+        if self.compactions_options.dry_run {
+            if !compactions_ids.is_empty() {
+                log::info!(
+                    "dry run: skipping compactions deletion [count={}]",
+                    compactions_ids.len()
+                );
+            }
+            for id in compactions_ids {
+                log::debug!(
+                    "dry run: would delete compactions but skipped [id={:?}]",
+                    id
+                );
+            }
+            return;
+        }
+
+        futures::stream::iter(compactions_ids)
+            .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
+                if let Err(e) = self
+                    .compactions_store
+                    .delete_compactions_unchecked(id)
+                    .await
+                {
+                    error!("error deleting compactions [id={:?}, error={}]", id, e);
+                } else {
+                    self.stats.gc_compactions_count.increment(1);
+                }
+            })
+            .await;
+    }
 }
 
 impl GcTask for CompactionsGcTask {
@@ -96,36 +131,12 @@ impl GcTask for CompactionsGcTask {
         }
         let compactions_to_delete =
             retain_allowed_by_gc_filter(&self.gc_filter, compactions_to_delete).await;
-        if self.compactions_options.dry_run {
-            if !compactions_to_delete.is_empty() {
-                log::info!(
-                    "dry run: skipping compactions deletion [count={}]",
-                    compactions_to_delete.len()
-                );
-            }
-            for compactions_metadata in compactions_to_delete {
-                log::debug!(
-                    "dry run: would delete compactions but skipped [id={:?}]",
-                    compactions_metadata.id
-                );
-            }
-            return Ok(());
-        }
-        futures::stream::iter(compactions_to_delete)
-            .for_each_concurrent(GC_DELETE_CONCURRENCY, |compactions_metadata| async move {
-                if let Err(e) = self
-                    .compactions_store
-                    .delete_compactions_unchecked(compactions_metadata.id)
-                    .await
-                {
-                    error!(
-                        "error deleting compactions [id={:?}, error={}]",
-                        compactions_metadata.id, e
-                    );
-                } else {
-                    self.stats.gc_compactions_count.increment(1);
-                }
-            })
+        let compactions_ids_to_delete = compactions_to_delete
+            .into_iter()
+            .map(|compactions_metadata| compactions_metadata.id)
+            .collect::<Vec<_>>();
+
+        self.maybe_delete_compactions(compactions_ids_to_delete)
             .await;
 
         Ok(())

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -44,6 +44,34 @@ impl ManifestGcTask {
     fn manifest_min_age(&self) -> chrono::Duration {
         chrono::Duration::from_std(self.manifest_options.min_age).expect("invalid duration")
     }
+
+    /// Deletes the given manifests from the manifest store.
+    ///
+    /// In case of dryrun, the actual deletion doesn't happen.
+    async fn maybe_delete_manifests(&self, manifest_ids: Vec<u64>) {
+        if self.manifest_options.dry_run {
+            if !manifest_ids.is_empty() {
+                log::info!(
+                    "dry run: skipping manifest deletion [count={}]",
+                    manifest_ids.len()
+                );
+            }
+            for id in manifest_ids {
+                log::debug!("dry run: would delete manifest but skipped [id={:?}]", id);
+            }
+            return;
+        }
+
+        futures::stream::iter(manifest_ids)
+            .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
+                if let Err(e) = self.manifest_store.delete_manifest_unchecked(id).await {
+                    error!("error deleting manifest [id={:?}, error={}]", id, e);
+                } else {
+                    self.stats.gc_manifest_count.increment(1);
+                }
+            })
+            .await;
+    }
 }
 
 impl GcTask for ManifestGcTask {
@@ -92,37 +120,12 @@ impl GcTask for ManifestGcTask {
         }
         let manifests_to_delete =
             retain_allowed_by_gc_filter(&self.gc_filter, manifests_to_delete).await;
-        if self.manifest_options.dry_run {
-            if !manifests_to_delete.is_empty() {
-                log::info!(
-                    "dry run: skipping manifest deletion [count={}]",
-                    manifests_to_delete.len()
-                );
-            }
-            for manifest_metadata in manifests_to_delete {
-                log::debug!(
-                    "dry run: would delete manifest but skipped [id={:?}]",
-                    manifest_metadata.id
-                );
-            }
-            return Ok(());
-        }
-        futures::stream::iter(manifests_to_delete)
-            .for_each_concurrent(GC_DELETE_CONCURRENCY, |manifest_metadata| async move {
-                if let Err(e) = self
-                    .manifest_store
-                    .delete_manifest_unchecked(manifest_metadata.id)
-                    .await
-                {
-                    error!(
-                        "error deleting manifest [id={:?}, error={}]",
-                        manifest_metadata.id, e
-                    );
-                } else {
-                    self.stats.gc_manifest_count.increment(1);
-                }
-            })
-            .await;
+        let manifest_ids_to_delete = manifests_to_delete
+            .into_iter()
+            .map(|manifest_metadata| manifest_metadata.id)
+            .collect::<Vec<_>>();
+
+        self.maybe_delete_manifests(manifest_ids_to_delete).await;
 
         Ok(())
     }

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -88,6 +88,49 @@ impl WalGcTask {
     fn wal_sst_min_age(&self) -> chrono::Duration {
         chrono::Duration::from_std(self.wal_options.min_age).expect("invalid duration")
     }
+
+    /// Deletes the given WAL SSTs from the table store.
+    ///
+    /// In case of dryrun, the actual deletion doesn't happen.
+    async fn maybe_delete_wal_ssts(&self, sst_ids: Vec<SsTableId>) {
+        if self.wal_options.dry_run {
+            if !sst_ids.is_empty() {
+                log::info!(
+                    "dry run: skipping {} deletion [count={}]",
+                    self.resource(),
+                    sst_ids.len()
+                );
+                if matches!(self.mode, WalGcMode::Fence) {
+                    log::info!(
+                        "WAL fence GC is dry-run by default. This is a conservative setting. \
+                        Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
+                        Silence this log with wal_fence_options=None. See #352 for details."
+                    );
+                }
+            }
+            for id in sst_ids {
+                log::debug!(
+                    "dry run: would delete {} but skipped [id={:?}]",
+                    self.resource(),
+                    id
+                );
+            }
+            return;
+        }
+
+        futures::stream::iter(sst_ids)
+            .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
+                if let Err(e) = self.table_store.delete_sst(&id).await {
+                    error!("error deleting WAL SST [id={:?}, error={}]", id, e);
+                } else {
+                    match self.mode {
+                        WalGcMode::Regular => self.stats.gc_wal_count.increment(1),
+                        WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(1),
+                    }
+                }
+            })
+            .await;
+    }
 }
 
 impl GcTask for WalGcTask {
@@ -131,42 +174,7 @@ impl GcTask for WalGcTask {
             .map(|wal_sst| wal_sst.id)
             .collect::<Vec<_>>();
 
-        if self.wal_options.dry_run {
-            if !sst_ids_to_delete.is_empty() {
-                log::info!(
-                    "dry run: skipping {} deletion [count={}]",
-                    self.resource(),
-                    sst_ids_to_delete.len()
-                );
-                if matches!(self.mode, WalGcMode::Fence) {
-                    log::info!(
-                        "WAL fence GC is dry-run by default. This is a conservative setting. \
-                        Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
-                        Silence this log with wal_fence_options=None. See #352 for details."
-                    );
-                }
-            }
-            for id in sst_ids_to_delete {
-                log::debug!(
-                    "dry run: would delete {} but skipped [id={:?}]",
-                    self.resource(),
-                    id
-                );
-            }
-            return Ok(());
-        }
-        futures::stream::iter(sst_ids_to_delete)
-            .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
-                if let Err(e) = self.table_store.delete_sst(&id).await {
-                    error!("error deleting WAL SST [id={:?}, error={}]", id, e);
-                } else {
-                    match self.mode {
-                        WalGcMode::Regular => self.stats.gc_wal_count.increment(1),
-                        WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(1),
-                    }
-                }
-            })
-            .await;
+        self.maybe_delete_wal_ssts(sst_ids_to_delete).await;
 
         Ok(())
     }


### PR DESCRIPTION
Addressing comment https://github.com/slatedb/slatedb/pull/1899#discussion_r3547758701 from a previous PR. 
The change extracts the deletion logic from GC for better testability


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
