### PR TITLE
Add a DST for DB rescaling

### DIFF
--- a/.github/workflows/dst-hourly.yaml
+++ b/.github/workflows/dst-hourly.yaml
@@ -20,6 +20,8 @@ jobs:
             test-filter: test_dst_bank_with_toxics
           - name: determinism
             test-filter: test_dst_is_deterministic
+          - name: rescaling
+            test-filter: test_dst_rescaling_preserves_data
           - name: segments
             test-filter: test_dst_segments_is_deterministic
     # Hard backstop for the whole job. The "Run DST Tests" step below sets a

--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -22,8 +22,6 @@ internal path dependency rather than from crates.io.
 
 - `Harness`: builder and executor for deterministic simulations
 - `Actor`: async actor trait run by the harness
-- `RescalingScenario`: RFC-0004 split/merge orchestration that runs projected
-  child databases concurrently in independent harnesses before unioning them
 - `actors`: reusable scenario actors, including workload, flusher, standalone
   compactor, shutdown, and bank-transfer/auditor actors
 - `DeterministicLocalFilesystem`: filesystem-backed `ObjectStore` with stable

--- a/slatedb-dst/README.md
+++ b/slatedb-dst/README.md
@@ -22,6 +22,8 @@ internal path dependency rather than from crates.io.
 
 - `Harness`: builder and executor for deterministic simulations
 - `Actor`: async actor trait run by the harness
+- `RescalingScenario`: RFC-0004 split/merge orchestration that runs projected
+  child databases concurrently in independent harnesses before unioning them
 - `actors`: reusable scenario actors, including workload, flusher, standalone
   compactor, shutdown, and bank-transfer/auditor actors
 - `DeterministicLocalFilesystem`: filesystem-backed `ObjectStore` with stable

--- a/slatedb-dst/src/actors/mod.rs
+++ b/slatedb-dst/src/actors/mod.rs
@@ -29,6 +29,7 @@ pub use self::fencer::{DbFencerActor, DbFencerActorOptions, SuppressFenced};
 pub use self::flusher::FlusherActor;
 pub use self::shutdown::ShutdownActor;
 pub use self::suppress_errors::SuppressErrorActor;
+pub(crate) use self::workload::decode_workload_value;
 pub use self::workload::{WorkloadActor, WorkloadActorOptions, WorkloadMergeOperator};
 
 /// Emit one progress log line every N completed steps for the looping actors.

--- a/slatedb-dst/src/actors/workload.rs
+++ b/slatedb-dst/src/actors/workload.rs
@@ -113,6 +113,12 @@ impl WorkloadActor {
             key_prefix: None,
         })
     }
+
+    /// Overrides the version assigned to the next generated workload value.
+    pub fn with_next_value_version(mut self, next_value_version: u64) -> Self {
+        self.next_value_version = AtomicU64::new(next_value_version);
+        self
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -434,7 +440,7 @@ fn observe_absent(key: &Bytes, observed: &mut BTreeMap<Bytes, Observation>) {
     }
 }
 
-fn decode_workload_value(value: &[u8]) -> u64 {
+pub(crate) fn decode_workload_value(value: &[u8]) -> u64 {
     let version_bytes: [u8; WORKLOAD_VALUE_VERSION_SIZE] = value[..WORKLOAD_VALUE_VERSION_SIZE]
         .try_into()
         .expect("workload value version slice has fixed size");

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -605,7 +605,7 @@ impl Harness {
     ///
     /// This is useful when multiple harnesses must share one deterministic
     /// scheduler. The caller is responsible for providing and seeding the
-    /// runtime; [`Harness::run`] remains the convenient synchronous entry point.
+    /// runtime.
     ///
     /// ## Returns
     /// - `Ok(())`: All actors completed successfully, or an actor requested

--- a/slatedb-dst/src/harness.rs
+++ b/slatedb-dst/src/harness.rs
@@ -598,7 +598,22 @@ impl Harness {
             .rng_seed(RngSeed::from_bytes(&runtime_seed.to_le_bytes()))
             .build_local(Default::default())
             .expect("failed to build dst harness runtime");
-        runtime.block_on(async move { self.run_inner().await })
+        runtime.block_on(self.run_async())
+    }
+
+    /// Runs the harness to completion on the current Tokio runtime.
+    ///
+    /// This is useful when multiple harnesses must share one deterministic
+    /// scheduler. The caller is responsible for providing and seeding the
+    /// runtime; [`Harness::run`] remains the convenient synchronous entry point.
+    ///
+    /// ## Returns
+    /// - `Ok(())`: All actors completed successfully, or an actor requested
+    ///   shutdown and all remaining actor exits were neutral.
+    /// - `Err(Error)`: Database startup failed, no actors were configured, or
+    ///   an actor returned or joined with an error.
+    pub async fn run_async(self) -> Result<(), Error> {
+        self.run_inner().await
     }
 
     async fn run_inner(self) -> Result<(), Error> {

--- a/slatedb-dst/src/lib.rs
+++ b/slatedb-dst/src/lib.rs
@@ -13,6 +13,7 @@ mod deterministic_local_filesystem;
 pub mod failing_object_store;
 mod harness;
 mod prefix_extractor;
+mod rescaling;
 mod scenarios;
 pub mod utils;
 
@@ -23,4 +24,5 @@ pub use self::failing_object_store::{
 };
 pub use self::harness::*;
 pub use self::prefix_extractor::FirstDelimiterPrefixExtractor;
+pub use self::rescaling::RescalingScenario;
 pub use self::scenarios::DeterministicScenario;

--- a/slatedb-dst/src/rescaling.rs
+++ b/slatedb-dst/src/rescaling.rs
@@ -19,11 +19,9 @@
 //!
 //! Every workload operation remains inside one actor prefix, so point
 //! operations, write batches, and scans stay within one child. The child
-//! harnesses have independent seeded Tokio runtimes, [`DbRand`] instances,
-//! [`MockSystemClock`] instances, and fault controllers. They share the same
-//! underlying [`DeterministicLocalFilesystem`] object stores, which exercises
-//! concurrent object-store access without making either runtime's scheduling
-//! order part of the other runtime's state.
+//! harnesses run on separate threads and share one underlying
+//! [`DeterministicLocalFilesystem`], exercising concurrent access to the same
+//! object store.
 //!
 //! Garbage collection remains enabled, but detach GC is disabled because both
 //! projected children reference the root checkpoint. WALs are disabled because
@@ -60,7 +58,6 @@ use crate::{DeterministicLocalFilesystem, Harness};
 
 type ScenarioError = Box<dyn std::error::Error + Send + Sync>;
 type ScenarioResult<T> = Result<T, ScenarioError>;
-type ProjectionRange = (Bound<Bytes>, Bound<Bytes>);
 type Rows = Vec<(Bytes, Bytes)>;
 
 const ROOT_ACTORS: &[&str] = &["workload-1", "workload-2", "workload-3", "workload-4"];
@@ -125,26 +122,14 @@ impl RescalingScenario {
     }
 }
 
-#[derive(Clone)]
-struct ScenarioStores {
-    main: Arc<dyn ObjectStore>,
-    wal: Arc<dyn ObjectStore>,
-}
-
 #[instrument(level = "debug", skip_all, fields(scenario = name, seed = seed))]
 fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResult<()> {
     let tempdir = TempDir::new()?;
-    let main_dir = tempdir.path().join("main");
-    let wal_dir = tempdir.path().join("wal");
-    std::fs::create_dir_all(&main_dir)?;
-    std::fs::create_dir_all(&wal_dir)?;
-
-    let stores = ScenarioStores {
-        main: Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?),
-        wal: Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?),
-    };
-    let plan_rand = DbRand::new(seed);
-    let next_seed = || plan_rand.rng().next_u64();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(
+        DeterministicLocalFilesystem::new_with_prefix(tempdir.path())?,
+    );
+    let seed_rng = DbRand::new(seed);
+    let next_seed = || seed_rng.rng().next_u64();
     let root_path = Path::from(format!("{name}/root"));
     let left_path = Path::from(format!("{name}/split/left"));
     let right_path = Path::from(format!("{name}/split/right"));
@@ -153,12 +138,12 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
     run_harness_phase(
         format!("{name}-root"),
         root_path.clone(),
-        stores.clone(),
+        object_store.clone(),
         next_seed(),
         shutdown_at_ms,
         ROOT_ACTORS,
     )?;
-    let root_rows = snapshot_rows(root_path.clone(), stores.clone(), next_seed())?;
+    let root_rows = snapshot_rows(root_path.clone(), object_store.clone(), next_seed())?;
 
     let split_key = Bytes::from_static(SPLIT_KEY);
     let left_range = (Bound::Unbounded, Bound::Excluded(split_key.clone()));
@@ -166,63 +151,70 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
     create_clone(
         left_path.clone(),
         vec![CloneSourceSpec::new(root_path.clone()).with_projection_range(left_range.clone())],
-        stores.clone(),
+        object_store.clone(),
         next_seed(),
     )?;
     create_clone(
         right_path.clone(),
         vec![CloneSourceSpec::new(root_path).with_projection_range(right_range.clone())],
-        stores.clone(),
+        object_store.clone(),
         next_seed(),
     )?;
 
-    let left_after_split = snapshot_rows(left_path.clone(), stores.clone(), next_seed())?;
-    let right_after_split = snapshot_rows(right_path.clone(), stores.clone(), next_seed())?;
+    let left_after_split = snapshot_rows(left_path.clone(), object_store.clone(), next_seed())?;
+    let right_after_split = snapshot_rows(right_path.clone(), object_store.clone(), next_seed())?;
     let (expected_left, expected_right): (Rows, Rows) = root_rows
         .into_iter()
         .partition(|(key, _)| key.as_ref() < SPLIT_KEY);
-    assert_eq!(left_after_split, expected_left);
-    assert_eq!(right_after_split, expected_right);
+    assert_eq!(
+        left_after_split, expected_left,
+        "projection mismatch [scenario={name}, seed={seed}, phase=split, partition=left]"
+    );
+    assert_eq!(
+        right_after_split, expected_right,
+        "projection mismatch [scenario={name}, seed={seed}, phase=split, partition=right]"
+    );
 
-    // Allocate both seeds before either thread starts so scheduling cannot
-    // change which random stream is assigned to a child.
-    let left_harness_seed = next_seed();
-    let right_harness_seed = next_seed();
-    let left_handle = {
-        let stores = stores.clone();
-        let path = left_path.clone();
-        std::thread::spawn(move || {
-            run_harness_phase(
-                format!("{name}-left"),
-                path,
-                stores,
-                left_harness_seed,
-                shutdown_at_ms,
-                LEFT_ACTORS,
-            )
-        })
-    };
-    let right_handle = {
-        let stores = stores.clone();
-        let path = right_path.clone();
-        std::thread::spawn(move || {
-            run_harness_phase(
-                format!("{name}-right"),
-                path,
-                stores,
-                right_harness_seed,
-                shutdown_at_ms,
-                RIGHT_ACTORS,
-            )
-        })
-    };
-    join_phase(name, "left", left_handle)?;
-    join_phase(name, "right", right_handle)?;
+    let child_handles = [
+        ("left", left_path.clone(), next_seed(), LEFT_ACTORS),
+        ("right", right_path.clone(), next_seed(), RIGHT_ACTORS),
+    ]
+    .map(|(phase, path, phase_seed, actors)| {
+        let object_store = object_store.clone();
+        (
+            phase,
+            std::thread::spawn(move || {
+                run_harness_phase(
+                    format!("{name}-{phase}"),
+                    path,
+                    object_store,
+                    phase_seed,
+                    shutdown_at_ms,
+                    actors,
+                )
+            }),
+        )
+    });
+    for (phase, handle) in child_handles {
+        match handle.join() {
+            Ok(result) => result?,
+            Err(payload) => {
+                error!("dst {name} child phase panicked [phase={phase}, seed={seed}]");
+                std::panic::resume_unwind(payload);
+            }
+        }
+    }
 
-    let left_rows = snapshot_rows(left_path.clone(), stores.clone(), next_seed())?;
-    let right_rows = snapshot_rows(right_path.clone(), stores.clone(), next_seed())?;
-    assert!(left_rows.iter().all(|(key, _)| key.as_ref() < SPLIT_KEY));
-    assert!(right_rows.iter().all(|(key, _)| key.as_ref() >= SPLIT_KEY));
+    let left_rows = snapshot_rows(left_path.clone(), object_store.clone(), next_seed())?;
+    let right_rows = snapshot_rows(right_path.clone(), object_store.clone(), next_seed())?;
+    assert!(
+        left_rows.iter().all(|(key, _)| key.as_ref() < SPLIT_KEY),
+        "child contains key outside its range [scenario={name}, seed={seed}, phase=children, partition=left]"
+    );
+    assert!(
+        right_rows.iter().all(|(key, _)| key.as_ref() >= SPLIT_KEY),
+        "child contains key outside its range [scenario={name}, seed={seed}, phase=children, partition=right]"
+    );
 
     create_clone(
         merged_path.clone(),
@@ -230,18 +222,21 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
             CloneSourceSpec::new(left_path).with_projection_range(left_range),
             CloneSourceSpec::new(right_path).with_projection_range(right_range),
         ],
-        stores.clone(),
+        object_store.clone(),
         next_seed(),
     )?;
 
-    let merged_rows = snapshot_rows(merged_path.clone(), stores.clone(), next_seed())?;
+    let merged_rows = snapshot_rows(merged_path.clone(), object_store.clone(), next_seed())?;
     let expected_merged = left_rows.into_iter().chain(right_rows).collect::<Rows>();
-    assert_eq!(merged_rows, expected_merged);
+    assert_eq!(
+        merged_rows, expected_merged,
+        "union mismatch [scenario={name}, seed={seed}, phase=merge]"
+    );
 
     run_harness_phase(
         format!("{name}-merged"),
         merged_path,
-        stores,
+        object_store,
         next_seed(),
         shutdown_at_ms,
         ROOT_ACTORS,
@@ -253,13 +248,11 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
 fn run_harness_phase(
     name: String,
     path: Path,
-    stores: ScenarioStores,
+    object_store: Arc<dyn ObjectStore>,
     seed: u64,
     shutdown_at_ms: i64,
     actor_names: &'static [&'static str],
 ) -> ScenarioResult<()> {
-    let rand = Arc::new(DbRand::new(seed));
-    let system_clock = Arc::new(MockSystemClock::new());
     let workload_options = WorkloadActorOptions {
         read_durability: DurabilityLevel::Remote,
         ..WorkloadActorOptions::default()
@@ -277,33 +270,29 @@ fn run_harness_phase(
         settings.l0_max_ssts = 4;
         settings.max_unflushed_bytes = 64 * 1024;
         settings.manifest_poll_interval = Duration::from_millis(10);
-        if let Some(gc_options) = settings.garbage_collector_options.as_mut() {
-            // Parallel projected children share a parent. Keep the shard-local
-            // GC tasks active, but prevent both children from concurrently
-            // releasing checkpoints in the parent's manifest.
-            gc_options.detach_options = None;
-        }
-        // RFC-0004 union cannot merge WAL state. Keep this scenario focused on
-        // projection/union and exercise WAL draining in a separate protocol test.
+        settings
+            .garbage_collector_options
+            .as_mut()
+            .expect("rescaling scenario requires garbage collection")
+            .detach_options = None;
+        // Manifest union rejects sources with live WAL data.
         settings.wal_enabled = false;
 
-        let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
-            .with_wal_object_store(ctx.wal_object_store().expect("configured"))
+        let db = Db::builder(ctx.path().clone(), ctx.main_object_store())
             .with_system_clock(ctx.system_clock())
             .with_fp_registry(ctx.fp_registry())
             .with_seed(db_seed)
-            .with_settings(settings);
-        if let Some(merge_operator) = ctx.merge_operator() {
-            builder = builder.with_merge_operator(merge_operator);
-        }
-        let db = builder.build().await?;
+            .with_settings(settings)
+            .with_merge_operator(
+                ctx.merge_operator()
+                    .expect("rescaling workload requires a merge operator"),
+            )
+            .build()
+            .await?;
         Ok(Arc::new(db))
     })
-    .with_rand(rand)
-    .with_system_clock(system_clock)
     .with_path(path)
-    .with_main_object_store(stores.main)
-    .with_wal_object_store(stores.wal)
+    .with_main_object_store(object_store)
     .with_merge_operator(Arc::new(WorkloadMergeOperator));
 
     for actor_name in actor_names {
@@ -316,20 +305,6 @@ fn run_harness_phase(
     info!("starting rescaling harness phase [name={harness_name}]");
     harness.run()?;
     Ok(())
-}
-
-fn join_phase(
-    scenario: &str,
-    phase: &str,
-    handle: std::thread::JoinHandle<ScenarioResult<()>>,
-) -> ScenarioResult<()> {
-    match handle.join() {
-        Ok(result) => result,
-        Err(payload) => {
-            error!("dst {scenario} child phase panicked [phase={phase}]");
-            std::panic::resume_unwind(payload);
-        }
-    }
 }
 
 fn block_on_seeded<F>(seed: u64, future: F) -> F::Output
@@ -345,14 +320,13 @@ where
 
 fn create_clone(
     clone_path: Path,
-    sources: Vec<CloneSourceSpec<ProjectionRange>>,
-    stores: ScenarioStores,
+    sources: Vec<CloneSourceSpec<(Bound<Bytes>, Bound<Bytes>)>>,
+    object_store: Arc<dyn ObjectStore>,
     seed: u64,
 ) -> Result<(), slatedb::Error> {
     block_on_seeded(seed, async move {
         let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
-        let admin = AdminBuilder::new(clone_path, stores.main.clone())
-            .with_wal_object_store(stores.wal.clone())
+        let admin = AdminBuilder::new(clone_path, object_store)
             .with_system_clock(system_clock.clone())
             .with_seed(seed)
             .build();
@@ -371,11 +345,14 @@ fn create_clone(
     })
 }
 
-fn snapshot_rows(path: Path, stores: ScenarioStores, seed: u64) -> ScenarioResult<Rows> {
+fn snapshot_rows(
+    path: Path,
+    object_store: Arc<dyn ObjectStore>,
+    seed: u64,
+) -> ScenarioResult<Rows> {
     block_on_seeded(seed, async move {
         let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
-        let reader = DbReader::builder(path, stores.main)
-            .with_wal_object_store(stores.wal)
+        let reader = DbReader::builder(path, object_store)
             .with_system_clock(system_clock)
             .with_seed(seed)
             .with_merge_operator(Arc::new(WorkloadMergeOperator))

--- a/slatedb-dst/src/rescaling.rs
+++ b/slatedb-dst/src/rescaling.rs
@@ -19,9 +19,10 @@
 //!
 //! Every workload operation remains inside one actor prefix, so point
 //! operations, write batches, and scans stay within one child. The child
-//! harnesses run on separate threads and share one underlying
-//! [`DeterministicLocalFilesystem`], exercising concurrent access to the same
-//! object store.
+//! harnesses run concurrently on one seeded current-thread runtime and share
+//! one underlying [`DeterministicLocalFilesystem`]. This exercises interleaved
+//! access to the same object store while keeping operation ordering
+//! reproducible from the scenario seed.
 //!
 //! Garbage collection remains enabled, but detach GC is disabled because both
 //! projected children reference the root checkpoint. WALs are disabled because
@@ -32,7 +33,6 @@
 //! primary assertions: every root row must appear in exactly one child, and
 //! every child row must appear in the merged database.
 
-use std::future::Future;
 use std::ops::Bound;
 use std::sync::Arc;
 use std::time::Duration;
@@ -82,10 +82,10 @@ pub struct RescalingScenario {
 impl RescalingScenario {
     /// Runs the rescaling scenario across the configured DST seed budget.
     ///
-    /// Each seed worker runs its root and merged phases locally and spawns two
-    /// child threads for the disjoint projected databases. The default number
-    /// of seed workers is half the available cores so the parallel child phase
-    /// does not systematically oversubscribe the machine.
+    /// Each seed worker runs all phases on one seeded current-thread runtime.
+    /// The disjoint child databases run as concurrent tasks on that shared
+    /// deterministic scheduler, so the default seed count matches the number
+    /// of available cores.
     pub fn run(self) -> ScenarioResult<()> {
         let Self {
             name,
@@ -94,7 +94,7 @@ impl RescalingScenario {
         let num_cores = std::thread::available_parallelism()
             .map(|p| p.get())
             .unwrap_or(1);
-        let seeds = dst_seeds((num_cores / 2).max(1))?;
+        let seeds = dst_seeds(num_cores)?;
 
         let handles = seeds
             .into_iter()
@@ -125,6 +125,14 @@ impl RescalingScenario {
 
 #[instrument(level = "debug", skip_all, fields(scenario = name, seed = seed))]
 fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResult<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .rng_seed(RngSeed::from_bytes(&seed.to_le_bytes()))
+        .build_local(Default::default())
+        .expect("failed to build rescaling scenario runtime");
+    runtime.block_on(run_seed_async(name, seed, shutdown_at_ms))
+}
+
+async fn run_seed_async(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResult<()> {
     let tempdir = TempDir::new()?;
     let object_store: Arc<dyn ObjectStore> = Arc::new(
         DeterministicLocalFilesystem::new_with_prefix(tempdir.path())?,
@@ -145,8 +153,9 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         shutdown_at_ms,
         1,
         ROOT_ACTORS,
-    )?;
-    let root_rows = snapshot_rows(root_path.clone(), object_store.clone(), next_seed())?;
+    )
+    .await?;
+    let root_rows = snapshot_rows(root_path.clone(), object_store.clone(), next_seed()).await?;
     let child_next_value_version = next_workload_value_version(&root_rows);
 
     let split_key = Bytes::from_static(SPLIT_KEY);
@@ -157,16 +166,20 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         vec![CloneSourceSpec::new(root_path.clone()).with_projection_range(left_range.clone())],
         object_store.clone(),
         next_seed(),
-    )?;
+    )
+    .await?;
     create_clone(
         right_path.clone(),
         vec![CloneSourceSpec::new(root_path).with_projection_range(right_range.clone())],
         object_store.clone(),
         next_seed(),
-    )?;
+    )
+    .await?;
 
-    let left_after_split = snapshot_rows(left_path.clone(), object_store.clone(), next_seed())?;
-    let right_after_split = snapshot_rows(right_path.clone(), object_store.clone(), next_seed())?;
+    let left_after_split =
+        snapshot_rows(left_path.clone(), object_store.clone(), next_seed()).await?;
+    let right_after_split =
+        snapshot_rows(right_path.clone(), object_store.clone(), next_seed()).await?;
     let (expected_left, expected_right): (Rows, Rows) = root_rows
         .into_iter()
         .partition(|(key, _)| key.as_ref() < SPLIT_KEY);
@@ -179,41 +192,32 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         "projection mismatch [scenario={name}, seed={seed}, phase=split, partition=right]"
     );
 
-    let child_handles = [
-        ("left", left_path.clone(), next_seed(), LEFT_ACTORS),
-        ("right", right_path.clone(), next_seed(), RIGHT_ACTORS),
-    ]
-    .map(|(phase, path, phase_seed, actors)| {
-        let object_store = object_store.clone();
-        (
-            phase,
-            std::thread::spawn(move || {
-                run_harness_phase(
-                    format!("{name}-{phase}"),
-                    path,
-                    object_store,
-                    phase_seed,
-                    root_end_ms,
-                    shutdown_at_ms,
-                    child_next_value_version,
-                    actors,
-                )
-            }),
-        )
-    });
-    let mut children_end_ms = root_end_ms;
-    for (phase, handle) in child_handles {
-        match handle.join() {
-            Ok(result) => children_end_ms = children_end_ms.max(result?),
-            Err(payload) => {
-                error!("dst {name} child phase panicked [phase={phase}, seed={seed}]");
-                std::panic::resume_unwind(payload);
-            }
-        }
-    }
+    let (left_end_ms, right_end_ms) = tokio::try_join!(
+        run_harness_phase(
+            format!("{name}-left"),
+            left_path.clone(),
+            object_store.clone(),
+            next_seed(),
+            root_end_ms,
+            shutdown_at_ms,
+            child_next_value_version,
+            LEFT_ACTORS,
+        ),
+        run_harness_phase(
+            format!("{name}-right"),
+            right_path.clone(),
+            object_store.clone(),
+            next_seed(),
+            root_end_ms,
+            shutdown_at_ms,
+            child_next_value_version,
+            RIGHT_ACTORS,
+        ),
+    )?;
+    let children_end_ms = left_end_ms.max(right_end_ms);
 
-    let left_rows = snapshot_rows(left_path.clone(), object_store.clone(), next_seed())?;
-    let right_rows = snapshot_rows(right_path.clone(), object_store.clone(), next_seed())?;
+    let left_rows = snapshot_rows(left_path.clone(), object_store.clone(), next_seed()).await?;
+    let right_rows = snapshot_rows(right_path.clone(), object_store.clone(), next_seed()).await?;
     assert!(
         left_rows.iter().all(|(key, _)| key.as_ref() < SPLIT_KEY),
         "child contains key outside its range [scenario={name}, seed={seed}, phase=children, partition=left]"
@@ -231,9 +235,10 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         ],
         object_store.clone(),
         next_seed(),
-    )?;
+    )
+    .await?;
 
-    let merged_rows = snapshot_rows(merged_path.clone(), object_store.clone(), next_seed())?;
+    let merged_rows = snapshot_rows(merged_path.clone(), object_store.clone(), next_seed()).await?;
     let expected_merged = left_rows.into_iter().chain(right_rows).collect::<Rows>();
     let merged_next_value_version = next_workload_value_version(&expected_merged);
     assert_eq!(
@@ -250,12 +255,13 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         shutdown_at_ms,
         merged_next_value_version,
         ROOT_ACTORS,
-    )?;
+    )
+    .await?;
 
     Ok(())
 }
 
-fn run_harness_phase(
+async fn run_harness_phase(
     name: String,
     path: Path,
     object_store: Arc<dyn ObjectStore>,
@@ -322,7 +328,7 @@ fn run_harness_phase(
         .actor("shutdown", ShutdownActor::new(shutdown_at_ms)?);
 
     info!("starting rescaling harness phase [name={harness_name}]");
-    harness.run()?;
+    harness.run_async().await?;
     Ok(system_clock.now().timestamp_millis())
 }
 
@@ -335,69 +341,54 @@ fn next_workload_value_version(rows: &Rows) -> u64 {
         .expect("workload value version must not overflow")
 }
 
-fn block_on_seeded<F>(seed: u64, future: F) -> F::Output
-where
-    F: Future,
-{
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .rng_seed(RngSeed::from_bytes(&seed.to_le_bytes()))
-        .build_local(Default::default())
-        .expect("failed to build rescaling scenario runtime");
-    runtime.block_on(future)
-}
-
-fn create_clone(
+async fn create_clone(
     clone_path: Path,
     sources: Vec<CloneSourceSpec<(Bound<Bytes>, Bound<Bytes>)>>,
     object_store: Arc<dyn ObjectStore>,
     seed: u64,
 ) -> Result<(), slatedb::Error> {
-    block_on_seeded(seed, async move {
-        let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
-        let admin = AdminBuilder::new(clone_path, object_store)
-            .with_system_clock(system_clock.clone())
-            .with_seed(seed)
-            .build();
-        let mut sources = sources.into_iter();
-        let first = sources
-            .next()
-            .expect("rescaling clone requires at least one source");
-        let mut builder = admin
-            .create_clone_builder_from_source(first)
-            .with_system_clock(system_clock)
-            .with_seed(seed);
-        for source in sources {
-            builder = builder.with_source(source);
-        }
-        builder.build().await
-    })
+    let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
+    let admin = AdminBuilder::new(clone_path, object_store)
+        .with_system_clock(system_clock.clone())
+        .with_seed(seed)
+        .build();
+    let mut sources = sources.into_iter();
+    let first = sources
+        .next()
+        .expect("rescaling clone requires at least one source");
+    let mut builder = admin
+        .create_clone_builder_from_source(first)
+        .with_system_clock(system_clock)
+        .with_seed(seed);
+    for source in sources {
+        builder = builder.with_source(source);
+    }
+    builder.build().await
 }
 
-fn snapshot_rows(
+async fn snapshot_rows(
     path: Path,
     object_store: Arc<dyn ObjectStore>,
     seed: u64,
 ) -> ScenarioResult<Rows> {
-    block_on_seeded(seed, async move {
-        let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
-        let reader = DbReader::builder(path, object_store)
-            .with_system_clock(system_clock)
-            .with_seed(seed)
-            .with_merge_operator(Arc::new(WorkloadMergeOperator))
-            .build()
-            .await?;
-        let rows_result = async {
-            let mut iter = reader.scan(..).await?;
-            let mut rows = Vec::new();
-            while let Some(kv) = iter.next().await? {
-                rows.push((kv.key, kv.value));
-            }
-            Ok::<_, slatedb::Error>(rows)
+    let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
+    let reader = DbReader::builder(path, object_store)
+        .with_system_clock(system_clock)
+        .with_seed(seed)
+        .with_merge_operator(Arc::new(WorkloadMergeOperator))
+        .build()
+        .await?;
+    let rows_result = async {
+        let mut iter = reader.scan(..).await?;
+        let mut rows = Vec::new();
+        while let Some(kv) = iter.next().await? {
+            rows.push((kv.key, kv.value));
         }
-        .await;
-        let close_result = reader.close().await;
-        let rows = rows_result?;
-        close_result?;
-        Ok::<_, ScenarioError>(rows)
-    })
+        Ok::<_, slatedb::Error>(rows)
+    }
+    .await;
+    let close_result = reader.close().await;
+    let rows = rows_result?;
+    close_result?;
+    Ok(rows)
 }

--- a/slatedb-dst/src/rescaling.rs
+++ b/slatedb-dst/src/rescaling.rs
@@ -51,7 +51,8 @@ use tokio::runtime::RngSeed;
 use tracing::instrument;
 
 use crate::actors::{
-    FlusherActor, ShutdownActor, WorkloadActor, WorkloadActorOptions, WorkloadMergeOperator,
+    decode_workload_value, FlusherActor, ShutdownActor, WorkloadActor, WorkloadActorOptions,
+    WorkloadMergeOperator,
 };
 use crate::utils::{build_settings, build_toxic, dst_seeds};
 use crate::{DeterministicLocalFilesystem, Harness};
@@ -142,9 +143,11 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         next_seed(),
         0,
         shutdown_at_ms,
+        1,
         ROOT_ACTORS,
     )?;
     let root_rows = snapshot_rows(root_path.clone(), object_store.clone(), next_seed())?;
+    let child_next_value_version = next_workload_value_version(&root_rows);
 
     let split_key = Bytes::from_static(SPLIT_KEY);
     let left_range = (Bound::Unbounded, Bound::Excluded(split_key.clone()));
@@ -192,6 +195,7 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
                     phase_seed,
                     root_end_ms,
                     shutdown_at_ms,
+                    child_next_value_version,
                     actors,
                 )
             }),
@@ -231,6 +235,7 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
 
     let merged_rows = snapshot_rows(merged_path.clone(), object_store.clone(), next_seed())?;
     let expected_merged = left_rows.into_iter().chain(right_rows).collect::<Rows>();
+    let merged_next_value_version = next_workload_value_version(&expected_merged);
     assert_eq!(
         merged_rows, expected_merged,
         "union mismatch [scenario={name}, seed={seed}, phase=merge]"
@@ -243,6 +248,7 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         next_seed(),
         children_end_ms,
         shutdown_at_ms,
+        merged_next_value_version,
         ROOT_ACTORS,
     )?;
 
@@ -256,6 +262,7 @@ fn run_harness_phase(
     seed: u64,
     start_at_ms: i64,
     shutdown_at_ms: i64,
+    next_value_version: u64,
     actor_names: &'static [&'static str],
 ) -> ScenarioResult<i64> {
     let system_clock = Arc::new(MockSystemClock::with_time(start_at_ms));
@@ -306,7 +313,9 @@ fn run_harness_phase(
     .with_merge_operator(Arc::new(WorkloadMergeOperator));
 
     for actor_name in actor_names {
-        harness = harness.actor(*actor_name, WorkloadActor::new(workload_options.clone())?);
+        let actor = WorkloadActor::new(workload_options.clone())?
+            .with_next_value_version(next_value_version);
+        harness = harness.actor(*actor_name, actor);
     }
     harness = harness
         .actor("flusher", FlusherActor::new(1_u64..=5_u64)?)
@@ -315,6 +324,15 @@ fn run_harness_phase(
     info!("starting rescaling harness phase [name={harness_name}]");
     harness.run()?;
     Ok(system_clock.now().timestamp_millis())
+}
+
+fn next_workload_value_version(rows: &Rows) -> u64 {
+    rows.iter()
+        .map(|(_, value)| decode_workload_value(value.as_ref()))
+        .max()
+        .unwrap_or(0)
+        .checked_add(1)
+        .expect("workload value version must not overflow")
 }
 
 fn block_on_seeded<F>(seed: u64, future: F) -> F::Output

--- a/slatedb-dst/src/rescaling.rs
+++ b/slatedb-dst/src/rescaling.rs
@@ -155,7 +155,13 @@ async fn run_seed_async(name: &'static str, seed: u64, shutdown_at_ms: i64) -> S
         ROOT_ACTORS,
     )
     .await?;
-    let root_rows = snapshot_rows(root_path.clone(), object_store.clone(), next_seed()).await?;
+    let root_rows = snapshot_rows(
+        root_path.clone(),
+        object_store.clone(),
+        next_seed(),
+        root_end_ms,
+    )
+    .await?;
     let child_next_value_version = next_workload_value_version(&root_rows);
 
     let split_key = Bytes::from_static(SPLIT_KEY);
@@ -166,6 +172,7 @@ async fn run_seed_async(name: &'static str, seed: u64, shutdown_at_ms: i64) -> S
         vec![CloneSourceSpec::new(root_path.clone()).with_projection_range(left_range.clone())],
         object_store.clone(),
         next_seed(),
+        root_end_ms,
     )
     .await?;
     create_clone(
@@ -173,13 +180,24 @@ async fn run_seed_async(name: &'static str, seed: u64, shutdown_at_ms: i64) -> S
         vec![CloneSourceSpec::new(root_path).with_projection_range(right_range.clone())],
         object_store.clone(),
         next_seed(),
+        root_end_ms,
     )
     .await?;
 
-    let left_after_split =
-        snapshot_rows(left_path.clone(), object_store.clone(), next_seed()).await?;
-    let right_after_split =
-        snapshot_rows(right_path.clone(), object_store.clone(), next_seed()).await?;
+    let left_after_split = snapshot_rows(
+        left_path.clone(),
+        object_store.clone(),
+        next_seed(),
+        root_end_ms,
+    )
+    .await?;
+    let right_after_split = snapshot_rows(
+        right_path.clone(),
+        object_store.clone(),
+        next_seed(),
+        root_end_ms,
+    )
+    .await?;
     let (expected_left, expected_right): (Rows, Rows) = root_rows
         .into_iter()
         .partition(|(key, _)| key.as_ref() < SPLIT_KEY);
@@ -216,8 +234,20 @@ async fn run_seed_async(name: &'static str, seed: u64, shutdown_at_ms: i64) -> S
     )?;
     let children_end_ms = left_end_ms.max(right_end_ms);
 
-    let left_rows = snapshot_rows(left_path.clone(), object_store.clone(), next_seed()).await?;
-    let right_rows = snapshot_rows(right_path.clone(), object_store.clone(), next_seed()).await?;
+    let left_rows = snapshot_rows(
+        left_path.clone(),
+        object_store.clone(),
+        next_seed(),
+        children_end_ms,
+    )
+    .await?;
+    let right_rows = snapshot_rows(
+        right_path.clone(),
+        object_store.clone(),
+        next_seed(),
+        children_end_ms,
+    )
+    .await?;
     assert!(
         left_rows.iter().all(|(key, _)| key.as_ref() < SPLIT_KEY),
         "child contains key outside its range [scenario={name}, seed={seed}, phase=children, partition=left]"
@@ -235,10 +265,17 @@ async fn run_seed_async(name: &'static str, seed: u64, shutdown_at_ms: i64) -> S
         ],
         object_store.clone(),
         next_seed(),
+        children_end_ms,
     )
     .await?;
 
-    let merged_rows = snapshot_rows(merged_path.clone(), object_store.clone(), next_seed()).await?;
+    let merged_rows = snapshot_rows(
+        merged_path.clone(),
+        object_store.clone(),
+        next_seed(),
+        children_end_ms,
+    )
+    .await?;
     let expected_merged = left_rows.into_iter().chain(right_rows).collect::<Rows>();
     let merged_next_value_version = next_workload_value_version(&expected_merged);
     assert_eq!(
@@ -346,8 +383,9 @@ async fn create_clone(
     sources: Vec<CloneSourceSpec<(Bound<Bytes>, Bound<Bytes>)>>,
     object_store: Arc<dyn ObjectStore>,
     seed: u64,
+    start_at_ms: i64,
 ) -> Result<(), slatedb::Error> {
-    let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
+    let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::with_time(start_at_ms));
     let admin = AdminBuilder::new(clone_path, object_store)
         .with_system_clock(system_clock.clone())
         .with_seed(seed)
@@ -370,8 +408,9 @@ async fn snapshot_rows(
     path: Path,
     object_store: Arc<dyn ObjectStore>,
     seed: u64,
+    start_at_ms: i64,
 ) -> ScenarioResult<Rows> {
-    let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
+    let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::with_time(start_at_ms));
     let reader = DbReader::builder(path, object_store)
         .with_system_clock(system_clock)
         .with_seed(seed)

--- a/slatedb-dst/src/rescaling.rs
+++ b/slatedb-dst/src/rescaling.rs
@@ -74,7 +74,7 @@ const SPLIT_KEY: &[u8] = b"workload-3/";
 pub struct RescalingScenario {
     /// Logical name used for harness labels and database paths.
     pub name: &'static str,
-    /// Per-harness mock-clock deadline, in milliseconds since the Unix epoch.
+    /// Per-harness mock-clock duration, in milliseconds.
     pub shutdown_at_ms: i64,
 }
 
@@ -135,11 +135,12 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
     let right_path = Path::from(format!("{name}/split/right"));
     let merged_path = Path::from(format!("{name}/merged"));
 
-    run_harness_phase(
+    let root_end_ms = run_harness_phase(
         format!("{name}-root"),
         root_path.clone(),
         object_store.clone(),
         next_seed(),
+        0,
         shutdown_at_ms,
         ROOT_ACTORS,
     )?;
@@ -189,15 +190,17 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
                     path,
                     object_store,
                     phase_seed,
+                    root_end_ms,
                     shutdown_at_ms,
                     actors,
                 )
             }),
         )
     });
+    let mut children_end_ms = root_end_ms;
     for (phase, handle) in child_handles {
         match handle.join() {
-            Ok(result) => result?,
+            Ok(result) => children_end_ms = children_end_ms.max(result?),
             Err(payload) => {
                 error!("dst {name} child phase panicked [phase={phase}, seed={seed}]");
                 std::panic::resume_unwind(payload);
@@ -238,6 +241,7 @@ fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResul
         merged_path,
         object_store,
         next_seed(),
+        children_end_ms,
         shutdown_at_ms,
         ROOT_ACTORS,
     )?;
@@ -250,9 +254,14 @@ fn run_harness_phase(
     path: Path,
     object_store: Arc<dyn ObjectStore>,
     seed: u64,
+    start_at_ms: i64,
     shutdown_at_ms: i64,
     actor_names: &'static [&'static str],
-) -> ScenarioResult<()> {
+) -> ScenarioResult<i64> {
+    let system_clock = Arc::new(MockSystemClock::with_time(start_at_ms));
+    let shutdown_at_ms = start_at_ms
+        .checked_add(shutdown_at_ms)
+        .expect("rescaling phase shutdown timestamp must not overflow");
     let workload_options = WorkloadActorOptions {
         read_durability: DurabilityLevel::Remote,
         ..WorkloadActorOptions::default()
@@ -293,6 +302,7 @@ fn run_harness_phase(
     })
     .with_path(path)
     .with_main_object_store(object_store)
+    .with_system_clock(system_clock.clone())
     .with_merge_operator(Arc::new(WorkloadMergeOperator));
 
     for actor_name in actor_names {
@@ -304,7 +314,7 @@ fn run_harness_phase(
 
     info!("starting rescaling harness phase [name={harness_name}]");
     harness.run()?;
-    Ok(())
+    Ok(system_clock.now().timestamp_millis())
 }
 
 fn block_on_seeded<F>(seed: u64, future: F) -> F::Output

--- a/slatedb-dst/src/rescaling.rs
+++ b/slatedb-dst/src/rescaling.rs
@@ -1,0 +1,398 @@
+//! Data-preservation checks for RFC-0004 split and merge scenarios.
+//!
+//! [`RescalingScenario`] keeps [`Harness`] focused on one physical database at
+//! a time. Rescaling happens between harness runs: the scenario stops the
+//! source database, uses SlateDB's administrative clone operations to project
+//! or union manifests, and starts new harnesses for the resulting databases.
+//!
+//! Each run performs these phases:
+//! - run four prefix-scoped workload actors against a root database
+//! - scan the quiesced root and project it at `workload-3/` into adjacent left
+//!   and right databases
+//! - verify that both projections exactly match their ranges in the root
+//! - run the left and right databases concurrently, assigning actors 1-2 to
+//!   the left database and actors 3-4 to the right
+//! - scan the quiesced children, union them into a merged database, and verify
+//!   that the merged rows exactly equal both child snapshots
+//! - run all four workload actors against the merged database to verify that it
+//!   remains usable after the union
+//!
+//! Every workload operation remains inside one actor prefix, so point
+//! operations, write batches, and scans stay within one child. The child
+//! harnesses have independent seeded Tokio runtimes, [`DbRand`] instances,
+//! [`MockSystemClock`] instances, and fault controllers. They share the same
+//! underlying [`DeterministicLocalFilesystem`] object stores, which exercises
+//! concurrent object-store access without making either runtime's scheduling
+//! order part of the other runtime's state.
+//!
+//! Garbage collection remains enabled, but detach GC is disabled because both
+//! projected children reference the root checkpoint. WALs are disabled because
+//! manifest union does not combine live WAL state. Projection and union run
+//! only after their source harnesses have stopped.
+//!
+//! The exact snapshot comparisons at the split and merge barriers are the
+//! primary assertions: every root row must appear in exactly one child, and
+//! every child row must appear in the merged database.
+
+use std::future::Future;
+use std::ops::Bound;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use log::{error, info};
+use object_store::path::Path;
+use object_store::ObjectStore;
+use rand::RngCore;
+use slatedb::admin::{AdminBuilder, CloneSourceSpec};
+use slatedb::config::DurabilityLevel;
+use slatedb::{Db, DbRand, DbReader};
+use slatedb_common::clock::{MockSystemClock, SystemClock};
+use tempfile::TempDir;
+use tokio::runtime::RngSeed;
+use tracing::instrument;
+
+use crate::actors::{
+    FlusherActor, ShutdownActor, WorkloadActor, WorkloadActorOptions, WorkloadMergeOperator,
+};
+use crate::utils::{build_settings, build_toxic, dst_seeds};
+use crate::{DeterministicLocalFilesystem, Harness};
+
+type ScenarioError = Box<dyn std::error::Error + Send + Sync>;
+type ScenarioResult<T> = Result<T, ScenarioError>;
+type ProjectionRange = (Bound<Bytes>, Bound<Bytes>);
+type Rows = Vec<(Bytes, Bytes)>;
+
+const ROOT_ACTORS: &[&str] = &["workload-1", "workload-2", "workload-3", "workload-4"];
+const LEFT_ACTORS: &[&str] = &["workload-1", "workload-2"];
+const RIGHT_ACTORS: &[&str] = &["workload-3", "workload-4"];
+const SPLIT_KEY: &[u8] = b"workload-3/";
+
+/// Configuration for the RFC-0004 split/merge data-preservation scenario.
+///
+/// A run exercises one root database, projects it into two children, runs the
+/// children concurrently, unions their quiesced states, and then runs the
+/// merged database. Exact snapshots verify that projection and union preserve
+/// every row.
+pub struct RescalingScenario {
+    /// Logical name used for harness labels and database paths.
+    pub name: &'static str,
+    /// Per-harness mock-clock deadline, in milliseconds since the Unix epoch.
+    pub shutdown_at_ms: i64,
+}
+
+impl RescalingScenario {
+    /// Runs the rescaling scenario across the configured DST seed budget.
+    ///
+    /// Each seed worker runs its root and merged phases locally and spawns two
+    /// child threads for the disjoint projected databases. The default number
+    /// of seed workers is half the available cores so the parallel child phase
+    /// does not systematically oversubscribe the machine.
+    pub fn run(self) -> ScenarioResult<()> {
+        let Self {
+            name,
+            shutdown_at_ms,
+        } = self;
+        let num_cores = std::thread::available_parallelism()
+            .map(|p| p.get())
+            .unwrap_or(1);
+        let seeds = dst_seeds((num_cores / 2).max(1))?;
+
+        let handles = seeds
+            .into_iter()
+            .enumerate()
+            .map(|(core, seed)| {
+                info!("dst {name} seed [core={core}, seed={seed}]");
+                (
+                    core,
+                    seed,
+                    std::thread::spawn(move || run_seed(name, seed, shutdown_at_ms)),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        for (core, seed, handle) in handles {
+            match handle.join() {
+                Ok(result) => result?,
+                Err(payload) => {
+                    error!("dst {name} panicked [core={core}, seed={seed}]");
+                    std::panic::resume_unwind(payload);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct ScenarioStores {
+    main: Arc<dyn ObjectStore>,
+    wal: Arc<dyn ObjectStore>,
+}
+
+#[instrument(level = "debug", skip_all, fields(scenario = name, seed = seed))]
+fn run_seed(name: &'static str, seed: u64, shutdown_at_ms: i64) -> ScenarioResult<()> {
+    let tempdir = TempDir::new()?;
+    let main_dir = tempdir.path().join("main");
+    let wal_dir = tempdir.path().join("wal");
+    std::fs::create_dir_all(&main_dir)?;
+    std::fs::create_dir_all(&wal_dir)?;
+
+    let stores = ScenarioStores {
+        main: Arc::new(DeterministicLocalFilesystem::new_with_prefix(&main_dir)?),
+        wal: Arc::new(DeterministicLocalFilesystem::new_with_prefix(&wal_dir)?),
+    };
+    let plan_rand = DbRand::new(seed);
+    let next_seed = || plan_rand.rng().next_u64();
+    let root_path = Path::from(format!("{name}/root"));
+    let left_path = Path::from(format!("{name}/split/left"));
+    let right_path = Path::from(format!("{name}/split/right"));
+    let merged_path = Path::from(format!("{name}/merged"));
+
+    run_harness_phase(
+        format!("{name}-root"),
+        root_path.clone(),
+        stores.clone(),
+        next_seed(),
+        shutdown_at_ms,
+        ROOT_ACTORS,
+    )?;
+    let root_rows = snapshot_rows(root_path.clone(), stores.clone(), next_seed())?;
+
+    let split_key = Bytes::from_static(SPLIT_KEY);
+    let left_range = (Bound::Unbounded, Bound::Excluded(split_key.clone()));
+    let right_range = (Bound::Included(split_key), Bound::Unbounded);
+    create_clone(
+        left_path.clone(),
+        vec![CloneSourceSpec::new(root_path.clone()).with_projection_range(left_range.clone())],
+        stores.clone(),
+        next_seed(),
+    )?;
+    create_clone(
+        right_path.clone(),
+        vec![CloneSourceSpec::new(root_path).with_projection_range(right_range.clone())],
+        stores.clone(),
+        next_seed(),
+    )?;
+
+    let left_after_split = snapshot_rows(left_path.clone(), stores.clone(), next_seed())?;
+    let right_after_split = snapshot_rows(right_path.clone(), stores.clone(), next_seed())?;
+    let (expected_left, expected_right): (Rows, Rows) = root_rows
+        .into_iter()
+        .partition(|(key, _)| key.as_ref() < SPLIT_KEY);
+    assert_eq!(left_after_split, expected_left);
+    assert_eq!(right_after_split, expected_right);
+
+    // Allocate both seeds before either thread starts so scheduling cannot
+    // change which random stream is assigned to a child.
+    let left_harness_seed = next_seed();
+    let right_harness_seed = next_seed();
+    let left_handle = {
+        let stores = stores.clone();
+        let path = left_path.clone();
+        std::thread::spawn(move || {
+            run_harness_phase(
+                format!("{name}-left"),
+                path,
+                stores,
+                left_harness_seed,
+                shutdown_at_ms,
+                LEFT_ACTORS,
+            )
+        })
+    };
+    let right_handle = {
+        let stores = stores.clone();
+        let path = right_path.clone();
+        std::thread::spawn(move || {
+            run_harness_phase(
+                format!("{name}-right"),
+                path,
+                stores,
+                right_harness_seed,
+                shutdown_at_ms,
+                RIGHT_ACTORS,
+            )
+        })
+    };
+    join_phase(name, "left", left_handle)?;
+    join_phase(name, "right", right_handle)?;
+
+    let left_rows = snapshot_rows(left_path.clone(), stores.clone(), next_seed())?;
+    let right_rows = snapshot_rows(right_path.clone(), stores.clone(), next_seed())?;
+    assert!(left_rows.iter().all(|(key, _)| key.as_ref() < SPLIT_KEY));
+    assert!(right_rows.iter().all(|(key, _)| key.as_ref() >= SPLIT_KEY));
+
+    create_clone(
+        merged_path.clone(),
+        vec![
+            CloneSourceSpec::new(left_path).with_projection_range(left_range),
+            CloneSourceSpec::new(right_path).with_projection_range(right_range),
+        ],
+        stores.clone(),
+        next_seed(),
+    )?;
+
+    let merged_rows = snapshot_rows(merged_path.clone(), stores.clone(), next_seed())?;
+    let expected_merged = left_rows.into_iter().chain(right_rows).collect::<Rows>();
+    assert_eq!(merged_rows, expected_merged);
+
+    run_harness_phase(
+        format!("{name}-merged"),
+        merged_path,
+        stores,
+        next_seed(),
+        shutdown_at_ms,
+        ROOT_ACTORS,
+    )?;
+
+    Ok(())
+}
+
+fn run_harness_phase(
+    name: String,
+    path: Path,
+    stores: ScenarioStores,
+    seed: u64,
+    shutdown_at_ms: i64,
+    actor_names: &'static [&'static str],
+) -> ScenarioResult<()> {
+    let rand = Arc::new(DbRand::new(seed));
+    let system_clock = Arc::new(MockSystemClock::new());
+    let workload_options = WorkloadActorOptions {
+        read_durability: DurabilityLevel::Remote,
+        ..WorkloadActorOptions::default()
+    };
+    let harness_name = name.clone();
+    let mut harness = Harness::new(name, seed, move |ctx| async move {
+        let failures = ctx.failure_controller();
+        for index in 0..10 {
+            failures.add_toxic(build_toxic(ctx.rand(), ctx.path().as_ref(), index));
+        }
+
+        let db_seed = ctx.rand().rng().next_u64();
+        let mut settings = build_settings(ctx.rand()).await;
+        settings.l0_sst_size_bytes = 1024;
+        settings.l0_max_ssts = 4;
+        settings.max_unflushed_bytes = 64 * 1024;
+        settings.manifest_poll_interval = Duration::from_millis(10);
+        if let Some(gc_options) = settings.garbage_collector_options.as_mut() {
+            // Parallel projected children share a parent. Keep the shard-local
+            // GC tasks active, but prevent both children from concurrently
+            // releasing checkpoints in the parent's manifest.
+            gc_options.detach_options = None;
+        }
+        // RFC-0004 union cannot merge WAL state. Keep this scenario focused on
+        // projection/union and exercise WAL draining in a separate protocol test.
+        settings.wal_enabled = false;
+
+        let mut builder = Db::builder(ctx.path().clone(), ctx.main_object_store())
+            .with_wal_object_store(ctx.wal_object_store().expect("configured"))
+            .with_system_clock(ctx.system_clock())
+            .with_fp_registry(ctx.fp_registry())
+            .with_seed(db_seed)
+            .with_settings(settings);
+        if let Some(merge_operator) = ctx.merge_operator() {
+            builder = builder.with_merge_operator(merge_operator);
+        }
+        let db = builder.build().await?;
+        Ok(Arc::new(db))
+    })
+    .with_rand(rand)
+    .with_system_clock(system_clock)
+    .with_path(path)
+    .with_main_object_store(stores.main)
+    .with_wal_object_store(stores.wal)
+    .with_merge_operator(Arc::new(WorkloadMergeOperator));
+
+    for actor_name in actor_names {
+        harness = harness.actor(*actor_name, WorkloadActor::new(workload_options.clone())?);
+    }
+    harness = harness
+        .actor("flusher", FlusherActor::new(1_u64..=5_u64)?)
+        .actor("shutdown", ShutdownActor::new(shutdown_at_ms)?);
+
+    info!("starting rescaling harness phase [name={harness_name}]");
+    harness.run()?;
+    Ok(())
+}
+
+fn join_phase(
+    scenario: &str,
+    phase: &str,
+    handle: std::thread::JoinHandle<ScenarioResult<()>>,
+) -> ScenarioResult<()> {
+    match handle.join() {
+        Ok(result) => result,
+        Err(payload) => {
+            error!("dst {scenario} child phase panicked [phase={phase}]");
+            std::panic::resume_unwind(payload);
+        }
+    }
+}
+
+fn block_on_seeded<F>(seed: u64, future: F) -> F::Output
+where
+    F: Future,
+{
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .rng_seed(RngSeed::from_bytes(&seed.to_le_bytes()))
+        .build_local(Default::default())
+        .expect("failed to build rescaling scenario runtime");
+    runtime.block_on(future)
+}
+
+fn create_clone(
+    clone_path: Path,
+    sources: Vec<CloneSourceSpec<ProjectionRange>>,
+    stores: ScenarioStores,
+    seed: u64,
+) -> Result<(), slatedb::Error> {
+    block_on_seeded(seed, async move {
+        let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
+        let admin = AdminBuilder::new(clone_path, stores.main.clone())
+            .with_wal_object_store(stores.wal.clone())
+            .with_system_clock(system_clock.clone())
+            .with_seed(seed)
+            .build();
+        let mut sources = sources.into_iter();
+        let first = sources
+            .next()
+            .expect("rescaling clone requires at least one source");
+        let mut builder = admin
+            .create_clone_builder_from_source(first)
+            .with_system_clock(system_clock)
+            .with_seed(seed);
+        for source in sources {
+            builder = builder.with_source(source);
+        }
+        builder.build().await
+    })
+}
+
+fn snapshot_rows(path: Path, stores: ScenarioStores, seed: u64) -> ScenarioResult<Rows> {
+    block_on_seeded(seed, async move {
+        let system_clock: Arc<dyn SystemClock> = Arc::new(MockSystemClock::new());
+        let reader = DbReader::builder(path, stores.main)
+            .with_wal_object_store(stores.wal)
+            .with_system_clock(system_clock)
+            .with_seed(seed)
+            .with_merge_operator(Arc::new(WorkloadMergeOperator))
+            .build()
+            .await?;
+        let rows_result = async {
+            let mut iter = reader.scan(..).await?;
+            let mut rows = Vec::new();
+            while let Some(kv) = iter.next().await? {
+                rows.push((kv.key, kv.value));
+            }
+            Ok::<_, slatedb::Error>(rows)
+        }
+        .await;
+        let close_result = reader.close().await;
+        let rows = rows_result?;
+        close_result?;
+        Ok::<_, ScenarioError>(rows)
+    })
+}

--- a/slatedb-dst/tests/rescaling.rs
+++ b/slatedb-dst/tests/rescaling.rs
@@ -40,7 +40,9 @@ type TestResult<T> = Result<T, TestError>;
 
 #[rstest]
 #[cfg_attr(not(slow), case::regular(200))]
-#[cfg_attr(slow, case::slow(2_400_000))]
+// Four physical harness clocks (root, left, right, and merged) make this a
+// 4.8M ms aggregate mock-clock budget per seed.
+#[cfg_attr(slow, case::slow(1_200_000))]
 fn test_dst_rescaling_preserves_data(#[case] shutdown_at_ms: i64) -> TestResult<()> {
     RescalingScenario {
         name: "rescaling",

--- a/slatedb-dst/tests/rescaling.rs
+++ b/slatedb-dst/tests/rescaling.rs
@@ -1,0 +1,40 @@
+//! Verifies that RFC-0004 projection and union preserve database contents.
+//!
+//! Each simulation run:
+//! - runs four prefix-scoped workload actors against one root database
+//! - quiesces the root and records its complete key/value state
+//! - projects the root at `workload-3/` into two adjacent child databases
+//! - checks that each child contains exactly its half of the root state
+//! - runs the two children concurrently in independent
+//!   [`slatedb_dst::Harness`] instances, with workload actors 1-2 assigned to
+//!   the left child and 3-4 to the right
+//! - quiesces both children and unions them into one database
+//! - checks that the union contains exactly the post-workload state of both
+//!   children, then runs all four workload actors against the merged database
+//!
+//! Actor prefixes keep every point operation, write batch, and prefix scan
+//! inside one child. The child harnesses use separate seeded runtimes, random
+//! number generators, clocks, and fault controllers while sharing the same
+//! underlying deterministic object stores. Garbage collection remains active,
+//! except for detach GC, so neither child mutates their shared parent's
+//! checkpoint state. WALs are disabled because manifest union does not merge
+//! WAL state.
+//!
+#![cfg(dst)]
+
+use rstest::rstest;
+use slatedb_dst::RescalingScenario;
+
+type TestError = Box<dyn std::error::Error + Send + Sync>;
+type TestResult<T> = Result<T, TestError>;
+
+#[rstest]
+#[cfg_attr(not(slow), case::regular(200))]
+#[cfg_attr(slow, case::slow(2_400_000))]
+fn test_dst_rescaling_preserves_data(#[case] shutdown_at_ms: i64) -> TestResult<()> {
+    RescalingScenario {
+        name: "rescaling",
+        shutdown_at_ms,
+    }
+    .run()
+}

--- a/slatedb-dst/tests/rescaling.rs
+++ b/slatedb-dst/tests/rescaling.rs
@@ -1,25 +1,33 @@
-//! Verifies that RFC-0004 projection and union preserve database contents.
+//! Verifies that RFC-0004 projection and union preserve database contents under
+//! DST workloads.
 //!
 //! Each simulation run:
-//! - runs four prefix-scoped workload actors against one root database
-//! - quiesces the root and records its complete key/value state
-//! - projects the root at `workload-3/` into two adjacent child databases
-//! - checks that each child contains exactly its half of the root state
-//! - runs the two children concurrently in independent
-//!   [`slatedb_dst::Harness`] instances, with workload actors 1-2 assigned to
-//!   the left child and 3-4 to the right
-//! - quiesces both children and unions them into one database
-//! - checks that the union contains exactly the post-workload state of both
-//!   children, then runs all four workload actors against the merged database
+//! - opens a root database on a deterministic filesystem-backed object store
+//! - runs four prefix-scoped workload actors with randomized SlateDB settings,
+//!   object-store faults, flushing, compaction, and garbage collection
+//! - quiesces the root and records its complete ordered key/value state
+//! - projects the root at `workload-3/` into adjacent left and right databases
+//! - checks that each projection exactly matches its range in the root snapshot
+//! - runs the children concurrently in separate [`slatedb_dst::Harness`]
+//!   instances, assigning actors 1-2 to the left child and 3-4 to the right
+//! - quiesces both children and records their post-workload state
+//! - unions the children and checks that the merged database exactly matches
+//!   the two child snapshots
+//! - runs all four workload actors against the merged database to confirm that
+//!   it remains readable and writable after the union
 //!
-//! Actor prefixes keep every point operation, write batch, and prefix scan
-//! inside one child. The child harnesses use separate seeded runtimes, random
-//! number generators, clocks, and fault controllers while sharing the same
-//! underlying deterministic object stores. Garbage collection remains active,
-//! except for detach GC, so neither child mutates their shared parent's
-//! checkpoint state. WALs are disabled because manifest union does not merge
-//! WAL state.
+//! Workload actor names are also key prefixes. The split boundary therefore
+//! keeps every point operation, write batch, and prefix scan inside one child.
+//! The child harnesses share the underlying object store but have independent
+//! seeded runtimes, clocks, and fault controllers.
 //!
+//! Garbage collection remains enabled during harness runs. Detach GC is
+//! disabled because both children retain checkpoints in the root manifest.
+//! WALs are disabled because manifest union rejects sources with live WAL data.
+//! Projection and union happen only after their source harnesses have stopped.
+//!
+//! A snapshot mismatch means projection dropped or misplaced a root row, or
+//! union failed to preserve the complete logical state of both children.
 #![cfg(dst)]
 
 use rstest::rstest;

--- a/slatedb-dst/tests/rescaling.rs
+++ b/slatedb-dst/tests/rescaling.rs
@@ -9,7 +9,8 @@
 //! - projects the root at `workload-3/` into adjacent left and right databases
 //! - checks that each projection exactly matches its range in the root snapshot
 //! - runs the children concurrently in separate [`slatedb_dst::Harness`]
-//!   instances, assigning actors 1-2 to the left child and 3-4 to the right
+//!   instances on one seeded runtime, assigning actors 1-2 to the left child
+//!   and actors 3-4 to the right
 //! - quiesces both children and records their post-workload state
 //! - unions the children and checks that the merged database exactly matches
 //!   the two child snapshots
@@ -18,8 +19,9 @@
 //!
 //! Workload actor names are also key prefixes. The split boundary therefore
 //! keeps every point operation, write batch, and prefix scan inside one child.
-//! The child harnesses share the underlying object store but have independent
-//! seeded runtimes, clocks, and fault controllers.
+//! The child harnesses share the underlying object store and seeded runtime but
+//! have independent clocks and fault controllers. The single-threaded runtime
+//! makes their interleaved object-store operations reproducible from the seed.
 //!
 //! Garbage collection remains enabled during harness runs. Detach GC is
 //! disabled because both children retain checkpoints in the root manifest.


### PR DESCRIPTION
## Summary

This PR adds a deterministic simulation test for DB rescaling (split/union'ing a DB). The test has four phases:

1. Run a single harness against a single DB.
2. Split the single DB into two separate DBs.
3. Run a distinct harness + workload on each separate DB.
4. Union the two distinct DBs back together.

Between each step, the rescaling test gathers the data from the source DB(s) and checks it against the data in the destination DB(s). If any data is missing or incorrect, the test fails. See the documentation in the `rescaling.rs` files for more.

## Changes

- Add `rescaling.rs` workloads in `slatedb-dst/src` and `slatedb-dst/test` (mimicking the other scenarios).
- Update `harness.rs` to allow with a `run_async` fn so the rescaling test can run two DB harnesses simultaneously on a single (deterministic) tokio runtime.
- Tweak `WorkloadActor` so that we can reconstruct it for split/merged DBs with the expected versions from the source DBs.

## Notes for Reviewers

My initial instinct was to modify `Harness` to support multiple (partitioned) DBs and try and have a split/union actor. That was _way_ messier than the approach taken in this PR, which does the rescaling _outside_ the harnesses.

We should probably move the scenarios.rs into a `scenarios/` module and put both determinism.rs and rescaling.rs inside it. I'll leave that for a future PR.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
