### PR TITLE
adds schema evolution docs wrt `PrefixExtractor`

### DIFF
--- a/bindings/uniffi/src/builder.rs
+++ b/bindings/uniffi/src/builder.rs
@@ -124,7 +124,10 @@ impl DbBuilder {
     /// Sets the segment extractor (RFC-0024). When configured, every write is
     /// routed through the extractor and the database tracks per-segment LSM
     /// state. The extractor must be configured at database creation time and
-    /// cannot be changed thereafter.
+    /// remain configured thereafter. Its name must remain stable; its
+    /// implementation may evolve only if it preserves routing for all existing
+    /// key schemas and keeps segment prefixes across schema versions an
+    /// antichain (no prefix may be a proper prefix of another).
     pub fn with_segment_extractor(&self, extractor: Arc<dyn PrefixExtractor>) -> Result<(), Error> {
         self.update_builder(|builder| {
             builder.with_segment_extractor(adapt_prefix_extractor(extractor))

--- a/bindings/uniffi/src/filter_policy.rs
+++ b/bindings/uniffi/src/filter_policy.rs
@@ -39,7 +39,7 @@ impl From<&slatedb::PrefixTarget> for PrefixTarget {
 }
 
 /// Application-provided prefix extractor used to configure prefix-based
-/// bloom filters.
+/// bloom filters and segmented compaction.
 #[uniffi::export(with_foreign)]
 pub trait PrefixExtractor: Send + Sync {
     /// Stable identifier for this extractor's configuration. Included in the

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -220,7 +220,11 @@ impl<P: Into<Path>> DbBuilder<P> {
     /// Set the segment extractor (RFC-0024). When configured, every
     /// write is routed through the extractor and the database tracks
     /// per-segment LSM state. The extractor must be configured at
-    /// database creation time and cannot be changed thereafter.
+    /// database creation time and remain configured thereafter. Its name
+    /// must remain stable; its implementation may evolve only if it preserves
+    /// routing for all existing key schemas and keeps segment prefixes across
+    /// schema versions an antichain (no prefix may be a proper prefix of
+    /// another).
     pub fn with_segment_extractor(
         mut self,
         extractor: Arc<dyn crate::prefix_extractor::PrefixExtractor>,

--- a/slatedb/src/prefix_extractor.rs
+++ b/slatedb/src/prefix_extractor.rs
@@ -1,7 +1,7 @@
 use bytes::Bytes;
 
 /// Extractor for a prefix from a byte string, used to build and probe
-/// prefix-based bloom filters.
+/// prefix-based bloom filters and segmented compaction.
 ///
 /// This trait is specific to `BloomFilterPolicy` — it is not part of the core
 /// `FilterPolicy`/`FilterBuilder`/`Filter` traits. Custom filter policies that

--- a/website/src/content/docs/docs/design/segmented-compaction.mdx
+++ b/website/src/content/docs/docs/design/segmented-compaction.mdx
@@ -158,13 +158,46 @@ every key to the segment named by its first three bytes.
 </Tabs>
 
 :::caution
-The extractor is fixed for the life of the database. Its `name()` is persisted
-in the manifest; opening with a different (or newly-added/removed) extractor
-fails. 
+Whether segmentation is enabled is fixed for the life of the database. The
+extractor's `name()` is persisted in the manifest; opening with a different
+name, or adding or removing an extractor, fails. This is primarily as a soft
+check against accidental misuse.
 :::
 
 List the segments that currently exist (in the manifest or in memtables) with
 [`DbStatus::list_segments()`](https://docs.rs/slatedb/latest/slatedb/struct.DbStatus.html#method.list_segments).
+
+## Evolving the key schema
+
+An extractor's name is fixed, but its implementation may evolve
+when the change is backward-compatible. For example, a schema byte can
+reserve disjoint key ranges for successive segmentation policies:
+
+```text
+# all records below use a schema marker as the first part of the key prefix
+
+# initially use weekly partitions
+[01][week]... -> [01][week]  # v1: weekly segments
+# later migrate to daily partitions
+[02][day]...  -> [02][day]   # v2: daily segments
+```
+
+The new implementation must keep extracting the original weekly prefixes for
+all v1 keys while adding daily prefixes only for v2 keys. In general:
+
+- Keep the same stable name and preserve the behavior of previous PrefixExtractor
+  implementations.
+- Ensure segment prefixes from all versions form an antichain: no
+  prefix may be a prefix of another (a schema discriminator at the
+  start of the key is a simple way to reserve disjoint ranges).
+
+SlateDB checks the name and, on open, asks the configured extractor to
+recognize every persisted segment prefix. It also rejects new writes that
+would introduce a nested prefix. These are guardrails rather than complete
+compatibility verification: SlateDB does not persist the implementation's
+version or revalidate every existing key. Maintaining backward-compatible
+routing under a stable name is therefore the application's responsibility.
+
 
 ## How it compacts
 


### PR DESCRIPTION
## Summary

After discord discussion, this adds a small documentation update indicating how to perform schema evolution under the same `PrefixExtractor` name post implementation of [RFC 24](https://github.com/slatedb/slatedb/blob/main/rfcs/0024-segment-oriented-compaction.md)

## Changes

- Indicates how to reserve disjoint keyspaces and evolve segment prefixing

