### PR TITLE
fix accounting for max_concurrent_compactions

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -275,7 +275,7 @@ impl CompactionStatus {
     }
 
     /// Returns whether this compaction still consumes scheduler capacity.
-    pub(crate) fn consumes_compaction_slot(self) -> bool {
+    pub(crate) fn counts_against_max_concurrent(self) -> bool {
         matches!(
             self,
             CompactionStatus::Submitted | CompactionStatus::Scheduled | CompactionStatus::Running
@@ -1381,12 +1381,12 @@ mod tests {
         assert!(!CompactionStatus::Completed.active());
         assert!(!CompactionStatus::Failed.active());
 
-        assert!(CompactionStatus::Submitted.consumes_compaction_slot());
-        assert!(CompactionStatus::Scheduled.consumes_compaction_slot());
-        assert!(CompactionStatus::Running.consumes_compaction_slot());
-        assert!(!CompactionStatus::Compacted.consumes_compaction_slot());
-        assert!(!CompactionStatus::Completed.consumes_compaction_slot());
-        assert!(!CompactionStatus::Failed.consumes_compaction_slot());
+        assert!(CompactionStatus::Submitted.counts_against_max_concurrent());
+        assert!(CompactionStatus::Scheduled.counts_against_max_concurrent());
+        assert!(CompactionStatus::Running.counts_against_max_concurrent());
+        assert!(!CompactionStatus::Compacted.counts_against_max_concurrent());
+        assert!(!CompactionStatus::Completed.counts_against_max_concurrent());
+        assert!(!CompactionStatus::Failed.counts_against_max_concurrent());
 
         assert!(!CompactionStatus::Submitted.finished());
         assert!(!CompactionStatus::Scheduled.finished());

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -274,6 +274,14 @@ impl CompactionStatus {
         )
     }
 
+    /// Returns whether this compaction still consumes scheduler capacity.
+    pub(crate) fn consumes_compaction_slot(self) -> bool {
+        matches!(
+            self,
+            CompactionStatus::Submitted | CompactionStatus::Scheduled | CompactionStatus::Running
+        )
+    }
+
     fn finished(self) -> bool {
         matches!(self, CompactionStatus::Completed | CompactionStatus::Failed)
     }
@@ -1365,14 +1373,25 @@ mod tests {
     }
 
     #[test]
-    fn test_compaction_status_active_and_finished() {
+    fn test_compaction_status_classifications() {
         assert!(CompactionStatus::Submitted.active());
+        assert!(CompactionStatus::Scheduled.active());
         assert!(CompactionStatus::Running.active());
+        assert!(CompactionStatus::Compacted.active());
         assert!(!CompactionStatus::Completed.active());
         assert!(!CompactionStatus::Failed.active());
 
+        assert!(CompactionStatus::Submitted.consumes_compaction_slot());
+        assert!(CompactionStatus::Scheduled.consumes_compaction_slot());
+        assert!(CompactionStatus::Running.consumes_compaction_slot());
+        assert!(!CompactionStatus::Compacted.consumes_compaction_slot());
+        assert!(!CompactionStatus::Completed.consumes_compaction_slot());
+        assert!(!CompactionStatus::Failed.consumes_compaction_slot());
+
         assert!(!CompactionStatus::Submitted.finished());
+        assert!(!CompactionStatus::Scheduled.finished());
         assert!(!CompactionStatus::Running.finished());
+        assert!(!CompactionStatus::Compacted.finished());
         assert!(CompactionStatus::Completed.finished());
         assert!(CompactionStatus::Failed.finished());
     }

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -191,7 +191,7 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
         // reservation, but do not count it against execution capacity.
         let compaction_slots_in_use = active_compactions
             .iter()
-            .filter(|c| c.status().consumes_compaction_slot())
+            .filter(|c| c.status().counts_against_max_concurrent())
             .count();
         let mut next_fresh_sr_id = next_global_sr_id(db_state, &active_compactions);
 

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -185,6 +185,14 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
             .flat_map(|c| c.core().recent_compactions())
             .filter(|c| c.active())
             .collect::<Vec<_>>();
+        // A Compacted job has finished using a worker slot, even though it
+        // remains active until its output is committed to the manifest. Keep
+        // it in `active_compactions` for conflict checks and destination-id
+        // reservation, but do not count it against execution capacity.
+        let compaction_slots_in_use = active_compactions
+            .iter()
+            .filter(|c| c.status().consumes_compaction_slot())
+            .count();
         let mut next_fresh_sr_id = next_global_sr_id(db_state, &active_compactions);
 
         // Precompute per-tree (sources, conflict checker, backpressure) once
@@ -235,7 +243,7 @@ impl CompactionScheduler for SizeTieredCompactionScheduler {
         loop {
             let mut picked_any = false;
             for tree in &mut trees {
-                if active_compactions.len() + compactions.len() >= self.max_concurrent_compactions {
+                if compaction_slots_in_use + compactions.len() >= self.max_concurrent_compactions {
                     break;
                 }
                 if let Some(compaction) = self.pick_next_compaction(tree, &mut next_fresh_sr_id) {
@@ -501,7 +509,7 @@ mod tests {
     use crate::compactor::{CompactionScheduler, CompactionSchedulerSupplier};
 
     use crate::compactor_state::{
-        Compaction, CompactionSpec, Compactions, CompactorState, SourceId,
+        Compaction, CompactionSpec, CompactionStatus, Compactions, CompactorState, SourceId,
     };
     use crate::config::{CompactorOptions, SizeTieredCompactionSchedulerOptions};
     use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
@@ -692,6 +700,37 @@ mod tests {
 
         // then:
         assert_eq!(requests.len(), 0);
+    }
+
+    #[test]
+    fn test_compacted_job_does_not_consume_compaction_slot() {
+        // A finished worker job in one tree is still waiting for its manifest
+        // commit, while a disjoint tree has eligible work. With one worker
+        // slot, the scheduler should immediately refill that slot.
+        let scheduler =
+            SizeTieredCompactionScheduler::new(SizeTieredCompactionSchedulerOptions::default(), 1);
+        let root_l0: Vec<SsTableView> = (0..4).map(|_| create_sst_view(1)).collect();
+        let segment_l0: Vec<SsTableView> = (0..4).map(|_| create_sst_view(1)).collect();
+        let mut core = create_db_state(root_l0.iter().cloned().collect(), Vec::new());
+        core.segments = vec![segment_with(
+            b"finished/",
+            segment_l0.iter().cloned().collect(),
+            Vec::new(),
+        )];
+        let mut state = create_compactor_state(core);
+
+        let completed_worker_job = Compaction::new(
+            ulid::Ulid::new(),
+            create_segment_l0_compaction(b"finished/", &segment_l0, 0),
+        )
+        .with_status(CompactionStatus::Compacted);
+        state.insert_compaction_for_test(completed_worker_job);
+
+        let requests = scheduler.propose(&(&state).into());
+
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].segment().is_empty());
+        assert_eq!(requests[0].destination(), Some(1));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Before this patch we would count `Comapcted` compactions against `max_concurrent_compactions`, which would starve out compactions that should be scheduled.

## Changes

- add `CompactionStatus::consumes_compaction_slot()` (which is basically `active` without `Compacted`)
- use it in the scheduling

## Notes for Reviewers

N/A pretty simple

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
