### PR TITLE
switch fence fault injection over to fail channel from fail-parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,7 +888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "fail-parallel"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
+checksum = "c29b33a0187823f1fa88b36980227dc96c7504ede2288e7d2a77d9d6d88b260c"
 dependencies = [
  "log",
  "once_cell",
@@ -1749,7 +1749,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2107,7 +2107,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2879,7 +2879,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2936,7 +2936,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3535,7 +3535,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4384,7 +4384,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ crossbeam-channel = "0.5.15"
 crossbeam-skiplist = "0.1.3"
 dotenvy = "0.15.7"
 duration-str = { version = "0.11.2", default-features = false }
-fail-parallel = "0.5.2"
+fail-parallel = "0.6.0"
 figment = "0.10.19"
 flate2 = "1.1.2"
 flatbuffers = "25.2.10"

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -2,11 +2,11 @@ use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
 use crate::Settings;
+use fail_parallel::{fail_point_send, FailPointTx};
 use slatedb_common::SystemClock;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
-use fail_parallel::{fail_point_send, FailPointTx};
 
 pub(crate) struct WriterFencer {
     table_store: Arc<TableStore>,
@@ -27,12 +27,7 @@ impl WriterFencer {
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
     ) -> Self {
-        Self::new_with_fp_handle(
-            table_store,
-            settings,
-            system_clock,
-            FailPointTx::dummy()
-        )
+        Self::new_with_fp_handle(table_store, settings, system_clock, FailPointTx::dummy())
     }
 
     fn new_with_fp_handle(
@@ -136,7 +131,7 @@ mod tests {
         FlushOptions, FlushType, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
     };
     use crate::error::SlateDBError;
-    use crate::fence::{WriterFencer};
+    use crate::fence::WriterFencer;
     use crate::format::sst::SsTableFormat;
     use crate::garbage_collector::GarbageCollector;
     use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -146,6 +141,7 @@ mod tests {
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::{CloseReason, Db, ErrorKind, Settings};
     use bytes::Bytes;
+    use fail_parallel::fail_point_channel;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -156,7 +152,6 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
-    use fail_parallel::fail_point_channel;
 
     struct WriterFencerTestHarness {
         object_store: Arc<dyn ObjectStore>,
@@ -197,7 +192,7 @@ mod tests {
                 table_store.clone(),
                 &settings,
                 system_clock.clone(),
-                fp_tx
+                fp_tx,
             );
             Self {
                 object_store,

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -2,51 +2,23 @@ use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
 use crate::Settings;
-#[cfg(test)]
-use fail_parallel::fail_point;
-use fail_parallel::FailPointRegistry;
 use slatedb_common::SystemClock;
-use std::collections::HashSet;
 use std::ops::Range;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
+use fail_parallel::{fail_point_send, FailPointTx};
 
 pub(crate) struct WriterFencer {
     table_store: Arc<TableStore>,
     manifest_update_timeout: Duration,
     system_clock: Arc<dyn SystemClock>,
     #[cfg_attr(not(test), allow(dead_code))]
-    fp_ctl: Arc<FailPointCtl>,
+    fp_tx: FailPointTx,
 }
 
 pub(crate) struct WriterFenceResult {
     pub(crate) manifest: FenceableManifest,
     pub(crate) replay_range: Range<u64>,
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-struct FailPointCtl {
-    fp_registry: Arc<FailPointRegistry>,
-    event_tx: tokio::sync::mpsc::UnboundedSender<String>,
-    event_toggles: Mutex<HashSet<String>>,
-}
-
-impl FailPointCtl {
-    fn new(
-        fp_registry: Arc<FailPointRegistry>,
-        event_tx: tokio::sync::mpsc::UnboundedSender<String>,
-    ) -> Self {
-        Self {
-            fp_registry,
-            event_tx,
-            event_toggles: Mutex::new(HashSet::new()),
-        }
-    }
-
-    #[cfg(test)]
-    fn enable_fp(&self, event: impl ToString) {
-        self.event_toggles.lock().unwrap().insert(event.to_string());
-    }
 }
 
 impl WriterFencer {
@@ -55,47 +27,31 @@ impl WriterFencer {
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
     ) -> Self {
-        let (event_tx, _) = tokio::sync::mpsc::unbounded_channel();
-        Self::new_with_fp_ctl(
+        Self::new_with_fp_handle(
             table_store,
             settings,
             system_clock,
-            Arc::new(FailPointCtl::new(
-                Arc::new(FailPointRegistry::new()),
-                event_tx,
-            )),
+            FailPointTx::dummy()
         )
     }
 
-    fn new_with_fp_ctl(
+    fn new_with_fp_handle(
         table_store: Arc<TableStore>,
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
-        fp_ctl: Arc<FailPointCtl>,
+        fp_tx: FailPointTx,
     ) -> Self {
         Self {
             table_store,
             manifest_update_timeout: settings.manifest_update_timeout,
             system_clock,
-            fp_ctl,
+            fp_tx,
         }
     }
 
-    #[cfg(test)]
-    fn fp_notify(&self, event: impl ToString) {
-        let event = event.to_string();
-        let _ = self.fp_ctl.event_tx.send(event.clone());
-        let event_toggle = HashSet::clone(&*self.fp_ctl.event_toggles.lock().unwrap());
-        fail_point!(
-            Arc::clone(&self.fp_ctl.fp_registry),
-            "fence_event",
-            event_toggle.contains(&event),
-            |_| {}
-        );
+    fn fail_point_send(&self, _name: impl ToString) {
+        fail_point_send!(self.fp_tx, _name, |_| {});
     }
-
-    #[cfg(not(test))]
-    fn fp_notify(&self, _event: impl ToString) {}
 
     /// Fences all writers with an older epoch than the provided `stored_manifest` by (1) writing
     /// a new `FenceableManifest` with a bumped epoch, and (2) writing an empty WAL file that acts
@@ -110,7 +66,7 @@ impl WriterFencer {
             .table_store
             .next_wal_sst_id(stored_manifest.manifest().core.replay_after_wal_id)
             .await?;
-        self.fp_notify("LoadEmptyWalId");
+        self.fail_point_send("LoadEmptyWalId");
 
         let mut manifest = FenceableManifest::init_writer(
             stored_manifest,
@@ -118,7 +74,7 @@ impl WriterFencer {
             self.system_clock.clone(),
         )
         .await?;
-        self.fp_notify("FenceManifest");
+        self.fail_point_send("FenceManifest");
 
         let mut manifest_dirty = manifest.prepare_dirty()?;
         // verify that the empty_wal_id we computed is still valid. Its possible that between
@@ -133,7 +89,7 @@ impl WriterFencer {
                 .await?;
             manifest.refresh().await?;
             manifest_dirty = manifest.prepare_dirty()?;
-            self.fp_notify("ReloadEmptyWalId");
+            self.fail_point_send("ReloadEmptyWalId");
             // at this point we still hold the epoch, so it should not be possible for the barrier
             // to have advanced past the computed empty_wal_id
             assert!(empty_wal_id > manifest_dirty.value.core.replay_after_wal_id);
@@ -147,13 +103,13 @@ impl WriterFencer {
                 Err(SlateDBError::Fenced) => false,
                 Err(err) => return Err(err),
             };
-            self.fp_notify(format!("{}:{}", "WriteWalFence", attempt));
+            self.fail_point_send(format!("{}:{}", "WriteWalFence", attempt));
 
             // Refresh validates that we own the latest epoch still.
             manifest.refresh().await?;
             let dirty_manifest = manifest.prepare_dirty()?;
             let replay_after_wal_id = dirty_manifest.value.core.replay_after_wal_id;
-            self.fp_notify(format!("{}:{}", "RefreshManifest", attempt));
+            self.fail_point_send(format!("{}:{}", "RefreshManifest", attempt));
 
             if wrote_fence {
                 // this writer is the only writer that could have written replay_after_wal_id,
@@ -180,7 +136,7 @@ mod tests {
         FlushOptions, FlushType, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
     };
     use crate::error::SlateDBError;
-    use crate::fence::{FailPointCtl, WriterFencer};
+    use crate::fence::{WriterFencer};
     use crate::format::sst::SsTableFormat;
     use crate::garbage_collector::GarbageCollector;
     use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -200,6 +156,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
+    use fail_parallel::fail_point_channel;
 
     struct WriterFencerTestHarness {
         object_store: Arc<dyn ObjectStore>,
@@ -207,7 +164,6 @@ mod tests {
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,
         fp_registry: Arc<FailPointRegistry>,
-        fp_ctl: Arc<FailPointCtl>,
         event_rx: tokio::sync::mpsc::UnboundedReceiver<String>,
         fencer: Option<WriterFencer>,
         stored_manifest: Option<StoredManifest>,
@@ -236,13 +192,12 @@ mod tests {
             .await
             .unwrap();
             let fp_registry = Arc::new(FailPointRegistry::new());
-            let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
-            let fp_ctl = Arc::new(FailPointCtl::new(fp_registry.clone(), event_tx));
-            let fencer = WriterFencer::new_with_fp_ctl(
+            let (fp_tx, event_rx) = fail_point_channel(fp_registry.clone());
+            let fencer = WriterFencer::new_with_fp_handle(
                 table_store.clone(),
                 &settings,
                 system_clock.clone(),
-                fp_ctl.clone(),
+                fp_tx
             );
             Self {
                 object_store,
@@ -250,7 +205,6 @@ mod tests {
                 manifest_store,
                 table_store,
                 fp_registry,
-                fp_ctl,
                 event_rx,
                 fencer: Some(fencer),
                 stored_manifest: Some(stored_manifest),
@@ -470,9 +424,8 @@ mod tests {
         // initialize a fencer. configure it to pause at LoadEmptyWalId (so the
         // fenced writer can race ahead) and at the case's event (so a new
         // writer can claim the epoch out from under the fencer).
-        h.fp_ctl.enable_fp("LoadEmptyWalId");
-        h.fp_ctl.enable_fp(case.pause_event);
-        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "pause").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), "LoadEmptyWalId", "pause").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), case.pause_event, "pause").unwrap();
 
         let fencer = h.fencer.take().unwrap();
         let stored_manifest = h.stored_manifest.take().unwrap();
@@ -482,7 +435,7 @@ mod tests {
 
         // after LoadEmptyWalId pause, have the fenced db write some wals and flush and gc.
         // This advances replay_after_wal_id past the fencer's stale empty_wal_id, so the
-        // recompute branch (and ReloadEmptyWalId fp_notify) fires when the fencer resumes.
+        // recompute branch (and ReloadEmptyWalId fail_point_send) fires when the fencer resumes.
         h.put(&db, 1, false).await;
         h.put(&db, 2, false).await;
         db.flush_with_options(FlushOptions {
@@ -503,7 +456,8 @@ mod tests {
         // resume the fencer. re-issuing "pause" wakes the current pause and
         // keeps the action set to "pause" so the next toggled event also
         // pauses.
-        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "pause").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), "LoadEmptyWalId", "pause").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), case.pause_event, "pause").unwrap();
 
         // wait for the case's pause event. fp_notify sends an event for every
         // failpoint regardless of whether it pauses, so drain intermediate
@@ -540,7 +494,8 @@ mod tests {
         }
 
         // resume the fencer
-        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "off").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), "LoadEmptyWalId", "off").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), case.pause_event, "off").unwrap();
 
         // validate that its fenced — the fencer's manifest.refresh sees the new db's
         // bumped epoch and returns Fenced.
@@ -571,8 +526,7 @@ mod tests {
         h.put(&db, 0, false).await;
 
         // configure the fencer to pause
-        h.fp_ctl.enable_fp(case.event);
-        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "pause").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), case.event, "pause").unwrap();
 
         // spawn WriterFencer on another task
         let fencer = h.fencer.take().unwrap();
@@ -612,7 +566,7 @@ mod tests {
         }
 
         // unpause WriterFencer
-        fail_parallel::cfg(h.fp_registry.clone(), "fence_event", "off").unwrap();
+        fail_parallel::cfg(h.fp_registry.clone(), case.event, "off").unwrap();
         // verify it returns successfully
         let result = jh.await.unwrap().unwrap();
         // The fencer's stale empty_wal_id was retried above the fenced writer's possibly


### PR DESCRIPTION
## Summary

Switches the fault injection in fence.rs to use the fail channel stuff added to fail-parallel in 0.6.0 (https://github.com/slatedb/fail-parallel/pull/3)

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
