### PR TITLE
Eliminate unnecessary object store requests made on each `CommitCompacted` tick and increase worker default heartbeat_interval

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -867,6 +867,7 @@ impl CompactorEventHandler {
             return Ok(());
         }
 
+        let mut manifest_changed = false;
         for compaction in compacted {
             let id = compaction.id();
             match self.validate_compaction(&compaction) {
@@ -884,6 +885,7 @@ impl CompactorEventHandler {
                             .collect(),
                     };
                     self.state_mut().finish_compaction(id, output_sr);
+                    manifest_changed = true;
                     self.stats
                         .last_compaction_ts
                         .set(self.system_clock.now().timestamp());
@@ -902,7 +904,13 @@ impl CompactorEventHandler {
         }
 
         self.log_compaction_state();
-        self.state_writer.write_state_safely().await?;
+        if manifest_changed {
+            self.state_writer.write_state_safely().await?;
+        } else {
+            // Validation failures only change `.compactions`. Avoid creating a
+            // checkpoint and writing an unchanged manifest.
+            self.state_writer.write_compactions_safely().await?;
+        }
 
         Ok(())
     }
@@ -6155,6 +6163,12 @@ mod tests {
             .handler
             .state_mut()
             .insert_compaction_for_test(compaction);
+        let manifest_id_before = fixture
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .id;
 
         // when:
         fixture
@@ -6176,6 +6190,16 @@ mod tests {
                 .expect("missing compaction")
                 .status(),
             CompactionStatus::Failed,
+        );
+        let manifest_id_after = fixture
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .id;
+        assert_eq!(
+            manifest_id_after, manifest_id_before,
+            "validation-only failures must not checkpoint or rewrite the manifest"
         );
     }
 

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -553,7 +553,7 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
                 // A remote worker can only produce a new Compacted result for a
                 // job the coordinator already tracks as active. When there are no
                 // active jobs, the regular manifest poll is sufficient to discover
-                // new submissions; avoid an otherwise idle object-store refresh.
+                // new submissions. We can avoid an otherwise idle object-store refresh.
                 if self.state().active_compactions().next().is_some() {
                     self.state_writer.load_compactions().await?;
                     self.update_distributed_compaction_metrics();

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -550,9 +550,15 @@ impl MessageHandler<CompactorMessage> for CompactorEventHandler {
             CompactorMessage::LogStats => self.handle_log_ticker(),
             CompactorMessage::PollManifest => self.handle_ticker().await?,
             CompactorMessage::CommitCompacted => {
-                self.state_writer.load_compactions().await?;
-                self.update_distributed_compaction_metrics();
-                self.commit_compacted_entries().await?;
+                // A remote worker can only produce a new Compacted result for a
+                // job the coordinator already tracks as active. When there are no
+                // active jobs, the regular manifest poll is sufficient to discover
+                // new submissions; avoid an otherwise idle object-store refresh.
+                if self.state().active_compactions().next().is_some() {
+                    self.state_writer.load_compactions().await?;
+                    self.update_distributed_compaction_metrics();
+                    self.commit_compacted_entries().await?;
+                }
             }
         }
         Ok(())
@@ -5025,6 +5031,71 @@ mod tests {
                 .expect("missing stored compaction")
                 .status(),
             CompactionStatus::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_compacted_ticker_skips_remote_refresh_when_idle() {
+        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        assert!(fixture
+            .handler
+            .state()
+            .active_compactions()
+            .next()
+            .is_none());
+
+        // Simulate an external submission arriving after the coordinator's last
+        // regular poll. An idle fast-commit tick must not read it from storage.
+        let remote_id = Ulid::new();
+        let mut external = StoredCompactions::try_load(fixture.compactions_store.clone())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut dirty = external.prepare_dirty().unwrap();
+        dirty.value.insert(Compaction::new(
+            remote_id,
+            CompactionSpec::new(Vec::new(), 0),
+        ));
+        external.update(dirty).await.unwrap();
+
+        fixture
+            .handler
+            .handle(CompactorMessage::CommitCompacted)
+            .await
+            .unwrap();
+        assert!(
+            !fixture
+                .handler
+                .state()
+                .compactions()
+                .value
+                .contains(&remote_id),
+            "idle fast-commit tick should not refresh .compactions"
+        );
+
+        // Once the coordinator has active work, the same fast tick must resume
+        // refreshing so it can observe worker transitions promptly.
+        let local_id = Ulid::new();
+        fixture
+            .handler
+            .state_mut()
+            .insert_compaction_for_test(Compaction::new(
+                local_id,
+                CompactionSpec::new(Vec::new(), 0),
+            ));
+        fixture
+            .handler
+            .handle(CompactorMessage::CommitCompacted)
+            .await
+            .unwrap();
+        assert!(
+            fixture
+                .handler
+                .state()
+                .compactions()
+                .value
+                .contains(&remote_id),
+            "active fast-commit tick should refresh .compactions"
         );
     }
 

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1265,7 +1265,7 @@ impl Default for CompactionWorkerOptions {
         Self {
             max_concurrent_compactions: 4,
             compactions_poll_interval: Duration::from_secs(5),
-            heartbeat_interval: Duration::from_secs(5),
+            heartbeat_interval: Duration::from_secs(10),
             max_sst_size: 256 * 1024 * 1024,
             max_fetch_tasks: 4,
             bytes_to_fetch: 2 * 1024 * 1024,


### PR DESCRIPTION
## Summary

A few optimizations to reduce the number of object store requests made with the new `CommitCompacted` ticker that was added for distributed compaction. This PR also increases the workers default `heartbeat_interval` to 10 seconds instead of 5. The main motivation behind these changes is to bring down the cost of running SlateDB while keeping distributed compaction functional.

## Changes

### Skip idle fast refreshes
The `CommitCompacted` ticker now refreshes .compactions only when the coordinator has at least one locally active compaction.
The ticker itself still fires; it simply returns without object-store I/O while the worker has nothing to commit.

### Avoid unchanged manifest writes
commit_compacted_entries() now tracks whether any successfully validated compaction modified the manifest.
  - If at least one entry modifies the manifest, it preserves the existing
    manifest-first write_state_safely() protocol.
  - If every entry fails validation, it writes only .compactions.

### Increase default worker `heartbeat_interval`

Reduce the baseline costs incurred from periodic heartbeats by increasing the default heartbeat interval from 5s to 10s.

## Notes for Reviewers

N/A pretty straight forward. Discord thread about cost reduction here - https://discord.com/channels/1232385660460204122/1526956520183566356


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
