### PR TITLE
[1923] Expose object_store_max_retries on UniFFI 

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -9471,6 +9471,11 @@ type GarbageCollectorOptions struct {
 	// as successful. Set `min_age` longer than the maximum lifetime of a stale process, and use the
 	// same setting for every GC operating on the database.
 	DisableBoundaryFiles bool
+	// Maximum number of wrapper-level retries for a single object-store
+	// operation, on top of the `object_store` client's own HTTP retries.
+	// `None` (default) retries transient errors indefinitely; `Some(n)` gives
+	// up after `n` retries and surfaces the underlying error.
+	ObjectStoreMaxRetries *uint32
 }
 
 func (r *GarbageCollectorOptions) Destroy() {
@@ -9481,6 +9486,7 @@ func (r *GarbageCollectorOptions) Destroy() {
 	FfiDestroyerOptionalGarbageCollectorDirectoryOptions{}.Destroy(r.CompactionsOptions)
 	FfiDestroyerOptionalGarbageCollectorScheduleOptions{}.Destroy(r.DetachOptions)
 	FfiDestroyerBool{}.Destroy(r.DisableBoundaryFiles)
+	FfiDestroyerOptionalUint32{}.Destroy(r.ObjectStoreMaxRetries)
 }
 
 type FfiConverterGarbageCollectorOptions struct{}
@@ -9500,6 +9506,7 @@ func (c FfiConverterGarbageCollectorOptions) Read(reader io.Reader) GarbageColle
 		FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Read(reader),
 		FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalUint32INSTANCE.Read(reader),
 	}
 }
 
@@ -9519,6 +9526,7 @@ func (c FfiConverterGarbageCollectorOptions) Write(writer io.Writer, value Garba
 	FfiConverterOptionalGarbageCollectorDirectoryOptionsINSTANCE.Write(writer, value.CompactionsOptions)
 	FfiConverterOptionalGarbageCollectorScheduleOptionsINSTANCE.Write(writer, value.DetachOptions)
 	FfiConverterBoolINSTANCE.Write(writer, value.DisableBoundaryFiles)
+	FfiConverterOptionalUint32INSTANCE.Write(writer, value.ObjectStoreMaxRetries)
 }
 
 type FfiDestroyerGarbageCollectorOptions struct{}
@@ -10244,6 +10252,11 @@ type ReaderOptions struct {
 	MaxMemtableBytes uint64
 	// Whether WAL replay should be skipped entirely.
 	SkipWalReplay bool
+	// Maximum number of wrapper-level retries for a single object-store
+	// operation, on top of the `object_store` client's own HTTP retries.
+	// `None` (default) retries transient errors indefinitely; `Some(n)` gives
+	// up after `n` retries and surfaces the underlying error.
+	ObjectStoreMaxRetries *uint32
 }
 
 func (r *ReaderOptions) Destroy() {
@@ -10251,6 +10264,7 @@ func (r *ReaderOptions) Destroy() {
 	FfiDestroyerUint64{}.Destroy(r.CheckpointLifetimeMs)
 	FfiDestroyerUint64{}.Destroy(r.MaxMemtableBytes)
 	FfiDestroyerBool{}.Destroy(r.SkipWalReplay)
+	FfiDestroyerOptionalUint32{}.Destroy(r.ObjectStoreMaxRetries)
 }
 
 type FfiConverterReaderOptions struct{}
@@ -10267,6 +10281,7 @@ func (c FfiConverterReaderOptions) Read(reader io.Reader) ReaderOptions {
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalUint32INSTANCE.Read(reader),
 	}
 }
 
@@ -10283,6 +10298,7 @@ func (c FfiConverterReaderOptions) Write(writer io.Writer, value ReaderOptions) 
 	FfiConverterUint64INSTANCE.Write(writer, value.CheckpointLifetimeMs)
 	FfiConverterUint64INSTANCE.Write(writer, value.MaxMemtableBytes)
 	FfiConverterBoolINSTANCE.Write(writer, value.SkipWalReplay)
+	FfiConverterOptionalUint32INSTANCE.Write(writer, value.ObjectStoreMaxRetries)
 }
 
 type FfiDestroyerReaderOptions struct{}

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/SlateDbAdminTest.java
@@ -184,7 +184,8 @@ class SlateDbAdminTest {
                             null,
                             null,
                             scheduleOptions,
-                            true);
+                            true,
+                            null);
 
             TestSupport.await(admin.runGcOnce(options));
         }

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/TestSupport.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/TestSupport.java
@@ -350,7 +350,7 @@ final class TestSupport {
     }
 
     static ReaderOptions readerOptions(boolean skipWalReplay) {
-        return new ReaderOptions(100L, 1000L, 64L * 1024 * 1024, skipWalReplay);
+        return new ReaderOptions(100L, 1000L, 64L * 1024 * 1024, skipWalReplay, null);
     }
 
     private static Throwable unwrap(Throwable thrown) {

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -194,6 +194,12 @@ pub struct ReaderOptions {
     pub max_memtable_bytes: u64,
     /// Whether WAL replay should be skipped entirely.
     pub skip_wal_replay: bool,
+    /// Maximum number of wrapper-level retries for a single object-store
+    /// operation, on top of the `object_store` client's own HTTP retries.
+    /// `None` (default) retries transient errors indefinitely; `Some(n)` gives
+    /// up after `n` retries and surfaces the underlying error.
+    #[uniffi(default = None)]
+    pub object_store_max_retries: Option<u32>,
 }
 
 impl Default for ReaderOptions {
@@ -203,6 +209,7 @@ impl Default for ReaderOptions {
             checkpoint_lifetime_ms: 600_000,
             max_memtable_bytes: 64 * 1024 * 1024,
             skip_wal_replay: false,
+            object_store_max_retries: None,
         }
     }
 }
@@ -214,6 +221,7 @@ impl From<ReaderOptions> for slatedb::config::DbReaderOptions {
             checkpoint_lifetime: Duration::from_millis(value.checkpoint_lifetime_ms),
             max_memtable_bytes: value.max_memtable_bytes,
             skip_wal_replay: value.skip_wal_replay,
+            object_store_max_retries: value.object_store_max_retries,
             ..Default::default()
         }
     }
@@ -459,6 +467,12 @@ pub struct GarbageCollectorOptions {
     /// same setting for every GC operating on the database.
     #[uniffi(default = false)]
     pub disable_boundary_files: bool,
+    /// Maximum number of wrapper-level retries for a single object-store
+    /// operation, on top of the `object_store` client's own HTTP retries.
+    /// `None` (default) retries transient errors indefinitely; `Some(n)` gives
+    /// up after `n` retries and surfaces the underlying error.
+    #[uniffi(default = None)]
+    pub object_store_max_retries: Option<u32>,
 }
 
 impl Default for GarbageCollectorOptions {
@@ -472,6 +486,7 @@ impl Default for GarbageCollectorOptions {
             compactions_options: core.compactions_options.map(Into::into),
             detach_options: core.detach_options.map(Into::into),
             disable_boundary_files: !core.boundary_files_enabled,
+            object_store_max_retries: core.object_store_max_retries,
         }
     }
 }
@@ -505,14 +520,14 @@ impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions 
             detach_options: value.detach_options.map(Into::into),
             metric_level: None,
             boundary_files_enabled: !value.disable_boundary_files,
-            object_store_max_retries: None,
+            object_store_max_retries: value.object_store_max_retries,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::GarbageCollectorOptions;
+    use super::{GarbageCollectorOptions, ReaderOptions};
 
     #[test]
     fn boundary_files_are_enabled_by_default() {
@@ -531,6 +546,43 @@ mod tests {
         .into();
 
         assert!(!gc.boundary_files_enabled);
+    }
+
+    #[test]
+    fn gc_object_store_max_retries_defaults_to_unbounded() {
+        let gc: slatedb::config::GarbageCollectorOptions =
+            GarbageCollectorOptions::default().into();
+
+        assert_eq!(gc.object_store_max_retries, None);
+    }
+
+    #[test]
+    fn gc_object_store_max_retries_threads_through() {
+        let gc: slatedb::config::GarbageCollectorOptions = GarbageCollectorOptions {
+            object_store_max_retries: Some(3),
+            ..GarbageCollectorOptions::default()
+        }
+        .into();
+
+        assert_eq!(gc.object_store_max_retries, Some(3));
+    }
+
+    #[test]
+    fn reader_object_store_max_retries_defaults_to_unbounded() {
+        let reader: slatedb::config::DbReaderOptions = ReaderOptions::default().into();
+
+        assert_eq!(reader.object_store_max_retries, None);
+    }
+
+    #[test]
+    fn reader_object_store_max_retries_threads_through() {
+        let reader: slatedb::config::DbReaderOptions = ReaderOptions {
+            object_store_max_retries: Some(5),
+            ..ReaderOptions::default()
+        }
+        .into();
+
+        assert_eq!(reader.object_store_max_retries, Some(5));
     }
 }
 


### PR DESCRIPTION

## Summary

- As part of https://github.com/slatedb/slatedb/pull/1924 we added max_retries settings.
- This PR addresses this comment to maintain parity with UniFFI https://github.com/slatedb/slatedb/pull/1924#discussion_r3589101849

## Notes for Reviewers

- Settings and compactor_options are reachable through the dotted-path Settings.set(key, value_json) (serde round-trip), so object_store_max_retries on those already flowed through with no binding change.
- ReaderOptions and GarbageCollectorOptions are typed uniffi::Records with explicit From impls, and those impls silently dropped the new field (..Default::default() for the reader, hardcoded None for GC). A caller going through the FFI DbReader / Admin::run_gc_once had no way to set the retry bound.
- This PR closes that gap: it adds object_store_max_retries: Option<u32> (default None = unbounded, matching core) to those two records and threads it through Default + From.

Where to focus:

- bindings/uniffi/src/config.rs is the only hand-written change — 2 record fields + From/Default threading + 4 round-trip tests.
- bindings/go/uniffi/slatedb.go is regenerated, not hand-edited: produced by ./scripts/generate-go-uniffi.sh with the CI-pinned uniffi-bindgen-go v0.7.0+v0.31.0. The diff is purely mechanical (a *uint32 field + destroyer + Read/Write converters on each record).

Not touched (intentionally): Python (__init__.py is a thin wrapper; real bindings are built by maturin at build time), Node, and Java check no generated sources into the tree carrying these records — they regenerate into gitignored dirs at build time. Go is the only binding with checked-in generated code, so it's the only one regenerated here.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
