### PR TITLE
[1932] Expose manifest structural counts as DbStats gauges

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -9622,16 +9622,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_should_record_l0_sst_count() {
+    async fn test_should_record_manifest_structural_counts() {
         // given:
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
-        let db = Db::builder("/tmp/test_should_record_l0_sst_count", object_store)
-            .with_settings(test_db_options(0, 1024, None))
-            .with_metrics_recorder(metrics_recorder.clone())
-            .build()
-            .await
-            .unwrap();
+        let db = Db::builder(
+            "/tmp/test_should_record_manifest_structural_counts",
+            object_store,
+        )
+        .with_settings(test_db_options(0, 1024, None))
+        .with_metrics_recorder(metrics_recorder.clone())
+        .build()
+        .await
+        .unwrap();
 
         // when: write data and flush memtable to L0
         db.put(b"k1", b"v1").await.unwrap();
@@ -9659,6 +9662,29 @@ mod tests {
         assert_eq!(
             segment_max, l0_count,
             "expected segment_max_l0_sst_count == l0_sst_count for an unsegmented DB"
+        );
+
+        // The single flushed L0 SST shows up as one SST view, with no sorted
+        // runs and no external DBs. These gauges are set at the same call site.
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::SST_VIEW_COUNT),
+            Some(1),
+            "expected sst_view_count == 1 for a single flushed L0 SST"
+        );
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::SST_COUNT),
+            Some(1),
+            "expected sst_count == 1 (one distinct physical SST) for a single flushed L0 SST"
+        );
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::SORTED_RUN_COUNT),
+            Some(0),
+            "expected sorted_run_count == 0 before any compaction"
+        );
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::EXTERNAL_DB_COUNT),
+            Some(0),
+            "expected external_db_count == 0 for a standalone DB"
         );
         db.close().await.unwrap();
     }

--- a/slatedb/src/db_stats.rs
+++ b/slatedb/src/db_stats.rs
@@ -26,6 +26,10 @@ pub const IMMUTABLE_MEMTABLE_FLUSHES: &str = db_stat_name!("immutable_memtable_f
 pub const TOTAL_MEM_SIZE_BYTES: &str = db_stat_name!("total_mem_size_bytes");
 pub const L0_SST_COUNT: &str = db_stat_name!("l0_sst_count");
 pub const SEGMENT_MAX_L0_SST_COUNT: &str = db_stat_name!("segment_max_l0_sst_count");
+pub const SORTED_RUN_COUNT: &str = db_stat_name!("sorted_run_count");
+pub const SST_VIEW_COUNT: &str = db_stat_name!("sst_view_count");
+pub const SST_COUNT: &str = db_stat_name!("sst_count");
+pub const EXTERNAL_DB_COUNT: &str = db_stat_name!("external_db_count");
 pub const L0_FLUSH_BYTES: &str = db_stat_name!("l0_flush_bytes");
 pub const SST_FILTER_FALSE_POSITIVE_COUNT: &str = db_stat_name!("sst_filter_false_positive_count");
 pub const SST_FILTER_POSITIVE_COUNT: &str = db_stat_name!("sst_filter_positive_count");
@@ -63,6 +67,10 @@ pub(crate) struct DbStatsInner {
     pub(crate) total_mem_size_bytes: Arc<dyn GaugeFn>,
     pub(crate) l0_sst_count: Arc<dyn GaugeFn>,
     pub(crate) segment_max_l0_sst_count: Arc<dyn GaugeFn>,
+    pub(crate) sorted_run_count: Arc<dyn GaugeFn>,
+    pub(crate) sst_view_count: Arc<dyn GaugeFn>,
+    pub(crate) sst_count: Arc<dyn GaugeFn>,
+    pub(crate) external_db_count: Arc<dyn GaugeFn>,
     pub(crate) l0_flush_bytes: Arc<dyn CounterFn>,
     pub(crate) merge_operator_read_operands: Arc<dyn CounterFn>,
     pub(crate) merge_operator_flush_operands: Arc<dyn CounterFn>,
@@ -137,6 +145,10 @@ impl DbStats {
             total_mem_size_bytes: recorder.gauge(TOTAL_MEM_SIZE_BYTES).register(),
             l0_sst_count: recorder.gauge(L0_SST_COUNT).register(),
             segment_max_l0_sst_count: recorder.gauge(SEGMENT_MAX_L0_SST_COUNT).register(),
+            sorted_run_count: recorder.gauge(SORTED_RUN_COUNT).register(),
+            sst_view_count: recorder.gauge(SST_VIEW_COUNT).register(),
+            sst_count: recorder.gauge(SST_COUNT).register(),
+            external_db_count: recorder.gauge(EXTERNAL_DB_COUNT).register(),
             l0_flush_bytes: recorder.counter(L0_FLUSH_BYTES).register(),
             merge_operator_read_operands: recorder
                 .counter(MERGE_OPERATOR_OPERANDS)

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -19,7 +19,7 @@ use super::uploader::UploadedMemtable;
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::{collect_touched_segments, DbState, SsTableView};
+use crate::db_state::{collect_touched_segments, DbState, SsTableId, SsTableView};
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
@@ -33,7 +33,7 @@ use futures::stream::BoxStream;
 use futures::StreamExt;
 use parking_lot::RwLockWriteGuard;
 use std::cmp;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
@@ -674,6 +674,33 @@ impl ManifestWriterHandler {
                 .fold((0usize, 0usize), |(sum, max), n| (sum + n, max.max(n)));
             self.db.db_stats.l0_sst_count.set(total as i64);
             self.db.db_stats.segment_max_l0_sst_count.set(max as i64);
+            // Structural manifest counts span every tree (root + each named segment
+            // per RFC-0024), matching the `l0_sst_count` scope above. `sst_view_count`
+            // sums L0 views and every sorted-run SST view; `sst_count` deduplicates
+            // those views by physical SST id (a range clone/rescale can project one
+            // SST into several views, so `sst_count <= sst_view_count`); `sorted_run_count`
+            // sums the sorted runs across trees; `external_db_count` is a top-level field.
+            let mut sorted_runs = 0usize;
+            let mut sst_views = 0usize;
+            let mut distinct_ssts: HashSet<SsTableId> = HashSet::new();
+            for tree in cow.core().trees() {
+                let all_views = tree
+                    .l0
+                    .iter()
+                    .chain(tree.compacted.iter().flat_map(|run| run.sst_views.iter()));
+                for view in all_views {
+                    sst_views += 1;
+                    distinct_ssts.insert(view.sst.id);
+                }
+                sorted_runs += tree.compacted.len();
+            }
+            self.db.db_stats.sorted_run_count.set(sorted_runs as i64);
+            self.db.db_stats.sst_view_count.set(sst_views as i64);
+            self.db.db_stats.sst_count.set(distinct_ssts.len() as i64);
+            self.db
+                .db_stats
+                .external_db_count
+                .set(cow.manifest.value.external_dbs.len() as i64);
             cow.manifest.clone()
         };
         self.db

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -19,7 +19,7 @@ use super::uploader::UploadedMemtable;
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::{collect_touched_segments, DbState, SsTableId, SsTableView};
+use crate::db_state::{collect_touched_segments, COWDbState, DbState, SsTableId, SsTableView};
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
@@ -663,49 +663,49 @@ impl ManifestWriterHandler {
             let mut wguard_state = self.db.state.write();
             wguard_state.merge_remote_manifest(remote_dirty);
             let cow = wguard_state.state();
-            // L0 SST counters span every tree (root + each named segment per
-            // RFC-0024). `l0_sst_count` reports the total; `segment_max_*`
-            // reports the largest single tree, which is the right quantity
-            // for backpressure since `l0_max_ssts` is enforced per-tree.
-            let (total, max) = cow
-                .core()
-                .trees()
-                .map(|t| t.l0.len())
-                .fold((0usize, 0usize), |(sum, max), n| (sum + n, max.max(n)));
-            self.db.db_stats.l0_sst_count.set(total as i64);
-            self.db.db_stats.segment_max_l0_sst_count.set(max as i64);
-            // Structural manifest counts span every tree (root + each named segment
-            // per RFC-0024), matching the `l0_sst_count` scope above. `sst_view_count`
-            // sums L0 views and every sorted-run SST view; `sst_count` deduplicates
-            // those views by physical SST id (a range clone/rescale can project one
-            // SST into several views, so `sst_count <= sst_view_count`); `sorted_run_count`
-            // sums the sorted runs across trees; `external_db_count` is a top-level field.
-            let mut sorted_runs = 0usize;
-            let mut sst_views = 0usize;
-            let mut distinct_ssts: HashSet<SsTableId> = HashSet::new();
-            for tree in cow.core().trees() {
-                let all_views = tree
-                    .l0
-                    .iter()
-                    .chain(tree.compacted.iter().flat_map(|run| run.sst_views.iter()));
-                for view in all_views {
-                    sst_views += 1;
-                    distinct_ssts.insert(view.sst.id);
-                }
-                sorted_runs += tree.compacted.len();
-            }
-            self.db.db_stats.sorted_run_count.set(sorted_runs as i64);
-            self.db.db_stats.sst_view_count.set(sst_views as i64);
-            self.db.db_stats.sst_count.set(distinct_ssts.len() as i64);
-            self.db
-                .db_stats
-                .external_db_count
-                .set(cow.manifest.value.external_dbs.len() as i64);
+            self.update_stats_for_manifest(&cow);
             cow.manifest.clone()
         };
         self.db
             .status_manager
             .report_manifest(dirty_manifest.into());
+    }
+
+    fn update_stats_for_manifest(&self, cow: &COWDbState) {
+        let mut l0_ssts = 0usize;
+        let mut segment_max_l0_ssts = 0usize;
+        let mut sorted_runs = 0usize;
+        let mut sst_views = 0usize;
+        let mut distinct_ssts: HashSet<SsTableId> = HashSet::new();
+        for tree in cow.core().trees() {
+            l0_ssts += tree.l0.len();
+            // Track the largest single tree: backpressure is driven by `segment_max_l0_sst_count`
+            // because `l0_max_ssts` is enforced per-tree.
+            segment_max_l0_ssts = segment_max_l0_ssts.max(tree.l0.len());
+            sorted_runs += tree.compacted.len();
+            let all_views = tree
+                .l0
+                .iter()
+                .chain(tree.compacted.iter().flat_map(|run| run.sst_views.iter()));
+            for view in all_views {
+                sst_views += 1;
+                // Dedupe by physical SST id: a range clone/rescale can project one SST into
+                // several views, so `sst_count <= sst_view_count`.
+                distinct_ssts.insert(view.sst.id);
+            }
+        }
+        self.db.db_stats.l0_sst_count.set(l0_ssts as i64);
+        self.db
+            .db_stats
+            .segment_max_l0_sst_count
+            .set(segment_max_l0_ssts as i64);
+        self.db.db_stats.sorted_run_count.set(sorted_runs as i64);
+        self.db.db_stats.sst_view_count.set(sst_views as i64);
+        self.db.db_stats.sst_count.set(distinct_ssts.len() as i64);
+        self.db
+            .db_stats
+            .external_db_count
+            .set(cow.manifest.value.external_dbs.len() as i64);
     }
 
     async fn write_checkpoint_safely(

--- a/website/src/content/docs/docs/operations/metrics.mdx
+++ b/website/src/content/docs/docs/operations/metrics.mdx
@@ -100,6 +100,10 @@ All metric names use dot-separated notation: `slatedb.<subsystem>.<metric>`.
 | `slatedb.db.total_mem_size_bytes` | gauge | | Total memory usage |
 | `slatedb.db.l0_sst_count` | gauge | | L0 SST count summed across all segment trees |
 | `slatedb.db.segment_max_l0_sst_count` | gauge | | Maximum L0 SST count across all segments (useful for detecting backpressure on specific segments) |
+| `slatedb.db.sorted_run_count` | gauge | | Number of sorted runs across all trees (root tree plus each named segment tree per RFC-0024) |
+| `slatedb.db.sst_view_count` | gauge | | Total number of SST views including L0 views and every sorted-run SST view across all trees |
+| `slatedb.db.sst_count` | gauge | | Number of distinct physical SSTables (deduplicates sst_view_count by SsTableId, so sst_count is at most sst_view_count) |
+| `slatedb.db.external_db_count` | gauge | | Number of external databases referenced in the manifest |
 | `slatedb.db.sst_filter_false_positive_count` | counter | | Bloom filter false positives |
 | `slatedb.db.sst_filter_positive_count` | counter | | Bloom filter positives |
 | `slatedb.db.sst_filter_negative_count` | counter | | Bloom filter negatives |


### PR DESCRIPTION
## Summary

Expose four manifest-derived structural counts as `DbStats` gauges, following the existing `l0_sst_count` / `segment_max_l0_sst_count` pattern:

- `sorted_run_count` — sorted runs across all trees (root + each named segment)
- `sst_view_count` — L0 views plus every sorted-run SST view
- `sst_count` — distinct physical SSTs (`sst_view_count` deduplicated by `SsTableId`); a range clone / rescale can project one physical SST into several views, so `sst_count <= sst_view_count`
- `external_db_count` — number of external DBs referenced by the manifest

`DbStats` already exposes `l0_sst_count` and `segment_max_l0_sst_count`, but there is no visibility into these other structural quantities, which are useful for monitoring compaction health and clone/rescale behavior. Consumers can introspect `Db::manifest()` and count these themselves, but having SlateDB own the counts keeps that logic out of every consumer.

Closes #1932. Discussion: https://discord.com/channels/1232385660460204122/1232385660946616433/1527032277735837878


## Changes

All four gauges are set on manifest merge, at the same call site in `merge_remote_manifest` where `l0_sst_count` is updated today. They share its cadence and add no work on the read/write path.

Split into two commits:
1. the three direct counts (`sorted_run_count`, `sst_view_count`, `external_db_count`)
2. the deduplicated `sst_count`

### Testing

Extended `test_should_record_manifest_structural_counts` (renamed from `test_should_record_l0_sst_count`) to assert the new gauges after a flush.

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
