### PR TITLE
Fix stale external SSTs after manifest merge

### DIFF
--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -970,6 +970,7 @@ impl CompactorState {
             sequence_tracker: remote_manifest.value.core.sequence_tracker,
         };
         remote_manifest.value.core = merged;
+        remote_manifest.value.prune_external_sst_ids();
         self.manifest = remote_manifest;
     }
 
@@ -1715,6 +1716,31 @@ mod tests {
             .map(|h| h.sst.id.unwrap_compacted_id())
             .collect();
         assert_eq!(expected_merged_l0s, merged_l0s);
+    }
+
+    #[test]
+    fn test_merge_remote_manifest_reestablishes_external_sst_invariant() {
+        let manifest = new_dirty_manifest();
+        let compactions = new_dirty_compactions(manifest.value.compactor_epoch);
+        let mut state = CompactorState::new(manifest, compactions);
+        let stale_id = SsTableId::Compacted(Ulid::new());
+        let mut remote = new_dirty_manifest();
+        remote.value.external_dbs = vec![crate::manifest::ExternalDb {
+            path: "/parent/db".to_string(),
+            source_checkpoint_id: uuid::Uuid::new_v4(),
+            final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+            sst_ids: vec![stale_id],
+        }];
+
+        state.merge_remote_manifest(remote);
+
+        let external = &state.manifest().value.external_dbs;
+        assert_eq!(external.len(), 1, "detach metadata must be retained");
+        assert!(
+            external[0].sst_ids.is_empty(),
+            "IDs absent from the merged tree must not be resurrected"
+        );
+        assert!(external[0].final_checkpoint_id.is_some());
     }
 
     #[test]

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -344,8 +344,9 @@ mod tests {
     use crate::error::SlateDBError;
     use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::manifest::store::{ManifestStore, StoredManifest};
-    use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
+    use crate::manifest::{ExternalDb, Manifest, ManifestCore, VersionedManifest};
     use crate::subcompaction::Subcompaction;
+    use crate::test_utils::GatedObjectStore;
     use bytes::Bytes;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -978,7 +979,9 @@ mod tests {
 
     #[tokio::test]
     async fn write_manifest_safely_retries_on_version_conflict() {
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let inner_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated_store = Arc::new(GatedObjectStore::new(Arc::clone(&inner_store)));
+        let object_store: Arc<dyn ObjectStore> = gated_store.clone();
         let manifest_store = Arc::new(ManifestStore::new(
             &Path::from(ROOT),
             Arc::clone(&object_store),
@@ -989,13 +992,24 @@ mod tests {
         ));
         let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
 
-        StoredManifest::create_new_db(
+        let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
             ManifestCore::new(),
             system_clock.clone(),
         )
         .await
         .unwrap();
+        let stale_sst_id = SsTableId::Compacted(Ulid::new());
+        let source_checkpoint_id = uuid::Uuid::new_v4();
+        let final_checkpoint_id = uuid::Uuid::new_v4();
+        let mut dirty = stored_manifest.prepare_dirty().unwrap();
+        dirty.value.external_dbs = vec![ExternalDb {
+            path: "/parent/db".to_string(),
+            source_checkpoint_id,
+            final_checkpoint_id: Some(final_checkpoint_id),
+            sst_ids: vec![stale_sst_id],
+        }];
+        stored_manifest.update(dirty).await.unwrap();
 
         let options = CompactorOptions::default();
         let rand = Arc::new(DbRand::new(7));
@@ -1013,25 +1027,51 @@ mod tests {
         // Record the version after fencing.
         let start_id = manifest_store.read_latest_manifest().await.unwrap().id;
 
-        // Simulate an external writer creating a checkpoint of the manifest and updating it.
-        let admin = AdminBuilder::new(ROOT, object_store.clone()).build();
-        admin
+        // Allow write_manifest's checkpoint through, then block its manifest update.
+        // The safe path has already loaded and pruned local state at that boundary.
+        let baseline_puts = gated_store.put_opts_gate.arrivals();
+        gated_store.put_opts_gate.close();
+        gated_store.put_opts_gate.admit(1);
+        let write_task = tokio::spawn(async move { writer.write_manifest_safely().await });
+        gated_store
+            .put_opts_gate
+            .wait_for_arrivals(baseline_puts + 2)
+            .await;
+
+        // Race a checkpoint into the exact version intended by the blocked update.
+        let admin = AdminBuilder::new(ROOT, inner_store).build();
+        let remote_checkpoint = admin
             .create_detached_checkpoint(&CheckpointOptions::default())
             .await
             .expect("create checkpoint failed");
 
         let conflicting_id = manifest_store.read_latest_manifest().await.unwrap().id;
-        assert_eq!(conflicting_id, start_id + 1);
+        assert_eq!(conflicting_id, start_id + 2);
 
-        // This should retry on conflict and succeed with a new version.
-        writer.write_manifest_safely().await.unwrap();
+        // Reloading and retrying must neither resurrect the pruned SST nor lose
+        // checkpoint metadata from either the external DB or the racing writer.
+        gated_store.put_opts_gate.release();
+        write_task.await.unwrap().unwrap();
 
-        let final_id = manifest_store.read_latest_manifest().await.unwrap().id;
+        let final_manifest = manifest_store.read_latest_manifest().await.unwrap();
+        let external = &final_manifest.manifest.external_dbs[0];
+        assert!(external.sst_ids.is_empty());
+        assert_eq!(external.source_checkpoint_id, source_checkpoint_id);
+        assert_eq!(external.final_checkpoint_id, Some(final_checkpoint_id));
+        assert!(final_manifest
+            .manifest
+            .core
+            .checkpoints
+            .iter()
+            .any(|checkpoint| checkpoint.id == remote_checkpoint.id));
+
+        let final_id = final_manifest.id;
         // write_manifest_safely now bumps the manifest twice per successful call because write_manifest
         // writes a checkpoint first:
         // - write_manifest() calls self.manifest.write_checkpoint(...) to create the checkpoint, then
         // - write_manifest() calls self.manifest.update(...) to update the manifest
-        // So we do +1 for the external update and +2 for the successful write_manifest_safely call.
-        assert_eq!(final_id, start_id + 3);
+        // So we do +1 for the first checkpoint, +1 for the external update, and +2 for
+        // the successful retry.
+        assert_eq!(final_id, start_id + 4);
     }
 }

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -822,6 +822,7 @@ impl<'a> StateModifier<'a> {
             checkpoints: remote_manifest.value.core.checkpoints,
             wal_object_store_uri: my_db_state.wal_object_store_uri.clone(),
         };
+        remote_manifest.value.prune_external_sst_ids();
         self.state.manifest = remote_manifest;
     }
 
@@ -877,6 +878,29 @@ mod tests {
 
         // then:
         assert_eq!(vec![checkpoint], db_state.state.core().checkpoints);
+    }
+
+    #[test]
+    fn test_merge_remote_manifest_reestablishes_external_sst_invariant() {
+        let mut db_state = DbState::new(new_dirty_manifest());
+        let stale_id = SsTableId::Compacted(ulid::Ulid::new());
+        let mut remote = new_dirty_manifest();
+        remote.value.external_dbs = vec![crate::manifest::ExternalDb {
+            path: "/parent/db".to_string(),
+            source_checkpoint_id: uuid::Uuid::new_v4(),
+            final_checkpoint_id: Some(uuid::Uuid::new_v4()),
+            sst_ids: vec![stale_id],
+        }];
+
+        db_state.merge_remote_manifest(remote);
+
+        let external = &db_state.state.manifest.value.external_dbs;
+        assert_eq!(external.len(), 1, "detach metadata must be retained");
+        assert!(
+            external[0].sst_ids.is_empty(),
+            "IDs absent from the merged tree must not be resurrected"
+        );
+        assert!(external[0].final_checkpoint_id.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Restore the `external_dbs.sst_ids` invariant after writer and compactor manifest merges. Wholesale adoption of a remote `Manifest` could otherwise resurrect IDs already pruned locally, retaining parent SSTs that are absent from the fully merged tree.

Closes #1935.

## Changes

- Run `Manifest::prune_external_sst_ids` after both compactor-side and writer-side manifest merges.
- Add focused regressions for both merge boundaries.
- Add a deterministic `GatedObjectStore` regression that races a remote checkpoint between the compactor checkpoint and final manifest update, forcing the CAS retry path.
- Verify that retry keeps stale SST IDs pruned while preserving external detach metadata and the racing checkpoint.

## Notes for Reviewers

The production change is two calls to the existing pruning helper at the points where a merged `ManifestCore` is installed into a remote `Manifest`. The helper scans both root and segment trees and retains `ExternalDb` entries, including source/final checkpoint metadata.

This PR was largely generated with OpenCode using `openai/gpt-5.6`. I reviewed the diff, understand the changes, and ran an independent review pass with no remaining findings.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all-features` (2,126 passed, 1 skipped)
- `cargo test --all-features`

No breaking changes. Performance impact is limited to invoking the existing referenced-SST scan when manifests merge.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant