### PR TITLE
Fix flaky local filesystem boundary test

### DIFF
--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -712,15 +712,15 @@ mod tests {
         boundary.check(MonotonicId::new(3)).await.unwrap();
 
         // Replace the file directly rather than calling BoundaryObject::advance, since
-        // LocalFileSystem does not support PutMode::Update. The stale ETag should cause
-        // the next check to read and enforce the new boundary.
+        // LocalFileSystem does not support PutMode::Update. Use a differently sized value
+        // so filesystems with coarse mtime resolution still produce a different ETag.
         object_store
-            .put(&boundary_path, PutPayload::from("4"))
+            .put(&boundary_path, PutPayload::from("40"))
             .await
             .unwrap();
         let err = boundary.check(MonotonicId::new(3)).await.unwrap_err();
         assert!(matches!(err, TransactionalObjectError::ObjectVersionExists));
-        boundary.check(MonotonicId::new(5)).await.unwrap();
+        boundary.check(MonotonicId::new(41)).await.unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fix the Windows local-filesystem boundary test by ensuring an overwrite changes the ETag size component.

From Sol:

```
The failure is a Windows-specific flaky test, unrelated to PR #1931’s compactor changes.

In the failed job (https://github.com/slatedb/slatedb/actions/runs/29467142417/job/87524417893):

- 2,076 tests passed.
- test_boundary_check_supports_local_filesystem_conditional_get failed.
- It panicked at slatedb-txn-obj/src/object_store.rs:721: unwrap_err() received Ok(()).

The causal chain:

1. The test writes boundary "2" and caches its filesystem ETag.
2. It immediately overwrites the file with "4"—the same byte length.
3. object_store 0.14.0 generates local ETags from inode, microsecond mtime, and size. On non-Unix platforms the inode component is always zero (/Users/chrisriccomini/.cargo/
   registry/src/index.crates.io-1949cf8c6b5b557f/object_store-0.14.0/src/local.rs:1408).
4. Windows produced the same effective mtime/size ETag for both writes.
5. The conditional GET therefore returned NotModified; SlateDB reused cached boundary 2, so checking ID 3 returned Ok(()) instead of rejecting it against boundary 4.
```

## Changes

- Use a different-length replacement boundary value.

## Notes for Reviewers

Removes the filesystem mtime-resolution dependency. No breaking changes or performance impact.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏