### PR TITLE
[1941] Fix stale nightly benchmark description in slatedb-bencher README

### DIFF
--- a/slatedb-bencher/README.md
+++ b/slatedb-bencher/README.md
@@ -78,7 +78,7 @@ The script also has a `SLATEDB_BENCH_CLEAN` environment variable which can be se
 
 ### `nightly.yaml`
 
-`benchmark-db.sh` is also used in `.github/workflows/nightly.yaml` to benchmark the nightly build and generate plots for the [SlateDB website](https://slatedb.io/performance/benchmarks/main/). The tests are run using [WarpBuild](https://warpbuild.com) and the results are uploaded using [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark). The job will also fail if the results are not within 200% of the previous results.
+`benchmark-db.sh` is also used in `.github/workflows/nightly.yaml` to benchmark the nightly build. The tests are run using [WarpBuild](https://warpbuild.com), and each run appends to mermaid `xyChart` files that are posted to the workflow's GitHub Actions job summary.
 
 ## `compaction` Subcommand
 


### PR DESCRIPTION
## Summary

The `slatedb-bencher/README.md` nightly section linked to a dead page
(`slatedb.io/performance/benchmarks/main/`) and described a github-action-benchmark
upload that was removed in #744. Results now go to the GitHub Actions job summary
as mermaid `xyChart` files.

## Changes

- Replace the dead link and github-action-benchmark description with the current
  behavior (mermaid charts in the job summary).
- Drop the "within 200% of previous results" note, which went away with the
  removed step.

## Notes for Reviewers

Docs-only change, scoped to one paragraph in `slatedb-bencher/README.md`.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Closes #1941.

Thank you for the review! 🙏
