### PR TITLE
remove fsync from cached object store

### DIFF
--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -270,7 +270,13 @@ impl FsCacheEntry {
                 .open(tmp_path)
                 .map_err(wrap_io_err)?;
             file.write_all(&buf).map_err(wrap_io_err)?;
-            file.sync_all().map_err(wrap_io_err)?;
+
+            // Note: There is no fsync before the rename. The cache holds copies
+            // of durable upstream bytes, so part durability is not required, only
+            // correctness. The tmp file plus atomic rename means a reader never
+            // observes a partially written part. If a crash leaves a renamed but
+            // not yet flushed part that reads back corrupt, block validation
+            // fails on read, the retried GET will override the cached entry.
             std::fs::rename(tmp_path, path).map_err(wrap_io_err)
         })
         .await?


### PR DESCRIPTION
## Summary

The change just removes `fsync` from `CachedObjectStore` given that it's not needed now as corrupted part is invalidated from the cache on read. 

## Notes for Reviewers

towards https://github.com/slatedb/slatedb/issues/1791

Checklist for RFC 0027 work: 

- use `ObjectStore` extensions in all GET and PUT calls for object store that provide context information. -> `DONE`
- [x] Create caching policy for cached object store that uses the extensions for admission/reads from the cache. 
     - Create caching policy. -> `DONE`
     - Make object store cache use the policy. ->`DONE`
     - Support cache invalidation on retrying invalid result. -> `DONE`
     - Fix issue of not caching head on `cache_puts` -> `DONE`
     - Fix issue of not caching multipart uploads when file size > 10 MB -> `DONE`
     - Make compactor able to use `CachedObjectStore` and support write through with compaction.  -> `DONE`
     - Make GC able to use `CachedObjectStore` to evict cached SSTs on GC delete. -> `DONE`
     - [x] remove `fsync` during cache writes.     
     
- [ ] Make `CachedObjectStore` public and pluggable (will be broken down to multiple PRs) 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
