### PR TITLE
Allow closing a DB without flushing the active memtable

### DIFF
--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -461,6 +461,32 @@ impl Default for FlushOptions {
     }
 }
 
+/// Options controlling how a database is closed.
+#[derive(Clone, Debug)]
+pub struct CloseOptions {
+    /// Whether to trigger a final flush of the active memtable before closing.
+    ///
+    /// When `false`, memtables already being flushed continue through the
+    /// existing shutdown pipeline. Defaults to `true`.
+    pub flush_memtables: bool,
+}
+
+impl Default for CloseOptions {
+    fn default() -> Self {
+        Self {
+            flush_memtables: true,
+        }
+    }
+}
+
+impl CloseOptions {
+    /// Configure whether the active memtable is flushed before closing.
+    pub fn with_flush_memtables(mut self, flush_memtables: bool) -> Self {
+        self.flush_memtables = flush_memtables;
+        self
+    }
+}
+
 /// Configuration for client write operations. `WriteOptions` is supplied for each
 /// write call and controls the behavior of the write.
 #[derive(Clone, Debug, Default)]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3479,6 +3479,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_close_with_options_default_flushes_final_memtable() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut settings = test_db_options(0, 1024, None);
+        settings.flush_interval = None;
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let db = Db::builder(
+            "/tmp/test_close_with_options_default_flushes_final_memtable",
+            object_store,
+        )
+        .with_settings(settings)
+        .with_metrics_recorder(metrics_recorder.clone())
+        .build()
+        .await
+        .unwrap();
+
+        db.put(b"test_key", b"test_value").await.unwrap();
+
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap_or(0),
+            0
+        );
+
+        db.close_with_options(CloseOptions::default())
+            .await
+            .unwrap();
+
+        assert!(
+            lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap() > 0,
+            "expected L0 flush during close with default options"
+        );
+    }
+
+    #[tokio::test]
     async fn test_close_with_options_skips_final_flush() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let mut settings = test_db_options(0, 1024, None);

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -48,8 +48,8 @@ use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
 use crate::config::{
-    FlushOptions, FlushType, MergeOptions, PutOptions, ReadOptions, ScanOptions, Settings,
-    WriteOptions,
+    CloseOptions, FlushOptions, FlushType, MergeOptions, PutOptions, ReadOptions, ScanOptions,
+    Settings, WriteOptions,
 };
 use crate::db_common::extract_segment_prefix;
 use crate::db_iter::{DbIterator, DbRecencyIterator};
@@ -681,6 +681,15 @@ impl Db {
     /// }
     /// ```
     pub async fn close(&self) -> Result<(), crate::Error> {
+        self.close_with_options(CloseOptions::default()).await
+    }
+
+    /// Close the database with custom options.
+    ///
+    /// Setting [`CloseOptions::flush_memtables`] to `false` skips the final
+    /// active memtable flush. Memtables already being flushed are allowed to
+    /// finish, and writes that are not durable may be lost.
+    pub async fn close_with_options(&self, options: CloseOptions) -> Result<(), crate::Error> {
         let should_flush = match self.status().close_reason {
             // If already closed, don't close again.
             Some(CloseReason::Clean) => return Err(SlateDBError::Closed.into()),
@@ -689,8 +698,9 @@ impl Db {
             // run when in a failed state (vs. a clean closure, which will return
             // Error::Closed(CloseReason::Clean) on subsequent calls).
             Some(_) => false,
-            // Flush outstanding writes if the database is still open.
-            None => true,
+            // Flush outstanding writes if the database is still open and the
+            // caller requested a final memtable flush.
+            None => options.flush_memtables,
         };
 
         // Mark the database as closed before flushing.
@@ -2222,7 +2232,7 @@ mod tests {
     use crate::config::DurabilityLevel::{Memory, Remote};
     use crate::config::MetricLevel;
     use crate::config::{
-        CheckpointOptions, CompactionWorkerOptions, CompactorOptions,
+        CheckpointOptions, CloseOptions, CompactionWorkerOptions, CompactorOptions,
         GarbageCollectorDirectoryOptions, GarbageCollectorOptions, ObjectStoreCacheOptions,
         PutOptions, ScanOptions, Settings, SstBlockSize, Ttl, WriteOptions,
     };
@@ -3466,6 +3476,66 @@ mod tests {
             lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap() > 0,
             "expected L0 flush during close"
         );
+    }
+
+    #[tokio::test]
+    async fn test_close_with_options_skips_final_flush() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut settings = test_db_options(0, 1024, None);
+        settings.flush_interval = None;
+        let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
+        let db = Db::builder(
+            "/tmp/test_close_with_options_skips_final_flush",
+            object_store,
+        )
+        .with_settings(settings)
+        .with_metrics_recorder(metrics_recorder.clone())
+        .build()
+        .await
+        .unwrap();
+
+        db.put(b"test_key", b"test_value").await.unwrap();
+
+        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap_or(0),
+            0
+        );
+    }
+
+    #[cfg(feature = "wal_disable")]
+    #[tokio::test]
+    async fn test_close_without_flush_fails_pending_durability_wait() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut settings = test_db_options(0, 1024, None);
+        settings.flush_interval = None;
+        settings.wal_enabled = false;
+        let db = Db::builder(
+            "/tmp/test_close_without_flush_fails_pending_durability_wait",
+            object_store,
+        )
+        .with_settings(settings)
+        .build()
+        .await
+        .unwrap();
+
+        let handle = db.put(b"key", b"value").await.unwrap();
+
+        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+            .await
+            .unwrap();
+
+        let error = tokio::time::timeout(Duration::from_secs(5), handle.await_durable())
+            .await
+            .expect("durability wait remained blocked after close")
+            .expect_err("discarded write should not become durable");
+        assert!(matches!(
+            error.kind(),
+            crate::ErrorKind::Closed(CloseReason::Clean)
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Support closing a DB without triggering a final active memtable flush.

This is useful for tests that create and close many DB instances and do not need pending writes to become durable.
When `flush_memtables` is disabled, close avoids triggering and waiting for a final active memtable flush, which can reduce teardown latency in tests that  frequently create and close DB instances. 

Closes #1835.

## Usage

Skip the final active memtable flush when closing:

```rust
use slatedb::config::CloseOptions;

db.close_with_options(
     CloseOptions::default().with_flush_memtables(false),
).await?;
```

The existing close API is unchanged:

```rust
db.close().await?;
```
It continues to flush the active memtable before closing. The new behavior is opt-in through close_with_options.

## Changes

- Add `CloseOptions` with a `flush_memtables` option.
- Add `Db::close_with_options`.
- Preserve the existing flush-on-close behavior in `Db::close`.
- Release pending memtable durability waiters on no-flush close when the WAL is disabled.
- Add tests covering skipped L0 flushes and WAL-disabled durability waiters.

There are no breaking changes.

## Notes for Reviewers

With the WAL disabled, when closing without flushing memtables, pending writes that are still waiting for durability return a `Closed` error after the writer task shuts down. Is `Closed` appropriate?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
