### PR TITLE
fix: prune SST IDs from external_dbs that were projected out

### DIFF
--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -1067,13 +1067,8 @@ impl Manifest {
         }
         projected.core.segments = kept;
 
-        // Drop unused external_dbs based on the surviving SST set across
-        // every tree (unsegmented + segments).
-        let used_sst_ids: HashSet<SsTableId> =
-            projected.core.all_sst_views().map(|v| v.sst.id).collect();
-        projected
-            .external_dbs
-            .retain(|e| e.sst_ids.iter().any(|id| used_sst_ids.contains(id)));
+        projected.prune_external_sst_ids();
+        projected.external_dbs.retain(|e| !e.sst_ids.is_empty());
         Ok(projected)
     }
 
@@ -3156,6 +3151,10 @@ mod tests {
 
         assert_eq!(projected.external_dbs.len(), 1);
         assert_eq!(projected.external_dbs[0].path, "/path/to/db1");
+        // The retained entry must have its out-of-range ID (sst_id_2) trimmed.
+        // Carrying it forward would keep the parent SST pinned in detach GC even
+        // though the projected tree no longer references it.
+        assert_eq!(projected.external_dbs[0].sst_ids, vec![sst_id_1]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Currently, the SSTs that were projected out during projection are not removed from `external_dbs` 
(the method used is not a mutation).

This PR aligns projection mehtod with other parts of the codebase.

## Notes for Reviewers

This is a [follow](https://github.com/slatedb/slatedb/pull/1936#issuecomment-4997343236) up on https://github.com/slatedb/slatedb/pull/1936

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
