### PR TITLE
[1943] Add Settings::validate to reject conflicting configuration

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -43,7 +43,8 @@ pub async fn build_settings(rand: &DbRand) -> Settings {
     let l0_sst_size_bytes = rng.random_range(MIB_1..MIB_500);
     let l0_max_ssts = rng.random_range(4..8);
     let l0_max_ssts_per_key = l0_max_ssts;
-    let max_unflushed_bytes = rng.random_range(MIB_1..GIB_2);
+    // Keep `max_unflushed_bytes` strictly greater than `l0_sst_size_bytes`.
+    let max_unflushed_bytes = rng.random_range((l0_sst_size_bytes + 1)..GIB_2);
     let compression_codec_idx = rng.random_range(0..COMPRESSION_CODECS.len());
     let compression_codec =
         if let Some(compression_codec) = COMPRESSION_CODECS[compression_codec_idx] {

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -820,6 +820,37 @@ impl Settings {
         serde_json::to_string(self)
     }
 
+    /// Validates that the settings are internally consistent, rejecting field
+    /// combinations that would deadlock or fail at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`crate::Error`] with [`crate::ErrorKind::Invalid`] describing
+    /// the first invalid setting or combination encountered.
+    pub fn validate(&self) -> Result<(), crate::Error> {
+        if self.l0_flush_parallelism == 0 {
+            return Err(crate::Error::invalid(
+                "invalid configuration: l0_flush_parallelism must be at least 1".into(),
+            ));
+        }
+        if self.max_wal_flushes_before_l0_flush < 4096 {
+            return Err(crate::Error::invalid(
+                "invalid configuration: max_wal_flushes_before_l0_flush must be at least 4096"
+                    .into(),
+            ));
+        }
+        // `max_unflushed_bytes` must exceed `l0_sst_size_bytes` so the active
+        // memtable is always frozen before backpressure permanently blocks writes.
+        if self.max_unflushed_bytes <= self.l0_sst_size_bytes {
+            return Err(crate::Error::invalid(format!(
+                "invalid configuration: max_unflushed_bytes ({}) must be greater than \
+                 l0_sst_size_bytes ({})",
+                self.max_unflushed_bytes, self.l0_sst_size_bytes,
+            )));
+        }
+        Ok(())
+    }
+
     /// Loads Settings from a file.
     ///
     /// This function attempts to read and parse a configuration file to create a Settings instance.
@@ -2006,5 +2037,59 @@ object_store_cache_options:
         assert_eq!(ts1, Some(99999));
         assert_eq!(ts2, Some(99999));
         assert_eq!(ts3, Some(99999));
+    }
+
+    #[test]
+    fn test_validate_accepts_default_settings() {
+        assert!(Settings::default().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_l0_flush_parallelism() {
+        let settings = Settings {
+            l0_flush_parallelism: 0,
+            ..Settings::default()
+        };
+        let err = settings.validate().expect_err("expected invalid settings");
+        assert!(err.to_string().contains("l0_flush_parallelism"));
+    }
+
+    #[test]
+    fn test_validate_rejects_low_max_wal_flushes_before_l0_flush() {
+        let settings = Settings {
+            max_wal_flushes_before_l0_flush: 4095,
+            ..Settings::default()
+        };
+        let err = settings.validate().expect_err("expected invalid settings");
+        assert!(err.to_string().contains("max_wal_flushes_before_l0_flush"));
+    }
+
+    #[test]
+    fn test_validate_rejects_max_unflushed_bytes_not_greater_than_l0_sst_size() {
+        // Equal is invalid: must be strictly greater.
+        let equal = Settings {
+            l0_sst_size_bytes: 64 * 1024 * 1024,
+            max_unflushed_bytes: 64 * 1024 * 1024,
+            ..Settings::default()
+        };
+        let err = equal.validate().expect_err("expected invalid settings");
+        assert!(err.to_string().contains("max_unflushed_bytes"));
+
+        let smaller = Settings {
+            l0_sst_size_bytes: 64 * 1024 * 1024,
+            max_unflushed_bytes: 32 * 1024 * 1024,
+            ..Settings::default()
+        };
+        assert!(smaller.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_accepts_max_unflushed_bytes_greater_than_l0_sst_size() {
+        let settings = Settings {
+            l0_sst_size_bytes: 64 * 1024 * 1024,
+            max_unflushed_bytes: 64 * 1024 * 1024 + 1,
+            ..Settings::default()
+        };
+        assert!(settings.validate().is_ok());
     }
 }

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -829,24 +829,26 @@ impl Settings {
     /// the first invalid setting or combination encountered.
     pub fn validate(&self) -> Result<(), crate::Error> {
         if self.l0_flush_parallelism == 0 {
-            return Err(crate::Error::invalid(
-                "invalid configuration: l0_flush_parallelism must be at least 1".into(),
-            ));
+            return Err(SlateDBError::InvalidConfiguration(
+                "l0_flush_parallelism must be at least 1".into(),
+            )
+            .into());
         }
         if self.max_wal_flushes_before_l0_flush < 4096 {
-            return Err(crate::Error::invalid(
-                "invalid configuration: max_wal_flushes_before_l0_flush must be at least 4096"
-                    .into(),
-            ));
+            return Err(SlateDBError::InvalidConfiguration(
+                "max_wal_flushes_before_l0_flush must be at least 4096".into(),
+            )
+            .into());
         }
-        // `max_unflushed_bytes` must exceed `l0_sst_size_bytes` so the active
-        // memtable is always frozen before backpressure permanently blocks writes.
+        // `max_unflushed_bytes` (the backpressure threshold) must exceed
+        // `l0_sst_size_bytes` (the memtable freeze threshold) so that memory can
+        // hold a memtable up to the freeze point before backpressure kicks in.
         if self.max_unflushed_bytes <= self.l0_sst_size_bytes {
-            return Err(crate::Error::invalid(format!(
-                "invalid configuration: max_unflushed_bytes ({}) must be greater than \
-                 l0_sst_size_bytes ({})",
+            return Err(SlateDBError::InvalidConfiguration(format!(
+                "max_unflushed_bytes ({}) must be greater than l0_sst_size_bytes ({})",
                 self.max_unflushed_bytes, self.l0_sst_size_bytes,
-            )));
+            ))
+            .into());
         }
         Ok(())
     }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -4987,7 +4987,9 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
         let mut options = test_db_options(0, 1, None);
-        options.max_unflushed_bytes = 1;
+        // Must stay above l0_sst_size_bytes (1) but small enough that a single
+        // write exceeds it and triggers backpressure.
+        options.max_unflushed_bytes = 2;
         let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
         let db = Db::builder(path, object_store.clone())
             .with_settings(options)
@@ -7046,8 +7048,8 @@ mod tests {
         let path = "/tmp/test_recent_snapshot_min_seq_monotonic";
         let object_store = Arc::new(InMemory::new());
         let settings = Settings {
-            l0_sst_size_bytes: 4 * 1024,   // Smaller to trigger flush more easily
-            max_unflushed_bytes: 2 * 1024, // Smaller to trigger flush more easily
+            l0_sst_size_bytes: 2 * 1024,   // Smaller to trigger flush more easily
+            max_unflushed_bytes: 4 * 1024, // Smaller to trigger flush more easily
             min_filter_keys: 0,
             flush_interval: Some(Duration::from_millis(100)),
             ..Default::default()

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -4278,7 +4278,7 @@ mod tests {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = "/tmp/test_flush_memtable_max_wal_flushes";
 
-        let mut settings = test_db_options(0, usize::MAX, None);
+        let mut settings = test_db_options(0, 64 * 1024 * 1024, None);
         settings.flush_interval = None; // Disable flushing
         settings.max_wal_flushes_before_l0_flush = MAX_WAL_FLUSHES_BEFORE_L0_FLUSH;
 
@@ -5064,12 +5064,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_backpressure_waiter_exits_when_db_is_fenced() {
-        // Build a DB whose WAL will not flush on a timer and whose backpressure
-        // threshold is low enough for one write to exceed it.
+        // Pause the L0 upload so a frozen memtable can't drain, keeping unflushed
+        // bytes above the backpressure threshold indefinitely.
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let mut options = test_db_options(0, 1024 * 1024, None);
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "pause").unwrap();
+
+        let mut options = test_db_options(0, 4 * 1024, None);
         options.flush_interval = None;
-        options.max_unflushed_bytes = 1;
+        options.max_unflushed_bytes = 8 * 1024;
 
         // Use a metrics recorder so the test can observe when the spawned task
         // has actually entered maybe_apply_backpressure().
@@ -5079,6 +5082,7 @@ mod tests {
             object_store,
         )
         .with_settings(options)
+        .with_fp_registry(fp_registry.clone())
         .with_metrics_recorder(metrics_recorder.clone())
         .build()
         .await
@@ -5088,13 +5092,10 @@ mod tests {
             ..Default::default()
         };
 
-        // Write enough data to leave bytes buffered in the WAL while avoiding
-        // any automatic WAL or memtable flush.
-        let large_value = vec![b'x'; 8 * 1024];
+        let large_value = vec![b'x'; 16 * 1024];
         db.put_with_options(b"key1", &large_value, &PutOptions::default(), &write_opts)
             .await
             .unwrap();
-        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
 
         // Start backpressure on a cloned inner handle. This parks the task on
         // the same wait path used by writers before they enqueue a batch.
@@ -5130,7 +5131,11 @@ mod tests {
             backpressure_task.abort();
             let _ = backpressure_task.await;
         }
-        db.close().await.unwrap();
+
+        // Resume the L0 upload so the pending memtable can drain and close can
+        // complete cleanly.
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
+        let _ = db.close().await;
 
         // Assert that the waiter exits with the terminal fenced error, not a
         // successful write path or some unrelated task failure.

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -409,17 +409,7 @@ impl<P: Into<Path>> DbBuilder<P> {
 
     /// Builds and opens the database.
     pub async fn build(self) -> Result<Db, crate::Error> {
-        if self.settings.l0_flush_parallelism == 0 {
-            return Err(crate::Error::invalid(
-                "invalid configuration: l0_flush_parallelism must be at least 1".into(),
-            ));
-        }
-        if self.settings.max_wal_flushes_before_l0_flush < 4096 {
-            return Err(crate::Error::invalid(
-                "invalid configuration: max_wal_flushes_before_l0_flush must be at least 4096"
-                    .into(),
-            ));
-        }
+        self.settings.validate()?;
 
         let path = self.path.into();
         // TODO: proper URI generation, for now it works just as a flag

--- a/slatedb/src/db_snapshot.rs
+++ b/slatedb/src/db_snapshot.rs
@@ -302,7 +302,7 @@ mod tests {
                 scheduler_options: Default::default(),
                 ..Default::default()
             }),
-            max_unflushed_bytes: 16 * 1024,
+            max_unflushed_bytes: 8 * 4096,
             min_filter_keys: 0,
             l0_sst_size_bytes: 4 * 4096,
             ..Default::default()
@@ -740,7 +740,7 @@ mod tests {
                 scheduler_options: Default::default(),
                 ..Default::default()
             }),
-            max_unflushed_bytes: 16 * 1024,
+            max_unflushed_bytes: 8 * 4096,
             min_filter_keys: 0,
             l0_sst_size_bytes: 4 * 4096,
             ..Default::default()

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -233,6 +233,9 @@ pub(crate) enum SlateDBError {
     #[error("invalid sst batch size. size=`{0}`")]
     InvalidSSTBatchSize(usize),
 
+    #[error("invalid configuration: {0}")]
+    InvalidConfiguration(String),
+
     #[error("cannot seek to a key outside the iterator range. key=`{key:?}`, start_key=`{start_key:?}`, end_key=`{end_key:?}`")]
     SeekKeyOutOfKeyRange {
         key: Vec<u8>,
@@ -645,6 +648,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::InvalidObjectStorePath(_) => Error::invalid(msg),
             SlateDBError::UnknownConfigurationFormat(_) => Error::invalid(msg),
             SlateDBError::InvalidSSTBatchSize(_) => Error::invalid(msg),
+            SlateDBError::InvalidConfiguration(_) => Error::invalid(msg),
             SlateDBError::InvalidCheckpointLifetime(_) => Error::invalid(msg),
             SlateDBError::InvalidManifestPollInterval(_) => Error::invalid(msg),
             SlateDBError::CheckpointLifetimeTooShort { .. } => Error::invalid(msg),

--- a/slatedb/tests/db.rs
+++ b/slatedb/tests/db.rs
@@ -186,8 +186,8 @@ async fn test_concurrent_writers_and_readers() {
             flush_interval: Some(Duration::from_millis(100)),
             manifest_poll_interval: Duration::from_millis(100),
             manifest_update_timeout: Duration::from_secs(300),
-            // Allow 16KB of unflushed data
-            max_unflushed_bytes: 16 * 1024,
+            // Allow 32KB of unflushed data (must exceed l0_sst_size_bytes)
+            max_unflushed_bytes: 8 * 4096,
             min_filter_keys: 0,
             // Allow up to four 4096-byte blocks per-SST
             l0_sst_size_bytes: 4 * 4096,


### PR DESCRIPTION
## Summary

Closes #1943.

`Settings` has many fields that are individually valid but conflict when
combined, leading to runtime deadlocks or failures. The motivating case (from
[#1939 review](https://github.com/slatedb/slatedb/pull/1939/changes#r3597809029)):
when `max_unflushed_bytes <= l0_sst_size_bytes`, a single write can push the
active memtable past the backpressure limit before it is ever frozen. With no
immutable memtable or WAL to drain, `maybe_apply_backpressure` blocks the next
write forever and spins on CPU — for an otherwise "valid" configuration.

This adds a `Settings::validate` that rejects such combinations up front so
misconfiguration fails loudly when the database is opened rather than hanging
later.

## Changes

- Add `Settings::validate`, which centralizes the two configuration checks
  previously inlined in `DbBuilder::build` (`l0_flush_parallelism >= 1`,
  `max_wal_flushes_before_l0_flush >= 4096`) and adds the new
  `max_unflushed_bytes > l0_sst_size_bytes` rule.
- Call `self.settings.validate()?` at the top of `DbBuilder::build` and remove
  the inlined checks, so all construction paths validate through one entry point.
- In the DST `build_settings`, derive `max_unflushed_bytes` from
  `l0_sst_size_bytes` (lower bound `l0_sst_size_bytes + 1`) so randomized
  configs never generate the invalid combination — matching the existing
  pattern used for `worker_heartbeat_timeout` and `checkpoint_lifetime`.
- Add unit tests covering the valid default, the strict-greater boundary, and
  each rejection case.

## Notes for Reviewers

The two migrated checks keep identical error messages and behavior; the existing
`DbBuilder` tests that assert those rejections pass unchanged. Cross-field
validation of `CompactorOptions` internals (heartbeat timeout vs. interval,
min/max compaction sources) is intentionally out of scope here — those live
behind a `HashMap<String, String>` scheduler config and can be added
incrementally as the issue suggests.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
