### PR TITLE
test(dst): vary scan options

### DIFF
--- a/slatedb-dst/src/actors/workload.rs
+++ b/slatedb-dst/src/actors/workload.rs
@@ -8,7 +8,7 @@ use rand::RngCore;
 use slatedb::config::{
     DurabilityLevel, MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions,
 };
-use slatedb::{Error, MergeOperator, MergeOperatorError, WriteBatch};
+use slatedb::{Error, IterationOrder, MergeOperator, MergeOperatorError, WriteBatch};
 use tracing::instrument;
 
 use crate::{Actor, ActorCtx};
@@ -351,7 +351,7 @@ async fn verify_scan(
     read_durability: DurabilityLevel,
     observed: &mut BTreeMap<Bytes, Observation>,
 ) -> Result<(), Error> {
-    let scan_options = ScanOptions::new().with_durability_filter(read_durability);
+    let scan_options = sample_scan_options(&mut *ctx.rand().rng(), read_durability);
     let mut iter = ctx
         .db()
         .scan_prefix_with_options(key_prefix.as_bytes(), .., &scan_options)
@@ -388,6 +388,36 @@ async fn verify_scan(
     }
 
     Ok(())
+}
+
+fn sample_scan_options(rng: &mut impl RngCore, read_durability: DurabilityLevel) -> ScanOptions {
+    let sample = rng.next_u64();
+    scan_options_from_sample(sample, read_durability)
+}
+
+fn scan_options_from_sample(sample: u64, read_durability: DurabilityLevel) -> ScanOptions {
+    let read_ahead_bytes = match sample & 0b11 {
+        0 => 1,
+        1 => 4 * 1024,
+        2 => 64 * 1024,
+        _ => 1024 * 1024,
+    };
+    let cache_blocks = sample & (1 << 2) != 0;
+    let max_fetch_tasks = 1 + ((sample >> 3) & 0b11) as usize;
+    let order = if sample & (1 << 5) == 0 {
+        IterationOrder::Ascending
+    } else {
+        IterationOrder::Descending
+    };
+
+    // Keep visibility semantics fixed so actor-local observations remain comparable.
+    // The remaining options only vary how the same logical scan is executed.
+    ScanOptions::new()
+        .with_durability_filter(read_durability)
+        .with_read_ahead_bytes(read_ahead_bytes)
+        .with_cache_blocks(cache_blocks)
+        .with_max_fetch_tasks(max_fetch_tasks)
+        .with_order(order)
 }
 
 fn observe_present(
@@ -445,4 +475,30 @@ pub(crate) fn decode_workload_value(value: &[u8]) -> u64 {
         .try_into()
         .expect("workload value version slice has fixed size");
     u64::from_be_bytes(version_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_scan_options_varies_safe_scan_parameters() {
+        let options = scan_options_from_sample(0, DurabilityLevel::Remote);
+
+        assert_eq!(options.durability_filter, DurabilityLevel::Remote);
+        assert!(!options.dirty);
+        assert_eq!(options.read_ahead_bytes, 1);
+        assert!(!options.cache_blocks);
+        assert_eq!(options.max_fetch_tasks, 1);
+        assert!(matches!(options.order, IterationOrder::Ascending));
+
+        let options = scan_options_from_sample(0b11_1111, DurabilityLevel::Memory);
+
+        assert_eq!(options.durability_filter, DurabilityLevel::Memory);
+        assert!(!options.dirty);
+        assert_eq!(options.read_ahead_bytes, 1024 * 1024);
+        assert!(options.cache_blocks);
+        assert_eq!(options.max_fetch_tasks, 4);
+        assert!(matches!(options.order, IterationOrder::Descending));
+    }
 }

--- a/slatedb-dst/src/actors/workload.rs
+++ b/slatedb-dst/src/actors/workload.rs
@@ -5,13 +5,11 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use log::info;
 use rand::RngCore;
-use slatedb::config::{
-    DurabilityLevel, MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions,
-};
+use slatedb::config::{DurabilityLevel, MergeOptions, PutOptions, ReadOptions, WriteOptions};
 use slatedb::{Error, IterationOrder, MergeOperator, MergeOperatorError, WriteBatch};
 use tracing::instrument;
 
-use crate::{Actor, ActorCtx};
+use crate::{utils::build_scan_options, Actor, ActorCtx};
 
 use super::PROGRESS_LOG_INTERVAL;
 
@@ -351,12 +349,13 @@ async fn verify_scan(
     read_durability: DurabilityLevel,
     observed: &mut BTreeMap<Bytes, Observation>,
 ) -> Result<(), Error> {
-    let scan_options = sample_scan_options(&mut *ctx.rand().rng(), read_durability);
+    let scan_options = build_scan_options(ctx.rand(), read_durability);
     let mut iter = ctx
         .db()
         .scan_prefix_with_options(key_prefix.as_bytes(), .., &scan_options)
         .await?;
     let mut seen = BTreeSet::new();
+    let mut previous_key: Option<Bytes> = None;
 
     while let Some(key_value) = iter.next().await? {
         assert!(
@@ -375,6 +374,23 @@ async fn verify_scan(
             key_prefix,
             String::from_utf8_lossy(key_value.key.as_ref()).into_owned(),
         );
+        if let Some(previous_key) = previous_key.as_ref() {
+            let is_ordered = match scan_options.order {
+                IterationOrder::Ascending => previous_key < &key_value.key,
+                IterationOrder::Descending => previous_key > &key_value.key,
+            };
+            assert!(
+                is_ordered,
+                "workload scan returned keys out of order [name={}, step={}, key_prefix={}, order={:?}, previous_key={}, key={}]",
+                ctx.name(),
+                step,
+                key_prefix,
+                scan_options.order,
+                String::from_utf8_lossy(previous_key.as_ref()),
+                String::from_utf8_lossy(key_value.key.as_ref()),
+            );
+        }
+        previous_key = Some(key_value.key.clone());
         observe_present(ctx, step, &key_value.key, &key_value.value, observed);
     }
 
@@ -388,36 +404,6 @@ async fn verify_scan(
     }
 
     Ok(())
-}
-
-fn sample_scan_options(rng: &mut impl RngCore, read_durability: DurabilityLevel) -> ScanOptions {
-    let sample = rng.next_u64();
-    scan_options_from_sample(sample, read_durability)
-}
-
-fn scan_options_from_sample(sample: u64, read_durability: DurabilityLevel) -> ScanOptions {
-    let read_ahead_bytes = match sample & 0b11 {
-        0 => 1,
-        1 => 4 * 1024,
-        2 => 64 * 1024,
-        _ => 1024 * 1024,
-    };
-    let cache_blocks = sample & (1 << 2) != 0;
-    let max_fetch_tasks = 1 + ((sample >> 3) & 0b11) as usize;
-    let order = if sample & (1 << 5) == 0 {
-        IterationOrder::Ascending
-    } else {
-        IterationOrder::Descending
-    };
-
-    // Keep visibility semantics fixed so actor-local observations remain comparable.
-    // The remaining options only vary how the same logical scan is executed.
-    ScanOptions::new()
-        .with_durability_filter(read_durability)
-        .with_read_ahead_bytes(read_ahead_bytes)
-        .with_cache_blocks(cache_blocks)
-        .with_max_fetch_tasks(max_fetch_tasks)
-        .with_order(order)
 }
 
 fn observe_present(
@@ -475,30 +461,4 @@ pub(crate) fn decode_workload_value(value: &[u8]) -> u64 {
         .try_into()
         .expect("workload value version slice has fixed size");
     u64::from_be_bytes(version_bytes)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn sample_scan_options_varies_safe_scan_parameters() {
-        let options = scan_options_from_sample(0, DurabilityLevel::Remote);
-
-        assert_eq!(options.durability_filter, DurabilityLevel::Remote);
-        assert!(!options.dirty);
-        assert_eq!(options.read_ahead_bytes, 1);
-        assert!(!options.cache_blocks);
-        assert_eq!(options.max_fetch_tasks, 1);
-        assert!(matches!(options.order, IterationOrder::Ascending));
-
-        let options = scan_options_from_sample(0b11_1111, DurabilityLevel::Memory);
-
-        assert_eq!(options.durability_filter, DurabilityLevel::Memory);
-        assert!(!options.dirty);
-        assert_eq!(options.read_ahead_bytes, 1024 * 1024);
-        assert!(options.cache_blocks);
-        assert_eq!(options.max_fetch_tasks, 4);
-        assert!(matches!(options.order, IterationOrder::Descending));
-    }
 }

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -4,11 +4,11 @@ use std::time::Duration;
 
 use rand::Rng;
 use slatedb::config::{
-    CompactionWorkerOptions, CompactorOptions, CompressionCodec, DbReaderOptions,
+    CompactionWorkerOptions, CompactorOptions, CompressionCodec, DbReaderOptions, DurabilityLevel,
     GarbageCollectorDirectoryOptions, GarbageCollectorOptions, GarbageCollectorScheduleOptions,
-    SizeTieredCompactionSchedulerOptions,
+    ScanOptions, SizeTieredCompactionSchedulerOptions,
 };
-use slatedb::{DbRand, Settings};
+use slatedb::{DbRand, IterationOrder, Settings};
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 
@@ -86,6 +86,24 @@ pub fn build_reader_options(rand: &DbRand) -> DbReaderOptions {
         max_memtable_bytes,
         ..DbReaderOptions::default()
     }
+}
+
+/// Builds randomized deterministic scan options for DST scenarios.
+pub fn build_scan_options(rand: &DbRand, read_durability: DurabilityLevel) -> ScanOptions {
+    let mut rng = rand.rng();
+    let read_ahead_options = [1, 4 * 1024, 64 * 1024, MIB_1];
+    let order = if rng.random_bool(0.5) {
+        IterationOrder::Ascending
+    } else {
+        IterationOrder::Descending
+    };
+
+    ScanOptions::new()
+        .with_durability_filter(read_durability)
+        .with_read_ahead_bytes(read_ahead_options[rng.random_range(0..read_ahead_options.len())])
+        .with_cache_blocks(rng.random_bool(0.5))
+        .with_max_fetch_tasks(rng.random_range(1..=4))
+        .with_order(order)
 }
 
 /// Builds randomized deterministic compactor options for DST scenarios.


### PR DESCRIPTION
## Summary

Randomize execution-only ScanOptions in the DST workload so scans explore more of the available state space.

Fixes #718.

## Changes

- Randomize read-ahead bytes, block caching, fetch concurrency, and iteration order from the deterministic DST RNG.
- Keep durability and dirty-read semantics fixed so actor-local observations remain comparable.
- Add focused coverage for the sampled option bounds.

## Notes for Reviewers

This intentionally excludes dirty and durability randomization because those affect visibility semantics rather than scan execution.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests)
- [x] Linked related issue(s)
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran cargo fmt, cargo clippy --all-targets --all-features, and cargo nextest run --all-features
- [x] No breaking changes
- [x] Considered performance impact; one existing deterministic RNG draw is added per scan

Validation run:
- cargo fmt --all -- --check
- RUSTFLAGS=--cfg tokio_unstable cargo test -p slatedb-dst --lib (26 passed)
- fixed-seed DST determinism test (passed)
- cargo clippy -p slatedb-dst --lib --all-features (completed with pre-existing warnings outside this change)