### PR TITLE
fix: avoid retaining full cache parts for range reads

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -46,10 +46,6 @@ pub(crate) struct CachedObjectStore {
     part_flights: SingleFlight<(Path, PartID), Bytes>,
 }
 
-fn copy_part_range(bytes: &Bytes, range: Range<usize>) -> Bytes {
-    Bytes::copy_from_slice(&bytes[range])
-}
-
 impl CachedObjectStore {
     pub(crate) fn new(
         object_store: Arc<dyn ObjectStore>,
@@ -538,7 +534,7 @@ impl CachedObjectStore {
             // Cache miss, so we need to fetch from the object store.
             // Read Part — deduplicate concurrent fetches of the same part.
             // The SingleFlight fetches the full part and saves it to cache; each
-            // caller then slices out their own range_in_part.
+            // caller then copies out their own range_in_part.
             let bytes = this
                 .part_flights
                 .call((location.clone(), part_id), || async {
@@ -570,7 +566,7 @@ impl CachedObjectStore {
                 .await?;
 
             Ok((
-                copy_part_range(&bytes, range_in_part),
+                Bytes::copy_from_slice(&bytes[range_in_part]),
                 ReadResultSource::Upstream,
             ))
         })
@@ -1016,7 +1012,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::{copy_part_range, CachedObjectStore};
+    use super::{CachedObjectStore, ReadResultSource};
     use crate::cached_object_store::policy::CachePutConfig;
     use crate::cached_object_store::stats::CachedObjectStoreStats;
     use crate::cached_object_store::storage::{LocalCacheStorage, PartID};
@@ -1041,20 +1037,14 @@ mod tests {
         std::path::PathBuf::from(path)
     }
 
-    #[test]
-    fn test_copy_part_range_does_not_retain_full_part() {
-        let part = Bytes::from(vec![7_u8; 4 * 1024 * 1024]);
-        let range = 1024..5120;
-        let source_range_ptr = part[range.clone()].as_ptr();
-
-        let copied = copy_part_range(&part, range);
-
-        assert_eq!(copied.len(), 4096);
-        assert!(copied.iter().all(|byte| *byte == 7));
-        assert_ne!(copied.as_ptr(), source_range_ptr);
+    fn new_cached_store(object_store: Arc<dyn ObjectStore>) -> Arc<CachedObjectStore> {
+        new_cached_store_with_part_size(object_store, 1024)
     }
 
-    fn new_cached_store(object_store: Arc<dyn ObjectStore>) -> Arc<CachedObjectStore> {
+    fn new_cached_store_with_part_size(
+        object_store: Arc<dyn ObjectStore>,
+        part_size_bytes: usize,
+    ) -> Arc<CachedObjectStore> {
         let test_cache_folder = new_test_cache_folder();
         let recorder = MetricsRecorderHelper::noop();
         let stats = Arc::new(CachedObjectStoreStats::new(&recorder));
@@ -1070,11 +1060,36 @@ mod tests {
         CachedObjectStore::new(
             object_store,
             cache_storage,
-            1024,
+            part_size_bytes,
             CachePutConfig::default(),
             stats,
         )
         .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_upstream_part_range_does_not_retain_full_part() {
+        let part_size = 4 * 1024 * 1024;
+        let part = Bytes::from(vec![7_u8; part_size]);
+        let range = 1024..5120;
+        let source_range_ptr = part[range.clone()].as_ptr();
+        let location = Path::from("test");
+        let object_store = Arc::new(object_store::memory::InMemory::new());
+        object_store
+            .put(&location, PutPayload::from_bytes(part))
+            .await
+            .unwrap();
+        let cached_store = new_cached_store_with_part_size(object_store, part_size);
+
+        let (copied, source) = cached_store
+            .read_part(&location, 0, range, false)
+            .await
+            .unwrap();
+
+        assert!(matches!(source, ReadResultSource::Upstream));
+        assert_eq!(copied.len(), 4096);
+        assert!(copied.iter().all(|byte| *byte == 7));
+        assert_ne!(copied.as_ptr(), source_range_ptr);
     }
 
     #[tokio::test]

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -46,6 +46,10 @@ pub(crate) struct CachedObjectStore {
     part_flights: SingleFlight<(Path, PartID), Bytes>,
 }
 
+fn copy_part_range(bytes: &Bytes, range: Range<usize>) -> Bytes {
+    Bytes::copy_from_slice(&bytes[range])
+}
+
 impl CachedObjectStore {
     pub(crate) fn new(
         object_store: Arc<dyn ObjectStore>,
@@ -565,7 +569,10 @@ impl CachedObjectStore {
                 })
                 .await?;
 
-            Ok((bytes.slice(range_in_part), ReadResultSource::Upstream))
+            Ok((
+                copy_part_range(&bytes, range_in_part),
+                ReadResultSource::Upstream,
+            ))
         })
     }
 
@@ -1009,7 +1016,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::CachedObjectStore;
+    use super::{copy_part_range, CachedObjectStore};
     use crate::cached_object_store::policy::CachePutConfig;
     use crate::cached_object_store::stats::CachedObjectStoreStats;
     use crate::cached_object_store::storage::{LocalCacheStorage, PartID};
@@ -1032,6 +1039,19 @@ mod tests {
         let path = format!("/tmp/testcache-{}", dir_name);
         let _ = std::fs::remove_dir_all(&path);
         std::path::PathBuf::from(path)
+    }
+
+    #[test]
+    fn test_copy_part_range_does_not_retain_full_part() {
+        let part = Bytes::from(vec![7_u8; 4 * 1024 * 1024]);
+        let range = 1024..5120;
+        let source_range_ptr = part[range.clone()].as_ptr();
+
+        let copied = copy_part_range(&part, range);
+
+        assert_eq!(copied.len(), 4096);
+        assert!(copied.iter().all(|byte| *byte == 7));
+        assert_ne!(copied.as_ptr(), source_range_ptr);
     }
 
     fn new_cached_store(object_store: Arc<dyn ObjectStore>) -> Arc<CachedObjectStore> {


### PR DESCRIPTION
## Summary

(From Sol xhigh)

- Copy a requested range from a freshly fetched object-store cache part before returning it.
- Add a regression test proving that a 4 KiB returned range does not share the 4 MiB part allocation.

## Why

On an object-store cache miss, `CachedObjectStore` fetches a whole cache part (4 MiB by default). It previously returned the requested range with `Bytes::slice`. Although the logical result is usually an SST block of about 4 KiB, that slice keeps the full part allocation alive.

When these results enter the block cache, cache accounting sees the logical range size while the process retains the full allocation. Random reads can therefore consume far more resident memory than the configured cache size. This surfaced in the SlateDB benchmark as random-read workers being terminated with exit code 143.

Copying the bounded range lets the full part allocation be released after the part is saved to the disk cache. The tradeoff is one small copy on an upstream cache-part miss; disk-cache hits are unchanged.

## Validation

- `cargo fmt -- --check`
- `cargo hack clippy --each-feature --no-dev-deps --workspace`
- `cargo hack clippy --workspace --tests`
- `cargo test -p slatedb test_upstream_part_range_does_not_retain_full_part --lib`
- All ten scaled SlateDB benchmark workloads completed locally against v0.14.1 golden data, including the three random-read workloads.