### PR TITLE
Freeze large memtables on WAL replay

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -505,6 +505,9 @@ impl DbInner {
         .await?;
 
         loop {
+            self.maybe_freeze_memtable(current_memtable_wal_id);
+            self.maybe_apply_backpressure().await?;
+
             let replayed_table = match replay_iter.next().await {
                 Ok(Some(replayed_table)) => replayed_table,
                 Ok(None) => break,
@@ -551,7 +554,6 @@ impl DbInner {
             // ensure the assertion holds true.
             assert!(self.oracle.last_remote_persisted_seq() <= replayed_table.last_seq);
             self.oracle.advance_durable_seq(replayed_table.last_seq);
-            self.maybe_apply_backpressure().await?;
             let replayed_table_last_wal_id = replayed_table.last_wal_id;
             self.replay_memtable(current_memtable_wal_id, replayed_table)?;
             current_memtable_wal_id = replayed_table_last_wal_id;
@@ -9935,6 +9937,77 @@ mod tests {
                 Some(Bytes::copy_from_slice(value))
             );
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_wal_replay_flushes_oversized_active_memtable_before_backpressure() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = "/tmp/test_wal_replay_flushes_oversized_active_memtable";
+
+        // Leave a single WAL SST whose replayed table is smaller than the
+        // source's freeze threshold. Keeping the source open simulates a crash:
+        // the recovery writer fences it without first flushing its memtable to L0.
+        let mut source_settings = test_db_options(0, 64 * 1024, None);
+        source_settings.flush_interval = None;
+        let source = Db::builder(path, object_store.clone())
+            .with_settings(source_settings)
+            .build()
+            .await
+            .unwrap();
+        let value = vec![b'x'; 16 * 1024];
+        source
+            .put_with_options(
+                b"oversized-replay-value",
+                &value,
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        source
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::Wal,
+            })
+            .await
+            .unwrap();
+
+        // On recovery, one complete WAL SST exceeds both thresholds. Replay
+        // must freeze it before backpressure; otherwise open spins forever with
+        // an oversized active memtable and nothing for the flusher to drain.
+        let mut replay_settings = test_db_options(0, 1024, None);
+        replay_settings.flush_interval = None;
+        replay_settings.max_unflushed_bytes = 2 * 1024;
+        let recovered = tokio::time::timeout(
+            Duration::from_secs(5),
+            Db::builder(path, object_store)
+                .with_settings(replay_settings)
+                .build(),
+        )
+        .await
+        .expect("WAL replay deadlocked on an oversized active memtable")
+        .expect("failed to recover database");
+
+        assert_eq!(
+            recovered.get(b"oversized-replay-value").await.unwrap(),
+            Some(Bytes::from(value))
+        );
+        recovered
+            .put_with_options(
+                b"write-after-replay",
+                b"value",
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("write after oversized WAL replay should succeed");
+
+        recovered.close().await.unwrap();
     }
 
     /// RFC-0024: WAL replay through a conforming extractor preserves the

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -505,9 +505,6 @@ impl DbInner {
         .await?;
 
         loop {
-            self.maybe_freeze_memtable(current_memtable_wal_id);
-            self.maybe_apply_backpressure().await?;
-
             let replayed_table = match replay_iter.next().await {
                 Ok(Some(replayed_table)) => replayed_table,
                 Ok(None) => break,
@@ -554,6 +551,8 @@ impl DbInner {
             // ensure the assertion holds true.
             assert!(self.oracle.last_remote_persisted_seq() <= replayed_table.last_seq);
             self.oracle.advance_durable_seq(replayed_table.last_seq);
+            self.maybe_freeze_memtable(current_memtable_wal_id);
+            self.maybe_apply_backpressure().await?;
             let replayed_table_last_wal_id = replayed_table.last_wal_id;
             self.replay_memtable(current_memtable_wal_id, replayed_table)?;
             current_memtable_wal_id = replayed_table_last_wal_id;

--- a/slatedb/src/db_common.rs
+++ b/slatedb/src/db_common.rs
@@ -26,6 +26,29 @@ pub(crate) fn extract_segment_prefix(
 }
 
 impl DbInner {
+    /// Freezes the active memtable when its estimated encoded size reaches
+    /// [`Settings::max_unflushed_bytes`](crate::config::Settings::max_unflushed_bytes).
+    ///
+    /// The frozen table is stamped with `replay_after_wal_id` and announced to
+    /// the memtable flusher. The caller must therefore pass the highest WAL ID
+    /// fully represented by the active memtable. This method does nothing when
+    /// the active memtable is below the threshold.
+    ///
+    /// # Arguments
+    ///
+    /// * `replay_after_wal_id` - Durable WAL boundary for the active memtable.
+    pub(crate) fn maybe_freeze_memtable(&self, replay_after_wal_id: u64) {
+        let mut guard = self.state.write();
+        let metadata = guard.memtable().table().metadata();
+        let estimated_bytes = self
+            .table_store
+            .estimate_encoded_size_compacted(metadata.entry_num, metadata.entries_size_in_bytes);
+
+        if estimated_bytes >= self.settings.max_unflushed_bytes {
+            self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
+        }
+    }
+
     pub(crate) fn replay_memtable(
         &self,
         current_memtable_wal_id: u64,


### PR DESCRIPTION
## Summary

DST has been failing sporadically for the past day or two. The original fault was introduced in #1939. We began counting active memtables toward the backpressure limit. The DST could generate a config that had the `l0_max_bytes` size greater than `max_unflushed_bytes`. This can lead to a deadlock: a large memtable exceeds max unflushed bytes, but is never frozen because it hasn't yet exceeded `l0_max_bytes`. @1996fanrui added a fix in #1950 to prevent DST from picking such a range.

The problem still persists for WAL replay, though. During WAL replay, we can generate an active memtable that is larger than `max_unflushed_bytes`. It then calls `maybe_apply_backpressure`. Since the `replay_wal` function does not freeze that memtable and notify the memtable flusher, we reach the same deadlock.

This PR adds a freeze-memtable check just before applying backpressure. It also moves the backpressure check to the top of the loop just to simplify readability (it shouldn't affect correctness).

## Changes

- Add `maybe_freeze_memtable` to `db_common.rs`
- Call `maybe_freeze_memtable` in `replay_wal` loop before applying backpressure
- Add test

## Notes for Reviewers

This seems to be the smallest fix that unblocks the immediate issue. In the long-run, I think it might be prudent to do this check in the `mabye_apply_backpressure` function itself. This would prevent deadlocks that might pop up in other places. There is some complexity in doing so if we want to handle both WAL replay and normal write paths cleanly, though. I didn't trace through it in detail. I'm a bit hesitant to mess with it too much while @rodesai is working on WAL extraction.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
