### PR TITLE
(RFC-0029) Move L0 SST id allocation to dispatch

### DIFF
--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -502,10 +502,10 @@ impl ManifestWriterHandler {
                 // still advances. (This is true with or without an
                 // extractor configured.)
                 for segment in &uploaded.segments {
-                    let view = SsTableView::new(
-                        self.db.rand.rng().gen_ulid(self.db.system_clock.as_ref()),
-                        segment.sst_handle.clone(),
-                    );
+                    // Identity view: the view id is the physical SST ULID, so
+                    // the timestamp `last_compacted_l0_sst_view_id` reads
+                    // equals the one GC deletion reads (RFC-0029).
+                    let view = SsTableView::identity(segment.sst_handle.clone());
                     let tree = if segmented {
                         // Extractor configured — every flush handle, including
                         // any with empty prefix, is routed into `segments`.
@@ -1909,6 +1909,41 @@ mod tests {
         assert_eq!(core.segments[1].tree.l0.len(), 1);
         assert_eq!(core.segments[0].tree.l0[0].sst.id, aaa_id);
         assert_eq!(core.segments[1].tree.l0[0].sst.id, bbb_id);
+        // Newly flushed L0s are identity views: the view id equals the
+        // physical SST ULID (RFC-0029).
+        assert_eq!(core.segments[0].tree.l0[0].id, aaa_id.unwrap_compacted_id());
+        assert_eq!(core.segments[1].tree.l0[0].id, bbb_id.unwrap_compacted_id());
+
+        started.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn should_create_identity_l0_view_on_flush() {
+        let harness = setup_harness(
+            "/tmp/test_manifest_writer_identity_l0_view",
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let inner = Arc::clone(&harness.inner);
+        let started = start_manifest_writer(
+            Arc::clone(&inner),
+            harness.manifest,
+            Duration::from_secs(3600),
+        );
+
+        let uploaded = next_uploaded_memtable(&inner, b"k1", b"v1").await;
+        let physical_id = uploaded.segments[0].sst_handle.id;
+        started.notify_uploaded(uploaded).await.unwrap();
+        let _ = expect_flushed(&started.tracker_rx).await;
+
+        // The published L0 view id must equal the physical SST ULID so the
+        // timestamp `last_compacted_l0_sst_view_id` reads matches the one GC
+        // deletion reads (RFC-0029).
+        let core = inner.state.read().state().core().clone();
+        assert_eq!(core.tree.l0.len(), 1);
+        let view = &core.tree.l0[0];
+        assert_eq!(view.sst.id, physical_id);
+        assert_eq!(view.id, physical_id.unwrap_compacted_id());
 
         started.shutdown().await;
     }

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -23,13 +23,16 @@ use crate::config::CheckpointOptions;
 use crate::db::DbInner;
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
+use crate::mem_table::ImmutableMemtable;
 use crate::memtable_flusher::manifest_writer::{FlushResult, ManifestWriter};
 use crate::memtable_flusher::uploader::{UploadJob, UploadedMemtable, Uploader};
 use crate::memtable_flusher::FlushTarget;
+use crate::utils::IdGenerator;
 use fail_parallel::fail_point;
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::Arc;
 use tokio::sync::oneshot;
+use ulid::Ulid;
 
 macro_rules! memtable_flush_stat_name {
     ($suffix:expr) => {
@@ -352,7 +355,12 @@ impl FlushTracker {
                 tracked.first_seq, last_seq
             );
 
-            self.uploader.submit(UploadJob::new(imm_memtable))?;
+            // Allocate physical SST ids here, in seqno-ordered dispatch, so
+            // their ULID timestamps never fall below an earlier-dispatched
+            // (and thus earlier-published) L0's (RFC-0029).
+            let segment_sst_ids = allocate_segment_sst_ids(&self.inner, &imm_memtable);
+            self.uploader
+                .submit(UploadJob::new(imm_memtable, segment_sst_ids))?;
         }
     }
 
@@ -381,6 +389,31 @@ impl FlushTracker {
             }
         }
     }
+}
+
+/// Allocate one physical SST id per segment `imm` will flush to, keyed by
+/// segment prefix.
+///
+/// Kept module-private to the tracker on purpose: L0 physical SST ids must be
+/// minted only here, in seqno-ordered dispatch, so their ULID timestamps match
+/// the order in which the manifest writer publishes L0s (RFC-0029). Exposing a
+/// reusable minting helper would invite an out-of-order minting path and
+/// reintroduce the GC race this fixes.
+///
+/// Without an extractor the sole segment is the compatibility-encoded
+/// `prefix=""` segment; with one, the segments are the imm's touched prefixes.
+/// A segment that retention later prunes to empty simply leaves its id unused.
+fn allocate_segment_sst_ids(inner: &DbInner, imm: &ImmutableMemtable) -> BTreeMap<Bytes, Ulid> {
+    let prefixes: BTreeSet<Bytes> = if inner.segment_extractor.is_some() {
+        imm.touched_segments()
+    } else {
+        BTreeSet::from([Bytes::new()])
+    };
+    let mut rng = inner.rand.rng();
+    prefixes
+        .into_iter()
+        .map(|prefix| (prefix, rng.gen_ulid(inner.system_clock.as_ref())))
+        .collect()
 }
 
 struct TrackedImm {
@@ -532,11 +565,14 @@ mod tests {
     use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
     use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
+    use crate::mem_table::{ImmutableMemtable, WritableKVTable};
     use crate::memtable_flusher::uploader::Uploader;
     use crate::memtable_flusher::{FlushTarget, MemtableFlusher};
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
+    use crate::prefix_extractor::PrefixExtractor;
     use crate::tablestore::{TableStore, TableStoreKind};
+    use crate::test_utils::FixedThreeBytePrefixExtractor;
     use crate::types::RowEntry;
     use crate::utils::{SafeSender, WatchableOnceCell};
     use crate::wal_buffer::WalBufferManager;
@@ -545,7 +581,7 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
-    use slatedb_common::clock::{DefaultSystemClock, SystemClock};
+    use slatedb_common::clock::{DefaultSystemClock, MockSystemClock, SystemClock};
     use slatedb_common::metrics::{
         lookup_metric_with_labels, DefaultMetricsRecorder, MetricLevel, MetricsRecorder,
         MetricsRecorderHelper,
@@ -568,8 +604,15 @@ mod tests {
         settings: Settings,
         fp_registry: Arc<FailPointRegistry>,
     ) -> TestHarness {
-        setup_harness_with_recorder(path, settings, fp_registry, MetricsRecorderHelper::noop())
-            .await
+        setup_harness_with_recorder(
+            path,
+            settings,
+            fp_registry,
+            MetricsRecorderHelper::noop(),
+            None,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
     }
 
     async fn setup_harness_with_recorder(
@@ -577,10 +620,11 @@ mod tests {
         settings: Settings,
         fp_registry: Arc<FailPointRegistry>,
         db_metrics: MetricsRecorderHelper,
+        segment_extractor: Option<Arc<dyn PrefixExtractor>>,
+        system_clock: Arc<dyn SystemClock>,
     ) -> TestHarness {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = path.to_string();
-        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
         let rand = Arc::new(DbRand::new(42));
         let manifest_store = Arc::new(ManifestStore::new(
             &Path::from(path.clone()),
@@ -628,7 +672,7 @@ mod tests {
                 fp_registry,
                 None,
                 status_manager,
-                None,
+                segment_extractor,
             )
             .await
             .unwrap(),
@@ -1189,6 +1233,8 @@ mod tests {
             settings,
             Arc::new(FailPointRegistry::new()),
             helper,
+            None,
+            Arc::new(DefaultSystemClock::new()),
         )
         .await;
         set_local_l0_len(&harness, 1);
@@ -1487,6 +1533,8 @@ mod tests {
             settings,
             Arc::new(FailPointRegistry::new()),
             helper,
+            None,
+            Arc::new(DefaultSystemClock::new()),
         )
         .await;
         let ranges: &[(&[u8], &[u8])] = &[(b"aaa", b"zzz")];
@@ -1571,6 +1619,89 @@ mod tests {
             .await
             .expect("timed out waiting for flush result");
         assert!(result.is_ok() || result.is_err());
+    }
+
+    fn imm_with_touched(entries: &[(&[u8], &[u8], u64)], touched: &[&[u8]]) -> ImmutableMemtable {
+        let table = WritableKVTable::new();
+        for (key, value, seq) in entries {
+            table.put(RowEntry::new_value(key, value, *seq));
+        }
+        if !touched.is_empty() {
+            table.record_touched_segments(
+                touched.iter().map(|p| Bytes::copy_from_slice(p)).collect(),
+            );
+        }
+        ImmutableMemtable::new(table, 0)
+    }
+
+    #[tokio::test]
+    async fn allocate_segment_sst_ids_without_extractor_uses_empty_prefix() {
+        let harness = setup_harness(
+            "/tmp/test_allocate_segment_sst_ids_empty_prefix",
+            Settings::default(),
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let imm = imm_with_touched(&[(b"k1", b"v1", 1)], &[]);
+
+        let ids = super::allocate_segment_sst_ids(&harness.inner, &imm);
+
+        assert_eq!(ids.len(), 1);
+        assert!(ids.contains_key(&Bytes::new()));
+    }
+
+    #[tokio::test]
+    async fn allocate_segment_sst_ids_with_extractor_covers_touched_segments() {
+        let harness = setup_harness_with_recorder(
+            "/tmp/test_allocate_segment_sst_ids_segments",
+            Settings::default(),
+            Arc::new(FailPointRegistry::new()),
+            MetricsRecorderHelper::noop(),
+            Some(Arc::new(FixedThreeBytePrefixExtractor)),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await;
+        let imm = imm_with_touched(
+            &[(b"aaa-1", b"v1", 1), (b"bbb-1", b"v2", 2)],
+            &[b"aaa", b"bbb"],
+        );
+
+        let ids = super::allocate_segment_sst_ids(&harness.inner, &imm);
+
+        let prefixes: Vec<&[u8]> = ids.keys().map(|k| k.as_ref()).collect();
+        assert_eq!(prefixes, vec![&b"aaa"[..], &b"bbb"[..]]);
+    }
+
+    /// RFC-0029 ordering guarantee at the allocation level: ids minted for a
+    /// later-dispatched memtable never carry an earlier ULID timestamp than an
+    /// earlier-dispatched one, so `newest_l0` cannot advance past a pending L0.
+    #[tokio::test]
+    async fn allocate_segment_sst_ids_do_not_regress_across_dispatch() {
+        let clock = Arc::new(MockSystemClock::new());
+        let harness = setup_harness_with_recorder(
+            "/tmp/test_allocate_segment_sst_ids_ordering",
+            Settings::default(),
+            Arc::new(FailPointRegistry::new()),
+            MetricsRecorderHelper::noop(),
+            None,
+            clock.clone(),
+        )
+        .await;
+
+        let imm1 = imm_with_touched(&[(b"k1", b"v1", 1)], &[]);
+        let first =
+            super::allocate_segment_sst_ids(&harness.inner, &imm1)[&Bytes::new()].timestamp_ms();
+
+        clock.advance(Duration::from_millis(10)).await;
+
+        let imm2 = imm_with_touched(&[(b"k2", b"v2", 2)], &[]);
+        let second =
+            super::allocate_segment_sst_ids(&harness.inner, &imm2)[&Bytes::new()].timestamp_ms();
+
+        assert!(
+            second > first,
+            "later dispatch must not regress: first={first}, second={second}"
+        );
     }
 
     mod frontier_tests {

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -394,12 +394,6 @@ impl FlushTracker {
 /// Allocate one physical SST id per segment `imm` will flush to, keyed by
 /// segment prefix.
 ///
-/// Kept module-private to the tracker on purpose: L0 physical SST ids must be
-/// minted only here, in seqno-ordered dispatch, so their ULID timestamps match
-/// the order in which the manifest writer publishes L0s (RFC-0029). Exposing a
-/// reusable minting helper would invite an out-of-order minting path and
-/// reintroduce the GC race this fixes.
-///
 /// Without an extractor the sole segment is the compatibility-encoded
 /// `prefix=""` segment; with one, the segments are the imm's touched prefixes.
 /// A segment that retention later prunes to empty simply leaves its id unused.

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -19,23 +19,29 @@ use crate::dispatcher::{MessageHandler, MessageHandlerExecutor};
 use crate::error::SlateDBError;
 use crate::flush::EncodedSegmentSst;
 use crate::mem_table::ImmutableMemtable;
-use crate::utils::{IdGenerator, SafeSender};
+use crate::utils::SafeSender;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use log::{info, warn};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
+use ulid::Ulid;
 
 const UPLOADER_TASK_NAME: &str = "l0_sst_uploader";
 
-/// One immutable-memtable upload request submitted to the uploader. The
-/// worker allocates SST ids for each segment internally.
+/// One immutable-memtable upload request submitted to the uploader. Physical
+/// SST ids are allocated at dispatch (in sequence order) and carried here, so
+/// the parallel upload workers never mint ids out of publish order (RFC-0029).
 pub(crate) struct UploadJob {
     /// Immutable memtable to build into one or more SSTs.
     pub(crate) imm_memtable: Arc<ImmutableMemtable>,
+    /// Pre-allocated physical SST id per segment prefix. A segment that
+    /// retention prunes to empty simply leaves its id unused.
+    pub(crate) segment_sst_ids: BTreeMap<Bytes, Ulid>,
 }
 
 impl std::fmt::Debug for UploadJob {
@@ -45,9 +51,15 @@ impl std::fmt::Debug for UploadJob {
 }
 
 impl UploadJob {
-    /// Creates a new upload job.
-    pub(crate) fn new(imm_memtable: Arc<ImmutableMemtable>) -> Self {
-        Self { imm_memtable }
+    /// Creates a new upload job with pre-allocated segment SST ids.
+    pub(crate) fn new(
+        imm_memtable: Arc<ImmutableMemtable>,
+        segment_sst_ids: BTreeMap<Bytes, Ulid>,
+    ) -> Self {
+        Self {
+            imm_memtable,
+            segment_sst_ids,
+        }
     }
 }
 
@@ -195,11 +207,22 @@ impl UploadHandler {
         // Upload all segment SSTs concurrently. `try_join_all` short-circuits
         // on the first fatal error and drops the remaining futures; sibling
         // uploads that already landed before the abort are left for the
-        // garbage collector to reclaim, since the worker allocates ids
-        // internally and they are not visible here for explicit cleanup.
-        let segments =
-            futures::future::try_join_all(built.iter().map(|sst| self.upload_segment_sst(sst)))
-                .await?;
+        // garbage collector to reclaim.
+        let segments = futures::future::try_join_all(built.iter().map(|sst| {
+            // Ids are pre-allocated at dispatch keyed by segment prefix. Every
+            // built prefix is a subset of the dispatched touched set, so a
+            // missing id is an internal invariant violation.
+            let sst_id = job
+                .segment_sst_ids
+                .get(&sst.prefix)
+                .copied()
+                .map(SsTableId::Compacted);
+            async move {
+                let sst_id = sst_id.ok_or(SlateDBError::InvalidDBState)?;
+                self.upload_segment_sst(sst, sst_id).await
+            }
+        }))
+        .await?;
 
         Ok(UploadedMemtable {
             imm_memtable: Arc::clone(&job.imm_memtable),
@@ -209,15 +232,15 @@ impl UploadHandler {
         })
     }
 
-    /// Upload a single segment SST with retry. Each retry reuses the
+    /// Upload a single segment SST with retry, writing it to the id
+    /// pre-allocated for its segment at dispatch. Each retry reuses the
     /// already-encoded SST so the upload loop never rebuilds from the
     /// memtable.
     async fn upload_segment_sst(
         &self,
         sst: &EncodedSegmentSst,
+        sst_id: SsTableId,
     ) -> Result<SegmentedSstHandle, SlateDBError> {
-        let sst_id =
-            SsTableId::Compacted(self.db.rand.rng().gen_ulid(self.db.system_clock.as_ref()));
         let written_bytes = sst.encoded.remaining_len() as u64;
         loop {
             match self.db.upload_sst(&sst_id, &sst.encoded, true).await {
@@ -277,12 +300,13 @@ mod tests {
     use super::{TrackerMessage, UploadJob, Uploader};
     use crate::config::Settings;
     use crate::db::DbInner;
-    use crate::db_state::SsTableView;
+    use crate::db_state::{SsTableId, SsTableView};
     use crate::db_status::{ClosedResultWriter, DbStatusManager};
     use crate::error::SlateDBError;
     use crate::format::sst::SsTableFormat;
     use crate::iter::RowEntryIterator;
     use crate::manifest::ManifestCore;
+    use crate::mem_table::ImmutableMemtable;
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
@@ -299,10 +323,24 @@ mod tests {
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
     use slatedb_common::metrics::{DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper};
     use slatedb_common::DbRand;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use std::time::Duration;
     use tokio::runtime::Handle;
     use tokio::time::timeout;
+    use ulid::Ulid;
+
+    /// Build a pre-allocated id map for a test job, mirroring dispatch-time
+    /// allocation: one id per segment prefix, falling back to the empty prefix
+    /// when no extractor recorded segments. The tracker owns the real
+    /// allocation path; tests only need a valid map covering the built SSTs.
+    fn preallocate_ids(imm: &ImmutableMemtable) -> BTreeMap<Bytes, Ulid> {
+        let mut prefixes = imm.touched_segments();
+        if prefixes.is_empty() {
+            prefixes.insert(Bytes::new());
+        }
+        prefixes.into_iter().map(|p| (p, Ulid::new())).collect()
+    }
 
     async fn setup_db(path: &str, fp_registry: Arc<FailPointRegistry>) -> Arc<DbInner> {
         setup_db_with_extractor(path, fp_registry, None).await
@@ -387,7 +425,8 @@ mod tests {
 
     fn next_upload_job(db: &DbInner, key: &[u8], value: &[u8], seq: u64) -> UploadJob {
         let imm_memtable = freeze_imm(db, key, value, seq);
-        UploadJob::new(imm_memtable)
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        UploadJob::new(imm_memtable, segment_sst_ids)
     }
 
     struct TestUploader {
@@ -499,6 +538,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_write_sst_to_preallocated_id() {
+        // The worker must write each segment SST to the id allocated at
+        // dispatch (carried in the job), not mint a fresh one (RFC-0029).
+        let db = setup_db(
+            "/tmp/test_parallel_l0_flush_uploader_preallocated_id",
+            Arc::new(FailPointRegistry::new()),
+        )
+        .await;
+        let job = next_upload_job(&db, b"key", b"value", 1);
+        let expected_id = *job
+            .segment_sst_ids
+            .get(&Bytes::new())
+            .expect("empty-prefix id should be pre-allocated");
+
+        let test = start_test_uploader(&db);
+        test.submit(job).unwrap();
+
+        let msg = timeout(Duration::from_secs(5), test.tracker_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        let TrackerMessage::UploadComplete(event) = msg else {
+            panic!("expected UploadComplete");
+        };
+        assert_eq!(event.segments.len(), 1);
+        assert_eq!(
+            event.segments[0].sst_handle.id,
+            SsTableId::Compacted(expected_id)
+        );
+
+        test.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn should_retry_upload_failures_until_success() {
         let fp_registry = Arc::new(FailPointRegistry::new());
         fail_parallel::cfg(
@@ -550,7 +623,8 @@ mod tests {
             .front()
             .cloned()
             .unwrap();
-        let job = UploadJob::new(imm_memtable);
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        let job = UploadJob::new(imm_memtable, segment_sst_ids);
 
         let test = start_test_uploader(&db);
         test.submit(job).unwrap();
@@ -623,7 +697,8 @@ mod tests {
             .front()
             .cloned()
             .unwrap();
-        let bad_job = UploadJob::new(imm_memtable);
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        let bad_job = UploadJob::new(imm_memtable, segment_sst_ids);
 
         let test = start_test_uploader(&db);
         test.submit(bad_job).unwrap();
@@ -716,7 +791,8 @@ mod tests {
             .front()
             .cloned()
             .unwrap();
-        let job = UploadJob::new(imm_memtable);
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        let job = UploadJob::new(imm_memtable, segment_sst_ids);
 
         let test = start_test_uploader(&db);
         test.submit(job).unwrap();
@@ -782,6 +858,16 @@ mod tests {
             ] {
                 guard.memtable().put(RowEntry::new_value(key, value, seq));
             }
+            // The production write path stamps these inline; this test
+            // bypasses that, so record explicitly.
+            guard
+                .memtable()
+                .table()
+                .record_touched_segments(std::collections::BTreeSet::from([
+                    Bytes::from_static(b"aaa"),
+                    Bytes::from_static(b"bbb"),
+                    Bytes::from_static(b"ccc"),
+                ]));
             guard.freeze_memtable(0);
         }
         let imm_memtable = db
@@ -792,7 +878,8 @@ mod tests {
             .front()
             .cloned()
             .unwrap();
-        let job = UploadJob::new(imm_memtable);
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        let job = UploadJob::new(imm_memtable, segment_sst_ids);
 
         let test = start_test_uploader(&db);
         test.submit(job).unwrap();


### PR DESCRIPTION
## Summary

This is the PR number 1 for the implementation of [RFC-0029](https://github.com/slatedb/slatedb/blob/main/rfcs/0029-gc-safe-sst-ulid-timestamps.md)

## Changes

- Move L0 physical SST ID allocation to seqno-ordered dispatch. IDs are now minted in FlushTracker::dispatch_ready_memtables (via allocate_segment_sst_ids, kept module-private to the tracker) instead of inside the parallel upload workers. Because dispatch runs in sequence-number order, an L0's ULID timestamp can never fall below an earlier-dispatched — and thus earlier-published — L0's, so newest_l0 cannot advance past a pending SST.
- Carry pre-allocated IDs on UploadJob. Added segment_sst_ids: BTreeMap<Bytes, Ulid>; the uploader writes each segment SST to its pre-allocated ID rather than minting a fresh one. A built prefix is always a subset of the allocated set; a missing ID is treated as an internal invariant violation (InvalidDBState).
- Identity L0 views. ManifestWriter::apply_uploaded_state now builds newly flushed L0 views with SsTableView::identity(handle), so the view ID read by last_compacted_l0_sst_view_id equals the physical SST ULID read by GC deletion.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
