### PR TITLE
[rfc-30 1/N]: refactor writer WAL write path to use new traits

### DIFF
--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -167,17 +167,20 @@ pub struct WalFileRange(pub Bound<u64>, pub Bound<u64>);
 
 /// Defines the types of errors that can be returned by WAL implementations.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum WalError {
     /// The WAL writer was fenced
     Fenced,
-    /// IO error writing/reading the WAL
-    IoError(Arc<std::io::Error>),
-    /// Fatal error indicating that the WAL is in some unexpected/unrecoverable state.
-    InternalError(Arc<dyn Error + Sync + Send + 'static>),
     /// A WalIterator observed that the tail of the WAL was truncated while iterating.
     WalTruncated,
     /// Operation against wal after it was closed
     Closed,
+    /// WAL is unavailable, e.g. due to an I/O error or error in the backing storage system
+    Unavailable(Arc<dyn Error + Sync + Send + 'static>),
+    /// WAL implementation detected invalid data/corruption
+    DataError(Arc<dyn Error + Sync + Send + 'static>),
+    /// Fatal error indicating that the WAL is in some unexpected/unrecoverable state.
+    InternalError(Arc<dyn Error + Sync + Send + 'static>),
 }
 
 /// The writer's manifest after fencing. [`crate::Db`] creates this after fencing the manifest
@@ -299,9 +302,8 @@ pub trait WalObserver: Send + Sync + 'static {
     /// Returns the current [`WalStatus`].
     fn status(&self) -> Result<WalStatus, WalStatus>;
 
-    /// Adds a listener that subscribes to event callbacks. On success, returns an initial 
-    /// [`WalStatus`]. The listener receives all updates after this initial status.
-    fn subscribe(&self, listener: WalStatusListener) -> Result<WalStatus, WalError>;
+    /// Adds a listener that subscribes to event callbacks.
+    fn subscribe(&self, listener: WalStatusListener) -> Result<(), WalError>;
 }
 
 /// A future that yields the result of flushing the WAL. Returned by [`WalWriter::flush`]
@@ -371,12 +373,12 @@ pub trait WalIterator: Send + 'static {
 #[async_trait]
 pub trait WalReader {
     /// Returns the name of the WAL implementation
-    fn name(&self) -> String,
+    fn name(&self) -> String;
     
     /// Returns an iterator over the specified range of WAL File IDs. The start of the range must
     /// not be `Unbounded`. If the end of the range is `Unbounded` then the returned iterator
     /// continues returning writes as new writes are appended to the WAL. Otherwise, it returns
-    /// `None` upon reaching the end of he range.
+    /// `None` upon reaching the end of the range.
     async fn iterator(
         &self,
         wal_file_id_range: WalFileRange,

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -28,7 +28,7 @@
 use async_trait::async_trait;
 use fail_parallel::fail_point;
 use futures::stream::BoxStream;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use log::warn;
 use std::sync::Arc;
 use std::time::Duration;
@@ -43,7 +43,7 @@ use crate::dispatcher::MessageHandler;
 use crate::mem_table::KVTable;
 use crate::types::RowEntry;
 use crate::utils::WatchableOnceCellReader;
-use crate::wal_buffer::WalBufferManager;
+use crate::wal::{FlushResultFuture, WalWriter};
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
 use bytes::Bytes;
 use parking_lot::RwLockWriteGuard;
@@ -52,13 +52,7 @@ use tokio::sync::oneshot;
 
 pub(crate) const WRITE_BATCH_TASK_NAME: &str = "writer";
 
-pub(crate) type WriteBatchResult = Result<
-    (
-        WriteHandle,
-        WatchableOnceCellReader<Result<(), SlateDBError>>,
-    ),
-    SlateDBError,
->;
+pub(crate) type WriteBatchResult = Result<WriteHandle, SlateDBError>;
 
 /// A message processed by the batch writer event loop.
 #[allow(clippy::large_enum_variant)]
@@ -75,7 +69,7 @@ pub(crate) struct BatchWriterFlush {
     /// Sends a message when the writer has processed the flush message. On successful receipt
     /// of a message, the caller should wait on the received Receiver to get the result of the
     /// wal flush.
-    done: oneshot::Sender<Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError>>,
+    done: oneshot::Sender<Result<FlushResultFuture, SlateDBError>>,
 }
 
 pub(crate) struct WriteBatchRequest {
@@ -109,15 +103,15 @@ impl std::fmt::Debug for BatchWriterMessage {
 pub(crate) struct WriteBatchEventHandler {
     db_inner: Arc<DbInner>,
     is_first_write: bool,
-    wal_buffer: WalBufferManager,
+    wal_writer: Box<dyn WalWriter>,
 }
 
 impl WriteBatchEventHandler {
-    pub(crate) fn new(db_inner: Arc<DbInner>, wal_buffer: WalBufferManager) -> Self {
+    pub(crate) fn new(db_inner: Arc<DbInner>, wal_writer: Box<dyn WalWriter>) -> Self {
         Self {
             db_inner,
             is_first_write: true,
-            wal_buffer,
+            wal_writer,
         }
     }
 }
@@ -134,22 +128,25 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
             }) => {
                 let result = self
                     .db_inner
-                    .write_batch(batch, &options, txn.as_ref(), &self.wal_buffer)
+                    .write_batch(
+                        batch,
+                        &options,
+                        txn.as_ref(),
+                        &mut self.wal_writer,
+                        self.is_first_write,
+                    )
                     .await;
-                // if this is the first write and the WAL is disabled, make sure users are flushing
-                // their memtables in a timely manner.
-                if self.is_first_write && !self.db_inner.wal_enabled && options.await_durable {
-                    if let Ok((_, this_watcher)) = &result {
-                        let this_watcher = this_watcher.clone();
-                        let this_clock = self.db_inner.system_clock.clone();
-                        tokio::spawn(async move {
-                            monitor_first_write(this_watcher, this_clock).await;
-                        });
+                self.is_first_write = false;
+                match result {
+                    Ok(write_result) => {
+                        let _ = done.send(write_result);
+                        Ok(())
+                    }
+                    Err(error) => {
+                        let _ = done.send(Err(error.clone()));
+                        Err(error)
                     }
                 }
-                self.is_first_write = false;
-                _ = done.send(result);
-                Ok(())
             }
             BatchWriterMessage::Flush(flush_msg) => {
                 let BatchWriterFlush {
@@ -158,9 +155,18 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 } = flush_msg;
                 let result = self
                     .db_inner
-                    .flush_batch_writer(freeze_memtable, &self.wal_buffer);
-                let _ = done.send(result);
-                Ok(())
+                    .flush_batch_writer(freeze_memtable, &mut self.wal_writer)
+                    .await;
+                match result {
+                    Ok(flush_result) => {
+                        let _ = done.send(Ok(flush_result));
+                        Ok(())
+                    }
+                    Err(error) => {
+                        let _ = done.send(Err(error.clone()));
+                        Err(error)
+                    }
+                }
             }
         }
     }
@@ -185,6 +191,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 }
             }
         }
+        self.wal_writer.close().await?;
         Ok(())
     }
 }
@@ -197,8 +204,9 @@ impl DbInner {
         batch: WriteBatch,
         options: &WriteOptions,
         txn: Option<&DbTransaction>,
-        wal_buffer: &WalBufferManager,
-    ) -> WriteBatchResult {
+        wal_writer: &mut Box<dyn WalWriter>,
+        is_first_write: bool,
+    ) -> Result<WriteBatchResult, SlateDBError> {
         let _options = options;
         #[cfg(not(dst))]
         let now = self.mono_clock.now().await?;
@@ -211,10 +219,10 @@ impl DbInner {
         let commit_seq = if options.seqnum > 0 {
             let current = self.oracle.last_seq();
             if options.seqnum <= current {
-                return Err(SlateDBError::InvalidSequenceNumber {
+                return Ok(Err(SlateDBError::InvalidSequenceNumber {
                     provided: options.seqnum,
                     current,
-                });
+                }));
             }
             self.oracle.advance_last_seq(options.seqnum);
             options.seqnum
@@ -226,13 +234,13 @@ impl DbInner {
         // if this batch is part of a transaction.
         if let Some(txn) = txn {
             if self.txn_manager.check_has_conflict(&txn.id()) {
-                return Err(SlateDBError::TransactionConflict);
+                return Ok(Err(SlateDBError::TransactionConflict));
             }
         }
 
         // Count batch-local merge folding on the flush path so DB-side merge
         // resolution uses one metric for both write batches and memtable flushes.
-        let (entries, touched_segments, entries_size) = batch
+        let (entries, touched_segments, entries_size) = match batch
             .extract_entries(
                 commit_seq,
                 now,
@@ -240,30 +248,43 @@ impl DbInner {
                 self.flush_merge_operator.clone(),
                 self.segment_extractor.as_deref(),
             )
-            .await?;
+            .await
+        {
+            Ok(extracted) => extracted,
+            Err(error) => return Ok(Err(error)),
+        };
 
         // RFC-0024 route-consistency: when a segment extractor is
         // configured, every write must extract a prefix that does
         // not nest with the current segment set. Runs before the
         // WAL append so a rejected batch produces no durable side
         // effects.
-        self.validate_segment_antichain(&touched_segments)?;
+        if let Err(error) = self.validate_segment_antichain(&touched_segments) {
+            return Ok(Err(error));
+        }
 
-        let durable_watcher = if self.wal_enabled {
+        if self.wal_enabled {
             // WAL entries must be appended to the wal buffer atomically. Otherwise,
             // the WAL buffer might flush the entries in the middle of the batch, which
             // would violate the guarantee that batches are written atomically. We do
             // this by appending the entire entry batch in a single call to the WAL buffer,
             // which holds a write lock during the append.
-            let wal_watcher = wal_buffer.append(&entries)?;
-            wal_buffer.maybe_trigger_flush()?;
+            wal_writer.append(&entries).await?;
             // TODO: handle sync here, if sync is enabled, we can call `flush` here. let's put this
             // in another Pull Request.
             self.write_entries_to_memtable(entries, touched_segments);
-            wal_watcher
         } else {
             // if WAL is disabled, we just write the entries to memtable.
-            self.write_entries_to_memtable(entries, touched_segments)
+            let watcher = self.write_entries_to_memtable(entries, touched_segments);
+            // if this is the first write and the WAL is disabled, make sure users are flushing
+            // their memtables in a timely manner.
+            if is_first_write && options.await_durable {
+                let this_watcher = watcher.clone();
+                let this_clock = self.system_clock.clone();
+                tokio::spawn(async move {
+                    monitor_first_write(this_watcher, this_clock).await;
+                });
+            }
         };
         // increment memtable_write_bytes by the size of the keys and values inserted into the memtable
         // after merge operators and overwrites are collapsed
@@ -301,18 +322,15 @@ impl DbInner {
         self.record_memtable_sequence(commit_seq);
 
         // maybe freeze the memtable.
-        self.maybe_freeze_current_memtable(wal_buffer)?;
+        self.maybe_freeze_current_memtable()?;
 
         let write_handle = WriteHandle::new(commit_seq, now);
 
-        Ok((write_handle, durable_watcher))
+        Ok(Ok(write_handle))
     }
 
-    fn maybe_freeze_current_memtable(
-        &self,
-        wal_buffer: &WalBufferManager,
-    ) -> Result<(), SlateDBError> {
-        let replay_after_wal_id = wal_buffer.last_flushed_wal_id();
+    fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {
+        let replay_after_wal_id = self.wal_observer.status()?.last_flushed_wal_id;
         let mut guard = self.state.write();
         let meta = guard.memtable().metadata();
 
@@ -340,25 +358,21 @@ impl DbInner {
         Ok(())
     }
 
-    fn flush_batch_writer(
+    async fn flush_batch_writer(
         &self,
         freeze_memtable: bool,
-        wal_buffer: &WalBufferManager,
-    ) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
+        wal_writer: &mut Box<dyn WalWriter>,
+    ) -> Result<FlushResultFuture, SlateDBError> {
         let flush_rx = if self.wal_enabled {
-            wal_buffer.flush()?
+            wal_writer.flush().await?
         } else {
-            let (flush_tx, flush_rx) = oneshot::channel();
-            flush_tx
-                .send(Ok(()))
-                .expect("unexpected oneshot send failure");
-            flush_rx
+            async { Ok(()) }.boxed()
         };
         if freeze_memtable {
             // Note that this likely won't reflect the result of the above flush call as we don't
             // block until the flush completes. That's fine, as any earlier wal is still a safe
             // replay point.
-            let replay_after_wal_id = wal_buffer.last_flushed_wal_id();
+            let replay_after_wal_id = self.wal_observer.status()?.last_flushed_wal_id;
             let mut guard = self.state.write();
             self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
         }
@@ -393,7 +407,7 @@ impl DbInner {
                 freeze_memtable,
                 done,
             }))?;
-        rx.await??.await?
+        Ok(rx.await??.await?)
     }
 
     /// RFC-0024 route-consistency check. Verifies that `batch_prefixes`,
@@ -522,7 +536,57 @@ async fn monitor_first_write(
 mod tests {
     use super::*;
     use crate::object_store::memory::InMemory;
+    use crate::wal::test_utils::FakeWalWriter;
+    use crate::wal::{WalError, WalObserver, WalStatus};
     use crate::Db;
+
+    enum FailingWalOperation {
+        Append,
+        Flush,
+    }
+
+    struct FailingWalWriter {
+        inner: FakeWalWriter,
+        operation: FailingWalOperation,
+    }
+
+    impl FailingWalWriter {
+        fn new(operation: FailingWalOperation) -> Self {
+            Self {
+                inner: FakeWalWriter::new(0),
+                operation,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl WalWriter for FailingWalWriter {
+        async fn append(&mut self, write_batch: &[RowEntry]) -> Result<(), WalError> {
+            if matches!(self.operation, FailingWalOperation::Append) {
+                return Err(WalError::Fenced);
+            }
+            self.inner.append(write_batch).await
+        }
+
+        async fn flush(&mut self) -> Result<FlushResultFuture, WalError> {
+            if matches!(self.operation, FailingWalOperation::Flush) {
+                return Err(WalError::Fenced);
+            }
+            self.inner.flush().await
+        }
+
+        fn observer(&self) -> Box<dyn WalObserver> {
+            self.inner.observer()
+        }
+
+        fn status(&self) -> Result<WalStatus, WalStatus> {
+            self.inner.status()
+        }
+
+        async fn close(&mut self) -> Result<(), WalError> {
+            self.inner.close().await
+        }
+    }
 
     /// Build a transaction-less `WriteBatchMessage` and its result receiver,
     /// keeping the `txn: None` and channel boilerplate out of individual tests.
@@ -554,16 +618,9 @@ mod tests {
         )
         .await
         .unwrap();
-        let wal_buffer = WalBufferManager::new(
-            db.inner.status_manager.clone(),
-            &db.inner.recorder,
-            0,
-            db.inner.table_store.clone(),
-            1024,
-            None,
-        );
 
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
+        let wal_writer = Box::new(FakeWalWriter::new(0));
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
         assert!(handler.is_first_write);
 
         let mut batch = WriteBatch::new();
@@ -578,21 +635,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_append_error_notifies_caller_and_fails_handler() {
+        let object_store = Arc::new(InMemory::new());
+        let db = Db::open(
+            "/tmp/test_append_error_notifies_caller_and_fails_handler",
+            object_store,
+        )
+        .await
+        .unwrap();
+        let wal_writer = Box::new(FailingWalWriter::new(FailingWalOperation::Append));
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+
+        let mut batch = WriteBatch::new();
+        batch.put(b"key", b"value");
+        let (msg, done_rx) = test_message(batch, WriteOptions::default());
+
+        let handler_error = handler.handle(msg).await.unwrap_err();
+        assert!(matches!(handler_error, SlateDBError::Fenced));
+        let caller_error = match done_rx.await.unwrap() {
+            Ok(_) => panic!("append unexpectedly succeeded"),
+            Err(error) => error,
+        };
+        assert!(matches!(caller_error, SlateDBError::Fenced));
+        assert_eq!(db.get(b"key").await.unwrap(), None);
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_flush_error_notifies_caller_and_fails_handler() {
+        let object_store = Arc::new(InMemory::new());
+        let db = Db::open(
+            "/tmp/test_flush_error_notifies_caller_and_fails_handler",
+            object_store,
+        )
+        .await
+        .unwrap();
+        let wal_writer = Box::new(FailingWalWriter::new(FailingWalOperation::Flush));
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+        let (done, done_rx) = tokio::sync::oneshot::channel();
+        let msg = BatchWriterMessage::Flush(BatchWriterFlush {
+            freeze_memtable: false,
+            done,
+        });
+
+        let handler_error = handler.handle(msg).await.unwrap_err();
+        assert!(matches!(handler_error, SlateDBError::Fenced));
+        let caller_error = match done_rx.await.unwrap() {
+            Ok(_) => panic!("flush unexpectedly succeeded"),
+            Err(error) => error,
+        };
+        assert!(matches!(caller_error, SlateDBError::Fenced));
+
+        db.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_user_defined_seqnum() {
         let object_store = Arc::new(InMemory::new());
         let db = Db::open("/tmp/test_user_defined_seqnum", object_store)
             .await
             .unwrap();
-        let wal_buffer = WalBufferManager::new(
-            db.inner.status_manager.clone(),
-            &db.inner.recorder,
-            0,
-            db.inner.table_store.clone(),
-            1024,
-            None,
-        );
-
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
+        let wal_writer = Box::new(FakeWalWriter::new(0));
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
 
         // Write with a user-defined seqnum
         let mut batch = WriteBatch::new();
@@ -605,7 +710,7 @@ mod tests {
             },
         );
         handler.handle(msg).await.unwrap();
-        let (write_handle, _) = done_rx.await.unwrap().unwrap();
+        let write_handle = done_rx.await.unwrap().unwrap();
         assert_eq!(write_handle.seqnum(), 42);
 
         // Write without a seqnum and verify auto-assigned is > 42
@@ -613,7 +718,7 @@ mod tests {
         batch.put(b"key2", b"value2");
         let (msg, done_rx) = test_message(batch, WriteOptions::default());
         handler.handle(msg).await.unwrap();
-        let (write_handle, _) = done_rx.await.unwrap().unwrap();
+        let write_handle = done_rx.await.unwrap().unwrap();
         assert!(write_handle.seqnum() > 42);
     }
 
@@ -626,23 +731,16 @@ mod tests {
         )
         .await
         .unwrap();
-        let wal_buffer = WalBufferManager::new(
-            db.inner.status_manager.clone(),
-            &db.inner.recorder,
-            0,
-            db.inner.table_store.clone(),
-            1024,
-            None,
-        );
+        let wal_writer = Box::new(FakeWalWriter::new(0));
 
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_buffer);
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
 
         // First, do a normal write to advance the oracle
         let mut batch = WriteBatch::new();
         batch.put(b"key1", b"value1");
         let (msg, done_rx) = test_message(batch, WriteOptions::default());
         handler.handle(msg).await.unwrap();
-        let (write_handle, _) = done_rx.await.unwrap().unwrap();
+        let write_handle = done_rx.await.unwrap().unwrap();
         let first_seq = write_handle.seqnum();
 
         // Try to write with a seqnum <= the current max

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -103,11 +103,11 @@ impl std::fmt::Debug for BatchWriterMessage {
 pub(crate) struct WriteBatchEventHandler {
     db_inner: Arc<DbInner>,
     is_first_write: bool,
-    wal_writer: Box<dyn WalWriter>,
+    wal_writer: Option<Box<dyn WalWriter>>,
 }
 
 impl WriteBatchEventHandler {
-    pub(crate) fn new(db_inner: Arc<DbInner>, wal_writer: Box<dyn WalWriter>) -> Self {
+    pub(crate) fn new(db_inner: Arc<DbInner>, wal_writer: Option<Box<dyn WalWriter>>) -> Self {
         Self {
             db_inner,
             is_first_write: true,
@@ -132,7 +132,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                         batch,
                         &options,
                         txn.as_ref(),
-                        &mut self.wal_writer,
+                        self.wal_writer.as_mut(),
                         self.is_first_write,
                     )
                     .await;
@@ -155,7 +155,7 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 } = flush_msg;
                 let result = self
                     .db_inner
-                    .flush_batch_writer(freeze_memtable, &mut self.wal_writer)
+                    .flush_batch_writer(freeze_memtable, self.wal_writer.as_mut())
                     .await;
                 match result {
                     Ok(flush_result) => {
@@ -191,7 +191,9 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 }
             }
         }
-        self.wal_writer.close().await?;
+        if let Some(wal_writer) = self.wal_writer.as_mut() {
+            wal_writer.close().await?;
+        }
         Ok(())
     }
 }
@@ -204,7 +206,7 @@ impl DbInner {
         batch: WriteBatch,
         options: &WriteOptions,
         txn: Option<&DbTransaction>,
-        wal_writer: &mut Box<dyn WalWriter>,
+        wal_writer: Option<&mut Box<dyn WalWriter>>,
         is_first_write: bool,
     ) -> Result<WriteBatchResult, SlateDBError> {
         let _options = options;
@@ -263,7 +265,8 @@ impl DbInner {
             return Ok(Err(error));
         }
 
-        if self.wal_enabled {
+        if let Some(wal_writer) = wal_writer {
+            assert!(self.wal_enabled);
             // WAL entries must be appended to the wal buffer atomically. Otherwise,
             // the WAL buffer might flush the entries in the middle of the batch, which
             // would violate the guarantee that batches are written atomically. We do
@@ -274,6 +277,7 @@ impl DbInner {
             // in another Pull Request.
             self.write_entries_to_memtable(entries, touched_segments);
         } else {
+            assert!(!self.wal_enabled);
             // if WAL is disabled, we just write the entries to memtable.
             let watcher = self.write_entries_to_memtable(entries, touched_segments);
             // if this is the first write and the WAL is disabled, make sure users are flushing
@@ -361,9 +365,9 @@ impl DbInner {
     async fn flush_batch_writer(
         &self,
         freeze_memtable: bool,
-        wal_writer: &mut Box<dyn WalWriter>,
+        wal_writer: Option<&mut Box<dyn WalWriter>>,
     ) -> Result<FlushResultFuture, SlateDBError> {
-        let flush_rx = if self.wal_enabled {
+        let flush_rx = if let Some(wal_writer) = wal_writer {
             wal_writer.flush().await?
         } else {
             async { Ok(()) }.boxed()
@@ -620,7 +624,7 @@ mod tests {
         .unwrap();
 
         let wal_writer = Box::new(FakeWalWriter::new(0));
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), Some(wal_writer));
         assert!(handler.is_first_write);
 
         let mut batch = WriteBatch::new();
@@ -644,7 +648,7 @@ mod tests {
         .await
         .unwrap();
         let wal_writer = Box::new(FailingWalWriter::new(FailingWalOperation::Append));
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), Some(wal_writer));
 
         let mut batch = WriteBatch::new();
         batch.put(b"key", b"value");
@@ -672,7 +676,7 @@ mod tests {
         .await
         .unwrap();
         let wal_writer = Box::new(FailingWalWriter::new(FailingWalOperation::Flush));
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), Some(wal_writer));
         let (done, done_rx) = tokio::sync::oneshot::channel();
         let msg = BatchWriterMessage::Flush(BatchWriterFlush {
             freeze_memtable: false,
@@ -697,7 +701,7 @@ mod tests {
             .await
             .unwrap();
         let wal_writer = Box::new(FakeWalWriter::new(0));
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), Some(wal_writer));
 
         // Write with a user-defined seqnum
         let mut batch = WriteBatch::new();
@@ -733,7 +737,7 @@ mod tests {
         .unwrap();
         let wal_writer = Box::new(FakeWalWriter::new(0));
 
-        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), wal_writer);
+        let mut handler = WriteBatchEventHandler::new(db.inner.clone(), Some(wal_writer));
 
         // First, do a normal write to advance the oracle
         let mut batch = WriteBatch::new();

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -6102,7 +6102,12 @@ mod tests {
                 let db_state = db.inner.state.read();
                 let cow_db_state = db_state.state();
                 (
-                    db.inner.wal_observer.status().buffered_wal_entries_count == 0,
+                    db.inner
+                        .wal_observer
+                        .status()
+                        .unwrap()
+                        .buffered_wal_entries_count
+                        == 0,
                     db_state.memtable().is_empty() && cow_db_state.imm_memtable.is_empty(),
                     db_state.state().core().clone(),
                 )

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -72,7 +72,6 @@ use crate::tablestore::TableStore;
 use crate::transaction_manager::TransactionManager;
 use crate::types::KeyValue;
 use crate::utils::{format_bytes_si, SafeSender, WatchableOnceCellReader};
-use crate::wal_buffer::{WalEvent, WalObserver, WalStatus, WAL_BUFFER_TASK_NAME};
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{DbCacheManagerOps, DbMetadataOps, DbReadOps, DbWriteOps};
 use slatedb_common::clock::SystemClock;
@@ -81,6 +80,7 @@ use slatedb_common::DbRand;
 use slatedb_txn_obj::DirtyObject;
 
 use crate::db_status::{ClosedResultWriter, DbStatusManager};
+use crate::wal::{WalEvent, WalObserver, WalStatus};
 pub use builder::DbBuilder;
 pub use builder::DbReaderBuilder;
 
@@ -115,7 +115,7 @@ pub(crate) struct DbInner {
     /// [`txn_manager`] tracks all the live transactions and related metadata.
     pub(crate) txn_manager: Arc<TransactionManager>,
     pub(crate) snapshot_manager: Arc<SnapshotManager>,
-    pub(crate) status_manager: DbStatusManager,
+    pub(crate) status_manager: Arc<DbStatusManager>,
     /// Segment extractor (RFC-0024). When `Some`, the writer routes every
     /// key through this extractor and groups flush output into per-segment
     /// L0 SSTs. When `None`, the database is the singleton `prefix=""`
@@ -132,11 +132,11 @@ impl DbInner {
         manifest: DirtyObject<Manifest>,
         memtable_flusher: Arc<MemtableFlusher>,
         write_notifier: SafeSender<BatchWriterMessage>,
-        wal_observer: WalObserver,
+        wal_observer: Box<dyn WalObserver>,
         recorder: MetricsRecorderHelper,
         fp_registry: Arc<FailPointRegistry>,
         merge_operator: Option<crate::merge_operator::MergeOperatorType>,
-        status_manager: DbStatusManager,
+        status_manager: Arc<DbStatusManager>,
         segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     ) -> Result<Self, SlateDBError> {
         // both last_seq and last_committed_seq will be updated after WAL replay.
@@ -180,7 +180,7 @@ impl DbInner {
             wal_observer,
             oracle.clone(),
             state.clone(),
-            status_manager.result_reader(),
+            status_manager.clone(),
         );
 
         let db_inner = Self {
@@ -303,10 +303,21 @@ impl DbInner {
 
         // TODO: this can be modified as awaiting the last_durable_seq watermark & fatal error.
 
-        let (write_handle, mut durable_watcher) = rx.await??;
+        let write_handle = rx.await??;
 
         if options.await_durable {
-            durable_watcher.await_value().await?;
+            let seq = write_handle.seq;
+            let mut status_subscription = self.status_manager.subscribe();
+            let durable = status_subscription.wait_for(|s| s.durable_seq >= seq);
+            let mut error = self.status_manager.result_reader();
+            tokio::select! {
+                result = durable => {
+                    result.map_err(|_| SlateDBError::Closed)?;
+                },
+                result = error.await_value() => {
+                    result?;
+                },
+            };
         }
 
         Ok(write_handle)
@@ -316,7 +327,7 @@ impl DbInner {
     pub(crate) async fn maybe_apply_backpressure(&self) -> Result<(), SlateDBError> {
         loop {
             self.check_closed()?;
-            let wal_status = self.wal_observer.status();
+            let wal_status = self.wal_observer.status()?;
             let (active_memtable_size_bytes, imm_memtable_size_bytes) = {
                 let guard = self.state.read();
                 let estimate = |metadata: KVTableMetadata| {
@@ -761,10 +772,6 @@ impl Db {
             .await
         {
             warn!("failed to shutdown writer task [error={:?}]", e);
-        }
-
-        if let Err(e) = self.task_executor.shutdown_task(WAL_BUFFER_TASK_NAME).await {
-            warn!("failed to shutdown wal writer task [error={:?}]", e);
         }
 
         if let Err(e) = self.inner.table_store.close_cache().await {
@@ -2067,55 +2074,70 @@ impl WriteHandle {
 /// via a [`tokio::sync::watch`] channel.
 #[derive(Clone)]
 pub(crate) struct DbWalObserver {
-    status_rx: tokio::sync::watch::Receiver<WalStatus>,
+    status_rx: tokio::sync::watch::Receiver<Result<WalStatus, WalStatus>>,
     closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
-    wrapped: WalObserver,
+    wrapped: Arc<dyn WalObserver>,
 }
 
 impl DbWalObserver {
     fn new(
-        wrapped: WalObserver,
+        wrapped: Box<dyn WalObserver>,
         oracle: Arc<DbOracle>,
         db_state: Arc<RwLock<DbState>>,
-        closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
+        closed_writer: Arc<dyn ClosedResultWriter>,
     ) -> Self {
         let (status_tx, status_rx) = tokio::sync::watch::channel(wrapped.status());
+        let closed_reader = closed_writer.result_reader();
         wrapped
             .subscribe(Arc::new(move |event| {
-                let WalEvent::WalFlushed(status) = event;
-                if let Some(seq) = status.last_flushed_seq {
-                    oracle.advance_durable_seq(seq);
-                }
-                let mut guard = db_state.write();
-                guard.set_next_wal_id(status.last_flushed_wal_id + 1);
-                drop(guard);
+                let status: Result<WalStatus, WalStatus> = match event {
+                    WalEvent::WalFlushed(status) => {
+                        if let Some(seq) = status.last_flushed_seq {
+                            oracle.advance_durable_seq(seq);
+                        }
+                        let mut guard = db_state.write();
+                        guard.set_next_wal_id(status.last_flushed_wal_id + 1);
+                        drop(guard);
+                        Ok(status)
+                    }
+                    WalEvent::WalClosed(status) => {
+                        closed_writer.write_result(Err(status.clone().into()));
+                        Err(status)
+                    }
+                };
                 let _ = status_tx.send(status);
             }))
             .expect("failed to subscribe to wal");
         Self {
             status_rx,
             closed_reader,
-            wrapped,
+            wrapped: wrapped.into(),
         }
     }
 
-    pub(crate) fn status(&self) -> WalStatus {
+    pub(crate) fn status(&self) -> Result<WalStatus, WalStatus> {
         self.wrapped.status()
     }
 
     async fn wait_on_condition(
         &self,
-        predicate: impl FnMut(&WalStatus) -> bool,
+        mut predicate: impl FnMut(&WalStatus) -> bool,
     ) -> Result<(), SlateDBError> {
         let mut status_rx = self.status_rx.clone();
-        let result = status_rx.wait_for(predicate).await.map(|_| ());
-        match result {
-            Ok(_) => Ok(()),
-            Err(_) => {
-                debug!("wal listener tx dropped - wait on db close");
-                self.closed_reader.clone().await_value().await
-            }
-        }
+        let result = status_rx
+            .wait_for(|s| match s {
+                Err(_) => true,
+                Ok(s) => predicate(s),
+            })
+            .await;
+        let Ok(result) = result else {
+            drop(result);
+            debug!("wal listener tx dropped - wait on db close");
+            return self.closed_reader.clone().await_value().await;
+        };
+        let result = result.clone();
+        result?;
+        Ok(())
     }
 
     /// Waits until the wal a given wal id is released by the wal writer
@@ -2160,6 +2182,7 @@ mod tests {
         OnDemandCompactionSchedulerSupplier, StringConcatMergeOperator,
     };
     use crate::types::RowEntry;
+    use crate::wal::WalError;
     use crate::wal_reader::WalReader;
     use crate::{proptest_util, test_utils, CloseReason, CompactorBuilder, KeyValue};
     use async_trait::async_trait;
@@ -3091,11 +3114,27 @@ mod tests {
             .unwrap();
 
         // a sanity check: the wal contains the most recent write
-        assert_ne!(kv_store.inner.wal_observer.status().estimated_bytes, 0);
+        assert_ne!(
+            kv_store
+                .inner
+                .wal_observer
+                .status()
+                .unwrap()
+                .estimated_bytes,
+            0
+        );
 
         // and a flush() should clear it
         kv_store.flush().await.unwrap();
-        assert_eq!(kv_store.inner.wal_observer.status().estimated_bytes, 0);
+        assert_eq!(
+            kv_store
+                .inner
+                .wal_observer
+                .status()
+                .unwrap()
+                .estimated_bytes,
+            0
+        );
     }
 
     #[tokio::test]
@@ -3133,6 +3172,7 @@ mod tests {
                 .inner
                 .wal_observer
                 .status()
+                .unwrap()
                 .buffered_wal_entries_count,
             1
         );
@@ -3153,6 +3193,7 @@ mod tests {
                 .inner
                 .wal_observer
                 .status()
+                .unwrap_err()
                 .buffered_wal_entries_count,
             0
         );
@@ -3196,20 +3237,24 @@ mod tests {
             .await
             .unwrap();
 
-        db.put_with_options(
-            b"test_key",
-            b"test_value",
-            &PutOptions::default(),
-            &WriteOptions {
-                await_durable: false,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        let put_seq = db
+            .put_with_options(
+                b"test_key",
+                b"test_value",
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .seq;
 
         // Sanity check: WAL has buffered entries before close.
-        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
+        let wal_status = db.inner.wal_observer.status().unwrap();
+        assert_eq!(wal_status.buffered_wal_entries_count, 1);
+        assert!(wal_status.last_flushed_seq.unwrap_or(0) < put_seq);
         assert_eq!(
             lookup_metric(
                 &metrics_recorder,
@@ -3227,7 +3272,9 @@ mod tests {
         // close() should succeed but not flush when failed.
         db.close().await.unwrap();
 
-        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
+        let wal_status = db.inner.wal_observer.status().unwrap_err();
+        assert!(matches!(wal_status.closed_reason, Some(WalError::Fenced)));
+        assert!(wal_status.last_flushed_seq.unwrap_or(0) < put_seq);
         assert_eq!(
             lookup_metric(
                 &metrics_recorder,
@@ -3256,19 +3303,23 @@ mod tests {
             .await
             .unwrap();
 
-        db.put_with_options(
-            b"test_key",
-            b"test_value",
-            &PutOptions::default(),
-            &WriteOptions {
-                await_durable: false,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
+        let put_seq = db
+            .put_with_options(
+                b"test_key",
+                b"test_value",
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+            .seq;
 
-        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 1);
+        let wal_status = db.inner.wal_observer.status().unwrap();
+        assert_eq!(wal_status.buffered_wal_entries_count, 1);
+        assert!(wal_status.last_flushed_seq.unwrap_or(0) < put_seq);
         assert_eq!(
             lookup_metric(
                 &metrics_recorder,
@@ -3280,7 +3331,9 @@ mod tests {
 
         db.close().await.unwrap();
 
-        assert_eq!(db.inner.wal_observer.status().buffered_wal_entries_count, 0);
+        let wal_status = db.inner.wal_observer.status().unwrap_err();
+        assert!(matches!(wal_status.closed_reason, Some(WalError::Closed)));
+        assert_eq!(wal_status.last_flushed_seq, Some(put_seq));
         assert_eq!(
             lookup_metric(
                 &metrics_recorder,
@@ -3487,6 +3540,14 @@ mod tests {
             .build()
             .await
             .unwrap();
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            db.task_executor
+                .join_task(crate::wal_buffer::WAL_BUFFER_TASK_NAME),
+        )
+        .await
+        .expect("native WAL task should not run when the WAL is disabled")
+        .unwrap();
         let put_options = PutOptions::default();
         let write_options = WriteOptions {
             await_durable: false,
@@ -4318,7 +4379,12 @@ mod tests {
         }
 
         // Verify WALs flushes.
-        let wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
+        let wal_id = kv_store
+            .inner
+            .wal_observer
+            .status()
+            .unwrap()
+            .last_flushed_wal_id;
         assert_eq!(wal_id, MAX_WAL_FLUSHES_BEFORE_L0_FLUSH); // account for the empty WAL written for fencing
 
         // Verify no memtable was frozen or L0 flush happened.
@@ -4482,7 +4548,12 @@ mod tests {
 
         // Verify that the WAL was also flushed since we guarantee
         // memtable data is persisted in the WAL prior to L0 flush.
-        let recent_flushed_wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
+        let recent_flushed_wal_id = kv_store
+            .inner
+            .wal_observer
+            .status()
+            .unwrap()
+            .last_flushed_wal_id;
         assert_eq!(recent_flushed_wal_id, 2);
 
         // Verify that the data is still accessible after flush
@@ -4551,6 +4622,7 @@ mod tests {
                 .inner
                 .wal_observer
                 .status()
+                .unwrap()
                 .buffered_wal_entries_count,
             1
         );
@@ -4567,6 +4639,7 @@ mod tests {
                 .inner
                 .wal_observer
                 .status()
+                .unwrap()
                 .buffered_wal_entries_count,
             0
         );
@@ -4889,7 +4962,12 @@ mod tests {
             .unwrap();
 
         // Get initial WAL ID to verify flush occurred
-        let initial_wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
+        let initial_wal_id = kv_store
+            .inner
+            .wal_observer
+            .status()
+            .unwrap()
+            .last_flushed_wal_id;
 
         // Flush WAL using flush_with_options - this should succeed without error
         let flush_result = kv_store
@@ -4910,7 +4988,12 @@ mod tests {
 
         // Verify that the WAL buffer is in a consistent state after flush
         // The recent_flushed_wal_id should be at least as high as before
-        let final_wal_id = kv_store.inner.wal_observer.status().last_flushed_wal_id;
+        let final_wal_id = kv_store
+            .inner
+            .wal_observer
+            .status()
+            .unwrap()
+            .last_flushed_wal_id;
         assert!(
             final_wal_id >= initial_wal_id,
             "WAL ID should not decrease after flush"
@@ -5040,12 +5123,12 @@ mod tests {
         // Wait for put to end up in the WAL buffer
         let this_wal_buffer = db.inner.wal_observer.clone();
         wait_for(Box::new(move || {
-            this_wal_buffer.status().buffered_wal_entries_count > 0
+            this_wal_buffer.status().unwrap().buffered_wal_entries_count > 0
         }))
         .await;
 
         // Verify that there is now 1 WAL entry in memory.
-        let wal_status = db.inner.wal_observer.status();
+        let wal_status = db.inner.wal_observer.status().unwrap();
         assert_eq!(wal_status.buffered_wal_entries_count, 1);
 
         let (active_memtable_size_bytes, imm_memtable_size_bytes) = {
@@ -5146,6 +5229,14 @@ mod tests {
         db.put_with_options(b"key1", &large_value, &PutOptions::default(), &write_opts)
             .await
             .unwrap();
+        assert_eq!(
+            db.inner
+                .wal_observer
+                .status()
+                .unwrap()
+                .buffered_wal_entries_count,
+            1
+        );
 
         // Start backpressure on a cloned inner handle. This parks the task on
         // the same wait path used by writers before they enqueue a batch.
@@ -5906,7 +5997,10 @@ mod tests {
         let value1 = [b'b'; 96];
         let result = db.put(&key1, &value1).await;
         assert!(result.is_ok(), "Failed to write key1");
-        assert_eq!(db.inner.wal_observer.status().last_flushed_wal_id, 2);
+        assert_eq!(
+            db.inner.wal_observer.status().unwrap().last_flushed_wal_id,
+            2
+        );
 
         // Let background flush attempts fail while WAL durability preserves recovery.
         // expect to fail as l0 upload is blocked
@@ -9895,11 +9989,21 @@ mod tests {
                 .await
                 .unwrap();
             if i == 0 {
-                first_l0_flushed_wal_id = source.inner.wal_observer.status().last_flushed_wal_id;
+                first_l0_flushed_wal_id = source
+                    .inner
+                    .wal_observer
+                    .status()
+                    .unwrap()
+                    .last_flushed_wal_id;
             }
             l0_flushed_seq = write.seqnum();
         }
-        let l0_flushed_boundary_wal_id = source.inner.wal_observer.status().last_flushed_wal_id;
+        let l0_flushed_boundary_wal_id = source
+            .inner
+            .wal_observer
+            .status()
+            .unwrap()
+            .last_flushed_wal_id;
         assert!(l0_flushed_boundary_wal_id > first_l0_flushed_wal_id);
 
         // Write several smaller records, each flushed into a separate WAL. On
@@ -9923,7 +10027,12 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let final_source_wal_id = source.inner.wal_observer.status().last_flushed_wal_id;
+        let final_source_wal_id = source
+            .inner
+            .wal_observer
+            .status()
+            .unwrap()
+            .last_flushed_wal_id;
         assert!(final_source_wal_id >= l0_flushed_boundary_wal_id + 2);
 
         // Recover with a much smaller replay target so WAL replay splits into

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -308,16 +308,18 @@ impl DbInner {
         if options.await_durable {
             let seq = write_handle.seq;
             let mut status_subscription = self.status_manager.subscribe();
-            let durable = status_subscription.wait_for(|s| s.durable_seq >= seq);
-            let mut error = self.status_manager.result_reader();
-            tokio::select! {
-                result = durable => {
-                    result.map_err(|_| SlateDBError::Closed)?;
-                },
-                result = error.await_value() => {
-                    result?;
-                },
-            };
+            let status = status_subscription
+                .wait_for(|s| s.durable_seq >= seq || s.close_reason.is_some())
+                .await
+                .map_err(|_| SlateDBError::Closed)?;
+            if status.durable_seq < seq {
+                self.check_closed()?;
+                warn!(
+                    "durable seq {} not advanced past write seq {} and db not closed",
+                    status.durable_seq, seq
+                );
+                return Err(SlateDBError::InvalidDBState);
+            }
         }
 
         Ok(write_handle)
@@ -6157,6 +6159,71 @@ mod tests {
         db.close()
             .await
             .expect_err("close should error out due to WAL IO error");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_await_durable_write_returns_error_if_db_closes_before_durable() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut settings = test_db_options(0, 1024, None);
+        settings.flush_interval = None;
+        let db = Arc::new(
+            Db::builder(
+                "/tmp/test_await_durable_write_returns_error_if_db_closes_before_durable",
+                object_store,
+            )
+            .with_settings(settings)
+            .with_fp_registry(fp_registry.clone())
+            .build()
+            .await
+            .unwrap(),
+        );
+        // pause writes so that we can force the write to fail on the close status before the
+        // final flush causes the write to become durable
+        fail_parallel::cfg(fp_registry.clone(), "write-wal-sst-io-error", "pause").unwrap();
+        let write_db = db.clone();
+        let write_task = tokio::spawn(async move {
+            write_db
+                .put_with_options(
+                    b"foo",
+                    b"bar",
+                    &PutOptions::default(),
+                    &WriteOptions::default(),
+                )
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                if db
+                    .inner
+                    .wal_observer
+                    .status()
+                    .unwrap()
+                    .buffered_wal_entries_count
+                    == 1
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("write was not buffered");
+        let close_db = db.clone();
+        let close_task = tokio::spawn(async move { close_db.close().await });
+
+        let write_error = tokio::time::timeout(Duration::from_secs(10), write_task)
+            .await
+            .expect("timed out waiting for write")
+            .expect("write task panicked")
+            .expect_err("write unexpectedly reported success");
+
+        assert_eq!(
+            write_error.kind(),
+            crate::ErrorKind::Closed(CloseReason::Clean)
+        );
+        fail_parallel::cfg(fp_registry, "write-wal-sst-io-error", "off").unwrap();
+        let _ = close_task.await.unwrap();
     }
 
     async fn do_test_should_read_compacted_db(mut options: Settings) {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -270,7 +270,7 @@ impl DbInner {
     }
 
     #[allow(unused_variables)]
-    fn wal_enabled_in_options(settings: &Settings) -> bool {
+    pub(crate) fn wal_enabled_in_options(settings: &Settings) -> bool {
         #[cfg(feature = "wal_disable")]
         return settings.wal_enabled;
         #[cfg(not(feature = "wal_disable"))]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -594,19 +594,19 @@ impl<P: Into<Path>> DbBuilder<P> {
         };
 
         let manifest_dirty = stored_manifest.prepare_dirty()?;
-        let status_manager = DbStatusManager::new_with_initial_values(
+        let status_manager = Arc::new(DbStatusManager::new_with_initial_values(
             manifest_dirty.value.core.last_l0_seq,
             manifest_dirty.into(),
             BTreeSet::new(),
-        );
+        ));
 
         let task_executor = Arc::new(MessageHandlerExecutor::new(
-            Arc::new(status_manager.clone()),
+            status_manager.clone(),
             system_clock.clone(),
         ));
 
         let fencer = WriterFencer::new(
-            status_manager.clone(),
+            status_manager.result_reader(),
             recorder.clone(),
             table_store.clone(),
             &self.settings,
@@ -616,8 +616,9 @@ impl<P: Into<Path>> DbBuilder<P> {
         let WriterFenceResult {
             manifest,
             replay_range,
-            wal_buffer,
+            wal_writer,
         } = fencer.fence(stored_manifest).await?;
+        let wal_observer = wal_writer.observer();
 
         let manifest_dirty = manifest.prepare_dirty()?;
         status_manager.report_fence_manifest(
@@ -630,7 +631,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         let (write_tx, write_rx) = SafeSender::unbounded_channel(reader);
 
         // Create the database inner state
-        let memtable_flusher = Arc::new(MemtableFlusher::new(&status_manager));
+        let memtable_flusher = Arc::new(MemtableFlusher::new(status_manager.as_ref()));
         let inner = Arc::new(
             DbInner::new(
                 self.settings.clone(),
@@ -640,11 +641,11 @@ impl<P: Into<Path>> DbBuilder<P> {
                 manifest_dirty,
                 Arc::clone(&memtable_flusher),
                 write_tx,
-                wal_buffer.observer(),
+                wal_observer,
                 recorder.clone(),
                 self.fp_registry.clone(),
                 self.merge_operator.clone(),
-                status_manager.clone(),
+                status_manager,
                 self.segment_extractor.clone(),
             )
             .await?,
@@ -654,7 +655,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         let tokio_handle = Handle::current();
         task_executor.add_handler(
             WRITE_BATCH_TASK_NAME.to_string(),
-            Box::new(WriteBatchEventHandler::new(inner.clone(), wal_buffer)),
+            Box::new(WriteBatchEventHandler::new(inner.clone(), wal_writer)),
             write_rx,
             &tokio_handle,
         )?;
@@ -795,7 +796,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             manifest,
             &tokio_handle,
             &task_executor,
-            &inner.status_manager,
+            inner.status_manager.as_ref(),
         )?;
 
         // Monitor background tasks

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -161,7 +161,6 @@ use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
 use crate::utils::WatchableOnceCell;
-use crate::wal_buffer::WalBufferManager;
 use slatedb_common::clock::DefaultSystemClock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorder;
@@ -594,30 +593,36 @@ impl<P: Into<Path>> DbBuilder<P> {
             }
         };
 
-        let fencer = WriterFencer::new(table_store.clone(), &self.settings, system_clock.clone());
-        let WriterFenceResult {
-            manifest,
-            replay_range,
-        } = fencer.fence(stored_manifest).await?;
-
-        let manifest_dirty = manifest.prepare_dirty()?;
-
-        // Shared lifecycle state — created before DbInner so it can be shared
-        // with the executor and future channel construction.
+        let manifest_dirty = stored_manifest.prepare_dirty()?;
         let status_manager = DbStatusManager::new_with_initial_values(
             manifest_dirty.value.core.last_l0_seq,
-            manifest_dirty.clone().into(),
+            manifest_dirty.into(),
             BTreeSet::new(),
         );
 
-        let recent_flushed_wal_id = replay_range.end - 1;
-        let mut wal_buffer = WalBufferManager::new(
+        let task_executor = Arc::new(MessageHandlerExecutor::new(
+            Arc::new(status_manager.clone()),
+            system_clock.clone(),
+        ));
+
+        let fencer = WriterFencer::new(
             status_manager.clone(),
-            &recorder,
-            recent_flushed_wal_id,
+            recorder.clone(),
             table_store.clone(),
-            self.settings.l0_sst_size_bytes,
-            self.settings.flush_interval,
+            &self.settings,
+            system_clock.clone(),
+            task_executor.clone(),
+        );
+        let WriterFenceResult {
+            manifest,
+            replay_range,
+            wal_buffer,
+        } = fencer.fence(stored_manifest).await?;
+
+        let manifest_dirty = manifest.prepare_dirty()?;
+        status_manager.report_fence_manifest(
+            manifest_dirty.value.core.last_l0_seq,
+            manifest_dirty.clone().into(),
         );
 
         // Setup communication channels wired to the shared closed state.
@@ -647,13 +652,6 @@ impl<P: Into<Path>> DbBuilder<P> {
 
         // Setup background tasks
         let tokio_handle = Handle::current();
-        let task_executor = Arc::new(MessageHandlerExecutor::new(
-            Arc::new(status_manager),
-            system_clock.clone(),
-        ));
-        if inner.wal_enabled {
-            wal_buffer.init(task_executor.clone()).await?;
-        };
         task_executor.add_handler(
             WRITE_BATCH_TASK_NAME.to_string(),
             Box::new(WriteBatchEventHandler::new(inner.clone(), wal_buffer)),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -161,6 +161,8 @@ use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
 use crate::utils::WatchableOnceCell;
+use crate::wal::wal_disabled::DisabledWalObserver;
+use crate::wal::WalObserver;
 use slatedb_common::clock::DefaultSystemClock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorder;
@@ -616,9 +618,22 @@ impl<P: Into<Path>> DbBuilder<P> {
         let WriterFenceResult {
             manifest,
             replay_range,
-            wal_writer,
+            mut wal_writer,
         } = fencer.fence(stored_manifest).await?;
-        let wal_observer = wal_writer.observer();
+        let (wal_writer, wal_observer) = if DbInner::wal_enabled_in_options(&self.settings) {
+            let wal_observer = wal_writer.observer();
+            (Some(wal_writer), wal_observer)
+        } else {
+            wal_writer.close().await.map_err(SlateDBError::from)?;
+            let Err(final_status) = wal_writer.status() else {
+                return Err(crate::Error::internal(
+                    "closed wal writer did not return terminal status".to_string(),
+                ));
+            };
+            let wal_observer =
+                Box::new(DisabledWalObserver::new(final_status)) as Box<dyn WalObserver>;
+            (None, wal_observer)
+        };
 
         let manifest_dirty = manifest.prepare_dirty()?;
         status_manager.report_fence_manifest(

--- a/slatedb/src/db_status.rs
+++ b/slatedb/src/db_status.rs
@@ -109,6 +109,14 @@ impl DbStatusManager {
         }
     }
 
+    pub(crate) fn report_fence_manifest(&self, durable_seq: u64, manifest: VersionedManifest) {
+        self.tx.send_if_modified(|s| {
+            s.durable_seq = durable_seq;
+            s.current_manifest = manifest;
+            true
+        });
+    }
+
     pub(crate) fn report_durable_seq(&self, seq: u64) {
         self.tx.send_if_modified(|s| {
             if seq > s.durable_seq {

--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -345,7 +345,7 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
         let (run_result, run_maybe_panic) = split_unwind_result(name.clone(), run_unwind_result);
         if let Err(ref err) = run_result {
             error!(
-                "background task panicked unexpectedly. [task_name={}, error={:?}, panic={:?}]",
+                "background task exited unexpectedly. [task_name={}, error={:?}, panic={:?}]",
                 name,
                 err,
                 run_maybe_panic.map(|p| panic_string(&p))
@@ -842,7 +842,7 @@ impl MessageHandlerExecutor {
         Ok(())
     }
 
-    /// Cancels a task and waits for it to complete.
+    /// Cancels a running task and waits for it to complete.
     ///
     /// ## Arguments
     ///
@@ -854,6 +854,32 @@ impl MessageHandlerExecutor {
     pub(crate) async fn shutdown_task(&self, name: &str) -> Result<(), SlateDBError> {
         self.cancel_task(name);
         self.join_task(name).await
+    }
+
+    /// Removes a task that may not have started yet, or cancels a running task and waits for it to
+    /// complete.
+    ///
+    /// ## Arguments
+    ///
+    /// * `name`: The name of the task to cancel and wait for.
+    ///
+    /// ## Returns
+    ///
+    /// [`Some`] with the result of the task if it was started, [`None`] otherwise
+    pub(crate) async fn shutdown_or_deregister_task(
+        &self,
+        name: &str,
+    ) -> Option<Result<(), SlateDBError>> {
+        {
+            let mut guard = self.futures.lock();
+            if let Some(task_definitions) = guard.as_mut() {
+                if task_definitions.iter().any(|task| task.name == name) {
+                    task_definitions.retain(|task| task.name != name);
+                    return None;
+                }
+            }
+        }
+        Some(self.shutdown_task(name).await)
     }
 }
 
@@ -1181,6 +1207,83 @@ mod test {
                 (Phase::Cleanup, TestMessage::Channel(77)),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_task_removes_handler_before_monitor_starts() {
+        let clock = Arc::new(DefaultSystemClock::new());
+        let closed_result = Arc::new(WatchableOnceCell::new());
+        let task_executor = MessageHandlerExecutor::new(closed_result.clone(), clock.clone());
+        let removed_cleanup = WatchableOnceCell::new();
+        let retained_cleanup = WatchableOnceCell::new();
+        let (removed_tx, removed_rx) = async_channel::unbounded();
+        let (_retained_tx, retained_rx) = async_channel::unbounded();
+
+        task_executor
+            .add_handler(
+                "removed".to_string(),
+                Box::new(TestHandler::new(
+                    Arc::new(Mutex::new(Vec::new())),
+                    removed_cleanup.clone(),
+                    clock.clone(),
+                )),
+                removed_rx,
+                &Handle::current(),
+            )
+            .unwrap();
+        task_executor
+            .add_handler(
+                "retained".to_string(),
+                Box::new(TestHandler::new(
+                    Arc::new(Mutex::new(Vec::new())),
+                    retained_cleanup.clone(),
+                    clock,
+                )),
+                retained_rx,
+                &Handle::current(),
+            )
+            .unwrap();
+
+        assert!(task_executor
+            .shutdown_or_deregister_task("removed")
+            .await
+            .is_none());
+        assert!(removed_tx.is_closed());
+        assert!(removed_cleanup.result_reader().read().is_none());
+
+        let monitor = task_executor.monitor_on(&Handle::current()).unwrap();
+        assert!(!task_executor.tokens.contains_key("removed"));
+        assert!(task_executor.tokens.contains_key("retained"));
+
+        task_executor
+            .shutdown_or_deregister_task("retained")
+            .await
+            .unwrap()
+            .unwrap();
+        monitor.await.unwrap();
+        assert!(retained_cleanup.result_reader().read().is_some());
+        assert!(closed_result.result_reader().read().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_task_cancels_when_pending_task_not_found() {
+        let task_executor = MessageHandlerExecutor::new(
+            Arc::new(WatchableOnceCell::new()),
+            Arc::new(DefaultSystemClock::new()),
+        );
+        let running_token = CancellationToken::new();
+        let running_result = WatchableOnceCell::new();
+        running_result.write(Ok(()));
+        task_executor
+            .tokens
+            .insert("running".to_string(), running_token.clone());
+        task_executor
+            .results
+            .insert("running".to_string(), running_result);
+
+        task_executor.shutdown_task("running").await.unwrap();
+
+        assert!(running_token.is_cancelled());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -77,6 +77,18 @@ pub(crate) enum SlateDBError {
     #[error("wal store reconfiguration unsupported")]
     WalStoreReconfigurationError,
 
+    #[error("wal truncated")]
+    WalTruncated,
+
+    #[error("wal unavailable")]
+    WalUnavailable(Arc<dyn std::error::Error + Sync + Send + 'static>),
+
+    #[error("wal internal error")]
+    WalInternalError(Arc<dyn std::error::Error + Sync + Send + 'static>),
+
+    #[error("wal data error")]
+    WalDataError(Arc<dyn std::error::Error + Sync + Send + 'static>),
+
     #[error("invalid compaction")]
     InvalidCompaction,
 
@@ -640,6 +652,7 @@ impl From<SlateDBError> for Error {
             #[cfg(feature = "foyer")]
             SlateDBError::FoyerError(err) => Error::unavailable(msg).with_source(Box::new(err)),
             SlateDBError::TransactionalObjectTimeout { .. } => Error::unavailable(msg),
+            SlateDBError::WalUnavailable(src) => Error::unavailable(msg).with_source(Box::new(src)),
 
             // Invalid errors
             SlateDBError::InvalidCachePartSize => Error::invalid(msg),
@@ -714,6 +727,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::CloneExternalDbMissing => Error::data(msg),
             SlateDBError::CloneIncorrectExternalDbCheckpoint { .. } => Error::data(msg),
             SlateDBError::CloneIncorrectFinalCheckpoint { .. } => Error::data(msg),
+            SlateDBError::WalDataError(src) => Error::data(msg).with_source(Box::new(src)),
 
             // Internal errors
             SlateDBError::CompactorExecutorFailed => Error::internal(msg),
@@ -728,6 +742,8 @@ impl From<SlateDBError> for Error {
             SlateDBError::TransactionalObjectError(err) => {
                 Error::internal(msg).with_source(Box::new(err))
             }
+            SlateDBError::WalTruncated => Error::internal(msg),
+            SlateDBError::WalInternalError(src) => Error::internal(msg).with_source(Box::new(src)),
         }
     }
 }

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -1,12 +1,13 @@
-use crate::db_status::DbStatusManager;
 use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
+use crate::utils::WatchableOnceCellReader;
 use crate::wal::writer_init::WalWriterInit;
-use crate::wal_buffer::WalBufferManager;
+use crate::wal::{WalWriter, WriterInit};
 use crate::Settings;
 use fail_parallel::{fail_point_send, FailPointTx};
+use log::error;
 use slatedb_common::metrics::MetricsRecorderHelper;
 use slatedb_common::SystemClock;
 use std::ops::Range;
@@ -14,7 +15,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub(crate) struct WriterFencer {
-    status_manager: DbStatusManager,
+    closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     recorder: MetricsRecorderHelper,
     settings: Settings,
     table_store: Arc<TableStore>,
@@ -28,12 +29,12 @@ pub(crate) struct WriterFencer {
 pub(crate) struct WriterFenceResult {
     pub(crate) manifest: FenceableManifest,
     pub(crate) replay_range: Range<u64>,
-    pub(crate) wal_buffer: WalBufferManager,
+    pub(crate) wal_writer: Box<dyn WalWriter>,
 }
 
 impl WriterFencer {
     pub(crate) fn new(
-        status_manager: DbStatusManager,
+        closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
         recorder: MetricsRecorderHelper,
         table_store: Arc<TableStore>,
         settings: &Settings,
@@ -41,7 +42,7 @@ impl WriterFencer {
         task_executor: Arc<MessageHandlerExecutor>,
     ) -> Self {
         Self::new_with_fp_handle(
-            status_manager,
+            closed_result_reader,
             recorder,
             table_store,
             settings,
@@ -52,7 +53,7 @@ impl WriterFencer {
     }
 
     fn new_with_fp_handle(
-        status_manager: DbStatusManager,
+        closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
         recorder: MetricsRecorderHelper,
         table_store: Arc<TableStore>,
         settings: &Settings,
@@ -61,10 +62,10 @@ impl WriterFencer {
         fp_tx: FailPointTx,
     ) -> Self {
         Self {
-            status_manager,
+            closed_result_reader,
             recorder,
-            settings: settings.clone(),
             table_store,
+            settings: settings.clone(),
             manifest_update_timeout: settings.manifest_update_timeout,
             system_clock,
             task_executor,
@@ -86,7 +87,7 @@ impl WriterFencer {
         stored_manifest: StoredManifest,
     ) -> Result<WriterFenceResult, SlateDBError> {
         let wal_writer_init = WalWriterInit::load(
-            self.status_manager.clone(),
+            self.closed_result_reader.clone(),
             self.recorder.clone(),
             self.table_store.clone(),
             &self.settings,
@@ -96,7 +97,7 @@ impl WriterFencer {
         )
         .await?;
 
-        let mut manifest = FenceableManifest::init_writer(
+        let manifest = FenceableManifest::init_writer(
             stored_manifest,
             self.manifest_update_timeout,
             self.system_clock.clone(),
@@ -104,16 +105,25 @@ impl WriterFencer {
         .await?;
         self.fail_point_send("FenceManifest");
 
+        let mut manifest = manifest.into();
         let result = wal_writer_init.fence_and_init(&mut manifest).await?;
+        let mut manifest: FenceableManifest = manifest.into();
 
         // Refresh validates that we own the latest epoch still.
         manifest.refresh().await?;
         fail_point_send!(self.fp_tx, "FinalRefreshManifest");
 
+        let replay_range = match result.replay_range.try_into() {
+            Ok(replay_range) => replay_range,
+            Err(_) => {
+                error!("replay range must use inclusive lower bound and exclusive upper bound");
+                return Err(SlateDBError::InvalidDBState);
+            }
+        };
         Ok(WriterFenceResult {
             manifest,
-            replay_range: result.replay_range,
-            wal_buffer: result.wal_buffer,
+            wal_writer: result.wal_writer,
+            replay_range,
         })
     }
 }
@@ -125,7 +135,6 @@ mod tests {
     use crate::config::{
         FlushOptions, FlushType, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
     };
-    use crate::db_status::DbStatusManager;
     use crate::dispatcher::MessageHandlerExecutor;
     use crate::error::SlateDBError;
     use crate::fence::WriterFencer;
@@ -136,6 +145,7 @@ mod tests {
     use crate::memtable_flusher::MANIFEST_REFRESH_COUNT;
     use crate::object_stores::ObjectStores;
     use crate::tablestore::{TableStore, TableStoreKind};
+    use crate::utils::WatchableOnceCell;
     use crate::{CloseReason, Db, ErrorKind, Settings};
     use bytes::Bytes;
     use fail_parallel::fail_point_channel;
@@ -188,22 +198,22 @@ mod tests {
             .unwrap();
             let fp_registry = Arc::new(FailPointRegistry::new());
             let (fp_tx, event_rx) = fail_point_channel(fp_registry.clone());
-            let status_manager = DbStatusManager::new(0);
+            let cell = Arc::new(WatchableOnceCell::new());
             let recorder = MetricsRecorderHelper::new(
                 Arc::new(DefaultMetricsRecorder::new()),
                 MetricLevel::Info,
             );
             let task_executor = Arc::new(MessageHandlerExecutor::new(
-                Arc::new(status_manager.clone()),
+                cell.clone(),
                 system_clock.clone(),
             ));
             let fencer = WriterFencer::new_with_fp_handle(
-                status_manager,
+                cell.reader(),
                 recorder,
                 table_store.clone(),
                 &settings,
                 system_clock.clone(),
-                task_executor,
+                task_executor.clone(),
                 fp_tx,
             );
             Self {

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -3,7 +3,7 @@ use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
 use crate::utils::WatchableOnceCellReader;
-use crate::wal::writer_init::WalWriterInit;
+use crate::wal::writer_init::{WalWriterInit, WalWriterInitOptions};
 use crate::wal::{WalWriter, WriterInit};
 use crate::Settings;
 use fail_parallel::{fail_point_send, FailPointTx};
@@ -17,7 +17,7 @@ use std::time::Duration;
 pub(crate) struct WriterFencer {
     closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     recorder: MetricsRecorderHelper,
-    settings: Settings,
+    wal_writer_init_options: WalWriterInitOptions,
     table_store: Arc<TableStore>,
     manifest_update_timeout: Duration,
     system_clock: Arc<dyn SystemClock>,
@@ -65,7 +65,7 @@ impl WriterFencer {
             closed_result_reader,
             recorder,
             table_store,
-            settings: settings.clone(),
+            wal_writer_init_options: settings.into(),
             manifest_update_timeout: settings.manifest_update_timeout,
             system_clock,
             task_executor,
@@ -90,7 +90,7 @@ impl WriterFencer {
             self.closed_result_reader.clone(),
             self.recorder.clone(),
             self.table_store.clone(),
-            &self.settings,
+            self.wal_writer_init_options,
             stored_manifest.manifest(),
             self.task_executor.clone(),
             self.fp_tx.clone(),

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -1,17 +1,26 @@
+use crate::db_status::DbStatusManager;
+use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
 use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
+use crate::wal::writer_init::WalWriterInit;
+use crate::wal_buffer::WalBufferManager;
 use crate::Settings;
 use fail_parallel::{fail_point_send, FailPointTx};
+use slatedb_common::metrics::MetricsRecorderHelper;
 use slatedb_common::SystemClock;
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 
 pub(crate) struct WriterFencer {
+    status_manager: DbStatusManager,
+    recorder: MetricsRecorderHelper,
+    settings: Settings,
     table_store: Arc<TableStore>,
     manifest_update_timeout: Duration,
     system_clock: Arc<dyn SystemClock>,
+    task_executor: Arc<MessageHandlerExecutor>,
     #[cfg_attr(not(test), allow(dead_code))]
     fp_tx: FailPointTx,
 }
@@ -19,27 +28,46 @@ pub(crate) struct WriterFencer {
 pub(crate) struct WriterFenceResult {
     pub(crate) manifest: FenceableManifest,
     pub(crate) replay_range: Range<u64>,
+    pub(crate) wal_buffer: WalBufferManager,
 }
 
 impl WriterFencer {
     pub(crate) fn new(
+        status_manager: DbStatusManager,
+        recorder: MetricsRecorderHelper,
         table_store: Arc<TableStore>,
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
+        task_executor: Arc<MessageHandlerExecutor>,
     ) -> Self {
-        Self::new_with_fp_handle(table_store, settings, system_clock, FailPointTx::dummy())
+        Self::new_with_fp_handle(
+            status_manager,
+            recorder,
+            table_store,
+            settings,
+            system_clock,
+            task_executor,
+            FailPointTx::dummy(),
+        )
     }
 
     fn new_with_fp_handle(
+        status_manager: DbStatusManager,
+        recorder: MetricsRecorderHelper,
         table_store: Arc<TableStore>,
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
+        task_executor: Arc<MessageHandlerExecutor>,
         fp_tx: FailPointTx,
     ) -> Self {
         Self {
+            status_manager,
+            recorder,
+            settings: settings.clone(),
             table_store,
             manifest_update_timeout: settings.manifest_update_timeout,
             system_clock,
+            task_executor,
             fp_tx,
         }
     }
@@ -57,11 +85,16 @@ impl WriterFencer {
         self,
         stored_manifest: StoredManifest,
     ) -> Result<WriterFenceResult, SlateDBError> {
-        let mut empty_wal_id = self
-            .table_store
-            .next_wal_sst_id(stored_manifest.manifest().core.replay_after_wal_id)
-            .await?;
-        self.fail_point_send("LoadEmptyWalId");
+        let wal_writer_init = WalWriterInit::load(
+            self.status_manager.clone(),
+            self.recorder.clone(),
+            self.table_store.clone(),
+            &self.settings,
+            stored_manifest.manifest(),
+            self.task_executor.clone(),
+            self.fp_tx.clone(),
+        )
+        .await?;
 
         let mut manifest = FenceableManifest::init_writer(
             stored_manifest,
@@ -71,56 +104,17 @@ impl WriterFencer {
         .await?;
         self.fail_point_send("FenceManifest");
 
-        let mut manifest_dirty = manifest.prepare_dirty()?;
-        // verify that the empty_wal_id we computed is still valid. Its possible that between
-        // computing empty_wal_id and fencing the manifest, the fenced writer advanced the gc
-        // boundary (replay_after_wal_id)
-        if empty_wal_id <= manifest_dirty.value.core.replay_after_wal_id {
-            // the wal gc boundary advanced because the old writer finished a flush - recompute
-            // the next wal id
-            empty_wal_id = self
-                .table_store
-                .next_wal_sst_id(manifest_dirty.value.core.replay_after_wal_id)
-                .await?;
-            manifest.refresh().await?;
-            manifest_dirty = manifest.prepare_dirty()?;
-            self.fail_point_send("ReloadEmptyWalId");
-            // at this point we still hold the epoch, so it should not be possible for the barrier
-            // to have advanced past the computed empty_wal_id
-            assert!(empty_wal_id > manifest_dirty.value.core.replay_after_wal_id);
-        }
+        let result = wal_writer_init.fence_and_init(&mut manifest).await?;
 
-        let mut attempt = 0;
-        loop {
-            attempt += 1;
-            let wrote_fence = match self.table_store.write_wal_fence(empty_wal_id).await {
-                Ok(()) => true,
-                Err(SlateDBError::Fenced) => false,
-                Err(err) => return Err(err),
-            };
-            self.fail_point_send(format!("{}:{}", "WriteWalFence", attempt));
+        // Refresh validates that we own the latest epoch still.
+        manifest.refresh().await?;
+        fail_point_send!(self.fp_tx, "FinalRefreshManifest");
 
-            // Refresh validates that we own the latest epoch still.
-            manifest.refresh().await?;
-            let dirty_manifest = manifest.prepare_dirty()?;
-            let replay_after_wal_id = dirty_manifest.value.core.replay_after_wal_id;
-            self.fail_point_send(format!("{}:{}", "RefreshManifest", attempt));
-
-            if wrote_fence {
-                // this writer is the only writer that could have written replay_after_wal_id,
-                // so it should not be possible for it to have advanced past the fencing wal.
-                // older writers would have failed with a stale epoch
-                assert!(empty_wal_id > replay_after_wal_id);
-                return Ok(WriterFenceResult {
-                    manifest,
-                    replay_range: replay_after_wal_id + 1..empty_wal_id + 1,
-                });
-            } else {
-                // The old writer managed to write a WAL before we could write the fencing wal.
-                // Try the next wal ID
-                empty_wal_id += 1;
-            }
-        }
+        Ok(WriterFenceResult {
+            manifest,
+            replay_range: result.replay_range,
+            wal_buffer: result.wal_buffer,
+        })
     }
 }
 
@@ -131,6 +125,8 @@ mod tests {
     use crate::config::{
         FlushOptions, FlushType, GarbageCollectorDirectoryOptions, GarbageCollectorOptions,
     };
+    use crate::db_status::DbStatusManager;
+    use crate::dispatcher::MessageHandlerExecutor;
     use crate::error::SlateDBError;
     use crate::fence::WriterFencer;
     use crate::format::sst::SsTableFormat;
@@ -148,7 +144,9 @@ mod tests {
     use object_store::path::Path;
     use object_store::ObjectStore;
     use rstest::rstest;
-    use slatedb_common::metrics::{lookup_metric, DefaultMetricsRecorder, MetricsRecorderHelper};
+    use slatedb_common::metrics::{
+        lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper,
+    };
     use slatedb_common::{DefaultSystemClock, SystemClock};
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -190,10 +188,22 @@ mod tests {
             .unwrap();
             let fp_registry = Arc::new(FailPointRegistry::new());
             let (fp_tx, event_rx) = fail_point_channel(fp_registry.clone());
+            let status_manager = DbStatusManager::new(0);
+            let recorder = MetricsRecorderHelper::new(
+                Arc::new(DefaultMetricsRecorder::new()),
+                MetricLevel::Info,
+            );
+            let task_executor = Arc::new(MessageHandlerExecutor::new(
+                Arc::new(status_manager.clone()),
+                system_clock.clone(),
+            ));
             let fencer = WriterFencer::new_with_fp_handle(
+                status_manager,
+                recorder,
                 table_store.clone(),
                 &settings,
                 system_clock.clone(),
+                task_executor,
                 fp_tx,
             );
             Self {

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -95,6 +95,7 @@ pub mod object_store_tag;
 pub mod prefix_extractor;
 pub mod seq_tracker;
 pub mod size_tiered_compaction;
+pub mod wal;
 
 mod batch;
 #[cfg(feature = "bench-internal")]
@@ -173,7 +174,6 @@ mod types;
 mod utils;
 
 mod fence;
-mod wal;
 mod wal_buffer;
 mod wal_reader;
 mod wal_replay;

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -66,6 +66,10 @@ impl FenceableManifest {
         Ok(Self { inner: fr, clock })
     }
 
+    pub(crate) fn manifest(&self) -> (u64, &Manifest) {
+        (self.inner.id().id(), self.inner.object())
+    }
+
     pub(crate) fn local_epoch(&self) -> u64 {
         self.inner.local_epoch()
     }

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -908,7 +908,9 @@ mod tests {
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::types::RowEntry;
     use crate::utils::WatchableOnceCell;
-    use crate::wal_buffer::WalBufferManager;
+
+    use crate::wal::test_utils::FakeWalWriter;
+    use crate::wal::WalWriter;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -916,7 +918,7 @@ mod tests {
     use object_store::ObjectStore;
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::clock::SystemClock;
-    use slatedb_common::metrics::{DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper};
+    use slatedb_common::metrics::MetricsRecorderHelper;
     use slatedb_common::DbRand;
     use std::sync::Arc;
     use std::time::Duration;
@@ -1070,16 +1072,7 @@ mod tests {
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
             crate::utils::SafeSender::unbounded_channel(status_manager.result_reader());
-        let recorder = Arc::new(DefaultMetricsRecorder::new());
-        let helper = MetricsRecorderHelper::new(recorder, MetricLevel::Info);
-        let wal_buffer = Arc::new(WalBufferManager::new(
-            status_manager.clone(),
-            &helper,
-            0,
-            table_store.clone(),
-            1024,
-            None,
-        ));
+        let wal_writer = Box::new(FakeWalWriter::new(0));
         let inner = Arc::new(
             DbInner::new(
                 settings.clone(),
@@ -1091,11 +1084,11 @@ mod tests {
                     &WatchableOnceCell::new(),
                 )),
                 write_tx,
-                wal_buffer.observer(),
+                wal_writer.observer(),
                 db_metrics,
                 fp_registry,
                 None,
-                status_manager,
+                Arc::new(status_manager),
                 segment_extractor,
             )
             .await

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -570,7 +570,9 @@ mod tests {
     use crate::test_utils::FixedThreeBytePrefixExtractor;
     use crate::types::RowEntry;
     use crate::utils::{SafeSender, WatchableOnceCell};
-    use crate::wal_buffer::WalBufferManager;
+
+    use crate::wal::test_utils::FakeWalWriter;
+    use crate::wal::WalWriter;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -644,16 +646,7 @@ mod tests {
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
             SafeSender::<BatchWriterMessage>::unbounded_channel(status_manager.result_reader());
-        let recorder = Arc::new(DefaultMetricsRecorder::new());
-        let helper = MetricsRecorderHelper::new(recorder, MetricLevel::Info);
-        let wal_buffer = Arc::new(WalBufferManager::new(
-            status_manager.clone(),
-            &helper,
-            0,
-            table_store.clone(),
-            1024,
-            None,
-        ));
+        let wal_writer = Box::new(FakeWalWriter::new(0));
         let inner = Arc::new(
             DbInner::new(
                 settings,
@@ -663,11 +656,11 @@ mod tests {
                 stored_manifest.prepare_dirty().unwrap(),
                 Arc::new(MemtableFlusher::new(&status_manager)),
                 write_tx,
-                wal_buffer.observer(),
+                wal_writer.observer(),
                 db_metrics,
                 fp_registry,
                 None,
-                status_manager,
+                Arc::new(status_manager),
                 segment_extractor,
             )
             .await

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -318,14 +318,16 @@ mod tests {
     use crate::test_utils::FixedThreeBytePrefixExtractor;
     use crate::types::{RowEntry, ValueDeletable};
     use crate::utils::WatchableOnceCell;
-    use crate::wal_buffer::WalBufferManager;
+
+    use crate::wal::test_utils::FakeWalWriter;
+    use crate::wal::WalWriter;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
     use slatedb_common::clock::{DefaultSystemClock, SystemClock};
-    use slatedb_common::metrics::{DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper};
+    use slatedb_common::metrics::MetricsRecorderHelper;
     use slatedb_common::DbRand;
     use std::collections::BTreeMap;
     use std::sync::Arc;
@@ -400,16 +402,7 @@ mod tests {
         let status_manager = DbStatusManager::new(0);
         let (write_tx, _) =
             crate::utils::SafeSender::unbounded_channel(status_manager.result_reader());
-        let recorder = Arc::new(DefaultMetricsRecorder::new());
-        let helper = MetricsRecorderHelper::new(recorder, MetricLevel::Info);
-        let wal_buffer = Arc::new(WalBufferManager::new(
-            status_manager.clone(),
-            &helper,
-            0,
-            table_store.clone(),
-            1024,
-            None,
-        ));
+        let wal_writer = Box::new(FakeWalWriter::new(0));
         Arc::new(
             DbInner::new(
                 settings,
@@ -421,11 +414,11 @@ mod tests {
                     &status_manager,
                 )),
                 write_tx,
-                wal_buffer.observer(),
+                wal_writer.observer(),
                 db_metrics,
                 fp_registry,
                 None,
-                status_manager,
+                Arc::new(status_manager),
                 segment_extractor,
             )
             .await

--- a/slatedb/src/oracle.rs
+++ b/slatedb/src/oracle.rs
@@ -1,5 +1,6 @@
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::Arc;
 
 use crate::db_status::DbStatusManager;
 
@@ -23,7 +24,7 @@ pub(crate) struct DbOracle {
     last_seq: AtomicU64,
     last_committed_seq: AtomicU64,
     last_durable_seq: AtomicU64,
-    status_reporter: DbStatusManager,
+    status_reporter: Arc<DbStatusManager>,
 }
 
 impl DbOracle {
@@ -31,7 +32,7 @@ impl DbOracle {
         last_seq: u64,
         last_committed_seq: u64,
         last_durable_seq: u64,
-        status_reporter: DbStatusManager,
+        status_reporter: Arc<DbStatusManager>,
     ) -> Self {
         Self {
             last_seq: AtomicU64::new(last_seq),

--- a/slatedb/src/snapshot_manager.rs
+++ b/slatedb/src/snapshot_manager.rs
@@ -71,7 +71,12 @@ mod tests {
 
     fn new_snapshot_manager(seq: u64) -> SnapshotManager {
         SnapshotManager::new(
-            Arc::new(DbOracle::new(seq, seq, seq, DbStatusManager::new(seq))),
+            Arc::new(DbOracle::new(
+                seq,
+                seq,
+                seq,
+                Arc::new(DbStatusManager::new(seq)),
+            )),
             Arc::new(DbRand::new(0)),
         )
     }

--- a/slatedb/src/transaction_manager.rs
+++ b/slatedb/src/transaction_manager.rs
@@ -411,7 +411,7 @@ mod tests {
     fn create_transaction_manager() -> TransactionManager {
         let db_rand = Arc::new(DbRand::new(0));
         let status_reporter = DbStatusManager::new(0);
-        let oracle = Arc::new(DbOracle::new(0, 0, 0, status_reporter));
+        let oracle = Arc::new(DbOracle::new(0, 0, 0, Arc::new(status_reporter)));
         TransactionManager::new(oracle, db_rand)
     }
 
@@ -419,7 +419,7 @@ mod tests {
     fn test_new_transaction_uses_oracle_seq() {
         let db_rand = Arc::new(DbRand::new(0));
         let status_reporter = DbStatusManager::new(123);
-        let oracle = Arc::new(DbOracle::new(123, 123, 123, status_reporter));
+        let oracle = Arc::new(DbOracle::new(123, 123, 123, Arc::new(status_reporter)));
         let txn_manager = TransactionManager::new(oracle, db_rand);
 
         let (txn_id, seq) = txn_manager.new_transaction();

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
+pub(crate) mod wal_disabled;
 pub(crate) mod wal_sst_builder;
 pub(crate) mod writer_init;
 

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -8,6 +8,8 @@ use std::fmt::{Display, Formatter};
 use std::ops::{Bound, Range};
 use std::sync::Arc;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub(crate) mod wal_sst_builder;
 pub(crate) mod writer_init;
 

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -1,2 +1,301 @@
+use crate::error::SlateDBError;
+use crate::manifest::store::FenceableManifest;
+use crate::{CloseReason, ErrorKind, RowEntry, VersionedManifest};
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::ops::{Bound, Range};
+use std::sync::Arc;
+
 pub(crate) mod wal_sst_builder;
 pub(crate) mod writer_init;
+
+/// A range of WAL File IDs
+pub struct WalFileRange(Bound<u64>, Bound<u64>);
+
+impl From<Range<u64>> for WalFileRange {
+    fn from(range: Range<u64>) -> Self {
+        WalFileRange(Bound::Included(range.start), Bound::Excluded(range.end))
+    }
+}
+
+impl TryFrom<WalFileRange> for Range<u64> {
+    type Error = ();
+
+    fn try_from(range: WalFileRange) -> Result<Self, Self::Error> {
+        match (range.0, range.1) {
+            (Bound::Included(start), Bound::Excluded(end)) => Ok(start..end),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Defines the types of errors that can be returned by WAL implementations.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum WalError {
+    /// The WAL writer was fenced
+    Fenced,
+    /// A WalIterator observed that the tail of the WAL was truncated while iterating.
+    WalTruncated,
+    /// Operation against wal after it was closed
+    Closed,
+    /// WAL is unavailable, e.g. due to an I/O error or error in the backing storage system
+    Unavailable(Arc<dyn Error + Sync + Send + 'static>),
+    /// WAL implementation detected invalid data/corruption
+    DataError(Arc<dyn Error + Sync + Send + 'static>),
+    /// Indicates that the WAL is in some unexpected/unrecoverable state.
+    InternalError(Arc<dyn Error + Sync + Send + 'static>),
+}
+
+impl Display for WalError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WalError::Fenced => write!(f, "WAL writer was fenced"),
+            WalError::WalTruncated => write!(f, "WAL was truncated"),
+            WalError::Closed => write!(f, "WAL is closed"),
+            WalError::Unavailable(source) => write!(f, "WAL is unavailable: {source}"),
+            WalError::DataError(source) => write!(f, "WAL data error: {source}"),
+            WalError::InternalError(source) => write!(f, "WAL internal error: {source}"),
+        }
+    }
+}
+
+impl Error for WalError {}
+
+/// The writer's manifest after fencing. Created by calling [`ManifestFencer::fence`]
+pub struct WriterManifest {
+    manifest: FenceableManifest,
+}
+
+impl From<WriterManifest> for FenceableManifest {
+    fn from(manifest: WriterManifest) -> Self {
+        manifest.manifest
+    }
+}
+
+impl From<FenceableManifest> for WriterManifest {
+    fn from(manifest: FenceableManifest) -> Self {
+        WriterManifest { manifest }
+    }
+}
+
+impl WriterManifest {
+    /// Returns the current manifest.
+    pub fn manifest(&self) -> VersionedManifest {
+        let (id, manifest) = self.manifest.manifest();
+        VersionedManifest::from_manifest(id, manifest.clone())
+    }
+
+    /// Returns the WAL ID up to which SlateDB has guaranteed to have stored all data in the
+    /// LSM tree.
+    pub fn replay_after_wal_id(&self) -> u64 {
+        self.manifest().core().replay_after_wal_id
+    }
+
+    /// Returns the writer's epoch
+    pub fn epoch(&self) -> u64 {
+        self.manifest().writer_epoch()
+    }
+
+    /// Refreshes the current manifest. Implementations of `WriterInit::fence_and_init` can
+    /// use this to detect whether the manifest has been fenced while executing the fencing
+    /// protocol. SlateDB will call this after calling [`WriterInit::fence_and_init`]
+    pub async fn refresh(&mut self) -> Result<(), WalError> {
+        self.manifest.refresh().await?;
+        Ok(())
+    }
+}
+
+/// The result returned by [`WriterInit::fence_and_init`]
+pub struct WriterInitResult {
+    // TODO: change me to an iterator
+    /// An iterator that returns writes that must be replayed before starting SlateDB to recover
+    /// data from the WAL.
+    pub replay_range: WalFileRange,
+    /// The WAL writer that will be used to append new writes to the WAL
+    pub wal_writer: Box<dyn WalWriter>,
+}
+
+/// API for fencing and initializing a new WAL writer for use by [`crate::db::Db`]. SlateDB requires
+/// WAL implementations to execute a fencing protocol that guarantees (1) that earlier writers no
+/// longer write to the db and (2) all rows present in the WAL but not in the LSM tree (L0 and
+/// sorted runs) are recovered.
+///
+/// Every [`crate::db::Db`] instance is assigned a unique `u64` epoch. The epoch is assigned when
+/// fencing the Manifest. A given Db instance writes both the WAL and its Manifest (e.g. with new
+/// SSTs) independently. The fencing protocol that yields epoch E must ensure that:
+/// (1) After the first write to the Manifest with epoch E, there are no further writes to either
+///     the Manifest or WAL with epoch E' < E
+/// (2) After the first write to the WAL with epoch E, there are no further writes to either the
+///     Manifest or WAL with epoch E' < E
+/// (3) All rows from the WAL from writers with epoch E' < E that are not present in L0/SRs are
+///     replayed before serving reads/writes.
+///
+/// `[WriterInit::fence_and_init]` is responsible for
+/// (1) Fencing the WAL such that no writers with an epoch earlier than [`WriterManifest::epoch`]
+/// (2) Constructing a [`WalWriter`] instance that the writer uses to append new WAL entries.
+/// (3) Resolving the end of the WAL and constructing a [`WalReplayIterator`] that returns all
+///     rows in WAL files between [`WriterManifest::replay_after_wal_id`] (exclusive) and the
+///     current end of the WAL.
+#[async_trait]
+pub trait WriterInit {
+    /// Fences the WAL and returns a [`WriterInitResult`] with a [`WalWriter`] and
+    /// [`WalReplayIterator`] used to recover writes that have not yet been flushed to the tree.
+    async fn fence_and_init(
+        &self,
+        manifest: &mut WriterManifest,
+    ) -> Result<WriterInitResult, WalError>;
+}
+
+/// Describes the current status of the WAL
+#[derive(Debug, Clone)]
+pub struct WalStatus {
+    /// Set to Some if the WAL has permanently shut down, along with the reason. The reason should
+    /// be [`WalError::Closed`] on a normal shutdown, and some other [`WalError`] variant on
+    /// failure.
+    pub closed_reason: Option<WalError>,
+    /// The estimated in-memory bytes used by the WAL to buffer unflushed writes.
+    pub estimated_bytes: usize,
+    /// The id of the last WAL file that was durably flushed
+    pub last_flushed_wal_id: u64,
+    /// The last sequence number that was durably flushed
+    pub last_flushed_seq: Option<u64>,
+    /// The number of writes currently buffered
+    #[allow(dead_code)]
+    pub buffered_wal_entries_count: usize,
+}
+
+/// An event emitted by a [`WalWriter`] to subscribers.
+#[derive(Debug, Clone)]
+pub enum WalEvent {
+    /// Emitted when a WAL file is durably flushed to storage. On receipt of this event, SlateDB
+    /// notifies write tasks blocked on [`crate::config::WriteOptions::await_durable`]
+    WalFlushed(WalStatus),
+    /// Emitted when the WAL has closed with the final wal status containing the closed reason
+    WalClosed(WalStatus),
+}
+
+/// A listener that's called back on WAL events.
+pub type WalStatusListener = Arc<dyn Fn(WalEvent) + Send + Sync + 'static>;
+
+/// An observer that can read the current [`WalStatus`] and subscribe to event callbacks.
+#[async_trait]
+pub trait WalObserver: Send + Sync + 'static {
+    /// Returns the current [`WalStatus`].
+    fn status(&self) -> Result<WalStatus, WalStatus>;
+
+    /// Adds a listener that subscribes to event callbacks.
+    fn subscribe(&self, listener: WalStatusListener) -> Result<(), WalError>;
+}
+
+pub type FlushResultFuture = BoxFuture<'static, Result<(), WalError>>;
+
+/// The WAL's write API. Used by SlateDB to append new WAL writes. Is returned by
+/// [`WalWriterInit::fence_and_init_writer`].
+///
+/// Each call to [`WalWriter::append`] takes a single SlateDB write batch, where all rows share
+/// the same sequence number ([`RowEntry::seq`]). [`WalWriter`] (optionally accumulates/buffers
+/// rows and) writes consecutive write batches into consecutive WAL Files, where each WAL File
+/// contains some rows from the total sequence of rows. Specifically:
+/// - WAL Files must have a total order and each WAL File must have a u64 id that is greater than
+///   all earlier WAL Files.
+/// - Reading WAL Files in order should yield rows in sequence order.
+/// - The writes in a given write batch must be written to WAL files atomically. That is, a
+///   [`WalIterator`] should either observe all the writes with a given sequence number or none
+///   of them.
+#[async_trait]
+pub trait WalWriter: Send {
+    /// Append a write batch to the WAL.
+    async fn append(&mut self, write_batch: &[RowEntry]) -> Result<(), WalError>;
+
+    /// Triggers a flush of all appended write batches to durable storage. Returns a
+    /// future that receives the result of the flush once it completes.
+    async fn flush(&mut self) -> Result<FlushResultFuture, WalError>;
+
+    /// Returns a `WalObserver` for reading [`WalStatus`] and subscribing to events.
+    fn observer(&self) -> Box<dyn WalObserver>;
+
+    /// Returns the current `WalStatus`. If the [`WalWriter`] has failed, then returns Err with the
+    /// final [`WalStatus`] and the reason for the failure in [`WalStatus::closed_reason`]
+    fn status(&self) -> Result<WalStatus, WalStatus>;
+
+    /// Close the `WalWriter` and release resources
+    async fn close(&mut self) -> Result<(), WalError>;
+}
+
+impl From<WalStatus> for WalError {
+    fn from(status: WalStatus) -> Self {
+        status
+            .closed_reason
+            .expect("unexpected conversion of wal status with no error")
+    }
+}
+
+impl From<WalStatus> for SlateDBError {
+    fn from(status: WalStatus) -> Self {
+        WalError::from(status).into()
+    }
+}
+
+impl From<SlateDBError> for WalError {
+    fn from(value: SlateDBError) -> Self {
+        {
+            let public: crate::Error = value.clone().into();
+            match public.kind() {
+                ErrorKind::Closed(CloseReason::Fenced) => WalError::Fenced,
+                ErrorKind::Closed(CloseReason::Clean) => WalError::Closed,
+                ErrorKind::Closed(_) => WalError::InternalError(Arc::new(value)),
+                ErrorKind::Unavailable => WalError::Unavailable(Arc::new(value)),
+                ErrorKind::Invalid => WalError::InternalError(Arc::new(value)),
+                ErrorKind::Data => WalError::DataError(Arc::new(value)),
+                ErrorKind::Internal => WalError::InternalError(Arc::new(value)),
+                ErrorKind::Transaction => WalError::InternalError(Arc::new(value)),
+            }
+        }
+    }
+}
+
+impl From<WalError> for SlateDBError {
+    fn from(value: WalError) -> Self {
+        match value {
+            WalError::Fenced => SlateDBError::Fenced,
+            WalError::WalTruncated => SlateDBError::WalTruncated,
+            WalError::Closed => SlateDBError::Closed,
+            WalError::Unavailable(err) => SlateDBError::WalUnavailable(err),
+            WalError::DataError(err) => SlateDBError::WalDataError(err),
+            WalError::InternalError(err) => SlateDBError::WalInternalError(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WalError;
+    use std::sync::Arc;
+
+    #[test]
+    fn wal_error_display() {
+        let source = || {
+            Arc::new(std::io::Error::other("source error"))
+                as Arc<dyn std::error::Error + Send + Sync + 'static>
+        };
+
+        assert_eq!(WalError::Fenced.to_string(), "WAL writer was fenced");
+        assert_eq!(WalError::WalTruncated.to_string(), "WAL was truncated");
+        assert_eq!(WalError::Closed.to_string(), "WAL is closed");
+        assert_eq!(
+            WalError::Unavailable(source()).to_string(),
+            "WAL is unavailable: source error"
+        );
+        assert_eq!(
+            WalError::DataError(source()).to_string(),
+            "WAL data error: source error"
+        );
+        assert_eq!(
+            WalError::InternalError(source()).to_string(),
+            "WAL internal error: source error"
+        );
+    }
+}

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod wal_sst_builder;
+pub(crate) mod writer_init;

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -221,7 +221,9 @@ pub trait WalWriter: Send {
     fn observer(&self) -> Box<dyn WalObserver>;
 
     /// Returns the current `WalStatus`. If the [`WalWriter`] has failed, then returns Err with the
-    /// final [`WalStatus`] and the reason for the failure in [`WalStatus::closed_reason`]
+    /// final [`WalStatus`] and the reason for the failure in [`WalStatus::closed_reason`]. This
+    /// allows callers to observe the final status after the [`WalWriter`] has shut down, e.g. to
+    /// read the last flushed wal file or sequence number.
     fn status(&self) -> Result<WalStatus, WalStatus>;
 
     /// Close the `WalWriter` and release resources

--- a/slatedb/src/wal/test_utils.rs
+++ b/slatedb/src/wal/test_utils.rs
@@ -1,0 +1,68 @@
+use crate::wal::{
+    FlushResultFuture, WalError, WalObserver, WalStatus, WalStatusListener, WalWriter,
+};
+use crate::RowEntry;
+use futures::FutureExt;
+
+pub(crate) struct FakeWalWriter {
+    status: WalStatus,
+}
+
+impl FakeWalWriter {
+    pub(crate) fn new(last_flushed_wal_id: u64) -> Self {
+        Self::new_with_closed_reason(last_flushed_wal_id, None)
+    }
+
+    pub(crate) fn new_with_closed_reason(
+        last_flushed_wal_id: u64,
+        closed_reason: Option<WalError>,
+    ) -> Self {
+        let status = WalStatus {
+            estimated_bytes: 0,
+            last_flushed_wal_id,
+            last_flushed_seq: None,
+            buffered_wal_entries_count: 0,
+            closed_reason,
+        };
+        Self { status }
+    }
+}
+
+#[async_trait::async_trait]
+impl WalWriter for FakeWalWriter {
+    async fn append(&mut self, _write_batch: &[RowEntry]) -> Result<(), WalError> {
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<FlushResultFuture, WalError> {
+        Ok(async { Ok(()) }.boxed())
+    }
+
+    fn observer(&self) -> Box<dyn WalObserver> {
+        Box::new(FakeWalObserver {
+            status: self.status.clone(),
+        })
+    }
+
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        Ok(self.status.clone())
+    }
+
+    async fn close(&mut self) -> Result<(), WalError> {
+        Ok(())
+    }
+}
+
+pub(crate) struct FakeWalObserver {
+    status: WalStatus,
+}
+
+impl WalObserver for FakeWalObserver {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        Ok(self.status.clone())
+    }
+
+    fn subscribe(&self, _listener: WalStatusListener) -> Result<(), WalError> {
+        Ok(())
+    }
+}

--- a/slatedb/src/wal/wal_disabled.rs
+++ b/slatedb/src/wal/wal_disabled.rs
@@ -1,0 +1,22 @@
+use crate::wal::{WalError, WalObserver, WalStatus, WalStatusListener};
+
+#[derive(Clone, Debug)]
+pub(crate) struct DisabledWalObserver {
+    status: WalStatus,
+}
+
+impl DisabledWalObserver {
+    pub(crate) fn new(status: WalStatus) -> Self {
+        Self { status }
+    }
+}
+
+impl WalObserver for DisabledWalObserver {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        Ok(self.status.clone())
+    }
+
+    fn subscribe(&self, _listener: WalStatusListener) -> Result<(), WalError> {
+        Ok(())
+    }
+}

--- a/slatedb/src/wal/writer_init.rs
+++ b/slatedb/src/wal/writer_init.rs
@@ -1,0 +1,122 @@
+use crate::db_status::DbStatusManager;
+use crate::dispatcher::MessageHandlerExecutor;
+use crate::error::SlateDBError;
+use crate::manifest::store::FenceableManifest;
+use crate::manifest::Manifest;
+use crate::tablestore::TableStore;
+use crate::wal_buffer::WalBufferManager;
+use crate::Settings;
+use fail_parallel::{fail_point_send, FailPointTx};
+use slatedb_common::metrics::MetricsRecorderHelper;
+use std::ops::Range;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub(crate) struct WalWriterInitResult {
+    pub(crate) replay_range: Range<u64>,
+    pub(crate) wal_buffer: WalBufferManager,
+}
+
+pub(crate) struct WalWriterInit {
+    status_manager: DbStatusManager,
+    recorder: MetricsRecorderHelper,
+    table_store: Arc<TableStore>,
+    max_wal_bytes_size: usize,
+    max_flush_interval: Option<Duration>,
+    empty_wal_id: u64,
+    task_executor: Arc<MessageHandlerExecutor>,
+    #[cfg_attr(not(test), allow(dead_code))]
+    fp_tx: FailPointTx,
+}
+
+impl WalWriterInit {
+    pub(crate) async fn load(
+        status_manager: DbStatusManager,
+        recorder: MetricsRecorderHelper,
+        table_store: Arc<TableStore>,
+        settings: &Settings,
+        manifest: &Manifest,
+        task_executor: Arc<MessageHandlerExecutor>,
+        fp_tx: FailPointTx,
+    ) -> Result<Self, SlateDBError> {
+        let empty_wal_id = table_store
+            .next_wal_sst_id(manifest.core.replay_after_wal_id)
+            .await?;
+        fail_point_send!(fp_tx, "LoadEmptyWalId");
+        Ok(Self {
+            status_manager,
+            recorder,
+            table_store,
+            max_wal_bytes_size: settings.l0_sst_size_bytes,
+            max_flush_interval: settings.flush_interval,
+            empty_wal_id,
+            task_executor,
+            fp_tx,
+        })
+    }
+
+    pub(crate) async fn fence_and_init(
+        &self,
+        manifest: &mut FenceableManifest,
+    ) -> Result<WalWriterInitResult, SlateDBError> {
+        let mut empty_wal_id = self.empty_wal_id;
+        let mut manifest_dirty = manifest.prepare_dirty()?;
+        // verify that the empty_wal_id we computed is still valid. Its possible that between
+        // computing empty_wal_id and fencing the manifest, the fenced writer advanced the gc
+        // boundary (replay_after_wal_id)
+        if empty_wal_id <= manifest_dirty.value.core.replay_after_wal_id {
+            // the wal gc boundary advanced because the old writer finished a flush - recompute
+            // the next wal id
+            empty_wal_id = self
+                .table_store
+                .next_wal_sst_id(manifest_dirty.value.core.replay_after_wal_id)
+                .await?;
+            manifest.refresh().await?;
+            manifest_dirty = manifest.prepare_dirty()?;
+            fail_point_send!(self.fp_tx, "ReloadEmptyWalId");
+            // at this point we still hold the epoch, so it should not be possible for the barrier
+            // to have advanced past the computed empty_wal_id
+            assert!(empty_wal_id > manifest_dirty.value.core.replay_after_wal_id);
+        }
+
+        let mut _attempt = 0;
+        loop {
+            _attempt += 1;
+            let wrote_fence = match self.table_store.write_wal_fence(empty_wal_id).await {
+                Ok(()) => true,
+                Err(SlateDBError::Fenced) => false,
+                Err(err) => return Err(err),
+            };
+            fail_point_send!(self.fp_tx, format!("{}:{}", "WriteWalFence", _attempt));
+
+            if wrote_fence {
+                // this writer is the only writer that could have written replay_after_wal_id,
+                // so it should not be possible for it to have advanced past the fencing wal.
+                // older writers would have failed with a stale epoch
+                let replay_after_wal_id = manifest_dirty.value.core.replay_after_wal_id;
+                assert!(empty_wal_id > replay_after_wal_id);
+                let mut wal_buffer = WalBufferManager::new(
+                    self.status_manager.clone(),
+                    &self.recorder,
+                    empty_wal_id,
+                    self.table_store.clone(),
+                    self.max_wal_bytes_size,
+                    self.max_flush_interval,
+                );
+                wal_buffer.init(self.task_executor.clone()).await?;
+                return Ok(WalWriterInitResult {
+                    replay_range: replay_after_wal_id + 1..empty_wal_id + 1,
+                    wal_buffer,
+                });
+            } else {
+                // Refresh validates that we own the latest epoch still.
+                manifest.refresh().await?;
+                manifest_dirty = manifest.prepare_dirty()?;
+                fail_point_send!(self.fp_tx, format!("{}:{}", "RefreshManifest", _attempt));
+                // The old writer managed to write a WAL before we could write the fencing wal.
+                // Try the next wal ID
+                empty_wal_id += 1;
+            }
+        }
+    }
+}

--- a/slatedb/src/wal/writer_init.rs
+++ b/slatedb/src/wal/writer_init.rs
@@ -1,24 +1,19 @@
-use crate::db_status::DbStatusManager;
 use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
-use crate::manifest::store::FenceableManifest;
 use crate::manifest::Manifest;
 use crate::tablestore::TableStore;
+use crate::utils::WatchableOnceCellReader;
+use crate::wal::{WalError, WriterInitResult, WriterManifest};
 use crate::wal_buffer::WalBufferManager;
-use crate::Settings;
+use crate::{wal, Settings};
+use async_trait::async_trait;
 use fail_parallel::{fail_point_send, FailPointTx};
 use slatedb_common::metrics::MetricsRecorderHelper;
-use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub(crate) struct WalWriterInitResult {
-    pub(crate) replay_range: Range<u64>,
-    pub(crate) wal_buffer: WalBufferManager,
-}
-
 pub(crate) struct WalWriterInit {
-    status_manager: DbStatusManager,
+    closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     recorder: MetricsRecorderHelper,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
@@ -31,7 +26,7 @@ pub(crate) struct WalWriterInit {
 
 impl WalWriterInit {
     pub(crate) async fn load(
-        status_manager: DbStatusManager,
+        closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
         recorder: MetricsRecorderHelper,
         table_store: Arc<TableStore>,
         settings: &Settings,
@@ -44,7 +39,7 @@ impl WalWriterInit {
             .await?;
         fail_point_send!(fp_tx, "LoadEmptyWalId");
         Ok(Self {
-            status_manager,
+            closed_result_reader,
             recorder,
             table_store,
             max_wal_bytes_size: settings.l0_sst_size_bytes,
@@ -54,30 +49,34 @@ impl WalWriterInit {
             fp_tx,
         })
     }
+}
 
-    pub(crate) async fn fence_and_init(
+#[async_trait]
+impl wal::WriterInit for WalWriterInit {
+    async fn fence_and_init(
         &self,
-        manifest: &mut FenceableManifest,
-    ) -> Result<WalWriterInitResult, SlateDBError> {
+        writer_manifest: &mut WriterManifest,
+    ) -> Result<WriterInitResult, WalError> {
         let mut empty_wal_id = self.empty_wal_id;
-        let mut manifest_dirty = manifest.prepare_dirty()?;
+        let mut manifest = writer_manifest.manifest();
         // verify that the empty_wal_id we computed is still valid. Its possible that between
         // computing empty_wal_id and fencing the manifest, the fenced writer advanced the gc
         // boundary (replay_after_wal_id)
-        if empty_wal_id <= manifest_dirty.value.core.replay_after_wal_id {
+        if empty_wal_id <= manifest.core().replay_after_wal_id {
             // the wal gc boundary advanced because the old writer finished a flush - recompute
             // the next wal id
             empty_wal_id = self
                 .table_store
-                .next_wal_sst_id(manifest_dirty.value.core.replay_after_wal_id)
+                .next_wal_sst_id(manifest.core().replay_after_wal_id)
                 .await?;
-            manifest.refresh().await?;
-            manifest_dirty = manifest.prepare_dirty()?;
+            writer_manifest.refresh().await?;
+            manifest = writer_manifest.manifest();
             fail_point_send!(self.fp_tx, "ReloadEmptyWalId");
             // at this point we still hold the epoch, so it should not be possible for the barrier
             // to have advanced past the computed empty_wal_id
-            assert!(empty_wal_id > manifest_dirty.value.core.replay_after_wal_id);
+            assert!(empty_wal_id > manifest.core().replay_after_wal_id);
         }
+        let manifest = manifest.clone();
 
         let mut _attempt = 0;
         loop {
@@ -85,7 +84,7 @@ impl WalWriterInit {
             let wrote_fence = match self.table_store.write_wal_fence(empty_wal_id).await {
                 Ok(()) => true,
                 Err(SlateDBError::Fenced) => false,
-                Err(err) => return Err(err),
+                Err(err) => return Err(err.into()),
             };
             fail_point_send!(self.fp_tx, format!("{}:{}", "WriteWalFence", _attempt));
 
@@ -93,25 +92,26 @@ impl WalWriterInit {
                 // this writer is the only writer that could have written replay_after_wal_id,
                 // so it should not be possible for it to have advanced past the fencing wal.
                 // older writers would have failed with a stale epoch
-                let replay_after_wal_id = manifest_dirty.value.core.replay_after_wal_id;
+                let replay_after_wal_id = manifest.core().replay_after_wal_id;
                 assert!(empty_wal_id > replay_after_wal_id);
-                let mut wal_buffer = WalBufferManager::new(
-                    self.status_manager.clone(),
+                let wal_writer = WalBufferManager::start_new(
+                    self.closed_result_reader.clone(),
                     &self.recorder,
                     empty_wal_id,
                     self.table_store.clone(),
                     self.max_wal_bytes_size,
                     self.max_flush_interval,
-                );
-                wal_buffer.init(self.task_executor.clone()).await?;
-                return Ok(WalWriterInitResult {
-                    replay_range: replay_after_wal_id + 1..empty_wal_id + 1,
-                    wal_buffer,
-                });
+                    self.task_executor.clone(),
+                )
+                .await?;
+                let result = WriterInitResult {
+                    replay_range: (replay_after_wal_id + 1..empty_wal_id + 1).into(),
+                    wal_writer: Box::new(wal_writer),
+                };
+                return Ok(result);
             } else {
                 // Refresh validates that we own the latest epoch still.
-                manifest.refresh().await?;
-                manifest_dirty = manifest.prepare_dirty()?;
+                writer_manifest.refresh().await?;
                 fail_point_send!(self.fp_tx, format!("{}:{}", "RefreshManifest", _attempt));
                 // The old writer managed to write a WAL before we could write the fencing wal.
                 // Try the next wal ID

--- a/slatedb/src/wal/writer_init.rs
+++ b/slatedb/src/wal/writer_init.rs
@@ -12,6 +12,21 @@ use slatedb_common::metrics::MetricsRecorderHelper;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[derive(Clone, Copy)]
+pub(crate) struct WalWriterInitOptions {
+    max_wal_bytes_size: usize,
+    max_flush_interval: Option<Duration>,
+}
+
+impl From<&Settings> for WalWriterInitOptions {
+    fn from(settings: &Settings) -> Self {
+        Self {
+            max_wal_bytes_size: settings.l0_sst_size_bytes,
+            max_flush_interval: settings.flush_interval,
+        }
+    }
+}
+
 pub(crate) struct WalWriterInit {
     closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     recorder: MetricsRecorderHelper,
@@ -29,7 +44,7 @@ impl WalWriterInit {
         closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
         recorder: MetricsRecorderHelper,
         table_store: Arc<TableStore>,
-        settings: &Settings,
+        options: WalWriterInitOptions,
         manifest: &Manifest,
         task_executor: Arc<MessageHandlerExecutor>,
         fp_tx: FailPointTx,
@@ -42,8 +57,8 @@ impl WalWriterInit {
             closed_result_reader,
             recorder,
             table_store,
-            max_wal_bytes_size: settings.l0_sst_size_bytes,
-            max_flush_interval: settings.flush_interval,
+            max_wal_bytes_size: options.max_wal_bytes_size,
+            max_flush_interval: options.max_flush_interval,
             empty_wal_id,
             task_executor,
             fp_tx,

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -5,24 +5,23 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::db_state::SsTableId;
-use crate::db_status::ClosedResultWriter;
 use crate::dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef};
 use crate::error::SlateDBError;
 use crate::tablestore::TableStore;
 use crate::types::RowEntry;
 use crate::utils::SafeSender;
 use crate::utils::{format_bytes_si, WatchableOnceCell, WatchableOnceCellReader};
+use crate::wal;
+use crate::wal::{FlushResultFuture, WalError, WalEvent, WalStatus, WalWriter};
 use crate::wal_buffer_stats::WalBufferStats;
 use async_trait::async_trait;
-use futures::{stream::BoxStream, StreamExt};
+use futures::{stream::BoxStream, FutureExt, StreamExt};
 use log::{error, trace, warn};
 use slatedb_common::metrics::MetricsRecorderHelper;
 use tokio::{runtime::Handle, sync::oneshot};
 use tracing::instrument;
 
 pub(crate) const WAL_BUFFER_TASK_NAME: &str = "wal_writer";
-
-pub(crate) type WalStatusListener = Arc<dyn Fn(WalEvent) + Send + Sync + 'static>;
 
 /// [`WalBufferManager`] buffers write operations in memory before flushing them to persistent storage.
 /// The flush operation only targets Remote storage right now, later we can add an option to flush to local
@@ -52,17 +51,12 @@ pub(crate) struct WalBufferManager {
     stats: Arc<WalBufferStats>,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
-    max_flush_interval: Option<Duration>,
     /// The largest flush_epoch for which a size-triggered flush request has been
     /// sent. Compared against `flush_epoch` in the inner struct to avoid sending
     /// redundant flush requests for the same WAL.
     last_flush_requested_epoch: AtomicU64,
-    /// The channel to send the flush work to the background worker.
-    flush_tx: SafeSender<WalFlushWork>,
-    /// The channel that the flush task waits on to receive work. Will be consumed by init
-    flush_rx: Option<async_channel::Receiver<WalFlushWork>>,
     /// task executor for the background worker.
-    task_executor: Option<Arc<MessageHandlerExecutor>>,
+    task_executor: Arc<MessageHandlerExecutor>,
 }
 
 struct WalBufferManagerInner {
@@ -80,6 +74,10 @@ struct WalBufferManagerInner {
     last_flushed_wal_id: u64,
     /// The last seq that was flushed to the WAL. This value will be None until the first flush.
     last_flushed_seq: Option<u64>,
+    /// Set to Some with error reason if the flush task has exited
+    flush_task_exited_reason: Option<WalError>,
+    /// The channel to send the flush work to the background worker.
+    flush_tx: SafeSender<WalFlushWork>,
 }
 
 /// Stores entries to the write-ahead log (WAL) in memory.
@@ -109,16 +107,18 @@ struct WalBufferIterator {
 }
 
 impl WalBufferManager {
-    pub(crate) fn new(
-        status_manager: crate::db_status::DbStatusManager,
+    pub(crate) async fn start_new(
+        closed_result_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
         recorder: &MetricsRecorderHelper,
         last_flushed_wal_id: u64,
         table_store: Arc<TableStore>,
         max_wal_bytes_size: usize,
         max_flush_interval: Option<Duration>,
-    ) -> Self {
+        task_executor: Arc<MessageHandlerExecutor>,
+    ) -> Result<Self, SlateDBError> {
         let current_wal = WalBuffer::new();
         let immutable_wals = VecDeque::new();
+        let (flush_tx, flush_rx) = SafeSender::unbounded_channel(closed_result_reader);
         let inner = WalBufferManagerInner {
             current_wal,
             immutable_wals,
@@ -126,73 +126,42 @@ impl WalBufferManager {
             last_flushed_wal_id,
             next_wal_id: last_flushed_wal_id + 1,
             last_flushed_seq: None,
-        };
-        let (flush_tx, flush_rx) = SafeSender::unbounded_channel(status_manager.result_reader());
-        Self {
-            inner: Arc::new(parking_lot::RwLock::new(inner)),
-            stats: Arc::new(WalBufferStats::new(recorder)),
-            table_store,
-            max_wal_bytes_size,
-            max_flush_interval,
-            last_flush_requested_epoch: AtomicU64::new(0),
+            flush_task_exited_reason: None,
             flush_tx,
-            flush_rx: Some(flush_rx),
-            task_executor: None,
-        }
-    }
-
-    // todo: consider consolidating with new
-    pub(crate) async fn init(
-        &mut self,
-        task_executor: Arc<MessageHandlerExecutor>,
-    ) -> Result<(), SlateDBError> {
-        let Some(flush_rx) = self.flush_rx.take() else {
-            error!("WalBufferManager#init called multiple times");
-            return Err(SlateDBError::InvalidDBState);
         };
-        assert!(self.task_executor.is_none());
+        let inner = Arc::new(parking_lot::RwLock::new(inner));
+        let stats = Arc::new(WalBufferStats::new(recorder));
         let wal_flush_handler = WalFlushHandler {
-            max_flush_interval: self.max_flush_interval,
-            inner: self.inner.clone(),
-            table_store: self.table_store.clone(),
-            stats: self.stats.clone(),
+            max_flush_interval,
+            inner: inner.clone(),
+            table_store: table_store.clone(),
+            stats: stats.clone(),
             listener: None,
         };
-        let result = task_executor.add_handler(
+        task_executor.add_handler(
             WAL_BUFFER_TASK_NAME.to_string(),
             Box::new(wal_flush_handler),
             flush_rx,
             &Handle::current(),
-        );
-        self.task_executor = Some(task_executor);
-        result
+        )?;
+        Ok(Self {
+            inner,
+            stats,
+            table_store,
+            max_wal_bytes_size,
+            last_flush_requested_epoch: AtomicU64::new(0),
+            task_executor,
+        })
     }
 
-    pub(crate) fn last_flushed_wal_id(&self) -> u64 {
-        let inner = self.inner.read();
-        inner.last_flushed_wal_id
-    }
-
-    pub(crate) fn status(&self) -> WalStatus {
-        self.inner.read().status(&self.table_store)
-    }
-
-    /// Append row entries to the current WAL. Returns a watcher for durability notification.
-    pub(crate) fn append(
-        &self,
-        entries: &[RowEntry],
-    ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
-        // TODO: check if the wal buffer is in a fatal error state.
-        self.inner.write().append(entries)
-    }
-
+    //TODO: do we still need durable watchers here?
     /// Check if we need to flush the wal with considering max_wal_size. the checking over `max_wal_size`
     /// is not very strict, we have to ensure a write batch into a single WAL file.
     ///
     /// It's the caller's duty to call `maybe_trigger_flush` after calling `append`.
-    pub(crate) fn maybe_trigger_flush(
+    fn maybe_trigger_flush(
         &self,
-    ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
+    ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, WalError> {
         let (durable_watcher, need_flush, flush_epoch) = {
             let inner = self.inner.read();
             // checks the size of the current wal
@@ -214,58 +183,95 @@ impl WalBufferManager {
             }
         }
 
-        let status = self.status();
+        let status = self.status()?;
         self.stats
             .estimated_bytes
             .set(status.estimated_bytes as i64);
         Ok(durable_watcher)
     }
 
-    pub(crate) fn observer(&self) -> WalObserver {
-        WalObserver {
-            inner: self.inner.clone(),
-            table_store: self.table_store.clone(),
-            flush_tx: self.flush_tx.clone(),
-        }
-    }
-
     /// Send a flush request to the background flush worker.
     fn send_flush_request(
         &self,
-        result_tx: Option<oneshot::Sender<Result<(), SlateDBError>>>,
-    ) -> Result<(), SlateDBError> {
+        result_tx: Option<oneshot::Sender<Result<(), WalError>>>,
+    ) -> Result<(), WalError> {
         self.stats.flush_requests.increment(1);
-        self.flush_tx.send(WalFlushWork::Flush { result_tx })
+        self.inner
+            .read()
+            .send_flush_msg(WalFlushWork::Flush { result_tx })
+    }
+}
+
+#[async_trait]
+impl WalWriter for WalBufferManager {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        self.inner.read().status(&self.table_store)
     }
 
-    pub(crate) fn flush(
-        &self,
-    ) -> Result<oneshot::Receiver<Result<(), SlateDBError>>, SlateDBError> {
+    /// Append row entries to the current WAL. Returns a watcher for durability notification.
+    async fn append(&mut self, entries: &[RowEntry]) -> Result<(), WalError> {
+        self.inner.write().append(entries)?;
+        self.maybe_trigger_flush()?;
+        Ok(())
+    }
+
+    fn observer(&self) -> Box<dyn wal::WalObserver> {
+        Box::new(WalObserver {
+            inner: self.inner.clone(),
+            table_store: self.table_store.clone(),
+        })
+    }
+
+    async fn flush(&mut self) -> Result<FlushResultFuture, WalError> {
         let (result_tx, result_rx) = oneshot::channel();
         self.send_flush_request(Some(result_tx))?;
-        Ok(result_rx)
+        Ok(async {
+            result_rx
+                .await
+                .unwrap_or_else(|e| Err(WalError::InternalError(Arc::new(e))))
+        }
+        .boxed())
     }
 
-    #[allow(dead_code)]
-    pub(crate) async fn close(&self) -> Result<(), SlateDBError> {
-        let task_executor = self
+    async fn close(&mut self) -> Result<(), WalError> {
+        if let Some(result) = self
             .task_executor
-            .as_ref()
-            .expect("task executor should be initialized");
-        task_executor.shutdown_task(WAL_BUFFER_TASK_NAME).await
+            .shutdown_or_deregister_task(WAL_BUFFER_TASK_NAME)
+            .await
+        {
+            return Ok(result?);
+        };
+        self.inner
+            .write()
+            .drain_on_close(WalError::Closed, &self.table_store);
+        Ok(())
     }
 }
 
 impl WalBufferManagerInner {
-    fn append(
-        &mut self,
-        entries: &[RowEntry],
-    ) -> Result<WatchableOnceCellReader<Result<(), SlateDBError>>, SlateDBError> {
+    fn check_exited(&self) -> Result<(), WalError> {
+        match self.flush_task_exited_reason.as_ref() {
+            Some(err) => Err(err.clone()),
+            None => Ok(()),
+        }
+    }
+
+    fn send_flush_msg(&self, msg: WalFlushWork) -> Result<(), WalError> {
+        self.check_exited()?;
+        // TODO: there is a small window here where the dispatcher closes `flush_rx` before
+        //       calling cleanup. In this case we may have exited with a different error than
+        //       a clean close. To fix this we'd need some pre-cleanup hook the dispatcher can
+        //       call to propagate the error
+        self.flush_tx.send(msg).map_err(|_e| WalError::Closed)
+    }
+
+    fn append(&mut self, entries: &[RowEntry]) -> Result<(), WalError> {
         // TODO: validate the seq number is always increasing.
+        self.check_exited()?;
         for entry in entries {
             self.current_wal.append(entry.clone());
         }
-        Ok(self.current_wal.durable_watcher())
+        Ok(())
     }
 
     fn needs_flush(&self, table_store: &TableStore, max_wal_bytes_size: usize) -> (bool, u64) {
@@ -303,7 +309,16 @@ impl WalBufferManagerInner {
         current_wal_size + imm_wal_size
     }
 
-    fn status(&self, table_store: &TableStore) -> WalStatus {
+    fn status(&self, table_store: &TableStore) -> Result<WalStatus, WalStatus> {
+        let status = self.compute_status(table_store);
+        if status.closed_reason.is_none() {
+            Ok(status)
+        } else {
+            Err(status)
+        }
+    }
+
+    fn compute_status(&self, table_store: &TableStore) -> WalStatus {
         let flushing_wal_entries_count = self
             .immutable_wals
             .iter()
@@ -311,11 +326,25 @@ impl WalBufferManagerInner {
             .sum::<usize>();
         let buffered_wal_entries_count = self.current_wal.len() + flushing_wal_entries_count;
         WalStatus {
+            closed_reason: self.flush_task_exited_reason.clone(),
             estimated_bytes: self.estimated_bytes(table_store),
             last_flushed_wal_id: self.last_flushed_wal_id,
             last_flushed_seq: self.last_flushed_seq,
             buffered_wal_entries_count,
         }
+    }
+
+    fn drain_on_close(
+        &mut self,
+        reason: WalError,
+        table_store: &TableStore,
+    ) -> (WalStatus, Vec<(u64, Arc<WalBuffer>)>) {
+        self.flush_task_exited_reason = Some(reason);
+        self.freeze_current_wal();
+        let unflushed_wals = self.flushing_wals();
+        self.immutable_wals.clear();
+        let status = self.compute_status(table_store);
+        (status, unflushed_wals)
     }
 
     fn freeze_current_wal(&mut self) {
@@ -434,10 +463,10 @@ impl WalBufferIterator {
 
 enum WalFlushWork {
     Flush {
-        result_tx: Option<oneshot::Sender<Result<(), SlateDBError>>>,
+        result_tx: Option<oneshot::Sender<Result<(), WalError>>>,
     },
     Subscribe {
-        listener: WalStatusListener,
+        listener: wal::WalStatusListener,
     },
 }
 
@@ -455,7 +484,7 @@ struct WalFlushHandler {
     inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
     table_store: Arc<TableStore>,
     stats: Arc<WalBufferStats>,
-    listener: Option<WalStatusListener>,
+    listener: Option<wal::WalStatusListener>,
 }
 
 impl WalFlushHandler {
@@ -481,7 +510,7 @@ impl WalFlushHandler {
             let status = {
                 let mut inner = self.inner.write();
                 inner.record_flushed_wal(wal_id, &wal);
-                inner.status(&self.table_store)
+                inner.compute_status(&self.table_store)
             };
 
             // we notify the listener first since that updates the oracle, and then notify
@@ -490,7 +519,7 @@ impl WalFlushHandler {
             // after notifying flushed before the wal memory is actually released.
             // TODO: once we change writes to block on the durable seq num from the oracle we
             //       can simplify this and fully drop the wal before notifying listeners
-            self.notify_listener(WalEvent::WalFlushed(status));
+            self.notify_listener(wal::WalEvent::WalFlushed(status));
             wal.notify_durable(result.clone());
             if Arc::strong_count(&wal) > 1 {
                 warn!("outstanding references to wal id {} after flushing", wal_id);
@@ -519,7 +548,7 @@ impl WalFlushHandler {
         Ok(())
     }
 
-    fn notify_listener(&self, event: WalEvent) {
+    fn notify_listener(&self, event: wal::WalEvent) {
         if let Some(l) = self.listener.as_ref() {
             (*l)(event);
         }
@@ -543,10 +572,10 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
             WalFlushWork::Flush { result_tx } => {
                 if let Some(result_tx) = result_tx {
                     let result = self.do_flush().await;
-                    let _ = result_tx.send(result.clone());
-                    result
+                    let _ = result_tx.send(result.clone().map_err(WalError::from));
+                    Ok(result?)
                 } else {
-                    self.do_flush().await
+                    Ok(self.do_flush().await?)
                 }
             }
             WalFlushWork::Subscribe { listener } => {
@@ -563,7 +592,17 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
         mut messages: BoxStream<'async_trait, WalFlushWork>,
         result: Result<(), SlateDBError>,
     ) -> Result<(), SlateDBError> {
-        let error = result.err().unwrap_or(SlateDBError::Closed);
+        let error = result
+            .clone()
+            .err()
+            .map(WalError::from)
+            .unwrap_or(WalError::Closed);
+
+        let (final_status, unflushed) = self
+            .inner
+            .write()
+            .drain_on_close(error.clone(), &self.table_store);
+        self.notify_listener(WalEvent::WalClosed(final_status.clone()));
 
         // drain remaining messages
         while let Some(msg) = messages.next().await {
@@ -573,20 +612,17 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
                         let _ = result_tx.send(Err(error.clone()));
                     }
                 }
-                WalFlushWork::Subscribe { listener: _ } => {}
+                WalFlushWork::Subscribe { listener } => {
+                    (*listener)(WalEvent::WalClosed(final_status.clone()))
+                }
             }
         }
 
         // notify all the flushing wals to be finished with fatal error or shutdown
         // error. we need ensure all the wal tables finally get notified. freeze current
         // WAL to notify writers in the subsequent flushing_wals loop.
-        let flushing_wals = {
-            let mut inner = self.inner.write();
-            inner.freeze_current_wal();
-            inner.flushing_wals()
-        };
-        for (_, wal) in flushing_wals.iter() {
-            wal.notify_durable(Err(error.clone()));
+        for (_, wal) in unflushed {
+            wal.notify_durable(Err(result.clone().err().unwrap_or(SlateDBError::Closed)));
         }
         Ok(())
     }
@@ -594,44 +630,21 @@ impl MessageHandler<WalFlushWork> for WalFlushHandler {
 
 /// Interface for getting information about the current state of the Wal
 #[derive(Clone)]
-pub(crate) struct WalObserver {
+struct WalObserver {
     inner: Arc<parking_lot::RwLock<WalBufferManagerInner>>,
     table_store: Arc<TableStore>,
-    flush_tx: SafeSender<WalFlushWork>,
 }
 
-/// Describes the current status of the WAL
-#[derive(Debug, Clone)]
-pub(crate) struct WalStatus {
-    /// The estimated in-memory bytes used by the WAL to buffer unflushed writes.
-    pub(crate) estimated_bytes: usize,
-    /// The id of the last WAL file that was durably flushed
-    pub(crate) last_flushed_wal_id: u64,
-    /// The last sequence number that was durably flushed
-    pub(crate) last_flushed_seq: Option<u64>,
-    /// The number of writes currently buffered
-    #[allow(dead_code)]
-    pub(crate) buffered_wal_entries_count: usize,
-}
-
-/// An event emitted by [`WalBufferManager`] to subscribers.
-#[derive(Debug, Clone)]
-pub(crate) enum WalEvent {
-    /// Emitted when a WAL file is durably flushed to storage. On receipt of this event, SlateDB
-    /// notifies write tasks blocked on [`crate::config::WriteOptions::await_durable`]
-    WalFlushed(WalStatus),
-}
-
-impl WalObserver {
+impl wal::WalObserver for WalObserver {
     /// Gets information about the Wal buffer's current state
-    pub(crate) fn status(&self) -> WalStatus {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
         self.inner.read().status(self.table_store.as_ref())
     }
 
-    pub(crate) fn subscribe(&self, listener: WalStatusListener) -> Result<(), SlateDBError> {
-        self.flush_tx
-            .send(WalFlushWork::Subscribe { listener })
-            .map_err(|_err| SlateDBError::Closed)
+    fn subscribe(&self, listener: wal::WalStatusListener) -> Result<(), WalError> {
+        self.inner
+            .read()
+            .send_flush_msg(WalFlushWork::Subscribe { listener })
     }
 }
 
@@ -673,7 +686,7 @@ pub mod stats {
 mod tests {
     use super::*;
     use crate::block_cache_policy::BlockCachePolicy;
-    use crate::db_status::DbStatusManager;
+    use crate::db_status::{ClosedResultWriter, DbStatusManager};
     use crate::format::sst::SsTableFormat;
     use crate::iter::RowEntryIterator;
     use crate::manifest::SsTableView;
@@ -689,7 +702,6 @@ mod tests {
         lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper,
     };
     use slatedb_common::MockSystemClock;
-    use std::sync::atomic::AtomicBool;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -886,7 +898,7 @@ mod tests {
 
     async fn setup_wal_buffer_with_args(
         flush_interval: Duration,
-        listener: WalStatusListener,
+        listener: wal::WalStatusListener,
     ) -> (
         WalBufferManager,
         Arc<TableStore>,
@@ -904,31 +916,35 @@ mod tests {
         ));
         let test_clock = Arc::new(MockSystemClock::new());
         let system_clock = Arc::new(DefaultSystemClock::new());
-        let status_manager = DbStatusManager::new(0);
+        let status_manager = Arc::new(DbStatusManager::new(0));
         let oracle = Arc::new(DbOracle::new(0, 0, 0, status_manager.clone()));
         let recorder = Arc::new(DefaultMetricsRecorder::new());
         let helper = MetricsRecorderHelper::new(recorder.clone(), MetricLevel::default());
-        let mut wal_buffer = WalBufferManager::new(
+        let task_executor = Arc::new(MessageHandlerExecutor::new(
             status_manager.clone(),
+            system_clock.clone(),
+        ));
+        let wal_buffer = WalBufferManager::start_new(
+            status_manager.result_reader(),
             &helper,
             0, // recent_flushed_wal_id
             table_store.clone(),
             1000,                 // max_wal_bytes_size
             Some(flush_interval), // max_flush_interval
-        );
+            task_executor.clone(),
+        )
+        .await
+        .unwrap();
         let observer = wal_buffer.observer();
         observer
             .subscribe(Arc::new(move |status| {
                 (*listener)(status.clone());
-                let WalEvent::WalFlushed(status) = status;
+                let wal::WalEvent::WalFlushed(status) = status else {
+                    return;
+                };
                 oracle.advance_durable_seq(status.last_flushed_seq.unwrap_or(0))
             }))
             .unwrap();
-        let task_executor = Arc::new(MessageHandlerExecutor::new(
-            Arc::new(status_manager),
-            system_clock.clone(),
-        ));
-        wal_buffer.init(task_executor.clone()).await.unwrap();
         task_executor
             .monitor_on(&Handle::current())
             .expect("failed to monitor executor");
@@ -937,17 +953,23 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_append_and_flush_operations() {
-        let (wal_buffer, table_store, _, _) = setup_wal_buffer().await;
+        let (mut wal_buffer, table_store, _, _) = setup_wal_buffer().await;
 
         // Append some entries
         let entry1 = make_entry("key1", "value1", 1, None);
         let entry2 = make_entry("key2", "value2", 2, None);
 
-        wal_buffer.append(std::slice::from_ref(&entry1)).unwrap();
-        wal_buffer.append(std::slice::from_ref(&entry2)).unwrap();
+        wal_buffer
+            .append(std::slice::from_ref(&entry1))
+            .await
+            .unwrap();
+        wal_buffer
+            .append(std::slice::from_ref(&entry2))
+            .await
+            .unwrap();
 
         // Flush the buffer
-        wal_buffer.flush().unwrap().await.unwrap().unwrap();
+        wal_buffer.flush().await.unwrap().await.unwrap();
 
         // Verify entries were written to storage
         let sst_iter_options = SstIteratorOptions {
@@ -979,39 +1001,39 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_size_based_flush_triggering() {
-        let (wal_buffer, _, _, _) = setup_wal_buffer_with_flush_interval(Duration::MAX).await;
+        let (mut wal_buffer, _, _, _) = setup_wal_buffer_with_flush_interval(Duration::MAX).await;
 
         // Append entries until we exceed the size threshold
         let mut seq = 1;
-        while wal_buffer.status().estimated_bytes < wal_buffer.max_wal_bytes_size {
+        while wal_buffer.status().unwrap().estimated_bytes < wal_buffer.max_wal_bytes_size {
             let entry = make_entry(&format!("key{}", seq), &format!("value{}", seq), seq, None);
-            wal_buffer.append(&[entry]).unwrap();
+            wal_buffer.append(&[entry]).await.unwrap();
             seq += 1;
         }
         let mut reader = wal_buffer.maybe_trigger_flush().unwrap();
         reader.await_value().await.unwrap();
 
-        assert_eq!(wal_buffer.last_flushed_wal_id(), 1);
+        assert_eq!(wal_buffer.status().unwrap().last_flushed_wal_id, 1);
     }
 
     #[tokio::test]
     async fn test_immutable_wal_reclaim() {
-        let (wal_buffer, _, _, _) = setup_wal_buffer().await;
+        let (mut wal_buffer, _, _, _) = setup_wal_buffer().await;
 
         // Append entries to create multiple WALs
         for i in 0..100 {
             let seq = i + 1;
             let entry = make_entry(&format!("key{}", i), &format!("value{}", i), seq, None);
-            wal_buffer.append(&[entry]).unwrap();
-            wal_buffer.flush().unwrap().await.unwrap().unwrap();
+            wal_buffer.append(&[entry]).await.unwrap();
+            wal_buffer.flush().await.unwrap().await.unwrap();
         }
-        assert_eq!(wal_buffer.last_flushed_wal_id(), 100);
+        assert_eq!(wal_buffer.status().unwrap().last_flushed_wal_id, 100);
         assert_eq!(wal_buffer.inner.read().immutable_wals.len(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_maybe_trigger_flush_spams_flush_requests() {
-        let (wal_buffer, _, _, recorder) =
+        let (mut wal_buffer, _, _, recorder) =
             setup_wal_buffer_with_flush_interval(Duration::MAX).await;
 
         // Simulate many writers each appending a small entry and calling
@@ -1021,7 +1043,7 @@ mod tests {
         let num_writes: u64 = 100;
         for seq in 1..=num_writes {
             let entry = make_entry(&format!("key{}", seq), &format!("value{}", seq), seq, None);
-            wal_buffer.append(&[entry]).unwrap();
+            wal_buffer.append(&[entry]).await.unwrap();
             wal_buffer.maybe_trigger_flush().unwrap();
         }
 
@@ -1029,7 +1051,7 @@ mod tests {
             lookup_metric(&recorder, stats::WAL_BUFFER_FLUSH_REQUESTS).unwrap();
 
         // Explicitly flush to drain everything, including any partial current WAL.
-        wal_buffer.flush().unwrap().await.unwrap().unwrap();
+        wal_buffer.flush().await.unwrap().await.unwrap();
 
         let actual_flushes = lookup_metric(&recorder, stats::WAL_BUFFER_FLUSHES).unwrap();
 
@@ -1049,7 +1071,7 @@ mod tests {
         );
     }
 
-    fn recording_listener() -> (WalStatusListener, Arc<Mutex<Vec<WalEvent>>>) {
+    fn recording_listener() -> (wal::WalStatusListener, Arc<Mutex<Vec<wal::WalEvent>>>) {
         let events = Arc::new(std::sync::Mutex::new(Vec::new()));
         let recorder = events.clone();
         let listener = Arc::new(move |event| {
@@ -1062,76 +1084,29 @@ mod tests {
     async fn test_listener_notified_when_flush_task_flushes_wal() {
         // given:
         let (listener, events) = recording_listener();
-        let (wal_buffer, _, _, _) = setup_wal_buffer_with_args(Duration::MAX, listener).await;
+        let (mut wal_buffer, _, _, _) = setup_wal_buffer_with_args(Duration::MAX, listener).await;
 
         // when: Append an entry and explicitly flush it, driving the background flush task.
         wal_buffer
             .append(&[make_entry("key1", "value1", 1, None)])
+            .await
             .unwrap();
-        wal_buffer.flush().unwrap().await.unwrap().unwrap();
+        wal_buffer.flush().await.unwrap().await.unwrap();
 
         // then: the listener should have been notified that wal 1 was flushed.
         let recorded = events.lock().unwrap().clone();
         let mut flushed: Vec<_> = recorded
             .iter()
-            .map(|e| {
-                let WalEvent::WalFlushed(status) = e;
-                status
+            .filter_map(|e| {
+                let wal::WalEvent::WalFlushed(status) = e else {
+                    return None;
+                };
+                Some(status)
             })
             .collect();
         assert_eq!(flushed.len(), 1);
         let status = flushed.pop().unwrap();
         assert_eq!(status.last_flushed_wal_id, 1);
         assert_eq!(status.last_flushed_seq, Some(1));
-    }
-
-    #[tokio::test]
-    async fn test_listener_notified_before_table_waiters() {
-        // given:
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let table_store = Arc::new(TableStore::new(
-            ObjectStores::new(object_store, None),
-            SsTableFormat::default(),
-            Path::from("/root"),
-            None,
-            TableStoreKind::Main,
-            BlockCachePolicy::default(),
-        ));
-        let system_clock = Arc::new(DefaultSystemClock::new());
-        let status_manager = DbStatusManager::new(0);
-        let recorder = Arc::new(DefaultMetricsRecorder::new());
-        let helper = MetricsRecorderHelper::new(recorder.clone(), MetricLevel::default());
-        let mut wal_buffer = WalBufferManager::new(
-            status_manager.clone(),
-            &helper,
-            0,
-            table_store.clone(),
-            1000,
-            Some(Duration::MAX),
-        );
-        let task_executor = Arc::new(MessageHandlerExecutor::new(
-            Arc::new(status_manager),
-            system_clock.clone(),
-        ));
-        wal_buffer.init(task_executor.clone()).await.unwrap();
-        task_executor
-            .monitor_on(&Handle::current())
-            .expect("failed to monitor executor");
-        let waiter = wal_buffer
-            .append(&[make_entry("key1", "value1", 1, None)])
-            .unwrap();
-        let called = Arc::new(AtomicBool::new(false));
-        let this_called = called.clone();
-        let listener = move |event| {
-            this_called.store(true, Ordering::SeqCst);
-            assert!(matches!(event, WalEvent::WalFlushed(_)));
-            // verifies that the table is not yet notified
-            assert!(waiter.read().is_none())
-        };
-        wal_buffer.observer().subscribe(Arc::new(listener)).unwrap();
-
-        // when/then:
-        wal_buffer.flush().unwrap().await.unwrap().unwrap();
-        assert!(called.load(Ordering::SeqCst));
     }
 }


### PR DESCRIPTION
## Summary

This patch refactors the write path in Db to use the interfaces proposed in RFC-0030:

## Changes

- Adds the proposed traits to slatedb/src/wal/mod.rs
- The existing WalBufferManager and WalObserver implement WalWriter and WalObserver, respectively.
- Fencing is split into WriterFencer and WalWriterInit. WriterFencer wraps the overall protocol. It fences the manifest, then calls into WriterInit to initialize/fence the WAL, and then validates the manifest is still fenced. WalWriterInit implements WriterInit for our WAL and has the logic for fencing the WAL.
- The WalWriter returned by WriterFencer (via WriterInit) is passed in to WriteBatchEventHandler which calls append/flush to append rows and flush.
- WriteBatchEventHandler now distinguishes between non-fatal errors (e.g. txn conflict) and fatal errors returned by the append.
- await_durable is implemented by blocking on the durable sequence number rather than relying on a watch returned by append.

Some misc/supporting changes that also slipped into this patch:
- WriteBatchEventHandler holds an Option<Box<dyn WalWriter>> thats set to None when the wal is disabled.
- MessageHandlerExecutor::shutdown_or_deregister_task - supports clearing a task that may not yet have started. Needed to close the WAL early when its disabled.

Changes deferred to later PRs:
- moving the wal traits to a separate slatedb-wal crate
- moving the existing wal types to the wal module
- adding apis for configuring a custom WAL
- changing the writer's replay path to use the new traits
- changing the reader to use the new traits
- tailing the live WAL from readers

## Notes for Reviewers

This patch can be reviewed commit-by-commit. If folks prefer, I can break it up into separate PRs along the commit boundaries.
- 6c5867f4: extends the message dispatcher to support shutting down tasks that have not started
- 45b8538: refactors fencing so that the WAL part is split out into a `WalWriterInit` as described in the RFC, but doesn't include the new traits.
- 518cfbfd: adds the RFC-30 traits with a couple tweaks to errors and subscribe
- 884eba3: updates the write-side WAL implementation to implement the traits and updates the write path 
- efecc05d: more explicitly models disabled wals as `Option<Box<dyn WalWriter>>`

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
