### PR TITLE
Apply ruff check --fix with ruff 0.16 for python bindings

### DIFF
--- a/bindings/python/slatedb/uniffi/__init__.py
+++ b/bindings/python/slatedb/uniffi/__init__.py
@@ -3,6 +3,6 @@
 from importlib import import_module
 
 _generated = import_module("._slatedb_uniffi.slatedb", __name__)
-from ._slatedb_uniffi import *  # noqa: E402,F403
+from ._slatedb_uniffi import *
 
 __all__ = _generated.__all__

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -4,8 +4,9 @@ import asyncio
 import inspect
 import threading
 import uuid
+from collections.abc import Callable
 from contextlib import asynccontextmanager
-from typing import Any, Callable
+from typing import Any
 
 from slatedb.uniffi import (
     DbBuilder,
@@ -23,8 +24,8 @@ from slatedb.uniffi import (
     PrefixExtractor,
     PrefixTarget,
     PutOptions,
-    ReadOptions,
     ReaderOptions,
+    ReadOptions,
     RowEntry,
     RowEntryKind,
     ScanOptions,
@@ -166,7 +167,7 @@ async def wait_until(
             if await _maybe_await(check()):
                 return
             last_error = None
-        except Exception as error:  # pragma: no cover - helper for polling assertions
+        except Exception as error:  # noqa: BLE001  # pragma: no cover - helper for polling assertions
             last_error = error
 
         if asyncio.get_running_loop().time() >= deadline:

--- a/bindings/python/tests/test_admin.py
+++ b/bindings/python/tests/test_admin.py
@@ -4,8 +4,8 @@ import asyncio
 import time
 
 import pytest
-
 from conftest import new_memory_store, open_db, open_reader, unique_path, wait_until
+
 from slatedb.uniffi import (
     AdminBuilder,
     CheckpointOptions,
@@ -227,7 +227,7 @@ async def test_admin_clone() -> None:
     for i in range(3):
         path = unique_path(f"admin-clone-original-{i}")
         async with open_db(store, path=path) as db:
-            await db.put(f"k{i}".encode("utf-8"), f"v{i}".encode("utf-8"))
+            await db.put(f"k{i}".encode(), f"v{i}".encode())
             await db.flush()
         sources.append(CloneSourceSpec(path=path, checkpoint=None, projection_range=None))
 
@@ -241,7 +241,7 @@ async def test_admin_clone() -> None:
 
     async with open_db(store, path=clone_path) as db:
         for i in range(3):
-            assert await db.get(f"k{i}".encode("utf-8")) == f"v{i}".encode("utf-8")
+            assert await db.get(f"k{i}".encode()) == f"v{i}".encode()
 
 
 @pytest.mark.asyncio

--- a/bindings/python/tests/test_db.py
+++ b/bindings/python/tests/test_db.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import pytest
-
 from conftest import (
+    TEST_DB_PATH,
     ConcatMergeOperator,
     FixedThreeByteSegmentExtractor,
-    TEST_DB_PATH,
     drain_iterator,
     merge_options,
     new_memory_store,
@@ -16,6 +15,7 @@ from conftest import (
     scan_options,
     write_options,
 )
+
 from slatedb.uniffi import (
     CloseReason,
     DbBuilder,

--- a/bindings/python/tests/test_logging.py
+++ b/bindings/python/tests/test_logging.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-
 from conftest import LogCollector, new_memory_store, open_db, unique_path, wait_until
+
 from slatedb.uniffi import Error, LogLevel, init_logging
 
 

--- a/bindings/python/tests/test_metrics.py
+++ b/bindings/python/tests/test_metrics.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-
 from conftest import new_memory_store, open_db, open_reader
+
 from slatedb.uniffi import (
     Counter,
     DefaultMetricsRecorder,

--- a/bindings/python/tests/test_reader.py
+++ b/bindings/python/tests/test_reader.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import pytest
-
 from conftest import (
-    ConcatMergeOperator,
     TEST_DB_PATH,
+    ConcatMergeOperator,
     drain_iterator,
     new_memory_store,
     open_db,
@@ -15,6 +14,7 @@ from conftest import (
     scan_options,
     wait_until,
 )
+
 from slatedb.uniffi import (
     CloseReason,
     DbReaderBuilder,
@@ -198,18 +198,17 @@ async def test_reader_refresh_polling_updates_visible_state() -> None:
 async def test_reader_default_mode_replays_new_wal_data() -> None:
     store = new_memory_store()
 
-    async with open_db(store) as db:
-        async with open_reader(
-            store,
-            configure=lambda builder: builder.with_options(reader_options(False)),
-        ) as reader:
-            await db.put(b"wal-key", b"wal-value")
-            await db.flush_with_options(FlushOptions(flush_type=FlushType.WAL))
+    async with open_db(store) as db, open_reader(
+        store,
+        configure=lambda builder: builder.with_options(reader_options(False)),
+    ) as reader:
+        await db.put(b"wal-key", b"wal-value")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.WAL))
 
-            async def has_wal_value() -> bool:
-                return await reader.get(b"wal-key") == b"wal-value"
+        async def has_wal_value() -> bool:
+            return await reader.get(b"wal-key") == b"wal-value"
 
-            await wait_until(has_wal_value)
+        await wait_until(has_wal_value)
 
 
 @pytest.mark.asyncio

--- a/bindings/python/tests/test_wal_reader.py
+++ b/bindings/python/tests/test_wal_reader.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-
 from conftest import (
     TEST_DB_PATH,
     drain_wal_iterator,
@@ -9,6 +8,7 @@ from conftest import (
     require_wal_row,
     seed_wal_files,
 )
+
 from slatedb.uniffi import Error, RowEntryKind, WalReader
 
 


### PR DESCRIPTION
## Summary 

PRs starting to fail in CI because ruff had a new version and we don't have a pinned version for it. 
The PR just runs `ruff check --fix` with the new version. 