### PR TITLE
Probe latest sequenced objects before listing

### DIFF
--- a/rfcs/0032-cached-probing-sequenced-metadata.md
+++ b/rfcs/0032-cached-probing-sequenced-metadata.md
@@ -46,16 +46,17 @@ Authors:
 
 ## Summary
 
-SlateDB finds the latest sequenced metadata object by listing every object in
-the namespace, selecting the highest ID, and reading that object. This RFC
-replaces LIST on the common path with a process-local cache and consecutive GET
-probes.
+SlateDB finds the latest sequenced metadata object (`.manifest` or
+`.compactions`) by listing every object in the metadata directory, selecting
+the highest ID, and reading that object. This RFC replaces LIST on the common
+path with a process-local cache and consecutive GET probes.
 
-Each sequenced metadata store caches the highest object ID and its encoded
-bytes. A latest read starts at the next ID and issues up to four GETs. A 404
-means the last successful GET or cached object is the latest version. Four
-consecutive hits fall back to the existing LIST path. A store with an empty
-cache also uses LIST to establish its starting point.
+Each sequenced metadata store (`ManifestStore` and `CompactionsStore`) caches
+the highest object ID and its encoded bytes. A latest read starts at the next
+ID and issues up to four GETs. A 404 means the last successful GET or cached
+object is the latest version. Four consecutive hits fall back to the existing
+LIST path. A store with an empty cache also uses LIST to establish its starting
+point.
 
 Successful writes update the same cache. Boundary checks from RFC-0026 remain
 in place and invalidate cached objects rejected by the GC boundary.
@@ -85,6 +86,10 @@ The LIST cost repeats on refreshes even when no writer has added a new object.
 LIST also returns metadata for the full retained history, although the caller
 needs one object.
 
+This pattern is expensive and wasteful for idle processes. A database that's
+idle for five minutes incures 560 LIST requests with default configuration.
+This comes out to $24.19 per-month in AWS S3 us-east-1 pricing.
+
 Sequenced metadata already supplies a cheaper lookup mechanism. Once a process
 has seen ID `N`, it can GET `N+1`. A 404 means `N` is still latest. If `N+1`
 exists, the process continues with `N+2`. The protocol's consecutive-ID
@@ -94,11 +99,11 @@ of downloading every intervening object.
 
 ## Goals
 
+- Idle databases should cost less than $5 per month.
+- Protocol should be freiendly to lagging readers.
 - Remove LIST when a warm reader is close to the latest version.
-- Bound catch-up probing before falling back to LIST.
 - Keep the existing object layout, write protocol, and GC boundary semantics.
 - Avoid rereading an unchanged latest object.
-- Let reads and writes share one monotonic cache.
 - Preserve the existing LIST fallback for cold stores, lagging readers, and GC
   races.
 
@@ -122,7 +127,6 @@ Mutex<Option<(MonotonicId, Bytes)>>
 
 The cache contains encoded bytes rather than `T`. This avoids adding a
 `T: Clone` bound and lets the write path reuse the bytes it already encoded.
-Cloning `Bytes` does not copy the object body.
 
 Cache updates are monotonic. An update replaces the entry only when its ID is
 higher than the cached ID:
@@ -225,8 +229,9 @@ An object above `N` may appear during the first probe. In that case, probing
 advances the cache and can find an object above the boundary without LIST.
 
 Deleting a cached object through the same protocol invalidates the matching
-entry after the object-store DELETE succeeds. Remote GC remains safe because
-the boundary check catches cached IDs from the deleted prefix.
+entry after the object-store DELETE succeeds. If another process deletes
+objects covered by a newer GC boundary, checked reads reject and invalidate
+any cached object covered by that boundary before returning it.
 
 ### Concurrency and Sharing
 
@@ -257,11 +262,6 @@ The probing path distinguishes a missing successor from other failures:
 - Four consecutive successful GETs: fall back to LIST.
 - Other GET error: return the error.
 - Decode error: return the codec error.
-
-The protocol relies on consecutive physical IDs above the GC boundary. A
-writer must continue to create `current_id + 1`; it cannot skip an occupied or
-failed slot. GC may remove a prefix after advancing the boundary, but it cannot
-create a gap in the live suffix.
 
 ## Impact Analysis
 
@@ -294,7 +294,7 @@ SlateDB features and components that this RFC interacts with.
 - [ ] Clones
 - [x] Garbage collection
 - [ ] Database splitting and merging
-- [x] Multi-writer
+- [ ] Multi-writer
 
 The manifest and compactions payload formats do not change. This RFC changes
 how callers locate the latest encoded object.
@@ -311,7 +311,7 @@ how callers locate the latest encoded object.
 
 - [ ] Write-ahead log (WAL)
 - [ ] Block cache
-- [x] Object store cache
+- [ ] Object store cache
 - [ ] Indexing (bloom filters, metadata)
 - [ ] SST format or block format
 
@@ -319,7 +319,7 @@ how callers locate the latest encoded object.
 
 - [ ] CLI tools
 - [ ] Language bindings (Go/Python/etc)
-- [x] Observability (metrics/logging/tracing)
+- [ ] Observability (metrics/logging/tracing)
 
 ## Operations
 
@@ -384,40 +384,13 @@ No public Rust API or language binding changes.
 
 ## Testing
 
-- Unit tests:
-  - a cold read uses LIST and caches the returned bytes;
-  - an unchanged warm read probes only the successor;
-  - a lagging reader probes consecutive objects and advances its cache;
-  - four successful probes cause a LIST fallback;
-  - a successful write populates the cache;
-  - a boundary rejection invalidates the matching entry;
-  - a listed object deleted before GET causes another LIST.
-- Integration tests:
-  - manifest refresh and write tests;
-  - compactions state refresh and write tests.
-- Fault-injection/chaos tests:
-  - inject GET failures during a probe;
-  - delete a cached prefix after advancing the boundary;
-  - race readers and writers that share a protocol instance.
-- Deterministic simulation tests:
-  - retain existing sequenced metadata and GC coverage.
-- Formal methods verification: none.
-- Performance tests:
-  - measure request counts for warm reads, cold starts, and readers lagging by
-    increasing numbers of versions;
-  - measure the memory retained by cached manifest and compactions bytes.
+- Unit test to verify reads fall back to LIST after four consecutive GET hits.
+- Run benchmarks to verify an idle SlateDB with default configuration stays
+  below $5 per month in AWS S3 us-east-1 pricing.
 
 ## Rollout
 
 The change is internal and does not require a feature flag.
-
-1. Add cache and probe request metrics.
-2. Enable probing for manifest and compactions stores.
-3. Compare LIST and GET request counts before and after deployment.
-4. Watch probes-per-read and cache memory by component.
-
-If probing causes unexpected request amplification, disabling the cache and
-returning to the existing LIST path requires no data migration.
 
 ## Alternatives
 
@@ -430,15 +403,6 @@ regardless of lag.
 The retained history makes LIST more expensive than the information needed by
 the caller. Repeating it when no version changed also adds avoidable request
 cost and latency.
-
-### Cache Only the Latest ID
-
-Cache `N` and probe `N+1`, but do not retain the bytes for `N`. When `N+1` is
-missing, the reader must either reread `N` or fall back to LIST before it can
-return the object.
-
-Caching bytes removes that extra object-store request and avoids a `T: Clone`
-bound. The memory cost is one encoded metadata object per protocol instance.
 
 ### Unbounded Linear Probing
 
@@ -529,8 +493,8 @@ This version of `CURRENT` is an advisory cursor. Object creation still commits
 a version, so RFC-0026 boundary files remain necessary. A stale writer could
 otherwise recreate an ID deleted by GC.
 
-`CURRENT` removes cold LISTs and the four-probe catch-up fallback. It also adds a
-mutable pointer update to every write. Its steady-state request profile is:
+`CURRENT` removes cold LISTs and the four-probe catch-up fallback. It also adds
+a mutable pointer update to every write. Its steady-state request profile is:
 
 | Operation | Cached probing | `CURRENT` cursor |
 |---|---:|---:|
@@ -583,10 +547,7 @@ objects as history.
 
 ## Open Questions
 
-- Should builders share manifest and compactions store instances across more
-  embedded components to reduce cold LISTs?
-- Does the latest-object cache need a size limit for unusually large metadata
-  objects?
+None.
 
 ## References
 

--- a/rfcs/0032-cached-probing-sequenced-metadata.md
+++ b/rfcs/0032-cached-probing-sequenced-metadata.md
@@ -359,10 +359,12 @@ not add objects to storage or increase write amplification.
 Add counters for:
 
 - latest cache hits and cold misses;
-- LIST fallbacks;
 - successful and missing probe GETs;
 - cache advances from reads and writes; and
 - boundary-driven cache invalidations.
+
+Log probe-limit LIST fallbacks at debug level with the object directory, last
+seen ID, and probe count.
 
 Record a histogram of probes per latest read. Existing object-store metrics
 continue to report request latency and failures.

--- a/rfcs/0032-cached-probing-sequenced-metadata.md
+++ b/rfcs/0032-cached-probing-sequenced-metadata.md
@@ -87,7 +87,7 @@ LIST also returns metadata for the full retained history, although the caller
 needs one object.
 
 This pattern is expensive and wasteful for idle processes. A database that's
-idle for five minutes incures 560 LIST requests with default configuration.
+idle for five minutes incurs 560 LIST requests with default configuration.
 This comes out to $24.19 per-month in AWS S3 us-east-1 pricing.
 
 Sequenced metadata already supplies a cheaper lookup mechanism. Once a process

--- a/rfcs/0032-cached-probing-sequenced-metadata.md
+++ b/rfcs/0032-cached-probing-sequenced-metadata.md
@@ -26,6 +26,11 @@ Table of Contents:
 - [Alternatives](#alternatives)
   - [LIST on Every Latest Read](#list-on-every-latest-read)
   - [Cache Only the Latest ID](#cache-only-the-latest-id)
+  - [Unbounded Linear Probing](#unbounded-linear-probing)
+  - [Exponential and Binary Probing](#exponential-and-binary-probing)
+  - [Parallel Window Probing](#parallel-window-probing)
+  - [HEAD Probing](#head-probing)
+  - [Adaptive Probe Limit](#adaptive-probe-limit)
   - [CURRENT Pointer](#current-pointer)
   - [Authoritative CURRENT Pointer](#authoritative-current-pointer)
 - [Open Questions](#open-questions)
@@ -47,10 +52,10 @@ replaces LIST on the common path with a process-local cache and consecutive GET
 probes.
 
 Each sequenced metadata store caches the highest object ID and its encoded
-bytes. A latest read starts at the next ID and issues GETs until the first 404.
-Since metadata IDs are contiguous, the last successful GET or cached object is
-the latest version. A store with an empty cache uses the existing LIST path to
-establish its starting point.
+bytes. A latest read starts at the next ID and issues up to four GETs. A 404
+means the last successful GET or cached object is the latest version. Four
+consecutive hits fall back to the existing LIST path. A store with an empty
+cache also uses LIST to establish its starting point.
 
 Successful writes update the same cache. Boundary checks from RFC-0026 remain
 in place and invalidate cached objects rejected by the GC boundary.
@@ -82,17 +87,20 @@ needs one object.
 
 Sequenced metadata already supplies a cheaper lookup mechanism. Once a process
 has seen ID `N`, it can GET `N+1`. A 404 means `N` is still latest. If `N+1`
-exists, the process continues with `N+2` until it reaches the first missing ID.
-The protocol's consecutive-ID invariant makes the first 404 a valid stopping
-condition.
+exists, the process continues with `N+2`. The protocol's consecutive-ID
+invariant makes the first 404 a valid stopping condition. Probing stops after
+four successful GETs so a reader that is far behind catches up with LIST instead
+of downloading every intervening object.
 
 ## Goals
 
-- Remove LIST from warm latest-version reads.
+- Remove LIST when a warm reader is close to the latest version.
+- Bound catch-up probing before falling back to LIST.
 - Keep the existing object layout, write protocol, and GC boundary semantics.
 - Avoid rereading an unchanged latest object.
 - Let reads and writes share one monotonic cache.
-- Preserve the existing LIST fallback for cold stores and GC races.
+- Preserve the existing LIST fallback for cold stores, lagging readers, and GC
+  races.
 
 ## Non-Goals
 
@@ -166,7 +174,9 @@ cached (N, bytes_N)
             +-- cache (N+1, bytes_N+1)
             +-- GET N+2
                     |
-                    +-- continue until the first 404
+                    +-- continue until the first 404 or fourth hit
+                            |
+                            +-- fourth hit ---> fall back to LIST
 ```
 
 The implementation never holds the cache mutex across an object-store request.
@@ -175,6 +185,7 @@ backward.
 
 The first missing successor terminates the probe. It does not trigger LIST.
 The cached bytes let the reader return the latest object without rereading it.
+Four consecutive successful probes fall through to the cold LIST path.
 
 ### Write-Through Updates
 
@@ -243,6 +254,7 @@ The probing path distinguishes a missing successor from other failures:
 
 - 404 for `N+1`: return cached `N`.
 - Successful GET for `N+1`: cache it and continue.
+- Four consecutive successful GETs: fall back to LIST.
 - Other GET error: return the error.
 - Decode error: return the codec error.
 
@@ -321,24 +333,23 @@ request.
 | Successful write | 1 object PUT + boundary GET | Same |
 | Cold latest read | 1 LIST + object GET + boundary GET | Same |
 | Warm unchanged read | 1 LIST + object GET + boundary GET | 1 missing-successor GET + boundary GET |
-| Warm read `k` versions behind | 1 LIST + object GET + boundary GET | `k` GET hits + 1 GET miss + boundary GET |
+| Warm read fewer than 4 versions behind | 1 LIST + object GET + boundary GET | `k` GET hits + 1 GET miss + boundary GET |
+| Warm read at least 4 versions behind | 1 LIST + object GET + boundary GET | 4 GET hits + 1 LIST + object GET + boundary GET |
 
 Object stores tend to bill LIST with PUT-class requests and GETs at a lower
 request rate. Exact prices depend on the provider and region. Probing should
 cost less when protocol instances live long enough to amortize their cold LIST
 and usually lag by a small number of versions.
 
-A process that falls far behind exchanges one LIST for many GETs. The ratio
-below captures that workload:
+A process that falls far behind issues at most four probe GETs before using
+LIST. The ratio below captures that workload:
 
 ```text
 probe_gets / latest_reads
 ```
 
 A ratio near `1` means most reads issue one 404 probe and return cached bytes.
-A high ratio means readers often catch up across many external writes. Metrics
-should determine whether a probe limit or a different lookup protocol is
-needed.
+A ratio near `4` means readers often hit the probe limit and fall back to LIST.
 
 The proposal adds one encoded object body per live protocol instance. It does
 not add objects to storage or increase write amplification.
@@ -375,6 +386,7 @@ No public Rust API or language binding changes.
   - a cold read uses LIST and caches the returned bytes;
   - an unchanged warm read probes only the successor;
   - a lagging reader probes consecutive objects and advances its cache;
+  - four successful probes cause a LIST fallback;
   - a successful write populates the cache;
   - a boundary rejection invalidates the matching entry;
   - a listed object deleted before GET causes another LIST.
@@ -426,6 +438,65 @@ return the object.
 Caching bytes removes that extra object-store request and avoids a `T: Clone`
 bound. The memory cost is one encoded metadata object per protocol instance.
 
+### Unbounded Linear Probing
+
+Continue reading `N+1`, `N+2`, and so on until the first 404. A reader that is
+`k` versions behind uses `k+1` GETs and avoids LIST. Each successful GET also
+supplies the bytes needed if that object is latest.
+
+The request count and latency grow linearly with lag. A process resuming after
+a long pause could download hundreds of obsolete objects before returning.
+The four-GET limit gives the common case the same behavior while bounding the
+catch-up cost.
+
+### Exponential and Binary Probing
+
+`TableStore::last_seen_wal_id` uses exponential probing followed by binary
+search to find the latest WAL SST. Starting at `N`, it probes offsets
+`1, 2, 4, 8, ...` in parallel groups of eight until one is missing, then
+binary searches between the highest hit and the first miss. Contiguous IDs make
+the existence test monotonic. A pure binary search would not work because the
+reader has no upper bound before the exponential phase.
+
+This finds a frontier `k` versions away with `O(log k)` existence checks. The
+reader must then GET the latest object because the search only establishes its
+ID. For small `k`, linear GETs use fewer requests and already have the latest
+bytes. Exponential probing is a better fit when large gaps are common enough to
+justify the extra code and concurrent request fan-out.
+
+### Parallel Window Probing
+
+Issue a fixed window of successor reads concurrently. If the window contains a
+404, the object before the first missing ID is latest. If every request
+succeeds, issue another window or fall back to LIST. A window of four can cross
+four versions in one round trip.
+
+Issuing the full window on every read turns an unchanged warm read from one
+request into four. A hybrid can probe `N+1` first and issue a window only after
+that request succeeds, but requests beyond the first missing ID do no useful
+work. This option trades request count for catch-up latency.
+
+### HEAD Probing
+
+Use HEAD requests to locate the frontier, then GET only the latest object.
+This avoids downloading intermediate object bodies when a reader is behind.
+An unchanged reader still needs one missing-successor request and can return
+its cached bytes.
+
+For small gaps, HEAD probing adds a final GET that linear GET probing avoids.
+Many object stores bill HEAD and GET at the same request rate, so this option
+reduces transferred bytes without reducing request charges.
+
+### Adaptive Probe Limit
+
+Change the probe limit based on recent reads. A store could raise the limit
+after repeated LIST fallbacks and lower it after 404s. This may help workloads
+where writers publish bursts that often exceed four versions.
+
+The store would need more cache state and a tuning policy. A fixed limit has a
+predictable request bound and keeps behavior consistent across protocol
+instances.
+
 ### CURRENT Pointer
 
 Store a small mutable `CURRENT` object containing the latest sequence ID.
@@ -456,8 +527,8 @@ This version of `CURRENT` is an advisory cursor. Object creation still commits
 a version, so RFC-0026 boundary files remain necessary. A stale writer could
 otherwise recreate an ID deleted by GC.
 
-`CURRENT` removes cold LISTs and long probe runs. It also adds a mutable pointer
-update to every write. Its steady-state request profile is:
+`CURRENT` removes cold LISTs and the four-probe catch-up fallback. It also adds a
+mutable pointer update to every write. Its steady-state request profile is:
 
 | Operation | Cached probing | `CURRENT` cursor |
 |---|---:|---:|

--- a/rfcs/0032-cached-probing-sequenced-metadata.md
+++ b/rfcs/0032-cached-probing-sequenced-metadata.md
@@ -1,0 +1,522 @@
+# Cached Probing for Sequenced Metadata
+
+Table of Contents:
+
+<!-- TOC start (generate with https://bitdowntoc.derlin.ch) -->
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Goals](#goals)
+- [Non-Goals](#non-goals)
+- [Design](#design)
+  - [Latest Object Cache](#latest-object-cache)
+  - [Cold Reads](#cold-reads)
+  - [Warm Reads](#warm-reads)
+  - [Write-Through Updates](#write-through-updates)
+  - [Boundary Checks and Garbage Collection](#boundary-checks-and-garbage-collection)
+  - [Concurrency and Sharing](#concurrency-and-sharing)
+  - [Failure Handling](#failure-handling)
+- [Impact Analysis](#impact-analysis)
+- [Operations](#operations)
+  - [Performance and Cost](#performance-and-cost)
+  - [Observability](#observability)
+  - [Compatibility](#compatibility)
+- [Testing](#testing)
+- [Rollout](#rollout)
+- [Alternatives](#alternatives)
+  - [LIST on Every Latest Read](#list-on-every-latest-read)
+  - [Cache Only the Latest ID](#cache-only-the-latest-id)
+  - [CURRENT Pointer](#current-pointer)
+  - [Authoritative CURRENT Pointer](#authoritative-current-pointer)
+- [Open Questions](#open-questions)
+- [References](#references)
+
+<!-- TOC end -->
+
+Status: Draft
+
+Authors:
+
+* [Chris Riccomini](https://github.com/criccomini)
+
+## Summary
+
+SlateDB finds the latest sequenced metadata object by listing every object in
+the namespace, selecting the highest ID, and reading that object. This RFC
+replaces LIST on the common path with a process-local cache and consecutive GET
+probes.
+
+Each sequenced metadata store caches the highest object ID and its encoded
+bytes. A latest read starts at the next ID and issues GETs until the first 404.
+Since metadata IDs are contiguous, the last successful GET or cached object is
+the latest version. A store with an empty cache uses the existing LIST path to
+establish its starting point.
+
+Successful writes update the same cache. Boundary checks from RFC-0026 remain
+in place and invalidate cached objects rejected by the GC boundary.
+
+## Motivation
+
+SlateDB stores manifests and compaction state as immutable, consecutively
+numbered objects:
+
+```text
+manifest/00000000000000000012.manifest
+manifest/00000000000000000013.manifest
+
+compactions/00000000000000000007.compactions
+compactions/00000000000000000008.compactions
+```
+
+`ObjectStoreSequencedStorageProtocol::try_read_latest` currently performs these
+operations:
+
+1. LIST the namespace.
+2. Sort the returned metadata by object ID.
+3. GET the object with the highest ID.
+4. Check the object ID against the GC boundary.
+
+The LIST cost repeats on refreshes even when no writer has added a new object.
+LIST also returns metadata for the full retained history, although the caller
+needs one object.
+
+Sequenced metadata already supplies a cheaper lookup mechanism. Once a process
+has seen ID `N`, it can GET `N+1`. A 404 means `N` is still latest. If `N+1`
+exists, the process continues with `N+2` until it reaches the first missing ID.
+The protocol's consecutive-ID invariant makes the first 404 a valid stopping
+condition.
+
+## Goals
+
+- Remove LIST from warm latest-version reads.
+- Keep the existing object layout, write protocol, and GC boundary semantics.
+- Avoid rereading an unchanged latest object.
+- Let reads and writes share one monotonic cache.
+- Preserve the existing LIST fallback for cold stores and GC races.
+
+## Non-Goals
+
+- Remove LIST from APIs that enumerate historical versions.
+- Add a durable pointer object or change the metadata commit point.
+- Share cache state across processes.
+- Change manifest or compactions serialization.
+- Replace the GC boundary protocol from RFC-0026.
+
+## Design
+
+### Latest Object Cache
+
+Each `ObjectStoreSequencedStorageProtocol<T>` stores one cache entry:
+
+```rust
+Mutex<Option<(MonotonicId, Bytes)>>
+```
+
+The cache contains encoded bytes rather than `T`. This avoids adding a
+`T: Clone` bound and lets the write path reuse the bytes it already encoded.
+Cloning `Bytes` does not copy the object body.
+
+Cache updates are monotonic. An update replaces the entry only when its ID is
+higher than the cached ID:
+
+```rust
+fn maybe_cache_latest(id, bytes):
+    lock latest
+    if latest is empty or id > latest.id:
+        latest = (id, bytes)
+```
+
+The cache holds one object body per protocol instance. A manifest can be
+several MiB, so this changes the steady-state memory footprint by the size of
+the latest encoded manifest and compactions object for each live store
+instance.
+
+### Cold Reads
+
+A protocol instance starts with an empty cache. Its first latest read keeps the
+existing behavior:
+
+```text
+LIST namespace
+    |
+    +-- empty --------------------> return None
+    |
+    +-- select highest ID N
+            |
+            +-- GET N succeeds ---> cache (N, bytes), return N
+            |
+            +-- GET N is 404 ------> repeat LIST
+```
+
+The LIST retry covers the race where GC deletes the listed object before the
+GET completes. Other object-store errors and codec errors return to the caller.
+
+### Warm Reads
+
+A warm read snapshots the cache, releases the mutex, and starts probing at the
+next ID:
+
+```text
+cached (N, bytes_N)
+    |
+    +-- GET N+1 is 404 -----------> decode bytes_N, return N
+    |
+    +-- GET N+1 succeeds
+            |
+            +-- cache (N+1, bytes_N+1)
+            +-- GET N+2
+                    |
+                    +-- continue until the first 404
+```
+
+The implementation never holds the cache mutex across an object-store request.
+Concurrent readers may issue duplicate probes. They cannot move the cache
+backward.
+
+The first missing successor terminates the probe. It does not trigger LIST.
+The cached bytes let the reader return the latest object without rereading it.
+
+### Write-Through Updates
+
+The write path encodes a new value once:
+
+1. Compute the next consecutive ID.
+2. Encode the value.
+3. PUT the object with create-if-absent.
+4. If the PUT succeeds, cache the ID and encoded bytes when the ID is higher
+   than the current cache entry.
+5. Run the existing boundary check.
+
+The generic checked write still decides whether the caller observes success.
+`write_unchecked` caches the object after its physical PUT because unchecked
+reads expose physically present objects.
+
+A write performed through the same protocol instance moves the read watermark
+without a LIST or a successful GET. The next latest read probes the following
+ID and returns the cached bytes on 404.
+
+### Boundary Checks and Garbage Collection
+
+RFC-0026 remains part of the protocol. The cache does not make deleted IDs safe
+to reuse and does not replace the durable GC boundary.
+
+A cached object can become stale after another process advances the boundary
+and GC deletes an old prefix. Checked latest reads already validate their
+result against the boundary:
+
+1. The probing path returns cached ID `N`.
+2. The boundary rejects `N`.
+3. The protocol invalidates the cache entry for `N`.
+4. The generic latest-read loop retries.
+5. The empty cache sends the retry through LIST.
+
+An object above `N` may appear during the first probe. In that case, probing
+advances the cache and can find an object above the boundary without LIST.
+
+Deleting a cached object through the same protocol invalidates the matching
+entry after the object-store DELETE succeeds. Remote GC remains safe because
+the boundary check catches cached IDs from the deleted prefix.
+
+### Concurrency and Sharing
+
+The cache belongs to `ObjectStoreSequencedStorageProtocol`, not the underlying
+`ObjectStore`. Components share it only when they share the same protocol
+instance, normally through an `Arc<ManifestStore>` or
+`Arc<CompactionsStore>`.
+
+Database components constructed together should reuse those store instances
+where their lifetimes allow it. A separately constructed GC process, admin
+client, or external compactor starts with an empty cache and pays one cold
+LIST. There is no process-wide registry keyed by object-store path.
+
+The cache update rule handles concurrent reads and writes:
+
+- A lower ID never replaces a higher cached ID.
+- Locks cover only cloning or replacing the cache entry.
+- Object bytes are immutable after create-if-absent succeeds.
+- A boundary rejection clears only the matching cached ID. It does not discard
+  a higher entry installed by another operation.
+
+### Failure Handling
+
+The probing path distinguishes a missing successor from other failures:
+
+- 404 for `N+1`: return cached `N`.
+- Successful GET for `N+1`: cache it and continue.
+- Other GET error: return the error.
+- Decode error: return the codec error.
+
+The protocol relies on consecutive physical IDs above the GC boundary. A
+writer must continue to create `current_id + 1`; it cannot skip an occupied or
+failed slot. GC may remove a prefix after advancing the boundary, but it cannot
+create a gap in the live suffix.
+
+## Impact Analysis
+
+SlateDB features and components that this RFC interacts with.
+
+### Core API & Query Semantics
+
+- [ ] Basic KV API (`get`/`put`/`delete`)
+- [ ] Range queries, iterators, seek semantics
+- [ ] Range deletions
+- [ ] Error model, API errors
+
+### Consistency, Isolation, and Multi-Versioning
+
+- [ ] Transactions
+- [ ] Snapshots
+- [ ] Sequence numbers
+
+### Time, Retention, and Derived State
+
+- [ ] Time to live (TTL)
+- [ ] Compaction filters
+- [ ] Merge operator
+- [ ] Change Data Capture (CDC)
+
+### Metadata, Coordination, and Lifecycles
+
+- [x] Manifest format
+- [x] Checkpoints
+- [ ] Clones
+- [x] Garbage collection
+- [ ] Database splitting and merging
+- [x] Multi-writer
+
+The manifest and compactions payload formats do not change. This RFC changes
+how callers locate the latest encoded object.
+
+### Compaction
+
+- [x] Compaction state persistence
+- [ ] Compaction filters
+- [ ] Compaction strategies
+- [ ] Distributed compaction
+- [ ] Compactions format
+
+### Storage Engine Internals
+
+- [ ] Write-ahead log (WAL)
+- [ ] Block cache
+- [x] Object store cache
+- [ ] Indexing (bloom filters, metadata)
+- [ ] SST format or block format
+
+### Ecosystem & Operations
+
+- [ ] CLI tools
+- [ ] Language bindings (Go/Python/etc)
+- [x] Observability (metrics/logging/tracing)
+
+## Operations
+
+### Performance and Cost
+
+The proposal moves object-store work from LIST to GET without adding a write
+request.
+
+| Operation | Existing LIST path | Cached probing |
+|---|---:|---:|
+| Successful write | 1 object PUT + boundary GET | Same |
+| Cold latest read | 1 LIST + object GET + boundary GET | Same |
+| Warm unchanged read | 1 LIST + object GET + boundary GET | 1 missing-successor GET + boundary GET |
+| Warm read `k` versions behind | 1 LIST + object GET + boundary GET | `k` GET hits + 1 GET miss + boundary GET |
+
+Object stores tend to bill LIST with PUT-class requests and GETs at a lower
+request rate. Exact prices depend on the provider and region. Probing should
+cost less when protocol instances live long enough to amortize their cold LIST
+and usually lag by a small number of versions.
+
+A process that falls far behind exchanges one LIST for many GETs. The ratio
+below captures that workload:
+
+```text
+probe_gets / latest_reads
+```
+
+A ratio near `1` means most reads issue one 404 probe and return cached bytes.
+A high ratio means readers often catch up across many external writes. Metrics
+should determine whether a probe limit or a different lookup protocol is
+needed.
+
+The proposal adds one encoded object body per live protocol instance. It does
+not add objects to storage or increase write amplification.
+
+### Observability
+
+Add counters for:
+
+- latest cache hits and cold misses;
+- LIST fallbacks;
+- successful and missing probe GETs;
+- cache advances from reads and writes; and
+- boundary-driven cache invalidations.
+
+Record a histogram of probes per latest read. Existing object-store metrics
+continue to report request latency and failures.
+
+No configuration is required.
+
+### Compatibility
+
+The object layout and payload formats do not change. Old and new SlateDB
+versions can read objects written by either implementation.
+
+Rolling upgrades are safe. Old processes continue to use LIST. New processes
+build their cache from LIST and then probe. Each process retains RFC-0026
+boundary checks, so mixed versions do not change GC fencing.
+
+No public Rust API or language binding changes.
+
+## Testing
+
+- Unit tests:
+  - a cold read uses LIST and caches the returned bytes;
+  - an unchanged warm read probes only the successor;
+  - a lagging reader probes consecutive objects and advances its cache;
+  - a successful write populates the cache;
+  - a boundary rejection invalidates the matching entry;
+  - a listed object deleted before GET causes another LIST.
+- Integration tests:
+  - manifest refresh and write tests;
+  - compactions state refresh and write tests.
+- Fault-injection/chaos tests:
+  - inject GET failures during a probe;
+  - delete a cached prefix after advancing the boundary;
+  - race readers and writers that share a protocol instance.
+- Deterministic simulation tests:
+  - retain existing sequenced metadata and GC coverage.
+- Formal methods verification: none.
+- Performance tests:
+  - measure request counts for warm reads, cold starts, and readers lagging by
+    increasing numbers of versions;
+  - measure the memory retained by cached manifest and compactions bytes.
+
+## Rollout
+
+The change is internal and does not require a feature flag.
+
+1. Add cache and probe request metrics.
+2. Enable probing for manifest and compactions stores.
+3. Compare LIST and GET request counts before and after deployment.
+4. Watch probes-per-read and cache memory by component.
+
+If probing causes unexpected request amplification, disabling the cache and
+returning to the existing LIST path requires no data migration.
+
+## Alternatives
+
+### LIST on Every Latest Read
+
+Keep listing the namespace and reading the highest object on every refresh.
+This has no process-local state and catches up in one LIST plus one GET,
+regardless of lag.
+
+The retained history makes LIST more expensive than the information needed by
+the caller. Repeating it when no version changed also adds avoidable request
+cost and latency.
+
+### Cache Only the Latest ID
+
+Cache `N` and probe `N+1`, but do not retain the bytes for `N`. When `N+1` is
+missing, the reader must either reread `N` or fall back to LIST before it can
+return the object.
+
+Caching bytes removes that extra object-store request and avoids a `T: Clone`
+bound. The memory cost is one encoded metadata object per protocol instance.
+
+### CURRENT Pointer
+
+Store a small mutable `CURRENT` object containing the latest sequence ID.
+Readers GET `CURRENT` and then GET the referenced metadata object. With a local
+bytes cache, an unchanged pointer can return the cached object after one GET.
+
+A pointer can support racing writes without making the pointer the commit
+point. Starting from object `N-1`, a writer races:
+
+1. create object `N` with create-if-absent; and
+2. update `CURRENT` from `N-1` to `N`.
+
+The two operations can complete in either order:
+
+| Result | Recovery |
+|---|---|
+| Both succeed | `N` is current. |
+| Object succeeds, pointer fails | Retry `CURRENT=N`. |
+| Pointer succeeds, object fails | Readers return `N-1`; writers retry object `N`. |
+| Object already exists | Another writer won `N`; refresh and return a write conflict. |
+
+A writer that observes `CURRENT=N` with object `N` missing must retry `N`.
+Advancing to `N+1` would create a gap and make reader fallback ambiguous.
+Once object `N` exists, it remains part of the sequence after `CURRENT`
+advances.
+
+This version of `CURRENT` is an advisory cursor. Object creation still commits
+a version, so RFC-0026 boundary files remain necessary. A stale writer could
+otherwise recreate an ID deleted by GC.
+
+`CURRENT` removes cold LISTs and long probe runs. It also adds a mutable pointer
+update to every write. Its steady-state request profile is:
+
+| Operation | Cached probing | `CURRENT` cursor |
+|---|---:|---:|
+| Successful write | 1 object PUT + boundary GET | 1 object PUT + 1 pointer PUT + boundary GET |
+| Warm unchanged read | 1 successor GET + boundary GET | 1 pointer GET + boundary GET |
+| Cold latest read | 1 LIST + object GET + boundary GET | 1 pointer GET + object GET + boundary GET |
+
+Both designs issue one lookup GET on an unchanged warm read. The pointer pays
+an extra PUT on every write to avoid cold LISTs and catch-up probes. Long-lived
+SlateDB processes with shared store instances should pay less with probing.
+Short-lived readers or processes that lag many versions may favor a pointer.
+A pointer that leads a failed object write adds a 404 GET and a fallback GET
+until some writer fills the reserved ID.
+
+Useful break-even inputs are:
+
+```text
+latest_reads
+cold_list_fallbacks
+probe_gets
+successful_writes
+```
+
+The pointer costs less when the LIST and probe requests it avoids cost more
+than one extra pointer PUT per successful write, including retries during write
+contention.
+
+### Authoritative CURRENT Pointer
+
+`CURRENT` could become the commit point instead of a cursor. A stale writer
+would write a candidate object and then conditionally update `CURRENT`. If the
+conditional update failed, readers would ignore the candidate. This could
+replace the GC boundary because recreating a deleted object would not publish
+it.
+
+That design changes the meaning of physical metadata files. A file could exist
+without ever becoming a committed historical version. A crash after writing
+deterministic object `N+1` but before updating `CURRENT` would also block later
+create-if-absent attempts for `N+1`.
+
+Writers could use unique candidate keys or skip occupied IDs, but both choices
+change the current layout and historical listing semantics. Racing publication
+before the candidate is durable can leave `CURRENT` pointing to a missing
+object. Reader fallback can handle the missing object, but the pointer then
+needs reservation and recovery rules.
+
+Cached probing keeps object creation as the commit point and preserves
+contiguous IDs. Existing tools can continue to treat physical sequenced
+objects as history.
+
+## Open Questions
+
+- Should builders share manifest and compactions store instances across more
+  embedded components to reduce cold LISTs?
+- Does the latest-object cache need a size limit for unusually large metadata
+  objects?
+
+## References
+
+- [RFC-0001: Manifest](0001-manifest.md)
+- [RFC-0026: Garbage Collector Boundary Files for Sequenced Metadata](0026-garbage-collector-boundary.md)
+- [slatedb/slatedb#1215: listed file missing before read](https://github.com/slatedb/slatedb/issues/1215)

--- a/rfcs/0032-cached-probing-sequenced-metadata.md
+++ b/rfcs/0032-cached-probing-sequenced-metadata.md
@@ -100,7 +100,7 @@ of downloading every intervening object.
 ## Goals
 
 - Idle databases should cost less than $5 per month.
-- Protocol should be freiendly to lagging readers.
+- Protocol should be friendly to lagging readers.
 - Remove LIST when a warm reader is close to the latest version.
 - Keep the existing object layout, write protocol, and GC boundary semantics.
 - Avoid rereading an unchanged latest object.

--- a/slatedb-txn-obj/src/lib.rs
+++ b/slatedb-txn-obj/src/lib.rs
@@ -604,8 +604,9 @@ pub trait BoundaryObject: Send + Sync {
 /// latest-version reads retry [`SequencedStorageProtocol::try_read_latest_unchecked`] until the
 /// returned ID is above the durable boundary; and [`SequencedStorageProtocol::delete`] only deletes
 /// versions at or below the boundary. Methods with `_unchecked` in their names, along with
-/// [`SequencedStorageProtocol::list`], expose physically present versions without boundary
-/// filtering.
+/// [`SequencedStorageProtocol::list`], do not filter against the durable boundary.
+/// [`SequencedStorageProtocol::try_read_latest_unchecked`] may return a process-local cached version
+/// after another process has deleted it from storage.
 #[async_trait]
 pub trait SequencedStorageProtocol<T: Send + Sync>:
     TransactionalStorageProtocol<T, MonotonicId> + BoundaryObject
@@ -621,6 +622,9 @@ pub trait SequencedStorageProtocol<T: Send + Sync>:
     ) -> Result<MonotonicId, TransactionalObjectError>;
 
     /// Read the latest version without checking it against the durable boundary.
+    ///
+    /// Implementations may serve a process-local cached version that is no longer physically
+    /// present in storage.
     ///
     /// Implementations provide this storage primitive and should rely on the generic
     /// [`TransactionalStorageProtocol::try_read_latest`] implementation for normal checked reads.

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -3,6 +3,7 @@ use crate::{
     BoundaryObject, MonotonicId, ObjectCodec, SequencedStorageProtocol, TransactionalObjectError,
 };
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::StreamExt;
 use log::{debug, error, warn};
 use object_store::path::Path;
@@ -33,6 +34,7 @@ pub struct ObjectStoreSequencedStorageProtocol<T> {
     codec: Box<dyn ObjectCodec<T>>,
     file_suffix: &'static str,
     boundary: Arc<dyn BoundaryObject>,
+    latest: Mutex<Option<(MonotonicId, Bytes)>>,
 }
 
 impl<T> ObjectStoreSequencedStorageProtocol<T> {
@@ -72,6 +74,7 @@ impl<T> ObjectStoreSequencedStorageProtocol<T> {
             codec,
             file_suffix,
             boundary,
+            latest: Mutex::new(None),
         }
     }
 
@@ -93,6 +96,40 @@ impl<T> ObjectStoreSequencedStorageProtocol<T> {
                 .map(MonotonicId::new)
                 .map_err(|_| TransactionalObjectError::InvalidObjectState),
             _ => Err(TransactionalObjectError::InvalidObjectState),
+        }
+    }
+
+    fn maybe_cache_latest(&self, id: MonotonicId, bytes: Bytes) {
+        let mut latest = self.latest.lock();
+        if latest
+            .as_ref()
+            .map(|(cached_id, _)| id > *cached_id)
+            .unwrap_or(true)
+        {
+            *latest = Some((id, bytes));
+        }
+    }
+
+    fn invalidate_cached(&self, id: MonotonicId) {
+        let mut latest = self.latest.lock();
+        if matches!(latest.as_ref(), Some((cached_id, _)) if *cached_id == id) {
+            *latest = None;
+        }
+    }
+
+    async fn try_read_bytes_unchecked(
+        &self,
+        id: MonotonicId,
+    ) -> Result<Option<Bytes>, TransactionalObjectError> {
+        let path = self.path_for(id);
+        match self.object_store.get(&path).await {
+            Ok(obj) => obj
+                .bytes()
+                .await
+                .map(Some)
+                .map_err(TransactionalObjectError::from),
+            Err(Error::NotFound { .. }) => Ok(None),
+            Err(e) => Err(TransactionalObjectError::from(e)),
         }
     }
 }
@@ -304,7 +341,11 @@ impl BoundaryObject for ObjectStoreBoundaryObject {
 #[async_trait]
 impl<T: Send + Sync> BoundaryObject for ObjectStoreSequencedStorageProtocol<T> {
     async fn check(&self, id: MonotonicId) -> Result<(), TransactionalObjectError> {
-        self.boundary.check(id).await
+        let result = self.boundary.check(id).await;
+        if matches!(&result, Err(TransactionalObjectError::ObjectVersionExists)) {
+            self.invalidate_cached(id);
+        }
+        result
     }
 
     async fn advance(&self, boundary: MonotonicId) -> Result<(), TransactionalObjectError> {
@@ -323,10 +364,11 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
             .map(|id| id.next())
             .unwrap_or(MonotonicId::initial());
         let path = self.path_for(id);
+        let bytes = self.codec.encode(new_value);
         self.object_store
             .put_opts(
                 &path,
-                PutPayload::from_bytes(self.codec.encode(new_value)),
+                PutPayload::from_bytes(bytes.clone()),
                 PutOptions::from(PutMode::Create),
             )
             .await
@@ -337,29 +379,53 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
                     TransactionalObjectError::from(err)
                 }
             })?;
+        self.maybe_cache_latest(id, bytes);
         Ok(id)
     }
 
     async fn try_read_latest_unchecked(
         &self,
     ) -> Result<Option<(MonotonicId, T)>, TransactionalObjectError> {
+        let cached = self.latest.lock().clone();
+        if let Some((mut id, mut bytes)) = cached {
+            loop {
+                let next_id = id.next();
+                match self.try_read_bytes_unchecked(next_id).await? {
+                    Some(next_bytes) => {
+                        id = next_id;
+                        bytes = next_bytes;
+                        self.maybe_cache_latest(id, bytes.clone());
+                    }
+                    // IDs are consecutive, so a missing successor means the
+                    // cached object is the latest version.
+                    None => {
+                        return self
+                            .codec
+                            .decode(&bytes)
+                            .map(|value| Some((id, value)))
+                            .map_err(CallbackError);
+                    }
+                }
+            }
+        }
+
         loop {
             let files = self.list(Unbounded, Unbounded).await?;
             if let Some(file) = files.last() {
-                let result = self
-                    .try_read_unchecked(file.id)
-                    .await
-                    .map(|opt| opt.map(|v| (file.id, v)));
-                match result {
+                match self.try_read_bytes_unchecked(file.id).await? {
                     // File listed but not found. Probably deleted by GC. Retry list/read.
                     // See https://github.com/slatedb/slatedb/issues/1215 for more details.
-                    Ok(None) => {
+                    None => {
                         warn!(
                             "listed file missing on read, retrying [location={}]",
                             file.metadata.location,
                         );
                     }
-                    _ => return result,
+                    Some(bytes) => {
+                        let value = self.codec.decode(&bytes).map_err(CallbackError)?;
+                        self.maybe_cache_latest(file.id, bytes);
+                        return Ok(Some((file.id, value)));
+                    }
                 }
             } else {
                 // No files found, so return None
@@ -373,16 +439,9 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
         &self,
         id: MonotonicId,
     ) -> Result<Option<T>, TransactionalObjectError> {
-        let path = self.path_for(id);
-        match self.object_store.get(&path).await {
-            Ok(obj) => match obj.bytes().await {
-                Ok(bytes) => self.codec.decode(&bytes).map(Some).map_err(CallbackError),
-                Err(e) => Err(TransactionalObjectError::from(e)),
-            },
-            Err(e) => match e {
-                Error::NotFound { .. } => Ok(None),
-                _ => Err(TransactionalObjectError::from(e)),
-            },
+        match self.try_read_bytes_unchecked(id).await? {
+            Some(bytes) => self.codec.decode(&bytes).map(Some).map_err(CallbackError),
+            None => Ok(None),
         }
     }
 
@@ -421,7 +480,9 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
         self.object_store
             .delete(&path)
             .await
-            .map_err(TransactionalObjectError::from)
+            .map_err(TransactionalObjectError::from)?;
+        self.invalidate_cached(id);
+        Ok(())
     }
 }
 
@@ -574,6 +635,7 @@ mod tests {
         inner: InMemory,
         get_opts_calls: AtomicUsize,
         if_none_match_gets: AtomicUsize,
+        list_calls: AtomicUsize,
         blocking_not_found: StdMutex<Option<BlockingNotFoundGet>>,
     }
 
@@ -583,6 +645,7 @@ mod tests {
                 inner: InMemory::new(),
                 get_opts_calls: AtomicUsize::new(0),
                 if_none_match_gets: AtomicUsize::new(0),
+                list_calls: AtomicUsize::new(0),
                 blocking_not_found: StdMutex::new(None),
             }
         }
@@ -655,6 +718,7 @@ mod tests {
         }
 
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
+            self.list_calls.fetch_add(1, Ordering::SeqCst);
             self.inner.list(prefix)
         }
 
@@ -673,6 +737,30 @@ mod tests {
         ) -> ObjectStoreResult<()> {
             self.inner.copy_opts(from, to, options).await
         }
+    }
+
+    fn new_counting_protocol() -> (
+        Arc<CountingGetStore>,
+        Arc<ObjectStoreSequencedStorageProtocol<TestVal>>,
+    ) {
+        let counting_store = Arc::new(CountingGetStore::new());
+        let object_store: Arc<dyn ObjectStore> = counting_store.clone();
+        let protocol = Arc::new(ObjectStoreSequencedStorageProtocol::new(
+            &Path::from("/root"),
+            object_store,
+            "test",
+            "val",
+            Box::new(TestValCodec),
+        ));
+        (counting_store, protocol)
+    }
+
+    async fn put_test_value(store: &CountingGetStore, id: u64, value: &TestVal) {
+        let path = Path::from(format!("/root/test/{:020}.val", id));
+        store
+            .put(&path, PutPayload::from_bytes(TestValCodec.encode(value)))
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -928,6 +1016,94 @@ mod tests {
         assert!(missing.is_none());
     }
 
+    #[tokio::test]
+    async fn test_latest_read_caches_bytes_after_list() {
+        let (object_store, store) = new_counting_protocol();
+        let expected = TestVal {
+            epoch: 1,
+            payload: 10,
+        };
+        put_test_value(&object_store, 1, &expected).await;
+
+        let first = store.try_read_latest_unchecked().await.unwrap().unwrap();
+        assert_eq!((MonotonicId::new(1), expected.clone()), first);
+        assert_eq!(1, object_store.list_calls.load(Ordering::SeqCst));
+
+        let gets = object_store.get_opts_calls.load(Ordering::SeqCst);
+        let second = store.try_read_latest_unchecked().await.unwrap().unwrap();
+        assert_eq!((MonotonicId::new(1), expected), second);
+        assert_eq!(1, object_store.list_calls.load(Ordering::SeqCst));
+        assert_eq!(
+            gets + 1,
+            object_store.get_opts_calls.load(Ordering::SeqCst),
+            "the warm read should only probe id 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_latest_read_linearly_probes_from_cached_id() {
+        let (object_store, store) = new_counting_protocol();
+        let first = TestVal {
+            epoch: 1,
+            payload: 10,
+        };
+        let second = TestVal {
+            epoch: 1,
+            payload: 20,
+        };
+        let third = TestVal {
+            epoch: 1,
+            payload: 30,
+        };
+        put_test_value(&object_store, 1, &first).await;
+        store.try_read_latest_unchecked().await.unwrap().unwrap();
+
+        put_test_value(&object_store, 2, &second).await;
+        put_test_value(&object_store, 3, &third).await;
+
+        let latest = store.try_read_latest_unchecked().await.unwrap().unwrap();
+        assert_eq!((MonotonicId::new(3), third), latest);
+        assert_eq!(1, object_store.list_calls.load(Ordering::SeqCst));
+        assert_eq!(
+            Some(MonotonicId::new(3)),
+            store.latest.lock().as_ref().map(|(id, _)| *id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_successful_write_populates_latest_cache() {
+        let (object_store, store) = new_counting_protocol();
+        let expected = TestVal {
+            epoch: 1,
+            payload: 10,
+        };
+
+        let id = store.write(None, &expected).await.unwrap();
+        let latest = store.try_read_latest().await.unwrap().unwrap();
+
+        assert_eq!((id, expected), latest);
+        assert_eq!(0, object_store.list_calls.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_boundary_rejection_invalidates_latest_cache() {
+        let (_, store) = new_counting_protocol();
+        let value = TestVal {
+            epoch: 1,
+            payload: 10,
+        };
+        let id = store.write(None, &value).await.unwrap();
+        store.advance(id).await.unwrap();
+
+        let error = store.check(id).await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            TransactionalObjectError::ObjectVersionExists
+        ));
+        assert!(store.latest.lock().is_none());
+    }
+
     /// Validate that try_read_latest retries when a listed file is missing on read.
     #[tokio::test]
     async fn test_try_read_latest_retries_missing_listed_file() {
@@ -961,6 +1137,7 @@ mod tests {
                 flaky_store.clone(),
                 "test",
             )),
+            latest: parking_lot::Mutex::new(None),
         };
 
         let latest = store.try_read_latest().await.unwrap().unwrap();

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -428,8 +428,14 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
 
         loop {
             let files = self.list(Unbounded, Unbounded).await?;
+            let cached = self.latest.lock().clone();
             if let Some(file) = files.last() {
-                match self.try_read_bytes_unchecked(file.id).await? {
+                // Reuse cached bytes when LIST selects the cached ID instead of issuing another GET.
+                let bytes = match cached {
+                    Some((cached_id, bytes)) if cached_id == file.id => Some(bytes),
+                    _ => self.try_read_bytes_unchecked(file.id).await?,
+                };
+                match bytes {
                     // File listed but not found. Probably deleted by GC. Retry list/read.
                     // See https://github.com/slatedb/slatedb/issues/1215 for more details.
                     None => {
@@ -445,7 +451,10 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
                     }
                 }
             } else {
-                // No files found, so return None
+                // Clear the observed entry so a later read cannot resurrect it after an empty LIST.
+                if let Some((cached_id, _)) = cached {
+                    self.invalidate_cached(cached_id);
+                }
                 break;
             }
         }
@@ -525,7 +534,7 @@ mod tests {
     };
     use std::collections::Bound::{Excluded, Included, Unbounded};
     use std::fmt;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex as StdMutex};
     use tokio::sync::Notify;
 
@@ -653,6 +662,7 @@ mod tests {
         get_opts_calls: AtomicUsize,
         if_none_match_gets: AtomicUsize,
         list_calls: AtomicUsize,
+        list_empty: AtomicBool,
         blocking_not_found: StdMutex<Option<BlockingNotFoundGet>>,
     }
 
@@ -663,6 +673,7 @@ mod tests {
                 get_opts_calls: AtomicUsize::new(0),
                 if_none_match_gets: AtomicUsize::new(0),
                 list_calls: AtomicUsize::new(0),
+                list_empty: AtomicBool::new(false),
                 blocking_not_found: StdMutex::new(None),
             }
         }
@@ -736,6 +747,9 @@ mod tests {
 
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, ObjectStoreResult<ObjectMeta>> {
             self.list_calls.fetch_add(1, Ordering::SeqCst);
+            if self.list_empty.load(Ordering::SeqCst) {
+                return stream::empty().boxed();
+            }
             self.inner.list(prefix)
         }
 
@@ -1117,6 +1131,62 @@ mod tests {
             object_store.get_opts_calls.load(Ordering::SeqCst),
             "the warm read should issue four probes and GET the object selected by LIST"
         );
+    }
+
+    #[tokio::test]
+    async fn test_latest_read_reuses_cached_bytes_after_four_probes() {
+        let (object_store, store) = new_counting_protocol();
+        let first = TestVal {
+            epoch: 1,
+            payload: 1,
+        };
+        put_test_value(&object_store, 1, &first).await;
+        store.try_read_latest_unchecked().await.unwrap().unwrap();
+
+        for id in 2..=5 {
+            let value = TestVal {
+                epoch: 1,
+                payload: id,
+            };
+            put_test_value(&object_store, id, &value).await;
+        }
+
+        let gets = object_store.get_opts_calls.load(Ordering::SeqCst);
+        let latest = store.try_read_latest_unchecked().await.unwrap().unwrap();
+
+        assert_eq!(MonotonicId::new(5), latest.0);
+        assert_eq!(5, latest.1.payload);
+        assert_eq!(2, object_store.list_calls.load(Ordering::SeqCst));
+        assert_eq!(
+            gets + 4,
+            object_store.get_opts_calls.load(Ordering::SeqCst),
+            "the LIST fallback should reuse the bytes from the fourth probe"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_latest_read_invalidates_cache_when_list_is_empty() {
+        let (object_store, store) = new_counting_protocol();
+        let first = TestVal {
+            epoch: 1,
+            payload: 1,
+        };
+        put_test_value(&object_store, 1, &first).await;
+        store.try_read_latest_unchecked().await.unwrap().unwrap();
+
+        for id in 2..=5 {
+            let value = TestVal {
+                epoch: 1,
+                payload: id,
+            };
+            put_test_value(&object_store, id, &value).await;
+        }
+        object_store.list_empty.store(true, Ordering::SeqCst);
+
+        let latest = store.try_read_latest_unchecked().await.unwrap();
+
+        assert!(latest.is_none());
+        assert!(store.latest.lock().is_none());
     }
 
     #[tokio::test]

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -18,6 +18,8 @@ use std::collections::Bound::Unbounded;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
+const MAX_PROBES: usize = 4;
+
 /// Implements `SequencedStorageProtocol<T>` on object storage.
 ///
 /// ## File layout and naming
@@ -388,7 +390,7 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
     ) -> Result<Option<(MonotonicId, T)>, TransactionalObjectError> {
         let cached = self.latest.lock().clone();
         if let Some((mut id, mut bytes)) = cached {
-            loop {
+            for _ in 0..MAX_PROBES {
                 let next_id = id.next();
                 match self.try_read_bytes_unchecked(next_id).await? {
                     Some(next_bytes) => {
@@ -1067,6 +1069,38 @@ mod tests {
         assert_eq!(
             Some(MonotonicId::new(3)),
             store.latest.lock().as_ref().map(|(id, _)| *id)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_latest_read_falls_back_to_list_after_four_probes() {
+        let (object_store, store) = new_counting_protocol();
+        let first = TestVal {
+            epoch: 1,
+            payload: 1,
+        };
+        put_test_value(&object_store, 1, &first).await;
+        store.try_read_latest_unchecked().await.unwrap().unwrap();
+        assert_eq!(1, object_store.list_calls.load(Ordering::SeqCst));
+
+        for id in 2..=8 {
+            let value = TestVal {
+                epoch: 1,
+                payload: id,
+            };
+            put_test_value(&object_store, id, &value).await;
+        }
+
+        let gets = object_store.get_opts_calls.load(Ordering::SeqCst);
+        let latest = store.try_read_latest_unchecked().await.unwrap().unwrap();
+
+        assert_eq!(MonotonicId::new(8), latest.0);
+        assert_eq!(8, latest.1.payload);
+        assert_eq!(2, object_store.list_calls.load(Ordering::SeqCst));
+        assert_eq!(
+            gets + 5,
+            object_store.get_opts_calls.load(Ordering::SeqCst),
+            "the warm read should issue four probes and GET the object selected by LIST"
         );
     }
 

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -119,6 +119,13 @@ impl<T> ObjectStoreSequencedStorageProtocol<T> {
         }
     }
 
+    fn invalidate_cached_through(&self, boundary: MonotonicId) {
+        let mut latest = self.latest.lock();
+        if matches!(latest.as_ref(), Some((cached_id, _)) if *cached_id <= boundary) {
+            *latest = None;
+        }
+    }
+
     async fn try_read_bytes_unchecked(
         &self,
         id: MonotonicId,
@@ -351,7 +358,9 @@ impl<T: Send + Sync> BoundaryObject for ObjectStoreSequencedStorageProtocol<T> {
     }
 
     async fn advance(&self, boundary: MonotonicId) -> Result<(), TransactionalObjectError> {
-        self.boundary.advance(boundary).await
+        self.boundary.advance(boundary).await?;
+        self.invalidate_cached_through(boundary);
+        Ok(())
     }
 }
 
@@ -1141,6 +1150,40 @@ mod tests {
             error,
             TransactionalObjectError::ObjectVersionExists
         ));
+        assert!(store.latest.lock().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_boundary_advance_invalidates_cached_entries_through_boundary() {
+        let (_, store) = new_counting_protocol();
+        let first_id = store
+            .write(
+                None,
+                &TestVal {
+                    epoch: 1,
+                    payload: 10,
+                },
+            )
+            .await
+            .unwrap();
+        let second_id = store
+            .write(
+                Some(first_id),
+                &TestVal {
+                    epoch: 1,
+                    payload: 20,
+                },
+            )
+            .await
+            .unwrap();
+
+        store.advance(first_id).await.unwrap();
+        assert_eq!(
+            Some(second_id),
+            store.latest.lock().as_ref().map(|(id, _)| *id)
+        );
+
+        store.advance(second_id).await.unwrap();
         assert!(store.latest.lock().is_none());
     }
 

--- a/slatedb-txn-obj/src/object_store.rs
+++ b/slatedb-txn-obj/src/object_store.rs
@@ -409,6 +409,12 @@ impl<T: Send + Sync> SequencedStorageProtocol<T> for ObjectStoreSequencedStorage
                     }
                 }
             }
+            debug!(
+                "latest read probe limit reached, falling back to list [directory={}, last_seen_id={}, probes={}]",
+                self.dir_path,
+                id.id(),
+                MAX_PROBES,
+            );
         }
 
         loop {


### PR DESCRIPTION
## Summary

The latest distributed compaction changes poll for data more frequently. This has cause the cost of an idle database to creep upwards of 25$/mo, which is way too high.

This PR adds an RFC and a patch to using linear probing with a LIST fallback rather than LIST'ing right away. It also introduces a simple cache for the most recently written/seen ID and bytes. Because the manifest and compactions stores are shared, this simple cache means the default configuration of `Db` with compactor scheduler and worker will all see the same data and further reduce GETs.

- Before: https://benchmark.slatedb.io/sha-5b494cc46af8/run/github-30164986567/workload/idle/ ~28$/mo
- After: https://benchmark.slatedb.io/sha-5b494cc46af8/run/github-30185019035/workload/idle/ $4.80/mo

Boundary checks remain intact. There is discussion in the RFC about alternatives to this design and why I opted for what I did.

For single-node DBs, this approach should be strictly better than `CURRENT` pointers (the other major alternative design in the RFC). For multi-node DBs (compactor scheduler, gc, and/or compaction worker on different machines), this approach will be better than `CURRENT` as long as there is not high churn on the metadata objects (> 4 mutations per-poll interval). If we see issues, we can add smarter probing (adaptive, non-linear, and/or in parallel).

The RFC and code is all Sol with steering from me.

## Changes

- cache the latest sequenced metadata ID and encoded bytes
- probe up to four successor objects before falling back to LIST
- update the cache after successful reads and writes, and invalidate stale entries after boundary rejection or deletion
- log probe-limit LIST fallbacks at debug level
- document the protocol, request costs, and alternatives in RFC 0032

## Why

Latest manifest and compactions reads currently LIST objects to find the latest. A process-local watermark turns an unchanged warm read into one missing-successor GET. The four-probe limit bounds catch-up requests when a reader falls behind.