### PR TITLE
Fix panic when probing a zero-bit prefix Bloom filter

### DIFF
--- a/slatedb/src/filter.rs
+++ b/slatedb/src/filter.rs
@@ -122,6 +122,13 @@ impl BloomFilter {
     }
 
     fn might_contain(&self, hash: u64) -> bool {
+        // A prefix-only filter built from an SST where the extractor yielded
+        // no prefixes has zero bits (and so do filters like it already
+        // persisted in existing SSTs). Nothing was hashed into it, so nothing
+        // can match; probing would divide by zero in probes_for_key.
+        if self.buffer.is_empty() {
+            return false;
+        }
         for p in probes_for_key(hash, self.num_probes, self.filter_bits()) {
             if !check_bit(p as usize, &self.buffer) {
                 return false;
@@ -441,5 +448,40 @@ mod tests {
             BloomFilter::estimate_encoded_size(num_keys, bits_per_key),
             expected_size
         );
+    }
+
+    /// Extracts a fixed 4-byte prefix, but only from targets that are at
+    /// least 4 bytes long. Shorter keys have no extractable prefix.
+    struct GatedFixed4;
+
+    impl PrefixExtractor for GatedFixed4 {
+        fn name(&self) -> &str {
+            "gated_fixed_4"
+        }
+
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let bytes = match target {
+                PrefixTarget::Point(k) => k.as_ref(),
+                PrefixTarget::Prefix(p) => p.as_ref(),
+            };
+            (bytes.len() >= 4).then_some(4)
+        }
+    }
+
+    #[test]
+    fn test_prefix_only_filter_with_no_extracted_prefixes() {
+        // With whole-key filtering off and a gated extractor that yields no
+        // prefix for any stored key, the built filter holds zero hashes and
+        // zero bits. Probing it with a query the extractor accepts must not
+        // panic, and reporting a miss is safe: no key in the SST carries any
+        // extractable prefix, so no key can match the queried one.
+        let mut builder = BloomFilterBuilder::new(10, false, Some(Arc::new(GatedFixed4)));
+        builder.add_key(&Bytes::from_static(b"a"));
+        builder.add_key(&Bytes::from_static(b"b"));
+        let filter = builder.build_filter();
+        assert!(filter.buffer.is_empty());
+
+        assert!(!filter.might_match(&FilterQuery::prefix(Bytes::from_static(b"aaaa"))));
+        assert!(!filter.might_match(&FilterQuery::point(Bytes::from_static(b"aaaa_key"))));
     }
 }

--- a/slatedb/src/filter.rs
+++ b/slatedb/src/filter.rs
@@ -122,10 +122,8 @@ impl BloomFilter {
     }
 
     fn might_contain(&self, hash: u64) -> bool {
-        // A prefix-only filter built from an SST where the extractor yielded
-        // no prefixes has zero bits (and so do filters like it already
-        // persisted in existing SSTs). Nothing was hashed into it, so nothing
-        // can match; probing would divide by zero in probes_for_key.
+        // A filter built with zero extracted hashes has zero bits: nothing can
+        // match, and probing it would divide by zero in probes_for_key.
         if self.buffer.is_empty() {
             return false;
         }
@@ -450,8 +448,7 @@ mod tests {
         );
     }
 
-    /// Extracts a fixed 4-byte prefix, but only from targets that are at
-    /// least 4 bytes long. Shorter keys have no extractable prefix.
+    /// Extracts a fixed 4-byte prefix; shorter targets yield no prefix.
     struct GatedFixed4;
 
     impl PrefixExtractor for GatedFixed4 {
@@ -470,11 +467,8 @@ mod tests {
 
     #[test]
     fn test_prefix_only_filter_with_no_extracted_prefixes() {
-        // With whole-key filtering off and a gated extractor that yields no
-        // prefix for any stored key, the built filter holds zero hashes and
-        // zero bits. Probing it with a query the extractor accepts must not
-        // panic, and reporting a miss is safe: no key in the SST carries any
-        // extractable prefix, so no key can match the queried one.
+        // Zero extracted prefixes + whole-key filtering off = zero-bit filter.
+        // Probing it must not panic, and a miss is safe: nothing was hashed in.
         let mut builder = BloomFilterBuilder::new(10, false, Some(Arc::new(GatedFixed4)));
         builder.add_key(&Bytes::from_static(b"a"));
         builder.add_key(&Bytes::from_static(b"b"));
@@ -483,5 +477,10 @@ mod tests {
 
         assert!(!filter.might_match(&FilterQuery::prefix(Bytes::from_static(b"aaaa"))));
         assert!(!filter.might_match(&FilterQuery::point(Bytes::from_static(b"aaaa_key"))));
+
+        // Queries the extractor rejects never reach the filter and must keep
+        // reporting "might match", so the stored short keys stay reachable.
+        assert!(filter.might_match(&FilterQuery::prefix(Bytes::from_static(b"a"))));
+        assert!(filter.might_match(&FilterQuery::point(Bytes::from_static(b"a"))));
     }
 }

--- a/slatedb/src/filter.rs
+++ b/slatedb/src/filter.rs
@@ -483,4 +483,19 @@ mod tests {
         assert!(filter.might_match(&FilterQuery::prefix(Bytes::from_static(b"a"))));
         assert!(filter.might_match(&FilterQuery::point(Bytes::from_static(b"a"))));
     }
+
+    #[test]
+    fn test_combined_filter_with_no_extracted_prefixes() {
+        // With whole-key filtering on, every key hashes into the filter even
+        // when the extractor yields nothing, so the empty-filter guard never fires.
+        let mut builder = BloomFilterBuilder::new(10, true, Some(Arc::new(GatedFixed4)));
+        builder.add_key(&Bytes::from_static(b"a"));
+        builder.add_key(&Bytes::from_static(b"b"));
+        let filter = builder.build_filter();
+        assert!(!filter.buffer.is_empty());
+
+        // Point lookups take the whole-key path and find the stored keys.
+        assert!(filter.might_match(&FilterQuery::point(Bytes::from_static(b"a"))));
+        assert!(filter.might_match(&FilterQuery::point(Bytes::from_static(b"b"))));
+    }
 }

--- a/slatedb/tests/prefix_filter.rs
+++ b/slatedb/tests/prefix_filter.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the prefix bloom filter.
 //!
-//! Three test modules:
+//! Four test modules:
 //!   * [`composite_filters`]: integration tests that configure two filter
 //!     policies on a single DB (one full-key, one conditional prefix) and
 //!     verify reads work after closing/reopening with policies in a different
@@ -8,6 +8,9 @@
 //!   * [`subrange`]: integration tests for `scan_prefix` restricted to a
 //!     subrange, asserting both correct results and actual SST pruning via
 //!     the filter-negative counter.
+//!   * [`empty_prefix_filter`]: regression tests for #1966 — a persisted
+//!     zero-bit prefix filter must report a miss instead of panicking, on
+//!     fresh and reopened DBs.
 //!   * [`prop_test`]: a property test asserting that `scan_prefix` (with and
 //!     without a subrange) returns the same results with and without a prefix
 //!     bloom filter configured. The filter must never introduce false
@@ -377,6 +380,141 @@ mod subrange {
             "plain range scans must not consult prefix filters"
         );
 
+        db.close().await.expect("close failed");
+    }
+}
+
+mod empty_prefix_filter {
+    use std::sync::Arc;
+
+    use slatedb::config::{FlushOptions, FlushType, PutOptions, Settings, WriteOptions};
+    use slatedb::db_stats::{
+        FILTER_KIND_LABEL, FILTER_KIND_POINT, FILTER_KIND_PREFIX, SST_FILTER_NEGATIVE_COUNT,
+    };
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::ObjectStore;
+    use slatedb::{BloomFilterPolicy, Db, PrefixExtractor, PrefixTarget};
+    use slatedb_common::metrics::{DefaultMetricsRecorder, MetricValue};
+
+    const PREFIX_LEN: usize = 4;
+
+    /// Extracts a 4-byte prefix only from inputs of at least 4 bytes, so an
+    /// SST holding only shorter keys builds a zero-bit prefix filter.
+    struct GatedPrefixExtractor;
+
+    impl PrefixExtractor for GatedPrefixExtractor {
+        fn name(&self) -> &str {
+            "gated4"
+        }
+
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let input = match target {
+                PrefixTarget::Point(k) => k.as_ref(),
+                PrefixTarget::Prefix(p) => p.as_ref(),
+            };
+            (input.len() >= PREFIX_LEN).then_some(PREFIX_LEN)
+        }
+    }
+
+    fn filter_negatives(recorder: &DefaultMetricsRecorder, kind: &'static str) -> u64 {
+        recorder
+            .snapshot()
+            .by_name_and_labels(SST_FILTER_NEGATIVE_COUNT, &[(FILTER_KIND_LABEL, kind)])
+            .map(|m| match m.value {
+                MetricValue::Counter(v) => v,
+                ref other => panic!("expected counter, got {:?}", other),
+            })
+            .unwrap_or(0)
+    }
+
+    async fn open_db(store: Arc<dyn ObjectStore>, recorder: Arc<DefaultMetricsRecorder>) -> Db {
+        Db::builder("/test/empty_prefix_filter", store)
+            .with_settings(Settings {
+                min_filter_keys: 0,
+                compactor_options: None,
+                ..Settings::default()
+            })
+            .with_filter_policies(vec![Arc::new(
+                BloomFilterPolicy::new(10)
+                    .with_whole_key_filtering(false)
+                    .with_prefix_extractor(Arc::new(GatedPrefixExtractor)),
+            )])
+            .with_metrics_recorder(recorder)
+            .build()
+            .await
+            .expect("failed to build db")
+    }
+
+    async fn collect_keys(mut iter: slatedb::DbIterator) -> Vec<Vec<u8>> {
+        let mut keys = Vec::new();
+        while let Some(kv) = iter.next().await.expect("iterator next failed") {
+            keys.push(kv.key.to_vec());
+        }
+        keys
+    }
+
+    async fn assert_empty_filter_reads(db: &Db, recorder: &DefaultMetricsRecorder) {
+        // Extractor-rejected queries bypass the filter; short keys stay reachable.
+        for key in [b"a".as_slice(), b"b".as_slice()] {
+            let got = db.get(key).await.expect("get failed");
+            assert!(got.is_some(), "expected key {:?} to be present", key);
+        }
+        let iter = db.scan_prefix(b"a", ..).await.expect("scan_prefix failed");
+        assert_eq!(collect_keys(iter).await, vec![b"a".to_vec()]);
+
+        // Extractor-accepted queries probe the zero-bit filter: before the
+        // fix this panicked with a division by zero; now the SST is skipped.
+        let negatives_before = filter_negatives(recorder, FILTER_KIND_PREFIX);
+        let iter = db
+            .scan_prefix(b"aaaa", ..)
+            .await
+            .expect("scan_prefix failed");
+        assert!(collect_keys(iter).await.is_empty());
+        assert_eq!(
+            filter_negatives(recorder, FILTER_KIND_PREFIX) - negatives_before,
+            1,
+            "expected the SST to be skipped on the empty prefix filter"
+        );
+
+        let negatives_before = filter_negatives(recorder, FILTER_KIND_POINT);
+        let got = db.get(b"aaaa").await.expect("get failed");
+        assert!(got.is_none());
+        assert_eq!(
+            filter_negatives(recorder, FILTER_KIND_POINT) - negatives_before,
+            1,
+            "expected the SST to be skipped on the empty prefix filter"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_filter_reports_miss_after_write_and_reopen() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let db = open_db(store.clone(), recorder.clone()).await;
+
+        let put = PutOptions::default();
+        let write = WriteOptions {
+            await_durable: false,
+            seqnum: 0,
+        };
+        for key in [b"a".as_slice(), b"b".as_slice()] {
+            db.put_with_options(key, b"v", &put, &write)
+                .await
+                .expect("put failed");
+        }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("memtable flush failed");
+
+        assert_empty_filter_reads(&db, &recorder).await;
+        db.close().await.expect("close failed");
+
+        // Reopen so the zero-bit filter is decoded from the persisted SST.
+        let recorder = Arc::new(DefaultMetricsRecorder::new());
+        let db = open_db(store, recorder.clone()).await;
+        assert_empty_filter_reads(&db, &recorder).await;
         db.close().await.expect("close failed");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1966.

A prefix-only Bloom filter panics with `attempt to calculate the remainder with a divisor of zero` (`filter.rs:208`) when it was built from an SST in which the configured prefix extractor yielded no prefix for any key.

How the filter ends up with zero bits: with `whole_key_filtering(false)`, a gated extractor (e.g. fixed-length, only extracting from keys ≥ N bytes) can return `None` for every key in an SST that still passes `min_filter_keys`. Nothing gets hashed, so `build_filter` sizes the buffer as `0 hashes × bits_per_key = 0` bits and persists a zero-bit filter. The first query the extractor accepts then probes it, and `probes_for_key` computes `hash % filter_bits` with `filter_bits = 0`.

The fix is a guard in `BloomFilter::might_contain`: an empty filter reports a miss (`false`) instead of probing.

## Why returning `false` is correct

Two directions to check — the filter must never produce a false negative, and unextractable keys must remain reachable:

**No false negatives (the skip is provably safe).** The extractor contract ties build time to query time: if the extractor accepts a query (`prefix_len` returns `Some(n)`), then any key that could match that query has an extractable prefix, and would have had that prefix hashed into the filter when the SST was built. Contrapositive: if the filter is empty, no key in this SST has any extractable prefix, so no key in this SST can match any extractor-accepted query. Reporting a miss is the exact truth, not an approximation — and it is also the optimal answer, since the SST is skipped.

**Unextractable keys stay findable (the guard is unreachable for them).** The keys that produced no hashes (e.g. keys shorter than a fixed-length extractor's N) can only be found by queries the extractor also rejects — `get("a")` or `scan("a")` make `prefix_len` return `None` on the query side, and `might_match` already returns `true` ("cannot prune") before `might_contain` is reached. Those reads proceed to the SST as they always did. So the guard only ever fires for queries whose match is impossible, and never hides a key.

**Worked example** — SST contains keys `"a"` and `"b"`, extractor is fixed-4-byte gated (extracts only from keys ≥ 4 bytes), whole-key filtering off, so the filter is empty:

1. `get("a")` — before probing, `might_match` asks the extractor about the query itself: `prefix_len(Point("a"))` → 1 byte, too short → `None`. The `None`-on-query rule (filter.rs:162) returns `true` ("can't prune — go read the SST"), so the SST is read and the block index finds `"a"`. The empty filter is never probed.
2. `scan(prefix = "a")` — same path: `None` → `true` → SST read → `"a"` found.
3. `scan(prefix = "aaaa")` — the case that used to panic. The extractor accepts the query (`Some(4)`), the empty filter is probed, and the guard returns `false` → SST skipped. Should this scan have found `"a"`? No: it only matches keys starting with `"aaaa"`, and a 1-byte key can't start with a 4-byte prefix. Nothing is lost.

| Query | Extractor says | Result |
|---|---|---|
| `get("a")` | `None` (too short) | filter skipped → SST read, `"a"` found |
| `scan("a")` | `None` (too short) | filter skipped → SST read, `"a"` found |
| `scan("aaaa")` | `Some(4)` | empty filter → `false` → SST skipped; correct, `"a"` can't match |

The guard is on the read side (rather than skipping filter creation at build time) deliberately: zero-bit filters are already persisted in SSTs written by existing databases, and `BloomFilter::decode` reloads them as empty buffers — they hit the same guard. A build-side-only fix would leave existing data panicking.

## Changes

- `BloomFilter::might_contain`: return `false` for a zero-bit filter instead of probing (probing would compute `hash % 0`).
- Regression test `test_prefix_only_filter_with_no_extracted_prefixes`: builds a prefix-only filter through a gated extractor that yields no prefixes, asserts the built filter is empty, and asserts both a prefix query and a point query the extractor accepts report a miss instead of panicking. Written before the fix; it reproduces the exact panic from the issue. Also asserts queries the extractor *rejects* still return "might match", so stored short keys stay reachable (no over-pruning).
- Test `test_combined_filter_with_no_extracted_prefixes`: same gated extractor and keys with `whole_key_filtering(true)` — the buffer is non-empty, the guard never fires, and point lookups find the stored keys via the whole-key path. Covers the "guard must preserve combined whole-key + prefix behavior" requirement from #1966.
- New integration test module `empty_prefix_filter` in `slatedb/tests/prefix_filter.rs`: E2E regression coverage for #1966, exercising a persisted zero-bit prefix filter through the full DB read path

## Notes for Reviewers

- The combined whole-key + prefix configuration is unaffected: with `whole_key_filtering(true)`, any non-empty SST produces at least one hash, so the buffer is non-empty and the guard never triggers.
- A possible follow-up is to also skip encoding zero-bit filters at build time (saves the 2-byte header + composite block entry). Left out to keep this scoped to the panic; the read-side guard is required either way for already-written SSTs.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features` (2144 passed, 1 skipped)
- [x] Called out any breaking changes and provided migration notes (none — read-side behavior change only turns a panic into a correct miss)
- [x] Considered performance impact; added notes or benchmarks if relevant (one `is_empty()` check per probe, negligible)

Thank you for the review! 🙏
