### PR TITLE
[rfc-30 2/N]: add traits for WAL iteration and update replay paths

### DIFF
--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -347,14 +347,8 @@ pub struct WalRows {
     /// The rows read from the WAL File. All the rows with a given sequence number must be present
     /// in th same [`WalRows`].
     pub rows: Vec<RowEntry>,
-    /// The id of the last WAL File containing rows from `rows`. There may still be rows with higher
-    /// sequence numbers in the WAL File with this id.
-    pub last_wal_file_id: u64,
-    /// True when this batch is the last one in its WAL file. This is an
-    /// optimization, so its harmless to always set to false. Callers can already infer that a
-    /// file is fully applied when they see a batch from a later file, but this flag lets them
-    /// advance their WAL watermark over the current file without waiting for the next one.
-    pub last_in_file: bool,
+    /// The id of the last WAL File for which all rows have been consumed by the iterator.
+    pub last_consumed_wal_file_id: u64,
 }
 
 /// An iterator over rows in some range of the WAL
@@ -714,8 +708,8 @@ implementation is correct. Some important test cases we'll cover (non-exhaustive
 - `WalWriter` emits events when rows are durably stored.
 - `WalIterator` always iterates over writes in sequence order
 - `WalIterator` always returns full write batches in `WalRows`
-- `WalIterator` tracks the WAL file id in `WalRows` correctly (TODO: this probably needs some 
-  test interfaces in the reader for listing/reading wal files)
+- `WalIterator` tracks the last consumed WAL file id in `WalRows` correctly (TODO: this probably
+  needs some test interfaces in the reader for listing/reading wal files)
 
 **Performance**
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -511,12 +511,12 @@ impl DbInner {
                 // indicate that a newer writer has advanced `replay_after_wal_id` and
                 // the GC has removed this WAL entry. Check the latest manifest's
                 // writer_epoch to see if this client is fenced.
-                Err(SlateDBError::WalTruncated) => {
+                Err(SlateDBError::WalTruncated(wal_id)) => {
                     self.memtable_flusher.refresh_manifest().await?;
                     if self.state.read().state().manifest.value.writer_epoch > writer_epoch {
                         return Err(SlateDBError::Fenced);
                     }
-                    return Err(SlateDBError::WalTruncated);
+                    return Err(SlateDBError::WalTruncated(wal_id));
                 }
                 Err(err) => return Err(err),
             };

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -23,8 +23,6 @@
 pub use crate::db_status::{DbStatus, SegmentPrefix};
 
 use crate::db_cache::CacheTarget;
-use crate::db_cache_manager;
-use std::ops::Range;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -37,7 +35,7 @@ use crate::db_transaction::DbTransaction;
 use crate::dispatcher::MessageHandlerExecutor;
 use crate::garbage_collector::GC_TASK_NAME;
 use crate::transaction_manager::IsolationLevel;
-use crate::CloseReason;
+use crate::{db_cache_manager, CloseReason};
 use log::{debug, info, trace, warn};
 use parking_lot::RwLock;
 use std::time::Duration;
@@ -57,7 +55,6 @@ use crate::db_snapshot::DbSnapshot;
 use crate::db_state::{collect_touched_segments, DbState, SsTableId};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
-use crate::iter::IterationOrder;
 use crate::manifest::{Manifest, VersionedManifest};
 use crate::mem_table::KVTableMetadata;
 use crate::memtable_flusher::{FlushResult, FlushTarget, MemtableFlusher};
@@ -67,7 +64,6 @@ use crate::paths::PathResolver;
 use crate::prefix_extractor::PrefixExtractor;
 use crate::reader::{Reader, ScanContext};
 use crate::snapshot_manager::SnapshotManager;
-use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
 use crate::transaction_manager::TransactionManager;
 use crate::types::KeyValue;
@@ -80,7 +76,7 @@ use slatedb_common::DbRand;
 use slatedb_txn_obj::DirtyObject;
 
 use crate::db_status::{ClosedResultWriter, DbStatusManager};
-use crate::wal::{WalEvent, WalObserver, WalStatus};
+use crate::wal::{WalEvent, WalIterator, WalObserver, WalStatus};
 pub use builder::DbBuilder;
 pub use builder::DbReaderBuilder;
 
@@ -477,7 +473,7 @@ impl DbInner {
         }
     }
 
-    async fn replay_wal(&self, wal_id_range: Range<u64>) -> Result<(), SlateDBError> {
+    async fn replay_wal(&self, wal_iterator: Box<dyn WalIterator>) -> Result<(), SlateDBError> {
         let mut current_memtable_wal_id = self
             .state
             .read()
@@ -494,32 +490,18 @@ impl DbInner {
             |_| -> Result<(), SlateDBError> { Ok(()) }
         );
 
-        let sst_iter_options = SstIteratorOptions {
-            max_fetch_tasks: 1,
-            blocks_to_fetch: 256,
-            cache_blocks: false,
-            cache_metadata: false,
-            eager_spawn: true,
-            order: IterationOrder::Ascending,
-            prefix: None,
-            filter_context: None,
-        };
-
         let replay_options = WalReplayOptions {
-            sst_batch_size: 4,
             max_memtable_bytes: self.settings.l0_sst_size_bytes,
-            sst_iter_options,
-            min_seq: None,
+            ..Default::default()
         };
 
         let db_state = self.state.read().state().core().clone();
-        let mut replay_iter = WalReplayIterator::range(
-            wal_id_range,
+        let mut replay_iter = WalReplayIterator::for_wal_iterator(
+            wal_iterator,
             &db_state,
             replay_options,
             Arc::clone(&self.table_store),
-        )
-        .await?;
+        )?;
 
         loop {
             let replayed_table = match replay_iter.next().await {
@@ -529,12 +511,12 @@ impl DbInner {
                 // indicate that a newer writer has advanced `replay_after_wal_id` and
                 // the GC has removed this WAL entry. Check the latest manifest's
                 // writer_epoch to see if this client is fenced.
-                Err(err) if err.has_object_store_not_found() => {
+                Err(SlateDBError::WalTruncated) => {
                     self.memtable_flusher.refresh_manifest().await?;
                     if self.state.read().state().manifest.value.writer_epoch > writer_epoch {
                         return Err(SlateDBError::Fenced);
                     }
-                    return Err(err);
+                    return Err(SlateDBError::WalTruncated);
                 }
                 Err(err) => return Err(err),
             };
@@ -2167,7 +2149,7 @@ mod tests {
         REQUEST_COUNT as OBJECT_STORE_REQUEST_COUNT,
         REQUEST_DURATION_SECONDS as OBJECT_STORE_REQUEST_DURATION_SECONDS,
     };
-    use crate::iter::RowEntryIterator;
+    use crate::iter::{IterationOrder, RowEntryIterator};
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::{ManifestCore, VersionedManifest};
     use crate::merge_operator::{

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -617,7 +617,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         );
         let WriterFenceResult {
             manifest,
-            replay_range,
+            replay_iterator,
             mut wal_writer,
         } = fencer.fence(stored_manifest).await?;
         let (wal_writer, wal_observer) = if DbInner::wal_enabled_in_options(&self.settings) {
@@ -818,7 +818,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         task_executor.monitor_on(&tokio_handle)?;
 
         // Replay WAL
-        inner.replay_wal(replay_range).await?;
+        inner.replay_wal(replay_iterator).await?;
 
         // Preload cache if enabled
         if let Some(cached_obj_store) = cached_object_store {

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -23,7 +23,7 @@ use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
 use crate::types::KeyValue;
 use crate::utils::IdGenerator;
-use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
+use crate::wal_replay::{WalIteratorOptions, WalReplayIterator, WalReplayOptions};
 use crate::{Checkpoint, DbIterator};
 use crate::{DbCacheManagerOps, DbMetadataOps, DbReadOps};
 use async_trait::async_trait;
@@ -611,10 +611,12 @@ impl DbReaderInner {
             core.next_wal_sst_id
         };
 
-        let replay_options = WalReplayOptions {
+        let iterator_options = WalIteratorOptions {
             sst_batch_size: 4,
-            max_memtable_bytes: reader_options.max_memtable_bytes as usize,
             sst_iter_options,
+        };
+        let replay_options = WalReplayOptions {
+            max_memtable_bytes: reader_options.max_memtable_bytes as usize,
             // Skip entries that we already have in `imm_memtable` (that might be above last_l0_seq).
             min_seq: Some(last_committed_seq),
         };
@@ -622,6 +624,7 @@ impl DbReaderInner {
         let mut replay_iter = WalReplayIterator::range(
             (replay_after_wal_id + 1)..wal_id_end,
             core,
+            iterator_options,
             replay_options,
             Arc::clone(&table_store),
         )
@@ -630,10 +633,13 @@ impl DbReaderInner {
         while let Some(replayed_table) = match replay_iter.next().await {
             Ok(Some(replayed_table)) => Some(replayed_table),
             Ok(None) => None,
-            Err(err) if has_not_found_object_store_error(&err) => None,
+            Err(SlateDBError::WalTruncated) => None,
             Err(err) => return Err(err),
         } {
-            assert!(replayed_table.last_wal_id > replay_after_wal_id);
+            // `last_wal_id` is a conservative watermark: a table that ends mid-file
+            // is tagged with the last fully replayed WAL ID, which may equal the
+            // watermark of the previous table.
+            assert!(replayed_table.last_wal_id >= replay_after_wal_id);
             replay_after_wal_id = replayed_table.last_wal_id;
             if !replayed_table.table.is_empty() && replayed_table.last_seq > last_committed_seq {
                 let first_seq = replayed_table
@@ -1364,24 +1370,6 @@ impl DbCacheManagerOps for DbReader {
         self.inner.check_closed()?;
         db_cache_manager::evict_cached_sst_impl(&self.inner.table_store, sst_id).await
     }
-}
-
-/// Checks if the error or any of its sources is an `object_store::Error::NotFound` error.
-fn has_not_found_object_store_error(err: &(dyn std::error::Error + 'static)) -> bool {
-    let mut current = Some(err);
-    while let Some(current_err) = current {
-        if current_err
-            .downcast_ref::<object_store::Error>()
-            .is_some_and(|err| matches!(err, object_store::Error::NotFound { .. }))
-            || current_err
-                .downcast_ref::<Arc<object_store::Error>>()
-                .is_some_and(|err| matches!(err.as_ref(), object_store::Error::NotFound { .. }))
-        {
-            return true;
-        }
-        current = current_err.source();
-    }
-    false
 }
 
 #[cfg(test)]
@@ -2289,26 +2277,6 @@ mod tests {
         .await;
     }
 
-    #[test]
-    fn has_not_found_object_store_error_should_walk_nested_error_sources() {
-        let err = crate::Error::from(SlateDBError::from(object_store::Error::NotFound {
-            path: "missing-wal".to_string(),
-            source: Box::new(std::io::Error::other("missing")),
-        }));
-
-        assert!(super::has_not_found_object_store_error(&err));
-    }
-
-    #[test]
-    fn has_not_found_object_store_error_should_ignore_non_not_found_errors() {
-        let err = SlateDBError::from(object_store::Error::NotImplemented {
-            operation: "test".to_string(),
-            implementer: "test".to_string(),
-        });
-
-        assert!(!super::has_not_found_object_store_error(&err));
-    }
-
     #[tokio::test]
     async fn replay_wal_into_should_treat_missing_wal_sst_as_end_of_iteration() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -2339,9 +2307,12 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(last_wal_id, 0);
-        assert_eq!(last_committed_seq, 0);
-        assert!(into_tables.is_empty());
+        // WAL 2 is missing and ends the iteration, but the rows already replayed
+        // from WAL 1 must still be returned.
+        assert_eq!(last_wal_id, 1);
+        assert_eq!(last_committed_seq, 1);
+        assert_eq!(into_tables.len(), 1);
+        assert_eq!(into_tables.front().unwrap().recent_flushed_wal_id(), 1);
     }
 
     #[tokio::test]

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -627,13 +627,12 @@ impl DbReaderInner {
             iterator_options,
             replay_options,
             Arc::clone(&table_store),
-        )
-        .await?;
+        )?;
 
         while let Some(replayed_table) = match replay_iter.next().await {
             Ok(Some(replayed_table)) => Some(replayed_table),
             Ok(None) => None,
-            Err(SlateDBError::WalTruncated) => None,
+            Err(SlateDBError::WalTruncated(_)) => None,
             Err(err) => return Err(err),
         } {
             // `last_wal_id` is a conservative watermark: a table that ends mid-file

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -77,8 +77,8 @@ pub(crate) enum SlateDBError {
     #[error("wal store reconfiguration unsupported")]
     WalStoreReconfigurationError,
 
-    #[error("wal truncated")]
-    WalTruncated,
+    #[error("wal truncated at wal file `{0}`")]
+    WalTruncated(u64),
 
     #[error("wal unavailable")]
     WalUnavailable(Arc<dyn std::error::Error + Sync + Send + 'static>),
@@ -727,7 +727,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::CloneExternalDbMissing => Error::data(msg),
             SlateDBError::CloneIncorrectExternalDbCheckpoint { .. } => Error::data(msg),
             SlateDBError::CloneIncorrectFinalCheckpoint { .. } => Error::data(msg),
-            SlateDBError::WalTruncated => Error::data(msg),
+            SlateDBError::WalTruncated(_) => Error::data(msg),
             SlateDBError::WalDataError(src) => Error::data(msg).with_source(Box::new(src)),
 
             // Internal errors

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -727,6 +727,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::CloneExternalDbMissing => Error::data(msg),
             SlateDBError::CloneIncorrectExternalDbCheckpoint { .. } => Error::data(msg),
             SlateDBError::CloneIncorrectFinalCheckpoint { .. } => Error::data(msg),
+            SlateDBError::WalTruncated => Error::data(msg),
             SlateDBError::WalDataError(src) => Error::data(msg).with_source(Box::new(src)),
 
             // Internal errors
@@ -742,7 +743,6 @@ impl From<SlateDBError> for Error {
             SlateDBError::TransactionalObjectError(err) => {
                 Error::internal(msg).with_source(Box::new(err))
             }
-            SlateDBError::WalTruncated => Error::internal(msg),
             SlateDBError::WalInternalError(src) => Error::internal(msg).with_source(Box::new(src)),
         }
     }

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -4,13 +4,11 @@ use crate::manifest::store::{FenceableManifest, StoredManifest};
 use crate::tablestore::TableStore;
 use crate::utils::WatchableOnceCellReader;
 use crate::wal::writer_init::{WalWriterInit, WalWriterInitOptions};
-use crate::wal::{WalWriter, WriterInit};
+use crate::wal::{WalIterator, WalWriter, WriterInit};
 use crate::Settings;
 use fail_parallel::{fail_point_send, FailPointTx};
-use log::error;
 use slatedb_common::metrics::MetricsRecorderHelper;
 use slatedb_common::SystemClock;
-use std::ops::Range;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -28,7 +26,7 @@ pub(crate) struct WriterFencer {
 
 pub(crate) struct WriterFenceResult {
     pub(crate) manifest: FenceableManifest,
-    pub(crate) replay_range: Range<u64>,
+    pub(crate) replay_iterator: Box<dyn WalIterator>,
     pub(crate) wal_writer: Box<dyn WalWriter>,
 }
 
@@ -80,8 +78,8 @@ impl WriterFencer {
     /// Fences all writers with an older epoch than the provided `stored_manifest` by (1) writing
     /// a new `FenceableManifest` with a bumped epoch, and (2) writing an empty WAL file that acts
     /// as a barrier. Any parallel old writers will fail with `SlateDBError::Fenced` when trying
-    /// to "re-write" this file. Returns a `WriterFence` with the `FenceableManifest` and range
-    /// that must be replayed to recover up to the current epoch
+    /// to "re-write" this file. Returns a `WriterFence` with the `FenceableManifest` and iterator
+    /// that must be replayed to recover up to the current epoch.
     pub(crate) async fn fence(
         self,
         stored_manifest: StoredManifest,
@@ -113,17 +111,10 @@ impl WriterFencer {
         manifest.refresh().await?;
         fail_point_send!(self.fp_tx, "FinalRefreshManifest");
 
-        let replay_range = match result.replay_range.try_into() {
-            Ok(replay_range) => replay_range,
-            Err(_) => {
-                error!("replay range must use inclusive lower bound and exclusive upper bound");
-                return Err(SlateDBError::InvalidDBState);
-            }
-        };
         Ok(WriterFenceResult {
             manifest,
             wal_writer: result.wal_writer,
-            replay_range,
+            replay_iterator: result.replay_iterator,
         })
     }
 }
@@ -586,10 +577,19 @@ mod tests {
         // unpause WriterFencer
         fail_parallel::cfg(h.fp_registry.clone(), case.event, "off").unwrap();
         // verify it returns successfully
-        let result = jh.await.unwrap().unwrap();
+        let mut result = jh.await.unwrap().unwrap();
         // The fencer's stale empty_wal_id was retried above the fenced writer's possibly
         // advanced replay_after_wal_id.
-        assert_eq!(result.replay_range.start, replay_after_wal_id + 1);
+        let first_replayed_wal = result
+            .replay_iterator
+            .next()
+            .await
+            .unwrap()
+            .expect("expected the replay iterator to contain the fencing WAL");
+        assert_eq!(
+            first_replayed_wal.last_consumed_wal_file_id,
+            replay_after_wal_id + 1
+        );
 
         // verify that fenced db is fenced (new write fails)
         use crate::error::{CloseReason, ErrorKind};

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -41,7 +41,7 @@ pub enum WalError {
     /// The WAL writer was fenced
     Fenced,
     /// A WalIterator observed that the tail of the WAL was truncated while iterating.
-    WalTruncated,
+    WalTruncated(u64),
     /// Operation against wal after it was closed
     Closed,
     /// WAL is unavailable, e.g. due to an I/O error or error in the backing storage system
@@ -56,7 +56,7 @@ impl Display for WalError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             WalError::Fenced => write!(f, "WAL writer was fenced"),
-            WalError::WalTruncated => write!(f, "WAL was truncated"),
+            WalError::WalTruncated(wal_id) => write!(f, "WAL was truncated at file {}", *wal_id),
             WalError::Closed => write!(f, "WAL is closed"),
             WalError::Unavailable(source) => write!(f, "WAL is unavailable: {source}"),
             WalError::DataError(source) => write!(f, "WAL data error: {source}"),
@@ -300,7 +300,7 @@ impl From<WalError> for SlateDBError {
     fn from(value: WalError) -> Self {
         match value {
             WalError::Fenced => SlateDBError::Fenced,
-            WalError::WalTruncated => SlateDBError::WalTruncated,
+            WalError::WalTruncated(wal_id) => SlateDBError::WalTruncated(wal_id),
             WalError::Closed => SlateDBError::Closed,
             WalError::Unavailable(err) => SlateDBError::WalUnavailable(err),
             WalError::DataError(err) => SlateDBError::WalDataError(err),
@@ -322,7 +322,7 @@ mod tests {
         };
 
         assert_eq!(WalError::Fenced.to_string(), "WAL writer was fenced");
-        assert_eq!(WalError::WalTruncated.to_string(), "WAL was truncated");
+        assert_eq!(WalError::WalTruncated(123).to_string(), "WAL was truncated at file 123");
         assert_eq!(WalError::Closed.to_string(), "WAL is closed");
         assert_eq!(
             WalError::Unavailable(source()).to_string(),

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod wal_sst_builder;
 pub(crate) mod writer_init;
 
 /// A range of WAL File IDs
-pub struct WalFileRange(Bound<u64>, Bound<u64>);
+pub struct WalFileRange(pub Bound<u64>, pub Bound<u64>);
 
 impl From<Range<u64>> for WalFileRange {
     fn from(range: Range<u64>) -> Self {
@@ -113,10 +113,9 @@ impl WriterManifest {
 
 /// The result returned by [`WriterInit::fence_and_init`]
 pub struct WriterInitResult {
-    // TODO: change me to an iterator
     /// An iterator that returns writes that must be replayed before starting SlateDB to recover
     /// data from the WAL.
-    pub replay_range: WalFileRange,
+    pub replay_iterator: Box<dyn WalIterator>,
     /// The WAL writer that will be used to append new writes to the WAL
     pub wal_writer: Box<dyn WalWriter>,
 }
@@ -230,6 +229,43 @@ pub trait WalWriter: Send {
     async fn close(&mut self) -> Result<(), WalError>;
 }
 
+/// Rows returned by [`WalIterator`]
+#[derive(Clone)]
+pub struct WalRows {
+    /// The rows read from the WAL File. All the rows with a given sequence number must be present
+    /// in th same [`WalRows`].
+    pub rows: Vec<RowEntry>,
+    /// The id of the last WAL File for which all rows have been consumed by the iterator and
+    /// returned wither in this [`WalRows`] or a [`WalRows`] returned by an earlier call to
+    /// [`WalIterator::next`]
+    pub last_consumed_wal_file_id: u64,
+}
+
+/// An iterator over rows in some range of the WAL
+#[async_trait]
+pub trait WalIterator: Send + 'static {
+    /// Returns the next set of rows. Rows must be returned in sequence and WAL File order.
+    /// Returns None when iterator's range is exhausted. Iterators created using an unbounded
+    /// end range that have exhausted the current WAL block until new rows are appended and never
+    /// return `None`.
+    /// Returns [`WalError::WalTruncated`] if the iterator observes that the WAL was truncated
+    /// while iterating.
+    async fn next(&mut self) -> Result<Option<WalRows>, WalError>;
+}
+
+/// API for reading from the WAL. Used by the Reader/
+#[async_trait]
+pub trait WalReader {
+    /// Returns an iterator over the specified range of WAL File IDs. The start of the range must
+    /// not be `Unbounded`. If the end of the range is `Unbounded` then the returned iterator
+    /// continues returning writes as new writes are appended to the WAL. Otherwise, it returns
+    /// `None` upon reaching the end of the range.
+    async fn iterator(
+        &self,
+        wal_file_id_range: WalFileRange,
+    ) -> Result<Box<dyn WalIterator>, WalError>;
+}
+
 impl From<WalStatus> for WalError {
     fn from(status: WalStatus) -> Self {
         status
@@ -246,18 +282,16 @@ impl From<WalStatus> for SlateDBError {
 
 impl From<SlateDBError> for WalError {
     fn from(value: SlateDBError) -> Self {
-        {
-            let public: crate::Error = value.clone().into();
-            match public.kind() {
-                ErrorKind::Closed(CloseReason::Fenced) => WalError::Fenced,
-                ErrorKind::Closed(CloseReason::Clean) => WalError::Closed,
-                ErrorKind::Closed(_) => WalError::InternalError(Arc::new(value)),
-                ErrorKind::Unavailable => WalError::Unavailable(Arc::new(value)),
-                ErrorKind::Invalid => WalError::InternalError(Arc::new(value)),
-                ErrorKind::Data => WalError::DataError(Arc::new(value)),
-                ErrorKind::Internal => WalError::InternalError(Arc::new(value)),
-                ErrorKind::Transaction => WalError::InternalError(Arc::new(value)),
-            }
+        let public: crate::Error = value.clone().into();
+        match public.kind() {
+            ErrorKind::Closed(CloseReason::Fenced) => WalError::Fenced,
+            ErrorKind::Closed(CloseReason::Clean) => WalError::Closed,
+            ErrorKind::Closed(_) => WalError::InternalError(Arc::new(value)),
+            ErrorKind::Unavailable => WalError::Unavailable(Arc::new(value)),
+            ErrorKind::Invalid => WalError::InternalError(Arc::new(value)),
+            ErrorKind::Data => WalError::DataError(Arc::new(value)),
+            ErrorKind::Internal => WalError::InternalError(Arc::new(value)),
+            ErrorKind::Transaction => WalError::InternalError(Arc::new(value)),
         }
     }
 }

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -322,7 +322,10 @@ mod tests {
         };
 
         assert_eq!(WalError::Fenced.to_string(), "WAL writer was fenced");
-        assert_eq!(WalError::WalTruncated(123).to_string(), "WAL was truncated at file 123");
+        assert_eq!(
+            WalError::WalTruncated(123).to_string(),
+            "WAL was truncated at file 123"
+        );
         assert_eq!(WalError::Closed.to_string(), "WAL is closed");
         assert_eq!(
             WalError::Unavailable(source()).to_string(),

--- a/slatedb/src/wal/writer_init.rs
+++ b/slatedb/src/wal/writer_init.rs
@@ -128,8 +128,7 @@ impl wal::WriterInit for WalWriterInit {
                         },
                     },
                     self.table_store.clone(),
-                )
-                .await?;
+                )?;
                 let wal_writer = WalBufferManager::start_new(
                     self.closed_result_reader.clone(),
                     &self.recorder,

--- a/slatedb/src/wal/writer_init.rs
+++ b/slatedb/src/wal/writer_init.rs
@@ -1,10 +1,13 @@
 use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
+use crate::iter::IterationOrder;
 use crate::manifest::Manifest;
+use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
 use crate::utils::WatchableOnceCellReader;
 use crate::wal::{WalError, WriterInitResult, WriterManifest};
 use crate::wal_buffer::WalBufferManager;
+use crate::wal_replay::{WalIterator, WalIteratorOptions};
 use crate::{wal, Settings};
 use async_trait::async_trait;
 use fail_parallel::{fail_point_send, FailPointTx};
@@ -109,6 +112,24 @@ impl wal::WriterInit for WalWriterInit {
                 // older writers would have failed with a stale epoch
                 let replay_after_wal_id = manifest.core().replay_after_wal_id;
                 assert!(empty_wal_id > replay_after_wal_id);
+                let replay_iterator = WalIterator::range(
+                    replay_after_wal_id + 1..empty_wal_id + 1,
+                    WalIteratorOptions {
+                        sst_batch_size: 4,
+                        sst_iter_options: SstIteratorOptions {
+                            max_fetch_tasks: 1,
+                            blocks_to_fetch: 256,
+                            cache_blocks: false,
+                            cache_metadata: false,
+                            eager_spawn: true,
+                            order: IterationOrder::Ascending,
+                            prefix: None,
+                            filter_context: None,
+                        },
+                    },
+                    self.table_store.clone(),
+                )
+                .await?;
                 let wal_writer = WalBufferManager::start_new(
                     self.closed_result_reader.clone(),
                     &self.recorder,
@@ -120,7 +141,7 @@ impl wal::WriterInit for WalWriterInit {
                 )
                 .await?;
                 let result = WriterInitResult {
-                    replay_range: (replay_after_wal_id + 1..empty_wal_id + 1).into(),
+                    replay_iterator: Box::new(replay_iterator),
                     wal_writer: Box::new(wal_writer),
                 };
                 return Ok(result);

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -376,7 +376,7 @@ impl WalBufferManagerInner {
         self.last_flushed_wal_id = flushed_wal_id;
         if let Some(seq) = flushed_wal.last_seq() {
             if let Some(last_flushed_seq) = self.last_flushed_seq {
-                assert!(seq >= last_flushed_seq);
+                assert!(seq > last_flushed_seq);
             }
             self.last_flushed_seq = Some(seq);
         }

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -76,7 +76,7 @@ pub(crate) struct WalReplayIterator {
 }
 
 impl WalReplayIterator {
-    pub(crate) async fn range(
+    pub(crate) fn range(
         wal_id_range: Range<u64>,
         db_state: &ManifestCore,
         iterator_options: WalIteratorOptions,
@@ -84,7 +84,7 @@ impl WalReplayIterator {
         table_store: Arc<TableStore>,
     ) -> Result<Self, SlateDBError> {
         let wal_iter =
-            WalIterator::range(wal_id_range, iterator_options, Arc::clone(&table_store)).await?;
+            WalIterator::range(wal_id_range, iterator_options, Arc::clone(&table_store))?;
         Self::for_wal_iterator(Box::new(wal_iter), db_state, replay_options, table_store)
     }
 
@@ -231,7 +231,7 @@ pub(crate) struct WalIterator {
 }
 
 impl WalIterator {
-    pub(crate) async fn range(
+    pub(crate) fn range(
         wal_id_range: Range<u64>,
         options: WalIteratorOptions,
         table_store: Arc<TableStore>,
@@ -309,7 +309,7 @@ impl WalIterator {
         ) -> Result<WalFileIter, WalError> {
             match try_open_file_iter(wal_id, sst_iter_options, table_store).await {
                 Ok(iter) => Ok(iter),
-                Err(err) if err.has_object_store_not_found() => Err(WalError::WalTruncated),
+                Err(err) if err.has_object_store_not_found() => Err(WalError::WalTruncated(wal_id)),
                 Err(err) => Err(err.into()),
             }
         }
@@ -326,10 +326,14 @@ impl WalIterator {
     /// Await the next preloaded WAL file and return an iterator over its rows.
     /// Returns `None` when there are no more files to read.
     async fn take_next_file(&mut self) -> Result<Option<WalFileIter>, WalError> {
-        let Some(join_handle) = self.next_files.pop_front() else {
+        // await a mutable ref to the task so that next remains cancel-safe
+        // see https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html#cancel-safety
+        let Some(join_handle) = self.next_files.front_mut() else {
             return Ok(None);
         };
-        match join_handle.await {
+        let result = join_handle.await;
+        self.next_files.pop_front();
+        match result {
             Ok(result) => result.map(Some),
             Err(join_err) => {
                 let task_name = format!("wal_replay[{:?}]", self.wal_id_range);
@@ -342,20 +346,20 @@ impl WalIterator {
                 } else {
                     format!("wal_replay task cancelled. [task_name={}]", task_name)
                 };
+                error!("{}", msg);
                 let error = Arc::from(Box::<dyn std::error::Error + Send + Sync>::from(msg));
                 Err(WalError::InternalError(error))
             }
         }
     }
 
-    async fn terminate(
+    fn terminate(
         &mut self,
         result: Result<Option<WalRows>, WalError>,
     ) -> Result<Option<WalRows>, WalError> {
         self.terminal_result = Some(result.clone());
         for task in self.next_files.drain(..) {
             task.abort();
-            let _ = task.await;
         }
         result
     }
@@ -378,10 +382,10 @@ impl WalIteratorTrait for WalIterator {
         let mut file_iter = match self.take_next_file().await {
             Ok(Some(file_iter)) => file_iter,
             Ok(None) => {
-                return self.terminate(Ok(None)).await;
+                return self.terminate(Ok(None));
             }
             Err(err) => {
-                return self.terminate(Err(err)).await;
+                return self.terminate(Err(err));
             }
         };
 
@@ -393,10 +397,10 @@ impl WalIteratorTrait for WalIterator {
                 Ok(Some(row)) => rows.push(row),
                 Ok(None) => break,
                 Err(err) if err.has_object_store_not_found() => {
-                    return self.terminate(Err(WalError::WalTruncated)).await;
+                    return self.terminate(Err(WalError::WalTruncated(file_iter.wal_id)));
                 }
                 Err(err) => {
-                    return self.terminate(Err(err.into())).await;
+                    return self.terminate(Err(err.into()));
                 }
             }
         }
@@ -415,7 +419,7 @@ impl WalIteratorTrait for WalIterator {
                     );
                     error!("{}", &msg);
                     let error = Arc::from(Box::<dyn std::error::Error + Send + Sync>::from(msg));
-                    return self.terminate(Err(WalError::InternalError(error))).await;
+                    return self.terminate(Err(WalError::InternalError(error)));
                 }
             }
             let max_seq = rows
@@ -490,7 +494,6 @@ mod tests {
                 options,
                 table_store,
             )
-            .await
         }
     }
 
@@ -505,12 +508,12 @@ mod tests {
                     rows: vec![first_row],
                     last_consumed_wal_file_id: 1,
                 })),
-                Err(WalError::WalTruncated),
+                Err(WalError::WalTruncated(2)),
                 // A terminal error must prevent the replay iterator from resuming
                 // the underlying iterator on later calls.
                 Ok(Some(WalRows {
                     rows: vec![later_row],
-                    last_consumed_wal_file_id: 2,
+                    last_consumed_wal_file_id: 3,
                 })),
             ]),
         };
@@ -532,11 +535,11 @@ mod tests {
 
         assert!(matches!(
             replay_iter.next().await,
-            Err(SlateDBError::WalTruncated)
+            Err(SlateDBError::WalTruncated(2))
         ));
         assert!(matches!(
             replay_iter.next().await,
-            Err(SlateDBError::WalTruncated)
+            Err(SlateDBError::WalTruncated(2))
         ));
     }
 
@@ -574,11 +577,10 @@ mod tests {
             WalIteratorOptions::default(),
             Arc::clone(&table_store),
         )
-        .await
         .unwrap();
 
-        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated)));
-        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated)));
+        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated(1))));
+        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated(1))));
     }
 
     #[tokio::test]
@@ -589,7 +591,6 @@ mod tests {
             WalIteratorOptions::default(),
             Arc::clone(&table_store),
         )
-        .await
         .unwrap();
 
         assert!(wal_iter.next().await.unwrap().is_none());
@@ -1033,7 +1034,6 @@ mod tests {
             WalIteratorOptions::default(),
             Arc::clone(&table_store),
         )
-        .await
         .unwrap();
 
         let mut returned_rows = BTreeMap::new();

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -7,6 +7,8 @@ use crate::mem_table::WritableKVTable;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::utils::panic_string;
+use crate::wal::{WalError, WalIterator as WalIteratorTrait, WalRows};
+use async_trait::async_trait;
 use log::error;
 use std::collections::VecDeque;
 use std::ops::Range;
@@ -14,17 +16,28 @@ use std::sync::Arc;
 use tokio::task;
 use tokio::task::JoinHandle;
 
-pub(crate) struct WalReplayOptions {
+pub(crate) struct WalIteratorOptions {
     /// The number of SSTs to preload while replaying
     pub(crate) sst_batch_size: usize,
 
-    /// The target maximum number of bytes in each returned table. WAL replay only
-    /// splits between complete WAL SSTs, so a returned table may exceed this if a
-    /// single WAL SST is larger.
-    pub(crate) max_memtable_bytes: usize,
-
     /// Options to pass through to underlying SST iterators
     pub(crate) sst_iter_options: SstIteratorOptions,
+}
+
+impl Default for WalIteratorOptions {
+    fn default() -> Self {
+        Self {
+            sst_batch_size: 4,
+            sst_iter_options: SstIteratorOptions::default(),
+        }
+    }
+}
+
+pub(crate) struct WalReplayOptions {
+    /// The target maximum number of bytes in each returned table. WAL replay only
+    /// splits between write batches (all rows of one commit stay in one table), so
+    /// a returned table may exceed this if a single write batch is larger.
+    pub(crate) max_memtable_bytes: usize,
 
     /// The minimum seq number to replay. If unset, will replay all
     /// entries after `last_l0_seq` in the manifest.
@@ -34,9 +47,7 @@ pub(crate) struct WalReplayOptions {
 impl Default for WalReplayOptions {
     fn default() -> Self {
         Self {
-            sst_batch_size: 4,
             max_memtable_bytes: 64 * 1024 * 1024,
-            sst_iter_options: SstIteratorOptions::default(),
             min_seq: None,
         }
     }
@@ -49,63 +60,40 @@ pub(crate) struct ReplayedMemtable {
     pub(crate) last_wal_id: u64,
 }
 
-struct WalIdAndIter {
-    wal_id: u64,
-    iter: Box<dyn RowEntryIterator + 'static>,
-}
-
-struct IteratorHolder<T> {
-    initialized: bool,
-    current_iter: Option<T>,
-}
-
-impl<T> IteratorHolder<T> {
-    fn new() -> Self {
-        Self {
-            initialized: false,
-            current_iter: None,
-        }
-    }
-
-    fn is_finished(&self) -> bool {
-        self.initialized && self.current_iter.is_none()
-    }
-
-    fn advance(&mut self, iterator: Option<T>) {
-        self.initialized = true;
-        self.current_iter = iterator;
-    }
-
-    fn reset(&mut self) {
-        self.initialized = false;
-        self.current_iter = None;
-    }
-}
-
 pub(crate) struct WalReplayIterator {
     options: WalReplayOptions,
-    wal_id_range: Range<u64>,
     table_store: Arc<TableStore>,
-    current_iter: IteratorHolder<WalIdAndIter>,
-    next_iters: VecDeque<JoinHandle<Result<Option<WalIdAndIter>, SlateDBError>>>,
+    wal_iter: Box<dyn WalIteratorTrait>,
+    terminal_result: Option<Result<(), SlateDBError>>,
+    /// The greatest WAL ID such that it and every WAL file before it in the replay
+    /// range are fully applied to returned tables. Tables are tagged with this
+    /// conservative watermark so that a table ending mid-file never claims a WAL
+    /// file it only partially contains.
+    last_consumed_wal_file_id: u64,
     last_tick: i64,
     last_seq: u64,
     min_seq: u64,
-    next_wal_id: u64,
 }
 
 impl WalReplayIterator {
     pub(crate) async fn range(
         wal_id_range: Range<u64>,
         db_state: &ManifestCore,
+        iterator_options: WalIteratorOptions,
+        replay_options: WalReplayOptions,
+        table_store: Arc<TableStore>,
+    ) -> Result<Self, SlateDBError> {
+        let wal_iter =
+            WalIterator::range(wal_id_range, iterator_options, Arc::clone(&table_store)).await?;
+        Self::for_wal_iterator(Box::new(wal_iter), db_state, replay_options, table_store)
+    }
+
+    pub(crate) fn for_wal_iterator(
+        wal_iter: Box<dyn WalIteratorTrait>,
+        db_state: &ManifestCore,
         options: WalReplayOptions,
         table_store: Arc<TableStore>,
     ) -> Result<Self, SlateDBError> {
-        let sst_batch_size = options.sst_batch_size;
-        if sst_batch_size < 1 {
-            return Err(SlateDBError::InvalidSSTBatchSize(sst_batch_size));
-        }
-
         // load the last seq number from manifest, and use it as the starting seq number to avoid
         // replaying the entries that are already in the L0 SST. while replaying the WALs, we'll
         // update the last seq number to the max seq number, and this final `last_seq` will be passed
@@ -113,32 +101,160 @@ impl WalReplayIterator {
         let min_seq = options.min_seq.unwrap_or(db_state.last_l0_seq);
         let last_seq = db_state.last_l0_seq;
         let last_tick = db_state.last_l0_clock_tick;
-        let next_wal_id = wal_id_range.start;
 
-        let mut replay_iter = WalReplayIterator {
+        Ok(WalReplayIterator {
             options,
-            wal_id_range,
-            table_store: Arc::clone(&table_store),
-            current_iter: IteratorHolder::new(),
-            next_iters: VecDeque::new(),
+            table_store,
+            wal_iter,
+            terminal_result: None,
+            last_consumed_wal_file_id: db_state.replay_after_wal_id,
             last_tick,
             last_seq,
             min_seq,
-            next_wal_id,
-        };
+        })
+    }
 
-        for _ in 0..sst_batch_size {
-            if !replay_iter.maybe_load_next_iter() {
-                break;
+    /// Get the next table replayed from the WAL. Replay accumulates write batches
+    /// until the returned table reaches [`WalReplayOptions::max_memtable_bytes`].
+    /// Tables are only split between write batches — all rows sharing a commit seq
+    /// stay in one table, and batches are applied in ascending seq order — so a
+    /// returned table may exceed the target when a single write batch is larger.
+    ///
+    /// The returned table's `last_wal_id` is a conservative watermark: the greatest
+    /// WAL ID such that it and every WAL file before it are fully contained in the
+    /// tables returned so far. A table that ends mid-file is tagged with the last
+    /// fully replayed WAL ID, so replaying from `last_wal_id + 1` and dropping rows
+    /// with seq <= the table's `last_seq` never misses or duplicates a commit.
+    pub(crate) async fn next(&mut self) -> Result<Option<ReplayedMemtable>, SlateDBError> {
+        if let Some(terminal_result) = self.terminal_result.clone() {
+            return terminal_result.map(|_v| None);
+        }
+
+        let table = WritableKVTable::new();
+        let mut applied_any = false;
+
+        loop {
+            let writes = match self.wal_iter.next().await {
+                Ok(Some(writes)) => writes,
+                Ok(None) => {
+                    // we've reached the end of iteration, mark the iterator as done
+                    self.terminal_result = Some(Ok(()));
+                    break;
+                }
+                // Hold the error back so the write batches already applied to this
+                // table are returned first. `DbReader` treats a missing WAL file as
+                // the end of the WAL, so rows replayed before the error must not be
+                // dropped with it.
+                Err(err) => {
+                    self.terminal_result = Some(Err(err.into()));
+                    break;
+                }
+            };
+
+            applied_any = true;
+            assert!(
+                writes.last_consumed_wal_file_id >= self.last_consumed_wal_file_id,
+                "WAL iterator moved its consumed file watermark backwards"
+            );
+            self.last_consumed_wal_file_id = writes.last_consumed_wal_file_id;
+
+            for row_entry in writes.rows {
+                // skip the entries that are already in the L0 SST.
+                if row_entry.seq <= self.min_seq {
+                    continue;
+                }
+
+                if let Some(ts) = row_entry.create_ts {
+                    self.last_tick = self.last_tick.max(ts);
+                }
+                self.last_seq = self.last_seq.max(row_entry.seq);
+                table.put(row_entry);
+            }
+
+            if !table.is_empty() {
+                let meta = table.metadata();
+                let estimated_bytes = self
+                    .table_store
+                    .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
+                if estimated_bytes >= self.options.max_memtable_bytes {
+                    break;
+                }
             }
         }
 
-        Ok(replay_iter)
+        if applied_any {
+            // we use the applied_any check here rather than checking non-empty table size to
+            // ensure that if we replayed values with a lower seq num we still carry the
+            // wal id in an empty replayed memtable
+            Ok(Some(ReplayedMemtable {
+                table,
+                last_tick: self.last_tick,
+                last_seq: self.last_seq,
+                last_wal_id: self.last_consumed_wal_file_id,
+            }))
+        } else {
+            self.terminal_result
+                .clone()
+                .expect("applied_any false but no terminal result")
+                .map(|_v| None)
+        }
+    }
+}
+
+/// A WAL file's id along with an iterator over its rows.
+struct WalFileIter {
+    wal_id: u64,
+    iter: Box<dyn RowEntryIterator + 'static>,
+}
+
+/// Iterates over the writes in a range of WAL files, preloading up to
+/// `sst_batch_size` WAL SSTs concurrently. Returns the rows of one WAL file per
+/// [`WalRows`], and verifies that files carry strictly increasing seq
+/// ranges — the ordering callers rely on to split and tag memtables safely.
+///
+/// Preloading only opens each WAL SST (footer, index, and any eagerly fetched
+/// blocks); a file's rows are read out only when it is returned from
+/// [`Self::next`], so at most one file's rows are materialized at a time.
+pub(crate) struct WalIterator {
+    options: WalIteratorOptions,
+    /// Range of WAL IDs to iterate over
+    wal_id_range: Range<u64>,
+    table_store: Arc<TableStore>,
+    next_files: VecDeque<JoinHandle<Result<WalFileIter, WalError>>>,
+    next_wal_id: u64,
+    /// The greatest seq returned so far, used to verify that WAL files arrive
+    /// with strictly increasing seq ranges.
+    last_seq: Option<u64>,
+    /// Set once iteration has ended, either because the range was exhausted or
+    /// because an error was returned.
+    terminal_result: Option<Result<Option<WalRows>, WalError>>,
+}
+
+impl WalIterator {
+    pub(crate) async fn range(
+        wal_id_range: Range<u64>,
+        options: WalIteratorOptions,
+        table_store: Arc<TableStore>,
+    ) -> Result<Self, SlateDBError> {
+        if options.sst_batch_size < 1 {
+            return Err(SlateDBError::InvalidSSTBatchSize(options.sst_batch_size));
+        }
+
+        let next_wal_id = wal_id_range.start;
+        Ok(WalIterator {
+            options,
+            wal_id_range,
+            table_store,
+            next_files: VecDeque::new(),
+            next_wal_id,
+            last_seq: None,
+            terminal_result: None,
+        })
     }
 
-    fn maybe_load_next_iter(&mut self) -> bool {
+    fn maybe_load_next_file(&mut self) -> bool {
         if !self.wal_id_range.contains(&self.next_wal_id)
-            || self.next_iters.len() >= self.options.sst_batch_size
+            || self.next_files.len() >= self.options.sst_batch_size
         {
             return false;
         }
@@ -146,20 +262,20 @@ impl WalReplayIterator {
         let next_wal_id = self.next_wal_id;
         self.next_wal_id += 1;
 
-        async fn load_iter(
+        async fn try_open_file_iter(
             wal_id: u64,
             sst_iter_options: SstIteratorOptions,
             table_store: Arc<TableStore>,
-        ) -> Result<Option<WalIdAndIter>, SlateDBError> {
+        ) -> Result<WalFileIter, SlateDBError> {
             let sst = match table_store.open_sst(&SsTableId::Wal(wal_id)).await {
                 Ok(sst) => sst,
                 Err(SlateDBError::EmptySSTable) => {
                     // Zero-byte WAL files are fence markers; replay them as empty WALs
                     // so the last replayed WAL ID still advances past the marker.
-                    return Ok(Some(WalIdAndIter {
+                    return Ok(WalFileIter {
                         wal_id,
                         iter: Box::new(EmptyIterator::new()),
-                    }));
+                    });
                 }
                 Err(err) => return Err(err),
             };
@@ -170,111 +286,156 @@ impl WalReplayIterator {
                 sst_iter_options,
             )
             .await?;
-            Ok(iter.map(|iter| WalIdAndIter {
+            // An unbounded, unfiltered scan over a WAL SST always yields an
+            // iterator. `None` means the file cannot be read, and replay must
+            // fail rather than silently end early and drop the remaining WALs.
+            let Some(iter) = iter else {
+                error!(
+                    "could not construct row iterator over WAL SST. [wal_id={}]",
+                    wal_id
+                );
+                return Err(SlateDBError::InvalidDBState);
+            };
+            Ok(WalFileIter {
                 wal_id,
                 iter: Box::new(iter) as Box<dyn RowEntryIterator + 'static>,
-            }))
+            })
         }
 
-        let handle = task::spawn(load_iter(
+        async fn open_file_iter(
+            wal_id: u64,
+            sst_iter_options: SstIteratorOptions,
+            table_store: Arc<TableStore>,
+        ) -> Result<WalFileIter, WalError> {
+            match try_open_file_iter(wal_id, sst_iter_options, table_store).await {
+                Ok(iter) => Ok(iter),
+                Err(err) if err.has_object_store_not_found() => Err(WalError::WalTruncated),
+                Err(err) => Err(err.into()),
+            }
+        }
+
+        let handle = task::spawn(open_file_iter(
             next_wal_id,
             self.options.sst_iter_options.clone(),
             Arc::clone(&self.table_store),
         ));
-        self.next_iters.push_back(handle);
+        self.next_files.push_back(handle);
         true
     }
 
-    async fn advance_current_iter(&mut self) -> Result<(), SlateDBError> {
-        let next_iter = if let Some(join_handle) = self.next_iters.pop_front() {
-            match join_handle.await {
-                Ok(Ok(sst_iter)) => sst_iter,
-                Ok(Err(slate_err)) => return Err(slate_err),
-                Err(join_err) => {
-                    let task_name = format!("wal_replay[{:?}]", self.wal_id_range);
-                    if let Ok(panic_err) = join_err.try_into_panic() {
-                        error!(
-                            "wal_replay task panicked unexpectedly. [task_name={}, panic={}]",
-                            task_name,
-                            panic_string(&panic_err),
-                        );
-                        return Err(SlateDBError::BackgroundTaskPanic(task_name));
-                    }
-                    return Err(SlateDBError::BackgroundTaskCancelled(task_name));
-                }
-            }
-        } else {
-            None
+    /// Await the next preloaded WAL file and return an iterator over its rows.
+    /// Returns `None` when there are no more files to read.
+    async fn take_next_file(&mut self) -> Result<Option<WalFileIter>, WalError> {
+        let Some(join_handle) = self.next_files.pop_front() else {
+            return Ok(None);
         };
-        self.current_iter.advance(next_iter);
-        Ok(())
+        match join_handle.await {
+            Ok(result) => result.map(Some),
+            Err(join_err) => {
+                let task_name = format!("wal_replay[{:?}]", self.wal_id_range);
+                let msg = if let Ok(panic_err) = join_err.try_into_panic() {
+                    format!(
+                        "wal_replay task panicked unexpectedly. [task_name={}, panic={}]",
+                        task_name,
+                        panic_string(&panic_err),
+                    )
+                } else {
+                    format!("wal_replay task cancelled. [task_name={}]", task_name)
+                };
+                let error = Arc::from(Box::<dyn std::error::Error + Send + Sync>::from(msg));
+                Err(WalError::InternalError(error))
+            }
+        }
     }
 
-    /// Get the next table replayed from the WAL. Replay accumulates complete WAL
-    /// SSTs until the returned table reaches [`WalReplayOptions::max_memtable_bytes`],
-    /// unless it is the final table replayed from the WAL. The final table may even
-    /// be empty since writers use an empty WAL to fence zombie writers. The empty
-    /// table must still be returned so that replay logic can account for the latest
-    /// WAL ID.
-    ///
-    /// The returned table may exceed [`WalReplayOptions::max_memtable_bytes`] when
-    /// a complete WAL SST is larger than the configured target, because replay
-    /// must not split a WAL SST across replayed memtables.
-    pub(crate) async fn next(&mut self) -> Result<Option<ReplayedMemtable>, SlateDBError> {
-        if self.current_iter.is_finished() {
-            return Ok(None);
+    async fn terminate(
+        &mut self,
+        result: Result<Option<WalRows>, WalError>,
+    ) -> Result<Option<WalRows>, WalError> {
+        self.terminal_result = Some(result.clone());
+        for task in self.next_files.drain(..) {
+            task.abort();
+            let _ = task.await;
+        }
+        result
+    }
+}
+
+#[async_trait]
+impl WalIteratorTrait for WalIterator {
+    /// Get the next set of writes from the WAL files in the range. Each returned
+    /// [`WalRows`] holds the rows of one WAL file; a WAL file with no rows
+    /// yields a batch with empty `rows`. Returns `None` once all WAL files in the
+    /// range have been read. It is an error if a WAL file in the range is not
+    /// present. Errors are returned only on calls that return no batch, so rows
+    /// read from earlier WAL files are never dropped with a later file's error.
+    async fn next(&mut self) -> Result<Option<WalRows>, WalError> {
+        if let Some(result) = self.terminal_result.clone() {
+            return result;
         }
 
-        let table = WritableKVTable::new();
-        let mut last_wal_id = 0;
+        while self.maybe_load_next_file() {}
+        let mut file_iter = match self.take_next_file().await {
+            Ok(Some(file_iter)) => file_iter,
+            Ok(None) => {
+                return self.terminate(Ok(None)).await;
+            }
+            Err(err) => {
+                return self.terminate(Err(err)).await;
+            }
+        };
 
-        while !self.current_iter.is_finished() {
-            if let Some(wal_id_and_iter) = &mut self.current_iter.current_iter {
-                while let Some(row_entry) = wal_id_and_iter.iter.next().await? {
-                    // skip the entries that are already in the L0 SST.
-                    if row_entry.seq <= self.min_seq {
-                        continue;
-                    }
-
-                    if let Some(ts) = row_entry.create_ts {
-                        self.last_tick = self.last_tick.max(ts);
-                    }
-                    self.last_seq = self.last_seq.max(row_entry.seq);
-                    table.put(row_entry);
+        // Read out the file's rows. Only the file being returned is materialized;
+        // preloaded files just hold opened iterators.
+        let mut rows = Vec::new();
+        loop {
+            match file_iter.iter.next().await {
+                Ok(Some(row)) => rows.push(row),
+                Ok(None) => break,
+                Err(err) if err.has_object_store_not_found() => {
+                    return self.terminate(Err(WalError::WalTruncated)).await;
                 }
-
-                last_wal_id = wal_id_and_iter.wal_id;
-
-                let meta = table.metadata();
-                let estimated_bytes = self
-                    .table_store
-                    .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
-                if !table.is_empty() && estimated_bytes >= self.options.max_memtable_bytes {
-                    self.current_iter.reset();
-                    break;
+                Err(err) => {
+                    return self.terminate(Err(err.into())).await;
                 }
             }
-
-            self.maybe_load_next_iter();
-            self.advance_current_iter().await?
         }
 
-        if last_wal_id > 0 {
-            Ok(Some(ReplayedMemtable {
-                table,
-                last_tick: self.last_tick,
-                last_seq: self.last_seq,
-                last_wal_id,
-            }))
-        } else {
-            Ok(None)
+        // Verify that WAL files carry strictly increasing seq ranges. Replay
+        // relies on this ordering to split and tag memtables safely: a commit seq
+        // spanning two WAL files, or files with overlapping seq ranges, would
+        // break recovery's (wal_id, seq) watermark filtering.
+        if let Some(min_seq) = rows.iter().map(|row| row.seq).min() {
+            if let Some(last_seq) = self.last_seq {
+                if min_seq <= last_seq {
+                    let msg = format!(
+                        "WAL replay saw out-of-order seqs across WAL files. \
+                         [wal_id={}, min_seq={}, last_seq={}]",
+                        file_iter.wal_id, min_seq, last_seq,
+                    );
+                    error!("{}", &msg);
+                    let error = Arc::from(Box::<dyn std::error::Error + Send + Sync>::from(msg));
+                    return self.terminate(Err(WalError::InternalError(error))).await;
+                }
+            }
+            let max_seq = rows
+                .iter()
+                .map(|row| row.seq)
+                .max()
+                .expect("non-empty rows have a max seq");
+            self.last_seq = Some(max_seq);
         }
+
+        Ok(Some(WalRows {
+            rows,
+            last_consumed_wal_file_id: file_iter.wal_id,
+        }))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{WalReplayIterator, WalReplayOptions};
+    use super::{WalIterator, WalIteratorOptions, WalReplayIterator, WalReplayOptions};
     use crate::block_cache_policy::BlockCachePolicy;
     use crate::bytes_range::BytesRange;
     use crate::db_state::SsTableId;
@@ -286,7 +447,9 @@ mod tests {
     use crate::proptest_util::{rng, sample};
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::types::RowEntry;
+    use crate::wal::{WalError, WalIterator as WalIteratorTrait, WalRows};
     use crate::{error::SlateDBError, test_utils};
+    use async_trait::async_trait;
     use bytes::Bytes;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -295,8 +458,19 @@ mod tests {
     use rand::Rng;
     use std::cmp::min;
     use std::collections::btree_map::Iter;
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet, VecDeque};
     use std::sync::Arc;
+
+    struct ScriptedWalIterator {
+        results: VecDeque<Result<Option<WalRows>, WalError>>,
+    }
+
+    #[async_trait]
+    impl WalIteratorTrait for ScriptedWalIterator {
+        async fn next(&mut self) -> Result<Option<WalRows>, WalError> {
+            self.results.pop_front().unwrap_or(Ok(None))
+        }
+    }
 
     impl WalReplayIterator {
         async fn all_wal_ids(
@@ -309,8 +483,159 @@ mod tests {
                 .last_seen_wal_id(db_state.replay_after_wal_id)
                 .await?;
             let wal_id_range = wal_id_start..(wal_id_end + 1);
-            Self::range(wal_id_range, db_state, options, table_store).await
+            Self::range(
+                wal_id_range,
+                db_state,
+                WalIteratorOptions::default(),
+                options,
+                table_store,
+            )
+            .await
         }
+    }
+
+    #[tokio::test]
+    async fn should_return_replayed_rows_before_repeating_terminal_error() {
+        let table_store = test_table_store();
+        let first_row = RowEntry::new_value(b"key_001", b"value_001", 1);
+        let later_row = RowEntry::new_value(b"key_002", b"value_002", 2);
+        let wal_iter = ScriptedWalIterator {
+            results: VecDeque::from([
+                Ok(Some(WalRows {
+                    rows: vec![first_row],
+                    last_consumed_wal_file_id: 1,
+                })),
+                Err(WalError::WalTruncated),
+                // A terminal error must prevent the replay iterator from resuming
+                // the underlying iterator on later calls.
+                Ok(Some(WalRows {
+                    rows: vec![later_row],
+                    last_consumed_wal_file_id: 2,
+                })),
+            ]),
+        };
+        let mut replay_iter = WalReplayIterator::for_wal_iterator(
+            Box::new(wal_iter),
+            &ManifestCore::new(),
+            WalReplayOptions {
+                max_memtable_bytes: usize::MAX,
+                ..WalReplayOptions::default()
+            },
+            Arc::clone(&table_store),
+        )
+        .unwrap();
+
+        let replayed = replay_iter.next().await.unwrap().unwrap();
+        assert_eq!(replayed.last_wal_id, 1);
+        assert_eq!(replayed.last_seq, 1);
+        assert_eq!(replayed.table.metadata().entry_num, 1);
+
+        assert!(matches!(
+            replay_iter.next().await,
+            Err(SlateDBError::WalTruncated)
+        ));
+        assert!(matches!(
+            replay_iter.next().await,
+            Err(SlateDBError::WalTruncated)
+        ));
+    }
+
+    #[tokio::test]
+    async fn should_repeat_terminal_none_for_wal_replay_iterator() {
+        let table_store = test_table_store();
+        let wal_iter = ScriptedWalIterator {
+            results: VecDeque::from([
+                Ok(None),
+                // Normal termination must prevent the replay iterator from
+                // resuming the underlying iterator on later calls.
+                Ok(Some(WalRows {
+                    rows: vec![RowEntry::new_value(b"key", b"value", 1)],
+                    last_consumed_wal_file_id: 1,
+                })),
+            ]),
+        };
+        let mut replay_iter = WalReplayIterator::for_wal_iterator(
+            Box::new(wal_iter),
+            &ManifestCore::new(),
+            WalReplayOptions::default(),
+            Arc::clone(&table_store),
+        )
+        .unwrap();
+
+        assert!(replay_iter.next().await.unwrap().is_none());
+        assert!(replay_iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn should_repeat_terminal_error_for_wal_iterator() {
+        let table_store = test_table_store();
+        let mut wal_iter = WalIterator::range(
+            1..2,
+            WalIteratorOptions::default(),
+            Arc::clone(&table_store),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated)));
+        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated)));
+    }
+
+    #[tokio::test]
+    async fn should_repeat_terminal_none_for_wal_iterator() {
+        let table_store = test_table_store();
+        let mut wal_iter = WalIterator::range(
+            1..1,
+            WalIteratorOptions::default(),
+            Arc::clone(&table_store),
+        )
+        .await
+        .unwrap();
+
+        assert!(wal_iter.next().await.unwrap().is_none());
+        assert!(wal_iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn should_use_last_consumed_wal_file_id_as_replay_watermark() {
+        let table_store = test_table_store();
+        let first_row = RowEntry::new_value(b"key_001", &[b'x'; 128], 1);
+        let second_row = RowEntry::new_value(b"key_002", &[b'x'; 128], 2);
+        let max_memtable_bytes =
+            table_store.estimate_encoded_size_compacted(1, first_row.estimated_size());
+        let wal_iter = ScriptedWalIterator {
+            results: VecDeque::from([
+                Ok(Some(WalRows {
+                    rows: vec![first_row],
+                    // The first batch ends partway through WAL file 1.
+                    last_consumed_wal_file_id: 0,
+                })),
+                Ok(Some(WalRows {
+                    rows: vec![second_row],
+                    // The second batch consumes the rest of WAL file 1.
+                    last_consumed_wal_file_id: 1,
+                })),
+            ]),
+        };
+        let mut replay_iter = WalReplayIterator::for_wal_iterator(
+            Box::new(wal_iter),
+            &ManifestCore::new(),
+            WalReplayOptions {
+                max_memtable_bytes,
+                ..WalReplayOptions::default()
+            },
+            Arc::clone(&table_store),
+        )
+        .unwrap();
+
+        let first = replay_iter.next().await.unwrap().unwrap();
+        assert_eq!(first.last_wal_id, 0);
+        assert_eq!(first.last_seq, 1);
+
+        let second = replay_iter.next().await.unwrap().unwrap();
+        assert_eq!(second.last_wal_id, 1);
+        assert_eq!(second.last_seq, 2);
+        assert!(replay_iter.next().await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -659,6 +984,116 @@ mod tests {
                 "WAL replay returned out-of-order memtable sequence ranges: {replayed_seq_ranges:?}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn should_return_atomic_wal_rows_in_increasing_seq_order() {
+        let table_store = test_table_store();
+        // Each file contains out-of-order rows and a sequence that appears twice.
+        // The iterator must keep both rows for a sequence in one batch, while the
+        // sequence range of the second batch must follow the first.
+        let wal_entries = [
+            vec![
+                RowEntry::new_value(b"key_001", &[b'x'; 128], 2),
+                RowEntry::new_value(b"key_002", &[b'x'; 128], 1),
+                RowEntry::new_value(b"key_003", &[b'x'; 128], 2),
+            ],
+            vec![
+                RowEntry::new_value(b"key_004", &[b'x'; 128], 4),
+                RowEntry::new_value(b"key_005", &[b'x'; 128], 3),
+                RowEntry::new_value(b"key_006", &[b'x'; 128], 4),
+            ],
+        ];
+        let mut expected_rows = BTreeMap::new();
+        let mut expected_rows_by_seq = BTreeMap::<u64, BTreeSet<Bytes>>::new();
+        let wal_file_count = wal_entries.len() as u64;
+        for (file_index, entries) in wal_entries.iter().enumerate() {
+            let wal_id = file_index as u64 + 1;
+            for row in entries {
+                expected_rows.insert(row.key.clone(), (row.clone(), wal_id));
+                expected_rows_by_seq
+                    .entry(row.seq)
+                    .or_default()
+                    .insert(row.key.clone());
+            }
+        }
+        for (index, entries) in wal_entries.into_iter().enumerate() {
+            let mut builder = table_store.wal_table_builder();
+            for entry in entries {
+                builder.add(entry).await.unwrap();
+            }
+            let encoded_sst = builder.build().await.unwrap();
+            table_store
+                .write_sst(&SsTableId::Wal(index as u64 + 1), &encoded_sst)
+                .await
+                .unwrap();
+        }
+        let mut wal_iter = WalIterator::range(
+            1..(wal_file_count + 1),
+            WalIteratorOptions::default(),
+            Arc::clone(&table_store),
+        )
+        .await
+        .unwrap();
+
+        let mut returned_rows = BTreeMap::new();
+        let mut previous_max_seq = None;
+        let mut last_consumed_wal_file_id = 0;
+        while let Some(batch) = wal_iter.next().await.unwrap() {
+            let batch_min_seq = batch.rows.iter().map(|r| r.seq).min().unwrap();
+            let batch_max_seq = batch.rows.iter().map(|r| r.seq).max().unwrap();
+            if let Some(previous_max_seq) = previous_max_seq {
+                assert!(
+                    batch_min_seq > previous_max_seq,
+                    "consecutive WAL batches have overlapping sequence ranges"
+                );
+            }
+            previous_max_seq = Some(batch_max_seq);
+
+            let mut batch_rows_by_seq = BTreeMap::<u64, BTreeSet<Bytes>>::new();
+            for row in &batch.rows {
+                assert!(
+                    returned_rows.insert(row.key.clone(), row.clone()).is_none(),
+                    "row was returned more than once: {:?}",
+                    row.key
+                );
+                batch_rows_by_seq
+                    .entry(row.seq)
+                    .or_default()
+                    .insert(row.key.clone());
+            }
+            for (seq, batch_rows) in batch_rows_by_seq {
+                assert_eq!(
+                    expected_rows_by_seq.get(&seq),
+                    Some(&batch_rows),
+                    "rows for seq {seq} were split across WAL batches"
+                );
+            }
+
+            assert!(
+                batch.last_consumed_wal_file_id >= last_consumed_wal_file_id,
+                "consumed WAL file watermark moved backwards"
+            );
+            assert!(batch.last_consumed_wal_file_id <= wal_file_count);
+            for wal_id in 1..=batch.last_consumed_wal_file_id {
+                let file_fully_returned =
+                    expected_rows.iter().all(|(key, (_, expected_wal_id))| {
+                        *expected_wal_id != wal_id || returned_rows.contains_key(key)
+                    });
+                assert!(
+                    file_fully_returned,
+                    "WAL file {wal_id} was marked consumed before all its rows were returned"
+                );
+            }
+            last_consumed_wal_file_id = batch.last_consumed_wal_file_id;
+        }
+
+        let expected_returned_rows = expected_rows
+            .into_iter()
+            .map(|(key, (row, _wal_id))| (key, row))
+            .collect();
+        assert_eq!(returned_rows, expected_returned_rows);
+        assert_eq!(last_consumed_wal_file_id, wal_file_count);
     }
 
     #[tokio::test]

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -8,6 +8,7 @@ use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
 use crate::utils::panic_string;
 use crate::wal::{WalError, WalIterator as WalIteratorTrait, WalRows};
+use crate::RowEntry;
 use async_trait::async_trait;
 use log::error;
 use std::collections::VecDeque;
@@ -201,10 +202,90 @@ impl WalReplayIterator {
     }
 }
 
-/// A WAL file's id along with an iterator over its rows.
-struct WalFileIter {
+struct WalRowsCollector {
     wal_id: u64,
     iter: Box<dyn RowEntryIterator + 'static>,
+    rows: Vec<RowEntry>,
+    drained: bool,
+}
+
+impl WalRowsCollector {
+    fn new(wal_id: u64, iter: Box<dyn RowEntryIterator + 'static>) -> Self {
+        Self {
+            wal_id,
+            iter,
+            rows: vec![],
+            drained: false,
+        }
+    }
+
+    async fn collect(&mut self) -> Result<(), WalError> {
+        loop {
+            match self.iter.next().await {
+                Ok(Some(row)) => self.rows.push(row),
+                Ok(None) => {
+                    self.drained = true;
+                    break Ok(());
+                }
+                Err(err) if err.has_object_store_not_found() => {
+                    break Err(WalError::WalTruncated(self.wal_id));
+                }
+                Err(err) => {
+                    break Err(err.into());
+                }
+            }
+        }
+    }
+}
+
+impl From<WalRowsCollector> for WalRows {
+    fn from(reader: WalRowsCollector) -> Self {
+        assert!(reader.drained);
+        WalRows {
+            last_consumed_wal_file_id: reader.wal_id,
+            rows: reader.rows,
+        }
+    }
+}
+
+struct CurrentWalFile {
+    initialized: bool,
+    collector: Option<WalRowsCollector>,
+}
+
+impl CurrentWalFile {
+    fn initial() -> Self {
+        Self {
+            initialized: false,
+            collector: None,
+        }
+    }
+
+    fn initialized(&self) -> bool {
+        self.initialized
+    }
+
+    async fn collect(&mut self) -> Result<Option<WalRows>, WalError> {
+        assert!(self.initialized);
+        let Some(collector) = &mut self.collector else {
+            return Ok(None);
+        };
+        collector.collect().await?;
+        let collector = self.collector.take().expect("unreachable");
+        self.initialized = false;
+        Ok(Some(collector.into()))
+    }
+
+    fn advance(&mut self, collector: WalRowsCollector) {
+        assert!(!self.initialized);
+        self.initialized = true;
+        self.collector = Some(collector);
+    }
+
+    fn finish(&mut self) {
+        self.initialized = true;
+        self.collector = None;
+    }
 }
 
 /// Iterates over the writes in a range of WAL files, preloading up to
@@ -220,7 +301,7 @@ pub(crate) struct WalIterator {
     /// Range of WAL IDs to iterate over
     wal_id_range: Range<u64>,
     table_store: Arc<TableStore>,
-    next_files: VecDeque<JoinHandle<Result<WalFileIter, WalError>>>,
+    next_files: VecDeque<JoinHandle<Result<WalRowsCollector, WalError>>>,
     next_wal_id: u64,
     /// The greatest seq returned so far, used to verify that WAL files arrive
     /// with strictly increasing seq ranges.
@@ -228,6 +309,7 @@ pub(crate) struct WalIterator {
     /// Set once iteration has ended, either because the range was exhausted or
     /// because an error was returned.
     terminal_result: Option<Result<Option<WalRows>, WalError>>,
+    current_file: CurrentWalFile,
 }
 
 impl WalIterator {
@@ -249,10 +331,11 @@ impl WalIterator {
             next_wal_id,
             last_seq: None,
             terminal_result: None,
+            current_file: CurrentWalFile::initial(),
         })
     }
 
-    fn maybe_load_next_file(&mut self) -> bool {
+    fn maybe_spawn_open(&mut self) -> bool {
         if !self.wal_id_range.contains(&self.next_wal_id)
             || self.next_files.len() >= self.options.sst_batch_size
         {
@@ -266,16 +349,16 @@ impl WalIterator {
             wal_id: u64,
             sst_iter_options: SstIteratorOptions,
             table_store: Arc<TableStore>,
-        ) -> Result<WalFileIter, SlateDBError> {
+        ) -> Result<WalRowsCollector, SlateDBError> {
             let sst = match table_store.open_sst(&SsTableId::Wal(wal_id)).await {
                 Ok(sst) => sst,
                 Err(SlateDBError::EmptySSTable) => {
                     // Zero-byte WAL files are fence markers; replay them as empty WALs
                     // so the last replayed WAL ID still advances past the marker.
-                    return Ok(WalFileIter {
+                    return Ok(WalRowsCollector::new(
                         wal_id,
-                        iter: Box::new(EmptyIterator::new()),
-                    });
+                        Box::new(EmptyIterator::new()),
+                    ));
                 }
                 Err(err) => return Err(err),
             };
@@ -296,17 +379,14 @@ impl WalIterator {
                 );
                 return Err(SlateDBError::InvalidDBState);
             };
-            Ok(WalFileIter {
-                wal_id,
-                iter: Box::new(iter) as Box<dyn RowEntryIterator + 'static>,
-            })
+            Ok(WalRowsCollector::new(wal_id, Box::new(iter)))
         }
 
         async fn open_file_iter(
             wal_id: u64,
             sst_iter_options: SstIteratorOptions,
             table_store: Arc<TableStore>,
-        ) -> Result<WalFileIter, WalError> {
+        ) -> Result<WalRowsCollector, WalError> {
             match try_open_file_iter(wal_id, sst_iter_options, table_store).await {
                 Ok(iter) => Ok(iter),
                 Err(err) if err.has_object_store_not_found() => Err(WalError::WalTruncated(wal_id)),
@@ -325,16 +405,23 @@ impl WalIterator {
 
     /// Await the next preloaded WAL file and return an iterator over its rows.
     /// Returns `None` when there are no more files to read.
-    async fn take_next_file(&mut self) -> Result<Option<WalFileIter>, WalError> {
+    async fn load_next_file(&mut self) -> Result<(), WalError> {
+        if self.current_file.initialized() {
+            return Ok(());
+        }
         // await a mutable ref to the task so that next remains cancel-safe
         // see https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html#cancel-safety
         let Some(join_handle) = self.next_files.front_mut() else {
-            return Ok(None);
+            self.current_file.finish();
+            return Ok(());
         };
         let result = join_handle.await;
         self.next_files.pop_front();
         match result {
-            Ok(result) => result.map(Some),
+            Ok(result) => {
+                self.current_file.advance(result?);
+                Ok(())
+            }
             Err(join_err) => {
                 let task_name = format!("wal_replay[{:?}]", self.wal_id_range);
                 let msg = if let Ok(panic_err) = join_err.try_into_panic() {
@@ -378,62 +465,43 @@ impl WalIteratorTrait for WalIterator {
             return result;
         }
 
-        while self.maybe_load_next_file() {}
-        let mut file_iter = match self.take_next_file().await {
-            Ok(Some(file_iter)) => file_iter,
-            Ok(None) => {
-                return self.terminate(Ok(None));
-            }
-            Err(err) => {
-                return self.terminate(Err(err));
-            }
-        };
-
-        // Read out the file's rows. Only the file being returned is materialized;
-        // preloaded files just hold opened iterators.
-        let mut rows = Vec::new();
-        loop {
-            match file_iter.iter.next().await {
-                Ok(Some(row)) => rows.push(row),
-                Ok(None) => break,
-                Err(err) if err.has_object_store_not_found() => {
-                    return self.terminate(Err(WalError::WalTruncated(file_iter.wal_id)));
+        while self.maybe_spawn_open() {}
+        if let Err(err) = self.load_next_file().await {
+            return self.terminate(Err(err));
+        }
+        match self.current_file.collect().await {
+            Err(err) => self.terminate(Err(err)),
+            Ok(None) => self.terminate(Ok(None)),
+            Ok(Some(rows)) => {
+                // Verify that WAL files carry strictly increasing seq ranges. Replay
+                // relies on this ordering to split and tag memtables safely: a commit seq
+                // spanning two WAL files, or files with overlapping seq ranges, would
+                // break recovery's (wal_id, seq) watermark filtering.
+                if let Some(min_seq) = rows.rows.iter().map(|row| row.seq).min() {
+                    if let Some(last_seq) = self.last_seq {
+                        if min_seq <= last_seq {
+                            let msg = format!(
+                                "WAL replay saw out-of-order seqs across WAL files. \
+                                [wal_id={}, min_seq={}, last_seq={}]",
+                                rows.last_consumed_wal_file_id, min_seq, last_seq,
+                            );
+                            error!("{}", &msg);
+                            let error =
+                                Arc::from(Box::<dyn std::error::Error + Send + Sync>::from(msg));
+                            return self.terminate(Err(WalError::InternalError(error)));
+                        }
+                    }
+                    let max_seq = rows
+                        .rows
+                        .iter()
+                        .map(|row| row.seq)
+                        .max()
+                        .expect("non-empty rows have a max seq");
+                    self.last_seq = Some(max_seq);
                 }
-                Err(err) => {
-                    return self.terminate(Err(err.into()));
-                }
+                Ok(Some(rows))
             }
         }
-
-        // Verify that WAL files carry strictly increasing seq ranges. Replay
-        // relies on this ordering to split and tag memtables safely: a commit seq
-        // spanning two WAL files, or files with overlapping seq ranges, would
-        // break recovery's (wal_id, seq) watermark filtering.
-        if let Some(min_seq) = rows.iter().map(|row| row.seq).min() {
-            if let Some(last_seq) = self.last_seq {
-                if min_seq <= last_seq {
-                    let msg = format!(
-                        "WAL replay saw out-of-order seqs across WAL files. \
-                         [wal_id={}, min_seq={}, last_seq={}]",
-                        file_iter.wal_id, min_seq, last_seq,
-                    );
-                    error!("{}", &msg);
-                    let error = Arc::from(Box::<dyn std::error::Error + Send + Sync>::from(msg));
-                    return self.terminate(Err(WalError::InternalError(error)));
-                }
-            }
-            let max_seq = rows
-                .iter()
-                .map(|row| row.seq)
-                .max()
-                .expect("non-empty rows have a max seq");
-            self.last_seq = Some(max_seq);
-        }
-
-        Ok(Some(WalRows {
-            rows,
-            last_consumed_wal_file_id: file_iter.wal_id,
-        }))
     }
 }
 
@@ -579,8 +647,14 @@ mod tests {
         )
         .unwrap();
 
-        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated(1))));
-        assert!(matches!(wal_iter.next().await, Err(WalError::WalTruncated(1))));
+        assert!(matches!(
+            wal_iter.next().await,
+            Err(WalError::WalTruncated(1))
+        ));
+        assert!(matches!(
+            wal_iter.next().await,
+            Err(WalError::WalTruncated(1))
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds traits for WAL iteration and updates replay paths in `Db`/`DbReader` to use them.

## Changes

- Adds rfc-30 traits for reading/iterating the WAL
- Adds `WalIterator` to wal_replay.rs that replays a fixed range of WAL files.
- Refactors `WalReplayIterator` to consume a `WalIterator` and write WalRows into memtables
- Updates the fencing code to return a `Box<dyn WalIterator>` instead of a replay range.

## Notes for Reviewers

- Review the RFC changes and defs in slatedb/src/wal/mod.rs
- Review the new iterator code in slatedb/src/wal_replay.rs
- Review the plumbing from fencing through to replay
- Review `DbReader` changes in `db_reader.rs`

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
