### PR TITLE
[1977] Fix flaky test_backpressure_waiter_exits_when_db_is_fenced

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -5231,14 +5231,9 @@ mod tests {
         db.put_with_options(b"key1", &large_value, &PutOptions::default(), &write_opts)
             .await
             .unwrap();
-        assert_eq!(
-            db.inner
-                .wal_observer
-                .status()
-                .unwrap()
-                .buffered_wal_entries_count,
-            1
-        );
+        // The frozen memtable is what parks the waiter below; without it
+        // maybe_apply_backpressure spins instead of blocking.
+        assert!(!db.inner.state.read().state().imm_memtable.is_empty());
 
         // Start backpressure on a cloned inner handle. This parks the task on
         // the same wait path used by writers before they enqueue a batch.
@@ -5246,7 +5241,7 @@ mod tests {
         let mut backpressure_task =
             tokio::spawn(async move { inner.maybe_apply_backpressure().await });
 
-        // Wait until the task has observed the buffered WAL bytes and incremented
+        // Wait until the task has observed the unflushed memtable and incremented
         // the backpressure counter, proving it is inside the wait path.
         tokio::time::timeout(Duration::from_secs(60), async {
             loop {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -5231,8 +5231,6 @@ mod tests {
         db.put_with_options(b"key1", &large_value, &PutOptions::default(), &write_opts)
             .await
             .unwrap();
-        // The frozen memtable is what parks the waiter below; without it
-        // maybe_apply_backpressure spins instead of blocking.
         assert!(!db.inner.state.read().state().imm_memtable.is_empty());
 
         // Start backpressure on a cloned inner handle. This parks the task on


### PR DESCRIPTION
## Summary

Closes #1977.

`assert_eq!(...buffered_wal_entries_count, 1)`, added by #1961, is racy. The WAL flushes at `l0_sst_size_bytes` (`wal/writer_init.rs:24`) = 4 KiB here while the test writes 16 KiB, so `append()` always fires an async flush and `await_durable: false` returns before it lands. On the `multi_thread` runtime the flush can pop the entry before the assert reads status.

Tuning can't fix it: `Settings::validate` requires `max_unflushed_bytes > l0_sst_size_bytes` (`config.rs:853`), so the flush threshold always sits below the backpressure threshold. WAL bytes stay buffered only while the flush is *blocked*, as `test_apply_wal_memory_backpressure` does and this test never does.

The test doesn't depend on WAL bytes anyway — backpressure here comes from the frozen memtable held by the paused L0 upload.

## Changes

Test-only.

- Assert `!imm_memtable.is_empty()` instead. Deterministic here (the 16 KiB write freezes the memtable before the write returns, and the paused L0 upload keeps it there), and it pins what the test needs: the waiter parks in `maybe_apply_backpressure`'s `select!` rather than spinning through the short circuit at the top of the loop. Spinning still increments `BACKPRESSURE_COUNT`, so the metric wait below wouldn't catch it.
- Fix the stale comment attributing backpressure to buffered WAL bytes; it predates #1967, which is what led #1961 to add the assert.

## Notes for Reviewers

Never reproduces standalone:

| | before | after |
|---|---|---|
| 48 concurrent processes | 9–11 fail | 0 fail |
| 50 ms sleep before assert | 3/3 fail | — |
| 500 ms sleep before assert | — | 0/10 fail |

Worth a separate follow-up: the panic leaves `write-compacted-sst-io-error` paused, so the L0 upload stays parked in the failpoint and `Runtime::drop` blocks instead of the assert failing fast. An RAII failpoint guard would fix that class.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
