### PR TITLE
fix flaky test_size_based_flush_triggering

### DIFF
--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -1003,15 +1003,14 @@ mod tests {
     async fn test_size_based_flush_triggering() {
         let (mut wal_buffer, _, _, _) = setup_wal_buffer_with_flush_interval(Duration::MAX).await;
 
-        // Append entries until we exceed the size threshold
-        let mut seq = 1;
-        while wal_buffer.status().unwrap().estimated_bytes < wal_buffer.max_wal_bytes_size {
-            let entry = make_entry(&format!("key{}", seq), &format!("value{}", seq), seq, None);
-            wal_buffer.append(&[entry]).await.unwrap();
-            seq += 1;
-        }
-        let mut reader = wal_buffer.maybe_trigger_flush().unwrap();
-        reader.await_value().await.unwrap();
+        // Watch the current WAL before the oversized append triggers its flush.
+        let mut durable_watcher = wal_buffer.maybe_trigger_flush().unwrap();
+        let value = "v".repeat(wal_buffer.max_wal_bytes_size);
+        wal_buffer
+            .append(&[make_entry("key", &value, 1, None)])
+            .await
+            .unwrap();
+        durable_watcher.await_value().await.unwrap();
 
         assert_eq!(wal_buffer.status().unwrap().last_flushed_wal_id, 1);
     }

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -701,7 +701,6 @@ mod tests {
     use slatedb_common::metrics::{
         lookup_metric, DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper,
     };
-    use slatedb_common::MockSystemClock;
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -879,7 +878,7 @@ mod tests {
     async fn setup_wal_buffer() -> (
         WalBufferManager,
         Arc<TableStore>,
-        Arc<MockSystemClock>,
+        Arc<DbStatusManager>,
         Arc<DefaultMetricsRecorder>,
     ) {
         setup_wal_buffer_with_flush_interval(Duration::from_millis(10)).await
@@ -890,7 +889,7 @@ mod tests {
     ) -> (
         WalBufferManager,
         Arc<TableStore>,
-        Arc<MockSystemClock>,
+        Arc<DbStatusManager>,
         Arc<DefaultMetricsRecorder>,
     ) {
         setup_wal_buffer_with_args(flush_interval, Arc::new(|_status| {})).await
@@ -902,7 +901,7 @@ mod tests {
     ) -> (
         WalBufferManager,
         Arc<TableStore>,
-        Arc<MockSystemClock>,
+        Arc<DbStatusManager>,
         Arc<DefaultMetricsRecorder>,
     ) {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -914,7 +913,6 @@ mod tests {
             TableStoreKind::Main,
             BlockCachePolicy::default(),
         ));
-        let test_clock = Arc::new(MockSystemClock::new());
         let system_clock = Arc::new(DefaultSystemClock::new());
         let status_manager = Arc::new(DbStatusManager::new(0));
         let oracle = Arc::new(DbOracle::new(0, 0, 0, status_manager.clone()));
@@ -948,7 +946,7 @@ mod tests {
         task_executor
             .monitor_on(&Handle::current())
             .expect("failed to monitor executor");
-        (wal_buffer, table_store, test_clock, recorder)
+        (wal_buffer, table_store, status_manager, recorder)
     }
 
     #[tokio::test]
@@ -1001,16 +999,20 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_size_based_flush_triggering() {
-        let (mut wal_buffer, _, _, _) = setup_wal_buffer_with_flush_interval(Duration::MAX).await;
-
-        // Watch the current WAL before the oversized append triggers its flush.
-        let mut durable_watcher = wal_buffer.maybe_trigger_flush().unwrap();
+        // Append an oversized entry to trigger a flush, then wait until its sequence is durable.
+        let (mut wal_buffer, _, status_manager, _) =
+            setup_wal_buffer_with_flush_interval(Duration::MAX).await;
+        let seq = 1;
         let value = "v".repeat(wal_buffer.max_wal_bytes_size);
         wal_buffer
-            .append(&[make_entry("key", &value, 1, None)])
+            .append(&[make_entry("key", &value, seq, None)])
             .await
             .unwrap();
-        durable_watcher.await_value().await.unwrap();
+        status_manager
+            .subscribe()
+            .wait_for(|status| status.durable_seq >= seq)
+            .await
+            .unwrap();
 
         assert_eq!(wal_buffer.status().unwrap().last_flushed_wal_id, 1);
     }


### PR DESCRIPTION
## Summary

`test_size_based_flush_triggering` failed last night in our flaky test check. The AI diagnosis below is pretty clear:

## AI Diagnosis

• The job failed because wal_buffer::tests::test_size_based_flush_triggering is racy after commit 40ef0294.

  That commit changed WalBufferManager::append() to call maybe_trigger_flush() automatically. However, the test still:

  1. Appends until the current WAL exceeds the threshold.
  2. Calls maybe_trigger_flush() again.
  3. Waits and asserts that exactly WAL 1 was flushed.

  Under CI scheduling, WAL 1 finished between loop iterations. The loop then filled and flushed WAL 2, producing:

  assertion `left == right` failed
    left: 2
   right: 1

  Relevant code: slatedb/src/wal_buffer.rs:208 and the stale test at slatedb/src/wal_buffer.rs:1001.

  This is a test synchronization bug, not evidence that production flushing wrote an incorrect WAL. The focused test passed once and then 200 consecutive
  times locally, consistent with a scheduling-sensitive failure. The nightly job runs tests concurrently with nextest and exposed the race on its first
  iteration.

## Changes

- Update test to always fill the WAL with a single large value that exceeds max bytes, then wait for the WAL buffer to trigger the flush.

## Notes for Reviewers

None.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
