### PR TITLE
Fix test_compactor_applies_output_cache_policy

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1443,6 +1443,7 @@ mod tests {
     use ulid::Ulid;
 
     use super::*;
+    use crate::batch::WriteBatch;
     use crate::block_cache_policy::BlockCachePolicy;
     use crate::compaction_worker::WorkerMessage;
     use crate::compactions_store::{FenceableCompactions, StoredCompactions};
@@ -1791,19 +1792,21 @@ mod tests {
             .await
             .unwrap();
 
+        // Keep all entries in one memtable so the explicit flush produces one
+        // L0 SST regardless of the configured memtable size threshold.
+        let mut batch = WriteBatch::new();
         for key in [b"a", b"b", b"c", b"d"] {
-            db.put_with_options(
-                key,
-                b"value",
-                &PutOptions::default(),
-                &WriteOptions {
-                    await_durable: false,
-                    ..Default::default()
-                },
-            )
-            .await
-            .unwrap();
+            batch.put(key, b"value");
         }
+        db.write_with_options(
+            batch,
+            &WriteOptions {
+                await_durable: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
         db.flush_with_options(FlushOptions {
             flush_type: FlushType::MemTable,
         })


### PR DESCRIPTION
## Summary

`test_compactor_applies_output_cache_policy` appears to be flaky:

https://github.com/slatedb/slatedb/actions/runs/30386216832/job/90366070393

It can generate outputs with multiple SSTs depending on the timing.

## Changes

- Force all writes into a single L0

## Notes for Reviewers

Ran 100x in a loop with all passing. Previously failed very quickly.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
