### PR TITLE
Add simple trivial moves to compactor scheduler

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -108,7 +108,7 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         manifest_update_timeout: rng
             .random_range(Duration::from_millis(100)..Duration::from_secs(60)),
         max_concurrent_compactions: rng.random_range(1..=4),
-        enable_trivial_move: true,
+        enable_trivial_move: rng.random_bool(0.5),
         scheduler_options: SizeTieredCompactionSchedulerOptions {
             min_compaction_sources,
             max_compaction_sources,

--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -108,6 +108,7 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         manifest_update_timeout: rng
             .random_range(Duration::from_millis(100)..Duration::from_secs(60)),
         max_concurrent_compactions: rng.random_range(1..=4),
+        enable_trivial_move: true,
         scheduler_options: SizeTieredCompactionSchedulerOptions {
             min_compaction_sources,
             max_compaction_sources,

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1784,12 +1784,14 @@ mod tests {
         options.flush_interval = None;
         // Ensure that filter is built.
         options.min_filter_keys = 1;
-        options
+        let compactor_options = options
             .compactor_options
             .as_mut()
-            .expect("compactor options must be set")
-            .scheduler_options = SizeTieredCompactionSchedulerOptions {
-            min_compaction_sources: 2,
+            .expect("compactor options must be set");
+        compactor_options.enable_trivial_move = false;
+        compactor_options.scheduler_options = SizeTieredCompactionSchedulerOptions {
+            // Compact even a single L0 so one flush is enough to trigger.
+            min_compaction_sources: 1,
             ..Default::default()
         }
         .into();
@@ -1805,28 +1807,24 @@ mod tests {
             .await
             .unwrap();
 
-        // Two overlapping L0s force executor compaction instead of a trivial
-        // move, which is what this output-cache-policy test needs to exercise.
-        for value in [b"old".as_slice(), b"value".as_slice()] {
-            for key in [b"a", b"b", b"c", b"d"] {
-                db.put_with_options(
-                    key,
-                    value,
-                    &PutOptions::default(),
-                    &WriteOptions {
-                        await_durable: false,
-                        ..Default::default()
-                    },
-                )
-                .await
-                .unwrap();
-            }
-            db.flush_with_options(FlushOptions {
-                flush_type: FlushType::MemTable,
-            })
+        for key in [b"a", b"b", b"c", b"d"] {
+            db.put_with_options(
+                key,
+                b"value",
+                &PutOptions::default(),
+                &WriteOptions {
+                    await_durable: false,
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
         }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
 
         let db_state = await_compaction(&db, os.clone(), Some(system_clock))
             .await
@@ -3576,12 +3574,12 @@ mod tests {
         }
         .into();
         let mut options = db_options(Some(compactor_options()));
-        options.flush_interval = None;
-        options
+        let compactor_options = options
             .compactor_options
             .as_mut()
-            .expect("compactor options missing")
-            .scheduler_options = scheduler_options;
+            .expect("compactor options missing");
+        compactor_options.enable_trivial_move = false;
+        compactor_options.scheduler_options = scheduler_options;
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_system_clock(insert_clock.clone())
@@ -3643,27 +3641,14 @@ mod tests {
         )
         .await
         .unwrap();
-        // Overwrite key 2 in the second L0 so this retention test exercises
-        // executor compaction rather than a trivial move.
-        db.put_with_options(
-            &[2; 16],
-            value,
-            &PutOptions {
-                ttl: Ttl::ExpireAt(i64::MAX),
-            },
-            &WriteOptions {
-                await_durable: false,
-                ..Default::default()
-            },
-        )
-        .await
-        .unwrap();
 
         db.flush_with_options(flush_opts.clone()).await.unwrap();
 
         // when: await_compaction advances clock by 60s per iteration,
         // so compaction_start_ts will be well past expire_at=10
-        let db_state = await_compaction(&db, os.clone(), Some(insert_clock)).await;
+        let db_state =
+            await_compaction_matching(&db, os.clone(), Some(insert_clock), has_single_output_sst)
+                .await;
 
         // then: key 1 should be expired (expire_at=10 < compaction_time),
         //       key 2 should survive (expire_at=i64::MAX), key 3 has no expiry
@@ -3686,8 +3671,8 @@ mod tests {
         assert_iterator(
             &mut iter,
             vec![
-                RowEntry::new_value(&[2; 16], value, 4)
-                    .with_create_ts(10)
+                RowEntry::new_value(&[2; 16], value, 2)
+                    .with_create_ts(5)
                     .with_expire_ts(i64::MAX),
                 RowEntry::new_value(&[3; 16], value, 3).with_create_ts(10),
             ],
@@ -4845,18 +4830,18 @@ mod tests {
             self.manifest.refresh().await.unwrap().core.clone()
         }
 
-        async fn write_l0(&mut self) {
-            let mut rng = rng::new_test_rng(None);
-            let mut k = vec![0u8; self.options.l0_sst_size_bytes];
-            rng.fill_bytes(&mut k);
-            self.write_l0_with_key(&k).await;
+        fn disable_trivial_moves(&mut self) {
+            Arc::make_mut(&mut self.handler.options).enable_trivial_move = false;
         }
 
-        async fn write_l0_with_key(&mut self, key: &[u8]) {
+        async fn write_l0(&mut self) {
+            let mut rng = rng::new_test_rng(None);
             let manifest = self.manifest.refresh().await.unwrap();
             let l0s = manifest.core.tree.l0.len();
             // TODO: add an explicit flush_memtable fn to db and use that instead
-            self.db.put(key, &[b'x'; 10]).await.unwrap();
+            let mut k = vec![0u8; self.options.l0_sst_size_bytes];
+            rng.fill_bytes(&mut k);
+            self.db.put(&k, &[b'x'; 10]).await.unwrap();
             self.db.flush().await.unwrap();
             loop {
                 let manifest = self.manifest.refresh().await.unwrap().clone();
@@ -4967,14 +4952,18 @@ mod tests {
     async fn test_should_record_last_compaction_ts() {
         // given:
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        fixture.disable_trivial_moves();
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker().await.unwrap();
+        fixture.simulate_worker_completes().await;
+
         let starting_last_ts =
             slatedb_common::metrics::lookup_metric(&fixture.test_recorder, LAST_COMPACTION_TS_SEC)
                 .expect("metric not found");
 
-        // when: the coordinator completes the trivial move
+        // when: coordinator commits the Compacted entry
         fixture.handler.handle_ticker().await.unwrap();
 
         // then:
@@ -5035,11 +5024,12 @@ mod tests {
     async fn test_should_persist_compactions_on_start_and_finish() {
         // given:
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        fixture.disable_trivial_moves();
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
 
-        // when: schedule and trivially complete the compaction
+        // when: schedule compaction → Scheduled persisted
         fixture.handler.handle_ticker().await.unwrap();
 
         let stored_compactions = fixture
@@ -5060,15 +5050,18 @@ mod tests {
             .next()
             .expect("compaction should be persisted")
             .id();
-        let state_compaction = fixture
+        let state_id = fixture
             .handler
             .state()
-            .compactions()
-            .value
-            .get(&scheduled_id)
+            .active_compactions()
+            .next()
             .expect("state missing compaction")
-            .clone();
-        assert_eq!(state_compaction.status(), CompactionStatus::Completed);
+            .id();
+        assert_eq!(scheduled_id, state_id);
+
+        // worker executes, writes Compacted; coordinator commits on next tick
+        fixture.simulate_worker_completes().await;
+        fixture.handler.handle_ticker().await.unwrap();
 
         // then: finished compaction is retained (one entry for GC)
         let stored_compactions = fixture
@@ -5124,21 +5117,10 @@ mod tests {
     #[tokio::test]
     async fn test_maybe_validate_submitted_compactions_promotes_to_scheduled() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        let l0 = bounded_sst_view(1, b"a", b"m");
-        let sr_view = bounded_sst_view(2, b"m", b"z");
-        let core = &mut fixture
-            .handler
-            .state_writer
-            .state
-            .manifest_mut_for_test()
-            .value
-            .core;
-        Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![sr_view],
-        }];
-        let spec = CompactionSpec::new(vec![SourceId::SstView(l0.id), SourceId::SortedRun(1)], 2);
+        fixture.disable_trivial_moves();
+        fixture.write_l0().await;
+        fixture.handler.state_writer.refresh().await.unwrap();
+        let spec = fixture.build_l0_compaction().await;
         let compaction_id = Ulid::new();
         fixture
             .handler
@@ -5406,8 +5388,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_ticker_completes_preexisting_submitted_trivial_move() {
-        let compactor_options = Arc::new(compactor_options());
+    async fn test_handle_ticker_starts_preexisting_submitted_compaction() {
+        let mut compactor_options = compactor_options();
+        compactor_options.enable_trivial_move = false;
+        let compactor_options = Arc::new(compactor_options);
         let options = db_options(None);
 
         let os = Arc::new(InMemory::new());
@@ -5481,8 +5465,7 @@ mod tests {
 
         handler.handle_ticker().await.unwrap();
 
-        // A single input SST is non-overlapping, so the coordinator completes
-        // the pre-existing submission without handing it to a worker.
+        // The pre-existing Submitted compaction should be promoted to Scheduled.
         let stored = compactions_store
             .read_latest_compactions()
             .await
@@ -5493,10 +5476,8 @@ mod tests {
                 .get(&compaction_id)
                 .expect("missing stored compaction")
                 .status(),
-            CompactionStatus::Completed
+            CompactionStatus::Scheduled
         );
-        assert!(handler.state().db_state().tree.l0.is_empty());
-        assert_eq!(handler.state().db_state().tree.compacted.len(), 1);
     }
 
     #[tokio::test]
@@ -5558,21 +5539,19 @@ mod tests {
 
     #[tokio::test]
     async fn test_should_not_schedule_conflicting_compaction() {
-        // given: one compaction already reserves the destination
+        // given: first ticker schedules a compaction (Scheduled in local state)
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        let compaction = CompactionSpec::new(vec![SourceId::SortedRun(1)], 2);
-        fixture
-            .handler
-            .state_mut()
-            .add_compaction(
-                Compaction::new(Ulid::new(), compaction.clone())
-                    .with_status(CompactionStatus::Scheduled),
-            )
-            .unwrap();
+        fixture.disable_trivial_moves();
+        fixture.write_l0().await;
+        let compaction = fixture.build_l0_compaction().await;
+        fixture.scheduler.inject_compaction(compaction.clone());
+        fixture.handler.handle_ticker().await.unwrap();
+        assert_eq!(fixture.get_scheduled_compactions().await.len(), 1);
+        fixture.write_l0().await;
         fixture.scheduler.inject_compaction(compaction.clone());
 
-        // when: scheduling the same spec again hits the destination guard
-        fixture.handler.maybe_schedule_compactions().await.unwrap();
+        // when: second ticker with same spec — add_compaction rejects duplicate destination
+        fixture.handler.handle_ticker().await.unwrap();
 
         // then: still only one active compaction (no duplicate added)
         assert_eq!(1, fixture.handler.state().active_compactions().count());
@@ -5906,6 +5885,7 @@ mod tests {
     #[tokio::test]
     async fn test_validate_compaction_rejects_parallel_l0() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        fixture.disable_trivial_moves();
         // write two L0s so we can build two disjoint L0 compactions
         fixture.write_l0().await;
         fixture.write_l0().await;
@@ -5917,15 +5897,9 @@ mod tests {
         // Build first L0 compaction from the oldest L0
         let first_l0 =
             CompactionSpec::new(vec![SourceId::SstView(state.tree.l0.back().unwrap().id)], 0);
-        // Seed the first claim directly. Running the normal submitted path
-        // would trivially move this single-SST compaction.
-        fixture
-            .handler
-            .state_mut()
-            .add_compaction(
-                Compaction::new(Ulid::new(), first_l0).with_status(CompactionStatus::Scheduled),
-            )
-            .unwrap();
+        // Inject and schedule it so it becomes active
+        fixture.scheduler.inject_compaction(first_l0.clone());
+        fixture.handler.handle_ticker().await.unwrap();
 
         // Build second L0 compaction from the newest L0 (disjoint sources)
         let second_l0 = CompactionSpec::new(

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1784,12 +1784,11 @@ mod tests {
         options.flush_interval = None;
         // Ensure that filter is built.
         options.min_filter_keys = 1;
-        let compactor_options = options
+        options
             .compactor_options
             .as_mut()
-            .expect("compactor options must be set");
-        compactor_options.enable_trivial_move = false;
-        compactor_options.scheduler_options = SizeTieredCompactionSchedulerOptions {
+            .expect("compactor options must be set")
+            .scheduler_options = SizeTieredCompactionSchedulerOptions {
             // Compact even a single L0 so one flush is enough to trigger.
             min_compaction_sources: 1,
             ..Default::default()
@@ -3574,12 +3573,11 @@ mod tests {
         }
         .into();
         let mut options = db_options(Some(compactor_options()));
-        let compactor_options = options
+        options
             .compactor_options
             .as_mut()
-            .expect("compactor options missing");
-        compactor_options.enable_trivial_move = false;
-        compactor_options.scheduler_options = scheduler_options;
+            .expect("compactor options missing")
+            .scheduler_options = scheduler_options;
         let db = Db::builder(PATH, os.clone())
             .with_settings(options)
             .with_system_clock(insert_clock.clone())
@@ -4830,10 +4828,6 @@ mod tests {
             self.manifest.refresh().await.unwrap().core.clone()
         }
 
-        fn disable_trivial_moves(&mut self) {
-            Arc::make_mut(&mut self.handler.options).enable_trivial_move = false;
-        }
-
         async fn write_l0(&mut self) {
             let mut rng = rng::new_test_rng(None);
             let manifest = self.manifest.refresh().await.unwrap();
@@ -4952,7 +4946,6 @@ mod tests {
     async fn test_should_record_last_compaction_ts() {
         // given:
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.disable_trivial_moves();
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
@@ -5024,7 +5017,6 @@ mod tests {
     async fn test_should_persist_compactions_on_start_and_finish() {
         // given:
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.disable_trivial_moves();
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
@@ -5117,7 +5109,6 @@ mod tests {
     #[tokio::test]
     async fn test_maybe_validate_submitted_compactions_promotes_to_scheduled() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.disable_trivial_moves();
         fixture.write_l0().await;
         fixture.handler.state_writer.refresh().await.unwrap();
         let spec = fixture.build_l0_compaction().await;
@@ -5162,7 +5153,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_maybe_validate_submitted_compactions_completes_trivial_move() {
-        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        let options = Arc::new(CompactorOptions {
+            enable_trivial_move: true,
+            ..compactor_options()
+        });
+        let mut fixture = CompactorEventHandlerTestFixture::new_with_clock(
+            Arc::new(DefaultSystemClock::new()),
+            options,
+        )
+        .await;
         let l0 = bounded_sst_view(2, b"m", b"n");
         let sr_first = bounded_sst_view(1, b"a", b"b");
         let sr_last = bounded_sst_view(3, b"z", b"z");
@@ -5389,9 +5388,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_ticker_starts_preexisting_submitted_compaction() {
-        let mut compactor_options = compactor_options();
-        compactor_options.enable_trivial_move = false;
-        let compactor_options = Arc::new(compactor_options);
+        let compactor_options = Arc::new(compactor_options());
         let options = db_options(None);
 
         let os = Arc::new(InMemory::new());
@@ -5541,7 +5538,6 @@ mod tests {
     async fn test_should_not_schedule_conflicting_compaction() {
         // given: first ticker schedules a compaction (Scheduled in local state)
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.disable_trivial_moves();
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
@@ -5606,12 +5602,11 @@ mod tests {
         let mut options = db_options(Some(compactor_options()));
         options.l0_sst_size_bytes = 128;
         options.compression_codec = Some(CompressionCodec::Zstd);
-        let compactor_options = options
+        options
             .compactor_options
             .as_mut()
-            .expect("compactor options missing");
-        compactor_options.scheduler_options = scheduler_options;
-        compactor_options.enable_trivial_move = false;
+            .expect("compactor options missing")
+            .scheduler_options = scheduler_options;
 
         let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
         let db = Db::builder(PATH, os.clone())
@@ -5885,7 +5880,6 @@ mod tests {
     #[tokio::test]
     async fn test_validate_compaction_rejects_parallel_l0() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.disable_trivial_moves();
         // write two L0s so we can build two disjoint L0 compactions
         fixture.write_l0().await;
         fixture.write_l0().await;

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1217,11 +1217,16 @@ impl CompactorEventHandler {
 
             // Coordinator-local compactions never enter Scheduled because no
             // worker runs them. Everything else becomes ready to claim.
+            let trivial_move_output = self
+                .options
+                .enable_trivial_move
+                .then(|| compaction.trivial_move_output(self.state().db_state()))
+                .flatten();
+
             if compaction.spec().is_drain() {
                 self.state_mut().finish_drain_compaction(compaction.id());
                 manifest_changed = true;
-            } else if let Some(output_sr) = compaction.trivial_move_output(self.state().db_state())
-            {
+            } else if let Some(output_sr) = trivial_move_output {
                 info!("trivially moving compaction [spec={}]", compaction.spec());
                 self.state_mut()
                     .finish_compaction(compaction.id(), output_sr);
@@ -5238,6 +5243,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_maybe_validate_submitted_compactions_schedules_when_trivial_move_disabled() {
+        let options = Arc::new(CompactorOptions {
+            enable_trivial_move: false,
+            ..compactor_options()
+        });
+        let mut fixture = CompactorEventHandlerTestFixture::new_with_clock(
+            Arc::new(DefaultSystemClock::new()),
+            options,
+        )
+        .await;
+        let l0 = bounded_sst_view(2, b"m", b"n");
+        let sr_first = bounded_sst_view(1, b"a", b"b");
+        let sr_last = bounded_sst_view(3, b"z", b"z");
+        let core = &mut fixture
+            .handler
+            .state_writer
+            .state
+            .manifest_mut_for_test()
+            .value
+            .core;
+        Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
+            id: 1,
+            sst_views: vec![sr_first, sr_last],
+        }];
+        let compaction_id = Ulid::new();
+        fixture
+            .handler
+            .state_mut()
+            .add_compaction(Compaction::new(
+                compaction_id,
+                CompactionSpec::new(vec![SourceId::SstView(l0.id), SourceId::SortedRun(1)], 2),
+            ))
+            .unwrap();
+
+        fixture
+            .handler
+            .maybe_validate_submitted_compactions()
+            .await
+            .unwrap();
+
+        let state = fixture.handler.state();
+        assert_eq!(
+            state
+                .compactions()
+                .value
+                .get(&compaction_id)
+                .unwrap()
+                .status(),
+            CompactionStatus::Scheduled
+        );
+        assert_eq!(state.db_state().tree.l0.len(), 1);
+        assert_eq!(state.db_state().tree.compacted[0].id, 1);
+    }
+
+    #[tokio::test]
     async fn test_maybe_validate_submitted_compactions_marks_invalid_failed() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
         let compaction_id = Ulid::new();
@@ -5566,11 +5627,12 @@ mod tests {
         let mut options = db_options(Some(compactor_options()));
         options.l0_sst_size_bytes = 128;
         options.compression_codec = Some(CompressionCodec::Zstd);
-        options
+        let compactor_options = options
             .compactor_options
             .as_mut()
-            .expect("compactor options missing")
-            .scheduler_options = scheduler_options;
+            .expect("compactor options missing");
+        compactor_options.scheduler_options = scheduler_options;
+        compactor_options.enable_trivial_move = false;
 
         let metrics_recorder = Arc::new(DefaultMetricsRecorder::new());
         let db = Db::builder(PATH, os.clone())

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1176,13 +1176,13 @@ impl CompactorEventHandler {
     }
 
     /// Validates every `Submitted` compaction against the current manifest and
-    /// promotes the valid tiered specs to `Scheduled` — the coordinator's
-    /// "ready for a worker to claim" state. Drain specs short-circuit the
-    /// executor and are applied directly to the in-memory manifest (→
+    /// promotes valid tiered specs to `Scheduled` — the coordinator's "ready
+    /// for a worker to claim" state. Drain specs and trivial moves short-circuit
+    /// the executor and are applied directly to the in-memory manifest (→
     /// `Completed`). Invalid specs are marked `Failed`. State changes are
     /// persisted before any worker (including the local executor) can act on
-    /// them: when any submission was a drain the manifest and `.compactions`
-    /// are written together, otherwise `.compactions` alone.
+    /// them: when a submission changed the manifest, the manifest and
+    /// `.compactions` are written together, otherwise `.compactions` alone.
     ///
     /// Workers exclusively claim `Scheduled` entries; they never act on
     /// `Submitted`. Routing validation through this single chokepoint keeps
@@ -1200,7 +1200,7 @@ impl CompactorEventHandler {
             return Ok(());
         }
 
-        let any_drain = submitted_compactions.iter().any(|c| c.spec().is_drain());
+        let mut manifest_changed = false;
 
         for compaction in &submitted_compactions {
             // Validate the candidate compaction; mark as failed if invalid.
@@ -1215,12 +1215,17 @@ impl CompactorEventHandler {
                 continue;
             }
 
-            // Drain specs apply the watermark advance and SR removal directly,
-            // marking the compaction Completed. They never enter Scheduled
-            // because no worker runs them. Tiered specs become Scheduled so a
-            // worker can claim them.
+            // Coordinator-local compactions never enter Scheduled because no
+            // worker runs them. Everything else becomes ready to claim.
             if compaction.spec().is_drain() {
                 self.state_mut().finish_drain_compaction(compaction.id());
+                manifest_changed = true;
+            } else if let Some(output_sr) = compaction.trivial_move_output(self.state().db_state())
+            {
+                info!("trivially moving compaction [spec={}]", compaction.spec());
+                self.state_mut()
+                    .finish_compaction(compaction.id(), output_sr);
+                manifest_changed = true;
             } else {
                 self.state_mut().update_compaction(&compaction.id(), |c| {
                     c.clear_ctx();
@@ -1229,8 +1234,11 @@ impl CompactorEventHandler {
             }
         }
 
-        if any_drain {
+        if manifest_changed {
             self.state_writer.write_state_safely().await?;
+            self.stats
+                .last_compaction_ts
+                .set(self.system_clock.now().timestamp());
         } else {
             self.state_writer.write_compactions_safely().await?;
         }
@@ -1473,7 +1481,9 @@ mod tests {
     use crate::proptest_util::rng;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
     use crate::tablestore::{TableStore, TableStoreKind};
-    use crate::test_utils::{assert_iterator, FixedThreeBytePrefixExtractor, GatedObjectStore};
+    use crate::test_utils::{
+        assert_iterator, bounded_sst_view, FixedThreeBytePrefixExtractor, GatedObjectStore,
+    };
     use crate::types::KeyValue;
     use crate::types::RowEntry;
     use bytes::Bytes;
@@ -1774,8 +1784,7 @@ mod tests {
             .as_mut()
             .expect("compactor options must be set")
             .scheduler_options = SizeTieredCompactionSchedulerOptions {
-            // Compact even a single L0 so one flush is enough to trigger.
-            min_compaction_sources: 1,
+            min_compaction_sources: 2,
             ..Default::default()
         }
         .into();
@@ -1791,24 +1800,28 @@ mod tests {
             .await
             .unwrap();
 
-        for key in [b"a", b"b", b"c", b"d"] {
-            db.put_with_options(
-                key,
-                b"value",
-                &PutOptions::default(),
-                &WriteOptions {
-                    await_durable: false,
-                    ..Default::default()
-                },
-            )
+        // Two overlapping L0s force executor compaction instead of a trivial
+        // move, which is what this output-cache-policy test needs to exercise.
+        for value in [b"old".as_slice(), b"value".as_slice()] {
+            for key in [b"a", b"b", b"c", b"d"] {
+                db.put_with_options(
+                    key,
+                    value,
+                    &PutOptions::default(),
+                    &WriteOptions {
+                        await_durable: false,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            }
+            db.flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
             .await
             .unwrap();
         }
-        db.flush_with_options(FlushOptions {
-            flush_type: FlushType::MemTable,
-        })
-        .await
-        .unwrap();
 
         let db_state = await_compaction(&db, os.clone(), Some(system_clock))
             .await
@@ -3558,6 +3571,7 @@ mod tests {
         }
         .into();
         let mut options = db_options(Some(compactor_options()));
+        options.flush_interval = None;
         options
             .compactor_options
             .as_mut()
@@ -3624,14 +3638,27 @@ mod tests {
         )
         .await
         .unwrap();
+        // Overwrite key 2 in the second L0 so this retention test exercises
+        // executor compaction rather than a trivial move.
+        db.put_with_options(
+            &[2; 16],
+            value,
+            &PutOptions {
+                ttl: Ttl::ExpireAt(i64::MAX),
+            },
+            &WriteOptions {
+                await_durable: false,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
         db.flush_with_options(flush_opts.clone()).await.unwrap();
 
         // when: await_compaction advances clock by 60s per iteration,
         // so compaction_start_ts will be well past expire_at=10
-        let db_state =
-            await_compaction_matching(&db, os.clone(), Some(insert_clock), has_single_output_sst)
-                .await;
+        let db_state = await_compaction(&db, os.clone(), Some(insert_clock)).await;
 
         // then: key 1 should be expired (expire_at=10 < compaction_time),
         //       key 2 should survive (expire_at=i64::MAX), key 3 has no expiry
@@ -3654,8 +3681,8 @@ mod tests {
         assert_iterator(
             &mut iter,
             vec![
-                RowEntry::new_value(&[2; 16], value, 2)
-                    .with_create_ts(5)
+                RowEntry::new_value(&[2; 16], value, 4)
+                    .with_create_ts(10)
                     .with_expire_ts(i64::MAX),
                 RowEntry::new_value(&[3; 16], value, 3).with_create_ts(10),
             ],
@@ -4815,12 +4842,16 @@ mod tests {
 
         async fn write_l0(&mut self) {
             let mut rng = rng::new_test_rng(None);
+            let mut k = vec![0u8; self.options.l0_sst_size_bytes];
+            rng.fill_bytes(&mut k);
+            self.write_l0_with_key(&k).await;
+        }
+
+        async fn write_l0_with_key(&mut self, key: &[u8]) {
             let manifest = self.manifest.refresh().await.unwrap();
             let l0s = manifest.core.tree.l0.len();
             // TODO: add an explicit flush_memtable fn to db and use that instead
-            let mut k = vec![0u8; self.options.l0_sst_size_bytes];
-            rng.fill_bytes(&mut k);
-            self.db.put(&k, &[b'x'; 10]).await.unwrap();
+            self.db.put(key, &[b'x'; 10]).await.unwrap();
             self.db.flush().await.unwrap();
             loop {
                 let manifest = self.manifest.refresh().await.unwrap().clone();
@@ -4934,14 +4965,11 @@ mod tests {
         fixture.write_l0().await;
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
-        fixture.handler.handle_ticker().await.unwrap();
-        fixture.simulate_worker_completes().await;
-
         let starting_last_ts =
             slatedb_common::metrics::lookup_metric(&fixture.test_recorder, LAST_COMPACTION_TS_SEC)
                 .expect("metric not found");
 
-        // when: coordinator commits the Compacted entry
+        // when: the coordinator completes the trivial move
         fixture.handler.handle_ticker().await.unwrap();
 
         // then:
@@ -5006,7 +5034,7 @@ mod tests {
         let compaction = fixture.build_l0_compaction().await;
         fixture.scheduler.inject_compaction(compaction.clone());
 
-        // when: schedule compaction → Scheduled persisted
+        // when: schedule and trivially complete the compaction
         fixture.handler.handle_ticker().await.unwrap();
 
         let stored_compactions = fixture
@@ -5027,18 +5055,15 @@ mod tests {
             .next()
             .expect("compaction should be persisted")
             .id();
-        let state_id = fixture
+        let state_compaction = fixture
             .handler
             .state()
-            .active_compactions()
-            .next()
+            .compactions()
+            .value
+            .get(&scheduled_id)
             .expect("state missing compaction")
-            .id();
-        assert_eq!(scheduled_id, state_id);
-
-        // worker executes, writes Compacted; coordinator commits on next tick
-        fixture.simulate_worker_completes().await;
-        fixture.handler.handle_ticker().await.unwrap();
+            .clone();
+        assert_eq!(state_compaction.status(), CompactionStatus::Completed);
 
         // then: finished compaction is retained (one entry for GC)
         let stored_compactions = fixture
@@ -5094,9 +5119,21 @@ mod tests {
     #[tokio::test]
     async fn test_maybe_validate_submitted_compactions_promotes_to_scheduled() {
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.write_l0().await;
-        fixture.handler.state_writer.refresh().await.unwrap();
-        let spec = fixture.build_l0_compaction().await;
+        let l0 = bounded_sst_view(1, b"a", b"m");
+        let sr_view = bounded_sst_view(2, b"m", b"z");
+        let core = &mut fixture
+            .handler
+            .state_writer
+            .state
+            .manifest_mut_for_test()
+            .value
+            .core;
+        Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
+            id: 1,
+            sst_views: vec![sr_view],
+        }];
+        let spec = CompactionSpec::new(vec![SourceId::SstView(l0.id), SourceId::SortedRun(1)], 2);
         let compaction_id = Ulid::new();
         fixture
             .handler
@@ -5134,6 +5171,70 @@ mod tests {
                 .status(),
             CompactionStatus::Scheduled
         );
+    }
+
+    #[tokio::test]
+    async fn test_maybe_validate_submitted_compactions_completes_trivial_move() {
+        let mut fixture = CompactorEventHandlerTestFixture::new().await;
+        let l0 = bounded_sst_view(2, b"m", b"n");
+        let sr_first = bounded_sst_view(1, b"a", b"b");
+        let sr_last = bounded_sst_view(3, b"z", b"z");
+        let core = &mut fixture
+            .handler
+            .state_writer
+            .state
+            .manifest_mut_for_test()
+            .value
+            .core;
+        Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
+            id: 1,
+            sst_views: vec![sr_first.clone(), sr_last.clone()],
+        }];
+
+        let compaction_id = Ulid::new();
+        fixture
+            .handler
+            .state_mut()
+            .add_compaction(Compaction::new(
+                compaction_id,
+                CompactionSpec::new(vec![SourceId::SstView(l0.id), SourceId::SortedRun(1)], 2),
+            ))
+            .expect("failed to add compaction");
+
+        fixture
+            .handler
+            .maybe_validate_submitted_compactions()
+            .await
+            .unwrap();
+
+        let state = fixture.handler.state();
+        assert_eq!(
+            state
+                .compactions()
+                .value
+                .get(&compaction_id)
+                .expect("missing compaction")
+                .status(),
+            CompactionStatus::Completed
+        );
+        assert!(state.db_state().tree.l0.is_empty());
+        assert_eq!(state.db_state().tree.compacted.len(), 1);
+        let output = &state.db_state().tree.compacted[0];
+        assert_eq!(output.id, 2);
+        assert_eq!(
+            output
+                .sst_views
+                .iter()
+                .map(|view| view.id)
+                .collect::<Vec<_>>(),
+            vec![sr_first.id, l0.id, sr_last.id]
+        );
+
+        let expected_output = output.clone();
+        let stored_manifest = fixture.latest_db_state().await;
+        assert!(stored_manifest.tree.l0.is_empty());
+        assert_eq!(stored_manifest.tree.compacted[0], expected_output);
     }
 
     #[tokio::test]
@@ -5244,7 +5345,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_ticker_starts_preexisting_submitted_compaction() {
+    async fn test_handle_ticker_completes_preexisting_submitted_trivial_move() {
         let compactor_options = Arc::new(compactor_options());
         let options = db_options(None);
 
@@ -5319,7 +5420,8 @@ mod tests {
 
         handler.handle_ticker().await.unwrap();
 
-        // The pre-existing Submitted compaction should be promoted to Scheduled.
+        // A single input SST is non-overlapping, so the coordinator completes
+        // the pre-existing submission without handing it to a worker.
         let stored = compactions_store
             .read_latest_compactions()
             .await
@@ -5330,8 +5432,10 @@ mod tests {
                 .get(&compaction_id)
                 .expect("missing stored compaction")
                 .status(),
-            CompactionStatus::Scheduled
+            CompactionStatus::Completed
         );
+        assert!(handler.state().db_state().tree.l0.is_empty());
+        assert_eq!(handler.state().db_state().tree.compacted.len(), 1);
     }
 
     #[tokio::test]
@@ -5393,18 +5497,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_should_not_schedule_conflicting_compaction() {
-        // given: first ticker schedules a compaction (Scheduled in local state)
+        // given: one compaction already reserves the destination
         let mut fixture = CompactorEventHandlerTestFixture::new().await;
-        fixture.write_l0().await;
-        let compaction = fixture.build_l0_compaction().await;
-        fixture.scheduler.inject_compaction(compaction.clone());
-        fixture.handler.handle_ticker().await.unwrap();
-        assert_eq!(fixture.get_scheduled_compactions().await.len(), 1);
-        fixture.write_l0().await;
+        let compaction = CompactionSpec::new(vec![SourceId::SortedRun(1)], 2);
+        fixture
+            .handler
+            .state_mut()
+            .add_compaction(
+                Compaction::new(Ulid::new(), compaction.clone())
+                    .with_status(CompactionStatus::Scheduled),
+            )
+            .unwrap();
         fixture.scheduler.inject_compaction(compaction.clone());
 
-        // when: second ticker with same spec — add_compaction rejects duplicate destination
-        fixture.handler.handle_ticker().await.unwrap();
+        // when: scheduling the same spec again hits the destination guard
+        fixture.handler.maybe_schedule_compactions().await.unwrap();
 
         // then: still only one active compaction (no duplicate added)
         assert_eq!(1, fixture.handler.state().active_compactions().count());
@@ -5748,9 +5855,15 @@ mod tests {
         // Build first L0 compaction from the oldest L0
         let first_l0 =
             CompactionSpec::new(vec![SourceId::SstView(state.tree.l0.back().unwrap().id)], 0);
-        // Inject and schedule it so it becomes active
-        fixture.scheduler.inject_compaction(first_l0.clone());
-        fixture.handler.handle_ticker().await.unwrap();
+        // Seed the first claim directly. Running the normal submitted path
+        // would trivially move this single-SST compaction.
+        fixture
+            .handler
+            .state_mut()
+            .add_compaction(
+                Compaction::new(Ulid::new(), first_l0).with_status(CompactionStatus::Scheduled),
+            )
+            .unwrap();
 
         // Build second L0 compaction from the newest L0 (disjoint sources)
         let second_l0 = CompactionSpec::new(

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -519,6 +519,35 @@ impl Compaction {
             .collect()
     }
 
+    /// Builds the output run when all input SST views have disjoint effective
+    /// key ranges. Reusing the views avoids reading or rewriting SST data.
+    pub(crate) fn trivial_move_output(&self, db_state: &ManifestCore) -> Option<SortedRun> {
+        let destination = self.spec.destination()?;
+        let mut sst_views = self.get_l0_sst_views(db_state);
+        sst_views.extend(
+            self.get_sorted_runs(db_state)
+                .into_iter()
+                .flat_map(|sr| sr.sst_views),
+        );
+        sst_views.sort_by(|left, right| {
+            left.compacted_effective_range()
+                .comparable_start_bound()
+                .cmp(&right.compacted_effective_range().comparable_start_bound())
+        });
+
+        (!sst_views.is_empty()
+            && sst_views.windows(2).all(|pair| {
+                pair[0]
+                    .compacted_effective_range()
+                    .intersect(pair[1].compacted_effective_range())
+                    .is_none()
+            }))
+        .then_some(SortedRun {
+            id: destination,
+            sst_views,
+        })
+    }
+
     /// The stable id (ULID) used to track this compaction across messages and attempts.
     pub fn id(&self) -> Ulid {
         self.id
@@ -1242,6 +1271,7 @@ mod tests {
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::{LsmTreeState, Segment};
+    use crate::test_utils::bounded_sst_view;
     use crate::utils::IdGenerator;
     use bytes::Bytes;
     use object_store::memory::InMemory;
@@ -1271,6 +1301,69 @@ mod tests {
             CompactionSpec::new(vec![SourceId::SortedRun(1)], 1),
         )
         .with_ctx(Some(CompactionContext::new(subcompactions, Some(0))))
+    }
+
+    #[test]
+    fn test_trivial_move_output_builds_sorted_run_from_disjoint_inputs() {
+        let l0 = bounded_sst_view(2, b"m", b"n");
+        let sr_first = bounded_sst_view(1, b"a", b"b");
+        let sr_last = bounded_sst_view(3, b"z", b"z");
+        let mut db_state = ManifestCore::new();
+        Arc::make_mut(&mut db_state.tree).l0 = VecDeque::from([l0.clone()]);
+        Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun {
+            id: 1,
+            sst_views: vec![sr_first.clone(), sr_last.clone()],
+        }];
+        let compaction = Compaction::new(
+            Ulid::new(),
+            CompactionSpec::new(vec![SstView(l0.id), SourceId::SortedRun(1)], 2),
+        );
+
+        let output = compaction
+            .trivial_move_output(&db_state)
+            .expect("disjoint inputs should be a trivial move");
+
+        assert_eq!(output.id, 2);
+        assert_eq!(
+            output
+                .sst_views
+                .iter()
+                .map(|view| view.id)
+                .collect::<Vec<_>>(),
+            vec![sr_first.id, l0.id, sr_last.id]
+        );
+    }
+
+    #[test]
+    fn test_trivial_move_output_rejects_overlapping_inputs() {
+        let l0 = bounded_sst_view(1, b"a", b"m");
+        let sr_view = bounded_sst_view(2, b"m", b"z");
+        let mut db_state = ManifestCore::new();
+        Arc::make_mut(&mut db_state.tree).l0 = VecDeque::from([l0.clone()]);
+        Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun {
+            id: 1,
+            sst_views: vec![sr_view],
+        }];
+        let compaction = Compaction::new(
+            Ulid::new(),
+            CompactionSpec::new(vec![SstView(l0.id), SourceId::SortedRun(1)], 2),
+        );
+
+        assert!(compaction.trivial_move_output(&db_state).is_none());
+    }
+
+    #[test]
+    fn test_trivial_move_output_rejects_drain() {
+        let db_state = ManifestCore::new();
+        let compaction = Compaction::new(
+            Ulid::new(),
+            CompactionSpec::drain_segment(
+                Bytes::from_static(b"segment/"),
+                vec![SourceId::SortedRun(1)],
+            ),
+        );
+
+        assert!(compaction.trivial_move_output(&db_state).is_none());
     }
 
     fn set_test_subcompactions(compaction: &mut Compaction, subcompactions: Vec<Subcompaction>) {

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1172,7 +1172,11 @@ pub struct CompactorOptions {
 
     /// Whether the coordinator may complete compactions with non-overlapping
     /// input SSTs by moving them directly into the destination sorted run,
-    /// without dispatching a worker job. Defaults to true.
+    /// without dispatching a worker job. Because a trivial move does not rewrite
+    /// rows, it does not remove tombstones, apply compaction filters, or process
+    /// merges during that compaction. It also preserves the input SST sizes,
+    /// which can increase manifest size and read amplification compared with
+    /// rewriting inputs into larger output SSTs. Defaults to true.
     #[serde(default = "default_true")]
     pub enable_trivial_move: bool,
 

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -59,6 +59,7 @@
 //! [compactor_options]
 //! poll_interval = "5s"
 //! max_concurrent_compactions = 4
+//! enable_trivial_move = true
 //!
 //! [compactor_options.worker]
 //! max_sst_size = 1073741824
@@ -110,6 +111,7 @@
 //!  "compactor_options": {
 //!    "poll_interval": "5s",
 //!    "max_concurrent_compactions": 4,
+//!    "enable_trivial_move": true,
 //!    "worker": {
 //!      "max_sst_size": 1073741824
 //!    },
@@ -165,6 +167,7 @@
 //! compactor_options:
 //!   poll_interval: '5s'
 //!   max_concurrent_compactions: 4
+//!   enable_trivial_move: true
 //!   worker:
 //!     max_sst_size: 1073741824
 //!   scheduler_options:
@@ -210,7 +213,7 @@ use crate::error::SlateDBError;
 
 use crate::garbage_collector::{DEFAULT_INTERVAL, DEFAULT_MIN_AGE};
 
-fn default_boundary_files_enabled() -> bool {
+fn default_true() -> bool {
     true
 }
 
@@ -1167,6 +1170,12 @@ pub struct CompactorOptions {
     /// The maximum number of concurrent compactions to execute at once
     pub max_concurrent_compactions: usize,
 
+    /// Whether the coordinator may complete compactions with non-overlapping
+    /// input SSTs by moving them directly into the destination sorted run,
+    /// without dispatching a worker job. Defaults to true.
+    #[serde(default = "default_true")]
+    pub enable_trivial_move: bool,
+
     /// Scheduler-specific options expressed as string key/value pairs.
     #[serde(default)]
     pub scheduler_options: HashMap<String, String>,
@@ -1219,6 +1228,7 @@ impl Default for CompactorOptions {
             poll_interval: Duration::from_secs(5),
             manifest_update_timeout: Duration::from_secs(300),
             max_concurrent_compactions: 4,
+            enable_trivial_move: true,
             scheduler_options: HashMap::new(),
             worker: Some(CompactionWorkerOptions::default()),
             metric_level: None,
@@ -1239,6 +1249,7 @@ impl std::fmt::Debug for CompactorOptions {
                 "max_concurrent_compactions",
                 &self.max_concurrent_compactions,
             )
+            .field("enable_trivial_move", &self.enable_trivial_move)
             .field("scheduler_options", &self.scheduler_options)
             .field("worker", &self.worker)
             .field("metric_level", &self.metric_level)
@@ -1509,7 +1520,7 @@ pub struct GarbageCollectorOptions {
     /// deleted metadata ID and incorrectly report its stale update as successful. Set `min_age`
     /// longer than the maximum lifetime of a stale process, and use the same setting for every
     /// garbage collector operating on the database.
-    #[serde(default = "default_boundary_files_enabled")]
+    #[serde(default = "default_true")]
     pub boundary_files_enabled: bool,
 
     /// Controls wrapper-level retries for this garbage collector's object-store
@@ -1786,6 +1797,16 @@ mod tests {
     fn test_db_options_default_metric_level() {
         let options = Settings::default();
         assert_eq!(MetricLevel::default(), options.metric_level);
+    }
+
+    #[test]
+    fn test_compactor_trivial_move_is_enabled_by_default_when_omitted() {
+        let mut value = serde_json::to_value(CompactorOptions::default()).unwrap();
+        value.as_object_mut().unwrap().remove("enable_trivial_move");
+
+        let options: CompactorOptions = serde_json::from_value(value).unwrap();
+
+        assert!(options.enable_trivial_move);
     }
 
     #[test]

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -59,7 +59,7 @@
 //! [compactor_options]
 //! poll_interval = "5s"
 //! max_concurrent_compactions = 4
-//! enable_trivial_move = true
+//! enable_trivial_move = false
 //!
 //! [compactor_options.worker]
 //! max_sst_size = 1073741824
@@ -111,7 +111,7 @@
 //!  "compactor_options": {
 //!    "poll_interval": "5s",
 //!    "max_concurrent_compactions": 4,
-//!    "enable_trivial_move": true,
+//!    "enable_trivial_move": false,
 //!    "worker": {
 //!      "max_sst_size": 1073741824
 //!    },
@@ -167,7 +167,7 @@
 //! compactor_options:
 //!   poll_interval: '5s'
 //!   max_concurrent_compactions: 4
-//!   enable_trivial_move: true
+//!   enable_trivial_move: false
 //!   worker:
 //!     max_sst_size: 1073741824
 //!   scheduler_options:
@@ -1176,8 +1176,8 @@ pub struct CompactorOptions {
     /// rows, it does not remove tombstones, apply compaction filters, or process
     /// merges during that compaction. It also preserves the input SST sizes,
     /// which can increase manifest size and read amplification compared with
-    /// rewriting inputs into larger output SSTs. Defaults to true.
-    #[serde(default = "default_true")]
+    /// rewriting inputs into larger output SSTs. Defaults to false.
+    #[serde(default)]
     pub enable_trivial_move: bool,
 
     /// Scheduler-specific options expressed as string key/value pairs.
@@ -1232,7 +1232,7 @@ impl Default for CompactorOptions {
             poll_interval: Duration::from_secs(5),
             manifest_update_timeout: Duration::from_secs(300),
             max_concurrent_compactions: 4,
-            enable_trivial_move: true,
+            enable_trivial_move: false,
             scheduler_options: HashMap::new(),
             worker: Some(CompactionWorkerOptions::default()),
             metric_level: None,
@@ -1801,16 +1801,6 @@ mod tests {
     fn test_db_options_default_metric_level() {
         let options = Settings::default();
         assert_eq!(MetricLevel::default(), options.metric_level);
-    }
-
-    #[test]
-    fn test_compactor_trivial_move_is_enabled_by_default_when_omitted() {
-        let mut value = serde_json::to_value(CompactorOptions::default()).unwrap();
-        value.as_object_mut().unwrap().remove("enable_trivial_move");
-
-        let options: CompactorOptions = serde_json::from_value(value).unwrap();
-
-        assert!(options.enable_trivial_move);
     }
 
     #[test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -11476,7 +11476,6 @@ mod tests {
                     // One subcompaction writes one output SST, keeping exact
                     // part counts deterministic.
                     let mut compactor_options = fast_compactor_options();
-                    compactor_options.enable_trivial_move = false;
                     if let Some(worker) = compactor_options.worker.as_mut() {
                         worker.max_subcompactions = 1;
                     }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -11476,6 +11476,7 @@ mod tests {
                     // One subcompaction writes one output SST, keeping exact
                     // part counts deterministic.
                     let mut compactor_options = fast_compactor_options();
+                    compactor_options.enable_trivial_move = false;
                     if let Some(worker) = compactor_options.worker.as_mut() {
                         worker.max_subcompactions = 1;
                     }
@@ -11574,26 +11575,6 @@ mod tests {
 
             fn l0_ids(&self) -> Vec<SsTableId> {
                 self.db.manifest().l0().iter().map(|v| v.sst.id).collect()
-            }
-
-            /// Writes two L0s whose key spans overlap without overwriting a
-            /// key, forcing tests that exercise executor behavior past the
-            /// trivial-move path.
-            async fn write_overlapping_l0s(&self) {
-                for keys in [
-                    [b"key0000".as_slice(), b"key0002".as_slice()],
-                    [b"key0001".as_slice(), b"key0003".as_slice()],
-                ] {
-                    for key in keys {
-                        self.db.put(key, &[b'v'; 64]).await.unwrap();
-                    }
-                    self.db
-                        .flush_with_options(FlushOptions {
-                            flush_type: FlushType::MemTable,
-                        })
-                        .await
-                        .unwrap();
-                }
             }
 
             /// Triggers one on-demand compaction and waits for a sorted run to
@@ -11903,7 +11884,16 @@ mod tests {
                 .build()
                 .await;
 
-            t.write_overlapping_l0s().await;
+            for i in 0..2u32 {
+                let key = format!("key{:04}", i);
+                t.db().put(key.as_bytes(), &[b'v'; 64]).await.unwrap();
+                t.db()
+                    .flush_with_options(FlushOptions {
+                        flush_type: FlushType::MemTable,
+                    })
+                    .await
+                    .unwrap();
+            }
             let l0_ids = t.l0_ids();
             assert_eq!(l0_ids.len(), 2);
 
@@ -11944,10 +11934,7 @@ mod tests {
             // Two ~10 MiB L0s; the ~20 MiB output crosses the multipart threshold.
             for sst in 0..2u32 {
                 for i in 0..10u32 {
-                    // Even keys in one L0 and odd keys in the other make the
-                    // physical key spans overlap while preserving 20 unique
-                    // output rows.
-                    let key = format!("k{:04}", i * 2 + sst);
+                    let key = format!("k{:04}", sst * 10 + i);
                     t.db()
                         .put(key.as_bytes(), &vec![i as u8; MIB])
                         .await
@@ -11989,7 +11976,16 @@ mod tests {
             .build()
             .await;
 
-            t.write_overlapping_l0s().await;
+            for i in 0..2u32 {
+                let key = format!("key{:04}", i);
+                t.db().put(key.as_bytes(), &[b'v'; 64]).await.unwrap();
+                t.db()
+                    .flush_with_options(FlushOptions {
+                        flush_type: FlushType::MemTable,
+                    })
+                    .await
+                    .unwrap();
+            }
             let l0_ids = t.l0_ids();
             assert_eq!(l0_ids.len(), 2);
 
@@ -12025,7 +12021,16 @@ mod tests {
                 }
                 let t = builder.build().await;
 
-                t.write_overlapping_l0s().await;
+                for i in 0..2u32 {
+                    let key = format!("key{:04}", i);
+                    t.db().put(key.as_bytes(), &[b'v'; 64]).await.unwrap();
+                    t.db()
+                        .flush_with_options(FlushOptions {
+                            flush_type: FlushType::MemTable,
+                        })
+                        .await
+                        .unwrap();
+                }
                 t.compact_and_wait().await;
 
                 let gets =

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -11576,6 +11576,26 @@ mod tests {
                 self.db.manifest().l0().iter().map(|v| v.sst.id).collect()
             }
 
+            /// Writes two L0s whose key spans overlap without overwriting a
+            /// key, forcing tests that exercise executor behavior past the
+            /// trivial-move path.
+            async fn write_overlapping_l0s(&self) {
+                for keys in [
+                    [b"key0000".as_slice(), b"key0002".as_slice()],
+                    [b"key0001".as_slice(), b"key0003".as_slice()],
+                ] {
+                    for key in keys {
+                        self.db.put(key, &[b'v'; 64]).await.unwrap();
+                    }
+                    self.db
+                        .flush_with_options(FlushOptions {
+                            flush_type: FlushType::MemTable,
+                        })
+                        .await
+                        .unwrap();
+                }
+            }
+
             /// Triggers one on-demand compaction and waits for a sorted run to
             /// land in the manifest. Requires `on_demand_compactor`.
             async fn compact_and_wait(&self) {
@@ -11883,16 +11903,7 @@ mod tests {
                 .build()
                 .await;
 
-            for i in 0..2u32 {
-                let key = format!("key{:04}", i);
-                t.db().put(key.as_bytes(), &[b'v'; 64]).await.unwrap();
-                t.db()
-                    .flush_with_options(FlushOptions {
-                        flush_type: FlushType::MemTable,
-                    })
-                    .await
-                    .unwrap();
-            }
+            t.write_overlapping_l0s().await;
             let l0_ids = t.l0_ids();
             assert_eq!(l0_ids.len(), 2);
 
@@ -11933,7 +11944,10 @@ mod tests {
             // Two ~10 MiB L0s; the ~20 MiB output crosses the multipart threshold.
             for sst in 0..2u32 {
                 for i in 0..10u32 {
-                    let key = format!("k{:04}", sst * 10 + i);
+                    // Even keys in one L0 and odd keys in the other make the
+                    // physical key spans overlap while preserving 20 unique
+                    // output rows.
+                    let key = format!("k{:04}", i * 2 + sst);
                     t.db()
                         .put(key.as_bytes(), &vec![i as u8; MIB])
                         .await
@@ -11975,16 +11989,7 @@ mod tests {
             .build()
             .await;
 
-            for i in 0..2u32 {
-                let key = format!("key{:04}", i);
-                t.db().put(key.as_bytes(), &[b'v'; 64]).await.unwrap();
-                t.db()
-                    .flush_with_options(FlushOptions {
-                        flush_type: FlushType::MemTable,
-                    })
-                    .await
-                    .unwrap();
-            }
+            t.write_overlapping_l0s().await;
             let l0_ids = t.l0_ids();
             assert_eq!(l0_ids.len(), 2);
 
@@ -12020,16 +12025,7 @@ mod tests {
                 }
                 let t = builder.build().await;
 
-                for i in 0..2u32 {
-                    let key = format!("key{:04}", i);
-                    t.db().put(key.as_bytes(), &[b'v'; 64]).await.unwrap();
-                    t.db()
-                        .flush_with_options(FlushOptions {
-                            flush_type: FlushType::MemTable,
-                        })
-                        .await
-                        .unwrap();
-                }
+                t.write_overlapping_l0s().await;
                 t.compact_and_wait().await;
 
                 let gets =

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -2,9 +2,10 @@ use crate::compactor::{CompactionScheduler, CompactionSchedulerSupplier};
 use crate::compactor_state::{CompactionSpec, SourceId};
 use crate::compactor_state_protocols::CompactorStateView;
 use crate::config::{CompactorOptions, PutOptions, WriteOptions};
-use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableView, SstType};
+use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView, SstType};
 use crate::error::{RetryReason, SlateDBError};
 use crate::format::row::SstRowCodecV0;
+use crate::format::sst::SST_FORMAT_VERSION_LATEST;
 use crate::iter::{IterationOrder, RowEntryIterator};
 use crate::object_store_tag::ObjectStoreCallTag;
 use crate::tablestore::{TableStore, TableStoreKind};
@@ -34,6 +35,18 @@ use tokio::sync::Notify;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
 use ulid::Ulid;
+
+pub(crate) fn bounded_sst_view(id: u64, first: &'static [u8], last: &'static [u8]) -> SsTableView {
+    SsTableView::identity(SsTableHandle::new(
+        SsTableId::Compacted(Ulid::from_parts(id, 0)),
+        SST_FORMAT_VERSION_LATEST,
+        SsTableInfo {
+            first_entry: Some(Bytes::from_static(first)),
+            last_entry: Some(Bytes::from_static(last)),
+            ..SsTableInfo::default()
+        },
+    ))
+}
 
 /// Asserts that the iterator returns the exact set of expected values in correct order.
 pub(crate) async fn assert_iterator<T: RowEntryIterator>(iterator: &mut T, entries: Vec<RowEntry>) {

--- a/website/src/content/docs/docs/design/compaction.mdx
+++ b/website/src/content/docs/docs/design/compaction.mdx
@@ -37,8 +37,8 @@ existing SSTs in the destination sorted run. The coordinator completes this
 without dispatching the job to an executor or reading and rewriting SST data. This reduces
 compaction I/O while still producing a sorted run of non-overlapping SSTs.
 
-Trivial moves are enabled by default. Set `CompactorOptions::enable_trivial_move` to `false`
-to force eligible compactions through the executor.
+Trivial moves are disabled by default. Set `CompactorOptions::enable_trivial_move` to `true`
+to enable them.
 
 To split data with different read/write profiles into independent LSM trees — each with its own
 compaction policy — and to retire whole key ranges cheaply, see

--- a/website/src/content/docs/docs/design/compaction.mdx
+++ b/website/src/content/docs/docs/design/compaction.mdx
@@ -29,6 +29,17 @@ sorted run. It implements the [`CompactionExecutor`] trait. Currently, the only 
 is the [`TokioCompactionExecutor`](https://github.com/slatedb/slatedb/blob/main/slatedb/src/compactor_executor.rs),
 which runs compaction on a local tokio runtime.
 
+## Trivial moves
+
+When every input SST has a non-overlapping effective key range, the compactor can reuse the
+existing SSTs in the destination sorted run. The coordinator completes this
+[trivial move](https://github.com/facebook/rocksdb/wiki/Compaction-Trivial-Move) itself,
+without dispatching the job to an executor or reading and rewriting SST data. This reduces
+compaction I/O while still producing a sorted run of non-overlapping SSTs.
+
+Trivial moves are enabled by default. Set `CompactorOptions::enable_trivial_move` to `false`
+to force eligible compactions through the executor.
+
 To split data with different read/write profiles into independent LSM trees — each with its own
 compaction policy — and to retire whole key ranges cheaply, see
 [Segmented Compaction](/docs/design/segmented-compaction).


### PR DESCRIPTION
## Summary

#1110 proposes trivial moves similar to RocksDB:

https://github.com/facebook/rocksdb/wiki/Compaction-Trivial-Move

There are (at least?) three ways we can implement this:

1. Move all input SSTs and input SR SSTs directly to the destination SR when there is no overlap amongst any of them.
2. Move _some_ input SSTs and _some_ SR SSTs directly to the destination SR when they don't overlap with any other inputs. Those that overlap will need to be compacted still.
3. Move _some_ input SSTs and _some_ SR SSTs to the destination SR when they don't overlap with any other inputs. Those that overlap can be split using new `SsTableViews` _or_ recompacted/combined depending on heuristics. See https://github.com/slatedb/slatedb/pull/1794.

This  PR implements only (1). The compactor simply checks if the submitted job has inputs that are all mutually exclusive key ranges. If so, it just moves them straight into the destination and marks the job completed. This follows the same path/style as drains, which also short circuit.

## Changes

- Add `CompactorState::trivial_move_output` to optionally return destination SSTs when a trivial move is possible.
- Test new behavior.
- Fix tests that depended on non-trivial moves when inputs didn't overlap.

## Notes for Reviewers

~This PR does not add an option to disable trivial moves. Consequently, users that are depending on compaction to trigger tombstone deletions, compaction filters, and merges might be surprised to see that their data isn't being reprocessed. Users might also experience slight bloat in their .manifest files and potentially slower reads because L0 SSTs might make their way into lower levels at 64 MiB (default size) rather than 256 MiB (default compacted size). LMK if y'all think an option is warranted. I kinda felt like punting on it until we know what "real" trivial moves will look like and what configs they'll have.~

Added `enable_trivial_move` to `CompactorOptions`. We'll probably need to revisit this when we add real trivial moves, since I suspect we might want more configuration to control when trivial moves happen, but for now, a simple bool will suffice.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
