### PR TITLE
convert block prefetch panic to error

### DIFF
--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use bytes::Bytes;
+use log::error;
 use slatedb_common::metrics::CounterFn;
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -10,7 +11,7 @@ use tokio::task::JoinHandle;
 
 use crate::block_iterator::DataBlockIterator;
 use crate::bytes_range::BytesRange;
-use crate::db_state::SsTableView;
+use crate::db_state::{SsTableId, SsTableView};
 use crate::db_stats::DbStats;
 use crate::error::SlateDBError;
 use crate::filter_policy::{FilterContext, FilterQuery, NamedFilter};
@@ -22,6 +23,7 @@ use crate::{
     partitioned_keyspace,
     tablestore::TableStore,
     types::RowEntry,
+    utils::panic_string,
 };
 
 enum FetchTask {
@@ -443,6 +445,7 @@ impl<'a> InternalSstIterator<'a> {
             return Ok(None);
         }
         let sst_version = self.view.table_as_ref().sst.format_version;
+        let sst_id = self.view.table_as_ref().sst.id;
         loop {
             if spawn_fetches {
                 self.spawn_fetches();
@@ -450,7 +453,9 @@ impl<'a> InternalSstIterator<'a> {
             if let Some(fetch_task) = self.fetch_tasks.front_mut() {
                 match fetch_task {
                     FetchTask::InFlight(jh) => {
-                        let blocks = jh.await.expect("join task failed")?;
+                        let blocks = jh
+                            .await
+                            .map_err(|join_err| block_fetch_join_error(join_err, sst_id))??;
                         *fetch_task = FetchTask::Finished(blocks);
                     }
                     FetchTask::Finished(blocks) => {
@@ -1054,6 +1059,26 @@ impl RowEntryIterator for SstIterator<'_> {
             SstIteratorDelegate::Direct(inner) => inner.seek(next_key).await,
             SstIteratorDelegate::Filter(inner) => inner.seek(next_key).await,
         }
+    }
+}
+
+/// Converts a failed join on a block fetch task into an error.
+///
+/// A fetch task is cancelled when the runtime it was spawned on shuts down,
+/// so the iterator reports the cancellation to its caller instead of panicking
+/// the task that is awaiting the fetch.
+fn block_fetch_join_error(join_err: tokio::task::JoinError, sst_id: SsTableId) -> SlateDBError {
+    let task_name = format!("sst_block_fetch[{:?}]", sst_id);
+    match join_err.try_into_panic() {
+        Ok(panic_err) => {
+            error!(
+                "sst block fetch task panicked unexpectedly. [task_name={}, panic={}]",
+                task_name,
+                panic_string(&panic_err),
+            );
+            SlateDBError::BackgroundTaskPanic(task_name)
+        }
+        Err(_) => SlateDBError::BackgroundTaskCancelled(task_name),
     }
 }
 
@@ -2805,5 +2830,48 @@ mod tests {
         let entry = iter.next().await.unwrap().expect("should find key_040");
         let kv: KeyValue = entry.into();
         assert_eq!(kv.key.as_ref(), b"key_040");
+    }
+
+    #[tokio::test]
+    async fn test_next_iter_prefetch_task_cancelled() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store, None),
+            SsTableFormat::default(),
+            Path::from(""),
+            None,
+            TableStoreKind::Main,
+            BlockCachePolicy::default(),
+        ));
+        let sst = build_single_block_sst(&table_store, &[b"key1", b"key2"]).await;
+
+        // A runtime that is shut down before anything is spawned on it.
+        // `shutdown_background` rather than a plain drop, which would itself
+        // panic inside an async context.
+        let dead = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .build()
+            .unwrap();
+        let dead_handle = dead.handle().clone();
+        dead.shutdown_background();
+
+        // Initialization walks `advance_block` -> `next_iter(true)` ->
+        // `spawn_fetches`, so the first fetch is spawned onto - and cancelled
+        // by - the dead runtime while its context is entered.
+        let result = {
+            let _guard = dead_handle.enter();
+            SstIterator::new_owned_initialized(
+                ..,
+                sst,
+                table_store.clone(),
+                SstIteratorOptions::default(),
+            )
+            .await
+        };
+
+        let Err(err) = result else {
+            panic!("a cancelled prefetch task must be reported as an error");
+        };
+        assert!(matches!(err, SlateDBError::BackgroundTaskCancelled(_)));
     }
 }


### PR DESCRIPTION
## Summary

closes https://github.com/slatedb/slatedb/issues/1973

The summary is in the issue in [this comment](https://github.com/slatedb/slatedb/issues/1973#issuecomment-5107795064)
This fix is mitigating the panic and translating it to an error, but a long term change can be to not make `FetchTask::Finished ` a long running blocking call. 


## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
