### PR TITLE
disallow clone with projection when WAL must be copied

### DIFF
--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -1356,6 +1356,124 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn should_project_wal_contents_in_clone() {
+        // Data that only lives in the parent's WAL at the checkpoint is copied
+        // to the clone verbatim and replayed on first open, so the projection
+        // range must apply to replayed WAL entries just as it does to L0 data.
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_parent_wal_projection");
+        let clone_path = Path::from("/tmp/test_clone_wal_projection");
+
+        let parent_db = Db::builder(parent_path.clone(), object_store.clone())
+            .with_fp_registry(fp_registry.clone())
+            .build()
+            .await
+            .unwrap();
+        let write_options = WriteOptions {
+            await_durable: false,
+            ..Default::default()
+        };
+        let put_options = PutOptions::default();
+
+        // Keys inside and outside the projection range [aaa, bbb), flushed
+        // through to L0 ...
+        parent_db
+            .put_with_options(b"aaa-l0", b"v1", &put_options, &write_options)
+            .await
+            .unwrap();
+        parent_db
+            .put_with_options(b"zzz-l0", b"v2", &put_options, &write_options)
+            .await
+            .unwrap();
+        parent_db.flush().await.unwrap();
+        parent_db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+
+        // ... and the same shape of data made durable only in the WAL.
+        parent_db
+            .put_with_options(b"aaa-wal", b"v3", &put_options, &write_options)
+            .await
+            .unwrap();
+        parent_db
+            .put_with_options(b"zzz-wal", b"v4", &put_options, &write_options)
+            .await
+            .unwrap();
+        parent_db.flush().await.unwrap();
+
+        let manifest = parent_db.manifest();
+        assert!(
+            !manifest.manifest.core.tree.l0.is_empty(),
+            "expected parent state to include L0 data"
+        );
+        assert!(
+            manifest.manifest.core.replay_after_wal_id + 1 < manifest.manifest.core.next_wal_sst_id,
+            "expected parent state to retain WAL-only SSTs"
+        );
+
+        // Block L0 uploads so the WAL-only data stays in the WAL.
+        fail_parallel::cfg(
+            fp_registry.clone(),
+            "write-compacted-sst-io-error",
+            "return",
+        )
+        .unwrap();
+        // expect to fail since l0 upload is blocked
+        assert!(parent_db.close().await.is_err());
+        fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
+
+        // Clone with a projection that keeps only keys in [aaa, bbb).
+        let range = (
+            Bound::Included(Bytes::from_static(b"aaa")),
+            Bound::Excluded(Bytes::from_static(b"bbb")),
+        );
+        crate::clone::create_clone(
+            vec![CloneSourceSpec::new(parent_path.clone())],
+            clone_path.clone(),
+            ObjectStores::new(object_store.clone(), Some(object_store.clone())),
+            Arc::new(FailPointRegistry::new()),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            Some(range),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let clone_db = Db::open(clone_path.clone(), object_store.clone())
+            .await
+            .unwrap();
+
+        // L0 data respects the projection.
+        assert_eq!(
+            clone_db.get(b"aaa-l0").await.unwrap(),
+            Some(Bytes::from_static(b"v1"))
+        );
+        assert_eq!(
+            clone_db.get(b"zzz-l0").await.unwrap(),
+            None,
+            "L0 entry outside the projection range must not be visible in the clone"
+        );
+
+        // Data replayed from the copied WAL SSTs must respect it too.
+        assert_eq!(
+            clone_db.get(b"aaa-wal").await.unwrap(),
+            Some(Bytes::from_static(b"v3"))
+        );
+        assert_eq!(
+            clone_db.get(b"zzz-wal").await.unwrap(),
+            None,
+            "WAL entry outside the projection range must not be visible in the clone"
+        );
+        clone_db.close().await.unwrap();
+    }
+
     fn segmented_table() -> BTreeMap<Bytes, Bytes> {
         BTreeMap::from([
             (Bytes::from_static(b"aaa-001"), Bytes::from_static(b"v1")),

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -152,15 +152,11 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                     || source_specs.iter().any(|s| s.projection_range.is_some());
 
                 let manifest: Manifest = match &sources[..] {
-                    // for a single source without a projection there is no need to call
-                    // validate_no_data_wal() because the WAL is copied by the caller
-                    // (create_clone)
                     [single_source] => {
-                        // A projection narrows only the manifest's tree state. WAL SSTs
-                        // are copied to the clone verbatim and replayed in full on first
-                        // open, so entries outside the projected range would leak into
-                        // the clone. Reject projected clones while the source still has
-                        // non-fence WALs to copy.
+                        // WAL SSTs are copied to the clone verbatim and replayed in full
+                        // when the clone is opened, so entries outside the projected
+                        // range would leak into the clone. So we reject projections if
+                        // there are non-fence WALs to copy.
                         if projection_requested {
                             validate_no_data_wal(&sources, &wal_object_store).await?;
                         }

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -146,15 +146,31 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                 )
                 .await?;
 
+                let projection_requested = projection_range.is_some()
+                    || segment_filter.is_some()
+                    || segment_projection.is_some()
+                    || source_specs.iter().any(|s| s.projection_range.is_some());
+
                 let manifest: Manifest = match &sources[..] {
-                    // no need to call validate_no_data_wal() because for single source,
-                    // WAL is copied by the caller (create_clone)
-                    [single_source] => Manifest::cloned(
-                        &single_source.manifest,
-                        single_source.path.to_string(),
-                        single_source.checkpoint.id,
-                        rand,
-                    ),
+                    // for a single source without a projection there is no need to call
+                    // validate_no_data_wal() because the WAL is copied by the caller
+                    // (create_clone)
+                    [single_source] => {
+                        // A projection narrows only the manifest's tree state. WAL SSTs
+                        // are copied to the clone verbatim and replayed in full on first
+                        // open, so entries outside the projected range would leak into
+                        // the clone. Reject projected clones while the source still has
+                        // non-fence WALs to copy.
+                        if projection_requested {
+                            validate_no_data_wal(&sources, &wal_object_store).await?;
+                        }
+                        Manifest::cloned(
+                            &single_source.manifest,
+                            single_source.path.to_string(),
+                            single_source.checkpoint.id,
+                            rand,
+                        )
+                    }
                     [..] => {
                         validate_no_data_wal(&sources, &wal_object_store).await?;
                         Manifest::cloned_from_union(sources, rand)?
@@ -368,7 +384,7 @@ async fn validate_no_data_wal(
         }
     }
     if !parents_with_wal.is_empty() {
-        return Err(SlateDBError::InvalidUnionSourceWithWal {
+        return Err(SlateDBError::InvalidCloneSourceWithWal {
             paths: parents_with_wal,
         });
     }
@@ -1357,10 +1373,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_project_wal_contents_in_clone() {
+    async fn should_disallow_projected_clone_when_source_has_data_wal() {
         // Data that only lives in the parent's WAL at the checkpoint is copied
-        // to the clone verbatim and replayed on first open, so the projection
-        // range must apply to replayed WAL entries just as it does to L0 data.
+        // to the clone verbatim and replayed in full on first open, so a
+        // projection cannot be applied to it. Cloning with a projection must
+        // fail while the source still has data in its WAL, and succeed once
+        // that data has been flushed into L0.
         let fp_registry = Arc::new(FailPointRegistry::new());
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let parent_path = Path::from("/tmp/test_parent_wal_projection");
@@ -1427,11 +1445,45 @@ mod tests {
         assert!(parent_db.close().await.is_err());
         fail_parallel::cfg(fp_registry.clone(), "write-compacted-sst-io-error", "off").unwrap();
 
-        // Clone with a projection that keeps only keys in [aaa, bbb).
+        // Cloning with a projection that keeps only keys in [aaa, bbb) must
+        // be rejected while the WAL-only data is still in the WAL.
         let range = (
             Bound::Included(Bytes::from_static(b"aaa")),
             Bound::Excluded(Bytes::from_static(b"bbb")),
         );
+        let err = crate::clone::create_clone(
+            vec![CloneSourceSpec::new(parent_path.clone())],
+            clone_path.clone(),
+            ObjectStores::new(object_store.clone(), Some(object_store.clone())),
+            Arc::new(FailPointRegistry::new()),
+            Arc::new(DefaultSystemClock::new()),
+            Arc::new(DbRand::default()),
+            Some(range.clone()),
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            SlateDBError::InvalidCloneSourceWithWal { ref paths }
+                if paths == &vec![parent_path.clone()]
+        ));
+
+        // Reopen the parent so the WAL tail is replayed, flush it into L0,
+        // and close cleanly. With no data WALs left to copy the projected
+        // clone is allowed.
+        let parent_db = Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap();
+        parent_db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+        parent_db.close().await.unwrap();
+
         crate::clone::create_clone(
             vec![CloneSourceSpec::new(parent_path.clone())],
             clone_path.clone(),
@@ -1461,7 +1513,8 @@ mod tests {
             "L0 entry outside the projection range must not be visible in the clone"
         );
 
-        // Data replayed from the copied WAL SSTs must respect it too.
+        // The formerly WAL-only data was flushed into L0 before the retry,
+        // so it must respect the projection too.
         assert_eq!(
             clone_db.get(b"aaa-wal").await.unwrap(),
             Some(Bytes::from_static(b"v3"))
@@ -1469,7 +1522,7 @@ mod tests {
         assert_eq!(
             clone_db.get(b"zzz-wal").await.unwrap(),
             None,
-            "WAL entry outside the projection range must not be visible in the clone"
+            "entry outside the projection range must not be visible in the clone"
         );
         clone_db.close().await.unwrap();
     }
@@ -1500,6 +1553,10 @@ mod tests {
         settings: Settings,
         table: &BTreeMap<Bytes, Bytes>,
     ) {
+        #[cfg(feature = "wal_disable")]
+        let wal_enabled = settings.wal_enabled;
+        #[cfg(not(feature = "wal_disable"))]
+        let wal_enabled = true;
         let db = Db::builder(path.clone(), object_store)
             .with_settings(settings)
             .with_segment_extractor(extractor)
@@ -1509,6 +1566,12 @@ mod tests {
         // await_durable would deadlock under wal_enabled=false because the
         // memtable flush is gated on the explicit call below.
         test_utils::seed_database(&db, table, false).await.unwrap();
+        if wal_enabled {
+            // Flush the WAL before the memtable so that `replay_after_wal_id`
+            // covers every data WAL; projected clones of this parent would
+            // otherwise be rejected.
+            db.flush().await.unwrap();
+        }
         db.flush_with_options(FlushOptions {
             flush_type: FlushType::MemTable,
         })
@@ -2213,7 +2276,7 @@ mod tests {
     }
 
     /// A union clone whose source references a real (non-empty) data WAL above
-    /// `replay_after_wal_id` must FAIL with `InvalidUnionSourceWithWal`, since
+    /// `replay_after_wal_id` must FAIL with `InvalidCloneSourceWithWal`, since
     /// the union clone would silently drop that WAL data.
     #[cfg(feature = "wal_disable")]
     #[tokio::test]
@@ -2262,10 +2325,10 @@ mod tests {
         .unwrap_err();
 
         match err {
-            SlateDBError::InvalidUnionSourceWithWal { paths } => {
+            SlateDBError::InvalidCloneSourceWithWal { paths } => {
                 assert!(paths.contains(&parent_path_a));
             }
-            other => panic!("expected InvalidUnionSourceWithWal, got {other:?}"),
+            other => panic!("expected InvalidCloneSourceWithWal, got {other:?}"),
         }
     }
 

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -218,8 +218,8 @@ pub(crate) enum SlateDBError {
     #[error("clone source paths must be unique, found duplicate: `{0}`")]
     DuplicatedCloneSourcePath(Path),
 
-    #[error("Manifest union of sources with WAL is not supported, source with WAL: `{paths:?}`")]
-    InvalidUnionSourceWithWal { paths: Vec<Path> },
+    #[error("Projection and/or union with WAL is not supported, sources with WAL: `{paths:?}`")]
+    InvalidCloneSourceWithWal { paths: Vec<Path> },
 
     #[error("Source manifest set must not be empty")]
     InvalidUnionSetEmpty(),
@@ -675,7 +675,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::SeekKeyLessThanLastReturnedKey => Error::invalid(msg),
             SlateDBError::IdenticalClonePaths { .. } => Error::invalid(msg),
             SlateDBError::DuplicatedCloneSourcePath(_) => Error::invalid(msg),
-            SlateDBError::InvalidUnionSourceWithWal { .. } => Error::invalid(msg),
+            SlateDBError::InvalidCloneSourceWithWal { .. } => Error::invalid(msg),
             SlateDBError::InvalidUnionSetEmpty() => Error::invalid(msg),
             SlateDBError::InvalidUnion(_) => Error::invalid(msg),
             SlateDBError::InvalidProjection { .. } => Error::invalid(msg),


### PR DESCRIPTION
## Summary

Currently a clone with a projection can leak rows that fall outside the projection range when the rows are
in the WAL. The Clone logic just copies over the WAL file-by-file without applying the projection. This patch
disallows projection when there are WAL files that must be copied.

## Changes

- Adds a test to repro the bug
- Disallows clones with projection in the presence of non-fencing WALs

## Notes for Reviewers

- first commit has the repro test
- second commit has the fix

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
