### PR TITLE
Add DbIterator.next_batch to the UniFFI binding

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -1400,6 +1400,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_dbiterator_next_batch()
+		})
+		if checksum != 61234 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_dbiterator_next_batch: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_dbiterator_seek()
 		})
 		if checksum != 61052 {
@@ -4578,6 +4587,16 @@ func (_ FfiDestroyerDbCache) Destroy(value *DbCache) {
 type DbIteratorInterface interface {
 	// Returns the next key/value pair from the iterator.
 	Next() (*KeyValue, error)
+	// Returns up to `max` key/value pairs from the iterator in one call.
+	//
+	// Locks the iterator once and pulls rows until it yields `max` items or the
+	// iterator is exhausted. A returned vector shorter than `max` (including an
+	// empty vector) means the iterator is exhausted. `max == 0` returns an empty
+	// vector without advancing.
+	//
+	// This exists so that callers crossing a foreign-function boundary can drain
+	// a scan with one call per batch instead of one call per row.
+	NextBatch(max uint32) ([]KeyValue, error)
 	// Seeks the iterator to the first entry at or after `key`.
 	Seek(key []byte) error
 }
@@ -4606,6 +4625,50 @@ func (_self *DbIterator) Next() (*KeyValue, error) {
 		},
 		C.uniffi_slatedb_uniffi_fn_method_dbiterator_next(
 			_pointer),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_rust_buffer(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_rust_buffer(handle)
+		},
+	)
+
+	if err == nil {
+		return res, nil
+	}
+
+	return res, err
+}
+
+// Returns up to `max` key/value pairs from the iterator in one call.
+//
+// Locks the iterator once and pulls rows until it yields `max` items or the
+// iterator is exhausted. A returned vector shorter than `max` (including an
+// empty vector) means the iterator is exhausted. `max == 0` returns an empty
+// vector without advancing.
+//
+// This exists so that callers crossing a foreign-function boundary can drain
+// a scan with one call per batch instead of one call per row.
+func (_self *DbIterator) NextBatch(max uint32) ([]KeyValue, error) {
+	_pointer := _self.ffiObject.incrementPointer("*DbIterator")
+	defer _self.ffiObject.decrementPointer()
+	res, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) RustBufferI {
+			res := C.ffi_slatedb_uniffi_rust_future_complete_rust_buffer(handle, status)
+			return GoRustBuffer{
+				inner: res,
+			}
+		},
+		// liftFn
+		func(ffi RustBufferI) []KeyValue {
+			return FfiConverterSequenceKeyValueINSTANCE.Lift(ffi)
+		},
+		C.uniffi_slatedb_uniffi_fn_method_dbiterator_next_batch(
+			_pointer, FfiConverterUint32INSTANCE.Lower(max)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_slatedb_uniffi_rust_future_poll_rust_buffer(handle, continuation, data)
@@ -14003,6 +14066,53 @@ type FfiDestroyerSequenceExternalDb struct{}
 func (FfiDestroyerSequenceExternalDb) Destroy(sequence []ExternalDb) {
 	for _, value := range sequence {
 		FfiDestroyerExternalDb{}.Destroy(value)
+	}
+}
+
+type FfiConverterSequenceKeyValue struct{}
+
+var FfiConverterSequenceKeyValueINSTANCE = FfiConverterSequenceKeyValue{}
+
+func (c FfiConverterSequenceKeyValue) Lift(rb RustBufferI) []KeyValue {
+	return LiftFromRustBuffer[[]KeyValue](c, rb)
+}
+
+func (c FfiConverterSequenceKeyValue) Read(reader io.Reader) []KeyValue {
+	length := readInt32(reader)
+	if length == 0 {
+		return nil
+	}
+	result := make([]KeyValue, 0, length)
+	for i := int32(0); i < length; i++ {
+		result = append(result, FfiConverterKeyValueINSTANCE.Read(reader))
+	}
+	return result
+}
+
+func (c FfiConverterSequenceKeyValue) Lower(value []KeyValue) C.RustBuffer {
+	return LowerIntoRustBuffer[[]KeyValue](c, value)
+}
+
+func (c FfiConverterSequenceKeyValue) LowerExternal(value []KeyValue) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[[]KeyValue](c, value))
+}
+
+func (c FfiConverterSequenceKeyValue) Write(writer io.Writer, value []KeyValue) {
+	if len(value) > math.MaxInt32 {
+		panic("[]KeyValue is too large to fit into Int32")
+	}
+
+	writeInt32(writer, int32(len(value)))
+	for _, item := range value {
+		FfiConverterKeyValueINSTANCE.Write(writer, item)
+	}
+}
+
+type FfiDestroyerSequenceKeyValue struct{}
+
+func (FfiDestroyerSequenceKeyValue) Destroy(sequence []KeyValue) {
+	for _, value := range sequence {
+		FfiDestroyerKeyValue{}.Destroy(value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -1349,6 +1349,11 @@ void uniffi_slatedb_uniffi_fn_free_dbiterator(uint64_t handle, RustCallStatus *o
 uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_next(uint64_t ptr
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_NEXT_BATCH
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_NEXT_BATCH
+uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_next_batch(uint64_t ptr, uint32_t max
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_SEEK
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DBITERATOR_SEEK
 uint64_t uniffi_slatedb_uniffi_fn_method_dbiterator_seek(uint64_t ptr, RustBuffer key
@@ -2688,6 +2693,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_prefixextractor_prefix_len(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT
 uint16_t uniffi_slatedb_uniffi_checksum_method_dbiterator_next(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT_BATCH
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DBITERATOR_NEXT_BATCH
+uint16_t uniffi_slatedb_uniffi_checksum_method_dbiterator_next_batch(void
     
 );
 #endif

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -3103,3 +3103,373 @@ func TestDbTtl(t *testing.T) {
 		})
 	}
 }
+
+// batchSeedRow describes one row written by seedBatchRows.
+type batchSeedRow struct {
+	key   string
+	value string
+	ttl   slatedb.Ttl
+}
+
+// batchSeedRows mixes rows with and without a TTL so that both the Some and the
+// None case of KeyValue.ExpireTs round trip through NextBatch. Six rows lets a
+// batch size of 3 or 6 exercise the exact-multiple case, where the drain loop
+// needs one extra call returning an empty slice to detect exhaustion.
+var batchSeedRows = []batchSeedRow{
+	{key: "batch:01", value: "one", ttl: slatedb.TtlNoExpiry{}},
+	{key: "batch:02", value: "two", ttl: slatedb.TtlExpireAfterTicks{Field0: batchSeedTtlTicks}},
+	{key: "batch:03", value: "three", ttl: slatedb.TtlNoExpiry{}},
+	{key: "batch:04", value: "four", ttl: slatedb.TtlExpireAfterTicks{Field0: batchSeedTtlTicks}},
+	{key: "batch:05", value: "five", ttl: slatedb.TtlNoExpiry{}},
+	{key: "batch:06", value: "six", ttl: slatedb.TtlExpireAfterTicks{Field0: batchSeedTtlTicks}},
+}
+
+// batchSeedTtlTicks is far enough in the future that TTL'd seed rows never
+// expire mid-test, while still producing a non-nil ExpireTs.
+const batchSeedTtlTicks = 3_600_000
+
+func seedBatchRows(t *testing.T, db *slatedb.Db) {
+	t.Helper()
+
+	writeOptions := slatedb.WriteOptions{AwaitDurable: true}
+	for _, row := range batchSeedRows {
+		putOptions := slatedb.PutOptions{Ttl: row.ttl}
+		if _, err := db.PutWithOptions([]byte(row.key), []byte(row.value), putOptions, writeOptions); err != nil {
+			t.Fatalf("PutWithOptions(%q): %v", row.key, err)
+		}
+	}
+}
+
+// scanBatchRows opens a full scan, which covers exactly the seed rows written
+// by seedBatchRows. An unbounded range keeps Seek keys unambiguous: they are
+// whole keys rather than suffixes relative to a prefix.
+func scanBatchRows(t *testing.T, db *slatedb.Db) *slatedb.DbIterator {
+	t.Helper()
+
+	iter, err := db.Scan(slatedb.KeyRange{})
+	if err != nil {
+		t.Fatalf("Scan(): %v", err)
+	}
+	t.Cleanup(iter.Destroy)
+	return iter
+}
+
+// drainBatch drains iter with NextBatch(max), applying the documented
+// exhaustion rule: a batch shorter than max (including an empty one) ends the
+// scan. When the row count is an exact multiple of max this performs one extra
+// call that returns an empty slice.
+func drainBatch(t *testing.T, iter *slatedb.DbIterator, max uint32) []slatedb.KeyValue {
+	t.Helper()
+
+	if max == 0 {
+		t.Fatalf("drainBatch requires max > 0; NextBatch(0) never advances")
+	}
+
+	var rows []slatedb.KeyValue
+	for {
+		batch, err := iter.NextBatch(max)
+		if err != nil {
+			t.Fatalf("NextBatch(%d): %v", max, err)
+		}
+		rows = append(rows, batch...)
+		if len(batch) < int(max) {
+			return rows
+		}
+	}
+}
+
+func int64PtrString(value *int64) string {
+	if value == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("%d", *value)
+}
+
+// requireKeyValuesEqual asserts two row slices are identical across every
+// KeyValue field, not just key and value.
+func requireKeyValuesEqual(t *testing.T, context string, got []slatedb.KeyValue, want []slatedb.KeyValue) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("%s: got %d rows, want %d", context, len(got), len(want))
+	}
+
+	for i := range want {
+		gotRow, wantRow := got[i], want[i]
+		if !bytes.Equal(gotRow.Key, wantRow.Key) {
+			t.Fatalf("%s: row %d key: got %q, want %q", context, i, gotRow.Key, wantRow.Key)
+		}
+		if !bytes.Equal(gotRow.Value, wantRow.Value) {
+			t.Fatalf("%s: row %d value: got %q, want %q", context, i, gotRow.Value, wantRow.Value)
+		}
+		if gotRow.Seq != wantRow.Seq {
+			t.Fatalf("%s: row %d seq: got %d, want %d", context, i, gotRow.Seq, wantRow.Seq)
+		}
+		if gotRow.CreateTs != wantRow.CreateTs {
+			t.Fatalf("%s: row %d create_ts: got %d, want %d", context, i, gotRow.CreateTs, wantRow.CreateTs)
+		}
+		if (gotRow.ExpireTs == nil) != (wantRow.ExpireTs == nil) ||
+			(gotRow.ExpireTs != nil && *gotRow.ExpireTs != *wantRow.ExpireTs) {
+			t.Fatalf("%s: row %d expire_ts: got %s, want %s",
+				context, i, int64PtrString(gotRow.ExpireTs), int64PtrString(wantRow.ExpireTs))
+		}
+	}
+}
+
+func TestDbIteratorNextBatchMatchesNext(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+	seedBatchRows(t, handle.db)
+
+	// Row-by-row Next() is the oracle every batch size is compared against.
+	want := drainIterator(t, scanBatchRows(t, handle.db))
+	if len(want) != len(batchSeedRows) {
+		t.Fatalf("oracle drain: got %d rows, want %d", len(want), len(batchSeedRows))
+	}
+
+	// Guard against the differential assertion going vacuous on expire_ts: the
+	// seed set must actually produce both Some and None.
+	var withTTL, withoutTTL int
+	for _, row := range want {
+		if row.ExpireTs != nil {
+			withTTL++
+		} else {
+			withoutTTL++
+		}
+	}
+	if withTTL == 0 || withoutTTL == 0 {
+		t.Fatalf("seed rows must cover both expire_ts states: with=%d without=%d", withTTL, withoutTTL)
+	}
+
+	// 3 and 6 divide the row count exactly; 4, 5 and 7 leave a short final
+	// batch; 1 must behave exactly like repeated Next(); 1000 exceeds the row
+	// count entirely.
+	for _, max := range []uint32{1, 2, 3, 4, 5, 6, 7, 1000} {
+		t.Run(fmt.Sprintf("max=%d", max), func(t *testing.T) {
+			got := drainBatch(t, scanBatchRows(t, handle.db), max)
+			requireKeyValuesEqual(t, fmt.Sprintf("NextBatch(%d) drain", max), got, want)
+		})
+	}
+}
+
+func TestDbIteratorNextBatchLargerThanRowCount(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+	seedBatchRows(t, handle.db)
+
+	want := drainIterator(t, scanBatchRows(t, handle.db))
+
+	iter := scanBatchRows(t, handle.db)
+	first, err := iter.NextBatch(1000)
+	if err != nil {
+		t.Fatalf("NextBatch(1000): %v", err)
+	}
+	requireKeyValuesEqual(t, "single oversized NextBatch", first, want)
+
+	second, err := iter.NextBatch(1000)
+	if err != nil {
+		t.Fatalf("NextBatch(1000) after exhaustion: %v", err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("NextBatch(1000) after exhaustion: got %d rows, want 0", len(second))
+	}
+}
+
+func TestDbIteratorNextBatchEmptyRange(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+	seedBatchRows(t, handle.db)
+
+	// A range that starts past every seeded key.
+	iter, err := handle.db.Scan(slatedb.KeyRange{
+		Start:          bytesPtr([]byte("zzz:")),
+		StartInclusive: true,
+	})
+	if err != nil {
+		t.Fatalf("Scan(empty range): %v", err)
+	}
+	t.Cleanup(iter.Destroy)
+
+	batch, err := iter.NextBatch(16)
+	if err != nil {
+		t.Fatalf("NextBatch(16) on empty range: %v", err)
+	}
+	if len(batch) != 0 {
+		t.Fatalf("NextBatch(16) on empty range: got %d rows, want 0", len(batch))
+	}
+}
+
+func TestDbIteratorNextBatchZeroMaxDoesNotAdvance(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+	seedBatchRows(t, handle.db)
+
+	want := drainIterator(t, scanBatchRows(t, handle.db))
+
+	iter := scanBatchRows(t, handle.db)
+	for i := 0; i < 3; i++ {
+		batch, err := iter.NextBatch(0)
+		if err != nil {
+			t.Fatalf("NextBatch(0) call %d: %v", i, err)
+		}
+		if len(batch) != 0 {
+			t.Fatalf("NextBatch(0) call %d: got %d rows, want 0", i, len(batch))
+		}
+	}
+
+	// The zero-max calls must not have consumed anything.
+	got, err := iter.NextBatch(1000)
+	if err != nil {
+		t.Fatalf("NextBatch(1000) after NextBatch(0): %v", err)
+	}
+	requireKeyValuesEqual(t, "NextBatch(1000) after NextBatch(0)", got, want)
+}
+
+func TestDbIteratorNextBatchAfterSeek(t *testing.T) {
+	store := newMemoryStore(t)
+	handle := openTestDB(t, store, nil)
+	seedBatchRows(t, handle.db)
+
+	seekKey := []byte("batch:04")
+
+	oracle := scanBatchRows(t, handle.db)
+	if err := oracle.Seek(seekKey); err != nil {
+		t.Fatalf("Seek(%q) on oracle iterator: %v", seekKey, err)
+	}
+	want := drainIterator(t, oracle)
+	if len(want) != 3 {
+		t.Fatalf("oracle drain after seek: got %d rows, want 3", len(want))
+	}
+
+	t.Run("seek then batch drain", func(t *testing.T) {
+		iter := scanBatchRows(t, handle.db)
+		if err := iter.Seek(seekKey); err != nil {
+			t.Fatalf("Seek(%q): %v", seekKey, err)
+		}
+		requireKeyValuesEqual(t, "NextBatch(2) after seek", drainBatch(t, iter, 2), want)
+	})
+
+	t.Run("seek mid batch drain", func(t *testing.T) {
+		iter := scanBatchRows(t, handle.db)
+		if _, err := iter.NextBatch(2); err != nil {
+			t.Fatalf("NextBatch(2) before seek: %v", err)
+		}
+		if err := iter.Seek(seekKey); err != nil {
+			t.Fatalf("Seek(%q) mid-drain: %v", seekKey, err)
+		}
+		requireKeyValuesEqual(t, "NextBatch(2) after mid-drain seek", drainBatch(t, iter, 2), want)
+	})
+}
+
+// benchScanRows is the number of rows each scan benchmark drains.
+const benchScanRows = 1000
+
+func openBenchDB(b *testing.B) *slatedb.Db {
+	b.Helper()
+
+	store, err := slatedb.ObjectStoreResolve("memory:///")
+	if err != nil {
+		b.Fatalf("ObjectStoreResolve(memory:///): %v", err)
+	}
+	b.Cleanup(store.Destroy)
+
+	builder := slatedb.NewDbBuilder(testDBPath, store)
+	defer builder.Destroy()
+
+	db, err := builder.Build()
+	if err != nil {
+		b.Fatalf("Build(): %v", err)
+	}
+	b.Cleanup(func() {
+		if err := db.Shutdown(); err != nil {
+			b.Errorf("Shutdown(): %v", err)
+		}
+		db.Destroy()
+	})
+
+	writeOptions := slatedb.WriteOptions{AwaitDurable: false}
+	putOptions := slatedb.PutOptions{Ttl: slatedb.TtlDefault{}}
+	for i := 0; i < benchScanRows; i++ {
+		key := []byte(fmt.Sprintf("bench:%06d", i))
+		value := []byte(fmt.Sprintf("value-%06d", i))
+		if _, err := db.PutWithOptions(key, value, putOptions, writeOptions); err != nil {
+			b.Fatalf("PutWithOptions(%q): %v", key, err)
+		}
+	}
+	if err := db.Flush(); err != nil {
+		b.Fatalf("Flush(): %v", err)
+	}
+
+	return db
+}
+
+func benchScanIterator(b *testing.B, db *slatedb.Db) *slatedb.DbIterator {
+	b.Helper()
+
+	iter, err := db.Scan(slatedb.KeyRange{})
+	if err != nil {
+		b.Fatalf("Scan(): %v", err)
+	}
+	return iter
+}
+
+// BenchmarkScanNext measures the row-at-a-time drain: one async FFI call, and
+// the RustBuffer decode that comes with it, per row.
+func BenchmarkScanNext(b *testing.B) {
+	db := openBenchDB(b)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		iter := benchScanIterator(b, db)
+		rows := 0
+		for {
+			row, err := iter.Next()
+			if err != nil {
+				b.Fatalf("Next(): %v", err)
+			}
+			if row == nil {
+				break
+			}
+			rows++
+		}
+		iter.Destroy()
+		if rows != benchScanRows {
+			b.Fatalf("drained %d rows, want %d", rows, benchScanRows)
+		}
+	}
+}
+
+// BenchmarkScanNextBatch measures the same drain amortized over batches, which
+// is the point of NextBatch: the per-call cost is paid once per batch instead
+// of once per row.
+func BenchmarkScanNextBatch(b *testing.B) {
+	db := openBenchDB(b)
+
+	for _, max := range []uint32{16, 64, 256, 1024} {
+		b.Run(fmt.Sprintf("max=%d", max), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				iter := benchScanIterator(b, db)
+				rows := 0
+				for {
+					batch, err := iter.NextBatch(max)
+					if err != nil {
+						b.Fatalf("NextBatch(%d): %v", max, err)
+					}
+					rows += len(batch)
+					if len(batch) < int(max) {
+						break
+					}
+				}
+				iter.Destroy()
+				if rows != benchScanRows {
+					b.Fatalf("drained %d rows, want %d", rows, benchScanRows)
+				}
+			}
+		})
+	}
+}

--- a/bindings/uniffi/src/iterator.rs
+++ b/bindings/uniffi/src/iterator.rs
@@ -4,6 +4,10 @@ use crate::error::Error;
 use crate::types::KeyValue;
 use crate::validation::validate_key;
 
+/// Upper bound on the number of rows `next_batch` preallocates room for, so a
+/// caller passing a very large `max` cannot force a large allocation up front.
+const MAX_BATCH_PREALLOC: u32 = 1024;
+
 /// Async iterator returned by scan APIs.
 #[derive(uniffi::Object)]
 pub struct DbIterator {
@@ -26,10 +30,126 @@ impl DbIterator {
         Ok(guard.next().await?.map(KeyValue::from))
     }
 
+    /// Returns up to `max` key/value pairs from the iterator in one call.
+    ///
+    /// Locks the iterator once and pulls rows until it yields `max` items or the
+    /// iterator is exhausted. A returned vector shorter than `max` (including an
+    /// empty vector) means the iterator is exhausted. `max == 0` returns an empty
+    /// vector without advancing.
+    ///
+    /// This exists so that callers crossing a foreign-function boundary can drain
+    /// a scan with one call per batch instead of one call per row.
+    pub async fn next_batch(&self, max: u32) -> Result<Vec<KeyValue>, Error> {
+        let mut guard = self.inner.lock().await;
+        let mut out = Vec::with_capacity(max.min(MAX_BATCH_PREALLOC) as usize);
+        for _ in 0..max {
+            match guard.next().await? {
+                Some(kv) => out.push(KeyValue::from(kv)),
+                None => break,
+            }
+        }
+        Ok(out)
+    }
+
     /// Seeks the iterator to the first entry at or after `key`.
     pub async fn seek(&self, key: Vec<u8>) -> Result<(), Error> {
         validate_key(&key)?;
         let mut guard = self.inner.lock().await;
         guard.seek(key).await.map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use slatedb::object_store::memory::InMemory;
+
+    use super::DbIterator;
+
+    const ROWS: u32 = 6;
+
+    async fn seeded_db() -> slatedb::Db {
+        let db = slatedb::Db::builder("test", Arc::new(InMemory::new()))
+            .build()
+            .await
+            .expect("failed to open db");
+        for i in 0..ROWS {
+            db.put(format!("key{i:02}"), format!("value{i:02}"))
+                .await
+                .expect("failed to put row");
+        }
+        db
+    }
+
+    async fn scan_all(db: &slatedb::Db) -> DbIterator {
+        DbIterator::new(db.scan(..).await.expect("failed to scan"))
+    }
+
+    /// Drains an iterator one row at a time; the oracle for the batch results.
+    async fn drain_rows(iter: &DbIterator) -> Vec<crate::types::KeyValue> {
+        let mut rows = Vec::new();
+        while let Some(row) = iter.next().await.expect("next() failed") {
+            rows.push(row);
+        }
+        rows
+    }
+
+    #[tokio::test]
+    async fn next_batch_matches_next() {
+        let db = seeded_db().await;
+        let want = drain_rows(&scan_all(&db).await).await;
+        assert_eq!(want.len(), ROWS as usize);
+
+        // 3 and 6 divide the row count exactly; 4 and 7 leave a short final
+        // batch; 1 must behave like repeated next().
+        for max in [1u32, 3, 4, 6, 7, 1000] {
+            let iter = scan_all(&db).await;
+            let mut got = Vec::new();
+            loop {
+                let batch = iter.next_batch(max).await.expect("next_batch() failed");
+                let exhausted = batch.len() < max as usize;
+                got.extend(batch);
+                if exhausted {
+                    break;
+                }
+            }
+            assert_eq!(got, want, "next_batch({max}) disagreed with next()");
+        }
+    }
+
+    #[tokio::test]
+    async fn next_batch_zero_max_does_not_advance() {
+        let db = seeded_db().await;
+        let iter = scan_all(&db).await;
+
+        assert!(iter
+            .next_batch(0)
+            .await
+            .expect("next_batch(0) failed")
+            .is_empty());
+
+        let rows = iter
+            .next_batch(1000)
+            .await
+            .expect("next_batch(1000) failed");
+        assert_eq!(rows.len(), ROWS as usize);
+    }
+
+    #[tokio::test]
+    async fn next_batch_returns_empty_once_exhausted() {
+        let db = seeded_db().await;
+        let iter = scan_all(&db).await;
+
+        let rows = iter
+            .next_batch(1000)
+            .await
+            .expect("next_batch(1000) failed");
+        assert_eq!(rows.len(), ROWS as usize);
+        assert!(iter
+            .next_batch(1000)
+            .await
+            .expect("next_batch(1000) after exhaustion failed")
+            .is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Draining a scan from Go costs one async FFI call per row: each Next() call allocates a channel, a `cgo.NewHandle`, four escaping closures, a `bytes.Reader` and a heap allocated `*KeyValue`. This PR instead adds a `next_batch` returning a `Vec<KeyValue>` in one call to amortize the allocations.

Over 1000 rows this cuts allocations from 17.0 to 7.1 per row (-59%), bytes from 505 KB to 142 KB per drain (-72%), and wall clock by 2.2x at max=256. The remaining 7 allocs/row are the per-field binary.Read boxing in the generated decoder, which a batch API cannot remove; only 2 of them are the real key/value slices.

A batch shorter than max, including an empty one, means the iterator is exhausted, so a drain loop over an exact multiple of max performs one extra call returning empty. max == 0 returns empty without advancing. The `with_capacity` preallocation is capped so a huge max cannot force a large allocation before any rows are read.

`next()` is unchanged and the core crate is untouched. Go bindings regenerated with `scripts/generate-go-uniffi.sh`.

Fixes #1975

## Changes

- Add `NextBatch` DbIterator wrapping Rust side `next_batch()`
- Add `next_batch()` to `DbIterator`
- Added Go bench tests for allocations proving reduction is real and stable-ish

## Notes for Reviewers

I'm not a Rust dev and this might be a rubbish change set. I disclose that this has been driven by claude, I have reviewed the changes myself and they appear to look "okay" ?

## Benchmarks

1000 rows, in-memory object store, `-benchmem`, Apple M5 (`goos=darwin`, `goarch=arm64`):

| Benchmark | ns/op | B/op | allocs/op | allocs/row |
|---|---:|---:|---:|---:|
| `BenchmarkScanNext` | 7,286,295 | 505,373 | 17,024 | 17.02 |
| `BenchmarkScanNextBatch/max=16` | 3,733,149 | 167,657 | 7,645 | 7.65 |
| `BenchmarkScanNextBatch/max=64` | 3,380,971 | 146,769 | 7,175 | 7.18 |
| `BenchmarkScanNextBatch/max=256` | 3,254,271 | 142,064 | 7,055 | 7.06 |
| `BenchmarkScanNextBatch/max=1024` | 3,134,039 | 139,064 | 7,025 | 7.03 |

At `max=256`: **−59% allocations, −72% bytes, 2.2× faster**. Returns are flat beyond ~256,
so there is no reason to batch larger than that.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
