### PR TITLE
Clarify TTL millisecond units

### DIFF
--- a/bindings/go/uniffi/doc.go
+++ b/bindings/go/uniffi/doc.go
@@ -107,7 +107,7 @@
 // [Db.Write] or [Db.WriteWithOptions]. Batches are single-use once submitted.
 //
 // TTL behavior is configured with [Ttl] implementations such as [TtlDefault],
-// [TtlNoExpiry], and [TtlExpireAfterTicks].
+// [TtlNoExpiry], and [TtlExpireAfterMillis].
 //
 // # Transactions
 //

--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -1573,7 +1573,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_settings_set()
 		})
-		if checksum != 34344 {
+		if checksum != 16989 {
 			// If this happens try cleaning and rebuilding your project
 			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_settings_set: UniFFI API checksum mismatch")
 		}
@@ -7999,8 +7999,8 @@ type SettingsInterface interface {
 	// Examples:
 	//
 	// - `set("flush_interval", "\"250ms\"")`
-	// - `set("default_ttl", "42")`
-	// - `set("default_ttl", "null")`
+	// - `set("default_ttl_millis", "42")`
+	// - `set("default_ttl_millis", "null")`
 	// - `set("compactor_options.max_sst_size", "33554432")`
 	// - `set("object_store_cache_options.root_folder", "\"/tmp/slatedb-cache\"")`
 	Set(key string, valueJson string) error
@@ -8104,8 +8104,8 @@ func SettingsLoad() (*Settings, error) {
 // Examples:
 //
 // - `set("flush_interval", "\"250ms\"")`
-// - `set("default_ttl", "42")`
-// - `set("default_ttl", "null")`
+// - `set("default_ttl_millis", "42")`
+// - `set("default_ttl_millis", "null")`
 // - `set("compactor_options.max_sst_size", "33554432")`
 // - `set("object_store_cache_options.root_folder", "\"/tmp/slatedb-cache\"")`
 func (_self *Settings) Set(key string, valueJson string) error {
@@ -12714,21 +12714,21 @@ type TtlNoExpiry struct {
 func (e TtlNoExpiry) Destroy() {
 }
 
-// Expire the value after the given number of clock ticks.
-type TtlExpireAfterTicks struct {
+// Expire the value after the given number of milliseconds.
+type TtlExpireAfterMillis struct {
 	Field0 uint64
 }
 
-func (e TtlExpireAfterTicks) Destroy() {
+func (e TtlExpireAfterMillis) Destroy() {
 	FfiDestroyerUint64{}.Destroy(e.Field0)
 }
 
-// Expire the value at the given absolute timestamp (clock ticks).
-type TtlExpireAt struct {
+// Expire the value at the given Unix timestamp in milliseconds.
+type TtlExpireAtMillis struct {
 	Field0 int64
 }
 
-func (e TtlExpireAt) Destroy() {
+func (e TtlExpireAtMillis) Destroy() {
 	FfiDestroyerInt64{}.Destroy(e.Field0)
 }
 
@@ -12755,11 +12755,11 @@ func (FfiConverterTtl) Read(reader io.Reader) Ttl {
 	case 2:
 		return TtlNoExpiry{}
 	case 3:
-		return TtlExpireAfterTicks{
+		return TtlExpireAfterMillis{
 			FfiConverterUint64INSTANCE.Read(reader),
 		}
 	case 4:
-		return TtlExpireAt{
+		return TtlExpireAtMillis{
 			FfiConverterInt64INSTANCE.Read(reader),
 		}
 	default:
@@ -12773,10 +12773,10 @@ func (FfiConverterTtl) Write(writer io.Writer, value Ttl) {
 		writeInt32(writer, 1)
 	case TtlNoExpiry:
 		writeInt32(writer, 2)
-	case TtlExpireAfterTicks:
+	case TtlExpireAfterMillis:
 		writeInt32(writer, 3)
 		FfiConverterUint64INSTANCE.Write(writer, variant_value.Field0)
-	case TtlExpireAt:
+	case TtlExpireAtMillis:
 		writeInt32(writer, 4)
 		FfiConverterInt64INSTANCE.Write(writer, variant_value.Field0)
 	default:

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -3072,7 +3072,7 @@ func TestDbTtl(t *testing.T) {
 
 	key, value := []byte("alpha"), []byte("one")
 
-	putOptions := slatedb.PutOptions{Ttl: slatedb.TtlExpireAt{Field0: 1}}
+	putOptions := slatedb.PutOptions{Ttl: slatedb.TtlExpireAtMillis{Field0: 1}}
 	writeOptions := slatedb.WriteOptions{AwaitDurable: true}
 	_, err := handle.db.PutWithOptions(key, value, putOptions, writeOptions)
 	if err != nil {
@@ -3117,16 +3117,16 @@ type batchSeedRow struct {
 // needs one extra call returning an empty slice to detect exhaustion.
 var batchSeedRows = []batchSeedRow{
 	{key: "batch:01", value: "one", ttl: slatedb.TtlNoExpiry{}},
-	{key: "batch:02", value: "two", ttl: slatedb.TtlExpireAfterTicks{Field0: batchSeedTtlTicks}},
+	{key: "batch:02", value: "two", ttl: slatedb.TtlExpireAfterMillis{Field0: batchSeedTtlMillis}},
 	{key: "batch:03", value: "three", ttl: slatedb.TtlNoExpiry{}},
-	{key: "batch:04", value: "four", ttl: slatedb.TtlExpireAfterTicks{Field0: batchSeedTtlTicks}},
+	{key: "batch:04", value: "four", ttl: slatedb.TtlExpireAfterMillis{Field0: batchSeedTtlMillis}},
 	{key: "batch:05", value: "five", ttl: slatedb.TtlNoExpiry{}},
-	{key: "batch:06", value: "six", ttl: slatedb.TtlExpireAfterTicks{Field0: batchSeedTtlTicks}},
+	{key: "batch:06", value: "six", ttl: slatedb.TtlExpireAfterMillis{Field0: batchSeedTtlMillis}},
 }
 
-// batchSeedTtlTicks is far enough in the future that TTL'd seed rows never
+// batchSeedTtlMillis is far enough in the future that TTL'd seed rows never
 // expire mid-test, while still producing a non-nil ExpireTs.
-const batchSeedTtlTicks = 3_600_000
+const batchSeedTtlMillis = 3_600_000
 
 func seedBatchRows(t *testing.T, db *slatedb.Db) {
 	t.Helper()

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -102,10 +102,10 @@ pub enum Ttl {
     Default,
     /// Store the value without expiration.
     NoExpiry,
-    /// Expire the value after the given number of clock ticks.
-    ExpireAfterTicks(u64),
-    /// Expire the value at the given absolute timestamp (clock ticks).
-    ExpireAt(i64),
+    /// Expire the value after the given number of milliseconds.
+    ExpireAfterMillis(u64),
+    /// Expire the value at the given Unix timestamp in milliseconds.
+    ExpireAtMillis(i64),
 }
 
 impl From<Ttl> for slatedb::config::Ttl {
@@ -113,8 +113,8 @@ impl From<Ttl> for slatedb::config::Ttl {
         match value {
             Ttl::Default => Self::Default,
             Ttl::NoExpiry => Self::NoExpiry,
-            Ttl::ExpireAfterTicks(ttl) => Self::ExpireAfter(ttl),
-            Ttl::ExpireAt(ts) => Self::ExpireAt(ts),
+            Ttl::ExpireAfterMillis(ttl_millis) => Self::ExpireAfterMillis(ttl_millis),
+            Ttl::ExpireAtMillis(timestamp_millis) => Self::ExpireAtMillis(timestamp_millis),
         }
     }
 }

--- a/bindings/uniffi/src/settings.rs
+++ b/bindings/uniffi/src/settings.rs
@@ -94,8 +94,8 @@ impl Settings {
     /// Examples:
     ///
     /// - `set("flush_interval", "\"250ms\"")`
-    /// - `set("default_ttl", "42")`
-    /// - `set("default_ttl", "null")`
+    /// - `set("default_ttl_millis", "42")`
+    /// - `set("default_ttl_millis", "null")`
     /// - `set("compactor_options.max_sst_size", "33554432")`
     /// - `set("object_store_cache_options.root_folder", "\"/tmp/slatedb-cache\"")`
     pub fn set(&self, key: String, value_json: String) -> Result<(), Error> {
@@ -271,13 +271,13 @@ mod tests {
         let settings = Arc::new(Settings::new(slatedb::Settings::default()));
 
         settings
-            .set("default_ttl".to_owned(), "100".to_owned())
+            .set("default_ttl_millis".to_owned(), "100".to_owned())
             .unwrap();
         settings
-            .set("default_ttl".to_owned(), "null".to_owned())
+            .set("default_ttl_millis".to_owned(), "null".to_owned())
             .unwrap();
 
-        assert_eq!(settings.inner().default_ttl, None);
+        assert_eq!(settings.inner().default_ttl_millis, None);
     }
 
     #[test]
@@ -315,13 +315,13 @@ mod tests {
         let settings = Arc::new(Settings::new(slatedb::Settings::default()));
 
         settings
-            .set("default_ttl".to_owned(), "42".to_owned())
+            .set("default_ttl_millis".to_owned(), "42".to_owned())
             .unwrap();
 
         let encoded = settings.to_json_string().unwrap();
         let decoded = Settings::from_json_string(encoded).unwrap();
 
-        assert_eq!(decoded.inner().default_ttl, Some(42));
+        assert_eq!(decoded.inner().default_ttl_millis, Some(42));
     }
 
     #[test]
@@ -367,7 +367,7 @@ flush_interval = "1s"
     #[test]
     fn settings_from_env_with_default_uses_default_snapshot() {
         figment::Jail::expect_with(|jail| {
-            jail.set_env("FFI_SETTINGS_DEFAULT_TTL", "42");
+            jail.set_env("FFI_SETTINGS_DEFAULT_TTL_MILLIS", "42");
 
             let defaults = Arc::new(Settings::new(slatedb::Settings::default()));
             defaults
@@ -382,7 +382,7 @@ flush_interval = "1s"
                 settings.inner().flush_interval,
                 Some(Duration::from_millis(250))
             );
-            assert_eq!(settings.inner().default_ttl, Some(42));
+            assert_eq!(settings.inner().default_ttl_millis, Some(42));
 
             Ok(())
         });

--- a/rfcs/0003-timestamps-and-ttl.md
+++ b/rfcs/0003-timestamps-and-ttl.md
@@ -93,11 +93,11 @@ tick and sleeping briefly if clock skew is detected.
 pub struct DbOptions {
     // ...
 
-    /// The default time-to-live (TTL) for insertions (note that re-inserting a key
-    /// with any value will update the TTL to use the default_ttl)
+    /// The default time-to-live (TTL), in milliseconds, for insertions (note that
+    /// re-inserting a key with any value will update the TTL to use default_ttl_millis)
     ///
     /// Default: no TTL (insertions will remain until deleted)
-    default_ttl: Option<u64>
+    default_ttl_millis: Option<u64>
 }
 ```
 
@@ -126,7 +126,7 @@ pub enum Ttl {
     /// No expiration for this entry
     NoExpiry,
     /// Expire after the specified duration (in milliseconds)
-    ExpireAfter(u64),
+    ExpireAfterMillis(u64),
 }
 
 pub struct PutOptions {
@@ -367,4 +367,4 @@ the original `seq0` insert as it logically happened "after" `seq1`.
   for testing or non-standard time sources.
 - Updated `DbOptions` to remove the `clock` configuration option
 - Updated `WriteOptions` to `PutOptions` with a `Ttl` enum that supports `Default`, `NoExpiry`,
-  and `ExpireAfter(u64)` variants
+  and `ExpireAfterMillis(u64)` variants

--- a/rfcs/0006-merge-operator.md
+++ b/rfcs/0006-merge-operator.md
@@ -220,12 +220,12 @@ impl DbOptions {
 
 ### Extending TTL support
 
-The last public API change is extending the `Ttl` enum to support a new `ExpireAt(ts)` variant. This allows users to set a specific expiration time for a key, which overrides the default TTL behavior.
+The last public API change is extending the `Ttl` enum to support a new `ExpireAtMillis(timestamp_millis)` variant. This allows users to set a specific expiration time for a key, expressed as milliseconds since the Unix epoch, which overrides the default TTL behavior.
 
 ```rust
 pub enum Ttl {
     ...
-    ExpireAt(i64),
+    ExpireAtMillis(i64),
 }
 ```
 
@@ -425,8 +425,8 @@ SlateDB supports two TTL approaches:
 
 1. **Operation-Level TTL**
    - Each operation (put/merge) has its own independent TTL, specified via:
-     - `Ttl::ExpireAfter(duration)`: Expires after specified duration (internally this is implemented as `ExpireAt(Instant::now() + duration)`)
-     - `Ttl::ExpireAt(timestamp)`: Expires at specified timestamp
+     - `Ttl::ExpireAfterMillis(duration_millis)`: Expires after the specified duration in milliseconds (internally this is implemented as `create_ts + duration_millis`)
+     - `Ttl::ExpireAtMillis(timestamp_millis)`: Expires at the specified Unix timestamp in milliseconds
    - Enables per-element expiration in collections
 
 2. **TTL Renewal (NOT SUPPORTED NATIVELY)**
@@ -439,7 +439,7 @@ When merging values with different TTLs, the merge operation only combines value
 
 Unlike regular values which become tombstones upon expiration, expired merge entries are simply removed, enabling per-element expiration in collections.
 
-Users can implement custom TTL patterns by consistently using either `ExpireAt` or `ExpireAfter` across operations.
+Users can implement custom TTL patterns by consistently using either `ExpireAtMillis` or `ExpireAfterMillis` across operations.
 
 ### Ordering Guarantees
 

--- a/slatedb/benches/db_transaction.rs
+++ b/slatedb/benches/db_transaction.rs
@@ -53,13 +53,13 @@ fn concat_merge_operator() -> Arc<dyn MergeOperator + Send + Sync> {
 
 fn put_options() -> PutOptions {
     PutOptions {
-        ttl: Ttl::ExpireAfter(3_600),
+        ttl: Ttl::ExpireAfterMillis(3_600_000),
     }
 }
 
 fn merge_options() -> MergeOptions {
     MergeOptions {
-        ttl: Ttl::ExpireAfter(3_600),
+        ttl: Ttl::ExpireAfterMillis(3_600_000),
     }
 }
 

--- a/slatedb/benches/write_batch.rs
+++ b/slatedb/benches/write_batch.rs
@@ -56,13 +56,13 @@ fn size_sum_merge_operator() -> Arc<dyn MergeOperator + Send + Sync> {
 
 fn put_options() -> PutOptions {
     PutOptions {
-        ttl: Ttl::ExpireAfter(3_600),
+        ttl: Ttl::ExpireAfterMillis(3_600_000),
     }
 }
 
 fn merge_options() -> MergeOptions {
     MergeOptions {
-        ttl: Ttl::ExpireAfter(3_600),
+        ttl: Ttl::ExpireAfterMillis(3_600_000),
     }
 }
 

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -309,7 +309,7 @@ impl WriteBatch {
         &self,
         seq: u64,
         now: i64,
-        default_ttl: Option<u64>,
+        default_ttl_millis: Option<u64>,
         merger: Option<MergeOperatorType>,
         extractor: Option<&dyn PrefixExtractor>,
     ) -> Result<(Vec<RowEntry>, BTreeSet<Bytes>, u64), SlateDBError> {
@@ -320,7 +320,7 @@ impl WriteBatch {
             IterationOrder::Ascending,
             seq,
             Some(now),
-            default_ttl,
+            default_ttl_millis,
         ));
         if self.has_merge_ops() {
             if let Some(ref merge_operator) = merger {
@@ -379,12 +379,12 @@ pub mod benches {
         batch: &WriteBatch,
         seq: u64,
         now: i64,
-        default_ttl: Option<u64>,
+        default_ttl_millis: Option<u64>,
         merger: Option<Arc<dyn MergeOperator + Send + Sync>>,
         extractor: Option<&dyn PrefixExtractor>,
     ) -> Result<(Vec<RowEntry>, BTreeSet<Bytes>, u64), Error> {
         batch
-            .extract_entries(seq, now, default_ttl, merger, extractor)
+            .extract_entries(seq, now, default_ttl_millis, merger, extractor)
             .await
             .map_err(Into::into)
     }
@@ -410,11 +410,11 @@ impl WriteBatchIterator {
         op: &WriteOp,
         seq: u64,
         now: Option<i64>,
-        default_ttl: Option<u64>,
+        default_ttl_millis: Option<u64>,
     ) -> RowEntry {
         let expire_ts = match (op, now) {
-            (WriteOp::Put(_, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
-            (WriteOp::Merge(_, opts), Some(now)) => opts.expire_ts_from(default_ttl, now),
+            (WriteOp::Put(_, opts), Some(now)) => opts.expire_ts_from(default_ttl_millis, now),
+            (WriteOp::Merge(_, opts), Some(now)) => opts.expire_ts_from(default_ttl_millis, now),
             _ => None,
         };
         op.to_row_entry(key, seq, now, expire_ts)
@@ -426,21 +426,21 @@ impl WriteBatchIterator {
         ordering: IterationOrder,
         seq: u64,
         now: Option<i64>,
-        default_ttl: Option<u64>,
+        default_ttl_millis: Option<u64>,
     ) -> Self {
         let entries: Vec<RowEntry> = match ordering {
             IterationOrder::Ascending => batch
                 .ops
                 .range(range)
                 .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
-                .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
+                .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl_millis))
                 .collect(),
             IterationOrder::Descending => batch
                 .ops
                 .range(range)
                 .rev()
                 .flat_map(|(key, ops)| ops.iter().rev().map(move |op| (key, op)))
-                .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl))
+                .map(|(key, op)| Self::write_op_to_row_entry(key, op, seq, now, default_ttl_millis))
                 .collect(),
         };
 
@@ -853,7 +853,7 @@ mod tests {
         // Given: an empty WriteBatch and custom merge options
         let mut batch = WriteBatch::new();
         let merge_options = MergeOptions {
-            ttl: Ttl::ExpireAfter(3600), // 1 hour
+            ttl: Ttl::ExpireAfterMillis(3_600_000), // 1 hour
         };
 
         // When: adding a merge operation with custom options
@@ -865,7 +865,7 @@ mod tests {
         match op {
             WriteOp::Merge(value, options) => {
                 assert_eq!(value.as_ref(), b"value1");
-                assert_eq!(options.ttl, Ttl::ExpireAfter(3600));
+                assert_eq!(options.ttl, Ttl::ExpireAfterMillis(3_600_000));
             }
             _ => panic!("Expected Merge operation"),
         }
@@ -1422,14 +1422,14 @@ mod tests {
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(3600),
+                ttl: Ttl::ExpireAfterMillis(3600),
             },
         );
         batch.merge_with_options(
             b"key1",
             b"b",
             &MergeOptions {
-                ttl: Ttl::ExpireAt(4600),
+                ttl: Ttl::ExpireAtMillis(4600),
             },
         );
 
@@ -1456,14 +1456,14 @@ mod tests {
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(3600),
+                ttl: Ttl::ExpireAfterMillis(3600),
             },
         );
         batch.merge_with_options(
             b"key1",
             b"b",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(7200),
+                ttl: Ttl::ExpireAfterMillis(7200),
             },
         );
 
@@ -1495,14 +1495,14 @@ mod tests {
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(3600),
+                ttl: Ttl::ExpireAfterMillis(3600),
             },
         );
         batch.merge_with_options(
             b"key2",
             b"b",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(7200),
+                ttl: Ttl::ExpireAfterMillis(7200),
             },
         );
 
@@ -1528,7 +1528,7 @@ mod tests {
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(7200),
+                ttl: Ttl::ExpireAfterMillis(7200),
             },
         );
 
@@ -1550,7 +1550,7 @@ mod tests {
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(7200),
+                ttl: Ttl::ExpireAfterMillis(7200),
             },
         );
 

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -246,7 +246,7 @@ impl DbInner {
             .extract_entries(
                 commit_seq,
                 now,
-                self.settings.default_ttl,
+                self.settings.default_ttl_millis,
                 self.flush_merge_operator.clone(),
                 self.segment_extractor.as_deref(),
             )

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -3151,7 +3151,7 @@ mod tests {
             b"key1",
             &[b'a'; 32],
             &crate::config::MergeOptions {
-                ttl: Ttl::ExpireAfter(10),
+                ttl: Ttl::ExpireAfterMillis(10),
             },
             &WriteOptions {
                 await_durable: true,
@@ -3343,7 +3343,7 @@ mod tests {
             b"key1",
             b"a",
             &crate::config::MergeOptions {
-                ttl: Ttl::ExpireAfter(100),
+                ttl: Ttl::ExpireAfterMillis(100),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3369,7 +3369,7 @@ mod tests {
             b"key1",
             b"b",
             &crate::config::MergeOptions {
-                ttl: Ttl::ExpireAfter(200),
+                ttl: Ttl::ExpireAfterMillis(200),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3478,13 +3478,13 @@ mod tests {
             flush_type: FlushType::MemTable,
         };
 
-        // write merge operations with the SAME ExpireAt timestamp at different clock times
+        // write merge operations with the SAME ExpireAtMillis timestamp at different clock times
         system_clock.set(100);
         db.merge_with_options(
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAt(1000),
+                ttl: Ttl::ExpireAtMillis(1000),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3500,7 +3500,7 @@ mod tests {
             b"key1",
             b"b",
             &MergeOptions {
-                ttl: Ttl::ExpireAt(1000),
+                ttl: Ttl::ExpireAtMillis(1000),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3601,7 +3601,7 @@ mod tests {
             &[1; 16],
             value,
             &PutOptions {
-                ttl: Ttl::ExpireAt(10),
+                ttl: Ttl::ExpireAtMillis(10),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3617,7 +3617,7 @@ mod tests {
             &[2; 16],
             value,
             &PutOptions {
-                ttl: Ttl::ExpireAt(i64::MAX),
+                ttl: Ttl::ExpireAtMillis(i64::MAX),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3694,7 +3694,7 @@ mod tests {
         }
         .into();
         let mut options = db_options(Some(compactor_options()));
-        options.default_ttl = Some(50);
+        options.default_ttl_millis = Some(50);
         options
             .compactor_options
             .as_mut()
@@ -3717,7 +3717,7 @@ mod tests {
             &[1; 16],
             value,
             &PutOptions {
-                ttl: Ttl::ExpireAfter(10),
+                ttl: Ttl::ExpireAfterMillis(10),
             },
             &WriteOptions {
                 await_durable: false,
@@ -3764,7 +3764,7 @@ mod tests {
             &[1; 16],
             value,
             &PutOptions {
-                ttl: Ttl::ExpireAfter(80),
+                ttl: Ttl::ExpireAfterMillis(80),
             },
             &WriteOptions {
                 await_durable: false,

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -503,25 +503,29 @@ pub struct PutOptions {
 }
 
 impl PutOptions {
-    pub(crate) fn expire_ts_from(&self, default: Option<u64>, now: i64) -> Option<i64> {
+    pub(crate) fn expire_ts_from(
+        &self,
+        default_ttl_millis: Option<u64>,
+        now_millis: i64,
+    ) -> Option<i64> {
         match self.ttl {
-            Ttl::Default => match default {
+            Ttl::Default => match default_ttl_millis {
                 None => None,
-                Some(default_ttl) => Self::checked_expire_ts(now, default_ttl),
+                Some(default_ttl_millis) => Self::checked_expire_ts(now_millis, default_ttl_millis),
             },
             Ttl::NoExpiry => None,
-            Ttl::ExpireAfter(ttl) => Self::checked_expire_ts(now, ttl),
-            Ttl::ExpireAt(ts) => Some(ts),
+            Ttl::ExpireAfterMillis(ttl_millis) => Self::checked_expire_ts(now_millis, ttl_millis),
+            Ttl::ExpireAtMillis(timestamp_millis) => Some(timestamp_millis),
         }
     }
 
-    fn checked_expire_ts(now: i64, ttl: u64) -> Option<i64> {
+    fn checked_expire_ts(now_millis: i64, ttl_millis: u64) -> Option<i64> {
         // for overflow, we will just assume no TTL
-        if ttl > i64::MAX as u64 {
+        if ttl_millis > i64::MAX as u64 {
             return None;
         };
-        let expire_ts = now + (ttl as i64);
-        if expire_ts < now {
+        let expire_ts = now_millis + (ttl_millis as i64);
+        if expire_ts < now_millis {
             return None;
         };
 
@@ -541,25 +545,29 @@ pub struct MergeOptions {
 
 impl MergeOptions {
     // TODO(agavra): deduplicate this with PutOptions::expire_ts_from
-    pub(crate) fn expire_ts_from(&self, default: Option<u64>, now: i64) -> Option<i64> {
+    pub(crate) fn expire_ts_from(
+        &self,
+        default_ttl_millis: Option<u64>,
+        now_millis: i64,
+    ) -> Option<i64> {
         match self.ttl {
-            Ttl::Default => match default {
+            Ttl::Default => match default_ttl_millis {
                 None => None,
-                Some(default_ttl) => Self::checked_expire_ts(now, default_ttl),
+                Some(default_ttl_millis) => Self::checked_expire_ts(now_millis, default_ttl_millis),
             },
             Ttl::NoExpiry => None,
-            Ttl::ExpireAfter(ttl) => Self::checked_expire_ts(now, ttl),
-            Ttl::ExpireAt(ts) => Some(ts),
+            Ttl::ExpireAfterMillis(ttl_millis) => Self::checked_expire_ts(now_millis, ttl_millis),
+            Ttl::ExpireAtMillis(timestamp_millis) => Some(timestamp_millis),
         }
     }
 
-    fn checked_expire_ts(now: i64, ttl: u64) -> Option<i64> {
+    fn checked_expire_ts(now_millis: i64, ttl_millis: u64) -> Option<i64> {
         // for overflow, we will just assume no TTL
-        if ttl > i64::MAX as u64 {
+        if ttl_millis > i64::MAX as u64 {
             return None;
         };
-        let expire_ts = now + (ttl as i64);
-        if expire_ts < now {
+        let expire_ts = now_millis + (ttl_millis as i64);
+        if expire_ts < now_millis {
             return None;
         };
 
@@ -567,14 +575,25 @@ impl MergeOptions {
     }
 }
 
+/// Time-to-live policy applied to an inserted value or merge operand.
+///
+/// TTL durations are expressed in milliseconds. Absolute expiration timestamps are
+/// expressed as milliseconds since the Unix epoch.
+///
+/// Expiration is applied during compaction and is therefore best effort; an expired
+/// value may remain visible until compaction processes it.
 #[non_exhaustive]
 #[derive(Clone, Default, PartialEq, Debug)]
 pub enum Ttl {
+    /// Use [`Settings::default_ttl_millis`].
     #[default]
     Default,
+    /// Store the value without an expiration.
     NoExpiry,
-    ExpireAfter(u64),
-    ExpireAt(i64),
+    /// Expire the value after the specified number of milliseconds.
+    ExpireAfterMillis(u64),
+    /// Expire the value at the specified Unix timestamp in milliseconds.
+    ExpireAtMillis(i64),
 }
 
 /// Defines the scope targeted by a given checkpoint. If set to All, then the checkpoint will
@@ -765,11 +784,12 @@ pub struct Settings {
     #[serde(default)]
     pub metric_level: MetricLevel,
 
-    /// The default time-to-live (TTL) for insertions (note that re-inserting a key
-    /// with any value will update the TTL to use the default_ttl)
+    /// The default time-to-live (TTL), in milliseconds, for insertions (note that
+    /// re-inserting a key with any value will update the TTL to use
+    /// `default_ttl_millis`).
     ///
     /// Default: no TTL (insertions will remain until deleted)
-    pub default_ttl: Option<u64>,
+    pub default_ttl_millis: Option<u64>,
 
     /// Maximum number of wrapper-level retries for a single object-store
     /// operation, on top of the `object_store` client's own HTTP retries.
@@ -819,7 +839,7 @@ impl std::fmt::Debug for Settings {
             )
             .field("garbage_collector_options", &self.garbage_collector_options)
             .field("metric_level", &self.metric_level)
-            .field("default_ttl", &self.default_ttl);
+            .field("default_ttl_millis", &self.default_ttl_millis);
         data.finish()
     }
 }
@@ -1049,7 +1069,7 @@ impl Default for Settings {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             garbage_collector_options: Some(GarbageCollectorOptions::default()),
             metric_level: MetricLevel::default(),
-            default_ttl: None,
+            default_ttl_millis: None,
             object_store_max_retries: None,
             #[cfg(test)]
             block_format: None,
@@ -1991,7 +2011,7 @@ object_store_cache_options:
     fn should_return_exact_timestamp_for_put_expire_at() {
         // given
         let opts = PutOptions {
-            ttl: Ttl::ExpireAt(12345),
+            ttl: Ttl::ExpireAtMillis(12345),
         };
 
         // when
@@ -2005,7 +2025,7 @@ object_store_cache_options:
     fn should_ignore_default_ttl_for_put_expire_at() {
         // given
         let opts = PutOptions {
-            ttl: Ttl::ExpireAt(12345),
+            ttl: Ttl::ExpireAtMillis(12345),
         };
 
         // when
@@ -2019,7 +2039,7 @@ object_store_cache_options:
     fn should_allow_past_timestamp_for_put_expire_at() {
         // given
         let opts = PutOptions {
-            ttl: Ttl::ExpireAt(50),
+            ttl: Ttl::ExpireAtMillis(50),
         };
 
         // when
@@ -2033,7 +2053,7 @@ object_store_cache_options:
     fn should_return_exact_timestamp_for_merge_expire_at() {
         // given
         let opts = MergeOptions {
-            ttl: Ttl::ExpireAt(12345),
+            ttl: Ttl::ExpireAtMillis(12345),
         };
 
         // when
@@ -2045,9 +2065,9 @@ object_store_cache_options:
 
     #[test]
     fn should_return_deterministic_expire_ts_for_expire_at() {
-        // given: same ExpireAt value used at different times
+        // given: same ExpireAtMillis value used at different times
         let opts = PutOptions {
-            ttl: Ttl::ExpireAt(99999),
+            ttl: Ttl::ExpireAtMillis(99999),
         };
 
         // when

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -7193,7 +7193,7 @@ mod tests {
         min_filter_keys: u32,
         l0_sst_size_bytes: usize,
         compactor_options: Option<CompactorOptions>,
-        ttl: Option<u64>,
+        default_ttl_millis: Option<u64>,
     ) -> Settings {
         Settings {
             flush_interval: Some(Duration::from_millis(100)),
@@ -7213,7 +7213,7 @@ mod tests {
             object_store_cache_options: ObjectStoreCacheOptions::default(),
             garbage_collector_options: None,
             metric_level: MetricLevel::default(),
-            default_ttl: ttl,
+            default_ttl_millis,
             object_store_max_retries: None,
             block_format: None,
         }
@@ -8144,7 +8144,7 @@ mod tests {
         // Put with options (TTL)
         clock.set(200);
         let put_opts = PutOptions {
-            ttl: Ttl::ExpireAfter(1000),
+            ttl: Ttl::ExpireAfterMillis(1000),
         };
         let handle = db
             .put_with_options(
@@ -9426,7 +9426,7 @@ mod tests {
             key,
             value,
             &PutOptions {
-                ttl: Ttl::ExpireAfter(50),
+                ttl: Ttl::ExpireAfterMillis(50),
             },
             &WriteOptions {
                 await_durable: false,
@@ -9459,7 +9459,7 @@ mod tests {
             .unwrap();
 
         let put_opts = PutOptions {
-            ttl: Ttl::ExpireAfter(50),
+            ttl: Ttl::ExpireAfterMillis(50),
         };
         let write_opts = WriteOptions {
             await_durable: false,
@@ -9529,13 +9529,13 @@ mod tests {
             .await
             .unwrap();
 
-        // when: write with ExpireAt at different clock times
+        // when: write with ExpireAtMillis at different clock times
         clock.set(100);
         db.put_with_options(
             b"key1",
             b"value1",
             &PutOptions {
-                ttl: Ttl::ExpireAt(500),
+                ttl: Ttl::ExpireAtMillis(500),
             },
             &WriteOptions {
                 await_durable: false,
@@ -9550,7 +9550,7 @@ mod tests {
             b"key2",
             b"value2",
             &PutOptions {
-                ttl: Ttl::ExpireAt(500),
+                ttl: Ttl::ExpireAtMillis(500),
             },
             &WriteOptions {
                 await_durable: false,
@@ -9719,14 +9719,14 @@ mod tests {
             b"key1",
             b"a",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(3600),
+                ttl: Ttl::ExpireAfterMillis(3600),
             },
         );
         batch.merge_with_options(
             b"key1",
             b"b",
             &MergeOptions {
-                ttl: Ttl::ExpireAfter(7200),
+                ttl: Ttl::ExpireAfterMillis(7200),
             },
         );
 

--- a/slatedb/src/db_transaction.rs
+++ b/slatedb/src/db_transaction.rs
@@ -2050,7 +2050,7 @@ mod tests {
             b"counter",
             1u64.to_le_bytes(),
             &MergeOptions {
-                ttl: crate::config::Ttl::ExpireAfter(3600),
+                ttl: crate::config::Ttl::ExpireAfterMillis(3600),
             },
         )
         .unwrap();
@@ -2058,7 +2058,7 @@ mod tests {
             b"counter",
             2u64.to_le_bytes(),
             &MergeOptions {
-                ttl: crate::config::Ttl::ExpireAfter(7200),
+                ttl: crate::config::Ttl::ExpireAfterMillis(7200),
             },
         )
         .unwrap();
@@ -2098,7 +2098,7 @@ mod tests {
             object_store_cache_options: crate::config::ObjectStoreCacheOptions::default(),
             garbage_collector_options: None,
             metric_level: MetricLevel::default(),
-            default_ttl: None,
+            default_ttl_millis: None,
             object_store_max_retries: None,
             block_format: None,
         }
@@ -2137,7 +2137,7 @@ mod tests {
         clock.set(200);
         let txn = db.begin(IsolationLevel::Snapshot).await.unwrap();
         let put_opts = PutOptions {
-            ttl: crate::config::Ttl::ExpireAfter(1000),
+            ttl: crate::config::Ttl::ExpireAfterMillis(1000),
         };
         txn.put_with_options(b"key2", b"value2", &put_opts).unwrap();
         let handle = txn

--- a/website/src/content/docs/docs/design/time.mdx
+++ b/website/src/content/docs/docs/design/time.mdx
@@ -33,18 +33,18 @@ SlateDB also preserves the same metadata in the WAL path, which is why [Change D
 
 ## Expiration
 
-TTL is stored as an absolute expiration timestamp, not a relative duration. On commit, SlateDB computes `expire_ts = create_ts + ttl`.
+TTL is stored as an absolute expiration timestamp in milliseconds since the Unix epoch, not as a relative duration. On commit, SlateDB computes `expire_ts = create_ts + ttl_millis`.
 
-[`Settings::default_ttl`](https://docs.rs/slatedb/latest/slatedb/config/struct.Settings.html#structfield.default_ttl) sets a default TTL for puts and merges. [`PutOptions`](https://docs.rs/slatedb/latest/slatedb/config/struct.PutOptions.html) and [`MergeOptions`](https://docs.rs/slatedb/latest/slatedb/config/struct.MergeOptions.html) can override that per operation:
+[`Settings::default_ttl_millis`](https://docs.rs/slatedb/latest/slatedb/config/struct.Settings.html#structfield.default_ttl_millis) sets a default TTL in milliseconds for puts and merges. [`PutOptions`](https://docs.rs/slatedb/latest/slatedb/config/struct.PutOptions.html) and [`MergeOptions`](https://docs.rs/slatedb/latest/slatedb/config/struct.MergeOptions.html) can override that per operation:
 
 - [`Ttl::NoExpiry`](https://docs.rs/slatedb/latest/slatedb/config/enum.Ttl.html#variant.NoExpiry) — store the value without expiration
-- [`Ttl::ExpireAfter(u64)`](https://docs.rs/slatedb/latest/slatedb/config/enum.Ttl.html#variant.ExpireAfter) — expire after a relative duration (clock ticks)
-- [`Ttl::ExpireAt(i64)`](https://docs.rs/slatedb/latest/slatedb/config/enum.Ttl.html#variant.ExpireAt) — expire at a fixed absolute timestamp (clock ticks)
+- [`Ttl::ExpireAfterMillis(u64)`](https://docs.rs/slatedb/latest/slatedb/config/enum.Ttl.html#variant.ExpireAfterMillis) — expire after a relative duration in milliseconds
+- [`Ttl::ExpireAtMillis(i64)`](https://docs.rs/slatedb/latest/slatedb/config/enum.Ttl.html#variant.ExpireAtMillis) — expire at a fixed Unix timestamp in milliseconds
 
 Deletes write tombstones and do not carry TTL.
 
 :::caution
-Batch-local merges requires one effective `expire_ts` per key. `Db::write(...)` and transaction commit return `ErrorKind::Invalid` if a single batch tries to merge the same key across different expiration timestamps. Effective timestamps are computed after applying `Settings::default_ttl`, so `Ttl::Default` can still differ from `Ttl::NoExpiry` or from another explicit TTL.
+Batch-local merges requires one effective `expire_ts` per key. `Db::write(...)` and transaction commit return `ErrorKind::Invalid` if a single batch tries to merge the same key across different expiration timestamps. Effective timestamps are computed after applying `Settings::default_ttl_millis`, so `Ttl::Default` can still differ from `Ttl::NoExpiry` or from another explicit TTL.
 :::
 
 :::note


### PR DESCRIPTION
## Summary

TTL values are currently named without a unit, so callers cannot tell from the API whether an integer represents seconds or milliseconds. This PR makes milliseconds explicit in the public API and documentation.

Closes #1988

## Changes

- Rename `Ttl::ExpireAfter` to `Ttl::ExpireAfterMillis` and `Ttl::ExpireAt` to `Ttl::ExpireAtMillis`.
- Rename `Settings::default_ttl` and its serialized key to `default_ttl_millis`.
- Document Unix epoch milliseconds for absolute expiration and note that expiration is best effort during compaction.
- Update RFCs, website docs, tests, benchmarks, and generated Go bindings.

## Notes for Reviewers

This is a breaking API and configuration change. Callers must rename the affected Rust and UniFFI variants, then change `default_ttl` to `default_ttl_millis` in code, settings files, environment variables, and dynamic settings calls.

The Go source was regenerated with `./scripts/generate-go-uniffi.sh`. This naming change does not alter TTL behavior or performance.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏