### PR TITLE
Apply retry policy to multipart part uploads with MultipartStore API (#1956)

### DIFF
--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -7,16 +7,20 @@ use crate::cached_object_store::storage_fs::FsCacheStorage;
 use crate::cached_object_store::LocalCacheEntry;
 use crate::config::ObjectStoreCacheOptions;
 use crate::object_store_tag::ObjectStoreCallTag;
+use crate::retrying_object_store::RetryingObjectStore;
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, stream, stream::BoxStream, StreamExt};
+use object_store::multipart::{MultipartStore, PartId};
 use object_store::{path::Path, GetOptions, GetResult, ObjectMeta, ObjectStore, ObjectStoreExt};
 use object_store::{
     Attributes, CopyOptions, Extensions, GetRange, GetResultPayload, PutMultipartOptions,
     PutResult, RenameOptions,
 };
-use object_store::{ListResult, MultipartUpload, PutOptions, PutPayload};
+use object_store::{ListResult, MultipartId, MultipartUpload, PutOptions, PutPayload};
 use slatedb_common::clock::{DefaultSystemClock, SystemClock};
 use slatedb_common::DbRand;
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Mutex;
 use std::{ops::Range, sync::Arc};
 
 use crate::single_flight::SingleFlight;
@@ -121,6 +125,22 @@ impl CachedObjectStore {
 
     pub(crate) async fn start_evictor(&self) {
         self.cache_storage.start_evictor().await;
+    }
+
+    /// Wraps a low-level [`MultipartStore`] handle so its uploads mirror
+    /// their bytes into this store's cache, as
+    /// [`CachedObjectStore::put_multipart_opts`] does for high-level uploads.
+    pub(crate) fn caching_multipart_store(
+        &self,
+        inner: Arc<dyn MultipartStore>,
+    ) -> Arc<dyn MultipartStore> {
+        Arc::new(CachingMultipartStore {
+            inner,
+            cache_storage: Arc::clone(&self.cache_storage),
+            part_size: self.part_size_bytes,
+            put_policy: Arc::clone(&self.put_policy),
+            uploads: Mutex::new(HashMap::new()),
+        })
     }
 
     /// Build a `CachedObjectStore` from `ObjectStoreCacheOptions`, returning `None`
@@ -1111,6 +1131,187 @@ impl MultipartUpload for CachingMultipartUpload {
     }
 }
 
+/// The [`MultipartStore`] analogue of [`CachingMultipartUpload`]: mirrors
+/// uploaded bytes into the local cache. Parts may complete out of order, so
+/// payloads are held until the contiguous prefix folds into cache parts
+/// (memory bounded by the caller's in-flight window). As in the high-level
+/// path, the head is the commit point and cache writes are best effort. A
+/// part index is assumed to be re-sent only with identical bytes.
+struct CachingMultipartStore {
+    inner: Arc<dyn MultipartStore>,
+    cache_storage: Arc<dyn LocalCacheStorage>,
+    part_size: usize,
+    put_policy: Arc<dyn PutPolicy>,
+    /// Mirror state per active upload; absent when the put policy skipped it.
+    uploads: Mutex<HashMap<MultipartId, UploadMirror>>,
+}
+
+struct UploadMirror {
+    location: Path,
+    attributes: Attributes,
+    /// Uploaded payloads waiting for the contiguous prefix to reach them.
+    pending: BTreeMap<usize, PutPayload>,
+    /// The next upload part index to fold into `buffer`.
+    next_idx: usize,
+    /// In-order bytes observed so far that have not yet filled a cache part.
+    buffer: BytesMut,
+    /// The next cache part number to write.
+    next_cache_part: PartID,
+    /// Total bytes teed so far; becomes the committed head's `size`.
+    total_len: u64,
+}
+
+impl std::fmt::Debug for CachingMultipartStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CachingMultipartStore")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl MultipartStore for CachingMultipartStore {
+    async fn create_multipart(&self, path: &Path) -> object_store::Result<MultipartId> {
+        self.create_multipart_opts(path, PutMultipartOptions::default())
+            .await
+    }
+
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<MultipartId> {
+        let tag = ObjectStoreCallTag::from_extensions(&opts.extensions);
+        let attributes = opts.attributes.clone();
+        let cache = self.put_policy.put_action(tag.as_ref()) == PutAction::Cache;
+
+        let id = self.inner.create_multipart_opts(path, opts).await?;
+        if cache {
+            self.uploads.lock().expect("lock poisoned").insert(
+                id.clone(),
+                UploadMirror {
+                    location: path.clone(),
+                    attributes,
+                    pending: BTreeMap::new(),
+                    next_idx: 0,
+                    buffer: BytesMut::new(),
+                    next_cache_part: 0,
+                    total_len: 0,
+                },
+            );
+        }
+        Ok(id)
+    }
+
+    async fn put_part(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        part_idx: usize,
+        data: PutPayload,
+    ) -> object_store::Result<PartId> {
+        let part = self
+            .inner
+            .put_part(path, id, part_idx, data.clone())
+            .await?;
+
+        // Tee the payload into the mirror once it is durable upstream, and
+        // collect any cache parts the contiguous prefix now fills.
+        let chunks = {
+            let mut uploads = self.uploads.lock().expect("lock poisoned");
+            let Some(mirror) = uploads.get_mut(id) else {
+                return Ok(part);
+            };
+            if part_idx >= mirror.next_idx {
+                mirror.pending.entry(part_idx).or_insert(data);
+            }
+            while let Some(data) = mirror.pending.remove(&mirror.next_idx) {
+                mirror.total_len += data.content_length() as u64;
+                mirror.buffer.reserve(data.content_length());
+                for bytes in &data {
+                    mirror.buffer.extend_from_slice(bytes);
+                }
+                mirror.next_idx += 1;
+            }
+            let mut chunks = Vec::new();
+            while mirror.buffer.len() >= self.part_size {
+                let chunk = mirror.buffer.split_to(self.part_size).freeze();
+                chunks.push((mirror.next_cache_part, chunk));
+                mirror.next_cache_part += 1;
+            }
+            (mirror.location.clone(), chunks)
+        };
+
+        let (location, chunks) = chunks;
+        if !chunks.is_empty() {
+            let entry = self.cache_storage.entry(&location, self.part_size);
+            for (part_number, chunk) in chunks {
+                // Best-effort: a failed cache write never fails the upload.
+                entry.save_part(part_number, chunk).await.ok();
+            }
+        }
+        Ok(part)
+    }
+
+    async fn complete_multipart(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        parts: Vec<PartId>,
+    ) -> object_store::Result<PutResult> {
+        let result = match self.inner.complete_multipart(path, id, parts).await {
+            Ok(result) => result,
+            // A transient error keeps the mirror for the retry layer's next
+            // attempt. A permanent error ends the retry loop for good (a lost
+            // complete resolves via put-id), so drop the mirror and entry.
+            Err(err) => {
+                if !RetryingObjectStore::should_retry(&err) {
+                    let mirror = self.uploads.lock().expect("lock poisoned").remove(id);
+                    if let Some(mirror) = mirror {
+                        self.cache_storage
+                            .entry(&mirror.location, self.part_size)
+                            .delete()
+                            .await;
+                    }
+                }
+                return Err(err);
+            }
+        };
+
+        let mirror = self.uploads.lock().expect("lock poisoned").remove(id);
+        if let Some(mut mirror) = mirror {
+            let entry = self.cache_storage.entry(&mirror.location, self.part_size);
+            if mirror.pending.is_empty() {
+                // Flush the trailing partial part, then commit by writing the
+                // head last (see CachingMultipartUpload::complete).
+                if !mirror.buffer.is_empty() {
+                    let chunk = std::mem::take(&mut mirror.buffer).freeze();
+                    entry.save_part(mirror.next_cache_part, chunk).await.ok();
+                }
+                let meta = build_head(&mirror.location, mirror.total_len, &result);
+                entry.save_head((&meta, &mirror.attributes)).await.ok();
+            } else {
+                // Some parts never reached the mirror; drop the incomplete
+                // entry instead of committing it.
+                entry.delete().await;
+            }
+        }
+        Ok(result)
+    }
+
+    async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> object_store::Result<()> {
+        let result = self.inner.abort_multipart(path, id).await;
+        let mirror = self.uploads.lock().expect("lock poisoned").remove(id);
+        if let Some(mirror) = mirror {
+            // The object will never exist upstream, so drop any cached parts.
+            self.cache_storage
+                .entry(&mirror.location, self.part_size)
+                .delete()
+                .await;
+        }
+        result
+    }
+}
+
 /// Where a read (of the object head or of a single part) was served from.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum ReadResultSource {
@@ -1170,7 +1371,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use super::{CachedObjectStore, ReadResultSource};
+    use super::{CachedObjectStore, CachingMultipartStore, ReadResultSource};
     use crate::cached_object_store::policy::CachePutConfig;
     use crate::cached_object_store::stats::CachedObjectStoreStats;
     use crate::cached_object_store::storage::{LocalCacheStorage, PartID};
@@ -1184,9 +1385,13 @@ mod tests {
     use crate::test_utils::{
         gen_rand_bytes, ExtensionMarker, ExtensionObjectStore, FlakyObjectStore, GatedObjectStore,
     };
+    use object_store::memory::InMemory;
+    use object_store::multipart::MultipartStore;
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::metrics::MetricsRecorderHelper;
     use slatedb_common::DbRand;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
 
     fn new_test_cache_folder() -> std::path::PathBuf {
         let mut rng = rand::rng();
@@ -2918,6 +3123,245 @@ mod tests {
         upload.complete().await.unwrap();
 
         assert_eq!(cached_part_count(&store, &location).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_upload_mirrors_out_of_order_parts() {
+        let upstream = Arc::new(object_store::memory::InMemory::new());
+        let store = policy_test_store(
+            upstream.clone(),
+            CachePutConfig {
+                cache_on_flush: false,
+                cache_on_compaction: true,
+            },
+        );
+        let multipart = store.caching_multipart_store(upstream);
+
+        let location = Path::from("compacted/big.sst");
+        let tag = ObjectStoreCallTag::new(TableStoreKind::Compactor, SstType::Compacted);
+        let chunks: Vec<Bytes> = (0..3).map(|_| gen_rand_bytes(1500)).collect();
+
+        let id = multipart
+            .create_multipart_opts(&location, multipart_opts(tag))
+            .await
+            .unwrap();
+        // Parts complete out of order; the mirror folds them in index order.
+        let part1 = multipart
+            .put_part(&location, &id, 1, chunks[1].clone().into())
+            .await
+            .unwrap();
+        let part0 = multipart
+            .put_part(&location, &id, 0, chunks[0].clone().into())
+            .await
+            .unwrap();
+        let part2 = multipart
+            .put_part(&location, &id, 2, chunks[2].clone().into())
+            .await
+            .unwrap();
+        multipart
+            .complete_multipart(&location, &id, vec![part0, part1, part2])
+            .await
+            .unwrap();
+
+        // The entry is committed with the full size...
+        let entry = store.cache_storage.entry(&location, store.part_size_bytes);
+        let head = entry
+            .read_head()
+            .await
+            .unwrap()
+            .expect("head should be committed on complete");
+        assert_eq!(head.0.size, 4500);
+
+        // ...and the teed bytes round-trip in order through the cache parts.
+        let expected: Vec<u8> = chunks.iter().flat_map(|c| c.to_vec()).collect();
+        let expected_part_sizes = [1024usize, 1024, 1024, 1024, 404];
+        let cached = entry.cached_parts().await.unwrap();
+        assert_eq!(
+            cached,
+            (0..expected_part_sizes.len()).collect::<Vec<PartID>>()
+        );
+        let mut offset = 0;
+        for (part_id, part_size) in expected_part_sizes.iter().enumerate() {
+            let bytes = entry
+                .read_part(part_id, 0..*part_size)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(&bytes[..], &expected[offset..offset + part_size]);
+            offset += part_size;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_upload_not_cached_when_policy_skips() {
+        let upstream = Arc::new(object_store::memory::InMemory::new());
+        let store = policy_test_store(
+            upstream.clone(),
+            CachePutConfig {
+                cache_on_flush: true,
+                cache_on_compaction: false,
+            },
+        );
+        let multipart = store.caching_multipart_store(upstream);
+
+        let location = Path::from("compacted/big.sst");
+        let tag = ObjectStoreCallTag::new(TableStoreKind::Compactor, SstType::Compacted);
+        let id = multipart
+            .create_multipart_opts(&location, multipart_opts(tag))
+            .await
+            .unwrap();
+        let part = multipart
+            .put_part(&location, &id, 0, gen_rand_bytes(2048).into())
+            .await
+            .unwrap();
+        multipart
+            .complete_multipart(&location, &id, vec![part])
+            .await
+            .unwrap();
+
+        assert_eq!(cached_part_count(&store, &location).await, 0);
+    }
+
+    /// Builds a [`CachingMultipartStore`] over `inner`, sharing `store`'s
+    /// cache storage and policy, keeping the concrete type so tests can
+    /// inspect the mirror map.
+    fn caching_multipart_store_fixture(
+        store: &CachedObjectStore,
+        inner: Arc<dyn MultipartStore>,
+    ) -> CachingMultipartStore {
+        CachingMultipartStore {
+            inner,
+            cache_storage: store.cache_storage.clone(),
+            part_size: store.part_size_bytes,
+            put_policy: store.put_policy.clone(),
+            uploads: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn mirror_count(caching: &CachingMultipartStore) -> usize {
+        caching.uploads.lock().unwrap().len()
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_abort_drops_mirror_and_cached_parts() {
+        let upstream = Arc::new(InMemory::new());
+        let store = policy_test_store(
+            upstream.clone(),
+            CachePutConfig {
+                cache_on_flush: false,
+                cache_on_compaction: true,
+            },
+        );
+        let caching = caching_multipart_store_fixture(&store, upstream);
+
+        let location = Path::from("compacted/big.sst");
+        let tag = ObjectStoreCallTag::new(TableStoreKind::Compactor, SstType::Compacted);
+        let id = caching
+            .create_multipart_opts(&location, multipart_opts(tag))
+            .await
+            .unwrap();
+        caching
+            .put_part(&location, &id, 0, gen_rand_bytes(2048).into())
+            .await
+            .unwrap();
+        assert_eq!(cached_part_count(&store, &location).await, 2);
+
+        caching.abort_multipart(&location, &id).await.unwrap();
+
+        assert_eq!(mirror_count(&caching), 0);
+        assert_eq!(cached_part_count(&store, &location).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_permanent_complete_error_drops_mirror() {
+        let upstream = Arc::new(InMemory::new());
+        let store = policy_test_store(
+            upstream.clone(),
+            CachePutConfig {
+                cache_on_flush: false,
+                cache_on_compaction: true,
+            },
+        );
+        // Complete finishes server-side but reports NotFound — the error the
+        // retry layer resolves by put-id verification without ever retrying.
+        let flaky = Arc::new(
+            FlakyObjectStore::new(upstream.clone(), 0)
+                .with_multipart_store(upstream)
+                .with_multipart_complete_succeeds_but_returns_not_found(),
+        );
+        let caching = caching_multipart_store_fixture(&store, flaky);
+
+        let location = Path::from("compacted/big.sst");
+        let tag = ObjectStoreCallTag::new(TableStoreKind::Compactor, SstType::Compacted);
+        let id = caching
+            .create_multipart_opts(&location, multipart_opts(tag))
+            .await
+            .unwrap();
+        let part = caching
+            .put_part(&location, &id, 0, gen_rand_bytes(2048).into())
+            .await
+            .unwrap();
+        assert_eq!(cached_part_count(&store, &location).await, 2);
+
+        let err = caching
+            .complete_multipart(&location, &id, vec![part])
+            .await
+            .expect_err("injected NotFound should surface");
+        assert!(matches!(err, object_store::Error::NotFound { .. }));
+
+        // The mirror and its uncommitted entry are dropped, not stranded.
+        assert_eq!(mirror_count(&caching), 0);
+        assert_eq!(cached_part_count(&store, &location).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_transient_complete_error_keeps_mirror_for_retry() {
+        let upstream = Arc::new(InMemory::new());
+        let store = policy_test_store(
+            upstream.clone(),
+            CachePutConfig {
+                cache_on_flush: false,
+                cache_on_compaction: true,
+            },
+        );
+        let flaky = Arc::new(
+            FlakyObjectStore::new(upstream.clone(), 0)
+                .with_multipart_store(upstream)
+                .with_multipart_complete_failures(1),
+        );
+        let caching = caching_multipart_store_fixture(&store, flaky);
+
+        let location = Path::from("compacted/big.sst");
+        let tag = ObjectStoreCallTag::new(TableStoreKind::Compactor, SstType::Compacted);
+        let id = caching
+            .create_multipart_opts(&location, multipart_opts(tag))
+            .await
+            .unwrap();
+        let part = caching
+            .put_part(&location, &id, 0, gen_rand_bytes(2048).into())
+            .await
+            .unwrap();
+
+        // Transient failure: the mirror survives for the retry...
+        caching
+            .complete_multipart(&location, &id, vec![part.clone()])
+            .await
+            .expect_err("first complete should fail transiently");
+        assert_eq!(mirror_count(&caching), 1);
+
+        // ...which commits the entry.
+        caching
+            .complete_multipart(&location, &id, vec![part])
+            .await
+            .unwrap();
+        assert_eq!(mirror_count(&caching), 0);
+        let head = store
+            .cache_storage
+            .entry(&location, store.part_size_bytes)
+            .read_head()
+            .await
+            .unwrap();
+        assert_eq!(head.expect("head should be committed").0.size, 2048);
     }
 
     #[tokio::test]

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -805,7 +805,10 @@ pub struct Settings {
     /// Maximum number of wrapper-level retries for a single object-store
     /// operation, on top of the `object_store` client's own HTTP retries.
     /// Applies to both foreground (user API) and background-task operations,
-    /// since both share the same retrying object store.
+    /// since both share the same retrying object store. Multipart part
+    /// uploads are covered only when the store is provided via
+    /// `Db::builder_with_multipart` (or `CompactorBuilder::new_with_multipart`
+    /// for a standalone compactor).
     ///
     /// * `None` (default): retry transient errors indefinitely (historical behavior).
     /// * `Some(n)`: give up after `n` retries and return the underlying error.

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -29,6 +29,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use fail_parallel::{fail_point, FailPointRegistry};
+use object_store::multipart::MultipartStore;
 use object_store::path::Path;
 use object_store::{parse_url_opts, ObjectStore};
 
@@ -658,6 +659,38 @@ impl Db {
     /// ```
     pub fn builder<P: Into<Path>>(path: P, object_store: Arc<dyn ObjectStore>) -> DbBuilder<P> {
         DbBuilder::new(path, object_store)
+    }
+
+    /// Like [`Db::builder`], but for an object store client that also
+    /// implements the low-level
+    /// [`MultipartStore`](object_store::multipart::MultipartStore) API (S3,
+    /// GCS, and Azure all do). This enables in-place retries of multipart
+    /// part uploads under
+    /// [`Settings::object_store_max_retries`](crate::config::Settings::object_store_max_retries);
+    /// with [`Db::builder`], a failed part is covered only by the client's
+    /// own retries.
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// use slatedb::{Db, Error};
+    /// use slatedb::object_store::memory::InMemory;
+    /// use std::sync::Arc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Error> {
+    ///     let object_store = Arc::new(InMemory::new());
+    ///     let db = Db::builder_with_multipart("/tmp/test_db", object_store)
+    ///         .build()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn builder_with_multipart<P: Into<Path>, T>(path: P, object_store: Arc<T>) -> DbBuilder<P>
+    where
+        T: ObjectStore + MultipartStore,
+    {
+        DbBuilder::new_with_multipart(path, object_store)
     }
 
     /// Close the database.

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -109,6 +109,7 @@ use bytes::Bytes;
 use fail_parallel::FailPointRegistry;
 use log::info;
 use log::warn;
+use object_store::multipart::MultipartStore;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use rand::RngCore;
@@ -179,6 +180,7 @@ pub struct DbBuilder<P: Into<Path>> {
     path: P,
     settings: Settings,
     main_object_store: Arc<dyn ObjectStore>,
+    multipart_store: Option<Arc<dyn MultipartStore>>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
     db_cache: Option<Arc<dyn DbCache>>,
     block_cache_policy: BlockCachePolicy,
@@ -207,6 +209,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         Self {
             path,
             main_object_store,
+            multipart_store: None,
             settings: Settings::default(),
             wal_object_store: None,
             db_cache: default_db_cache(),
@@ -224,6 +227,25 @@ impl<P: Into<Path>> DbBuilder<P> {
             metrics_recorder: Arc::new(NoopMetricsRecorder::new()),
             segment_extractor: None,
         }
+    }
+
+    /// Like [`DbBuilder::new`], but for a client that also implements the
+    /// low-level [`MultipartStore`] API (S3, GCS, and Azure all do), enabling
+    /// in-place retries of multipart part uploads under
+    /// [`Settings::object_store_max_retries`]. Without it, a failed part is
+    /// covered only by the client's own retries (the high-level
+    /// [`ObjectStore`] multipart API offers no way to retry a part).
+    ///
+    /// Applies to components sharing the main store (db, compactor, GC).
+    /// These uploads are instrumented and, when object store caching is
+    /// configured, mirror their bytes into the cache like high-level writes.
+    pub fn new_with_multipart<T>(path: P, store: Arc<T>) -> Self
+    where
+        T: ObjectStore + MultipartStore,
+    {
+        let mut builder = Self::new(path, store.clone());
+        builder.multipart_store = Some(store);
+        builder
     }
 
     /// Set the segment extractor (RFC-0024). When configured, every
@@ -445,19 +467,22 @@ impl<P: Into<Path>> DbBuilder<P> {
         // under the given component and store-type metric labels. Each
         // component (db, compactor, gc) gets its own layer over the store its
         // builder holds.
-        let wrap_object_store = |store: Arc<dyn ObjectStore>,
-                                 component: ObjectStoreComponent,
-                                 store_type: ObjectStoreType| {
-            instrumented_retrying_object_store(
-                store,
-                &recorder,
-                component,
-                store_type,
-                rand.clone(),
-                system_clock.clone(),
-                max_retries,
-            )
-        };
+        let wrap_object_store =
+            |store: Arc<dyn ObjectStore>,
+             component: ObjectStoreComponent,
+             store_type: ObjectStoreType,
+             multipart_store: Option<Arc<dyn MultipartStore>>| {
+                instrumented_retrying_object_store(
+                    store,
+                    &recorder,
+                    component,
+                    store_type,
+                    rand.clone(),
+                    system_clock.clone(),
+                    max_retries,
+                    multipart_store,
+                )
+            };
         // Set up the object store with optional caching from the settings,
         // producing the same layering as a caller-built
         // [`CachedObjectStore`] passed to [`DbBuilder::new`]: the cache sits
@@ -477,14 +502,33 @@ impl<P: Into<Path>> DbBuilder<P> {
             None => self.main_object_store.clone(),
         };
 
+        // A component's multipart handle: its own if set, else the DB's when
+        // it uses the main store instance; wrapped to mirror uploads into the
+        // shared cache like the high-level write path.
+        let multipart_store_for = {
+            let db_multipart_store = self.multipart_store.clone();
+            let main_object_store = self.main_object_store.clone();
+            let cached_object_store = cached_object_store.clone();
+            move |store: &Arc<dyn ObjectStore>, own_handle: Option<Arc<dyn MultipartStore>>| {
+                let uses_main_store = Arc::ptr_eq(store, &main_object_store);
+                own_handle
+                    .or_else(|| db_multipart_store.clone().filter(|_| uses_main_store))
+                    .map(|handle| match &cached_object_store {
+                        Some(cached) if uses_main_store => cached.caching_multipart_store(handle),
+                        _ => handle,
+                    })
+            }
+        };
+
         let retrying_main_object_store = wrap_object_store(
             maybe_cached_main_object_store,
             ObjectStoreComponent::Db,
             ObjectStoreType::Main,
+            multipart_store_for(&self.main_object_store, None),
         );
         let retrying_wal_object_store: Option<Arc<dyn ObjectStore>> = self
             .wal_object_store
-            .map(|s| wrap_object_store(s, ObjectStoreComponent::Db, ObjectStoreType::Wal));
+            .map(|s| wrap_object_store(s, ObjectStoreComponent::Db, ObjectStoreType::Wal, None));
 
         // Log the database opening
         if let Ok(settings_json) = self.settings.to_json_string() {
@@ -721,6 +765,8 @@ impl<P: Into<Path>> DbBuilder<P> {
                 background_component_store(builder.main_object_store.clone()),
                 ObjectStoreComponent::Compactor,
                 ObjectStoreType::Main,
+                // The compactor's own handle wins; else inherit the DB's.
+                multipart_store_for(&builder.main_object_store, builder.multipart_store.clone()),
             );
             let compactor_table_store = Arc::new(TableStore::new_with_fp_registry(
                 ObjectStores::new(
@@ -778,6 +824,8 @@ impl<P: Into<Path>> DbBuilder<P> {
                 background_component_store(gc_builder.main_object_store.clone()),
                 ObjectStoreComponent::Gc,
                 ObjectStoreType::Main,
+                // GC never streams multipart uploads.
+                None,
             );
             let gc_table_store = Arc::new(TableStore::new_with_fp_registry(
                 ObjectStores::new(gc_object_store.clone(), retrying_wal_object_store.clone()),
@@ -1047,6 +1095,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             self.rand.clone(),
             self.system_clock.clone(),
             self.options.object_store_max_retries,
+            None,
         );
         let retrying_wal_object_store = self.wal_object_store.map(|s| {
             instrumented_retrying_object_store(
@@ -1057,6 +1106,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
                 self.rand.clone(),
                 self.system_clock.clone(),
                 self.options.object_store_max_retries,
+                None,
             )
         });
         let manifest_store = Arc::new(ManifestStore::new(
@@ -1113,6 +1163,7 @@ pub(crate) struct CompactorHandlers {
 pub struct CompactorBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,
+    multipart_store: Option<Arc<dyn MultipartStore>>,
     compaction_runtime: Handle,
     options: CompactorOptions,
     scheduler_supplier: Option<Arc<dyn CompactionSchedulerSupplier>>,
@@ -1134,6 +1185,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
         Self {
             path,
             main_object_store,
+            multipart_store: None,
             compaction_runtime: Handle::current(),
             options: CompactorOptions::default(),
             scheduler_supplier: None,
@@ -1150,10 +1202,25 @@ impl<P: Into<Path>> CompactorBuilder<P> {
         }
     }
 
+    /// Like [`CompactorBuilder::new`], but for a client that also implements
+    /// [`MultipartStore`], enabling in-place retries of multipart part
+    /// uploads; see [`DbBuilder::new_with_multipart`]. When embedded via
+    /// [`DbBuilder::with_compactor_builder`], a plain [`CompactorBuilder::new`]
+    /// falls back to the DbBuilder's multipart handle.
+    pub fn new_with_multipart<T>(path: P, store: Arc<T>) -> Self
+    where
+        T: ObjectStore + MultipartStore,
+    {
+        let mut builder = Self::new(path, store.clone());
+        builder.multipart_store = Some(store);
+        builder
+    }
+
     pub fn into_path_builder(self) -> CompactorBuilder<Path> {
         CompactorBuilder {
             path: self.path.into(),
             main_object_store: self.main_object_store,
+            multipart_store: self.multipart_store,
             compaction_runtime: self.compaction_runtime,
             options: self.options,
             scheduler_supplier: self.scheduler_supplier,
@@ -1281,6 +1348,7 @@ impl<P: Into<Path>> CompactorBuilder<P> {
             self.rand.clone(),
             self.system_clock.clone(),
             self.options.object_store_max_retries,
+            self.multipart_store,
         );
         let manifest_store = Arc::new(ManifestStore::new(
             &path,
@@ -1794,6 +1862,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             self.rand.clone(),
             self.system_clock.clone(),
             self.options.object_store_max_retries,
+            None,
         );
 
         let retrying_wal_object_store: Option<Arc<dyn ObjectStore>> =
@@ -1806,6 +1875,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
                     self.rand.clone(),
                     self.system_clock.clone(),
                     self.options.object_store_max_retries,
+                    None,
                 )
             });
 
@@ -2079,19 +2149,21 @@ fn instrumented_retrying_object_store(
     rand: Arc<DbRand>,
     system_clock: Arc<dyn SystemClock>,
     max_retries: Option<u32>,
+    multipart_store: Option<Arc<dyn MultipartStore>>,
 ) -> Arc<dyn ObjectStore> {
-    let instrumented: Arc<dyn ObjectStore> = Arc::new(InstrumentedObjectStore::new(
+    let instrumented = Arc::new(InstrumentedObjectStore::new(
         object_store,
         recorder,
         component,
         store_type,
     ));
-    Arc::new(RetryingObjectStore::new(
-        instrumented,
-        rand,
-        system_clock,
-        max_retries,
-    ))
+    let mut retrying =
+        RetryingObjectStore::new(instrumented.clone(), rand, system_clock, max_retries);
+    if let Some(multipart_store) = multipart_store {
+        retrying =
+            retrying.with_multipart_store(instrumented.instrument_multipart_store(multipart_store));
+    }
+    Arc::new(retrying)
 }
 
 #[allow(unreachable_code)]
@@ -2423,6 +2495,63 @@ mod tests {
         assert!(!cached_db_path.join("compactions").exists());
         assert!(!cached_db_path.join("gc").exists());
 
+        db.close().await.expect("failed to close db");
+    }
+
+    #[tokio::test]
+    async fn test_builder_with_multipart_wires_retries_and_cache_mirroring() {
+        let inner = Arc::new(InMemory::new());
+        let flaky = Arc::new(
+            crate::test_utils::FlakyObjectStore::new(inner.clone(), 0)
+                .with_multipart_store(inner)
+                .with_put_part_failures(2),
+        );
+        let path = Path::from("test_builder_with_multipart");
+        let cache_dir = tempfile::Builder::new()
+            .prefix("multipart_cache_test_")
+            .tempdir()
+            .expect("failed to create cache dir");
+        let mut settings = Settings {
+            garbage_collector_options: None,
+            ..Settings::default()
+        };
+        settings.object_store_cache_options.root_folder = Some(cache_dir.path().to_path_buf());
+        settings.object_store_cache_options.part_size_bytes = 1024;
+        settings.object_store_cache_options.cache_on_flush = true;
+
+        let db = crate::Db::builder_with_multipart(path.clone(), flaky.clone())
+            .with_settings(settings)
+            .build()
+            .await
+            .expect("failed to build db");
+
+        // Exceed BufWriter's 10 MiB buffer so the L0 flush streams a
+        // multipart upload through the injected part failures.
+        let value = vec![42u8; 11 * 1024 * 1024];
+        db.put(b"k1", &value).await.expect("failed to put");
+        db.flush_with_options(crate::config::FlushOptions {
+            flush_type: crate::config::FlushType::MemTable,
+        })
+        .await
+        .expect("failed to flush");
+
+        // The low-level path recovered in place: one create, no restart,
+        // more part attempts than a clean upload.
+        assert_eq!(flaky.multipart_attempts(), 1);
+        assert!(flaky.put_part_attempts() >= 3);
+        assert_eq!(flaky.multipart_complete_attempts(), 1);
+
+        // The upload mirrored into the object store cache on flush.
+        let cached_compacted =
+            std::fs::read_dir(cache_dir.path().join(path.as_ref()).join("compacted"))
+                .expect("expected cached compacted dir")
+                .count();
+        assert!(cached_compacted > 0);
+
+        assert_eq!(
+            db.get(b"k1").await.expect("failed to get").as_deref(),
+            Some(value.as_slice())
+        );
         db.close().await.expect("failed to close db");
     }
 

--- a/slatedb/src/instrumented_object_store.rs
+++ b/slatedb/src/instrumented_object_store.rs
@@ -34,10 +34,12 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::{FutureExt, StreamExt};
+use object_store::multipart::{MultipartStore, PartId};
 use object_store::path::Path;
 use object_store::{
-    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta,
+    ObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    RenameOptions,
 };
 use slatedb_common::metrics::MetricsRecorderHelper;
 
@@ -95,6 +97,18 @@ impl InstrumentedObjectStore {
             )),
         }
     }
+
+    /// Wraps a low-level [`MultipartStore`] handle so its calls are recorded
+    /// under this store's (component, store_type) metrics.
+    pub(crate) fn instrument_multipart_store(
+        &self,
+        inner: Arc<dyn MultipartStore>,
+    ) -> Arc<dyn MultipartStore> {
+        Arc::new(InstrumentedMultipartStore {
+            inner,
+            stats: Arc::clone(&self.stats),
+        })
+    }
 }
 
 impl std::fmt::Display for InstrumentedObjectStore {
@@ -145,6 +159,77 @@ impl MultipartUpload for InstrumentedMultipartUpload {
 
     async fn abort(&mut self) -> object_store::Result<()> {
         self.inner.abort().await
+    }
+}
+
+/// Records the low-level [`MultipartStore`] calls under the same metrics as
+/// [`InstrumentedMultipartUpload`] records the high-level ones.
+struct InstrumentedMultipartStore {
+    inner: Arc<dyn MultipartStore>,
+    stats: Arc<stats::ObjectStoreStats>,
+}
+
+impl std::fmt::Debug for InstrumentedMultipartStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstrumentedMultipartStore").finish()
+    }
+}
+
+#[async_trait]
+impl MultipartStore for InstrumentedMultipartStore {
+    async fn create_multipart(&self, path: &Path) -> object_store::Result<MultipartId> {
+        let start = Instant::now();
+        let result = self.inner.create_multipart(path).await;
+        self.stats
+            .multipart_init
+            .record(start.elapsed(), result.is_ok());
+        result
+    }
+
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<MultipartId> {
+        let start = Instant::now();
+        let result = self.inner.create_multipart_opts(path, opts).await;
+        self.stats
+            .multipart_init
+            .record(start.elapsed(), result.is_ok());
+        result
+    }
+
+    async fn put_part(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        part_idx: usize,
+        data: PutPayload,
+    ) -> object_store::Result<PartId> {
+        let start = Instant::now();
+        let result = self.inner.put_part(path, id, part_idx, data).await;
+        self.stats
+            .multipart_part
+            .record(start.elapsed(), result.is_ok());
+        result
+    }
+
+    async fn complete_multipart(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        parts: Vec<PartId>,
+    ) -> object_store::Result<PutResult> {
+        let start = Instant::now();
+        let result = self.inner.complete_multipart(path, id, parts).await;
+        self.stats
+            .multipart_complete
+            .record(start.elapsed(), result.is_ok());
+        result
+    }
+
+    async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> object_store::Result<()> {
+        self.inner.abort_multipart(path, id).await
     }
 }
 
@@ -742,6 +827,45 @@ mod tests {
             ),
             Some(1)
         );
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_records_each_api_call() {
+        // given:
+        let (recorder, helper) = test_recorder_helper();
+        let inner = Arc::new(InMemory::new());
+        let store = InstrumentedObjectStore::new(
+            inner.clone(),
+            &helper,
+            ObjectStoreComponent::Db,
+            ObjectStoreType::Main,
+        );
+        let multipart = store.instrument_multipart_store(inner);
+        let path = Path::from("multipart");
+
+        // when:
+        let id = multipart.create_multipart(&path).await.unwrap();
+        let part = multipart
+            .put_part(&path, &id, 0, "hello".into())
+            .await
+            .unwrap();
+        multipart
+            .complete_multipart(&path, &id, vec![part])
+            .await
+            .unwrap();
+
+        // then:
+        for api in ["multipart_init", "multipart_part", "multipart_complete"] {
+            assert_eq!(
+                lookup_metric_with_labels(
+                    &recorder,
+                    REQUEST_COUNT,
+                    &get_labels(ObjectStoreComponent::Db, ObjectStoreType::Main, "put", api),
+                ),
+                Some(1),
+                "expected one {api} request recorded"
+            );
+        }
     }
 
     #[test]

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -18,6 +18,7 @@ use crate::db_status::ClosedResultWriter;
 use crate::dispatcher::{MessageHandler, MessageHandlerExecutor};
 use crate::error::SlateDBError;
 use crate::flush::EncodedSegmentSst;
+use crate::format::sst::EncodedSsTable;
 use crate::mem_table::ImmutableMemtable;
 use crate::utils::SafeSender;
 use async_trait::async_trait;
@@ -243,7 +244,7 @@ impl UploadHandler {
     ) -> Result<SegmentedSstHandle, SlateDBError> {
         let written_bytes = sst.encoded.remaining_len() as u64;
         loop {
-            match self.db.upload_sst(&sst_id, &sst.encoded).await {
+            match self.upload_sst_unless_closed(&sst_id, &sst.encoded).await {
                 Ok(sst_handle) => {
                     self.db.db_stats.l0_flush_bytes.increment(written_bytes);
                     return Ok(SegmentedSstHandle {
@@ -265,6 +266,30 @@ impl UploadHandler {
                     self.db.system_clock.sleep(self.retry_backoff).await;
                 }
             }
+        }
+    }
+
+    /// Uploads one SST, abandoning the attempt if the database closes first.
+    ///
+    /// The object-store retry policy under `upload_sst` may be unbounded
+    /// (`object_store_max_retries = None`), so a persistently failing upload
+    /// never returns an error for the shutdown check above to act on. With the
+    /// WAL enabled the data is already durable, so racing the close signal
+    /// keeps shutdown bounded; without it this upload is the only durability
+    /// and must keep retrying.
+    async fn upload_sst_unless_closed(
+        &self,
+        sst_id: &SsTableId,
+        encoded: &EncodedSsTable,
+    ) -> Result<SsTableHandle, SlateDBError> {
+        if !self.db.wal_enabled {
+            return self.db.upload_sst(sst_id, encoded).await;
+        }
+        let mut closed = self.db.status_manager.result_reader();
+        tokio::select! {
+            biased;
+            result = self.db.upload_sst(sst_id, encoded) => result,
+            _ = closed.await_value() => Err(SlateDBError::Closed),
         }
     }
 }
@@ -315,7 +340,7 @@ mod tests {
     use crate::paths::PathResolver;
     use crate::sst_iter::{SstIterator, SstIteratorOptions};
     use crate::tablestore::{TableStore, TableStoreKind};
-    use crate::test_utils::FixedThreeBytePrefixExtractor;
+    use crate::test_utils::{FixedThreeBytePrefixExtractor, GatedObjectStore};
     use crate::types::{RowEntry, ValueDeletable};
     use crate::utils::WatchableOnceCell;
 
@@ -374,7 +399,25 @@ mod tests {
         cache: Option<Arc<dyn DbCache>>,
         block_cache_policy: BlockCachePolicy,
     ) -> Arc<DbInner> {
-        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        setup_db_with_object_store(
+            path,
+            fp_registry,
+            segment_extractor,
+            cache,
+            block_cache_policy,
+            Arc::new(InMemory::new()),
+        )
+        .await
+    }
+
+    async fn setup_db_with_object_store(
+        path: &str,
+        fp_registry: Arc<FailPointRegistry>,
+        segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
+        cache: Option<Arc<dyn DbCache>>,
+        block_cache_policy: BlockCachePolicy,
+        object_store: Arc<dyn ObjectStore>,
+    ) -> Arc<DbInner> {
         let settings = Settings::default();
         let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
         let rand = Arc::new(DbRand::new(42));
@@ -792,6 +835,42 @@ mod tests {
             .await
             .expect("uploader should stop retrying on shutdown");
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn should_abandon_stalled_upload_on_shutdown_when_wal_enabled() {
+        // A stalled upload never returns an error, so the retry loop's
+        // shutdown check never runs. The upload itself must race the close
+        // signal, otherwise shutdown blocks for as long as the object store
+        // keeps retrying (potentially forever).
+        let gated = Arc::new(GatedObjectStore::new(Arc::new(InMemory::new())));
+        let db = setup_db_with_object_store(
+            "/tmp/test_parallel_l0_flush_uploader_stalled_upload",
+            Arc::new(FailPointRegistry::new()),
+            None,
+            None,
+            BlockCachePolicy::default(),
+            Arc::clone(&gated) as Arc<dyn ObjectStore>,
+        )
+        .await;
+        assert!(db.wal_enabled);
+
+        // Park every SST write inside the object store.
+        gated.put_opts_gate.close();
+        let job = next_upload_job(&db, b"key", b"value", 1);
+
+        let test = start_test_uploader(&db);
+        test.submit(job).unwrap();
+        gated.put_opts_gate.wait_for_arrivals(1).await;
+
+        // Mark the database as closed (simulates Db::close()) while the
+        // upload is still parked.
+        db.status_manager.write_result(Ok(()));
+
+        let result = timeout(Duration::from_secs(5), test.await_closed())
+            .await
+            .expect("uploader should abandon the stalled upload on shutdown");
+        assert!(matches!(result, Err(SlateDBError::Closed)), "{:?}", result);
     }
 
     #[tokio::test]

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -9,11 +9,12 @@ use backon::{ExponentialBuilder, Retryable, Sleeper};
 use futures::stream::BoxStream;
 use futures::{stream, StreamExt, TryStreamExt};
 use log::{debug, info};
+use object_store::multipart::{MultipartStore, PartId};
 use object_store::path::Path;
 use object_store::{
     Attribute, CopyOptions, Extensions, GetOptions, GetRange, GetResult, GetResultPayload,
-    ListResult, MultipartUpload, ObjectMeta, ObjectStore, ObjectStoreExt, PutMultipartOptions,
-    PutOptions, PutPayload, PutResult, RenameOptions,
+    ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore, ObjectStoreExt,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
 };
 
 use crate::utils::IdGenerator;
@@ -53,9 +54,13 @@ impl Sleeper for SystemClockSleeper {
 /// returns its underlying error instead of retrying forever. This applies to
 /// both foreground and background object-store operations, since both go
 /// through this wrapper.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct RetryingObjectStore {
     inner: Arc<dyn ObjectStore>,
+    /// Low-level multipart handle for the same backend as `inner`. When set,
+    /// part uploads are retried in place; without it, parts get only the
+    /// inner client's retries (`MultipartUpload` can't re-send a failed part).
+    multipart_store: Option<Arc<dyn MultipartStore>>,
     rand: Arc<DbRand>,
     clock: Arc<dyn SystemClock>,
     /// Maximum wrapper-level retries per operation. `None` = unbounded.
@@ -71,10 +76,18 @@ impl RetryingObjectStore {
     ) -> Self {
         Self {
             inner,
+            multipart_store: None,
             rand,
             clock,
             max_retries,
         }
+    }
+
+    /// Enables in-place part-upload retries. `multipart_store` must be
+    /// backed by the same storage as the wrapped store.
+    pub(crate) fn with_multipart_store(mut self, multipart_store: Arc<dyn MultipartStore>) -> Self {
+        self.multipart_store = Some(multipart_store);
+        self
     }
 
     #[inline]
@@ -104,7 +117,7 @@ impl RetryingObjectStore {
     }
 
     #[inline]
-    fn should_retry(err: &object_store::Error) -> bool {
+    pub(crate) fn should_retry(err: &object_store::Error) -> bool {
         let retry = !matches!(
             err,
             object_store::Error::AlreadyExists { .. }
@@ -170,6 +183,115 @@ impl RetryingObjectStore {
         new_attrs
     }
 
+    /// Converts `result` into success if the object in the store carries our
+    /// put id, else returns it unchanged.
+    async fn resolved_by_put_id(
+        &self,
+        location: &Path,
+        put_id: &str,
+        result: object_store::Result<PutResult>,
+    ) -> object_store::Result<PutResult> {
+        if let Some(meta) = self.verify_put_succeeded(location, put_id).await {
+            return Ok(PutResult {
+                e_tag: meta.e_tag,
+                version: meta.version,
+                extensions: Extensions::new(),
+            });
+        }
+        result
+    }
+
+    /// Converts an AlreadyExists/Precondition result into success if the
+    /// object in the store carries our put id (a timeout-after-write).
+    async fn verified_result(
+        &self,
+        location: &Path,
+        put_id: &str,
+        result: object_store::Result<PutResult>,
+    ) -> object_store::Result<PutResult> {
+        match &result {
+            Err(object_store::Error::AlreadyExists { .. })
+            | Err(object_store::Error::Precondition { .. }) => {
+                self.resolved_by_put_id(location, put_id, result).await
+            }
+            _ => result,
+        }
+    }
+
+    /// Like [`Self::verified_result`], but for multipart completes NotFound
+    /// is ambiguous too: a complete whose response was lost leaves the upload
+    /// finished server-side, so a retry fails with e.g. S3's NoSuchUpload.
+    async fn verified_complete_result(
+        &self,
+        location: &Path,
+        put_id: &str,
+        result: object_store::Result<PutResult>,
+    ) -> object_store::Result<PutResult> {
+        match &result {
+            Err(object_store::Error::NotFound { .. }) => {
+                self.resolved_by_put_id(location, put_id, result).await
+            }
+            _ => self.verified_result(location, put_id, result).await,
+        }
+    }
+
+    /// Runs `op` under this store's retry policy.
+    async fn with_retries<T, F, Fut>(&self, op: F) -> object_store::Result<T>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = object_store::Result<T>>,
+    {
+        op.retry(self.retry_builder())
+            .sleep(self.sleeper())
+            .notify(Self::notify)
+            .when(Self::should_retry)
+            .await
+    }
+
+    /// Runs `op` with the put-id attribute merged into `attributes`, under
+    /// the retry policy. If the store rejects attributes as unsupported,
+    /// retries once more with the original attributes.
+    async fn with_put_id_fallback<T, F, Fut>(
+        &self,
+        attributes: &object_store::Attributes,
+        put_id: &str,
+        op: F,
+    ) -> object_store::Result<T>
+    where
+        F: Fn(object_store::Attributes) -> Fut,
+        Fut: Future<Output = object_store::Result<T>>,
+    {
+        let result = self
+            .with_retries(|| op(Self::with_put_id(attributes.clone(), put_id)))
+            .await;
+        match result {
+            Err(
+                object_store::Error::NotSupported { .. }
+                | object_store::Error::NotImplemented { .. },
+            ) => self.with_retries(|| op(attributes.clone())).await,
+            result => result,
+        }
+    }
+
+    /// Creates a multipart upload via the low-level [`MultipartStore`] API
+    /// with the put-id attribute.
+    async fn create_multipart_id(
+        &self,
+        multipart_store: &Arc<dyn MultipartStore>,
+        location: &Path,
+        opts: &PutMultipartOptions,
+        put_id: &str,
+    ) -> object_store::Result<MultipartId> {
+        self.with_put_id_fallback(&opts.attributes, put_id, |attributes| {
+            let opts = PutMultipartOptions {
+                attributes,
+                ..opts.clone()
+            };
+            async move { multipart_store.create_multipart_opts(location, opts).await }
+        })
+        .await
+    }
+
     /// Compute the expected byte length of a range read, truncating at the
     /// actual file size. This handles the case where a `GetRange::Bounded`
     /// end exceeds the file length.
@@ -191,7 +313,19 @@ impl std::fmt::Display for RetryingObjectStore {
     }
 }
 
-/// Wrapper around MultipartUpload that adds ULID verification on complete() failure.
+impl std::fmt::Debug for RetryingObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RetryingObjectStore")
+            .field("inner", &self.inner)
+            .field("multipart_store", &self.multipart_store.is_some())
+            .field("max_retries", &self.max_retries)
+            .finish()
+    }
+}
+
+/// MultipartUpload wrapper that adds put-id verification on complete().
+/// Parts delegate to the inner upload and can't be retried here (see
+/// [`RetryingObjectStore::multipart_store`]); [`MultipartStoreUpload`] can.
 struct RetryingMultipartUpload {
     inner: Box<dyn MultipartUpload>,
     retrying_store: RetryingObjectStore,
@@ -216,29 +350,121 @@ impl MultipartUpload for RetryingMultipartUpload {
 
     async fn complete(&mut self) -> object_store::Result<PutResult> {
         let result = self.inner.complete().await;
-
-        match &result {
-            Err(object_store::Error::AlreadyExists { .. })
-            | Err(object_store::Error::Precondition { .. }) => {
-                if let Some(meta) = self
-                    .retrying_store
-                    .verify_put_succeeded(&self.location, &self.put_id)
-                    .await
-                {
-                    return Ok(PutResult {
-                        e_tag: meta.e_tag,
-                        version: meta.version,
-                        extensions: Extensions::new(),
-                    });
-                }
-                result
-            }
-            _ => result,
-        }
+        self.retrying_store
+            .verified_complete_result(&self.location, &self.put_id, result)
+            .await
     }
 
     async fn abort(&mut self) -> object_store::Result<()> {
         self.inner.abort().await
+    }
+}
+
+/// MultipartUpload backed by the low-level [`MultipartStore`] API: parts
+/// carry explicit indexes, so a failed part is retried in place. Dropping
+/// an unfinished upload aborts it best-effort.
+struct MultipartStoreUpload {
+    retrying_store: RetryingObjectStore,
+    multipart_store: Arc<dyn MultipartStore>,
+    location: Path,
+    multipart_id: MultipartId,
+    put_id: String,
+    /// Part ids indexed by part index, filled in as part futures resolve.
+    parts: Arc<Mutex<Vec<Option<PartId>>>>,
+    /// Set once complete succeeds or abort runs; suppresses the drop abort.
+    finished: bool,
+}
+
+impl Drop for MultipartStoreUpload {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        let store = Arc::clone(&self.multipart_store);
+        let location = self.location.clone();
+        let id = self.multipart_id.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                store.abort_multipart(&location, &id).await.ok();
+            });
+        }
+    }
+}
+
+impl std::fmt::Debug for MultipartStoreUpload {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultipartStoreUpload")
+            .field("location", &self.location)
+            .field("multipart_id", &self.multipart_id)
+            .field("put_id", &self.put_id)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl MultipartUpload for MultipartStoreUpload {
+    fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
+        let part_idx = {
+            let mut parts = self.parts.lock().expect("lock poisoned");
+            parts.push(None);
+            parts.len() - 1
+        };
+
+        let store = self.retrying_store.clone();
+        let multipart_store = Arc::clone(&self.multipart_store);
+        let location = self.location.clone();
+        let multipart_id = self.multipart_id.clone();
+        let parts = Arc::clone(&self.parts);
+        Box::pin(async move {
+            let part = store
+                .with_retries(|| async {
+                    multipart_store
+                        .put_part(&location, &multipart_id, part_idx, data.clone())
+                        .await
+                })
+                .await?;
+            parts.lock().expect("lock poisoned")[part_idx] = Some(part);
+            Ok(())
+        })
+    }
+
+    async fn complete(&mut self) -> object_store::Result<PutResult> {
+        // Read, don't drain: a failed complete leaves the slots intact so it
+        // can be retried once in-flight parts settle.
+        let parts = self
+            .parts
+            .lock()
+            .expect("lock poisoned")
+            .iter()
+            .cloned()
+            .map(|part| {
+                part.ok_or_else(|| object_store::Error::Generic {
+                    store: "retrying_object_store",
+                    source: "complete() called before all part uploads finished".into(),
+                })
+            })
+            .collect::<object_store::Result<Vec<_>>>()?;
+
+        let store = &self.retrying_store;
+        let result = store
+            .with_retries(|| async {
+                self.multipart_store
+                    .complete_multipart(&self.location, &self.multipart_id, parts.clone())
+                    .await
+            })
+            .await;
+        let result = store
+            .verified_complete_result(&self.location, &self.put_id, result)
+            .await;
+        self.finished |= result.is_ok();
+        result
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        self.finished = true;
+        self.multipart_store
+            .abort_multipart(&self.location, &self.multipart_id)
+            .await
     }
 }
 
@@ -386,6 +612,22 @@ impl ObjectStore for RetryingObjectStore {
         opts: PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
         let put_id = self.rand.rng().gen_ulid(self.clock.as_ref()).to_string();
+
+        if let Some(multipart_store) = &self.multipart_store {
+            let multipart_id = self
+                .create_multipart_id(multipart_store, location, &opts, &put_id)
+                .await?;
+            return Ok(Box::new(MultipartStoreUpload {
+                retrying_store: self.clone(),
+                multipart_store: Arc::clone(multipart_store),
+                location: location.clone(),
+                multipart_id,
+                put_id,
+                parts: Arc::new(Mutex::new(Vec::new())),
+                finished: false,
+            }));
+        }
+
         let opts_with_id = PutMultipartOptions {
             attributes: Self::with_put_id(opts.attributes.clone(), &put_id),
             ..opts.clone()
@@ -1115,6 +1357,341 @@ mod tests {
         assert_eq!(bytes, Bytes::from_static(b"hello"));
         // 1 truncated attempt + 1 successful retry
         assert_eq!(flaky.get_range_attempts(), 2);
+    }
+
+    /// Builds a retrying store over a flaky store with the low-level
+    /// multipart path enabled, backed by a shared InMemory. `configure` adds
+    /// failure injection to the flaky store.
+    fn multipart_fixture(
+        max_retries: Option<u32>,
+        configure: impl FnOnce(FlakyObjectStore) -> FlakyObjectStore,
+    ) -> (Arc<FlakyObjectStore>, RetryingObjectStore) {
+        let inner = Arc::new(InMemory::new());
+        let flaky = FlakyObjectStore::new(inner.clone(), 0).with_multipart_store(inner);
+        let flaky = Arc::new(configure(flaky));
+        let retrying =
+            RetryingObjectStore::new(flaky.clone(), test_rand(), test_clock(), max_retries)
+                .with_multipart_store(flaky.clone());
+        (flaky, retrying)
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_part_transient_failure_retried_in_place() {
+        let (flaky, retrying) = multipart_fixture(None, |f| f.with_put_part_failures(1));
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .expect("part should succeed after in-place retry");
+        upload
+            .put_part(PutPayload::from_static(b"part1"))
+            .await
+            .unwrap();
+        upload.complete().await.expect("complete should succeed");
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(
+            got.bytes().await.unwrap(),
+            Bytes::from_static(b"part0part1")
+        );
+        // 1 failure + retry of the same index + second part.
+        assert_eq!(flaky.put_part_attempts(), 3);
+        // The upload is created exactly once; no restart.
+        assert_eq!(flaky.multipart_attempts(), 1);
+        assert_eq!(flaky.multipart_complete_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_part_failures_exhaust_bounded_retries() {
+        let (flaky, retrying) =
+            multipart_fixture(Some(2), |f| f.with_put_part_failures(usize::MAX));
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        let err = upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .expect_err("bounded retries should exhaust and surface at the part");
+        assert!(matches!(err, object_store::Error::Generic { .. }));
+
+        // Initial attempt + 2 retries.
+        assert_eq!(flaky.put_part_attempts(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_part_permanent_error_fails_fast() {
+        // Unbounded retries: a permanent error must still surface immediately.
+        let (flaky, retrying) = multipart_fixture(None, |f| f.with_put_part_permanent_failures(1));
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        let err = upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .expect_err("permanent error should fail fast");
+        assert!(matches!(err, object_store::Error::NotSupported { .. }));
+        assert_eq!(flaky.put_part_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_create_falls_back_when_attributes_unsupported() {
+        let (flaky, retrying) =
+            multipart_fixture(None, |f| f.with_multipart_create_attributes_unsupported());
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .expect("create should fall back to attribute-less options");
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+        upload.complete().await.unwrap();
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"part0"));
+        // Attributed attempt rejected with NotSupported, then the fallback.
+        assert_eq!(flaky.multipart_attempts(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_lost_complete_surfaces_without_put_id_attribute() {
+        // With the attribute fallback in play the object carries no put id,
+        // so a complete whose response was lost cannot be resolved and the
+        // NotFound must surface instead of being converted to success.
+        let (_, retrying) = multipart_fixture(None, |f| {
+            f.with_multipart_create_attributes_unsupported()
+                .with_multipart_complete_succeeds_but_returns_not_found()
+        });
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+        let err = upload
+            .complete()
+            .await
+            .expect_err("lost complete should surface without a put id to verify");
+        assert!(matches!(err, object_store::Error::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_complete_with_in_flight_part_does_not_panic() {
+        let (_, retrying) = multipart_fixture(None, |f| f);
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        let part_fut = upload.put_part(PutPayload::from_static(b"part0"));
+
+        // Misuse: complete before the part future resolved. It must error...
+        let err = upload
+            .complete()
+            .await
+            .expect_err("complete with an unresolved part should error");
+        assert!(matches!(err, object_store::Error::Generic { .. }));
+
+        // ...without disturbing the racing part future or the slots: once
+        // the part settles, complete can be retried successfully.
+        part_fut.await.unwrap();
+        upload
+            .complete()
+            .await
+            .expect("complete should succeed once the part settled");
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"part0"));
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_complete_transient_failure_retried_without_reupload() {
+        let (flaky, retrying) = multipart_fixture(None, |f| f.with_multipart_complete_failures(1));
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part1"))
+            .await
+            .unwrap();
+        upload
+            .complete()
+            .await
+            .expect("complete should succeed after retry");
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(
+            got.bytes().await.unwrap(),
+            Bytes::from_static(b"part0part1")
+        );
+        assert_eq!(flaky.multipart_complete_attempts(), 2);
+        // Parts are not re-uploaded when only complete fails.
+        assert_eq!(flaky.put_part_attempts(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_complete_succeeds_on_matching_ulid() {
+        // Complete finishes server-side but the response is lost (NotFound on
+        // the surfaced error); the put-id check should resolve it to success.
+        let (flaky, retrying) = multipart_fixture(None, |f| {
+            f.with_multipart_complete_succeeds_but_returns_not_found()
+        });
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+        upload
+            .complete()
+            .await
+            .expect("complete should succeed via ULID verification");
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from_static(b"part0"));
+        assert_eq!(flaky.multipart_complete_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_abort_forwards_to_multipart_api() {
+        let (flaky, retrying) = multipart_fixture(None, |f| f);
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+        upload.abort().await.expect("abort should succeed");
+        assert_eq!(flaky.multipart_abort_attempts(), 1);
+
+        // An explicitly aborted upload is not aborted again on drop.
+        drop(upload);
+        assert_eq!(wait_for_abort_attempts(&flaky, 1).await, 1);
+    }
+
+    /// Yields until the spawned drop-guard abort lands (or a bounded number
+    /// of yields passes) and returns the observed abort count.
+    async fn wait_for_abort_attempts(flaky: &FlakyObjectStore, expected: usize) -> usize {
+        for _ in 0..100 {
+            if flaky.multipart_abort_attempts() == expected {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        flaky.multipart_abort_attempts()
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_dropped_unfinished_upload_aborts_best_effort() {
+        let (flaky, retrying) = multipart_fixture(None, |f| f);
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+
+        // Dropped without complete/abort: the guard aborts the upload so it
+        // isn't stranded server-side (or as a mirror in the caching layer).
+        drop(upload);
+        assert_eq!(wait_for_abort_attempts(&flaky, 1).await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_store_dropped_completed_upload_does_not_abort() {
+        let (flaky, retrying) = multipart_fixture(None, |f| f);
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .unwrap();
+        upload.complete().await.unwrap();
+
+        drop(upload);
+        assert_eq!(wait_for_abort_attempts(&flaky, 1).await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_buf_writer_recovers_from_transient_part_failures() {
+        use tokio::io::AsyncWriteExt;
+
+        let (flaky, retrying) = multipart_fixture(None, |f| f.with_put_part_failures(2));
+        let retrying: Arc<dyn ObjectStore> = Arc::new(retrying);
+        let path = Path::from("/data/sst");
+
+        let data: Vec<u8> = (0..5000u32).flat_map(|i| i.to_le_bytes()).collect();
+        let mut writer =
+            object_store::buffered::BufWriter::with_capacity(retrying.clone(), path.clone(), 1024);
+        writer.write_all(&data).await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let got = retrying.get(&path).await.unwrap();
+        assert_eq!(got.bytes().await.unwrap(), Bytes::from(data));
+        assert!(flaky.put_part_attempts() > 2);
+        assert_eq!(flaky.multipart_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_multipart_without_multipart_store_does_not_retry_parts() {
+        // Without the low-level handle, part failures surface to the caller;
+        // only the inner client's own retries apply.
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_put_part_failures(1));
+        let retrying = RetryingObjectStore::new(flaky.clone(), test_rand(), test_clock(), None);
+        let path = Path::from("/data/multipart");
+
+        let mut upload = retrying
+            .put_multipart_opts(&path, Default::default())
+            .await
+            .unwrap();
+        let err = upload
+            .put_part(PutPayload::from_static(b"part0"))
+            .await
+            .expect_err("part failure should surface without a MultipartStore");
+        assert!(matches!(err, object_store::Error::Generic { .. }));
+        assert_eq!(flaky.put_part_attempts(), 1);
     }
 
     #[tokio::test]

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1207,12 +1207,42 @@ async fn write_sst_streaming_in_object_store(
     tag: ObjectStoreCallTag,
 ) -> Result<(), SlateDBError> {
     let mut writer = tagged_buf_writer(object_store, path.clone(), tag);
-    for block in &encoded_sst.unconsumed_blocks {
-        writer.put(block.encoded_bytes.clone()).await?;
+    let result: Result<(), SlateDBError> = async {
+        for block in &encoded_sst.unconsumed_blocks {
+            writer.put(block.encoded_bytes.clone()).await?;
+        }
+        writer.put(encoded_sst.footer.clone()).await?;
+        Ok(())
     }
-    writer.put(encoded_sst.footer.clone()).await?;
-    writer.shutdown().await?;
+    .await;
+    if let Err(err) = result {
+        abort_sst_upload(&mut writer, path).await;
+        return Err(err);
+    }
+    if let Err(err) = writer.shutdown().await {
+        warn_sst_upload_not_aborted(path, &err);
+        return Err(err.into());
+    }
     Ok(())
+}
+
+/// Best-effort abort of a failed SST upload so it doesn't leak server-side.
+/// Must not be called once `shutdown` has run — `BufWriter` panics; see
+/// [`warn_sst_upload_not_aborted`] for that phase.
+async fn abort_sst_upload(writer: &mut BufWriter, path: &Path) {
+    if let Err(err) = writer.abort().await {
+        warn!("failed to abort SST upload [path={}, error={}]", path, err);
+    }
+}
+
+/// A failure surfacing from `shutdown` cannot be aborted through `BufWriter`:
+/// the upload is left behind until lifecycle cleanup or, on the low-level
+/// multipart path, the dropped writer's best-effort abort.
+fn warn_sst_upload_not_aborted(path: &Path, err: &std::io::Error) {
+    warn!(
+        "SST upload failed at shutdown and may be left incomplete [path={}, error={}]",
+        path, err
+    );
 }
 
 pub(crate) struct EncodedSsTableWriter {
@@ -1234,13 +1264,34 @@ impl EncodedSsTableWriter {
         Ok(block_size)
     }
 
-    pub(crate) async fn close(mut self) -> Result<SsTableHandle, SlateDBError> {
-        let encoded_sst = self.builder.build().await?;
-        for block in &encoded_sst.unconsumed_blocks {
-            self.writer.write_all(block.encoded_bytes.as_ref()).await?;
+    pub(crate) async fn close(self) -> Result<SsTableHandle, SlateDBError> {
+        let EncodedSsTableWriter {
+            id,
+            builder,
+            mut writer,
+            table_store,
+            ..
+        } = self;
+        let result: Result<EncodedSsTable, SlateDBError> = async {
+            let encoded_sst = builder.build().await?;
+            for block in &encoded_sst.unconsumed_blocks {
+                writer.write_all(block.encoded_bytes.as_ref()).await?;
+            }
+            writer.write_all(encoded_sst.footer.as_ref()).await?;
+            Ok(encoded_sst)
         }
-        self.writer.write_all(encoded_sst.footer.as_ref()).await?;
-        self.writer.shutdown().await?;
+        .await;
+        let encoded_sst = match result {
+            Ok(encoded_sst) => encoded_sst,
+            Err(err) => {
+                abort_sst_upload(&mut writer, &table_store.path(&id)).await;
+                return Err(err);
+            }
+        };
+        if let Err(err) = writer.shutdown().await {
+            warn_sst_upload_not_aborted(&table_store.path(&id), &err);
+            return Err(err.into());
+        }
 
         // Cache inserts happen after writer shutdown so an SST whose upload
         // fails contributes no metadata entries.
@@ -1248,11 +1299,9 @@ impl EncodedSsTableWriter {
         // Blocks drained while entries were added are cached by `write_block`,
         // so the only data block left for `cache_on_sst_write` is the tail
         // block that `build` finished.
-        self.table_store
-            .cache_on_sst_write(self.id, &encoded_sst)
-            .await;
+        table_store.cache_on_sst_write(id, &encoded_sst).await;
         Ok(SsTableHandle::new(
-            self.id,
+            id,
             encoded_sst.format_version,
             encoded_sst.info,
         ))
@@ -1269,8 +1318,16 @@ impl EncodedSsTableWriter {
         Ok(())
     }
 
+    async fn abort_upload(&mut self) {
+        let path = self.table_store.path(&self.id);
+        abort_sst_upload(&mut self.writer, &path).await;
+    }
+
     async fn write_block(&mut self, block: EncodedSsTableBlock) -> Result<(), SlateDBError> {
-        self.writer.write_all(block.encoded_bytes.as_ref()).await?;
+        if let Err(err) = self.writer.write_all(block.encoded_bytes.as_ref()).await {
+            self.abort_upload().await;
+            return Err(err.into());
+        }
         if let (Some(cache), Some(key_span)) = (&self.table_store.cache, &block.key_span) {
             let targets = self.table_store.targets_to_cache(&self.id);
             if should_cache_data_block(targets, key_span) {
@@ -1324,7 +1381,7 @@ mod tests {
     use crate::db_cache::{CachedKey, DbCache, DbCacheWrapper};
     use crate::error;
     use crate::format::block::Block;
-    use crate::format::sst::SsTableFormat;
+    use crate::format::sst::{EncodedSsTable, SsTableFormat};
     use crate::manifest::SsTableView;
     use crate::object_stores::ObjectStores;
     use crate::retrying_object_store::RetryingObjectStore;
@@ -1522,6 +1579,69 @@ mod tests {
         if let Some(wal_store) = wal_store {
             assert_eq!(count_ssts_in(&wal_store).await, 0);
         }
+    }
+
+    fn flaky_table_store(flaky: Arc<FlakyObjectStore>) -> Arc<TableStore> {
+        Arc::new(TableStore::new(
+            ObjectStores::new(flaky, None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+            TableStoreKind::Main,
+            BlockCachePolicy::default(),
+        ))
+    }
+
+    async fn build_large_sst(ts: &TableStore, mib: usize) -> EncodedSsTable {
+        let mut builder = ts.table_builder();
+        let value = vec![7u8; 1024 * 1024];
+        for i in 0..mib {
+            builder
+                .add(RowEntry::new_value(&(i as u64).to_be_bytes(), &value, 0))
+                .await
+                .unwrap();
+        }
+        builder.build().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_streaming_sst_write_part_failure_aborts_upload() {
+        // given: every part fails, no retry layer. The SST exceeds BufWriter's
+        // in-flight cap (8 parts of 10 MiB), so a put polls its upload tasks
+        // and surfaces the failure before shutdown, where abort is possible.
+        let inner = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_put_part_failures(usize::MAX));
+        let ts = flaky_table_store(flaky.clone());
+        let encoded = build_large_sst(&ts, 95).await;
+        let id = SsTableId::Compacted(ulid::Ulid::new());
+
+        // when:
+        ts.write_sst(&id, &encoded)
+            .await
+            .expect_err("write should surface the part failure");
+
+        // then: the failed upload was aborted, not abandoned.
+        assert_eq!(flaky.multipart_abort_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_part_failure_at_shutdown_surfaces_without_abort() {
+        // given: a single part failure below the in-flight cap, so it is
+        // first observed by shutdown, where BufWriter offers no way to abort:
+        // the write must surface the error cleanly and skip the abort.
+        let inner = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0).with_put_part_failures(1));
+        let ts = flaky_table_store(flaky.clone());
+        let encoded = build_large_sst(&ts, 12).await;
+        let id = SsTableId::Compacted(ulid::Ulid::new());
+
+        // when:
+        ts.write_sst(&id, &encoded)
+            .await
+            .expect_err("write should surface the part failure");
+
+        // then:
+        assert_eq!(flaky.multipart_abort_attempts(), 0);
     }
 
     #[rstest]

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -14,10 +14,13 @@ use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::BoxStream;
 use futures::{stream, StreamExt};
+use object_store::memory::InMemory;
+use object_store::multipart::{MultipartStore, PartId};
 use object_store::path::Path;
 use object_store::{
-    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions as OS_PutOptions, PutPayload, PutResult, RenameOptions,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOptions, PutOptions as OS_PutOptions, PutPayload, PutResult,
+    RenameOptions,
 };
 use rand::{Rng, RngCore};
 use std::cmp::Ordering as CmpOrdering;
@@ -573,6 +576,28 @@ pub(crate) struct FlakyObjectStore {
     // get_range: truncate response body to this many bytes on first N attempts (0 = no truncation)
     truncate_get_range_bytes: AtomicUsize,
     truncate_get_range_count: AtomicUsize,
+    // Multipart part/complete failure injection, shared with returned uploads
+    multipart_failures: Arc<MultipartFailures>,
+    // Low-level multipart handle, set via with_multipart_store
+    inner_multipart: Option<Arc<InMemory>>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct MultipartFailures {
+    // Transient failures on the first N put_part calls
+    fail_first_put_part: AtomicUsize,
+    // Permanent (NotSupported) failures on the first N put_part calls
+    fail_first_put_part_permanent: AtomicUsize,
+    // Low-level create rejects non-default attributes with NotSupported
+    create_attributes_unsupported: std::sync::atomic::AtomicBool,
+    put_part_attempts: AtomicUsize,
+    // Transient failures on the first N complete calls
+    fail_first_complete: AtomicUsize,
+    complete_attempts: AtomicUsize,
+    // Complete succeeds but returns NotFound, simulating a lost response
+    // followed by a retry against the finished upload
+    complete_succeeds_but_returns_not_found: std::sync::atomic::AtomicBool,
+    abort_attempts: AtomicUsize,
 }
 
 impl FlakyObjectStore {
@@ -598,7 +623,21 @@ impl FlakyObjectStore {
             get_range_attempts: AtomicUsize::new(0),
             truncate_get_range_bytes: AtomicUsize::new(0),
             truncate_get_range_count: AtomicUsize::new(0),
+            multipart_failures: Arc::new(MultipartFailures::default()),
+            inner_multipart: None,
         }
+    }
+
+    /// Exposes the low-level multipart API via the same `InMemory` as `inner`.
+    pub(crate) fn with_multipart_store(mut self, inner: Arc<InMemory>) -> Self {
+        self.inner_multipart = Some(inner);
+        self
+    }
+
+    fn multipart_store(&self) -> &Arc<InMemory> {
+        self.inner_multipart
+            .as_ref()
+            .expect("FlakyObjectStore built without with_multipart_store")
     }
 
     pub(crate) fn with_put_precondition_always(self) -> Self {
@@ -686,6 +725,63 @@ impl FlakyObjectStore {
 
     pub(crate) fn get_range_attempts(&self) -> usize {
         self.get_range_attempts.load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn with_put_part_failures(self, n: usize) -> Self {
+        self.multipart_failures
+            .fail_first_put_part
+            .store(n, Ordering::SeqCst);
+        self
+    }
+
+    pub(crate) fn with_put_part_permanent_failures(self, n: usize) -> Self {
+        self.multipart_failures
+            .fail_first_put_part_permanent
+            .store(n, Ordering::SeqCst);
+        self
+    }
+
+    /// Low-level create rejects non-default attributes with NotSupported,
+    /// simulating a store without attribute support.
+    pub(crate) fn with_multipart_create_attributes_unsupported(self) -> Self {
+        self.multipart_failures
+            .create_attributes_unsupported
+            .store(true, Ordering::SeqCst);
+        self
+    }
+
+    pub(crate) fn with_multipart_complete_failures(self, n: usize) -> Self {
+        self.multipart_failures
+            .fail_first_complete
+            .store(n, Ordering::SeqCst);
+        self
+    }
+
+    /// Complete finishes the upload but returns NotFound, simulating a
+    /// timeout after a successful complete.
+    pub(crate) fn with_multipart_complete_succeeds_but_returns_not_found(self) -> Self {
+        self.multipart_failures
+            .complete_succeeds_but_returns_not_found
+            .store(true, Ordering::SeqCst);
+        self
+    }
+
+    pub(crate) fn multipart_abort_attempts(&self) -> usize {
+        self.multipart_failures
+            .abort_attempts
+            .load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn put_part_attempts(&self) -> usize {
+        self.multipart_failures
+            .put_part_attempts
+            .load(Ordering::SeqCst)
+    }
+
+    pub(crate) fn multipart_complete_attempts(&self) -> usize {
+        self.multipart_failures
+            .complete_attempts
+            .load(Ordering::SeqCst)
     }
 
     /// Inject a failure after `fail_after` successful items in the stream.
@@ -871,7 +967,11 @@ impl ObjectStore for FlakyObjectStore {
         opts: object_store::PutMultipartOptions,
     ) -> object_store::Result<Box<dyn MultipartUpload>> {
         self.put_multipart_attempts.fetch_add(1, Ordering::SeqCst);
-        self.inner.put_multipart_opts(location, opts).await
+        let inner = self.inner.put_multipart_opts(location, opts).await?;
+        Ok(Box::new(FlakyMultipartUpload {
+            inner,
+            failures: Arc::clone(&self.multipart_failures),
+        }))
     }
 
     fn delete_stream(
@@ -945,6 +1045,153 @@ impl ObjectStore for FlakyObjectStore {
         options: CopyOptions,
     ) -> object_store::Result<()> {
         self.inner.copy_opts(from, to, options).await
+    }
+}
+
+/// Multipart upload returned by [`FlakyObjectStore`] that injects transient
+/// failures into `put_part` calls. Complete/abort failure injection lives on
+/// the [`MultipartStore`] impl, the only path that retries them.
+struct FlakyMultipartUpload {
+    inner: Box<dyn MultipartUpload>,
+    failures: Arc<MultipartFailures>,
+}
+
+impl fmt::Debug for FlakyMultipartUpload {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FlakyMultipartUpload").finish()
+    }
+}
+
+impl MultipartFailures {
+    fn injected_error(op: &'static str) -> object_store::Error {
+        object_store::Error::Generic {
+            store: "flaky_multipart",
+            source: Box::new(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("injected {op} timeout"),
+            )),
+        }
+    }
+
+    fn permanent_error(op: &'static str) -> object_store::Error {
+        object_store::Error::NotSupported {
+            source: format!("injected permanent {op} failure").into(),
+        }
+    }
+
+    fn take_failure(counter: &AtomicUsize) -> bool {
+        counter
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                if v > 0 {
+                    Some(v - 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok()
+    }
+}
+
+#[async_trait::async_trait]
+impl MultipartUpload for FlakyMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
+        self.failures
+            .put_part_attempts
+            .fetch_add(1, Ordering::SeqCst);
+        if MultipartFailures::take_failure(&self.failures.fail_first_put_part) {
+            return Box::pin(async { Err(MultipartFailures::injected_error("put_part")) });
+        }
+        self.inner.put_part(data)
+    }
+
+    async fn complete(&mut self) -> object_store::Result<PutResult> {
+        self.inner.complete().await
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        self.failures.abort_attempts.fetch_add(1, Ordering::SeqCst);
+        self.inner.abort().await
+    }
+}
+
+/// Low-level multipart API with the same failure injection as
+/// [`FlakyMultipartUpload`]. Requires [`FlakyObjectStore::with_multipart_store`].
+#[async_trait::async_trait]
+impl MultipartStore for FlakyObjectStore {
+    async fn create_multipart(&self, path: &Path) -> object_store::Result<MultipartId> {
+        self.create_multipart_opts(path, PutMultipartOptions::default())
+            .await
+    }
+
+    async fn create_multipart_opts(
+        &self,
+        path: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<MultipartId> {
+        self.put_multipart_attempts.fetch_add(1, Ordering::SeqCst);
+        if self
+            .multipart_failures
+            .create_attributes_unsupported
+            .load(Ordering::SeqCst)
+            && !opts.attributes.is_empty()
+        {
+            return Err(MultipartFailures::permanent_error("create with attributes"));
+        }
+        self.multipart_store()
+            .create_multipart_opts(path, opts)
+            .await
+    }
+
+    async fn put_part(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        part_idx: usize,
+        data: PutPayload,
+    ) -> object_store::Result<PartId> {
+        let failures = &self.multipart_failures;
+        failures.put_part_attempts.fetch_add(1, Ordering::SeqCst);
+        if MultipartFailures::take_failure(&failures.fail_first_put_part) {
+            return Err(MultipartFailures::injected_error("put_part"));
+        }
+        if MultipartFailures::take_failure(&failures.fail_first_put_part_permanent) {
+            return Err(MultipartFailures::permanent_error("put_part"));
+        }
+        self.multipart_store()
+            .put_part(path, id, part_idx, data)
+            .await
+    }
+
+    async fn complete_multipart(
+        &self,
+        path: &Path,
+        id: &MultipartId,
+        parts: Vec<PartId>,
+    ) -> object_store::Result<PutResult> {
+        let failures = &self.multipart_failures;
+        failures.complete_attempts.fetch_add(1, Ordering::SeqCst);
+        if MultipartFailures::take_failure(&failures.fail_first_complete) {
+            return Err(MultipartFailures::injected_error("complete"));
+        }
+        let result = self.multipart_store().complete_multipart(path, id, parts);
+        if failures
+            .complete_succeeds_but_returns_not_found
+            .load(Ordering::SeqCst)
+        {
+            result.await?;
+            return Err(object_store::Error::NotFound {
+                path: path.to_string(),
+                source: "injected not found after successful complete".into(),
+            });
+        }
+        result.await
+    }
+
+    async fn abort_multipart(&self, path: &Path, id: &MultipartId) -> object_store::Result<()> {
+        self.multipart_failures
+            .abort_attempts
+            .fetch_add(1, Ordering::SeqCst);
+        self.multipart_store().abort_multipart(path, id).await
     }
 }
 


### PR DESCRIPTION
Closes #1956.

`RetryingObjectStore` retried transient failures for every operation except multipart uploads — a transient `put_part` or `complete` failure surfaced straight to callers (e.g. `BufWriter` streaming SST writes), even with `max_retries = None` ("retry indefinitely") configured.

The high-level `MultipartUpload` API cannot retry a failed part: `put_part` assigns part indexes internally per call, so a failed part can't be re-sent at its index. The low-level `MultipartStore` API (implemented by S3, GCS, Azure, and `InMemory`) can — parts carry explicit indexes, so a failed part is simply re-uploaded in place.

This PR wires that in end to end:

- **New constructors** — `Db::builder_with_multipart`, `DbBuilder::new_with_multipart`, and `CompactorBuilder::new_with_multipart` — accept a single `Arc<T: ObjectStore + MultipartStore>`. Taking one value for both roles makes a mismatched-backend multipart handle unrepresentable; the plain `Db::builder(path, Arc<dyn ObjectStore>)` entry point is untouched.
- **`MultipartStoreUpload`** retries each part in place under the existing retry policy (exponential backoff, `object_store_max_retries`), holding only in-flight payloads in memory.
- **Same layering as the main store** — the multipart handle is wrapped by `InstrumentedMultipartStore` (calls recorded under the existing multipart metrics) and, when object store caching is configured, by `CachingMultipartStore` (uploads mirror their bytes into the cache like high-level writes, tolerating out-of-order part completion).
- **Upload cleanup** — a streaming SST write that fails before shutdown aborts its multipart upload instead of abandoning it (billed on S3 until lifecycle cleanup), and dropping an upload that was never completed or aborted aborts it best-effort.

```text
put_multipart_opts(location, opts)
├── multipart handle configured (builder_with_multipart)?
│   ├── yes → create_multipart (retried, put-id attribute)
│   │        └── MultipartStoreUpload
│   │            ├── put_part:  put_part(location, id, part_idx, data)
│   │            │              retried in place under the retry policy
│   │            ├── complete:  complete_multipart retried,
│   │            │              then put-id ULID verification
│   │            └── drop:      abort_multipart best-effort if unfinished
│   └── no  → RetryingMultipartUpload
│            ├── put_part:  delegates to inner upload (client retries only)
│            └── complete:  put-id ULID verification
```


## Usage

Opt in by passing the object store client to the new constructor instead of `Db::builder`. Nothing else changes; `Db::builder` keeps its current behavior.

```rust
use slatedb::Db;
use slatedb::object_store::aws::AmazonS3Builder;
use std::sync::Arc;

// Keep the client's concrete type — `MultipartStore` is needed alongside
// `ObjectStore`, so don't erase it to `Arc<dyn ObjectStore>`.
let store = Arc::new(
    AmazonS3Builder::from_env()
        .with_bucket_name("my-bucket")
        .build()?,
);

let db = Db::builder_with_multipart("/my/db/path", store)
    .with_settings(Settings {
        // Retry budget for every operation, now including multipart parts.
        object_store_max_retries: Some(5), // `None` = retry indefinitely
        ..Default::default()
    })
    .build()
    .await?;
```

With `Db::builder`, a failed `put_part` or `complete` is covered only by the client's own HTTP retries and otherwise surfaces to the caller. With `Db::builder_with_multipart`, a failed part is re-uploaded in place under `Settings::object_store_max_retries`, and only the failed part is retransmitted.

The handle is inherited by the components that share the main store — db writes, compactor, and GC. A separately configured WAL object store (`DbBuilder::with_wal_object_store`) is not covered.

`DbBuilder::new_with_multipart` is the equivalent entry point when building the builder directly:

```rust
let db = DbBuilder::new_with_multipart("/my/db/path", store).build().await?;
```

#### Standalone compactor

A compactor running in its own process gets the same treatment via `CompactorBuilder::new_with_multipart`, with the retry budget coming from `CompactorOptions::object_store_max_retries`:

```rust
let compactor = CompactorBuilder::new_with_multipart(path, store)
    .with_options(CompactorOptions {
        object_store_max_retries: Some(5),
        ..Default::default()
    })
    .build();
```

For a compactor embedded via `DbBuilder::with_compactor_builder`, a plain `CompactorBuilder::new` falls back to the `DbBuilder`'s multipart handle when both use the same store instance, so only the `DbBuilder` needs the `_with_multipart` constructor. A handle set on the `CompactorBuilder` itself takes precedence.

### Supported stores

Any client implementing `object_store::multipart::MultipartStore`: `AmazonS3`, `GoogleCloudStorage`, `MicrosoftAzure`, and `InMemory`. Stores without it (e.g. `LocalFileSystem`) continue to use `Db::builder`.

### Why this is safe

- Parts are addressed by explicit index: a retried part overwrites its own slot; ordering and concurrency are unaffected.
- Timeout-after-success on `complete`: a `complete_multipart` whose response was lost leaves the upload finished server-side, so a retry can fail with `AlreadyExists`/`Precondition`/`NotFound` (e.g. S3 `NoSuchUpload`). `verified_complete_result` treats these as ambiguous and returns success only if the stored object carries our put-id ULID.
- Permanent errors (`NotSupported`, `Precondition`, …) still fail fast.
- The cache mirror commits (writes the head) only after a successful complete; a lost complete resolved by put-id costs a cache miss, never a wrong cache entry.

### Cost

Happy path is unchanged: `O(S)` bytes uploaded once, and memory stays bounded by `BufWriter`'s in-flight concurrency cap — parts are dropped once acknowledged, never buffered for replay. Worst case, a flaky part costs `≤ max_retries + 1` uploads *of that part only*; there is no whole-upload replay. The cache mirror holds at most the in-flight window while folding out-of-order parts.

## Changes

- `Db::builder_with_multipart` / `DbBuilder::new_with_multipart` / `CompactorBuilder::new_with_multipart`: constructors taking `Arc<T: ObjectStore + MultipartStore>`; the handle flows to the db and compactor (GC never streams multipart uploads), instrumented and cache-mirrored like the main store
- `MultipartStoreUpload`: per-part in-place retries, retried `complete_multipart`, and best-effort abort on drop of an unfinished upload
- `RetryingMultipartUpload`: unchanged part behavior for stores without a multipart handle, plus put-id verification on `complete`
- `verified_complete_result`: extends the put-id check to treat `NotFound` as ambiguous for multipart completes
- `InstrumentedMultipartStore` / `CachingMultipartStore`: metrics and cache mirroring for the low-level path, matching the high-level one
- `tablestore`: streaming SST writes abort the upload on failure before shutdown; a failure first observed at shutdown surfaces with a warning (`BufWriter` can't abort at that point)
- `FlakyObjectStore`: multipart failure injection; new tests cover in-place part retry, complete retry without re-upload, bounded-retry exhaustion, timeout-after-success on complete (ULID match), abort forwarding, drop-abort, fail-fast without a handle, out-of-order cache mirroring, tablestore abort behavior, end-to-end `BufWriter` recovery, and an end-to-end `Db` flush through injected part failures

## Notes for Reviewers

- `put_part` returns `'static` futures that can't borrow `self`; resolved `PartId`s are collected in an `Arc<Mutex<Vec<Option<PartId>>>>` indexed by part slot. `complete()` reads the slots without draining them and fails if any is unresolved, so it can be retried once in-flight parts settle.
- An earlier iteration of this PR retried parts by buffering every payload and replaying the whole upload from `complete()`. That was dropped for its `O(object size)` memory retention (up to ~1 GiB per in-flight upload at default SST sizes) in favor of the `MultipartStore` approach. Consequence: without a multipart handle, parts get no wrapper-level retries — same as before this PR, plus the new put-id verification on `complete`.
- Constructor naming (`new_with_<capability>` / `builder_with_<capability>`) follows the Rust API guidelines and the crate's existing pattern (`TableStore::new_with_fp_registry`, `CachedObjectStore::new_with_policies`, upstream `LocalFileSystem::new_with_prefix`).

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes (none — new constructors are additive)
- [x] Considered performance impact; added notes or benchmarks if relevant (see Cost)

Thank you for the review! 🙏
