### PR TITLE
Increase default GC interval to 10 minutes

### DIFF
--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1551,7 +1551,7 @@ impl GarbageCollectorOptions {
 
 /// Default options for the garbage collector for a directory.
 ///
-/// By default, the garbage collector will run every minute and deletes files
+/// By default, the garbage collector will run every 10 minutes and deletes files
 /// that are at least 5 minutes old.
 impl Default for GarbageCollectorDirectoryOptions {
     fn default() -> Self {

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -53,7 +53,7 @@ mod wal_gc;
 pub use filter::GcFilter;
 
 pub(crate) const DEFAULT_MIN_AGE: Duration = Duration::from_secs(300);
-pub(crate) const DEFAULT_INTERVAL: Duration = Duration::from_secs(60);
+pub(crate) const DEFAULT_INTERVAL: Duration = Duration::from_secs(600);
 pub(crate) const GC_TASK_NAME: &str = "garbage_collector";
 /// Maximum number of concurrent object-store deletes issued by a GC task's
 /// deletion pass. Deletes are independent single-object operations, so a small


### PR DESCRIPTION
## Summary

When I was working on idle DB cost, GC cost was second in line after the LIST cost for read_latest. Now that linear probing fixes that, this PR bumps the default GC polling default from 1 minute to 10 minutes. This cuts object-store scans by 10x. Using S3 Standard pricing, the storage increase is small compared with the LIST savings on large databases.

@sorenbs raised an alternative PR that uses telescoping backoff (#1991). I'd prefer we KISS and just bump the default up.

Closes #1991

## Changes

- Set `DEFAULT_INTERVAL` to 600 seconds.
- Update the public configuration documentation.

## Notes for Reviewers

Cost model using $0.023 per GB-month, $0.005 per 1,000 LIST requests, and a 30-day month:

- Moving from 1 minute to 10 minutes adds 270 seconds of average retention. At 1 GiB/s of eligible garbage, that is 270 GiB or about $6.21/month. At 5 GiB/s, it is 1.32 TiB or about $31.05/month.
- Compacted GC lists the full compacted namespace. With 256 MiB SSTs and 1 GiB/s of retained growth, the first month averages 5.18 million objects. Estimated LIST cost falls from about $1,120/month to $112/month, saving about $1,008.

Eligible garbage can remain for up to 9 additional minutes, and deletion batches can be 10x larger. There is no API break. Users that need faster collection can set an explicit interval.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏