### PR TITLE
Remove unnecessary SR clones in scan APIs 

### DIFF
--- a/bindings/uniffi/src/types.rs
+++ b/bindings/uniffi/src/types.rs
@@ -832,7 +832,7 @@ impl From<&CoreSortedRun> for SortedRun {
     fn from(value: &CoreSortedRun) -> Self {
         Self {
             id: value.id,
-            sst_views: value.sst_views.iter().map(SsTableView::from).collect(),
+            sst_views: value.sst_views().iter().map(SsTableView::from).collect(),
             estimated_size_bytes: value.estimate_size(),
         }
     }

--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -146,6 +146,10 @@ name = "scan_prefix_bench"
 harness = false
 
 [[bench]]
+name = "scan_prefix_large_sorted_run_bench"
+harness = false
+
+[[bench]]
 name = "block_iterator_v2"
 harness = false
 required-features = ["bench-internal"]

--- a/slatedb/benches/scan_prefix_large_sorted_run_bench.rs
+++ b/slatedb/benches/scan_prefix_large_sorted_run_bench.rs
@@ -19,8 +19,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use object_store::memory::InMemory;
 use pprof::criterion::{Output, PProfProfiler};
 use slatedb::config::{
-    CompactorOptions, DurabilityLevel, FlushOptions, FlushType, PutOptions, ScanOptions, Settings,
-    WriteOptions,
+    CompactorOptions, DurabilityLevel, FlushOptions, FlushType, ScanOptions, Settings,
 };
 use slatedb::Db;
 use slatedb_common::clock::{DefaultSystemClock, SystemClock};
@@ -111,16 +110,9 @@ fn scan_options() -> ScanOptions {
 }
 
 async fn populate(db: &Db) {
-    let write_opts = WriteOptions {
-        await_durable: false,
-        ..WriteOptions::default()
-    };
-    let put_opts = PutOptions::default();
     for idx in 0..NUM_SSTS {
         let key = make_key(idx);
-        db.put_with_options(&key, &key, &put_opts, &write_opts)
-            .await
-            .expect("put failed");
+        db.put(&key, &key).await.expect("put failed");
         db.flush_with_options(FlushOptions {
             flush_type: FlushType::MemTable,
         })

--- a/slatedb/benches/scan_prefix_large_sorted_run_bench.rs
+++ b/slatedb/benches/scan_prefix_large_sorted_run_bench.rs
@@ -1,0 +1,250 @@
+// our microbenchmarks use pprof, but it doesn't work on windows
+#![cfg(not(windows))]
+
+//! Measures how much of a prefix scan's setup cost comes from handing a
+//! `SortedRun` to a scan iterator when the run holds far more SSTs than the
+//! query range covers.
+//!
+//! Fixture: one sorted run of 1000 SSTs, one key per SST, disjoint and ordered
+//! key ranges, with no memtable or L0 data left behind. Keys are `sr/000`
+//! through `sr/999`, so each shorter prefix selects ten times as many SSTs.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use chrono::TimeDelta;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use object_store::memory::InMemory;
+use pprof::criterion::{Output, PProfProfiler};
+use slatedb::config::{
+    CompactorOptions, DurabilityLevel, FlushOptions, FlushType, PutOptions, ScanOptions, Settings,
+    WriteOptions,
+};
+use slatedb::Db;
+use slatedb_common::clock::{DefaultSystemClock, SystemClock};
+use tokio::runtime::Runtime;
+
+/// Keys are `sr/000` through `sr/999`, one per SST.
+const NUM_SSTS: usize = 1000;
+
+struct Case {
+    prefix: &'static str,
+    /// Keys under the prefix, which is also the number of rows a full prefix
+    /// scan returns.
+    keys: usize,
+    /// SST views `tables_covering_range` returns for the prefix range.
+    covering: usize,
+}
+
+/// Each prefix drops one digit, so it selects ten times as many keys as the one
+/// below it.
+const CASES: [Case; 3] = [
+    Case {
+        prefix: "sr/222",
+        keys: 1,
+        covering: 1, // the prefix is a single key, so it covers one SST view.
+    },
+    Case {
+        prefix: "sr/22",
+        keys: 10,
+        covering: 11, // the prefix covers 11 SST views.
+    },
+    Case {
+        prefix: "sr/2",
+        keys: 100,
+        covering: 101, // the prefix covers 101 SST views.
+    },
+];
+
+fn make_key(idx: usize) -> Bytes {
+    Bytes::from(format!("sr/{idx:03}"))
+}
+
+fn prefix_start(prefix: &'static str) -> Bytes {
+    Bytes::from_static(prefix.as_bytes())
+}
+
+/// Exclusive upper bound of the prefix range. Every prefix here ends in `2`, so
+/// incrementing the last byte is enough.
+fn prefix_end(prefix: &str) -> Bytes {
+    let mut end = prefix.as_bytes().to_vec();
+    *end.last_mut().expect("prefix is non-empty") += 1;
+    Bytes::from(end)
+}
+
+fn settings() -> Settings {
+    let mut scheduler_options = HashMap::new();
+    // Fire exactly one compaction, and only once every L0 SST exists.
+    scheduler_options.insert("min_compaction_sources".to_string(), NUM_SSTS.to_string());
+    scheduler_options.insert("max_compaction_sources".to_string(), NUM_SSTS.to_string());
+
+    Settings {
+        // Writers stall at these limits and the fixture parks NUM_SSTS in L0.
+        l0_max_ssts: NUM_SSTS + 16,
+        l0_max_ssts_per_key: NUM_SSTS + 16,
+        // One key per SST stays under the default min_filter_keys, so no SST
+        // carries a filter and every case is decided by key range overlap.
+        compactor_options: Some(CompactorOptions {
+            poll_interval: Duration::from_millis(50),
+            max_concurrent_compactions: 1,
+            // A trivial move preserves the one flush per SST topology. A
+            // rewriting compaction would choose its own output boundaries.
+            enable_trivial_move: true,
+            // No worker, so the coordinator either completes the compaction as
+            // a trivial move or the fixture assertion fails.
+            worker: None,
+            scheduler_options,
+            ..CompactorOptions::default()
+        }),
+        ..Settings::default()
+    }
+}
+
+fn scan_options() -> ScanOptions {
+    ScanOptions {
+        cache_blocks: true,
+        durability_filter: DurabilityLevel::Remote,
+        ..ScanOptions::default()
+    }
+}
+
+async fn populate(db: &Db) {
+    let write_opts = WriteOptions {
+        await_durable: false,
+        ..WriteOptions::default()
+    };
+    let put_opts = PutOptions::default();
+    for idx in 0..NUM_SSTS {
+        let key = make_key(idx);
+        db.put_with_options(&key, &key, &put_opts, &write_opts)
+            .await
+            .expect("put failed");
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .expect("flush failed");
+    }
+}
+
+async fn await_single_sorted_run(db: &Db) {
+    let clock = DefaultSystemClock::new();
+    let deadline = clock.now() + TimeDelta::seconds(300);
+    loop {
+        db.refresh_manifest()
+            .await
+            .expect("refresh_manifest failed");
+        let manifest = db.manifest();
+        let l0 = manifest.l0().len();
+        let runs = manifest.compacted();
+        let ssts = runs
+            .first()
+            .map_or(0, |run| run.tables_covering_range(..).len());
+        if l0 == 0 && runs.len() == 1 && ssts == NUM_SSTS {
+            return;
+        }
+        assert!(
+            clock.now() < deadline,
+            "compaction never produced one sorted run of {NUM_SSTS} ssts (l0={l0}, runs={}, ssts={ssts})",
+            runs.len()
+        );
+        clock.sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn count_prefix_rows(db: &Db, prefix: &'static str) -> usize {
+    let mut iter = db
+        .scan_prefix_with_options(prefix_start(prefix), .., &scan_options())
+        .await
+        .expect("scan_prefix failed");
+    let mut count = 0usize;
+    while iter.next().await.expect("iterator next failed").is_some() {
+        count += 1;
+    }
+    count
+}
+
+async fn validate_fixture(db: &Db) {
+    let manifest = db.manifest();
+    let run = manifest
+        .compacted()
+        .first()
+        .expect("fixture has one sorted run");
+    for case in &CASES {
+        let covering = run
+            .tables_covering_range(prefix_start(case.prefix)..prefix_end(case.prefix))
+            .len();
+        assert_eq!(
+            covering, case.covering,
+            "prefix {} covers {covering} sst views",
+            case.prefix
+        );
+        let rows = count_prefix_rows(db, case.prefix).await;
+        assert_eq!(
+            rows, case.keys,
+            "prefix {} scanned {rows} rows",
+            case.prefix
+        );
+    }
+}
+
+async fn build_fixture() -> Db {
+    let store = Arc::new(InMemory::new());
+    let db = Db::builder("/bench/sorted_run", store)
+        .with_settings(settings())
+        .build()
+        .await
+        .expect("failed to build db");
+    populate(&db).await;
+    await_single_sorted_run(&db).await;
+    validate_fixture(&db).await;
+    db
+}
+
+fn bench_scan_prefix_large_sorted_run(c: &mut Criterion) {
+    let runtime = Runtime::new().expect("failed to create runtime");
+    let db = runtime.block_on(build_fixture());
+
+    let scan_opts = scan_options();
+    let mut group = c.benchmark_group("scan_prefix_large_sorted_run");
+
+    for case in &CASES {
+        let label = format!("K={}", case.keys);
+
+        group.bench_function(BenchmarkId::new("first_entry", &label), |b| {
+            b.to_async(&runtime).iter(|| async {
+                let mut iter = db
+                    .scan_prefix_with_options(prefix_start(case.prefix), .., &scan_opts)
+                    .await
+                    .expect("scan_prefix failed");
+                let entry = iter.next().await.expect("iterator next failed");
+                assert!(entry.is_some());
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("first_entry_by_recency", &label), |b| {
+            b.to_async(&runtime).iter(|| async {
+                let mut iter = db
+                    .scan_prefix_by_recency_with_options(prefix_start(case.prefix), &scan_opts)
+                    .await
+                    .expect("scan_prefix_by_recency failed");
+                let entry = iter.next_entry().await.expect("iterator next_entry failed");
+                assert!(entry.is_some());
+            });
+        });
+    }
+
+    group.finish();
+    runtime.block_on(async { db.close().await.expect("close failed") });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    targets = bench_scan_prefix_large_sorted_run
+}
+
+criterion_main!(benches);

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -307,7 +307,7 @@ impl CompactionExecuteBench {
             id: rand.rng().gen_ulid(system_clock.as_ref()),
             compaction_id: job.id(),
             destination: 0,
-            l0_sst_views: vec![],
+            l0_sst_views: vec![].into(),
             sorted_runs: srs,
             compaction_clock_tick: state.last_l0_clock_tick,
             is_dest_last_run,

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -307,7 +307,7 @@ impl CompactionExecuteBench {
             id: rand.rng().gen_ulid(system_clock.as_ref()),
             compaction_id: job.id(),
             destination: 0,
-            l0_sst_views: vec![].into(),
+            l0_sst_views: vec![],
             sorted_runs: srs,
             compaction_clock_tick: state.last_l0_clock_tick,
             is_dest_last_run,

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -1116,7 +1116,7 @@ mod tests {
         );
         let sorted_run = SortedRun {
             id: 0,
-            sst_views: vec![SsTableView::identity(output_handle.clone())],
+            sst_views: vec![SsTableView::identity(output_handle.clone())].into(),
         };
 
         fx.handler

--- a/slatedb/src/compaction_worker.rs
+++ b/slatedb/src/compaction_worker.rs
@@ -616,7 +616,13 @@ impl CompactionWorkerHandler {
             let heartbeat_ms = self.clock.now().timestamp_millis() as u64;
             let updated = existing
                 .with_status(CompactionStatus::Compacted)
-                .with_output_ssts(sorted_run.sst_views.iter().map(|v| v.sst.clone()).collect())
+                .with_output_ssts(
+                    sorted_run
+                        .sst_views()
+                        .iter()
+                        .map(|v| v.sst.clone())
+                        .collect(),
+                )
                 .with_worker(Some(WorkerSpec::new(self.worker_id.clone(), heartbeat_ms)))
                 .with_ctx(None);
             dirty.value.insert(updated);
@@ -1114,10 +1120,7 @@ mod tests {
                 ..SsTableInfo::default()
             },
         );
-        let sorted_run = SortedRun {
-            id: 0,
-            sst_views: vec![SsTableView::identity(output_handle.clone())].into(),
-        };
+        let sorted_run = SortedRun::new(0, [SsTableView::identity(output_handle.clone())]);
 
         fx.handler
             .handle_finished(id, Ok(sorted_run))

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -882,14 +882,13 @@ impl CompactorEventHandler {
                         .spec()
                         .destination()
                         .expect("Compacted tiered compaction must have a destination SR id");
-                    let output_sr = SortedRun {
-                        id: destination,
-                        sst_views: compaction
+                    let output_sr = SortedRun::new(
+                        destination,
+                        compaction
                             .output_ssts()
                             .iter()
-                            .map(|sst| SsTableView::identity(sst.clone()))
-                            .collect(),
-                    };
+                            .map(|sst| SsTableView::identity(sst.clone())),
+                    );
                     self.state_mut().finish_compaction(id, output_sr);
                     manifest_changed = true;
                     self.stats
@@ -1707,7 +1706,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         for run in db_state.tree.compacted.iter() {
-            for sst in run.sst_views.iter() {
+            for sst in run.sst_views() {
                 let mut iter = SstIterator::new_borrowed_initialized(
                     ..,
                     sst,
@@ -1836,7 +1835,7 @@ mod tests {
             .tree
             .compacted
             .iter()
-            .flat_map(|sr| sr.sst_views.iter())
+            .flat_map(|sr| sr.sst_views().iter())
             .collect();
         assert_eq!(output_ssts.len(), 1);
         let view = output_ssts[0];
@@ -2364,7 +2363,7 @@ mod tests {
         .unwrap();
         assert_eq!(db_state.tree.compacted.len(), 1);
 
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2464,7 +2463,7 @@ mod tests {
         .unwrap();
         assert_eq!(db_state.tree.compacted.len(), 1);
 
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2605,7 +2604,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.tree.compacted.len(), 1);
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2825,7 +2824,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.tree.compacted.len(), 1);
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -2947,7 +2946,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.tree.compacted.len(), 1);
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -3082,7 +3081,7 @@ mod tests {
         // then:
         let db_state = db_state.expect("db was not compacted");
         assert_eq!(db_state.tree.compacted.len(), 1);
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -3182,7 +3181,7 @@ mod tests {
         assert_eq!(db_state.last_l0_clock_tick, 20);
 
         // then: the compacted SST should only contain the non-expired merge
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -3408,7 +3407,7 @@ mod tests {
         );
 
         // The compacted sorted run should contain both merge operations separately
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -3525,7 +3524,7 @@ mod tests {
             "compaction should have occurred"
         );
 
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
 
@@ -3656,7 +3655,7 @@ mod tests {
         let db_state = db_state.expect("db was not compacted");
         assert!(db_state.tree.last_compacted_l0_sst_view_id.is_some());
         assert_eq!(db_state.tree.compacted.len(), 1);
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -3786,7 +3785,7 @@ mod tests {
         assert!(db_state.tree.last_compacted_l0_sst_view_id.is_some());
         assert_eq!(db_state.tree.compacted.len(), 1);
         assert_eq!(db_state.last_l0_clock_tick, 70);
-        let compacted = &db_state.tree.compacted.first().unwrap().sst_views;
+        let compacted = db_state.tree.compacted.first().unwrap().sst_views();
         assert_eq!(compacted.len(), 1);
         let handle = compacted.first().unwrap();
         let mut iter = SstIterator::new_borrowed_initialized(
@@ -3894,10 +3893,7 @@ mod tests {
                 ..SsTableInfo::default()
             },
         ));
-        let segment_sr = SortedRun {
-            id: 7,
-            sst_views: vec![segment_sr_view.clone()].into(),
-        };
+        let segment_sr = SortedRun::new(7, [segment_sr_view.clone()]);
 
         let mut core = ManifestCore::new();
         core.segments = vec![Segment {
@@ -4178,24 +4174,22 @@ mod tests {
         Arc::make_mut(&mut dirty.value.core.tree).l0 =
             VecDeque::from(vec![l0_view_newest, l0_view_oldest]);
         Arc::make_mut(&mut dirty.value.core.tree).compacted = vec![
-            SortedRun {
-                id: 2,
-                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+            SortedRun::new(
+                2,
+                [SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::new()),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                ))]
-                .into(),
-            },
-            SortedRun {
-                id: 1,
-                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                ))],
+            ),
+            SortedRun::new(
+                1,
+                [SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::new()),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                ))]
-                .into(),
-            },
+                ))],
+            ),
         ];
         stored_manifest.update(dirty).await.unwrap();
 
@@ -4283,24 +4277,22 @@ mod tests {
         ));
         Arc::make_mut(&mut core.tree).l0 = VecDeque::from(vec![l0_view_first, l0_view_second]);
         Arc::make_mut(&mut core.tree).compacted = vec![
-            SortedRun {
-                id: 5,
-                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+            SortedRun::new(
+                5,
+                [SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(10, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                ))]
-                .into(),
-            },
-            SortedRun {
-                id: 2,
-                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                ))],
+            ),
+            SortedRun::new(
+                2,
+                [SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(11, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info,
-                ))]
-                .into(),
-            },
+                ))],
+            ),
         ];
         let state = CompactorStateView {
             compactions: None,
@@ -4382,24 +4374,22 @@ mod tests {
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
                 compacted: vec![
-                    SortedRun {
-                        id: 7,
-                        sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                    SortedRun::new(
+                        7,
+                        [SsTableView::identity(SsTableHandle::new(
                             SsTableId::Compacted(Ulid::from_parts(70, 0)),
                             SST_FORMAT_VERSION_LATEST,
                             sr_info.clone(),
-                        ))]
-                        .into(),
-                    },
-                    SortedRun {
-                        id: 3,
-                        sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                        ))],
+                    ),
+                    SortedRun::new(
+                        3,
+                        [SsTableView::identity(SsTableHandle::new(
                             SsTableId::Compacted(Ulid::from_parts(30, 0)),
                             SST_FORMAT_VERSION_LATEST,
                             sr_info,
-                        ))]
-                        .into(),
-                    },
+                        ))],
+                    ),
                 ],
             }),
         }];
@@ -4439,15 +4429,14 @@ mod tests {
             first_entry: Some(Bytes::from_static(b"r")),
             ..SsTableInfo::default()
         };
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 9,
-            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(
+            9,
+            [SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(Ulid::from_parts(90, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 sr_info,
-            ))]
-            .into(),
-        }];
+            ))],
+        )];
         let state = CompactorStateView {
             compactions: None,
             manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
@@ -4476,15 +4465,14 @@ mod tests {
             first_entry: Some(Bytes::from_static(b"a")),
             ..SsTableInfo::default()
         };
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 4,
-            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(
+            4,
+            [SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(Ulid::from_parts(40, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 sr_info,
-            ))]
-            .into(),
-        }];
+            ))],
+        )];
         let state = CompactorStateView {
             compactions: None,
             manifest: VersionedManifest::from_manifest(0, Manifest::initial(core)),
@@ -4516,24 +4504,22 @@ mod tests {
             ..SsTableInfo::default()
         };
         Arc::make_mut(&mut core.tree).compacted = vec![
-            SortedRun {
-                id: 8,
-                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+            SortedRun::new(
+                8,
+                [SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(80, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     info.clone(),
-                ))]
-                .into(),
-            },
-            SortedRun {
-                id: 4,
-                sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                ))],
+            ),
+            SortedRun::new(
+                4,
+                [SsTableView::identity(SsTableHandle::new(
                     SsTableId::Compacted(Ulid::from_parts(40, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     info.clone(),
-                ))]
-                .into(),
-            },
+                ))],
+            ),
         ];
         core.segment_extractor_name = Some("test".into());
         core.segments = vec![
@@ -4543,15 +4529,14 @@ mod tests {
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
-                    compacted: vec![SortedRun {
-                        id: 3,
-                        sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                    compacted: vec![SortedRun::new(
+                        3,
+                        [SsTableView::identity(SsTableHandle::new(
                             SsTableId::Compacted(Ulid::from_parts(30, 0)),
                             SST_FORMAT_VERSION_LATEST,
                             info.clone(),
-                        ))]
-                        .into(),
-                    }],
+                        ))],
+                    )],
                 }),
             },
             Segment {
@@ -4561,24 +4546,22 @@ mod tests {
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
                     compacted: vec![
-                        SortedRun {
-                            id: 9,
-                            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                        SortedRun::new(
+                            9,
+                            [SsTableView::identity(SsTableHandle::new(
                                 SsTableId::Compacted(Ulid::from_parts(90, 0)),
                                 SST_FORMAT_VERSION_LATEST,
                                 info.clone(),
-                            ))]
-                            .into(),
-                        },
-                        SortedRun {
-                            id: 6,
-                            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+                            ))],
+                        ),
+                        SortedRun::new(
+                            6,
+                            [SsTableView::identity(SsTableHandle::new(
                                 SsTableId::Compacted(Ulid::from_parts(60, 0)),
                                 SST_FORMAT_VERSION_LATEST,
                                 info,
-                            ))]
-                            .into(),
-                        },
+                            ))],
+                        ),
                     ],
                 }),
             },
@@ -4622,15 +4605,14 @@ mod tests {
             first_entry: Some(Bytes::from_static(b"x")),
             ..SsTableInfo::default()
         };
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 5,
-            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(
+            5,
+            [SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(Ulid::from_parts(50, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 info.clone(),
-            ))]
-            .into(),
-        }];
+            ))],
+        )];
         core.segment_extractor_name = Some("test".into());
         core.segments = vec![
             // L0-only: still skipped because L0 SSTs are ineligible inputs.
@@ -4946,7 +4928,9 @@ mod tests {
                     let completed = compaction
                         .clone()
                         .with_status(CompactionStatus::Compacted)
-                        .with_output_ssts(result.sst_views.iter().map(|v| v.sst.clone()).collect())
+                        .with_output_ssts(
+                            result.sst_views().iter().map(|v| v.sst.clone()).collect(),
+                        )
                         .with_ctx(None);
                     dirty.value.insert(completed);
                     match stored.update(dirty).await {
@@ -5015,7 +4999,7 @@ mod tests {
             .compacted
             .first()
             .unwrap()
-            .sst_views
+            .sst_views()
             .iter()
             .map(|view| view.sst.id.unwrap_compacted_id())
             .collect();
@@ -5190,10 +5174,8 @@ mod tests {
             .value
             .core;
         Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![sr_first.clone(), sr_last.clone()].into(),
-        }];
+        Arc::make_mut(&mut core.tree).compacted =
+            vec![SortedRun::new(1, [sr_first.clone(), sr_last.clone()])];
 
         let compaction_id = Ulid::new();
         fixture
@@ -5227,7 +5209,7 @@ mod tests {
         assert_eq!(output.id, 2);
         assert_eq!(
             output
-                .sst_views
+                .sst_views()
                 .iter()
                 .map(|view| view.id)
                 .collect::<Vec<_>>(),
@@ -5262,10 +5244,7 @@ mod tests {
             .value
             .core;
         Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![sr_first, sr_last].into(),
-        }];
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(1, [sr_first, sr_last])];
         let compaction_id = Ulid::new();
         fixture
             .handler
@@ -5754,10 +5733,7 @@ mod tests {
         // Root tree holds SR(7) — the global max. The segment-targeted spec
         // below proposes dst=3, which is above the segment's local max (0)
         // but below the global max.
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 7,
-            sst_views: Vec::new().into(),
-        }];
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(7, [])];
         core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
@@ -5799,10 +5775,7 @@ mod tests {
             .manifest_mut_for_test()
             .value
             .core;
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 7,
-            sst_views: Vec::new().into(),
-        }];
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(7, [])];
         core.segments = vec![Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
@@ -5852,10 +5825,7 @@ mod tests {
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![make_view(l0_view)]),
-                compacted: vec![SortedRun {
-                    id: 7,
-                    sst_views: Vec::new().into(),
-                }],
+                compacted: vec![SortedRun::new(7, [])],
             }),
         }];
 
@@ -6039,10 +6009,7 @@ mod tests {
             .manifest_mut_for_test()
             .value
             .core;
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 99,
-            sst_views: Vec::new().into(),
-        }];
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(99, [])];
         let prefix = Bytes::from_static(b"seg/");
         core.segments = vec![Segment {
             prefix: prefix.clone(),
@@ -6082,10 +6049,7 @@ mod tests {
             .core;
         // Place SR(7) in the root tree. The segment-targeted spec below uses 7 as
         // its destination but does not list it among its sources.
-        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
-            id: 7,
-            sst_views: Vec::new().into(),
-        }];
+        Arc::make_mut(&mut core.tree).compacted = vec![SortedRun::new(7, [])];
         // Seed SR(99) into the segment so the source-existence check passes and
         // destination-overwrite is the rejection reason.
         let prefix = Bytes::from_static(b"seg/");
@@ -6095,10 +6059,7 @@ mod tests {
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
-                compacted: vec![SortedRun {
-                    id: 99,
-                    sst_views: Vec::new().into(),
-                }],
+                compacted: vec![SortedRun::new(99, [])],
             }),
         }];
 
@@ -6295,7 +6256,7 @@ mod tests {
                 .tree
                 .compacted
                 .first()
-                .is_some_and(|sr| sr.sst_views.len() == 1)
+                .is_some_and(|sr| sr.sst_views().len() == 1)
     }
 
     /// If a clock is provided, it will be advanced the clock by 60 seconds on each iteration to
@@ -6476,7 +6437,10 @@ mod tests {
             sr.is_some(),
             "output SR {destination} not found in manifest"
         );
-        assert_eq!(sr.unwrap().sst_views.first().unwrap().sst.id, output_sst.id);
+        assert_eq!(
+            sr.unwrap().sst_views().first().unwrap().sst.id,
+            output_sst.id
+        );
 
         // given: a Compacted SR0→SR1 compaction to validate the SR source path removed when not in L0
         let sr1_output_sst = fake_output_sst();
@@ -6508,7 +6472,7 @@ mod tests {
         let sr1 = core2.tree.compacted.iter().find(|sr| sr.id == 1);
         assert!(sr1.is_some(), "SR 1 should exist");
         assert_eq!(
-            sr1.unwrap().sst_views.first().unwrap().sst.id,
+            sr1.unwrap().sst_views().first().unwrap().sst.id,
             sr1_output_sst.id
         );
         let stored2 = fixture

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -1836,7 +1836,7 @@ mod tests {
             .tree
             .compacted
             .iter()
-            .flat_map(|sr| &sr.sst_views)
+            .flat_map(|sr| sr.sst_views.iter())
             .collect();
         assert_eq!(output_ssts.len(), 1);
         let view = output_ssts[0];
@@ -3896,7 +3896,7 @@ mod tests {
         ));
         let segment_sr = SortedRun {
             id: 7,
-            sst_views: vec![segment_sr_view.clone()],
+            sst_views: vec![segment_sr_view.clone()].into(),
         };
 
         let mut core = ManifestCore::new();
@@ -4184,7 +4184,8 @@ mod tests {
                     SsTableId::Compacted(Ulid::new()),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                ))],
+                ))]
+                .into(),
             },
             SortedRun {
                 id: 1,
@@ -4192,7 +4193,8 @@ mod tests {
                     SsTableId::Compacted(Ulid::new()),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                ))],
+                ))]
+                .into(),
             },
         ];
         stored_manifest.update(dirty).await.unwrap();
@@ -4287,7 +4289,8 @@ mod tests {
                     SsTableId::Compacted(Ulid::from_parts(10, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info.clone(),
-                ))],
+                ))]
+                .into(),
             },
             SortedRun {
                 id: 2,
@@ -4295,7 +4298,8 @@ mod tests {
                     SsTableId::Compacted(Ulid::from_parts(11, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     sr_info,
-                ))],
+                ))]
+                .into(),
             },
         ];
         let state = CompactorStateView {
@@ -4384,7 +4388,8 @@ mod tests {
                             SsTableId::Compacted(Ulid::from_parts(70, 0)),
                             SST_FORMAT_VERSION_LATEST,
                             sr_info.clone(),
-                        ))],
+                        ))]
+                        .into(),
                     },
                     SortedRun {
                         id: 3,
@@ -4392,7 +4397,8 @@ mod tests {
                             SsTableId::Compacted(Ulid::from_parts(30, 0)),
                             SST_FORMAT_VERSION_LATEST,
                             sr_info,
-                        ))],
+                        ))]
+                        .into(),
                     },
                 ],
             }),
@@ -4439,7 +4445,8 @@ mod tests {
                 SsTableId::Compacted(Ulid::from_parts(90, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 sr_info,
-            ))],
+            ))]
+            .into(),
         }];
         let state = CompactorStateView {
             compactions: None,
@@ -4475,7 +4482,8 @@ mod tests {
                 SsTableId::Compacted(Ulid::from_parts(40, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 sr_info,
-            ))],
+            ))]
+            .into(),
         }];
         let state = CompactorStateView {
             compactions: None,
@@ -4514,7 +4522,8 @@ mod tests {
                     SsTableId::Compacted(Ulid::from_parts(80, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     info.clone(),
-                ))],
+                ))]
+                .into(),
             },
             SortedRun {
                 id: 4,
@@ -4522,7 +4531,8 @@ mod tests {
                     SsTableId::Compacted(Ulid::from_parts(40, 0)),
                     SST_FORMAT_VERSION_LATEST,
                     info.clone(),
-                ))],
+                ))]
+                .into(),
             },
         ];
         core.segment_extractor_name = Some("test".into());
@@ -4539,7 +4549,8 @@ mod tests {
                             SsTableId::Compacted(Ulid::from_parts(30, 0)),
                             SST_FORMAT_VERSION_LATEST,
                             info.clone(),
-                        ))],
+                        ))]
+                        .into(),
                     }],
                 }),
             },
@@ -4556,7 +4567,8 @@ mod tests {
                                 SsTableId::Compacted(Ulid::from_parts(90, 0)),
                                 SST_FORMAT_VERSION_LATEST,
                                 info.clone(),
-                            ))],
+                            ))]
+                            .into(),
                         },
                         SortedRun {
                             id: 6,
@@ -4564,7 +4576,8 @@ mod tests {
                                 SsTableId::Compacted(Ulid::from_parts(60, 0)),
                                 SST_FORMAT_VERSION_LATEST,
                                 info,
-                            ))],
+                            ))]
+                            .into(),
                         },
                     ],
                 }),
@@ -4615,7 +4628,8 @@ mod tests {
                 SsTableId::Compacted(Ulid::from_parts(50, 0)),
                 SST_FORMAT_VERSION_LATEST,
                 info.clone(),
-            ))],
+            ))]
+            .into(),
         }];
         core.segment_extractor_name = Some("test".into());
         core.segments = vec![
@@ -5178,7 +5192,7 @@ mod tests {
         Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
         Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
             id: 1,
-            sst_views: vec![sr_first.clone(), sr_last.clone()],
+            sst_views: vec![sr_first.clone(), sr_last.clone()].into(),
         }];
 
         let compaction_id = Ulid::new();
@@ -5250,7 +5264,7 @@ mod tests {
         Arc::make_mut(&mut core.tree).l0 = VecDeque::from([l0.clone()]);
         Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
             id: 1,
-            sst_views: vec![sr_first, sr_last],
+            sst_views: vec![sr_first, sr_last].into(),
         }];
         let compaction_id = Ulid::new();
         fixture
@@ -5742,7 +5756,7 @@ mod tests {
         // but below the global max.
         Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
             id: 7,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         }];
         core.segments = vec![Segment {
             prefix: prefix.clone(),
@@ -5787,7 +5801,7 @@ mod tests {
             .core;
         Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
             id: 7,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         }];
         core.segments = vec![Segment {
             prefix: prefix.clone(),
@@ -5840,7 +5854,7 @@ mod tests {
                 l0: VecDeque::from(vec![make_view(l0_view)]),
                 compacted: vec![SortedRun {
                     id: 7,
-                    sst_views: Vec::new(),
+                    sst_views: Vec::new().into(),
                 }],
             }),
         }];
@@ -6027,7 +6041,7 @@ mod tests {
             .core;
         Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
             id: 99,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         }];
         let prefix = Bytes::from_static(b"seg/");
         core.segments = vec![Segment {
@@ -6070,7 +6084,7 @@ mod tests {
         // its destination but does not list it among its sources.
         Arc::make_mut(&mut core.tree).compacted = vec![SortedRun {
             id: 7,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         }];
         // Seed SR(99) into the segment so the source-existence check passes and
         // destination-overwrite is the rejection reason.
@@ -6083,7 +6097,7 @@ mod tests {
                 l0: VecDeque::new(),
                 compacted: vec![SortedRun {
                     id: 99,
-                    sst_views: Vec::new(),
+                    sst_views: Vec::new().into(),
                 }],
             }),
         }];

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -765,16 +765,13 @@ impl TokioCompactionExecutorInner {
             );
             return Err(SlateDBError::CompactorExecutorFailed);
         }
-        Ok(SortedRun {
-            id: destination,
-            sst_views: output_ssts
-                .into_iter()
-                .map(|sst| {
-                    let id = self.rand.rng().gen_ulid(self.clock.as_ref());
-                    SsTableView::new(id, sst.clone())
-                })
-                .collect(),
-        })
+        Ok(SortedRun::new(
+            destination,
+            output_ssts.into_iter().map(|sst| {
+                let id = self.rand.rng().gen_ulid(self.clock.as_ref());
+                SsTableView::new(id, sst.clone())
+            }),
+        ))
     }
 
     /// Runs the merge for one key range of a compaction job and returns the
@@ -1522,10 +1519,10 @@ mod tests {
                     sr_ssts.extend(ssts);
                     all_entries.extend(entries.iter().cloned());
                 }
-                sorted_runs.push(SortedRun {
-                    id: sr_id as u32,
-                    sst_views: sr_ssts.into_iter().map(SsTableView::identity).collect(),
-                });
+                sorted_runs.push(SortedRun::new(
+                    sr_id as u32,
+                    sr_ssts.into_iter().map(SsTableView::identity),
+                ));
             }
         }
 
@@ -1749,7 +1746,7 @@ mod tests {
                     .unwrap();
 
                 let mut expected_entries = Vec::new();
-                for view in full_run.sst_views.iter() {
+                for view in full_run.sst_views() {
                     let mut iter = SstIterator::new(
                         SstView::Owned(
                             Box::new(SsTableView::identity(view.sst.clone())),
@@ -1801,7 +1798,7 @@ mod tests {
                         .unwrap();
 
                     let mut resumed_entries = Vec::new();
-                    for view in resumed_run.sst_views.iter() {
+                    for view in resumed_run.sst_views() {
                         let mut iter = SstIterator::new(
                             SstView::Owned(
                                 Box::new(SsTableView::identity(view.sst.clone())),
@@ -1828,7 +1825,7 @@ mod tests {
     /// runs can be compared for byte-identical merged output.
     async fn read_run_entries(table_store: &Arc<TableStore>, run: &SortedRun) -> Vec<RowEntry> {
         let mut entries = Vec::new();
-        for sst in run.sst_views.iter() {
+        for sst in run.sst_views() {
             let mut iter = SstIterator::new(
                 SstView::Borrowed(sst, BytesRange::from(..)),
                 table_store.clone(),
@@ -2079,7 +2076,7 @@ mod tests {
             .sum();
         assert_eq!(
             final_output,
-            split.sst_views.len(),
+            split.sst_views().len(),
             "final snapshot should capture every output SST"
         );
     }
@@ -2148,7 +2145,7 @@ mod tests {
             );
             for sst in snapshot.iter().flat_map(|s| s.output_ssts()) {
                 assert!(
-                    resumed.sst_views.iter().any(|v| v.sst.id == sst.id),
+                    resumed.sst_views().iter().any(|v| v.sst.id == sst.id),
                     "previously recorded subcompaction output SST was not reused"
                 );
             }
@@ -2159,7 +2156,7 @@ mod tests {
             if index == snapshots.len() - 1 {
                 let recorded: usize = snapshot.iter().map(|s| s.output_ssts().len()).sum();
                 assert_eq!(
-                    resumed.sst_views.len(),
+                    resumed.sst_views().len(),
                     recorded,
                     "resuming a completed compaction must not produce new SSTs"
                 );
@@ -2740,7 +2737,7 @@ mod tests {
 
         // then: multiple output SSTs were produced (proving real boundaries and
         // background closes ran) ...
-        let result_ssts = &result.sst_views;
+        let result_ssts = result.sst_views();
         assert!(
             result_ssts.len() >= 2,
             "expected multiple output SSTs, got {}",
@@ -2922,8 +2919,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, result.sst_views.len());
-        let sst = result.sst_views[0].clone();
+        assert_eq!(1, result.sst_views().len());
+        let sst = result.sst_views()[0].clone();
         let mut iter = SstIterator::new(
             SstView::Borrowed(&sst, BytesRange::from(..)),
             table_store.clone(),
@@ -3061,8 +3058,8 @@ mod tests {
         let result = ctx.run_compaction(vec![l0], true, None).await.unwrap();
 
         // Verify the output SST
-        assert_eq!(1, result.sst_views.len());
-        let sst = result.sst_views[0].clone();
+        assert_eq!(1, result.sst_views().len());
+        let sst = result.sst_views()[0].clone();
         let mut iter = SstIterator::new(
             SstView::Borrowed(&sst, BytesRange::from(..)),
             table_store.clone(),

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -1749,7 +1749,7 @@ mod tests {
                     .unwrap();
 
                 let mut expected_entries = Vec::new();
-                for view in &full_run.sst_views {
+                for view in full_run.sst_views.iter() {
                     let mut iter = SstIterator::new(
                         SstView::Owned(
                             Box::new(SsTableView::identity(view.sst.clone())),
@@ -1801,7 +1801,7 @@ mod tests {
                         .unwrap();
 
                     let mut resumed_entries = Vec::new();
-                    for view in &resumed_run.sst_views {
+                    for view in resumed_run.sst_views.iter() {
                         let mut iter = SstIterator::new(
                             SstView::Owned(
                                 Box::new(SsTableView::identity(view.sst.clone())),
@@ -1828,7 +1828,7 @@ mod tests {
     /// runs can be compared for byte-identical merged output.
     async fn read_run_entries(table_store: &Arc<TableStore>, run: &SortedRun) -> Vec<RowEntry> {
         let mut entries = Vec::new();
-        for sst in &run.sst_views {
+        for sst in run.sst_views.iter() {
             let mut iter = SstIterator::new(
                 SstView::Borrowed(sst, BytesRange::from(..)),
                 table_store.clone(),
@@ -2748,7 +2748,7 @@ mod tests {
         );
         // ... and the merged output preserves every key in ascending order.
         let mut read_back = Vec::new();
-        for view in result_ssts {
+        for view in result_ssts.iter() {
             let mut iter = SstIterator::new(
                 SstView::Owned(
                     Box::new(SsTableView::identity(view.sst.clone())),

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -527,7 +527,7 @@ impl Compaction {
         sst_views.extend(
             self.get_sorted_runs(db_state)
                 .iter()
-                .flat_map(|sr| sr.sst_views.iter().cloned()),
+                .flat_map(|sr| sr.sst_views().iter().cloned()),
         );
         sst_views.sort_by(|left, right| {
             left.compacted_effective_range()
@@ -542,10 +542,7 @@ impl Compaction {
                     .intersect(pair[1].compacted_effective_range())
                     .is_none()
             }))
-        .then_some(SortedRun {
-            id: destination,
-            sst_views: sst_views.into(),
-        })
+        .then_some(SortedRun::new(destination, sst_views))
     }
 
     /// The stable id (ULID) used to track this compaction across messages and attempts.
@@ -1310,10 +1307,8 @@ mod tests {
         let sr_last = bounded_sst_view(3, b"z", b"z");
         let mut db_state = ManifestCore::new();
         Arc::make_mut(&mut db_state.tree).l0 = VecDeque::from([l0.clone()]);
-        Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![sr_first.clone(), sr_last.clone()].into(),
-        }];
+        Arc::make_mut(&mut db_state.tree).compacted =
+            vec![SortedRun::new(1, [sr_first.clone(), sr_last.clone()])];
         let compaction = Compaction::new(
             Ulid::new(),
             CompactionSpec::new(vec![SstView(l0.id), SourceId::SortedRun(1)], 2),
@@ -1326,7 +1321,7 @@ mod tests {
         assert_eq!(output.id, 2);
         assert_eq!(
             output
-                .sst_views
+                .sst_views()
                 .iter()
                 .map(|view| view.id)
                 .collect::<Vec<_>>(),
@@ -1340,10 +1335,7 @@ mod tests {
         let sr_view = bounded_sst_view(2, b"m", b"z");
         let mut db_state = ManifestCore::new();
         Arc::make_mut(&mut db_state.tree).l0 = VecDeque::from([l0.clone()]);
-        Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![sr_view].into(),
-        }];
+        Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun::new(1, [sr_view])];
         let compaction = Compaction::new(
             Ulid::new(),
             CompactionSpec::new(vec![SstView(l0.id), SourceId::SortedRun(1)], 2),
@@ -1664,11 +1656,7 @@ mod tests {
             .expect("failed to add compaction");
 
         // when:
-        let compacted_ssts = before_compaction.tree.l0.iter().cloned().collect();
-        let sr = SortedRun {
-            id: 0,
-            sst_views: compacted_ssts,
-        };
+        let sr = SortedRun::new(0, before_compaction.tree.l0.iter().cloned());
         state.finish_compaction(compaction_id, sr.clone());
 
         // then:
@@ -1679,14 +1667,14 @@ mod tests {
         assert_eq!(state.db_state().tree.l0.len(), 0);
         assert_eq!(state.db_state().tree.compacted.len(), 1);
         assert_eq!(state.db_state().tree.compacted.first().unwrap().id, sr.id);
-        let expected_ids: Vec<SsTableId> = sr.sst_views.iter().map(|h| h.sst.id).collect();
+        let expected_ids: Vec<SsTableId> = sr.sst_views().iter().map(|h| h.sst.id).collect();
         let found_ids: Vec<SsTableId> = state
             .db_state()
             .tree
             .compacted
             .first()
             .unwrap()
-            .sst_views
+            .sst_views()
             .iter()
             .map(|h| h.sst.id)
             .collect();
@@ -1728,10 +1716,7 @@ mod tests {
             .add_compaction(Compaction::new(compaction_id, spec))
             .expect("failed to add compaction");
 
-        let sr = SortedRun {
-            id: 0,
-            sst_views: before_compaction.tree.l0.iter().cloned().collect(),
-        };
+        let sr = SortedRun::new(0, before_compaction.tree.l0.iter().cloned());
         state.finish_compaction(compaction_id, sr);
 
         let external_dbs = &state.manifest().value.external_dbs;
@@ -1762,11 +1747,7 @@ mod tests {
             .expect("failed to add compaction");
 
         // when:
-        let compacted_ssts = before_compaction.tree.l0.iter().cloned().collect();
-        let sr = SortedRun {
-            id: 0,
-            sst_views: compacted_ssts,
-        };
+        let sr = SortedRun::new(0, before_compaction.tree.l0.iter().cloned());
         state.finish_compaction(compaction_id, sr);
 
         // then:
@@ -1851,10 +1832,7 @@ mod tests {
             .expect("failed to add compaction");
         state.finish_compaction(
             compaction_id,
-            SortedRun {
-                id: 0,
-                sst_views: vec![original_l0s.back().unwrap().clone()].into(),
-            },
+            SortedRun::new(0, [original_l0s.back().unwrap().clone()]),
         );
         // open a new db and write another l0
         let db = build_db(os.clone(), rt.handle());
@@ -1918,10 +1896,7 @@ mod tests {
             .expect("failed to add compaction");
         state.finish_compaction(
             compaction_id,
-            SortedRun {
-                id: 0,
-                sst_views: original_l0s.iter().cloned().collect(),
-            },
+            SortedRun::new(0, original_l0s.iter().cloned()),
         );
         assert_eq!(state.db_state().tree.l0.len(), 0);
         // open a new db and write another l0
@@ -2212,7 +2187,7 @@ mod tests {
     fn sorted_run_to_description(sr: &SortedRun) -> SortedRunDescription {
         SortedRunDescription {
             id: sr.id,
-            ssts: sr.sst_views.iter().map(|h| h.sst.id).collect(),
+            ssts: sr.sst_views().iter().map(|h| h.sst.id).collect(),
         }
     }
 
@@ -2250,14 +2225,8 @@ mod tests {
         // Add a named segment with two compacted SRs (ids 5 and 3, list-position
         // ordered newest-first as per ManifestCore conventions).
         let prefix = Bytes::from_static(b"hour=12/");
-        let sr5 = SortedRun {
-            id: 5,
-            sst_views: Vec::new().into(),
-        };
-        let sr3 = SortedRun {
-            id: 3,
-            sst_views: Vec::new().into(),
-        };
+        let sr5 = SortedRun::new(5, []);
+        let sr3 = SortedRun::new(3, []);
         let segment = Segment {
             prefix: prefix.clone(),
             tree: Arc::new(LsmTreeState {
@@ -2283,10 +2252,7 @@ mod tests {
             .expect("failed to add compaction");
 
         // Finish the compaction with a fresh output SR.
-        let output = SortedRun {
-            id: 7,
-            sst_views: Vec::new().into(),
-        };
+        let output = SortedRun::new(7, []);
         state.finish_compaction(compaction_id, output);
 
         // The segment's compacted list now holds only the new SR(7).
@@ -2317,10 +2283,7 @@ mod tests {
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
-                compacted: vec![SortedRun {
-                    id: 7,
-                    sst_views: Vec::new().into(),
-                }],
+                compacted: vec![SortedRun::new(7, [])],
             }),
         }];
 
@@ -2333,10 +2296,7 @@ mod tests {
         // Segment dropped after submission, before finish.
         state.manifest.value.core.segments = Vec::new();
 
-        let output = SortedRun {
-            id: 7,
-            sst_views: Vec::new().into(),
-        };
+        let output = SortedRun::new(7, []);
         state.finish_compaction(compaction_id, output);
 
         let compaction = state
@@ -2358,10 +2318,7 @@ mod tests {
 
         // Seed real sources so the source-isolation check passes for both
         // submissions. Root tree gets SR(99); segment "seg/" gets SR(100).
-        Arc::make_mut(&mut state.manifest.value.core.tree).compacted = vec![SortedRun {
-            id: 99,
-            sst_views: Vec::new().into(),
-        }];
+        Arc::make_mut(&mut state.manifest.value.core.tree).compacted = vec![SortedRun::new(99, [])];
         let prefix = Bytes::from_static(b"seg/");
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),
@@ -2369,10 +2326,7 @@ mod tests {
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::new(),
-                compacted: vec![SortedRun {
-                    id: 100,
-                    sst_views: Vec::new().into(),
-                }],
+                compacted: vec![SortedRun::new(100, [])],
             }),
         }];
 
@@ -2401,10 +2355,7 @@ mod tests {
 
         // Seed SR(7) in the root tree so the source-isolation check passes
         // for the first submission; the spec rewrites that SR (destination=7).
-        Arc::make_mut(&mut state.manifest.value.core.tree).compacted = vec![SortedRun {
-            id: 7,
-            sst_views: Vec::new().into(),
-        }];
+        Arc::make_mut(&mut state.manifest.value.core.tree).compacted = vec![SortedRun::new(7, [])];
 
         let first_id = rand.rng().gen_ulid(system_clock.as_ref());
         let first = CompactionSpec::new(vec![SourceId::SortedRun(7)], 7);
@@ -2559,10 +2510,7 @@ mod tests {
         // Two L0s (newest first) and one SR in the segment.
         let l0_newer = drain_test_view(2);
         let l0_older = drain_test_view(1);
-        let sr = SortedRun {
-            id: 5,
-            sst_views: Vec::new().into(),
-        };
+        let sr = SortedRun::new(5, []);
         let prefix = Bytes::from_static(b"hour=10/");
         state.manifest.value.core.segments = vec![Segment {
             prefix: prefix.clone(),

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -526,8 +526,8 @@ impl Compaction {
         let mut sst_views = self.get_l0_sst_views(db_state);
         sst_views.extend(
             self.get_sorted_runs(db_state)
-                .into_iter()
-                .flat_map(|sr| sr.sst_views),
+                .iter()
+                .flat_map(|sr| sr.sst_views.iter().cloned()),
         );
         sst_views.sort_by(|left, right| {
             left.compacted_effective_range()
@@ -544,7 +544,7 @@ impl Compaction {
             }))
         .then_some(SortedRun {
             id: destination,
-            sst_views,
+            sst_views: sst_views.into(),
         })
     }
 
@@ -1312,7 +1312,7 @@ mod tests {
         Arc::make_mut(&mut db_state.tree).l0 = VecDeque::from([l0.clone()]);
         Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun {
             id: 1,
-            sst_views: vec![sr_first.clone(), sr_last.clone()],
+            sst_views: vec![sr_first.clone(), sr_last.clone()].into(),
         }];
         let compaction = Compaction::new(
             Ulid::new(),
@@ -1342,7 +1342,7 @@ mod tests {
         Arc::make_mut(&mut db_state.tree).l0 = VecDeque::from([l0.clone()]);
         Arc::make_mut(&mut db_state.tree).compacted = vec![SortedRun {
             id: 1,
-            sst_views: vec![sr_view],
+            sst_views: vec![sr_view].into(),
         }];
         let compaction = Compaction::new(
             Ulid::new(),
@@ -1853,7 +1853,7 @@ mod tests {
             compaction_id,
             SortedRun {
                 id: 0,
-                sst_views: vec![original_l0s.back().unwrap().clone()],
+                sst_views: vec![original_l0s.back().unwrap().clone()].into(),
             },
         );
         // open a new db and write another l0
@@ -1920,7 +1920,7 @@ mod tests {
             compaction_id,
             SortedRun {
                 id: 0,
-                sst_views: original_l0s.clone().into(),
+                sst_views: original_l0s.iter().cloned().collect(),
             },
         );
         assert_eq!(state.db_state().tree.l0.len(), 0);
@@ -2252,11 +2252,11 @@ mod tests {
         let prefix = Bytes::from_static(b"hour=12/");
         let sr5 = SortedRun {
             id: 5,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         };
         let sr3 = SortedRun {
             id: 3,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         };
         let segment = Segment {
             prefix: prefix.clone(),
@@ -2285,7 +2285,7 @@ mod tests {
         // Finish the compaction with a fresh output SR.
         let output = SortedRun {
             id: 7,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         };
         state.finish_compaction(compaction_id, output);
 
@@ -2319,7 +2319,7 @@ mod tests {
                 l0: VecDeque::new(),
                 compacted: vec![SortedRun {
                     id: 7,
-                    sst_views: Vec::new(),
+                    sst_views: Vec::new().into(),
                 }],
             }),
         }];
@@ -2335,7 +2335,7 @@ mod tests {
 
         let output = SortedRun {
             id: 7,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         };
         state.finish_compaction(compaction_id, output);
 
@@ -2360,7 +2360,7 @@ mod tests {
         // submissions. Root tree gets SR(99); segment "seg/" gets SR(100).
         Arc::make_mut(&mut state.manifest.value.core.tree).compacted = vec![SortedRun {
             id: 99,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         }];
         let prefix = Bytes::from_static(b"seg/");
         state.manifest.value.core.segments = vec![Segment {
@@ -2371,7 +2371,7 @@ mod tests {
                 l0: VecDeque::new(),
                 compacted: vec![SortedRun {
                     id: 100,
-                    sst_views: Vec::new(),
+                    sst_views: Vec::new().into(),
                 }],
             }),
         }];
@@ -2403,7 +2403,7 @@ mod tests {
         // for the first submission; the spec rewrites that SR (destination=7).
         Arc::make_mut(&mut state.manifest.value.core.tree).compacted = vec![SortedRun {
             id: 7,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         }];
 
         let first_id = rand.rng().gen_ulid(system_clock.as_ref());
@@ -2561,7 +2561,7 @@ mod tests {
         let l0_older = drain_test_view(1);
         let sr = SortedRun {
             id: 5,
-            sst_views: Vec::new(),
+            sst_views: Vec::new().into(),
         };
         let prefix = Bytes::from_static(b"hour=10/");
         state.manifest.value.core.segments = vec![Segment {

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -9222,7 +9222,7 @@ mod tests {
                         .tree
                         .compacted
                         .first()
-                        .is_some_and(|sr| sr.sst_views.len() > 1)
+                        .is_some_and(|sr| sr.sst_views().len() > 1)
                     {
                         break;
                     }
@@ -9380,7 +9380,7 @@ mod tests {
                         .tree
                         .compacted
                         .first()
-                        .is_some_and(|sr| sr.sst_views.len() > 1)
+                        .is_some_and(|sr| sr.sst_views().len() > 1)
                     {
                         break;
                     }
@@ -11595,7 +11595,7 @@ mod tests {
                     .manifest()
                     .compacted()
                     .iter()
-                    .flat_map(|sr| sr.sst_views.iter())
+                    .flat_map(|sr| sr.sst_views().iter())
                     .map(|v| v.sst.id)
                     .filter(|id| !l0_ids.contains(id))
                     .collect()

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -3159,7 +3159,7 @@ mod tests {
                 l0: VecDeque::from(vec![view(1)]),
                 compacted: vec![SortedRun {
                     id: 0,
-                    sst_views: vec![view(4)],
+                    sst_views: vec![view(4)].into(),
                 }],
             },
         )];

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -3157,10 +3157,7 @@ mod tests {
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![view(1)]),
-                compacted: vec![SortedRun {
-                    id: 0,
-                    sst_views: vec![view(4)].into(),
-                }],
+                compacted: vec![SortedRun::new(0, [view(4)])],
             },
         )];
         assert!(

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -492,7 +492,11 @@ pub struct SortedRun {
     /// The unique identifier for this sorted run.
     pub id: u32,
     /// The list of SSTable views in this sorted run.
-    pub sst_views: Vec<SsTableView>,
+    ///
+    /// Held behind an `Arc` so cloning a `SortedRun` (e.g. per read in the
+    /// scan path) is a single refcount bump rather than a deep clone of every
+    /// view's `Bytes` handles.
+    pub sst_views: Arc<[SsTableView]>,
 }
 
 impl SortedRun {
@@ -647,12 +651,12 @@ impl SortedRun {
         &self.sst_views[matching_range]
     }
 
-    pub(crate) fn into_tables_covering_range(
-        mut self,
-        range: &BytesRange,
-    ) -> VecDeque<SsTableView> {
+    pub(crate) fn into_tables_covering_range(self, range: &BytesRange) -> VecDeque<SsTableView> {
         let matching_range = self.table_idx_covering_range(range);
-        self.sst_views.drain(matching_range).collect()
+        // `sst_views` is shared behind an `Arc`, so we clone only the few
+        // covering views rather than draining the whole run. The full slice
+        // is released with a single refcount decrement when `self` drops.
+        self.sst_views[matching_range].iter().cloned().collect()
     }
 }
 
@@ -1182,7 +1186,8 @@ mod tests {
                 create_compacted_sst_view_with_bounds(b"k", Some(b"k")),
                 create_compacted_sst_view_with_bounds(b"k", Some(b"m")),
                 create_compacted_sst_view_with_bounds(b"z", Some(b"z")),
-            ],
+            ]
+            .into(),
         };
 
         let covering_tables = sorted_run.tables_covering_point_key(b"k");
@@ -1210,7 +1215,7 @@ mod tests {
         }
         SortedRun {
             id,
-            sst_views: ssts,
+            sst_views: ssts.into(),
         }
     }
 

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -496,10 +496,23 @@ pub struct SortedRun {
     /// Held behind an `Arc` so cloning a `SortedRun` (e.g. per read in the
     /// scan path) is a single refcount bump rather than a deep clone of every
     /// view's `Bytes` handles.
-    pub sst_views: Arc<[SsTableView]>,
+    sst_views: Arc<[SsTableView]>,
 }
 
 impl SortedRun {
+    /// Create a sorted run from an ordered collection of SSTable views.
+    pub fn new(id: u32, sst_views: impl IntoIterator<Item = SsTableView>) -> Self {
+        Self {
+            id,
+            sst_views: sst_views.into_iter().collect(),
+        }
+    }
+
+    /// Return the ordered SSTable views in this sorted run.
+    pub fn sst_views(&self) -> &[SsTableView] {
+        &self.sst_views
+    }
+
     /// Estimate the total size of all SSTables in this sorted run.
     pub fn estimate_size(&self) -> u64 {
         self.sst_views.iter().map(|sst| sst.estimate_size()).sum()
@@ -1145,6 +1158,14 @@ mod tests {
             let sorted_first_keys: BTreeSet<Bytes> = table_first_keys.into_iter().collect();
             let sorted_run = create_sorted_run(0, &sorted_first_keys);
             let covering_tables = sorted_run.tables_covering_range(range.clone());
+            let borrowed_ids: Vec<_> = covering_tables.iter().map(|view| view.id).collect();
+            let owned_ids: Vec<_> = sorted_run
+                .clone()
+                .into_tables_covering_range(&range)
+                .iter()
+                .map(|view| view.id)
+                .collect();
+            assert_eq!(owned_ids, borrowed_ids);
             let first_key = sorted_first_keys.first().unwrap().clone();
 
             let range_start_key = test_utils::bound_as_option(range.start_bound())
@@ -1179,16 +1200,15 @@ mod tests {
 
     #[test]
     fn test_sorted_run_collect_tables_for_point_key() {
-        let sorted_run = SortedRun {
-            id: 0,
-            sst_views: vec![
+        let sorted_run = SortedRun::new(
+            0,
+            [
                 create_compacted_sst_view_with_bounds(b"a", Some(b"k")),
                 create_compacted_sst_view_with_bounds(b"k", Some(b"k")),
                 create_compacted_sst_view_with_bounds(b"k", Some(b"m")),
                 create_compacted_sst_view_with_bounds(b"z", Some(b"z")),
-            ]
-            .into(),
-        };
+            ],
+        );
 
         let covering_tables = sorted_run.tables_covering_point_key(b"k");
         assert_eq!(covering_tables.len(), 3);
@@ -1208,15 +1228,21 @@ mod tests {
         assert!(sorted_run.tables_covering_point_key(b"0").is_empty());
     }
 
+    #[test]
+    fn test_sorted_run_clone_shares_sst_views() {
+        let sorted_run = SortedRun::new(0, [create_compacted_sst_view(Some(Bytes::from("a")))]);
+        let cloned = sorted_run.clone();
+
+        assert!(Arc::ptr_eq(&sorted_run.sst_views, &cloned.sst_views));
+        assert_eq!(sorted_run.sst_views(), cloned.sst_views());
+    }
+
     fn create_sorted_run(id: u32, first_keys: &BTreeSet<Bytes>) -> SortedRun {
         let mut ssts = Vec::new();
         for first_key in first_keys {
             ssts.push(create_compacted_sst_view(Some(first_key.clone())));
         }
-        SortedRun {
-            id,
-            sst_views: ssts.into(),
-        }
+        SortedRun::new(id, ssts)
     }
 
     fn create_compacted_sst_view(first_entry: Option<Bytes>) -> SsTableView {

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -277,10 +277,7 @@ impl FlatBufferManifestCodec {
                     manifest_sst.visible_range().map(Self::decode_bytes_range),
                 ));
             }
-            compacted.push(db_state::SortedRun {
-                id: manifest_sr.id(),
-                sst_views: ssts.into(),
-            })
+            compacted.push(db_state::SortedRun::new(manifest_sr.id(), ssts))
         }
         let checkpoints: Vec<checkpoint::Checkpoint> = manifest
             .checkpoints()
@@ -478,10 +475,7 @@ impl FlatBufferManifestCodec {
                         .iter()
                         .map(|view| Self::decode_compacted_sst_view(&view, sst_lookup))
                         .collect::<Result<Vec<_>, _>>()?;
-                    Ok(db_state::SortedRun {
-                        id: sr.id(),
-                        sst_views: ssts.into(),
-                    })
+                    Ok(db_state::SortedRun::new(sr.id(), ssts))
                 },
             )
             .collect()
@@ -955,7 +949,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         &mut self,
         sorted_run: &db_state::SortedRun,
     ) -> WIPOffset<SortedRunV2<'b>> {
-        let ssts = self.add_compacted_sst_views(sorted_run.sst_views.iter());
+        let ssts = self.add_compacted_sst_views(sorted_run.sst_views().iter());
         SortedRunV2::create(
             &mut self.builder,
             &SortedRunV2Args {
@@ -1022,7 +1016,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
         sorted_run: &db_state::SortedRun,
     ) -> WIPOffset<FbSortedRunV1<'b>> {
         let ssts: Vec<WIPOffset<CompactedSsTable>> = sorted_run
-            .sst_views
+            .sst_views()
             .iter()
             .map(|view| self.add_compacted_sst_from_view(view))
             .collect();
@@ -1290,7 +1284,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
                 }
             }
             for sr in tree.compacted.iter() {
-                for view in sr.sst_views.iter() {
+                for view in sr.sst_views() {
                     if let SsTableId::Compacted(ulid) = view.sst.id {
                         unique_ssts.entry(ulid).or_insert(&view.sst);
                     }
@@ -1676,23 +1670,21 @@ mod tests {
             new_sst_handle(b"a", Some(BytesRange::from_ref("c"..="d"))),
         ]);
         Arc::make_mut(&mut manifest.core.tree).compacted = vec![
-            SortedRun {
-                id: 0,
-                sst_views: vec![
+            SortedRun::new(
+                0,
+                [
                     new_sst_handle(b"a", None),
                     new_sst_handle(b"d", Some(BytesRange::from_ref("e".."f"))),
-                ]
-                .into(),
-            },
-            SortedRun {
-                id: 0,
-                sst_views: vec![
+                ],
+            ),
+            SortedRun::new(
+                0,
+                [
                     new_sst_handle(b"a", None),
                     new_sst_handle(b"c", Some(BytesRange::from_ref("c"..))),
                     new_sst_handle(b"d", Some(BytesRange::from_ref("e".."f"))),
-                ]
-                .into(),
-            },
+                ],
+            ),
         ];
 
         let codec = FlatBufferManifestCodec {};
@@ -1728,11 +1720,11 @@ mod tests {
         let root = Arc::make_mut(&mut manifest.core.tree);
         root.l0 = (0..16).map(new_sst_view).collect();
         root.compacted = (0..4)
-            .map(|run| SortedRun {
-                id: run as u32,
-                sst_views: (0..8)
-                    .map(|offset| new_sst_view(100 + run * 8 + offset))
-                    .collect(),
+            .map(|run| {
+                SortedRun::new(
+                    run as u32,
+                    (0..8).map(|offset| new_sst_view(100 + run * 8 + offset)),
+                )
             })
             .collect();
         manifest.core.segment_extractor_name = Some("test".to_string());
@@ -1742,12 +1734,10 @@ mod tests {
                     l0: (0..4)
                         .map(|offset| new_sst_view(1_000 + segment * 16 + offset))
                         .collect(),
-                    compacted: vec![SortedRun {
-                        id: 100 + segment as u32,
-                        sst_views: (0..4)
-                            .map(|offset| new_sst_view(2_000 + segment * 16 + offset))
-                            .collect(),
-                    }],
+                    compacted: vec![SortedRun::new(
+                        100 + segment as u32,
+                        (0..4).map(|offset| new_sst_view(2_000 + segment * 16 + offset)),
+                    )],
                     ..Default::default()
                 };
                 Segment {
@@ -1928,10 +1918,7 @@ mod tests {
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
-                    compacted: vec![SortedRun {
-                        id: 0,
-                        sst_views: vec![new_sst_view(), new_sst_view()].into(),
-                    }],
+                    compacted: vec![SortedRun::new(0, [new_sst_view(), new_sst_view()])],
                 }),
             },
             Segment {
@@ -1940,10 +1927,7 @@ mod tests {
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![new_sst_view(), new_sst_view()]),
-                    compacted: vec![SortedRun {
-                        id: 1,
-                        sst_views: vec![new_sst_view()].into(),
-                    }],
+                    compacted: vec![SortedRun::new(1, [new_sst_view()])],
                 }),
             },
         ];
@@ -2325,18 +2309,17 @@ mod tests {
                     ..Default::default()
                 },
             ))]);
-        Arc::make_mut(&mut manifest.core.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+        Arc::make_mut(&mut manifest.core.tree).compacted = vec![SortedRun::new(
+            1,
+            [SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(ulid::Ulid::new()),
                 SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::from_static(b"srkey")),
                     ..Default::default()
                 },
-            ))]
-            .into(),
-        }];
+            ))],
+        )];
         let codec = FlatBufferManifestCodec {};
 
         // when:
@@ -2349,7 +2332,7 @@ mod tests {
             SST_FORMAT_VERSION_LATEST
         );
         assert_eq!(
-            decoded.core.tree.compacted[0].sst_views[0]
+            decoded.core.tree.compacted[0].sst_views()[0]
                 .sst
                 .format_version,
             SST_FORMAT_VERSION_LATEST
@@ -2455,7 +2438,7 @@ mod tests {
             super::ORIGINAL_SST_FORMAT_VERSION
         );
         assert_eq!(
-            decoded.core.tree.compacted[0].sst_views[0]
+            decoded.core.tree.compacted[0].sst_views()[0]
                 .sst
                 .format_version,
             super::ORIGINAL_SST_FORMAT_VERSION
@@ -2777,22 +2760,20 @@ mod tests {
             new_view(b"b", Some(BytesRange::from_ref("c"..="d"))),
         ]);
         Arc::make_mut(&mut manifest.core.tree).compacted = vec![
-            SortedRun {
-                id: 1,
-                sst_views: vec![
+            SortedRun::new(
+                1,
+                [
                     new_view(b"e", None),
                     new_view(b"f", Some(BytesRange::from_ref("g".."h"))),
-                ]
-                .into(),
-            },
-            SortedRun {
-                id: 2,
-                sst_views: vec![
+                ],
+            ),
+            SortedRun::new(
+                2,
+                [
                     new_view(b"i", None),
                     new_view(b"j", Some(BytesRange::from_ref("k"..))),
-                ]
-                .into(),
-            },
+                ],
+            ),
         ];
         Arc::make_mut(&mut manifest.core.tree).last_compacted_l0_sst_view_id =
             Some(manifest.core.tree.l0[0].id);
@@ -2853,18 +2834,17 @@ mod tests {
                     ..Default::default()
                 },
             ))]);
-        Arc::make_mut(&mut manifest.core.tree).compacted = vec![SortedRun {
-            id: 1,
-            sst_views: vec![SsTableView::identity(SsTableHandle::new(
+        Arc::make_mut(&mut manifest.core.tree).compacted = vec![SortedRun::new(
+            1,
+            [SsTableView::identity(SsTableHandle::new(
                 SsTableId::Compacted(ulid::Ulid::new()),
                 SST_FORMAT_VERSION_LATEST,
                 SsTableInfo {
                     first_entry: Some(Bytes::from_static(b"srkey")),
                     ..Default::default()
                 },
-            ))]
-            .into(),
-        }];
+            ))],
+        )];
         manifest.writer_epoch = 5;
         manifest.compactor_epoch = 3;
 

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -279,7 +279,7 @@ impl FlatBufferManifestCodec {
             }
             compacted.push(db_state::SortedRun {
                 id: manifest_sr.id(),
-                sst_views: ssts,
+                sst_views: ssts.into(),
             })
         }
         let checkpoints: Vec<checkpoint::Checkpoint> = manifest
@@ -477,10 +477,10 @@ impl FlatBufferManifestCodec {
                         .ssts()
                         .iter()
                         .map(|view| Self::decode_compacted_sst_view(&view, sst_lookup))
-                        .collect::<Result<_, _>>()?;
+                        .collect::<Result<Vec<_>, _>>()?;
                     Ok(db_state::SortedRun {
                         id: sr.id(),
-                        sst_views: ssts,
+                        sst_views: ssts.into(),
                     })
                 },
             )
@@ -1681,7 +1681,8 @@ mod tests {
                 sst_views: vec![
                     new_sst_handle(b"a", None),
                     new_sst_handle(b"d", Some(BytesRange::from_ref("e".."f"))),
-                ],
+                ]
+                .into(),
             },
             SortedRun {
                 id: 0,
@@ -1689,7 +1690,8 @@ mod tests {
                     new_sst_handle(b"a", None),
                     new_sst_handle(b"c", Some(BytesRange::from_ref("c"..))),
                     new_sst_handle(b"d", Some(BytesRange::from_ref("e".."f"))),
-                ],
+                ]
+                .into(),
             },
         ];
 
@@ -1928,7 +1930,7 @@ mod tests {
                     l0: VecDeque::new(),
                     compacted: vec![SortedRun {
                         id: 0,
-                        sst_views: vec![new_sst_view(), new_sst_view()],
+                        sst_views: vec![new_sst_view(), new_sst_view()].into(),
                     }],
                 }),
             },
@@ -1940,7 +1942,7 @@ mod tests {
                     l0: VecDeque::from(vec![new_sst_view(), new_sst_view()]),
                     compacted: vec![SortedRun {
                         id: 1,
-                        sst_views: vec![new_sst_view()],
+                        sst_views: vec![new_sst_view()].into(),
                     }],
                 }),
             },
@@ -2332,7 +2334,8 @@ mod tests {
                     first_entry: Some(Bytes::from_static(b"srkey")),
                     ..Default::default()
                 },
-            ))],
+            ))]
+            .into(),
         }];
         let codec = FlatBufferManifestCodec {};
 
@@ -2779,14 +2782,16 @@ mod tests {
                 sst_views: vec![
                     new_view(b"e", None),
                     new_view(b"f", Some(BytesRange::from_ref("g".."h"))),
-                ],
+                ]
+                .into(),
             },
             SortedRun {
                 id: 2,
                 sst_views: vec![
                     new_view(b"i", None),
                     new_view(b"j", Some(BytesRange::from_ref("k"..))),
-                ],
+                ]
+                .into(),
             },
         ];
         Arc::make_mut(&mut manifest.core.tree).last_compacted_l0_sst_view_id =
@@ -2857,7 +2862,8 @@ mod tests {
                     first_entry: Some(Bytes::from_static(b"srkey")),
                     ..Default::default()
                 },
-            ))],
+            ))]
+            .into(),
         }];
         manifest.writer_epoch = 5;
         manifest.compactor_epoch = 3;

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1455,7 +1455,8 @@ mod tests {
             sst_views: vec![
                 SsTableView::identity(active_sst_handle.clone()),
                 SsTableView::identity(active_expired_sst_handle.clone()),
-            ],
+            ]
+            .into(),
         });
         StoredManifest::create_new_db(
             manifest_store.clone(),
@@ -1571,11 +1572,11 @@ mod tests {
             ));
         Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
             id: 1,
-            sst_views: vec![SsTableView::identity(active_sst_handle.clone())],
+            sst_views: vec![SsTableView::identity(active_sst_handle.clone())].into(),
         });
         Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
             id: 2,
-            sst_views: vec![SsTableView::identity(active_checkpoint_sst_handle.clone())],
+            sst_views: vec![SsTableView::identity(active_checkpoint_sst_handle.clone())].into(),
         });
         let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
@@ -1756,7 +1757,7 @@ mod tests {
             }
 
             for sr in &manifest.core.tree.compacted {
-                for view in &sr.sst_views {
+                for view in sr.sst_views.iter() {
                     assert!(compacted_ssts.contains(&view.sst.id));
                 }
             }
@@ -2223,7 +2224,7 @@ mod tests {
             .push_back(SsTableView::identity(active_l0_handle));
         Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
             id: 1,
-            sst_views: vec![SsTableView::identity(active_handle)],
+            sst_views: vec![SsTableView::identity(active_handle)].into(),
         });
         // inactive_expired_handle is NOT in manifest -> eligible for GC
         StoredManifest::create_new_db(

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -1449,15 +1449,16 @@ mod tests {
             .l0
             .push_back(SsTableView::identity(active_expired_l0_sst_handle.clone()));
         // Dont' push inactive_expired_l0_sst_handle
-        Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
-            id: 1,
-            // Don't add inactive_expired_sst_handle
-            sst_views: vec![
-                SsTableView::identity(active_sst_handle.clone()),
-                SsTableView::identity(active_expired_sst_handle.clone()),
-            ]
-            .into(),
-        });
+        Arc::make_mut(&mut state.tree)
+            .compacted
+            .push(SortedRun::new(
+                1,
+                // Don't add inactive_expired_sst_handle
+                [
+                    SsTableView::identity(active_sst_handle.clone()),
+                    SsTableView::identity(active_expired_sst_handle.clone()),
+                ],
+            ));
         StoredManifest::create_new_db(
             manifest_store.clone(),
             state.clone(),
@@ -1489,7 +1490,7 @@ mod tests {
         assert_eq!(current_manifest.manifest.core.tree.compacted.len(), 1);
         assert_eq!(
             current_manifest.manifest.core.tree.compacted[0]
-                .sst_views
+                .sst_views()
                 .len(),
             2
         );
@@ -1526,7 +1527,7 @@ mod tests {
         assert_eq!(current_manifest.manifest.core.tree.compacted.len(), 1);
         assert_eq!(
             current_manifest.manifest.core.tree.compacted[0]
-                .sst_views
+                .sst_views()
                 .len(),
             2
         );
@@ -1570,14 +1571,18 @@ mod tests {
             .push_back(SsTableView::identity(
                 active_checkpoint_l0_sst_handle.clone(),
             ));
-        Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
-            id: 1,
-            sst_views: vec![SsTableView::identity(active_sst_handle.clone())].into(),
-        });
-        Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
-            id: 2,
-            sst_views: vec![SsTableView::identity(active_checkpoint_sst_handle.clone())].into(),
-        });
+        Arc::make_mut(&mut state.tree)
+            .compacted
+            .push(SortedRun::new(
+                1,
+                [SsTableView::identity(active_sst_handle.clone())],
+            ));
+        Arc::make_mut(&mut state.tree)
+            .compacted
+            .push(SortedRun::new(
+                2,
+                [SsTableView::identity(active_checkpoint_sst_handle.clone())],
+            ));
         let mut stored_manifest = StoredManifest::create_new_db(
             manifest_store.clone(),
             state.clone(),
@@ -1757,7 +1762,7 @@ mod tests {
             }
 
             for sr in &manifest.core.tree.compacted {
-                for view in sr.sst_views.iter() {
+                for view in sr.sst_views() {
                     assert!(compacted_ssts.contains(&view.sst.id));
                 }
             }
@@ -2222,10 +2227,9 @@ mod tests {
         Arc::make_mut(&mut state.tree)
             .l0
             .push_back(SsTableView::identity(active_l0_handle));
-        Arc::make_mut(&mut state.tree).compacted.push(SortedRun {
-            id: 1,
-            sst_views: vec![SsTableView::identity(active_handle)].into(),
-        });
+        Arc::make_mut(&mut state.tree)
+            .compacted
+            .push(SortedRun::new(1, [SsTableView::identity(active_handle)]));
         // inactive_expired_handle is NOT in manifest -> eligible for GC
         StoredManifest::create_new_db(
             manifest_store.clone(),

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -149,7 +149,7 @@ fn collect_active_ssts<'a>(manifests: impl Iterator<Item = &'a Manifest>) -> Has
                 active.insert(view.sst.id);
             }
             for sr in tree.compacted.iter() {
-                for view in sr.sst_views.iter() {
+                for view in sr.sst_views() {
                     active.insert(view.sst.id);
                 }
             }
@@ -741,10 +741,7 @@ mod tests {
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::from(vec![segment_l0.clone()]),
-                    compacted: vec![SortedRun {
-                        id: 0,
-                        sst_views: vec![segment_sr.clone()].into(),
-                    }],
+                    compacted: vec![SortedRun::new(0, [segment_sr.clone()])],
                 }),
             }],
         );

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -743,7 +743,7 @@ mod tests {
                     l0: VecDeque::from(vec![segment_l0.clone()]),
                     compacted: vec![SortedRun {
                         id: 0,
-                        sst_views: vec![segment_sr.clone()],
+                        sst_views: vec![segment_sr.clone()].into(),
                     }],
                 }),
             }],

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -74,7 +74,7 @@ impl LsmTreeState {
             + self
                 .compacted
                 .iter()
-                .map(|sr| sr.sst_views.len())
+                .map(|sr| sr.sst_views().len())
                 .sum::<usize>()
     }
 
@@ -554,7 +554,7 @@ impl ManifestCore {
         self.trees().flat_map(|tree| {
             tree.l0
                 .iter()
-                .chain(tree.compacted.iter().flat_map(|sr| sr.sst_views.iter()))
+                .chain(tree.compacted.iter().flat_map(|sr| sr.sst_views().iter()))
         })
     }
 
@@ -1151,12 +1151,9 @@ impl Manifest {
         let l0: VecDeque<SsTableView> = Self::filter_view_handles(&tree.l0, true, range).into();
         let mut sorted_runs_filtered = vec![];
         for sr in &tree.compacted {
-            let sst_views = Self::filter_view_handles(sr.sst_views.iter(), false, range);
+            let sst_views = Self::filter_view_handles(sr.sst_views().iter(), false, range);
             if !sst_views.is_empty() {
-                sorted_runs_filtered.push(SortedRun {
-                    id: sr.id,
-                    sst_views: sst_views.into(),
-                });
+                sorted_runs_filtered.push(SortedRun::new(sr.id, sst_views));
             }
         }
         tree.l0 = l0;
@@ -2086,7 +2083,7 @@ mod tests {
                 l0: writer_l0.clone(),
                 compacted: vec![],
             };
-            let compactor_compacted = vec![SortedRun { id: 42, sst_views: vec![].into() }];
+            let compactor_compacted = vec![SortedRun::new(42, [])];
             let compactor = LsmTreeState {
                 last_compacted_l0_sst_view_id: last_view,
                 last_compacted_l0_sst_id: last_sst,
@@ -2469,13 +2466,8 @@ mod tests {
                     }
                     tree.last_compacted_l0_sst_view_id = Some(newest);
                     self.next_sr_id += 1;
-                    tree.compacted.insert(
-                        0,
-                        SortedRun {
-                            id: self.next_sr_id,
-                            sst_views: sr_views.into(),
-                        },
-                    );
+                    tree.compacted
+                        .insert(0, SortedRun::new(self.next_sr_id, sr_views));
                 }
             }
 
@@ -2574,7 +2566,7 @@ mod tests {
                 }
                 for seg in &self.store {
                     for sr in &seg.tree.compacted {
-                        for view in sr.sst_views.iter() {
+                        for view in sr.sst_views() {
                             assert!(
                                 self.flushed_l0s.contains(&view.id),
                                 "SR {} references L0 {} that was never flushed",
@@ -2661,7 +2653,7 @@ mod tests {
                 for seg in &self.store {
                     let l0_ids: BTreeSet<Ulid> = seg.tree.l0.iter().map(|v| v.id).collect();
                     for sr in &seg.tree.compacted {
-                        for view in sr.sst_views.iter() {
+                        for view in sr.sst_views() {
                             assert!(
                                 !l0_ids.contains(&view.id),
                                 "L0 {} appears in both l0 list and SR {} of segment {:?}",
@@ -2978,28 +2970,25 @@ mod tests {
                 ));
         }
         for (idx, sorted_run) in manifest.sorted_runs.iter().enumerate() {
-            Arc::make_mut(&mut core.tree).compacted.push(SortedRun {
-                id: idx as u32,
-                sst_views: sorted_run
-                    .iter()
-                    .map(|entry| {
-                        let sst_id = sst_id_fn(entry.sst_alias);
-                        let view_id = sst_id.unwrap_compacted_id();
-                        SsTableView::new_projected(
-                            view_id,
-                            SsTableHandle::new(
-                                sst_id,
-                                SST_FORMAT_VERSION_LATEST,
-                                SsTableInfo {
-                                    first_entry: Some(entry.first_entry.clone()),
-                                    ..SsTableInfo::default()
-                                },
-                            ),
-                            entry.visible_range.clone(),
-                        )
-                    })
-                    .collect(),
-            });
+            Arc::make_mut(&mut core.tree).compacted.push(SortedRun::new(
+                idx as u32,
+                sorted_run.iter().map(|entry| {
+                    let sst_id = sst_id_fn(entry.sst_alias);
+                    let view_id = sst_id.unwrap_compacted_id();
+                    SsTableView::new_projected(
+                        view_id,
+                        SsTableHandle::new(
+                            sst_id,
+                            SST_FORMAT_VERSION_LATEST,
+                            SsTableInfo {
+                                first_entry: Some(entry.first_entry.clone()),
+                                ..SsTableInfo::default()
+                            },
+                        ),
+                        entry.visible_range.clone(),
+                    )
+                }),
+            ));
         }
         Manifest::initial(core)
     }
@@ -3172,10 +3161,9 @@ mod tests {
         Arc::make_mut(&mut core.tree)
             .l0
             .push_back(create_sst_view(live_l0, b"a"));
-        Arc::make_mut(&mut core.tree).compacted.push(SortedRun {
-            id: 0,
-            sst_views: vec![create_sst_view(live_compacted, b"b")].into(),
-        });
+        Arc::make_mut(&mut core.tree)
+            .compacted
+            .push(SortedRun::new(0, [create_sst_view(live_compacted, b"b")]));
 
         let mut manifest = Manifest::initial(core);
         manifest.external_dbs = vec![
@@ -3229,10 +3217,10 @@ mod tests {
                 last_compacted_l0_sst_view_id: None,
                 last_compacted_l0_sst_id: None,
                 l0: VecDeque::from(vec![create_sst_view(segment_l0, b"seg/a")]),
-                compacted: vec![SortedRun {
-                    id: 0,
-                    sst_views: vec![create_sst_view(segment_compacted, b"seg/b")].into(),
-                }],
+                compacted: vec![SortedRun::new(
+                    0,
+                    [create_sst_view(segment_compacted, b"seg/b")],
+                )],
             }),
         }];
 
@@ -3276,9 +3264,9 @@ mod tests {
         visible_range: BytesRange,
     ) -> Manifest {
         let mut core = ManifestCore::new();
-        Arc::make_mut(&mut core.tree).compacted.push(SortedRun {
-            id: 0,
-            sst_views: vec![SsTableView::new_projected(
+        Arc::make_mut(&mut core.tree).compacted.push(SortedRun::new(
+            0,
+            [SsTableView::new_projected(
                 sst_id.unwrap_compacted_id(),
                 SsTableHandle::new(
                     sst_id,
@@ -3289,9 +3277,8 @@ mod tests {
                     },
                 ),
                 Some(visible_range),
-            )]
-            .into(),
-        });
+            )],
+        ));
         Manifest::initial(core)
     }
 
@@ -3976,9 +3963,9 @@ mod tests {
                     ),
                     Some(visible_range.clone()),
                 )]),
-                compacted: vec![SortedRun {
-                    id: 0, // gets renumbered globally by the union
-                    sst_views: vec![SsTableView::new_projected(
+                compacted: vec![SortedRun::new(
+                    0, // gets renumbered globally by the union
+                    [SsTableView::new_projected(
                         sr_sst.unwrap_compacted_id(),
                         SsTableHandle::new(
                             sr_sst,
@@ -3989,9 +3976,8 @@ mod tests {
                             },
                         ),
                         Some(visible_range),
-                    )]
-                    .into(),
-                }],
+                    )],
+                )],
             }),
         }];
         (Manifest::initial(core), l0_sst, sr_sst)
@@ -4049,10 +4035,7 @@ mod tests {
         // entry has the highest id (matching the descending-id-by-list-
         // position convention).
         fn make_sr(id: u32) -> SortedRun {
-            SortedRun {
-                id, // intentionally collides across trees pre-renumber
-                sst_views: vec![].into(),
-            }
+            SortedRun::new(id, []) // intentionally collides across trees pre-renumber
         }
 
         let mut core = ManifestCore::new();
@@ -4254,9 +4237,9 @@ mod tests {
                         ),
                         Some(range.clone()),
                     )]),
-                    compacted: vec![SortedRun {
-                        id: 0,
-                        sst_views: vec![SsTableView::new_projected(
+                    compacted: vec![SortedRun::new(
+                        0,
+                        [SsTableView::new_projected(
                             sr_id.unwrap_compacted_id(),
                             SsTableHandle::new(
                                 sr_id,
@@ -4267,9 +4250,8 @@ mod tests {
                                 },
                             ),
                             Some(range),
-                        )]
-                        .into(),
-                    }],
+                        )],
+                    )],
                 }),
             }
         }
@@ -4696,9 +4678,9 @@ mod tests {
                         ),
                         Some(BytesRange::from_ref("a".."d")),
                     )]),
-                    compacted: vec![SortedRun {
-                        id: 0,
-                        sst_views: vec![SsTableView::new_projected(
+                    compacted: vec![SortedRun::new(
+                        0,
+                        [SsTableView::new_projected(
                             sr_a.unwrap_compacted_id(),
                             SsTableHandle::new(
                                 sr_a,
@@ -4709,9 +4691,8 @@ mod tests {
                                 },
                             ),
                             Some(BytesRange::from_ref("a".."m")),
-                        )]
-                        .into(),
-                    }],
+                        )],
+                    )],
                 }),
             },
             Segment {
@@ -4720,9 +4701,9 @@ mod tests {
                     last_compacted_l0_sst_view_id: None,
                     last_compacted_l0_sst_id: None,
                     l0: VecDeque::new(),
-                    compacted: vec![SortedRun {
-                        id: 1,
-                        sst_views: vec![SsTableView::new_projected(
+                    compacted: vec![SortedRun::new(
+                        1,
+                        [SsTableView::new_projected(
                             sr_b.unwrap_compacted_id(),
                             SsTableHandle::new(
                                 sr_b,
@@ -4733,9 +4714,8 @@ mod tests {
                                 },
                             ),
                             Some(BytesRange::from_ref("n".."z")),
-                        )]
-                        .into(),
-                    }],
+                        )],
+                    )],
                 }),
             },
         ];
@@ -4779,14 +4759,13 @@ mod tests {
             )
         };
         let mut core = ManifestCore::new();
-        Arc::make_mut(&mut core.tree).compacted.push(SortedRun {
-            id: 0,
-            sst_views: vec![
+        Arc::make_mut(&mut core.tree).compacted.push(SortedRun::new(
+            0,
+            [
                 make(sst1, b"a", b"c", BytesRange::from_ref("a".."d")),
                 make(sst2, b"m", b"p", BytesRange::from_ref("m".."q")),
-            ]
-            .into(),
-        });
+            ],
+        ));
         Manifest::initial(core)
     }
 
@@ -4820,7 +4799,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(projected.core.tree.compacted.len(), 1);
-        assert_eq!(projected.core.tree.compacted[0].sst_views.len(), 1);
+        assert_eq!(projected.core.tree.compacted[0].sst_views().len(), 1);
     }
 
     #[test]

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -1151,11 +1151,11 @@ impl Manifest {
         let l0: VecDeque<SsTableView> = Self::filter_view_handles(&tree.l0, true, range).into();
         let mut sorted_runs_filtered = vec![];
         for sr in &tree.compacted {
-            let sst_views = Self::filter_view_handles(&sr.sst_views, false, range);
+            let sst_views = Self::filter_view_handles(sr.sst_views.iter(), false, range);
             if !sst_views.is_empty() {
                 sorted_runs_filtered.push(SortedRun {
                     id: sr.id,
-                    sst_views,
+                    sst_views: sst_views.into(),
                 });
             }
         }
@@ -2086,7 +2086,7 @@ mod tests {
                 l0: writer_l0.clone(),
                 compacted: vec![],
             };
-            let compactor_compacted = vec![SortedRun { id: 42, sst_views: vec![] }];
+            let compactor_compacted = vec![SortedRun { id: 42, sst_views: vec![].into() }];
             let compactor = LsmTreeState {
                 last_compacted_l0_sst_view_id: last_view,
                 last_compacted_l0_sst_id: last_sst,
@@ -2473,7 +2473,7 @@ mod tests {
                         0,
                         SortedRun {
                             id: self.next_sr_id,
-                            sst_views: sr_views,
+                            sst_views: sr_views.into(),
                         },
                     );
                 }
@@ -2574,7 +2574,7 @@ mod tests {
                 }
                 for seg in &self.store {
                     for sr in &seg.tree.compacted {
-                        for view in &sr.sst_views {
+                        for view in sr.sst_views.iter() {
                             assert!(
                                 self.flushed_l0s.contains(&view.id),
                                 "SR {} references L0 {} that was never flushed",
@@ -2661,7 +2661,7 @@ mod tests {
                 for seg in &self.store {
                     let l0_ids: BTreeSet<Ulid> = seg.tree.l0.iter().map(|v| v.id).collect();
                     for sr in &seg.tree.compacted {
-                        for view in &sr.sst_views {
+                        for view in sr.sst_views.iter() {
                             assert!(
                                 !l0_ids.contains(&view.id),
                                 "L0 {} appears in both l0 list and SR {} of segment {:?}",
@@ -3174,7 +3174,7 @@ mod tests {
             .push_back(create_sst_view(live_l0, b"a"));
         Arc::make_mut(&mut core.tree).compacted.push(SortedRun {
             id: 0,
-            sst_views: vec![create_sst_view(live_compacted, b"b")],
+            sst_views: vec![create_sst_view(live_compacted, b"b")].into(),
         });
 
         let mut manifest = Manifest::initial(core);
@@ -3231,7 +3231,7 @@ mod tests {
                 l0: VecDeque::from(vec![create_sst_view(segment_l0, b"seg/a")]),
                 compacted: vec![SortedRun {
                     id: 0,
-                    sst_views: vec![create_sst_view(segment_compacted, b"seg/b")],
+                    sst_views: vec![create_sst_view(segment_compacted, b"seg/b")].into(),
                 }],
             }),
         }];
@@ -3289,7 +3289,8 @@ mod tests {
                     },
                 ),
                 Some(visible_range),
-            )],
+            )]
+            .into(),
         });
         Manifest::initial(core)
     }
@@ -3988,7 +3989,8 @@ mod tests {
                             },
                         ),
                         Some(visible_range),
-                    )],
+                    )]
+                    .into(),
                 }],
             }),
         }];
@@ -4049,7 +4051,7 @@ mod tests {
         fn make_sr(id: u32) -> SortedRun {
             SortedRun {
                 id, // intentionally collides across trees pre-renumber
-                sst_views: vec![],
+                sst_views: vec![].into(),
             }
         }
 
@@ -4265,7 +4267,8 @@ mod tests {
                                 },
                             ),
                             Some(range),
-                        )],
+                        )]
+                        .into(),
                     }],
                 }),
             }
@@ -4706,7 +4709,8 @@ mod tests {
                                 },
                             ),
                             Some(BytesRange::from_ref("a".."m")),
-                        )],
+                        )]
+                        .into(),
                     }],
                 }),
             },
@@ -4729,7 +4733,8 @@ mod tests {
                                 },
                             ),
                             Some(BytesRange::from_ref("n".."z")),
-                        )],
+                        )]
+                        .into(),
                     }],
                 }),
             },
@@ -4779,7 +4784,8 @@ mod tests {
             sst_views: vec![
                 make(sst1, b"a", b"c", BytesRange::from_ref("a".."d")),
                 make(sst2, b"m", b"p", BytesRange::from_ref("m".."q")),
-            ],
+            ]
+            .into(),
         });
         Manifest::initial(core)
     }

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -686,7 +686,7 @@ impl ManifestWriterHandler {
             let all_views = tree
                 .l0
                 .iter()
-                .chain(tree.compacted.iter().flat_map(|run| run.sst_views.iter()));
+                .chain(tree.compacted.iter().flat_map(|run| run.sst_views().iter()));
             for view in all_views {
                 sst_views += 1;
                 // Dedupe by physical SST id: a range clone/rescale can project one SST into

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -577,11 +577,13 @@ mod tests {
             // Find or create the sorted run
             let tree = Arc::make_mut(&mut self.core.tree);
             if let Some(sr) = tree.compacted.iter_mut().find(|sr| sr.id == sr_id) {
-                sr.sst_views.push(SsTableView::identity(sst_handle));
+                let mut views = sr.sst_views.to_vec();
+                views.push(SsTableView::identity(sst_handle));
+                sr.sst_views = views.into();
             } else {
                 let new_sr = SortedRun {
                     id: sr_id,
-                    sst_views: vec![SsTableView::identity(sst_handle)],
+                    sst_views: vec![SsTableView::identity(sst_handle)].into(),
                 };
                 tree.compacted.push(new_sr);
             }

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -574,19 +574,11 @@ mod tests {
             }
             let sst_handle = self.build_sst(entries).await?;
 
-            // Find or create the sorted run
-            let tree = Arc::make_mut(&mut self.core.tree);
-            if let Some(sr) = tree.compacted.iter_mut().find(|sr| sr.id == sr_id) {
-                let mut views = sr.sst_views.to_vec();
-                views.push(SsTableView::identity(sst_handle));
-                sr.sst_views = views.into();
-            } else {
-                let new_sr = SortedRun {
-                    id: sr_id,
-                    sst_views: vec![SsTableView::identity(sst_handle)].into(),
-                };
-                tree.compacted.push(new_sr);
-            }
+            // The fixture groups all entries for a run into one SST before
+            // calling this helper, so each run is constructed exactly once.
+            Arc::make_mut(&mut self.core.tree)
+                .compacted
+                .push(SortedRun::new(sr_id, [SsTableView::identity(sst_handle)]));
             Ok(())
         }
 

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -1013,7 +1013,7 @@ mod tests {
         let ssts: Vec<SsTableView> = (0..num_ssts).map(|_| create_sst_view(sst_size)).collect();
         SortedRun {
             id,
-            sst_views: ssts,
+            sst_views: ssts.into(),
         }
     }
 

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -1011,10 +1011,7 @@ mod tests {
 
     fn create_sr(id: u32, sst_size: u64, num_ssts: usize) -> SortedRun {
         let ssts: Vec<SsTableView> = (0..num_ssts).map(|_| create_sst_view(sst_size)).collect();
-        SortedRun {
-            id,
-            sst_views: ssts.into(),
-        }
+        SortedRun::new(id, ssts)
     }
 
     fn create_db_state(l0: VecDeque<SsTableView>, srs: Vec<SortedRun>) -> ManifestCore {

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -300,10 +300,7 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id = SsTableId::Compacted(ulid::Ulid::new());
         let handle = table_store.write_sst(&id, &encoded).await.unwrap();
-        let sr = SortedRun {
-            id: 0,
-            sst_views: vec![SsTableView::identity(handle)].into(),
-        };
+        let sr = SortedRun::new(0, [SsTableView::identity(handle)]);
 
         let mut iter = SortedRunIterator::new_owned_initialized(
             ..,
@@ -363,14 +360,13 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id2 = SsTableId::Compacted(ulid::Ulid::new());
         let handle2 = table_store.write_sst(&id2, &encoded).await.unwrap();
-        let sr = SortedRun {
-            id: 0,
-            sst_views: vec![
+        let sr = SortedRun::new(
+            0,
+            [
                 SsTableView::identity(handle1),
                 SsTableView::identity(handle2),
-            ]
-            .into(),
-        };
+            ],
+        );
 
         let mut iter = SortedRunIterator::new_owned_initialized(
             ..,
@@ -436,9 +432,9 @@ mod tests {
         let encoded = builder.build().await.unwrap();
         let id2 = SsTableId::Compacted(ulid::Ulid::new());
         let handle2 = table_store.write_sst(&id2, &encoded).await.unwrap();
-        let sr = SortedRun {
-            id: 0,
-            sst_views: vec![
+        let sr = SortedRun::new(
+            0,
+            [
                 SsTableView::new_projected(
                     ulid::Ulid::new(),
                     handle1,
@@ -449,9 +445,8 @@ mod tests {
                     handle2,
                     Some(BytesRange::from_ref("key5".."key7")),
                 ),
-            ]
-            .into(),
-        };
+            ],
+        );
 
         // when: iterating the full range, then: only visible keys appear
         let mut iter = SortedRunIterator::new_borrowed_initialized(
@@ -681,10 +676,7 @@ mod tests {
             ssts.push(SsTableView::identity(handle));
         }
 
-        SortedRun {
-            id: 0,
-            sst_views: ssts.into(),
-        }
+        SortedRun::new(0, ssts)
     }
 
     async fn build_sr_with_ssts(
@@ -705,10 +697,7 @@ mod tests {
             let sst = writer.close().await.unwrap();
             ssts.push(SsTableView::identity(sst));
         }
-        SortedRun {
-            id: 0,
-            sst_views: ssts.into(),
-        }
+        SortedRun::new(0, ssts)
     }
 
     mod mixed_version_tests {
@@ -784,16 +773,15 @@ mod tests {
             )
             .await;
 
-            let sorted_run = SortedRun {
-                id: 0,
-                sst_views: vec![
+            let sorted_run = SortedRun::new(
+                0,
+                [
                     SsTableView::identity(sst1_v1),
                     SsTableView::identity(sst2_v2),
                     SsTableView::identity(sst3_v1),
                     SsTableView::identity(sst4_v2),
-                ]
-                .into(),
-            };
+                ],
+            );
 
             // when: iterating over the sorted run
             let mut iter = SortedRunIterator::new_owned_initialized(
@@ -858,16 +846,15 @@ mod tests {
             )
             .await;
 
-            let sorted_run = SortedRun {
-                id: 0,
-                sst_views: vec![
+            let sorted_run = SortedRun::new(
+                0,
+                [
                     SsTableView::identity(sst1_v1),
                     SsTableView::identity(sst2_v2),
                     SsTableView::identity(sst3_v1),
                     SsTableView::identity(sst4_v2),
-                ]
-                .into(),
-            };
+                ],
+            );
 
             let mut iter = SortedRunIterator::new_owned_initialized(
                 ..,

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -302,7 +302,7 @@ mod tests {
         let handle = table_store.write_sst(&id, &encoded).await.unwrap();
         let sr = SortedRun {
             id: 0,
-            sst_views: vec![SsTableView::identity(handle)],
+            sst_views: vec![SsTableView::identity(handle)].into(),
         };
 
         let mut iter = SortedRunIterator::new_owned_initialized(
@@ -368,7 +368,8 @@ mod tests {
             sst_views: vec![
                 SsTableView::identity(handle1),
                 SsTableView::identity(handle2),
-            ],
+            ]
+            .into(),
         };
 
         let mut iter = SortedRunIterator::new_owned_initialized(
@@ -448,7 +449,8 @@ mod tests {
                     handle2,
                     Some(BytesRange::from_ref("key5".."key7")),
                 ),
-            ],
+            ]
+            .into(),
         };
 
         // when: iterating the full range, then: only visible keys appear
@@ -681,7 +683,7 @@ mod tests {
 
         SortedRun {
             id: 0,
-            sst_views: ssts,
+            sst_views: ssts.into(),
         }
     }
 
@@ -705,7 +707,7 @@ mod tests {
         }
         SortedRun {
             id: 0,
-            sst_views: ssts,
+            sst_views: ssts.into(),
         }
     }
 
@@ -789,7 +791,8 @@ mod tests {
                     SsTableView::identity(sst2_v2),
                     SsTableView::identity(sst3_v1),
                     SsTableView::identity(sst4_v2),
-                ],
+                ]
+                .into(),
             };
 
             // when: iterating over the sorted run
@@ -862,7 +865,8 @@ mod tests {
                     SsTableView::identity(sst2_v2),
                     SsTableView::identity(sst3_v1),
                     SsTableView::identity(sst4_v2),
-                ],
+                ]
+                .into(),
             };
 
             let mut iter = SortedRunIterator::new_owned_initialized(

--- a/slatedb/src/subcompaction.rs
+++ b/slatedb/src/subcompaction.rs
@@ -121,7 +121,7 @@ pub(crate) async fn plan_subcompaction_ranges(
         .chain(
             sorted_runs
                 .iter()
-                .flat_map(|sr| sr.sst_views.iter().cloned()),
+                .flat_map(|sr| sr.sst_views().iter().cloned()),
         )
         .collect();
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -460,10 +460,7 @@ pub(crate) async fn build_sorted_runs(
             let ssts = write_ssts(table_store, entries, max_sst_size).await;
             sr_ssts.extend(ssts.into_iter().map(SsTableView::identity));
         }
-        sorted_runs.push(SortedRun {
-            id: sr_id as u32,
-            sst_views: sr_ssts.into(),
-        });
+        sorted_runs.push(SortedRun::new(sr_id as u32, sr_ssts));
     }
 
     sorted_runs

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -462,7 +462,7 @@ pub(crate) async fn build_sorted_runs(
         }
         sorted_runs.push(SortedRun {
             id: sr_id as u32,
-            sst_views: sr_ssts,
+            sst_views: sr_ssts.into(),
         });
     }
 

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -390,7 +390,7 @@ pub(crate) fn sign_extend(val: u32, bits: u8) -> i32 {
 /// Returns:
 /// - The effective max parallelism.
 pub(crate) fn compute_max_parallel(l0_count: usize, srs: &[SortedRun], cap: usize) -> usize {
-    let total_ssts = l0_count + srs.iter().map(|sr| sr.sst_views.len()).sum::<usize>();
+    let total_ssts = l0_count + srs.iter().map(|sr| sr.sst_views().len()).sum::<usize>();
     total_ssts.min(cap).max(1)
 }
 
@@ -416,7 +416,7 @@ pub(crate) fn estimate_bytes_before_key(sorted_runs: &[SortedRun], key: &Bytes) 
                 return 0;
             };
             sorted_run
-                .sst_views
+                .sst_views()
                 .iter()
                 .take(idx)
                 .map(|sst| sst.estimate_size())
@@ -1328,20 +1328,19 @@ mod tests {
 
     #[test]
     fn test_estimate_bytes_before_key() {
-        let run1 = SortedRun {
-            id: 1,
-            sst_views: vec![
+        let run1 = SortedRun::new(
+            1,
+            [
                 make_sst_view("a", 10),
                 make_sst_view("k", 20), // k < m < z, so only "a" counts
                 make_sst_view("z", 30),
-            ]
-            .into(),
-        };
-        let run2 = SortedRun {
-            id: 2,
+            ],
+        );
+        let run2 = SortedRun::new(
+            2,
             // f < m < ..., so only "b" counts
-            sst_views: vec![make_sst_view("b", 40), make_sst_view("f", 50)].into(),
-        };
+            [make_sst_view("b", 40), make_sst_view("f", 50)],
+        );
 
         let key = Bytes::from("m");
         let total = estimate_bytes_before_key(&[run1, run2], &key);

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -1334,12 +1334,13 @@ mod tests {
                 make_sst_view("a", 10),
                 make_sst_view("k", 20), // k < m < z, so only "a" counts
                 make_sst_view("z", 30),
-            ],
+            ]
+            .into(),
         };
         let run2 = SortedRun {
             id: 2,
             // f < m < ..., so only "b" counts
-            sst_views: vec![make_sst_view("b", 40), make_sst_view("f", 50)],
+            sst_views: vec![make_sst_view("b", 40), make_sst_view("f", 50)].into(),
         };
 
         let key = Bytes::from("m");


### PR DESCRIPTION
## Summary

What is being changed and why?

This came out of test prefix scans with 1TB (~5k SSTs) and noticing that cloning the SRs was taking more than 50% CPU of a random read workload and noticed that performance just degrades over time. 

- For `scan` and `scan_prefix_by_recency`, we clone the SRs before filtering to get the matching SSTs. I did a fix initially that was suggested by AI by filtering the matching SSTs first and then cloning only these SSTs, but realized later it's a potentially a foot gun for this issue to happen again. I switched to a different fix where we can just make the sst_views behind an arc, so cloning the whole SR becomes a ref count increment. 

- In order to make future changes to the SR `sst_views` simpler and simplify the call sites, I made it private and added a constructor and a getter. This means `sst_views` become immutable as well in the SR which makes sense; changes for the views should probably happen through the SR itself if needed instead of making it possible to be mutated externally.

- Note that this is not a full mitigation for the problem. We clone the SR in O(1) after this change, but if we have a large number of matching SST views, we still clone all of these views. Ideally we shouldn't clone matching SST views as well, but we can do this as a followup. 

- Added a benchmark to detect regressions for similar cases. 
## Benchmark Results

| Case | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `first_entry/K=1` | 48.15 | 14.25 | 3.4x |
| `first_entry/K=10` | 72.96 | 35.32 | 2.1x |
| `first_entry/K=100` | 74.39 | 38.86 | 1.9x |
| `first_entry_by_recency/K=1` | 50.41 | 10.71 | 4.7x |
| `first_entry_by_recency/K=10` | 46.35 | 10.90 | 4.3x |
| `first_entry_by_recency/K=100` | 46.64 | 14.65 | 3.2x |


## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
