### PR TITLE
Disable descending scan checks in DST

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -93,11 +93,9 @@ pub fn build_reader_options(rand: &DbRand) -> DbReaderOptions {
 pub fn build_scan_options(rand: &DbRand, read_durability: DurabilityLevel) -> ScanOptions {
     let mut rng = rand.rng();
     let read_ahead_options = [1, 4 * 1024, 64 * 1024, MIB_1];
-    let order = if rng.random_bool(0.5) {
-        IterationOrder::Ascending
-    } else {
-        IterationOrder::Descending
-    };
+    // Descending sorted-run iteration is currently broken.
+    // See https://github.com/slatedb/slatedb/pull/1995.
+    let order = IterationOrder::Ascending;
 
     ScanOptions::new()
         .with_durability_filter(read_durability)


### PR DESCRIPTION
## Summary

- Use ascending iteration order for DST scan options.
- Temporarily disable descending scans until the sorted-run iteration issue is fixed.

## Testing

Not run (not requested).