### PR TITLE
Deflake object store cache metrics test

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2299,6 +2299,35 @@ mod tests {
             })
     }
 
+    fn lookup_object_store_api_request_count(
+        recorder: &DefaultMetricsRecorder,
+        component: &'static str,
+        store_type: &'static str,
+        op: &'static str,
+        api: &'static str,
+    ) -> i64 {
+        lookup_metric_with_labels(
+            recorder,
+            OBJECT_STORE_REQUEST_COUNT,
+            &object_store_labels(component, store_type, op, api),
+        )
+        .unwrap_or(0)
+    }
+
+    fn lookup_object_store_api_histogram_count(
+        recorder: &DefaultMetricsRecorder,
+        component: &'static str,
+        store_type: &'static str,
+        op: &'static str,
+        api: &'static str,
+    ) -> u64 {
+        lookup_object_store_histogram_count(
+            recorder,
+            &object_store_labels(component, store_type, op, api),
+        )
+        .unwrap_or(0)
+    }
+
     fn lookup_object_store_op_request_count(
         recorder: &DefaultMetricsRecorder,
         component: &'static str,
@@ -2319,12 +2348,7 @@ mod tests {
 
         apis.iter()
             .map(|api| {
-                lookup_metric_with_labels(
-                    recorder,
-                    OBJECT_STORE_REQUEST_COUNT,
-                    &object_store_labels(component, store_type, op, api),
-                )
-                .unwrap_or(0)
+                lookup_object_store_api_request_count(recorder, component, store_type, op, api)
             })
             .sum()
     }
@@ -2349,11 +2373,7 @@ mod tests {
 
         apis.iter()
             .map(|api| {
-                lookup_object_store_histogram_count(
-                    recorder,
-                    &object_store_labels(component, store_type, op, api),
-                )
-                .unwrap_or(0)
+                lookup_object_store_api_histogram_count(recorder, component, store_type, op, api)
             })
             .sum()
     }
@@ -11781,26 +11801,56 @@ mod tests {
                 .await
                 .unwrap();
 
-            let requests_before =
-                lookup_object_store_op_request_count(&metrics_recorder, "db", "main", "get");
+            let requests_before = lookup_object_store_api_request_count(
+                &metrics_recorder,
+                "db",
+                "main",
+                "get",
+                "get_range",
+            );
+            let histograms_before = lookup_object_store_api_histogram_count(
+                &metrics_recorder,
+                "db",
+                "main",
+                "get",
+                "get_range",
+            );
             let _val = kv_store.get(b"test_key").await.unwrap();
-            let requests_after_first =
-                lookup_object_store_op_request_count(&metrics_recorder, "db", "main", "get");
+            let requests_after_first = lookup_object_store_api_request_count(
+                &metrics_recorder,
+                "db",
+                "main",
+                "get",
+                "get_range",
+            );
             let got = kv_store.get(b"test_key").await.unwrap();
-            let requests_after_second =
-                lookup_object_store_op_request_count(&metrics_recorder, "db", "main", "get");
+            let requests_after_second = lookup_object_store_api_request_count(
+                &metrics_recorder,
+                "db",
+                "main",
+                "get",
+                "get_range",
+            );
+            let histograms_after_second = lookup_object_store_api_histogram_count(
+                &metrics_recorder,
+                "db",
+                "main",
+                "get",
+                "get_range",
+            );
 
             // The instrumented store sits above the object store cache and counts
             // logical read calls whether they are served from the cache or the
-            // remote store.
+            // remote store. Restrict the assertion to range reads so background
+            // manifest polling, which uses plain get calls, cannot affect it.
             // A point get reads the single-part SST in three sub-ranges (index,
             // filter and block).
             assert_eq!(requests_after_first, requests_before + 3);
             assert_eq!(got, Some(Bytes::from_static(b"test_value")));
             assert_eq!(requests_after_second, requests_after_first + 3);
             assert_eq!(
-                lookup_object_store_op_histogram_count(&metrics_recorder, "db", "main", "get"),
-                requests_after_second as u64
+                histograms_after_second - histograms_before,
+                (requests_after_second - requests_before) as u64
             );
             kv_store.close().await.unwrap();
         }


### PR DESCRIPTION
## Summary

CI failed on this run:

https://github.com/slatedb/slatedb/actions/runs/30587569150/job/91022448888

I suspect this was caused by #1968. Instead of LIST, we now do GETs, which can bump the metric.

Some Sol digging found `test_db_records_read_calls_into_cached_object_store` compares aggregate `db/main/get` metrics around a point lookup. The manifest writer can run its immediate poll in the same window and add two plain `get` calls.

The test now measures the `get_range` API used for SST subrange reads. It also compares histogram deltas from the same baseline so earlier object-store activity does not affect the result.

## Changes

- Add exact object-store API lookup helpers for request and histogram metrics.
- Use those helpers in the aggregate lookups and the cache metrics test.

## Notes for Reviewers

The existing test was already this way, and I mostly want to unblock things. I ran:

```
loop cargo test test_db_records_read_calls_into_cached_object_store -p slatedb --lib
```

Before patch, it fails every 5-10 loops. After, it didn't fail at all when run > 580 times.

I acknowledge that this is a bit hacky. The existing test was kind of already this way. Since the metrics are already scoped to db/main, I figure it's at least _somewhat_ specific. If the test continues to cause problems, we can reivist.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

This test-only change has no runtime or migration impact.

Thank you for the review! 🙏