### PR TITLE
[rfc-30 3/N]: add trait and native implementation for wal gc

### DIFF
--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -24,6 +24,7 @@ use crate::manifest::store::{ManifestStore, StoredManifest};
 use crate::manifest::Manifest;
 use crate::tablestore::TableStore;
 use crate::utils::WatchableOnceCell;
+use crate::wal::gc::{SlateDbWalGc, WalGcMode};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use compacted_gc::CompactedGcTask;
@@ -40,7 +41,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tracing::instrument;
-use wal_gc::{WalGcMode, WalGcTask};
+use wal_gc::WalGcTask;
 
 mod compacted_gc;
 mod compactions_gc;
@@ -50,6 +51,7 @@ mod manifest_gc;
 pub mod stats;
 mod wal_gc;
 
+pub(crate) use filter::retain_allowed_by_gc_filter;
 pub use filter::GcFilter;
 
 pub(crate) const DEFAULT_MIN_AGE: Duration = Duration::from_secs(300);
@@ -243,24 +245,30 @@ impl GarbageCollector {
             system_clock.clone(),
         ));
         let wal_gc_task = options.wal_options.map(|wal_options| {
-            WalGcTask::new(
-                manifest_store.clone(),
+            let wal_gc = Arc::new(SlateDbWalGc::new(
                 table_store.clone(),
                 stats.clone(),
                 wal_options,
                 WalGcMode::Regular,
                 gc_filter.clone(),
+                system_clock.clone(),
+            ));
+            WalGcTask::new(
+                manifest_store.clone(),
+                wal_gc,
+                WalGcMode::Regular.resource(),
             )
         });
         let wal_fence_gc_task = options.wal_fence_options.map(|wal_fence_options| {
-            WalGcTask::new(
-                manifest_store.clone(),
+            let wal_gc = Arc::new(SlateDbWalGc::new(
                 table_store.clone(),
                 stats.clone(),
                 wal_fence_options,
                 WalGcMode::Fence,
                 gc_filter.clone(),
-            )
+                system_clock.clone(),
+            ));
+            WalGcTask::new(manifest_store.clone(), wal_gc, WalGcMode::Fence.resource())
         });
         let compacted_gc_task = options.compacted_options.map(|compacted_options| {
             CompactedGcTask::new(

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -1,51 +1,27 @@
 use crate::manifest::Manifest;
 use crate::{
-    config::GarbageCollectorDirectoryOptions, db_state::SsTableId, error::SlateDBError,
-    manifest::store::ManifestStore, tablestore::TableStore,
+    error::SlateDBError,
+    manifest::store::ManifestStore,
+    wal::{WalFileRange, WalGC},
 };
 use chrono::{DateTime, Utc};
-use futures::StreamExt;
-use log::error;
 use std::collections::BTreeMap;
+use std::ops::Bound;
 use std::sync::Arc;
 
-use super::filter::retain_allowed_by_gc_filter;
-use super::{GcFilter, GcStats, GcTask, GC_DELETE_CONCURRENCY};
-use slatedb_common::object_metadata::IdentifiedObjectMetadata;
-
-/// Selects which class of WAL object a [`WalGcTask`] collects.
-///
-/// Regular WAL SSTs and zero-byte WAL fence objects share the same WAL
-/// directory and `SsTableId::Wal` identifier space, but they have separate
-/// retention policies. This mode keeps a single task implementation while
-/// allowing regular WAL GC and fence WAL GC to run on independent schedules.
-#[derive(Debug, Clone, Copy)]
-pub(super) enum WalGcMode {
-    /// Collect non-empty WAL SSTs that are older than the compacted WAL
-    /// boundary, old enough for retention, and unreferenced by active
-    /// checkpoint manifests.
-    Regular,
-
-    /// Collect zero-byte WAL fence objects under the same safety checks as
-    /// regular WAL GC.
-    Fence,
-}
+use super::GcTask;
 
 #[derive(Clone)]
 pub(crate) struct WalGcTask {
     manifest_store: Arc<ManifestStore>,
-    table_store: Arc<TableStore>,
-    stats: Arc<GcStats>,
-    wal_options: GarbageCollectorDirectoryOptions,
-    mode: WalGcMode,
-    gc_filter: Option<Arc<dyn GcFilter>>,
+    wal_gc: Arc<dyn WalGC>,
+    resource: &'static str,
 }
 
 impl std::fmt::Debug for WalGcTask {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WalGcTask")
-            .field("wal_options", &self.wal_options)
-            .field("mode", &self.mode)
+            .field("resource", &self.resource.to_string())
             .finish()
     }
 }
@@ -53,136 +29,165 @@ impl std::fmt::Debug for WalGcTask {
 impl WalGcTask {
     pub(super) fn new(
         manifest_store: Arc<ManifestStore>,
-        table_store: Arc<TableStore>,
-        stats: Arc<GcStats>,
-        wal_options: GarbageCollectorDirectoryOptions,
-        mode: WalGcMode,
-        gc_filter: Option<Arc<dyn GcFilter>>,
+        wal_gc: Arc<dyn WalGC>,
+        resource: &'static str,
     ) -> Self {
-        WalGcTask {
+        Self {
             manifest_store,
-            table_store,
-            stats,
-            wal_options,
-            mode,
-            gc_filter,
+            wal_gc,
+            resource,
         }
     }
 
-    fn is_wal_sst_eligible_for_deletion(
-        utc_now: &DateTime<Utc>,
-        wal_sst: &IdentifiedObjectMetadata<SsTableId>,
-        min_age: &chrono::Duration,
+    fn referenced_wal_ranges(
+        latest_manifest_id: u64,
         active_manifests: &BTreeMap<u64, Manifest>,
-    ) -> bool {
-        if utc_now.signed_duration_since(wal_sst.metadata.last_modified) <= *min_age {
-            return false;
-        }
-
-        let wal_sst_id = wal_sst.id.unwrap_wal_id();
-        !active_manifests
-            .values()
-            .any(|manifest| manifest.has_wal_sst_reference(wal_sst_id))
-    }
-
-    fn wal_sst_min_age(&self) -> chrono::Duration {
-        chrono::Duration::from_std(self.wal_options.min_age).expect("invalid duration")
-    }
-
-    /// Deletes the given WAL SSTs from the table store.
-    ///
-    /// In case of dryrun, the actual deletion doesn't happen.
-    async fn maybe_delete_wal_ssts(&self, sst_ids: Vec<SsTableId>) {
-        if self.wal_options.dry_run {
-            if !sst_ids.is_empty() {
-                log::info!(
-                    "dry run: skipping {} deletion [count={}]",
-                    self.resource(),
-                    sst_ids.len()
-                );
-                if matches!(self.mode, WalGcMode::Fence) {
-                    log::info!(
-                        "WAL fence GC is dry-run by default. This is a conservative setting. \
-                        Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
-                        Silence this log with wal_fence_options=None. See #352 for details."
-                    );
-                }
-            }
-            for id in sst_ids {
-                log::debug!(
-                    "dry run: would delete {} but skipped [id={:?}]",
-                    self.resource(),
-                    id
-                );
-            }
-            return;
-        }
-
-        futures::stream::iter(sst_ids)
-            .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
-                if let Err(e) = self.table_store.delete_sst(&id).await {
-                    error!("error deleting WAL SST [id={:?}, error={}]", id, e);
+    ) -> Vec<WalFileRange> {
+        active_manifests
+            .iter()
+            .map(|(manifest_id, manifest)| {
+                if *manifest_id == latest_manifest_id {
+                    // Keep the current compaction boundary and everything after it. Retaining the
+                    // boundary matches the existing GC protocol and protects concurrent writers.
+                    WalFileRange(
+                        Bound::Included(manifest.core.replay_after_wal_id),
+                        Bound::Unbounded,
+                    )
                 } else {
-                    match self.mode {
-                        WalGcMode::Regular => self.stats.gc_wal_count.increment(1),
-                        WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(1),
-                    }
+                    // A checkpoint only references WALs that must be replayed for its manifest.
+                    WalFileRange(
+                        Bound::Excluded(manifest.core.replay_after_wal_id),
+                        Bound::Excluded(manifest.core.next_wal_sst_id),
+                    )
                 }
             })
-            .await;
+            .collect()
     }
 }
 
 impl GcTask for WalGcTask {
-    /// Collect garbage from the WAL SSTs. This will delete any WAL SSTs that meet
-    /// the following conditions:
-    ///  - not referenced by an active checkpoint
-    ///  - older than the minimum age specified in the options
-    ///  - older than the last compacted WAL SST.
-    async fn collect(&self, utc_now: DateTime<Utc>) -> Result<(), SlateDBError> {
+    /// Resolve the WAL ranges referenced by the current manifest and active checkpoints, then
+    /// delegate collection to the configured WAL implementation.
+    async fn collect(&self, _utc_now: DateTime<Utc>) -> Result<(), SlateDBError> {
         let latest_manifest = self.manifest_store.read_latest_manifest().await?;
         let active_manifests = self
             .manifest_store
             .read_referenced_manifests(latest_manifest.id, &latest_manifest.manifest)
             .await?;
-        let last_compacted_wal_sst_id = latest_manifest.manifest.core.replay_after_wal_id;
-        let min_age = self.wal_sst_min_age();
-        let ssts_to_delete = self
-            .table_store
-            .list_wal_ssts(..last_compacted_wal_sst_id)
-            .await?
-            .into_iter()
-            .filter(|wal_sst| match self.mode {
-                // In regular mode, only consider WAL SSTs with size > 0 for deletion.
-                WalGcMode::Regular => wal_sst.metadata.size > 0,
-                // In fence mode, only consider zero-byte WAL SSTs for deletion.
-                WalGcMode::Fence => wal_sst.metadata.size == 0,
-            })
-            // Respect min_age and any WAL references held by active checkpoint manifests.
-            .filter(|wal_sst| {
-                Self::is_wal_sst_eligible_for_deletion(
-                    &utc_now,
-                    wal_sst,
-                    &min_age,
-                    &active_manifests,
-                )
-            })
-            .collect::<Vec<_>>();
-        let ssts_to_delete = retain_allowed_by_gc_filter(&self.gc_filter, ssts_to_delete).await;
-        let sst_ids_to_delete = ssts_to_delete
-            .into_iter()
-            .map(|wal_sst| wal_sst.id)
-            .collect::<Vec<_>>();
+        let referenced_ranges = Self::referenced_wal_ranges(latest_manifest.id, &active_manifests);
 
-        self.maybe_delete_wal_ssts(sst_ids_to_delete).await;
-
-        Ok(())
+        self.wal_gc
+            .collect(referenced_ranges)
+            .await
+            .map_err(Into::into)
     }
 
     fn resource(&self) -> &str {
-        match self.mode {
-            WalGcMode::Regular => "WAL",
-            WalGcMode::Fence => "WAL fence",
+        self.resource
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::Checkpoint;
+    use crate::manifest::store::StoredManifest;
+    use crate::manifest::ManifestCore;
+    use crate::wal::WalError;
+    use async_trait::async_trait;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use slatedb_common::clock::DefaultSystemClock;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    #[derive(Default)]
+    struct RecordingWalGc {
+        calls: Mutex<Vec<Vec<WalFileRange>>>,
+    }
+
+    impl RecordingWalGc {
+        fn calls(&self) -> Vec<Vec<WalFileRange>> {
+            self.calls.lock().unwrap().clone()
         }
+    }
+
+    #[async_trait]
+    impl WalGC for RecordingWalGc {
+        async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
+            self.calls.lock().unwrap().push(referenced_ranges);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_referenced_wal_ranges() {
+        let mut checkpoint_core = ManifestCore::new();
+        checkpoint_core.replay_after_wal_id = 2;
+        checkpoint_core.next_wal_sst_id = 6;
+
+        let mut current_core = ManifestCore::new();
+        current_core.replay_after_wal_id = 5;
+        current_core.next_wal_sst_id = 8;
+
+        let active_manifests = BTreeMap::from([
+            (1, Manifest::initial(checkpoint_core)),
+            (2, Manifest::initial(current_core)),
+        ]);
+
+        assert_eq!(
+            WalGcTask::referenced_wal_ranges(2, &active_manifests),
+            vec![
+                WalFileRange(Bound::Excluded(2), Bound::Excluded(6)),
+                WalFileRange(Bound::Included(5), Bound::Unbounded),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_collect_calls_wal_gc_with_referenced_ranges() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from("/test/wal-gc-ranges"),
+            object_store,
+        ));
+
+        let mut checkpoint_core = ManifestCore::new();
+        checkpoint_core.replay_after_wal_id = 2;
+        checkpoint_core.next_wal_sst_id = 6;
+        let mut stored_manifest = StoredManifest::create_new_db(
+            manifest_store.clone(),
+            checkpoint_core,
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        let checkpoint_manifest_id = stored_manifest.id();
+
+        let mut dirty = stored_manifest.prepare_dirty().unwrap();
+        dirty.value.core.replay_after_wal_id = 5;
+        dirty.value.core.next_wal_sst_id = 8;
+        dirty.value.core.checkpoints.push(Checkpoint {
+            id: Uuid::new_v4(),
+            manifest_id: checkpoint_manifest_id,
+            expire_time: None,
+            create_time: Utc::now(),
+            name: None,
+        });
+        stored_manifest.update(dirty).await.unwrap();
+
+        let wal_gc = Arc::new(RecordingWalGc::default());
+        let task = WalGcTask::new(manifest_store, wal_gc.clone(), "WAL");
+
+        task.collect(Utc::now()).await.unwrap();
+
+        assert_eq!(
+            wal_gc.calls(),
+            vec![vec![
+                WalFileRange(Bound::Excluded(2), Bound::Excluded(6)),
+                WalFileRange(Bound::Included(5), Bound::Unbounded),
+            ]]
+        );
     }
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -1546,10 +1546,6 @@ impl Manifest {
             .collect()
     }
 
-    pub(crate) fn has_wal_sst_reference(&self, wal_sst_id: u64) -> bool {
-        wal_sst_id > self.core.replay_after_wal_id && wal_sst_id < self.core.next_wal_sst_id
-    }
-
     /// Shrinks each `ExternalDb.sst_ids` to only IDs still referenced by this manifest's
     /// L0 and compacted sorted runs. `ExternalDb` entries are retained even when their
     /// `sst_ids` becomes empty — detaching a clone from its parent is done by the GC,

--- a/slatedb/src/wal/gc.rs
+++ b/slatedb/src/wal/gc.rs
@@ -1,0 +1,415 @@
+use crate::config::GarbageCollectorDirectoryOptions;
+use crate::db_state::SsTableId;
+use crate::garbage_collector::stats::GcStats;
+use crate::garbage_collector::{retain_allowed_by_gc_filter, GcFilter, GC_DELETE_CONCURRENCY};
+use crate::tablestore::TableStore;
+use crate::wal::{WalError, WalFileRange, WalGC};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use log::error;
+use slatedb_common::clock::SystemClock;
+use slatedb_common::object_metadata::IdentifiedObjectMetadata;
+use std::ops::Bound;
+use std::sync::Arc;
+
+/// Selects which class of SlateDB WAL object is collected.
+///
+/// Regular WAL SSTs and zero-byte WAL fence objects share the same WAL
+/// directory and `SsTableId::Wal` identifier space, but they have separate
+/// retention policies. This mode keeps a single implementation while
+/// allowing regular WAL GC and fence WAL GC to run on independent schedules.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum WalGcMode {
+    /// Collect non-empty WAL SSTs that are old enough for retention and unreferenced by active
+    /// manifests.
+    Regular,
+
+    /// Collect zero-byte WAL fence objects under the same safety checks as regular WAL GC.
+    Fence,
+}
+
+impl WalGcMode {
+    pub(crate) fn resource(self) -> &'static str {
+        match self {
+            WalGcMode::Regular => "WAL",
+            WalGcMode::Fence => "WAL fence",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SlateDbWalGc {
+    table_store: Arc<TableStore>,
+    stats: Arc<GcStats>,
+    wal_options: GarbageCollectorDirectoryOptions,
+    mode: WalGcMode,
+    gc_filter: Option<Arc<dyn GcFilter>>,
+    system_clock: Arc<dyn SystemClock>,
+}
+
+impl std::fmt::Debug for SlateDbWalGc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SlateDbWalGc")
+            .field("wal_options", &self.wal_options)
+            .field("mode", &self.mode)
+            .finish()
+    }
+}
+
+impl SlateDbWalGc {
+    pub(crate) fn new(
+        table_store: Arc<TableStore>,
+        stats: Arc<GcStats>,
+        wal_options: GarbageCollectorDirectoryOptions,
+        mode: WalGcMode,
+        gc_filter: Option<Arc<dyn GcFilter>>,
+        system_clock: Arc<dyn SystemClock>,
+    ) -> Self {
+        Self {
+            table_store,
+            stats,
+            wal_options,
+            mode,
+            gc_filter,
+            system_clock,
+        }
+    }
+
+    fn is_wal_sst_eligible_for_deletion(
+        utc_now: &DateTime<Utc>,
+        wal_sst: &IdentifiedObjectMetadata<SsTableId>,
+        min_age: &chrono::Duration,
+        referenced_ranges: &[WalFileRange],
+    ) -> bool {
+        if utc_now.signed_duration_since(wal_sst.metadata.last_modified) <= *min_age {
+            return false;
+        }
+
+        let wal_sst_id = wal_sst.id.unwrap_wal_id();
+        !referenced_ranges
+            .iter()
+            .any(|range| Self::range_contains(range, wal_sst_id))
+    }
+
+    fn range_contains(range: &WalFileRange, wal_sst_id: u64) -> bool {
+        let after_start = match &range.0 {
+            Bound::Included(start) => wal_sst_id >= *start,
+            Bound::Excluded(start) => wal_sst_id > *start,
+            Bound::Unbounded => true,
+        };
+        let before_end = match &range.1 {
+            Bound::Included(end) => wal_sst_id <= *end,
+            Bound::Excluded(end) => wal_sst_id < *end,
+            Bound::Unbounded => true,
+        };
+        after_start && before_end
+    }
+
+    fn wal_sst_min_age(&self) -> chrono::Duration {
+        chrono::Duration::from_std(self.wal_options.min_age).expect("invalid duration")
+    }
+
+    /// Deletes the given WAL SSTs from the table store.
+    ///
+    /// In case of dryrun, the actual deletion doesn't happen.
+    async fn maybe_delete_wal_ssts(&self, sst_ids: Vec<SsTableId>) {
+        if self.wal_options.dry_run {
+            if !sst_ids.is_empty() {
+                log::info!(
+                    "dry run: skipping {} deletion [count={}]",
+                    self.mode.resource(),
+                    sst_ids.len()
+                );
+                if matches!(self.mode, WalGcMode::Fence) {
+                    log::info!(
+                        "WAL fence GC is dry-run by default. This is a conservative setting. \
+                        Set wal_fence_options.dry_run=false and use a conservative min_age to enable. \
+                        Silence this log with wal_fence_options=None. See #352 for details."
+                    );
+                }
+            }
+            for id in sst_ids {
+                log::debug!(
+                    "dry run: would delete {} but skipped [id={:?}]",
+                    self.mode.resource(),
+                    id
+                );
+            }
+            return;
+        }
+
+        futures::stream::iter(sst_ids)
+            .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
+                if let Err(e) = self.table_store.delete_sst(&id).await {
+                    error!("error deleting WAL SST [id={:?}, error={}]", id, e);
+                } else {
+                    match self.mode {
+                        WalGcMode::Regular => self.stats.gc_wal_count.increment(1),
+                        WalGcMode::Fence => self.stats.gc_wal_fence_count.increment(1),
+                    }
+                }
+            })
+            .await;
+    }
+}
+
+#[async_trait]
+impl WalGC for SlateDbWalGc {
+    async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
+        let utc_now = self.system_clock.now();
+        let min_age = self.wal_sst_min_age();
+        let ssts_to_delete = self
+            .table_store
+            .list_wal_ssts(..)
+            .await?
+            .into_iter()
+            .filter(|wal_sst| match self.mode {
+                // In regular mode, only consider WAL SSTs with size > 0 for deletion.
+                WalGcMode::Regular => wal_sst.metadata.size > 0,
+                // In fence mode, only consider zero-byte WAL SSTs for deletion.
+                WalGcMode::Fence => wal_sst.metadata.size == 0,
+            })
+            .filter(|wal_sst| {
+                Self::is_wal_sst_eligible_for_deletion(
+                    &utc_now,
+                    wal_sst,
+                    &min_age,
+                    &referenced_ranges,
+                )
+            })
+            .collect::<Vec<_>>();
+        let ssts_to_delete = retain_allowed_by_gc_filter(&self.gc_filter, ssts_to_delete).await;
+        let sst_ids_to_delete = ssts_to_delete
+            .into_iter()
+            .map(|wal_sst| wal_sst.id)
+            .collect::<Vec<_>>();
+
+        self.maybe_delete_wal_ssts(sst_ids_to_delete).await;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_cache_policy::BlockCachePolicy;
+    use crate::format::sst::SsTableFormat;
+    use crate::object_stores::ObjectStores;
+    use crate::tablestore::TableStoreKind;
+    use crate::RowEntry;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use slatedb_common::clock::MockSystemClock;
+    use slatedb_common::metrics::MetricsRecorderHelper;
+    use std::time::Duration;
+
+    fn build_table_store() -> Arc<TableStore> {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        Arc::new(TableStore::new(
+            ObjectStores::new(object_store, None),
+            SsTableFormat::default(),
+            Path::from("/"),
+            None,
+            TableStoreKind::GC,
+            BlockCachePolicy::default(),
+        ))
+    }
+
+    fn build_collector(
+        table_store: Arc<TableStore>,
+        clock: Arc<MockSystemClock>,
+        mode: WalGcMode,
+        min_age: Duration,
+    ) -> SlateDbWalGc {
+        SlateDbWalGc::new(
+            table_store,
+            Arc::new(GcStats::new(&MetricsRecorderHelper::noop())),
+            GarbageCollectorDirectoryOptions {
+                interval: None,
+                min_age,
+                dry_run: false,
+            },
+            mode,
+            None,
+            clock,
+        )
+    }
+
+    async fn write_regular_wal(table_store: &Arc<TableStore>, wal_id: u64) {
+        let mut sst = table_store.wal_table_builder();
+        sst.add(RowEntry::new_value(b"key", b"value", wal_id))
+            .await
+            .unwrap();
+        let sst = sst.build().await.unwrap();
+        table_store
+            .write_sst(&SsTableId::Wal(wal_id), &sst)
+            .await
+            .unwrap();
+    }
+
+    async fn write_fence_wal(table_store: &Arc<TableStore>, wal_id: u64) {
+        table_store.write_wal_fence(wal_id).await.unwrap();
+    }
+
+    async fn wal_ids(table_store: &Arc<TableStore>) -> Vec<u64> {
+        table_store
+            .list_wal_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|wal| wal.id.unwrap_wal_id())
+            .collect()
+    }
+
+    async fn make_all_wals_older_than(
+        table_store: &Arc<TableStore>,
+        clock: &MockSystemClock,
+        min_age: Duration,
+    ) {
+        let newest_wal = table_store
+            .list_wal_ssts(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|wal| wal.metadata.last_modified)
+            .max()
+            .expect("expected at least one WAL");
+        let min_age_millis =
+            i64::try_from(min_age.as_millis()).expect("min_age should fit in i64 milliseconds");
+        clock.set(newest_wal.timestamp_millis() + min_age_millis + 1_000);
+    }
+
+    fn protect_outer_wals() -> Vec<WalFileRange> {
+        vec![
+            WalFileRange(Bound::Included(1), Bound::Excluded(2)),
+            WalFileRange(Bound::Included(4), Bound::Unbounded),
+        ]
+    }
+
+    #[tokio::test]
+    async fn regular_mode_deletes_unreferenced_range_and_keeps_referenced_wals() {
+        let table_store = build_table_store();
+        let clock = Arc::new(MockSystemClock::new());
+        for wal_id in 1..=4 {
+            write_regular_wal(&table_store, wal_id).await;
+        }
+        make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
+        let collector = build_collector(
+            table_store.clone(),
+            clock,
+            WalGcMode::Regular,
+            Duration::ZERO,
+        );
+
+        collector.collect(protect_outer_wals()).await.unwrap();
+
+        assert_eq!(wal_ids(&table_store).await, vec![1, 4]);
+    }
+
+    #[tokio::test]
+    async fn regular_mode_does_not_touch_fence_wals() {
+        let table_store = build_table_store();
+        let clock = Arc::new(MockSystemClock::new());
+        write_regular_wal(&table_store, 1).await;
+        write_fence_wal(&table_store, 2).await;
+        make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
+        let collector = build_collector(
+            table_store.clone(),
+            clock,
+            WalGcMode::Regular,
+            Duration::ZERO,
+        );
+
+        collector.collect(vec![]).await.unwrap();
+
+        assert_eq!(wal_ids(&table_store).await, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn regular_mode_respects_min_age() {
+        let table_store = build_table_store();
+        let clock = Arc::new(MockSystemClock::new());
+        write_regular_wal(&table_store, 1).await;
+        let last_modified = table_store
+            .metadata(&SsTableId::Wal(1))
+            .await
+            .unwrap()
+            .last_modified;
+        let min_age = Duration::from_secs(60 * 60);
+        let collector = build_collector(
+            table_store.clone(),
+            clock.clone(),
+            WalGcMode::Regular,
+            min_age,
+        );
+
+        clock.set((last_modified + chrono::Duration::minutes(30)).timestamp_millis());
+        collector.collect(vec![]).await.unwrap();
+        assert_eq!(wal_ids(&table_store).await, vec![1]);
+
+        clock.set((last_modified + chrono::Duration::minutes(61)).timestamp_millis());
+        collector.collect(vec![]).await.unwrap();
+        assert!(wal_ids(&table_store).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fence_mode_deletes_unreferenced_range_and_keeps_referenced_wals() {
+        let table_store = build_table_store();
+        let clock = Arc::new(MockSystemClock::new());
+        for wal_id in 1..=4 {
+            write_fence_wal(&table_store, wal_id).await;
+        }
+        make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
+        let collector =
+            build_collector(table_store.clone(), clock, WalGcMode::Fence, Duration::ZERO);
+
+        collector.collect(protect_outer_wals()).await.unwrap();
+
+        assert_eq!(wal_ids(&table_store).await, vec![1, 4]);
+    }
+
+    #[tokio::test]
+    async fn fence_mode_does_not_touch_regular_wals() {
+        let table_store = build_table_store();
+        let clock = Arc::new(MockSystemClock::new());
+        write_fence_wal(&table_store, 1).await;
+        write_regular_wal(&table_store, 2).await;
+        make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
+        let collector =
+            build_collector(table_store.clone(), clock, WalGcMode::Fence, Duration::ZERO);
+
+        collector.collect(vec![]).await.unwrap();
+
+        assert_eq!(wal_ids(&table_store).await, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn fence_mode_respects_min_age() {
+        let table_store = build_table_store();
+        let clock = Arc::new(MockSystemClock::new());
+        write_fence_wal(&table_store, 1).await;
+        let last_modified = table_store
+            .metadata(&SsTableId::Wal(1))
+            .await
+            .unwrap()
+            .last_modified;
+        let min_age = Duration::from_secs(60 * 60);
+        let collector = build_collector(
+            table_store.clone(),
+            clock.clone(),
+            WalGcMode::Fence,
+            min_age,
+        );
+
+        clock.set((last_modified + chrono::Duration::minutes(30)).timestamp_millis());
+        collector.collect(vec![]).await.unwrap();
+        assert_eq!(wal_ids(&table_store).await, vec![1]);
+
+        clock.set((last_modified + chrono::Duration::minutes(61)).timestamp_millis());
+        collector.collect(vec![]).await.unwrap();
+        assert!(wal_ids(&table_store).await.is_empty());
+    }
+}

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -268,7 +268,10 @@ pub trait WalReader {
     ) -> Result<Box<dyn WalIterator>, WalError>;
 }
 
-/// API for plugging into WAL GC
+/// Trait that defines the contract between SlateDB's garbage collector and a custom WAL
+/// implementation. SlateDB tracks the set of currently referenced WAL ranges in its manifest.
+/// When the Garbage Collector runs, it computes this set and calls [`WalGC::collect`] so that
+/// the implementation can clean up any un-referenced WAL storage.
 #[async_trait]
 pub trait WalGC: Send + Sync + 'static {
     /// Hook for garbage collecting the WAL. Takes a list of ranges of WAL Files that are currently

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::{Display, Formatter};
 use std::ops::{Bound, Range};
 use std::sync::Arc;
 
+pub(crate) mod gc;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod wal_disabled;
@@ -15,6 +16,7 @@ pub(crate) mod wal_sst_builder;
 pub(crate) mod writer_init;
 
 /// A range of WAL File IDs
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WalFileRange(pub Bound<u64>, pub Bound<u64>);
 
 impl From<Range<u64>> for WalFileRange {
@@ -264,6 +266,15 @@ pub trait WalReader {
         &self,
         wal_file_id_range: WalFileRange,
     ) -> Result<Box<dyn WalIterator>, WalError>;
+}
+
+/// API for plugging into WAL GC
+#[async_trait]
+pub trait WalGC: Send + Sync + 'static {
+    /// Hook for garbage collecting the WAL. Takes a list of ranges of WAL Files that are currently
+    /// referenced by some active Manifest. The implementation may delete any WAL File that is not
+    /// included in the ranges in this list.
+    async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError>;
 }
 
 impl From<WalStatus> for WalError {


### PR DESCRIPTION
## Summary

- Add the WalGc trait from rfc-30
- Add SlateDbWalGc implementation for slatedb's native wal
- Refactor wal gc to use the new trait

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
