### PR TITLE
Add cleanup_db admin fn and cli command for clone teardown

### DIFF
--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -128,6 +128,14 @@ pub(crate) enum CliCommands {
         id: Uuid,
     },
 
+    /// Clean up a database: delete the checkpoints it pinned in each parent, and
+    /// (with --force) delete the db's own objects.
+    CleanupDb {
+        /// Also delete the db's own objects. Guards against wiping a live db.
+        #[arg(long)]
+        force: bool,
+    },
+
     /// List the current checkpoints of the db.
     ListCheckpoints {
         /// Optionally specify the name to filter the checkpoints. Note that name may not be unique

--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -128,12 +128,13 @@ pub(crate) enum CliCommands {
         id: Uuid,
     },
 
-    /// Clean up a clone: delete the checkpoints it pinned in each parent, and
-    /// (with --force) delete the clone's own objects.
-    CleanupClone {
-        /// Also delete the clone's own objects. Guards against wiping a live db.
+    /// Delete a database: strip any checkpoints it pinned in parent databases,
+    /// then delete its own objects. Without --confirm, prints what it would
+    /// delete and does nothing.
+    DeleteDb {
+        /// Actually delete. Without it, this is a dry run.
         #[arg(long)]
-        force: bool,
+        confirm: bool,
     },
 
     /// List the current checkpoints of the db.

--- a/slatedb-cli/src/args.rs
+++ b/slatedb-cli/src/args.rs
@@ -128,10 +128,10 @@ pub(crate) enum CliCommands {
         id: Uuid,
     },
 
-    /// Clean up a database: delete the checkpoints it pinned in each parent, and
-    /// (with --force) delete the db's own objects.
-    CleanupDb {
-        /// Also delete the db's own objects. Guards against wiping a live db.
+    /// Clean up a clone: delete the checkpoints it pinned in each parent, and
+    /// (with --force) delete the clone's own objects.
+    CleanupClone {
+        /// Also delete the clone's own objects. Guards against wiping a live db.
         #[arg(long)]
         force: bool,
     },

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -66,6 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             exec_refresh_checkpoint(&admin, id, lifetime).await?;
         }
         CliCommands::DeleteCheckpoint { id } => exec_delete_checkpoint(&admin, id).await?,
+        CliCommands::CleanupDb { force } => exec_cleanup_db(&admin, force).await?,
         CliCommands::ListCheckpoints { name } => exec_list_checkpoints(&admin, name).await?,
         CliCommands::RunGarbageCollection {
             resource,
@@ -277,6 +278,11 @@ async fn exec_refresh_checkpoint(
 
 async fn exec_delete_checkpoint(admin: &Admin, id: Uuid) -> Result<(), Box<dyn Error>> {
     println!("{:?}", admin.delete_checkpoint(id).await?);
+    Ok(())
+}
+
+async fn exec_cleanup_db(admin: &Admin, force: bool) -> Result<(), Box<dyn Error>> {
+    admin.cleanup_db(force).await?;
     Ok(())
 }
 

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             exec_refresh_checkpoint(&admin, id, lifetime).await?;
         }
         CliCommands::DeleteCheckpoint { id } => exec_delete_checkpoint(&admin, id).await?,
-        CliCommands::CleanupClone { force } => exec_cleanup_clone(&admin, force).await?,
+        CliCommands::DeleteDb { confirm } => exec_delete_db(&admin, confirm).await?,
         CliCommands::ListCheckpoints { name } => exec_list_checkpoints(&admin, name).await?,
         CliCommands::RunGarbageCollection {
             resource,
@@ -281,8 +281,17 @@ async fn exec_delete_checkpoint(admin: &Admin, id: Uuid) -> Result<(), Box<dyn E
     Ok(())
 }
 
-async fn exec_cleanup_clone(admin: &Admin, force: bool) -> Result<(), Box<dyn Error>> {
-    admin.cleanup_db(force).await?;
+async fn exec_delete_db(admin: &Admin, confirm: bool) -> Result<(), Box<dyn Error>> {
+    let paths = admin.delete_db(confirm).await?;
+    if confirm {
+        println!("deleted {} objects", paths.len());
+    } else {
+        println!("would delete {} objects:", paths.len());
+        for path in &paths {
+            println!("  {path}");
+        }
+        println!("rerun with --confirm to delete");
+    }
     Ok(())
 }
 

--- a/slatedb-cli/src/main.rs
+++ b/slatedb-cli/src/main.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             exec_refresh_checkpoint(&admin, id, lifetime).await?;
         }
         CliCommands::DeleteCheckpoint { id } => exec_delete_checkpoint(&admin, id).await?,
-        CliCommands::CleanupDb { force } => exec_cleanup_db(&admin, force).await?,
+        CliCommands::CleanupClone { force } => exec_cleanup_clone(&admin, force).await?,
         CliCommands::ListCheckpoints { name } => exec_list_checkpoints(&admin, name).await?,
         CliCommands::RunGarbageCollection {
             resource,
@@ -281,7 +281,7 @@ async fn exec_delete_checkpoint(admin: &Admin, id: Uuid) -> Result<(), Box<dyn E
     Ok(())
 }
 
-async fn exec_cleanup_db(admin: &Admin, force: bool) -> Result<(), Box<dyn Error>> {
+async fn exec_cleanup_clone(admin: &Admin, force: bool) -> Result<(), Box<dyn Error>> {
     admin.cleanup_db(force).await?;
     Ok(())
 }

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -564,21 +564,22 @@ impl Admin {
     /// pinned in each parent. `force` must be true to also delete the db's own
     /// objects (guards against wiping a live db). Idempotent.
     pub async fn cleanup_db(&self, force: bool) -> Result<(), crate::Error> {
-        // If this db's manifest is already gone, there is nothing to clean up.
-        let Some(manifest) = self.manifest_store().try_read_latest_manifest().await? else {
-            return Ok(());
-        };
-
-        for external_db in manifest.external_dbs() {
-            let Some(final_checkpoint_id) = external_db.final_checkpoint_id else {
-                continue;
-            };
-            let parent_store = Arc::new(ManifestStore::new(
-                &Path::from(external_db.path.as_str()),
-                self.retrying_store(ObjectStoreType::Main),
-            ));
-            let mut parent = StoredManifest::load(parent_store, self.system_clock.clone()).await?;
-            parent.delete_checkpoint(final_checkpoint_id).await?;
+        // The manifest may already be gone from a prior partial run. The parent
+        // checkpoint cleanup needs it, but the `force` prefix delete does not, so
+        // we still fall through to it to finish an interrupted deletion
+        if let Some(manifest) = self.manifest_store().try_read_latest_manifest().await? {
+            for external_db in manifest.external_dbs() {
+                let Some(final_checkpoint_id) = external_db.final_checkpoint_id else {
+                    continue;
+                };
+                let parent_store = Arc::new(ManifestStore::new(
+                    &Path::from(external_db.path.as_str()),
+                    self.retrying_store(ObjectStoreType::Main),
+                ));
+                let mut parent =
+                    StoredManifest::load(parent_store, self.system_clock.clone()).await?;
+                parent.delete_checkpoint(final_checkpoint_id).await?;
+            }
         }
 
         if force {
@@ -1583,6 +1584,59 @@ mod tests {
             .cleanup_db(true)
             .await
             .expect("second cleanup should be a no-op");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_db_force_finishes_partial_deletion() {
+        use crate::admin::CloneSourceSpec;
+        use crate::Db;
+        use futures::StreamExt;
+        use object_store::ObjectStoreExt;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_cleanup_partial_parent");
+        let clone_path = Path::from("/tmp/test_cleanup_partial_clone");
+
+        Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap()
+            .close()
+            .await
+            .unwrap();
+
+        let clone_admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+        clone_admin
+            .create_clone_builder_from_source(CloneSourceSpec::new(parent_path.clone()))
+            .build()
+            .await
+            .expect("clone should succeed");
+
+        // Simulate a crash mid-cleanup: the manifests are gone but the clone's
+        // other objects under the prefix remain
+        let manifest_prefix = Path::from("/tmp/test_cleanup_partial_clone/manifest");
+        let mut listing = object_store.list(Some(&manifest_prefix));
+        while let Some(meta) = listing.next().await {
+            object_store.delete(&meta.unwrap().location).await.unwrap();
+        }
+        let count_under = |prefix: Path| {
+            let object_store = object_store.clone();
+            async move { object_store.list(Some(&prefix)).count().await }
+        };
+        assert!(
+            count_under(clone_path.clone()).await > 0,
+            "leftover clone objects should remain after partial deletion"
+        );
+
+        // force must finish the job even though the manifest is already gone
+        clone_admin
+            .cleanup_db(true)
+            .await
+            .expect("cleanup should finish partial deletion");
+        assert_eq!(
+            count_under(clone_path.clone()).await,
+            0,
+            "leftover objects should be gone"
+        );
     }
 
     #[cfg(feature = "wal_disable")]

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -19,8 +19,9 @@ use crate::seq_tracker::FindOption;
 use crate::utils::IdGenerator;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use futures::StreamExt;
 use object_store::path::Path;
-use object_store::ObjectStore;
+use object_store::{ObjectStore, ObjectStoreExt};
 use rand::RngCore;
 use slatedb_common::DbRand;
 use std::env;
@@ -557,6 +558,55 @@ impl Admin {
             })
             .await
             .map_err(Into::into)
+    }
+
+    /// Cleans up a database that is no longer needed: deletes the checkpoints it
+    /// pinned in each parent. `force` must be true to also delete the db's own
+    /// objects (guards against wiping a live db). Idempotent.
+    pub async fn cleanup_db(&self, force: bool) -> Result<(), crate::Error> {
+        // If this db's manifest is already gone, there is nothing to clean up.
+        let Some(manifest) = self.manifest_store().try_read_latest_manifest().await? else {
+            return Ok(());
+        };
+
+        for external_db in manifest.external_dbs() {
+            let Some(final_checkpoint_id) = external_db.final_checkpoint_id else {
+                continue;
+            };
+            let parent_store = Arc::new(ManifestStore::new(
+                &Path::from(external_db.path.as_str()),
+                self.retrying_store(ObjectStoreType::Main),
+            ));
+            let mut parent = StoredManifest::load(parent_store, self.system_clock.clone()).await?;
+            parent.delete_checkpoint(final_checkpoint_id).await?;
+        }
+
+        if force {
+            self.delete_prefix(&self.retrying_store(ObjectStoreType::Main))
+                .await?;
+            if self.object_stores.has_wal_object_store() {
+                self.delete_prefix(&self.retrying_store(ObjectStoreType::Wal))
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Deletes every object under this db's path prefix in the given store.
+    async fn delete_prefix(&self, store: &Arc<dyn ObjectStore>) -> Result<(), crate::Error> {
+        let mut listing = store.list(Some(&self.path));
+        while let Some(meta) = listing
+            .next()
+            .await
+            .transpose()
+            .map_err(SlateDBError::from)?
+        {
+            store
+                .delete(&meta.location)
+                .await
+                .map_err(SlateDBError::from)?;
+        }
+        Ok(())
     }
 
     /// Returns the timestamp or sequence from the latest manifest's sequence tracker.
@@ -1389,6 +1439,152 @@ mod tests {
         assert!(manifest.is_ok(), "cloned manifest should exist");
     }
 
+    #[tokio::test]
+    async fn test_cleanup_db_removes_checkpoint_from_parent() {
+        use crate::admin::CloneSourceSpec;
+        use crate::config::CheckpointOptions;
+        use crate::manifest::store::{ManifestStore, StoredManifest};
+        use crate::Db;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
+        let parent_path = Path::from("/tmp/test_cleanup_parent");
+        let clone_path = Path::from("/tmp/test_cleanup_clone");
+
+        let parent_db = Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap();
+        parent_db.close().await.unwrap();
+
+        // An unrelated checkpoint in the parent that cleanup must not touch.
+        let parent_admin = AdminBuilder::new(parent_path.clone(), object_store.clone()).build();
+        let unrelated = parent_admin
+            .create_detached_checkpoint(&CheckpointOptions::default())
+            .await
+            .unwrap()
+            .id;
+
+        let clone_admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+        clone_admin
+            .create_clone_builder_from_source(CloneSourceSpec::new(parent_path.clone()))
+            .build()
+            .await
+            .expect("clone should succeed");
+
+        // The checkpoint the clone pinned in the parent.
+        let clone_ms = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_stored = StoredManifest::load(clone_ms, system_clock.clone())
+            .await
+            .unwrap();
+        let pinned = clone_stored.manifest().external_dbs[0]
+            .final_checkpoint_id
+            .expect("clone pins a final_checkpoint_id in the parent");
+
+        let read_parent_checkpoints = || {
+            let object_store = object_store.clone();
+            let system_clock = system_clock.clone();
+            let parent_path = parent_path.clone();
+            async move {
+                let ms = Arc::new(ManifestStore::new(&parent_path, object_store));
+                let stored = StoredManifest::load(ms, system_clock).await.unwrap();
+                stored
+                    .manifest()
+                    .core
+                    .checkpoints
+                    .iter()
+                    .map(|c| c.id)
+                    .collect::<Vec<_>>()
+            }
+        };
+
+        let before = read_parent_checkpoints().await;
+        assert!(
+            before.contains(&pinned),
+            "parent should have pinned checkpoint before cleanup"
+        );
+        assert!(
+            before.contains(&unrelated),
+            "parent should have unrelated checkpoint"
+        );
+
+        clone_admin
+            .cleanup_db(true)
+            .await
+            .expect("cleanup should succeed");
+
+        let after = read_parent_checkpoints().await;
+        assert!(
+            !after.contains(&pinned),
+            "pinned checkpoint should be gone from parent"
+        );
+        assert!(
+            after.contains(&unrelated),
+            "unrelated checkpoint should remain"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_db_deletes_own_objects_only_with_force() {
+        use crate::admin::CloneSourceSpec;
+        use crate::Db;
+        use futures::StreamExt;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_cleanup_force_parent");
+        let clone_path = Path::from("/tmp/test_cleanup_force_clone");
+
+        Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap()
+            .close()
+            .await
+            .unwrap();
+
+        let clone_admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+        clone_admin
+            .create_clone_builder_from_source(CloneSourceSpec::new(parent_path.clone()))
+            .build()
+            .await
+            .expect("clone should succeed");
+
+        let count_under = |prefix: Path| {
+            let object_store = object_store.clone();
+            async move { object_store.list(Some(&prefix)).count().await }
+        };
+
+        assert!(
+            count_under(clone_path.clone()).await > 0,
+            "clone should have objects"
+        );
+
+        // force = false leaves the clone's own data untouched.
+        clone_admin
+            .cleanup_db(false)
+            .await
+            .expect("cleanup should succeed");
+        assert!(
+            count_under(clone_path.clone()).await > 0,
+            "clone objects should remain without force"
+        );
+
+        // force = true deletes the clone's own objects.
+        clone_admin
+            .cleanup_db(true)
+            .await
+            .expect("cleanup should succeed");
+        assert_eq!(
+            count_under(clone_path.clone()).await,
+            0,
+            "clone objects should be gone with force"
+        );
+
+        // Idempotent: a second run over an already-cleaned db is a clean no-op.
+        clone_admin
+            .cleanup_db(true)
+            .await
+            .expect("second cleanup should be a no-op");
+    }
+
     #[cfg(feature = "wal_disable")]
     #[tokio::test]
     async fn test_create_clone_with_multiple_sources() {
@@ -1470,5 +1666,84 @@ mod tests {
             2,
             "clone should have an external database for each parent"
         );
+    }
+
+    #[cfg(feature = "wal_disable")]
+    #[tokio::test]
+    async fn test_cleanup_db_removes_checkpoints_from_all_parents() {
+        use crate::config::{PutOptions, Settings, WriteOptions};
+        use crate::manifest::store::{ManifestStore, StoredManifest};
+        use crate::{admin::CloneSourceSpec, Db};
+        use uuid::Uuid;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let system_clock = Arc::new(DefaultSystemClock::new());
+        let parent_path1 = Path::from("/tmp/test_cleanup_multi_parent1");
+        let parent_path2 = Path::from("/tmp/test_cleanup_multi_parent2");
+        let clone_path = Path::from("/tmp/test_cleanup_multi_clone");
+
+        let settings = Settings {
+            wal_enabled: false,
+            ..Settings::default()
+        };
+        let write_opts = WriteOptions::default();
+
+        // Two parents with disjoint single-key SSTs (the union path rejects overlaps).
+        for (path, key) in [(&parent_path1, b"a"), (&parent_path2, b"z")] {
+            let db = Db::builder(path.clone(), object_store.clone())
+                .with_settings(settings.clone())
+                .build()
+                .await
+                .unwrap();
+            db.put_with_options(key, b"1", &PutOptions::default(), &write_opts)
+                .await
+                .unwrap();
+            db.close().await.unwrap();
+        }
+
+        let clone_admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+        clone_admin
+            .create_clone_builder_from_source(CloneSourceSpec::new(parent_path1.clone()))
+            .with_source(CloneSourceSpec::new(parent_path2.clone()))
+            .build()
+            .await
+            .expect("clone with multiple sources should succeed");
+
+        // Collect the checkpoint each parent got pinned with.
+        let clone_ms = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
+        let clone_stored = StoredManifest::load(clone_ms, system_clock.clone())
+            .await
+            .unwrap();
+        let pinned: Vec<(String, Uuid)> = clone_stored
+            .manifest()
+            .external_dbs
+            .iter()
+            .map(|e| (e.path.clone(), e.final_checkpoint_id.unwrap()))
+            .collect();
+        assert_eq!(pinned.len(), 2);
+
+        clone_admin
+            .cleanup_db(true)
+            .await
+            .expect("cleanup should succeed");
+
+        for (parent_path, checkpoint_id) in pinned {
+            let ms = Arc::new(ManifestStore::new(
+                &parent_path.into(),
+                object_store.clone(),
+            ));
+            let stored = StoredManifest::load(ms, system_clock.clone())
+                .await
+                .unwrap();
+            assert!(
+                !stored
+                    .manifest()
+                    .core
+                    .checkpoints
+                    .iter()
+                    .any(|c| c.id == checkpoint_id),
+                "pinned checkpoint should be removed from every parent"
+            );
+        }
     }
 }

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -560,14 +560,48 @@ impl Admin {
             .map_err(Into::into)
     }
 
-    /// Cleans up a database that is no longer needed: deletes the checkpoints it
-    /// pinned in each parent. `force` must be true to also delete the db's own
-    /// objects (guards against wiping a live db). Idempotent.
-    pub async fn cleanup_db(&self, force: bool) -> Result<(), crate::Error> {
-        // The manifest may already be gone from a prior partial run. The parent
-        // checkpoint cleanup needs it, but the `force` prefix delete does not, so
-        // we still fall through to it to finish an interrupted deletion
-        if let Some(manifest) = self.manifest_store().try_read_latest_manifest().await? {
+    /// Deletes a database, stripping any checkpoints it pinned in parent
+    /// databases (a clone) before removing its own objects. Works for plain and
+    /// cloned dbs alike: a plain db just has no parent checkpoints to strip.
+    ///
+    /// Without `confirm` this is a dry run: it returns every object it *would*
+    /// delete and touches nothing. Pass `confirm` to actually delete.
+    ///
+    /// The delete writes a `.deleting` marker while the manifest still proves
+    /// this is a slatedb dir, then removes everything else, then the marker. If a
+    /// prior run crashed mid-delete, the leftover marker lets a rerun finish the
+    /// job. A `confirm` delete of a dir with neither a manifest nor a marker is
+    /// refused, so a fat-fingered `--path` can't wipe an unrelated directory.
+    /// Idempotent.
+    pub async fn delete_db(&self, confirm: bool) -> Result<Vec<Path>, crate::Error> {
+        let main = self.retrying_store(ObjectStoreType::Main);
+
+        if !confirm {
+            return self.list_prefix(&main).await;
+        }
+
+        let marker = self.path.clone().join(".deleting");
+        let marker_exists = main.get(&marker).await.map(|_| true).or_else(|e| match e {
+            object_store::Error::NotFound { .. } => Ok(false),
+            other => Err(SlateDBError::from(other)),
+        })?;
+
+        let manifest = self.manifest_store().try_read_latest_manifest().await?;
+
+        // No manifest and no marker means we never proved this is a slatedb dir.
+        // If there are objects under the prefix, it may be a fat-fingered path we
+        // must not wipe, so refuse. If empty, there's nothing to delete anyway
+        // (also the already-deleted no-op), so fall through to a clean return.
+        if manifest.is_none()
+            && !marker_exists
+            && !collect_prefix(&main, &self.path).await?.is_empty()
+        {
+            return Err(SlateDBError::InvalidDBState.into());
+        }
+
+        // Strip the checkpoints this db pinned in each parent. Needs the
+        // manifest, which a resumed (marker-only) run may no longer have.
+        if let Some(manifest) = manifest.as_ref() {
             for external_db in manifest.external_dbs() {
                 let Some(final_checkpoint_id) = external_db.final_checkpoint_id else {
                     continue;
@@ -582,32 +616,54 @@ impl Admin {
             }
         }
 
-        if force {
-            self.delete_prefix(&self.retrying_store(ObjectStoreType::Main))
-                .await?;
-            if self.object_stores.has_wal_object_store() {
-                self.delete_prefix(&self.retrying_store(ObjectStoreType::Wal))
-                    .await?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Deletes every object under this db's path prefix in the given store.
-    async fn delete_prefix(&self, store: &Arc<dyn ObjectStore>) -> Result<(), crate::Error> {
-        let mut listing = store.list(Some(&self.path));
-        while let Some(meta) = listing
-            .next()
-            .await
-            .transpose()
-            .map_err(SlateDBError::from)?
-        {
-            store
-                .delete(&meta.location)
+        // Commit the intent to delete while the manifest still proves this dir.
+        if !marker_exists {
+            main.put(&marker, Bytes::new().into())
                 .await
                 .map_err(SlateDBError::from)?;
         }
-        Ok(())
+
+        // Delete everything but the marker, then the marker last, so a crash in
+        // between leaves the marker to prove a rerun should finish.
+        let mut deleted = self.delete_prefix(&main, Some(&marker)).await?;
+        if self.object_stores.has_wal_object_store() {
+            deleted.extend(
+                self.delete_prefix(&self.retrying_store(ObjectStoreType::Wal), None)
+                    .await?,
+            );
+        }
+        main.delete(&marker).await.map_err(SlateDBError::from)?;
+        deleted.push(marker);
+        Ok(deleted)
+    }
+
+    /// Lists every object under this db's path prefix across the main and WAL stores.
+    async fn list_prefix(&self, main: &Arc<dyn ObjectStore>) -> Result<Vec<Path>, crate::Error> {
+        let mut paths = collect_prefix(main, &self.path).await?;
+        if self.object_stores.has_wal_object_store() {
+            paths.extend(
+                collect_prefix(&self.retrying_store(ObjectStoreType::Wal), &self.path).await?,
+            );
+        }
+        Ok(paths)
+    }
+
+    /// Deletes every object under this db's path prefix in the given store,
+    /// skipping `keep` if set. Returns the deleted paths.
+    async fn delete_prefix(
+        &self,
+        store: &Arc<dyn ObjectStore>,
+        keep: Option<&Path>,
+    ) -> Result<Vec<Path>, crate::Error> {
+        let mut deleted = Vec::new();
+        for path in collect_prefix(store, &self.path).await? {
+            if Some(&path) == keep {
+                continue;
+            }
+            store.delete(&path).await.map_err(SlateDBError::from)?;
+            deleted.push(path);
+        }
+        Ok(deleted)
     }
 
     /// Returns the timestamp or sequence from the latest manifest's sequence tracker.
@@ -864,6 +920,24 @@ pub fn load_gcp() -> Result<Arc<dyn ObjectStore>, crate::Error> {
             source: Box::new(error),
         }))
     })?) as Arc<dyn ObjectStore>)
+}
+
+/// Collects every object path under `prefix` in the given store.
+async fn collect_prefix(
+    store: &Arc<dyn ObjectStore>,
+    prefix: &Path,
+) -> Result<Vec<Path>, crate::Error> {
+    let mut listing = store.list(Some(prefix));
+    let mut paths = Vec::new();
+    while let Some(meta) = listing
+        .next()
+        .await
+        .transpose()
+        .map_err(SlateDBError::from)?
+    {
+        paths.push(meta.location);
+    }
+    Ok(paths)
 }
 
 #[cfg(test)]
@@ -1441,7 +1515,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cleanup_db_removes_checkpoint_from_parent() {
+    async fn test_delete_db_removes_checkpoint_from_parent() {
         use crate::admin::CloneSourceSpec;
         use crate::config::CheckpointOptions;
         use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -1509,9 +1583,9 @@ mod tests {
         );
 
         clone_admin
-            .cleanup_db(true)
+            .delete_db(true)
             .await
-            .expect("cleanup should succeed");
+            .expect("delete should succeed");
 
         let after = read_parent_checkpoints().await;
         assert!(
@@ -1525,14 +1599,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_cleanup_db_deletes_own_objects_only_with_force() {
+    async fn test_delete_db_deletes_own_objects_only_with_confirm() {
         use crate::admin::CloneSourceSpec;
         use crate::Db;
         use futures::StreamExt;
 
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let parent_path = Path::from("/tmp/test_cleanup_force_parent");
-        let clone_path = Path::from("/tmp/test_cleanup_force_clone");
+        let parent_path = Path::from("/tmp/test_delete_confirm_parent");
+        let clone_path = Path::from("/tmp/test_delete_confirm_clone");
 
         Db::open(parent_path.clone(), object_store.clone())
             .await
@@ -1553,49 +1627,54 @@ mod tests {
             async move { object_store.list(Some(&prefix)).count().await }
         };
 
-        assert!(
-            count_under(clone_path.clone()).await > 0,
-            "clone should have objects"
+        let initial = count_under(clone_path.clone()).await;
+        assert!(initial > 0, "clone should have objects");
+
+        // confirm = false is a dry run: it reports what it would delete and
+        // touches nothing.
+        let would_delete = clone_admin
+            .delete_db(false)
+            .await
+            .expect("dry run should succeed");
+        assert_eq!(
+            would_delete.len(),
+            initial,
+            "dry run should report every object under the prefix"
+        );
+        assert_eq!(
+            count_under(clone_path.clone()).await,
+            initial,
+            "dry run must not delete anything"
         );
 
-        // force = false leaves the clone's own data untouched.
+        // confirm = true deletes the clone's own objects.
         clone_admin
-            .cleanup_db(false)
+            .delete_db(true)
             .await
-            .expect("cleanup should succeed");
-        assert!(
-            count_under(clone_path.clone()).await > 0,
-            "clone objects should remain without force"
-        );
-
-        // force = true deletes the clone's own objects.
-        clone_admin
-            .cleanup_db(true)
-            .await
-            .expect("cleanup should succeed");
+            .expect("delete should succeed");
         assert_eq!(
             count_under(clone_path.clone()).await,
             0,
-            "clone objects should be gone with force"
+            "clone objects should be gone after confirm"
         );
 
-        // Idempotent: a second run over an already-cleaned db is a clean no-op.
+        // Idempotent: a second run over an already-deleted db is a clean no-op.
         clone_admin
-            .cleanup_db(true)
+            .delete_db(true)
             .await
-            .expect("second cleanup should be a no-op");
+            .expect("second delete should be a no-op");
     }
 
     #[tokio::test]
-    async fn test_cleanup_db_force_finishes_partial_deletion() {
+    async fn test_delete_db_finishes_partial_deletion_via_marker() {
         use crate::admin::CloneSourceSpec;
         use crate::Db;
         use futures::StreamExt;
         use object_store::ObjectStoreExt;
 
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
-        let parent_path = Path::from("/tmp/test_cleanup_partial_parent");
-        let clone_path = Path::from("/tmp/test_cleanup_partial_clone");
+        let parent_path = Path::from("/tmp/test_delete_partial_parent");
+        let clone_path = Path::from("/tmp/test_delete_partial_clone");
 
         Db::open(parent_path.clone(), object_store.clone())
             .await
@@ -1611,9 +1690,16 @@ mod tests {
             .await
             .expect("clone should succeed");
 
-        // Simulate a crash mid-cleanup: the manifests are gone but the clone's
-        // other objects under the prefix remain
-        let manifest_prefix = Path::from("/tmp/test_cleanup_partial_clone/manifest");
+        // Simulate a crash mid-delete: the marker was written, then the manifests
+        // (and some objects) were removed, but the marker and other objects remain.
+        object_store
+            .put(
+                &clone_path.clone().join(".deleting"),
+                bytes::Bytes::new().into(),
+            )
+            .await
+            .unwrap();
+        let manifest_prefix = Path::from("/tmp/test_delete_partial_clone/manifest");
         let mut listing = object_store.list(Some(&manifest_prefix));
         while let Some(meta) = listing.next().await {
             object_store.delete(&meta.unwrap().location).await.unwrap();
@@ -1627,16 +1713,45 @@ mod tests {
             "leftover clone objects should remain after partial deletion"
         );
 
-        // force must finish the job even though the manifest is already gone
+        // The marker proves this is a real slatedb dir, so delete resumes and
+        // finishes the job even though the manifest is already gone.
         clone_admin
-            .cleanup_db(true)
+            .delete_db(true)
             .await
-            .expect("cleanup should finish partial deletion");
+            .expect("delete should finish partial deletion");
         assert_eq!(
             count_under(clone_path.clone()).await,
             0,
-            "leftover objects should be gone"
+            "leftover objects, including the marker, should be gone"
         );
+    }
+
+    #[tokio::test]
+    async fn test_delete_db_refuses_without_manifest_or_marker() {
+        use futures::StreamExt;
+        use object_store::ObjectStoreExt;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let dir = Path::from("/tmp/test_delete_fat_finger");
+
+        // A directory that is NOT a slatedb dir: no manifest, no .deleting marker.
+        // This stands in for a fat-fingered --path.
+        object_store
+            .put(
+                &dir.clone().join("important.txt"),
+                bytes::Bytes::from_static(b"keepme").into(),
+            )
+            .await
+            .unwrap();
+
+        let admin = AdminBuilder::new(dir.clone(), object_store.clone()).build();
+        admin
+            .delete_db(true)
+            .await
+            .expect_err("delete must refuse a dir with no manifest and no marker");
+
+        let count = object_store.list(Some(&dir)).count().await;
+        assert_eq!(count, 1, "the unrelated object must be left untouched");
     }
 
     #[cfg(feature = "wal_disable")]
@@ -1724,7 +1839,7 @@ mod tests {
 
     #[cfg(feature = "wal_disable")]
     #[tokio::test]
-    async fn test_cleanup_db_removes_checkpoints_from_all_parents() {
+    async fn test_delete_db_removes_checkpoints_from_all_parents() {
         use crate::config::{PutOptions, Settings, WriteOptions};
         use crate::manifest::store::{ManifestStore, StoredManifest};
         use crate::{admin::CloneSourceSpec, Db};
@@ -1777,9 +1892,9 @@ mod tests {
         assert_eq!(pinned.len(), 2);
 
         clone_admin
-            .cleanup_db(true)
+            .delete_db(true)
             .await
-            .expect("cleanup should succeed");
+            .expect("delete should succeed");
 
         for (parent_path, checkpoint_id) in pinned {
             let ms = Arc::new(ManifestStore::new(

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -611,7 +611,12 @@ impl Admin {
                     self.retrying_store(ObjectStoreType::Main),
                 ));
                 let mut parent =
-                    StoredManifest::load(parent_store, self.system_clock.clone()).await?;
+                    match StoredManifest::load(parent_store, self.system_clock.clone()).await {
+                        Ok(parent) => parent,
+                        // parent already deleted: no checkpoint left to strip, skip it
+                        Err(SlateDBError::LatestTransactionalObjectVersionMissing) => continue,
+                        Err(e) => return Err(e.into()),
+                    };
                 parent.delete_checkpoint(final_checkpoint_id).await?;
             }
         }
@@ -1595,6 +1600,51 @@ mod tests {
         assert!(
             after.contains(&unrelated),
             "unrelated checkpoint should remain"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_db_deletes_clone_after_parent_already_gone() {
+        use crate::admin::CloneSourceSpec;
+        use crate::Db;
+        use futures::StreamExt;
+        use object_store::ObjectStoreExt;
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_delete_orphan_parent");
+        let clone_path = Path::from("/tmp/test_delete_orphan_clone");
+
+        Db::open(parent_path.clone(), object_store.clone())
+            .await
+            .unwrap()
+            .close()
+            .await
+            .unwrap();
+
+        let clone_admin = AdminBuilder::new(clone_path.clone(), object_store.clone()).build();
+        clone_admin
+            .create_clone_builder_from_source(CloneSourceSpec::new(parent_path.clone()))
+            .build()
+            .await
+            .expect("clone should succeed");
+
+        // Wipe the parent out from under the clone. The clone still names it in
+        // external_dbs with a pinned checkpoint, but the parent manifest is gone.
+        let mut parent_listing = object_store.list(Some(&parent_path));
+        while let Some(meta) = parent_listing.next().await {
+            object_store.delete(&meta.unwrap().location).await.unwrap();
+        }
+
+        // A missing parent means there is no checkpoint left to strip, so the
+        // clone must still be deletable rather than wedged on a Data error.
+        clone_admin
+            .delete_db(true)
+            .await
+            .expect("clone should delete even with parent already gone");
+        assert_eq!(
+            object_store.list(Some(&clone_path)).count().await,
+            0,
+            "clone objects should be gone"
         );
     }
 


### PR DESCRIPTION
## Summary

deleting a clone is a manual multi-step chore today: you remove the clone's own data, then go remove the checkpoint the clone left in its source. this adds an `Admin::cleanup_db` fn that does both plus a `slatedb-cli cleanup-db` command

closes #1049. this follows the review direction on #1050 from Barre and rodesai (cleanup should handle all associated resources, not just the checkpoint) and supersedes that stale PR

## Changes

- `Admin::cleanup_db(force)`: reads the manifest, deletes the checkpoint this db pinned in each parent, and with `force` deletes the db's own objects under its path prefix (main and WAL stores). idempotent.
- `slatedb-cli cleanup-db [--force]` subcommand.

## Notes for Reviewers

the own-data delete is gated behind `--force` for now so it can't wipe a live db by accident. i left an open question on the issue about whether it should be unconditional. un-gating later is a one line change if you'd rather it always run

step 3 is a destructive prefix delete, so worth a look: it lists and deletes only under `self.path` on each store. object_store path matching is segment based, so a sibling like `foo-clone` is never caught by a `foo` prefix. verified end to end against a local fs store (clone wiped, parent checkpoint removed, parent data and a sibling path both untouched).

## Checklist

- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏