### PR TITLE
fix(compactor): prevent terminal compaction resurrection

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -635,8 +635,18 @@ impl CompactorEventHandler {
             .active_compactions()
             .filter(|c| c.status() != CompactionStatus::Compacted)
         {
-            let estimated_source_bytes =
-                Self::calculate_estimated_source_bytes(compaction, db_state);
+            let Some(estimated_source_bytes) =
+                Self::calculate_estimated_source_bytes(compaction, db_state)
+            else {
+                warn!(
+                    "skipping compaction progress because a source is absent from the manifest \
+                     [id={}, status={:?}, spec={}]",
+                    compaction.id(),
+                    compaction.status(),
+                    compaction.spec(),
+                );
+                continue;
+            };
             total_estimated_bytes += estimated_source_bytes;
             total_bytes_processed += compaction.bytes_processed();
 
@@ -690,10 +700,11 @@ impl CompactorEventHandler {
     }
 
     /// Calculates the estimated total source bytes for a compaction.
-    fn calculate_estimated_source_bytes(compaction: &Compaction, db_state: &ManifestCore) -> u64 {
-        let tree = db_state
-            .tree_for_segment(compaction.spec().segment())
-            .expect("compaction target segment missing from manifest");
+    fn calculate_estimated_source_bytes(
+        compaction: &Compaction,
+        db_state: &ManifestCore,
+    ) -> Option<u64> {
+        let tree = db_state.tree_for_segment(compaction.spec().segment())?;
 
         let views_by_id: HashMap<Ulid, &SsTableView> =
             tree.l0.iter().map(|view| (view.id, view)).collect();
@@ -704,17 +715,13 @@ impl CompactorEventHandler {
             .spec()
             .sources()
             .iter()
-            .map(|source| match source {
-                SourceId::SstView(id) => views_by_id
-                    .get(id)
-                    .expect("compaction source view not found in L0")
-                    .estimate_size(),
-                SourceId::SortedRun(id) => srs_by_id
-                    .get(id)
-                    .expect("compaction source sorted run not found")
-                    .estimate_size(),
+            .try_fold(0, |total, source| {
+                let source_bytes = match source {
+                    SourceId::SstView(id) => views_by_id.get(id)?.estimate_size(),
+                    SourceId::SortedRun(id) => srs_by_id.get(id)?.estimate_size(),
+                };
+                Some(total + source_bytes)
             })
-            .sum()
     }
 
     /// Handles a polling tick by refreshing compactions and the manifest, then possibly scheduling compactions.
@@ -3870,7 +3877,23 @@ mod tests {
 
         let expected = segment_l0.estimate_size() + segment_sr.estimate_size();
         let actual = CompactorEventHandler::calculate_estimated_source_bytes(&compaction, &core);
-        assert_eq!(actual, expected);
+        assert_eq!(actual, Some(expected));
+    }
+
+    #[test]
+    fn test_calculate_estimated_source_bytes_returns_none_for_missing_source() {
+        let missing_l0 = Ulid::new();
+        let compaction = Compaction::new(
+            Ulid::new(),
+            CompactionSpec::new(vec![SourceId::SstView(missing_l0)], 1),
+        );
+
+        let actual = CompactorEventHandler::calculate_estimated_source_bytes(
+            &compaction,
+            &ManifestCore::new(),
+        );
+
+        assert_eq!(actual, None);
     }
 
     #[tokio::test]

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -678,9 +678,9 @@ impl CompactionsCore {
         self
     }
 
-    /// Returns an iterator over all recent compactions. Recent compactions include all
-    /// active (submitted or running) compactions as well as the most recently finished
-    /// compaction (failed or completed).
+    /// Returns all compactions retained in this state. Persisted state contains all active
+    /// compactions and the most recently finished one; process-local state may also retain
+    /// older terminal entries until its next successful write.
     pub(crate) fn recent_compactions(&self) -> impl Iterator<Item = &Compaction> {
         self.recent_compactions.values()
     }

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -821,7 +821,8 @@ impl Compactions {
 ///
 /// This is the in-memory view that a single compactor task uses to:
 /// - keep a fresh `DirtyManifest` (view of `CoreDbState`),
-/// - track in-flight compactions by id (ULID).
+/// - track in-flight compactions by id (ULID), and
+/// - retain terminal tombstones until their `.compactions` write succeeds.
 pub struct CompactorState {
     manifest: DirtyObject<Manifest>,
     compactions: DirtyObject<Compactions>,
@@ -918,11 +919,11 @@ impl CompactorState {
         // For compactions not in local state (Vacant), accept new submissions,
         // worker-completed results, and retained terminal entries. On a write
         // conflict, the retry path reloads and merges the persisted `.compactions`
-        // object before writing again. At that point, local state may already have
-        // committed or pruned an entry while persisted state still contains an older
-        // Compacted/Completed/Failed view. Insert those entries, let the commit path
-        // resolve stale Compacted entries via `validate_compaction`, and let the compactions
-        // write path resolve stale terminal entries via `retain_active_and_last_finished`.
+        // object before writing again. Process-local terminal entries are deliberately
+        // retained until that write succeeds, so an older remote state for the same id
+        // is treated as a stale transition rather than resurrected as active work.
+        // Insert genuinely absent entries and let the commit path resolve stale
+        // Compacted entries via `validate_compaction`.
         //
         // Scheduled/Running are different: they carry no finished output and require prior
         // coordinator ownership, so seeing them absent from local state remains anomalous.
@@ -960,11 +961,10 @@ impl CompactorState {
             }
         }
 
-        let mut merged_compactions = Compactions {
+        let merged_compactions = Compactions {
             compactor_epoch: self.compactions.value.compactor_epoch,
             core: CompactionsCore::new().with_compactions(merged),
         };
-        merged_compactions.retain_active_and_last_finished();
         remote_compactions.value = merged_compactions;
         self.set_compactions(remote_compactions);
     }
@@ -1050,7 +1050,13 @@ impl CompactorState {
         Ok(())
     }
 
-    /// Mutates a compaction in place if it exists, then trims retained state.
+    /// Mutates a compaction in place if it exists.
+    ///
+    /// Terminal entries remain in process-local state until the next successful
+    /// `.compactions` write. They act as tombstones during conflict retries so
+    /// an older persisted `Submitted` or `Compacted` record cannot be resurrected.
+    /// The persisted value is still trimmed by
+    /// [`crate::compactor_state_protocols::CompactorStateWriter`].
     pub(crate) fn update_compaction<F>(&mut self, compaction_id: &Ulid, f: F)
     where
         F: FnOnce(&mut Compaction),
@@ -1064,7 +1070,6 @@ impl CompactorState {
         {
             f(compaction);
         }
-        self.compactions.value.retain_active_and_last_finished();
     }
 
     /// Applies the effects of a finished compaction to the in-memory manifest.

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -679,7 +679,7 @@ impl CompactionsCore {
     }
 
     /// Returns all compactions retained in this state. Persisted state contains all active
-    /// compactions and the most recently finished one; process-local state may also retain
+    /// compactions and the most recently finished one. Process-local state may also retain
     /// older terminal entries until its next successful write.
     pub(crate) fn recent_compactions(&self) -> impl Iterator<Item = &Compaction> {
         self.recent_compactions.values()

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -290,6 +290,11 @@ impl CompactorStateWriter {
     /// Persists the current compactions state to the compactions store and refreshes the
     /// local dirty object with the latest version.
     ///
+    /// Process-local state retains every terminal transition until this write succeeds.
+    /// Only the outgoing value is trimmed to the latest terminal entry. This preserves
+    /// terminal entries as tombstones across conflict retries while keeping the persisted
+    /// `.compactions` object bounded.
+    ///
     /// ## Returns
     /// - `Ok(())` when compactions are successfully written.
     /// - `SlateDBError` if an unrecoverable error occurs.
@@ -307,8 +312,10 @@ impl CompactorStateWriter {
                 }
                 Err(err) if err.is_sequenced_write_conflict() => {
                     // Merge the latest remote state (e.g. a worker's Compacted write) into
-                    // the coordinator's view before retrying. Without this, retrying with a stale
-                    // desired_value could silently overwrite worker progress.
+                    // the coordinator's untrimmed local view before retrying. Without this,
+                    // retrying with a stale desired_value could silently overwrite worker
+                    // progress. Local terminal entries also prevent stale remote active states
+                    // for the same ids from being resurrected.
                     self.load_compactions().await?;
                     desired_value = self.state.compactions().value.clone();
                     desired_value.retain_active_and_last_finished();
@@ -888,6 +895,82 @@ mod tests {
             .unwrap()
             .id;
         assert_eq!(final_id, start_id + 2);
+    }
+
+    #[tokio::test]
+    async fn test_write_compactions_safely_does_not_resurrect_terminal_on_conflict() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&object_store),
+        ));
+        let compactions_store = Arc::new(CompactionsStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&object_store),
+        ));
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            system_clock.clone(),
+        )
+        .await
+        .unwrap();
+
+        let mut writer = CompactorStateWriter::new(
+            manifest_store,
+            compactions_store.clone(),
+            system_clock,
+            &CompactorOptions::default(),
+            Arc::new(DbRand::new(7)),
+        )
+        .await
+        .unwrap();
+
+        let completed_id = Ulid::from_parts(10, 0);
+        let failed_id = Ulid::from_parts(20, 0);
+        let spec = CompactionSpec::new(vec![], 0);
+        writer
+            .state
+            .insert_compaction_for_test(Compaction::new(completed_id, spec.clone()));
+        writer
+            .state
+            .insert_compaction_for_test(Compaction::new(failed_id, spec.clone()));
+        writer.state.update_compaction(&completed_id, |compaction| {
+            compaction.set_status(CompactionStatus::Completed)
+        });
+        writer.state.update_compaction(&failed_id, |compaction| {
+            compaction.set_status(CompactionStatus::Failed)
+        });
+
+        // Advance the remote version with the pre-transition state of the completed
+        // compaction. This forces the coordinator's first write to conflict and reload.
+        let mut external = StoredCompactions::load(compactions_store.clone())
+            .await
+            .unwrap();
+        let mut dirty = external.prepare_dirty().unwrap();
+        dirty.value.insert(Compaction::new(completed_id, spec));
+        external.update(dirty).await.unwrap();
+
+        writer.write_compactions_safely().await.unwrap();
+
+        let persisted = compactions_store.read_latest_compactions().await.unwrap();
+        assert!(
+            persisted
+                .recent_compactions()
+                .all(|compaction| compaction.id() != completed_id),
+            "stale Submitted compaction was resurrected"
+        );
+        assert_eq!(
+            persisted
+                .recent_compactions()
+                .find(|compaction| compaction.id() == failed_id)
+                .expect("latest terminal compaction was not retained")
+                .status(),
+            CompactionStatus::Failed
+        );
+        assert_eq!(writer.state.active_compactions().count(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Compactor state now keeps terminal compactions in memory until the coordinator writes `.compactions`. A sequenced-write conflict could reload an older `Submitted` record after a trivial move removed its sources from the manifest. The coordinator then treated that record as active work, and progress metrics panicked while looking up a missing source.

Context: [DST failure](https://github.com/Barre/slatedb/actions/runs/30705046759/job/91382600554)

The failure in the DST goes like this:

t0: trivial move workload-2 L0 → SR 144
t1: finish that compaction
t2: reject workload-1 SR 143 because expected destination is 145
--- at this point, workload-2 is trimmed because workload-1 is more recent ---
t3: worker claim updates .compactions
t4: workload-2 L0 → SR 144 appears “in-flight” again
t5: panic looking up its removed L0 source

The panic came from a log statement. It was `.expect()`'d that inputs for in-flight jobs always have their inputs, which makes sense.

This bug was introduced by my #1982 patch. Prior to that, the transition from submitted to completed always required a transition to scheduled->running->completed, which happened through .compactions.

I _suspect_ this might have been an issue for drains as well. But it's fixed now either way.

## Changes

- Keep terminal transitions as local tombstones across `.compactions` conflict retries, while trimming the copy written to object storage.
- Cover the stale-remote sequence with a regression test and make progress metrics skip compactions whose sources are absent from the manifest.

## Notes for Reviewers

The main behavior change is the lifetime of terminal entries. Process-local state can contain more than one terminal compaction during a write retry. A successful write replaces it with the trimmed persisted state, so the `.compactions` object remains bounded.

The metrics guard is defensive. It does not change compaction scheduling or validation.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

No breaking changes or migration steps.

Thank you for the review!