### PR TITLE
Actually skip the WAL at DbReader open when skip_wal_replay is set (helps #2003)

### DIFF
--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1111,12 +1111,11 @@ pub struct DbReaderOptions {
     /// local filesystem, mirroring the behaviour of `Db`.
     pub object_store_cache_options: ObjectStoreCacheOptions,
 
-    /// When true, skip WAL replay entirely. The reader will only see data that has been
-    /// compacted into L0 or lower levels. This is useful for read-heavy workloads that
-    /// don't need to see the most recent uncommitted writes and want to minimize the
+    /// When true, skip WAL replay entirely, in every reader mode. The reader reads no WAL
+    /// when it opens or when it refreshes its state, so it only sees data that has been
+    /// flushed to L0 or lower levels. This is useful for read-heavy workloads that
+    /// don't need to see the most recent writes and want to minimize the
     /// cost of opening many readers.
-    ///
-    /// WAL replay is also skipped in [`crate::DbReaderMode::Checkpoint`] mode.
     ///
     /// When combined with a reader mode that polls manifests, the reader will still see newly
     /// compacted data as manifests are updated.

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -495,8 +495,7 @@ impl DbReaderInner {
                 .await?
             }
             // Skipping replay reads no WAL at all: the reader stays at the
-            // watermark it has already reached, which is the manifest's when it
-            // has replayed nothing.
+            // watermark it has already reached (the most recently read manifest)
             None => Self::replayed_watermark(&manifest.core, &imm_memtable),
         };
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1,46 +1,50 @@
-use crate::bytes_range::{ByteRangeBounds, BytesRange};
-use crate::cached_object_store::CachedObjectStore;
-use crate::clock::MonotonicClock;
-use crate::config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions};
-use crate::db_cache::CacheTarget;
-use crate::db_cache_manager;
-use crate::db_common::extract_segment_prefix;
-use crate::db_state::{collect_touched_segments, SsTableId};
-use crate::db_stats::DbStats;
-use crate::db_status::{ClosedResultWriter, DbStatus, DbStatusManager};
-use crate::dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef};
-use crate::error::SlateDBError;
-use crate::iter::IterationOrder;
-use crate::manifest::store::{ManifestStore, StoredManifest};
-use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
-use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
-use crate::merge_operator::MergeOperatorType;
-use crate::oracle::DbReaderOracle;
-use crate::paths::PathResolver;
-use crate::prefix_extractor::PrefixExtractor;
-use crate::reader::{DbStateReader, Reader, ScanContext};
-use crate::sst_iter::SstIteratorOptions;
-use crate::tablestore::TableStore;
-use crate::types::KeyValue;
-use crate::utils::IdGenerator;
-use crate::wal_replay::{WalIteratorOptions, WalReplayIterator, WalReplayOptions};
-use crate::{Checkpoint, DbIterator};
-use crate::{DbCacheManagerOps, DbMetadataOps, DbReadOps};
-use async_trait::async_trait;
-use bytes::Bytes;
-use futures::stream::BoxStream;
-use log::{info, warn};
-use object_store::path::Path;
-use object_store::ObjectStore;
-use parking_lot::RwLock;
-use slatedb_common::clock::SystemClock;
-use slatedb_common::DbRand;
-use std::collections::{BTreeSet, VecDeque};
-use std::ops::Sub;
-use std::sync::Arc;
-use std::sync::LazyLock;
-use tokio::runtime::Handle;
-use uuid::Uuid;
+use {
+    crate::{
+        bytes_range::{ByteRangeBounds, BytesRange},
+        cached_object_store::CachedObjectStore,
+        clock::MonotonicClock,
+        config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions},
+        db_cache::CacheTarget,
+        db_cache_manager,
+        db_common::extract_segment_prefix,
+        db_state::{collect_touched_segments, SsTableId},
+        db_stats::DbStats,
+        db_status::{ClosedResultWriter, DbStatus, DbStatusManager},
+        dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef},
+        error::SlateDBError,
+        iter::IterationOrder,
+        manifest::{
+            store::{ManifestStore, StoredManifest},
+            Manifest, ManifestCore, VersionedManifest,
+        },
+        mem_table::{ImmutableMemtable, KVTable, WritableKVTable},
+        merge_operator::MergeOperatorType,
+        oracle::DbReaderOracle,
+        paths::PathResolver,
+        prefix_extractor::PrefixExtractor,
+        reader::{DbStateReader, Reader, ScanContext},
+        sst_iter::SstIteratorOptions,
+        tablestore::TableStore,
+        types::KeyValue,
+        utils::IdGenerator,
+        wal_replay::{WalIteratorOptions, WalReplayIterator, WalReplayOptions},
+        Checkpoint, DbCacheManagerOps, DbIterator, DbMetadataOps, DbReadOps,
+    },
+    async_trait::async_trait,
+    bytes::Bytes,
+    futures::stream::BoxStream,
+    log::{info, warn},
+    object_store::{path::Path, ObjectStore},
+    parking_lot::RwLock,
+    slatedb_common::{clock::SystemClock, DbRand},
+    std::{
+        collections::{BTreeSet, VecDeque},
+        ops::Sub,
+        sync::{Arc, LazyLock},
+    },
+    tokio::runtime::Handle,
+    uuid::Uuid,
+};
 
 pub(crate) const DB_READER_TASK_NAME: &str = "manifest_poller";
 
@@ -206,8 +210,8 @@ impl DbReaderInner {
             initial_state.core().last_l0_clock_tick,
         ));
 
-        // initial_state contains the last_committed_seq after WAL replay. in no-wal mode, we can simply fallback
-        // to last_l0_seq.
+        // initial_state contains the last_committed_seq after WAL replay. in no-wal mode, we can
+        // simply fallback to last_l0_seq.
         let initial_durable_seq = initial_state
             .last_remote_persisted_seq
             .max(initial_state.core().last_l0_seq);
@@ -477,12 +481,12 @@ impl DbReaderInner {
         manifest_id: u64,
         manifest: Manifest,
         mut imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
-        and_replay_wal: Option<WalReplayEnd>,
+        replay_wals: Option<WalReplayEnd>,
         table_store: Arc<TableStore>,
         options: &DbReaderOptions,
         segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<ReaderState, SlateDBError> {
-        let (last_wal_id, last_committed_seq) = match and_replay_wal {
+        let (last_wal_id, last_committed_seq) = match replay_wals {
             Some(replay_end) => {
                 Self::replay_wal_into(
                     Arc::clone(&table_store),
@@ -663,7 +667,8 @@ impl DbReaderInner {
         };
         let replay_options = WalReplayOptions {
             max_memtable_bytes: reader_options.max_memtable_bytes as usize,
-            // Skip entries that we already have in `imm_memtable` (that might be above last_l0_seq).
+            // Skip entries that we already have in `imm_memtable` (that might be above
+            // last_l0_seq).
             min_seq: Some(last_committed_seq),
         };
 
@@ -741,8 +746,8 @@ impl DbReaderInner {
     ///
     /// ## Returns
     /// - `Ok(())` if the reader is still open.
-    /// - `Err(SlateDBError::Closed)` if the reader was closed successfully
-    ///   (state.result_reader() returns Ok(())).
+    /// - `Err(SlateDBError::Closed)` if the reader was closed successfully (state.result_reader()
+    ///   returns Ok(())).
     /// - `Err(e)` if the reader was closed with an error, where `e` is the error
     ///   (state.result_reader() returns Err(e)).
     pub(crate) fn check_closed(&self) -> Result<(), SlateDBError> {
@@ -910,9 +915,13 @@ impl DbReader {
     /// # Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, Error};
-    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
-    /// use std::sync::Arc;
+    /// use {
+    ///     slatedb::{
+    ///         object_store::{memory::InMemory, ObjectStore},
+    ///         Db, DbReader, Error,
+    ///     },
+    ///     std::sync::Arc,
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Error> {
@@ -921,9 +930,7 @@ impl DbReader {
     ///     let db = Db::open("test_db", Arc::clone(&object_store)).await?;
     ///     db.close().await?;
     ///     // Then open a reader
-    ///     let reader = DbReader::builder("test_db", object_store)
-    ///         .build()
-    ///         .await?;
+    ///     let reader = DbReader::builder("test_db", object_store).build().await?;
     ///     Ok(())
     /// }
     /// ```
@@ -1010,9 +1017,14 @@ impl DbReader {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, DbReaderMode, config::DbReaderOptions, Error};
-    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
-    /// use std::sync::Arc;
+    /// use {
+    ///     slatedb::{
+    ///         config::DbReaderOptions,
+    ///         object_store::{memory::InMemory, ObjectStore},
+    ///         Db, DbReader, DbReaderMode, Error,
+    ///     },
+    ///     std::sync::Arc,
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Error> {
@@ -1022,11 +1034,12 @@ impl DbReader {
     ///     db.flush().await?;
     ///
     ///     let reader = DbReader::open(
-    ///       "test_db",
-    ///       Arc::clone(&object_store),
-    ///       DbReaderMode::ManagedCheckpoint,
-    ///       DbReaderOptions::default(),
-    ///     ).await?;
+    ///         "test_db",
+    ///         Arc::clone(&object_store),
+    ///         DbReaderMode::ManagedCheckpoint,
+    ///         DbReaderOptions::default(),
+    ///     )
+    ///     .await?;
     ///     assert_eq!(reader.get(b"key").await?, Some("value".into()));
     ///     Ok(())
     /// }
@@ -1058,9 +1071,14 @@ impl DbReader {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, DbReaderMode, config::DbReaderOptions, config::ReadOptions, Error};
-    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
-    /// use std::sync::Arc;
+    /// use {
+    ///     slatedb::{
+    ///         config::{DbReaderOptions, ReadOptions},
+    ///         object_store::{memory::InMemory, ObjectStore},
+    ///         Db, DbReader, DbReaderMode, Error,
+    ///     },
+    ///     std::sync::Arc,
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Error> {
@@ -1070,12 +1088,16 @@ impl DbReader {
     ///     db.flush().await?;
     ///
     ///     let reader = DbReader::open(
-    ///       "test_db",
-    ///       Arc::clone(&object_store),
-    ///       DbReaderMode::ManagedCheckpoint,
-    ///       DbReaderOptions::default(),
-    ///     ).await?;
-    ///     assert_eq!(db.get_with_options(b"key", &ReadOptions::default()).await?, Some("value".into()));
+    ///         "test_db",
+    ///         Arc::clone(&object_store),
+    ///         DbReaderMode::ManagedCheckpoint,
+    ///         DbReaderOptions::default(),
+    ///     )
+    ///     .await?;
+    ///     assert_eq!(
+    ///         db.get_with_options(b"key", &ReadOptions::default()).await?,
+    ///         Some("value".into())
+    ///     );
     ///     Ok(())
     /// }
     /// ```
@@ -1129,9 +1151,14 @@ impl DbReader {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, DbReaderMode, config::DbReaderOptions, Error};
-    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
-    /// use std::sync::Arc;
+    /// use {
+    ///     slatedb::{
+    ///         config::DbReaderOptions,
+    ///         object_store::{memory::InMemory, ObjectStore},
+    ///         Db, DbReader, DbReaderMode, Error,
+    ///     },
+    ///     std::sync::Arc,
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Error> {
@@ -1142,11 +1169,12 @@ impl DbReader {
     ///     db.flush().await?;
     ///
     ///     let reader = DbReader::open(
-    ///       "test_db",
-    ///       Arc::clone(&object_store),
-    ///       DbReaderMode::ManagedCheckpoint,
-    ///       DbReaderOptions::default(),
-    ///     ).await?;
+    ///         "test_db",
+    ///         Arc::clone(&object_store),
+    ///         DbReaderMode::ManagedCheckpoint,
+    ///         DbReaderOptions::default(),
+    ///     )
+    ///     .await?;
     ///     let mut iter = reader.scan("a".."b").await?;
     ///     let kv = iter.next().await?.unwrap();
     ///     assert_eq!(kv.key.as_ref(), b"a");
@@ -1234,8 +1262,8 @@ impl DbReader {
     ///
     /// ## Arguments
     /// - `prefix`: the key prefix to scan
-    /// - `subrange`: the range of key suffixes (relative to `prefix`) to
-    ///   scan; `..` scans all keys with the prefix
+    /// - `subrange`: the range of key suffixes (relative to `prefix`) to scan; `..` scans all keys
+    ///   with the prefix
     ///
     /// ## Returns
     /// - `Result<DbIterator, Error>`: An iterator with the results of the scan
@@ -1258,8 +1286,8 @@ impl DbReader {
     ///
     /// ## Arguments
     /// - `prefix`: the key prefix to scan
-    /// - `subrange`: the range of key suffixes (relative to `prefix`) to
-    ///   scan; `..` scans all keys with the prefix
+    /// - `subrange`: the range of key suffixes (relative to `prefix`) to scan; `..` scans all keys
+    ///   with the prefix
     /// - `options`: the scan options to use
     ///
     /// ## Returns
@@ -1290,9 +1318,14 @@ impl DbReader {
     /// ## Examples
     ///
     /// ```
-    /// use slatedb::{Db, DbReader, DbReaderMode, config::DbReaderOptions, Error};
-    /// use slatedb::object_store::{ObjectStore, memory::InMemory};
-    /// use std::sync::Arc;
+    /// use {
+    ///     slatedb::{
+    ///         config::DbReaderOptions,
+    ///         object_store::{memory::InMemory, ObjectStore},
+    ///         Db, DbReader, DbReaderMode, Error,
+    ///     },
+    ///     std::sync::Arc,
+    /// };
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Error> {
@@ -1304,12 +1337,12 @@ impl DbReader {
     ///         object_store.clone(),
     ///         DbReaderMode::ManagedCheckpoint,
     ///         options,
-    ///     ).await?;
+    ///     )
+    ///     .await?;
     ///     reader.close().await?;
     ///     Ok(())
     /// }
     /// ```
-    ///
     pub async fn close(&self) -> Result<(), crate::Error> {
         self.task_executor
             .shutdown_task(DB_READER_TASK_NAME)
@@ -1419,46 +1452,54 @@ impl DbCacheManagerOps for DbReader {
 
 #[cfg(test)]
 mod tests {
-    use super::{DbReaderMessage, ManifestPoller, ReaderState, WalReplayEnd};
-    use crate::block_cache_policy::BlockCachePolicy;
-    use crate::clock::MonotonicClock;
-    use crate::config::{
-        CheckpointOptions, CheckpointScope, CloseOptions, FlushOptions, FlushType, MergeOptions,
-        PutOptions, Settings, WriteOptions,
+    use {
+        super::{DbReaderMessage, ManifestPoller, ReaderState, WalReplayEnd},
+        crate::{
+            block_cache_policy::BlockCachePolicy,
+            clock::MonotonicClock,
+            config::{
+                CheckpointOptions, CheckpointScope, CloseOptions, FlushOptions, FlushType,
+                MergeOptions, PutOptions, Settings, WriteOptions,
+            },
+            db_reader::{DbReader, DbReaderInner, DbReaderMode, DbReaderOptions},
+            db_state::{SsTableId, SstType},
+            db_stats::DbStats,
+            db_status::DbStatusManager,
+            dispatcher::MessageHandler,
+            error::SlateDBError,
+            format::sst::SsTableFormat,
+            iter::IterationOrder,
+            manifest::{
+                store::{ManifestStore, StoredManifest},
+                Manifest, ManifestCore, VersionedManifest,
+            },
+            mem_table::{ImmutableMemtable, WritableKVTable},
+            merge_operator::MergeOperatorType,
+            object_stores::ObjectStores,
+            oracle::DbReaderOracle,
+            paths::PathResolver,
+            proptest_util::{rng::new_test_rng, sample},
+            reader::Reader,
+            tablestore::{TableStore, TableStoreKind},
+            test_utils,
+            types::RowEntry,
+            CloseReason, Db,
+        },
+        bytes::Bytes,
+        fail_parallel::FailPointRegistry,
+        object_store::{memory::InMemory, path::Path, ObjectStore, ObjectStoreExt},
+        rstest::rstest,
+        slatedb_common::{
+            clock::{DefaultSystemClock, SystemClock},
+            DbRand, MockSystemClock,
+        },
+        std::{
+            collections::{BTreeMap, VecDeque},
+            sync::Arc,
+            time::Duration,
+        },
+        uuid::Uuid,
     };
-    use crate::db_reader::{DbReader, DbReaderInner, DbReaderMode, DbReaderOptions};
-    use crate::db_state::{SsTableId, SstType};
-    use crate::db_stats::DbStats;
-    use crate::db_status::DbStatusManager;
-    use crate::dispatcher::MessageHandler;
-    use crate::format::sst::SsTableFormat;
-    use crate::iter::IterationOrder;
-    use crate::manifest::store::{ManifestStore, StoredManifest};
-    use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
-    use crate::mem_table::{ImmutableMemtable, WritableKVTable};
-    use crate::merge_operator::MergeOperatorType;
-    use crate::object_stores::ObjectStores;
-    use crate::oracle::DbReaderOracle;
-    use crate::paths::PathResolver;
-    use crate::proptest_util::rng::new_test_rng;
-    use crate::proptest_util::sample;
-    use crate::reader::Reader;
-    use crate::tablestore::{TableStore, TableStoreKind};
-    use crate::types::RowEntry;
-    use crate::{error::SlateDBError, test_utils, CloseReason, Db};
-    use bytes::Bytes;
-    use fail_parallel::FailPointRegistry;
-    use object_store::memory::InMemory;
-    use object_store::path::Path;
-    use object_store::{ObjectStore, ObjectStoreExt};
-    use rstest::rstest;
-    use slatedb_common::clock::{DefaultSystemClock, SystemClock};
-    use slatedb_common::DbRand;
-    use slatedb_common::MockSystemClock;
-    use std::collections::{BTreeMap, VecDeque};
-    use std::sync::Arc;
-    use std::time::Duration;
-    use uuid::Uuid;
 
     #[tokio::test]
     async fn should_get_value_from_db() {
@@ -3258,9 +3299,11 @@ mod tests {
         // RFC-0024: per-segment compactions, drains, and segment-set changes
         // are invisible to the root-tree diff. Verify the segments comparison
         // fires on each of those shapes.
-        use crate::db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView};
-        use crate::format::sst::SST_FORMAT_VERSION_LATEST;
-        use crate::manifest::{LsmTreeState, Segment};
+        use crate::{
+            db_state::{SortedRun, SsTableHandle, SsTableId, SsTableInfo, SsTableView},
+            format::sst::SST_FORMAT_VERSION_LATEST,
+            manifest::{LsmTreeState, Segment},
+        };
 
         fn view(seq: u64) -> SsTableView {
             SsTableView::identity(SsTableHandle::new(

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -2823,8 +2823,16 @@ mod tests {
         // Write data that stays in the WAL, then close without flushing the
         // memtable. Closing persists the manifest, so `next_wal_sst_id` covers
         // these WAL files while `replay_after_wal_id` stays at the last L0 flush.
+        // The write must be awaited to durability first: closing without a
+        // memtable flush does not flush the WAL, so an unawaited write would
+        // race the flush interval and might never reach a WAL SST.
         let wal_only_key = b"wal_only_key";
-        db.put(wal_only_key, b"wal_only_value").await.unwrap();
+        db.put(wal_only_key, b"wal_only_value")
+            .await
+            .unwrap()
+            .await_durable()
+            .await
+            .unwrap();
         db.close_with_options(CloseOptions::default().with_flush_memtables(false))
             .await
             .unwrap();

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -68,6 +68,39 @@ pub enum DbReaderMode {
     FollowLatest,
 }
 
+/// Where a reader stops replaying the WAL when it builds its state.
+///
+/// This is only reached when replay is wanted at all; a reader configured with
+/// [`DbReaderOptions::skip_wal_replay`] reads no WAL, which
+/// [`WalReplayEnd::for_reader`] expresses as `None`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WalReplayEnd {
+    /// Stop at the manifest's `next_wal_sst_id`, replaying exactly the WAL that
+    /// the manifest itself records as durable.
+    Manifest,
+
+    /// Probe the object store for the newest WAL file and replay through it,
+    /// picking up writes made after the manifest was written.
+    Latest,
+}
+
+impl WalReplayEnd {
+    /// Returns `None` when the reader is configured to skip WAL replay, in which
+    /// case it observes only the state recorded in the manifest (L0 and below).
+    fn for_reader(mode: DbReaderMode, options: &DbReaderOptions) -> Option<Self> {
+        if options.skip_wal_replay {
+            return None;
+        }
+        Some(match mode {
+            // A pinned checkpoint reads the state its manifest captured, so it
+            // stops at that manifest's WAL boundary instead of following WAL
+            // files written after the checkpoint was taken.
+            DbReaderMode::Checkpoint(_) => Self::Manifest,
+            DbReaderMode::ManagedCheckpoint | DbReaderMode::FollowLatest => Self::Latest,
+        })
+    }
+}
+
 /// Read-only interface for accessing a database from either
 /// the latest persistent state or from an arbitrary checkpoint.
 pub struct DbReader {
@@ -154,15 +187,13 @@ impl DbReaderInner {
         } else {
             (manifest.id(), manifest.manifest().clone())
         };
-        let replay_new_wals =
-            !matches!(mode, DbReaderMode::Checkpoint(_)) && !options.skip_wal_replay;
         let initial_state = Arc::new(
             Self::build_reader_state(
                 checkpoint,
                 manifest_id,
                 initial_manifest,
                 VecDeque::new(),
-                replay_new_wals,
+                WalReplayEnd::for_reader(mode, &options),
                 Arc::clone(&table_store),
                 &options,
                 segment_extractor.as_ref(),
@@ -363,7 +394,7 @@ impl DbReaderInner {
                 &self.options,
                 current_state.core(),
                 &mut imm_memtable,
-                true,
+                WalReplayEnd::Latest,
                 self.segment_extractor.as_ref(),
             )
             .await?;
@@ -433,7 +464,7 @@ impl DbReaderInner {
             manifest_id,
             manifest,
             imm_memtable,
-            !self.options.skip_wal_replay,
+            WalReplayEnd::for_reader(self.mode, &self.options),
             Arc::clone(&self.table_store),
             &self.options,
             self.segment_extractor.as_ref(),
@@ -446,20 +477,28 @@ impl DbReaderInner {
         manifest_id: u64,
         manifest: Manifest,
         mut imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
-        replay_new_wals: bool,
+        and_replay_wal: Option<WalReplayEnd>,
         table_store: Arc<TableStore>,
         options: &DbReaderOptions,
         segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<ReaderState, SlateDBError> {
-        let (last_wal_id, last_committed_seq) = Self::replay_wal_into(
-            Arc::clone(&table_store),
-            options,
-            &manifest.core,
-            &mut imm_memtable,
-            replay_new_wals,
-            segment_extractor,
-        )
-        .await?;
+        let (last_wal_id, last_committed_seq) = match and_replay_wal {
+            Some(replay_end) => {
+                Self::replay_wal_into(
+                    Arc::clone(&table_store),
+                    options,
+                    &manifest.core,
+                    &mut imm_memtable,
+                    replay_end,
+                    segment_extractor,
+                )
+                .await?
+            }
+            // Skipping replay reads no WAL at all: the reader stays at the
+            // watermark it has already reached, which is the manifest's when it
+            // has replayed nothing.
+            None => Self::replayed_watermark(&manifest.core, &imm_memtable),
+        };
 
         Ok(ReaderState {
             manifest_id,
@@ -577,12 +616,28 @@ impl DbReaderInner {
         result
     }
 
+    /// The `(last replayed WAL id, last committed seq)` the reader has already
+    /// reached: the watermark of the most recently replayed table, or the
+    /// manifest's own boundary when nothing has been replayed into `tables`.
+    fn replayed_watermark(
+        core: &ManifestCore,
+        tables: &VecDeque<Arc<ImmutableMemtable>>,
+    ) -> (u64, u64) {
+        match tables.front() {
+            Some(latest_replayed_table) => (
+                latest_replayed_table.recent_flushed_wal_id(),
+                latest_replayed_table.table().last_seq().unwrap_or(0),
+            ),
+            None => (core.replay_after_wal_id, core.last_l0_seq),
+        }
+    }
+
     async fn replay_wal_into(
         table_store: Arc<TableStore>,
         reader_options: &DbReaderOptions,
         core: &ManifestCore,
         into_tables: &mut VecDeque<Arc<ImmutableMemtable>>,
-        replay_new_wals: bool,
+        replay_end: WalReplayEnd,
         segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<(u64, u64), SlateDBError> {
         let sst_iter_options = SstIteratorOptions {
@@ -597,18 +652,10 @@ impl DbReaderInner {
         };
 
         let (mut replay_after_wal_id, mut last_committed_seq) =
-            if let Some(latest_replayed_table) = into_tables.front() {
-                (
-                    latest_replayed_table.recent_flushed_wal_id(),
-                    latest_replayed_table.table().last_seq().unwrap_or(0),
-                )
-            } else {
-                (core.replay_after_wal_id, core.last_l0_seq)
-            };
-        let wal_id_end = if replay_new_wals {
-            table_store.last_seen_wal_id(replay_after_wal_id).await? + 1
-        } else {
-            core.next_wal_sst_id
+            Self::replayed_watermark(core, into_tables);
+        let wal_id_end = match replay_end {
+            WalReplayEnd::Manifest => core.next_wal_sst_id,
+            WalReplayEnd::Latest => table_store.last_seen_wal_id(replay_after_wal_id).await? + 1,
         };
 
         let iterator_options = WalIteratorOptions {
@@ -1373,15 +1420,15 @@ impl DbCacheManagerOps for DbReader {
 
 #[cfg(test)]
 mod tests {
-    use super::{DbReaderMessage, ManifestPoller, ReaderState};
+    use super::{DbReaderMessage, ManifestPoller, ReaderState, WalReplayEnd};
     use crate::block_cache_policy::BlockCachePolicy;
     use crate::clock::MonotonicClock;
     use crate::config::{
-        CheckpointOptions, CheckpointScope, FlushOptions, FlushType, MergeOptions, PutOptions,
-        Settings, WriteOptions,
+        CheckpointOptions, CheckpointScope, CloseOptions, FlushOptions, FlushType, MergeOptions,
+        PutOptions, Settings, WriteOptions,
     };
     use crate::db_reader::{DbReader, DbReaderInner, DbReaderMode, DbReaderOptions};
-    use crate::db_state::SsTableId;
+    use crate::db_state::{SsTableId, SstType};
     use crate::db_stats::DbStats;
     use crate::db_status::DbStatusManager;
     use crate::dispatcher::MessageHandler;
@@ -2263,7 +2310,7 @@ mod tests {
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
-            false,
+            WalReplayEnd::Manifest,
             None,
         )
         .await
@@ -2308,7 +2355,7 @@ mod tests {
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
-            false,
+            WalReplayEnd::Manifest,
             None,
         )
         .await
@@ -2363,7 +2410,7 @@ mod tests {
             &reader_options,
             &core,
             &mut into_tables,
-            false,
+            WalReplayEnd::Manifest,
             None,
         )
         .await
@@ -2399,7 +2446,7 @@ mod tests {
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
-            true,
+            WalReplayEnd::Latest,
             None,
         )
         .await
@@ -2430,7 +2477,7 @@ mod tests {
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
-            true,
+            WalReplayEnd::Latest,
             None,
         )
         .await
@@ -2476,7 +2523,7 @@ mod tests {
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
-            true,
+            WalReplayEnd::Latest,
             None,
         )
         .await
@@ -2708,6 +2755,152 @@ mod tests {
             reader.get(key).await.unwrap(),
             Some(Bytes::from_static(value))
         );
+    }
+
+    /// A manifest records the WAL files written since the last L0 flush in
+    /// `next_wal_sst_id`. Opening a reader must not read them when WAL replay
+    /// is skipped: that range is exactly the expensive one, since it grows
+    /// with everything written between L0 flushes.
+    #[tokio::test]
+    async fn skip_wal_replay_should_not_read_wals_recorded_in_manifest() {
+        let recording_store = Arc::new(test_utils::RecordingObjectStore::new(Arc::new(
+            InMemory::new(),
+        )));
+        let object_store: Arc<dyn ObjectStore> = recording_store.clone();
+        let path = Path::from("/tmp/test_kv_store");
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
+
+        let db = test_provider.new_db(Settings::default()).await.unwrap();
+        let flushed_key = b"flushed_key";
+        let flushed_value = b"flushed_value";
+        db.put(flushed_key, flushed_value).await.unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // Write data that stays in the WAL, then close without flushing the
+        // memtable. Closing persists the manifest, so `next_wal_sst_id` covers
+        // these WAL files while `replay_after_wal_id` stays at the last L0 flush.
+        let wal_only_key = b"wal_only_key";
+        db.put(wal_only_key, b"wal_only_value").await.unwrap();
+        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+            .await
+            .unwrap();
+
+        let core = test_provider
+            .manifest_store()
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core;
+        assert!(
+            core.replay_after_wal_id + 1 < core.next_wal_sst_id,
+            "test needs a manifest that records live WAL files \
+             [replay_after_wal_id={}, next_wal_sst_id={}]",
+            core.replay_after_wal_id,
+            core.next_wal_sst_id
+        );
+
+        recording_store.clear();
+        let reader = test_provider
+            .new_db_reader(
+                DbReaderOptions {
+                    skip_wal_replay: true,
+                    ..DbReaderOptions::default()
+                },
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let wal_reads = recording_store
+            .get_sst_types(false)
+            .into_iter()
+            .chain(recording_store.get_sst_types(true))
+            .filter(|sst_type| *sst_type == Some(SstType::Wal))
+            .count();
+        assert_eq!(wal_reads, 0, "reader read WAL SSTs despite skip_wal_replay");
+
+        assert_eq!(reader.get(wal_only_key).await.unwrap(), None);
+        assert_eq!(
+            reader.get(flushed_key).await.unwrap(),
+            Some(Bytes::from_static(flushed_value))
+        );
+    }
+
+    /// A checkpoint captures the WAL files that were durable when it was taken,
+    /// so a pinned reader replays them by default. `skip_wal_replay` opts out of
+    /// that read, at the cost of not seeing the checkpointed WAL writes.
+    #[rstest]
+    #[case(true, None)]
+    #[case(false, Some(Bytes::from_static(b"wal_only_value")))]
+    #[tokio::test]
+    async fn skip_wal_replay_should_control_checkpoint_wal_reads(
+        #[case] skip_wal_replay: bool,
+        #[case] expected: Option<Bytes>,
+    ) {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_kv_store");
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
+
+        let db = test_provider.new_db(Settings::default()).await.unwrap();
+        db.put(b"flushed_key", b"flushed_value").await.unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // This write is only durable in the WAL, so the checkpoint references it
+        // through the manifest's `next_wal_sst_id` rather than through L0. The
+        // scope must be `Durable`: `All` would flush the memtable to L0 first,
+        // leaving the checkpoint with no live WAL.
+        let wal_only_key = b"wal_only_key";
+        db.put(wal_only_key, b"wal_only_value").await.unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::Wal,
+        })
+        .await
+        .unwrap();
+        let checkpoint = db
+            .create_checkpoint(CheckpointScope::Durable, &CheckpointOptions::default())
+            .await
+            .unwrap();
+        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+            .await
+            .unwrap();
+
+        let core = test_provider
+            .manifest_store()
+            .read_manifest(checkpoint.manifest_id)
+            .await
+            .unwrap()
+            .core;
+        assert!(
+            core.replay_after_wal_id + 1 < core.next_wal_sst_id,
+            "test needs a checkpoint whose manifest records live WAL files \
+             [replay_after_wal_id={}, next_wal_sst_id={}]",
+            core.replay_after_wal_id,
+            core.next_wal_sst_id
+        );
+
+        let reader = test_provider
+            .new_db_reader(
+                DbReaderOptions {
+                    skip_wal_replay,
+                    ..DbReaderOptions::default()
+                },
+                Some(checkpoint.id),
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(reader.get(wal_only_key).await.unwrap(), expected);
     }
 
     struct TestProvider {


### PR DESCRIPTION
## Summary

`DbReaderOptions::skip_wal_replay` documents that it skips WAL replay entirely ([matching the rationale behind the option](https://github.com/slatedb/slatedb/pull/1218#issue-3851876875)), but `build_reader_state` called `replay_wal_into` unconditionally. The flag only fed `replay_new_wals`, which picks where replay *stops* — probe the object store for the newest WAL, or trust the manifest's `next_wal_sst_id` — so the range
`(replay_after_wal_id + 1)..wal_id_end` was read either way. Only the background poller honored the flag, but `open` wouldn't.

This means an extra ~`l0_sst_size_bytes` read. In addition that read is *slow*, because it's read 1MiB at a time (basically regardless of `l0_sst_size_bytes`) (which should also probably be fixed separately, see #2003).

## Changes

- Internal API: Replace the `replay_new_wals` bool on `build_reader_state` with `and_replay_wal: Option<WalReplayEnd>` so the two decisions stop being conflated: `None` reads no WAL at all, and the two `Some` variants choose the manifest-recorded boundary (pinned checkpoints) or the latest WAL on the object store.
- Fix documentation that was claiming "WAL replay is also skipped in `DbReaderMode::Checkpoint` mode": it wasn't, only *newer* WALs weren't replayed (of course, it's a checkpoint), but it was actually replaying the WALs that were durable when it was taken. `skip_wal_replay` is now respected here as well: WALs of checkpoint capture time are replayed based on whether the option is enabled.

## Notes for Reviewers

It's expected that the *only* behavioral change is:
```rust
        if options.skip_wal_replay {
            return None;
        }
```
while most diff lines are just about changing the representation `replay_new_wals: bool` to `and_replay_wal: Option<WalReplayEnd>`, where previous behavior was simply always:
```rust
        if options.skip_wal_replay {
             return Some(Self::Manifest); // pre-fix behavior                                                                                                           
        }
```
Of course the main logic to check for correctness is this:
https://github.com/Ten0/slatedb/blob/ea076894645e220f5fb182222f7c9179d8b16f77/slatedb/src/db_reader.rs#L497-L500
is it sound to just skip wal replay there and inject the initial values of `let (mut replay_after_wal_id, mut last_committed_seq)` in `replay_wal_into`?

I have tested this patched version on my project and can confirm it does strip the 15s initialization time I was observing (#2003, down to ~500ms), doesn't crash, and produces the same results (modulo very minor diff stored in WAL of course).

This does not fully *close* #2003: the serialized 1 MiB-per-request replay fetch is left for a follow-up.

Disclaimer: regression tests are written by Claude

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
