### PR TITLE
[2004] Do not invoke user metrics callbacks under the db.state write lock

### DIFF
--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -2273,7 +2273,8 @@ mod tests {
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::clock::MockSystemClock;
     use slatedb_common::metrics::{
-        lookup_metric, lookup_metric_with_labels, DefaultMetricsRecorder, MetricValue,
+        lookup_metric, lookup_metric_with_labels, CounterFn, DefaultMetricsRecorder, GaugeFn,
+        HistogramFn, MetricValue, MetricsRecorder, NoopMetricsRecorder, UpDownCounterFn,
     };
     use std::collections::BTreeMap;
     use std::collections::Bound::Included;
@@ -10142,6 +10143,130 @@ mod tests {
             Some(0),
             "expected external_db_count == 0 for a standalone DB"
         );
+        db.close().await.unwrap();
+    }
+
+    struct GaugeBlockControl {
+        target: &'static str,
+        armed: AtomicBool,
+        tripped: AtomicBool,
+        release: AtomicBool,
+        entered_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    }
+
+    struct BlockableGauge {
+        name: String,
+        control: Arc<GaugeBlockControl>,
+    }
+
+    impl GaugeFn for BlockableGauge {
+        fn set(&self, _value: i64) {
+            if self.name != self.control.target {
+                return;
+            }
+            if !self.control.armed.load(Ordering::SeqCst) {
+                return;
+            }
+            if self.control.tripped.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            let _ = self.control.entered_tx.send(());
+            while !self.control.release.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
+    }
+
+    struct BlockingGaugeRecorder {
+        control: Arc<GaugeBlockControl>,
+    }
+
+    impl MetricsRecorder for BlockingGaugeRecorder {
+        fn register_counter(
+            &self,
+            name: &str,
+            description: &str,
+            labels: &[(&str, &str)],
+        ) -> Arc<dyn CounterFn> {
+            NoopMetricsRecorder.register_counter(name, description, labels)
+        }
+
+        fn register_gauge(
+            &self,
+            name: &str,
+            _description: &str,
+            _labels: &[(&str, &str)],
+        ) -> Arc<dyn GaugeFn> {
+            Arc::new(BlockableGauge {
+                name: name.to_string(),
+                control: self.control.clone(),
+            })
+        }
+
+        fn register_up_down_counter(
+            &self,
+            name: &str,
+            description: &str,
+            labels: &[(&str, &str)],
+        ) -> Arc<dyn UpDownCounterFn> {
+            NoopMetricsRecorder.register_up_down_counter(name, description, labels)
+        }
+
+        fn register_histogram(
+            &self,
+            name: &str,
+            description: &str,
+            labels: &[(&str, &str)],
+            boundaries: &[f64],
+        ) -> Arc<dyn HistogramFn> {
+            NoopMetricsRecorder.register_histogram(name, description, labels, boundaries)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_should_not_hold_state_lock_during_metrics_callbacks() {
+        // User metrics callbacks must not run under the `db.state` write
+        // lock. Block a gauge callback and assert `get()` still completes.
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (entered_tx, mut entered_rx) = tokio::sync::mpsc::unbounded_channel();
+        let control = Arc::new(GaugeBlockControl {
+            target: crate::db_stats::L0_SST_COUNT,
+            armed: AtomicBool::new(false),
+            tripped: AtomicBool::new(false),
+            release: AtomicBool::new(false),
+            entered_tx,
+        });
+        let recorder = Arc::new(BlockingGaugeRecorder {
+            control: control.clone(),
+        });
+        let db = Db::builder(
+            "/tmp/test_should_not_hold_state_lock_during_metrics_callbacks",
+            object_store,
+        )
+        .with_settings(test_db_options(0, 1024, None))
+        .with_metrics_recorder(recorder)
+        .build()
+        .await
+        .unwrap();
+
+        control.armed.store(true, Ordering::SeqCst);
+        tokio::time::timeout(Duration::from_secs(10), entered_rx.recv())
+            .await
+            .expect("manifest stats gauge was never set")
+            .unwrap();
+
+        let read_task = tokio::spawn({
+            let db = db.clone();
+            async move { db.get(b"key").await }
+        });
+        let read_result = tokio::time::timeout(Duration::from_secs(5), read_task).await;
+        control.release.store(true, Ordering::SeqCst);
+        let value = read_result
+            .expect("db.get() deadlocked while a metrics callback was in flight")
+            .unwrap()
+            .unwrap();
+        assert_eq!(value, None);
+
         db.close().await.unwrap();
     }
 

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -19,10 +19,11 @@ use super::uploader::UploadedMemtable;
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
-use crate::db_state::{collect_touched_segments, COWDbState, DbState, SsTableId, SsTableView};
+use crate::db_state::{collect_touched_segments, DbState, SsTableId, SsTableView};
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
+use crate::manifest::Manifest;
 use crate::oracle::Oracle;
 use crate::utils::IdGenerator;
 use crate::utils::SafeSender;
@@ -32,6 +33,7 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use parking_lot::RwLockWriteGuard;
+use slatedb_txn_obj::DirtyObject;
 use std::cmp;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -620,9 +622,7 @@ impl ManifestWriterHandler {
         Ok(())
     }
 
-    fn clone_local_manifest_for_write(
-        &self,
-    ) -> slatedb_txn_obj::DirtyObject<crate::manifest::Manifest> {
+    fn clone_local_manifest_for_write(&self) -> DirtyObject<Manifest> {
         let dirty = {
             let rguard_state = self.db.state.read();
             rguard_state.state().manifest.clone()
@@ -655,29 +655,23 @@ impl ManifestWriterHandler {
         result
     }
 
-    fn merge_remote_manifest(
-        &self,
-        remote_dirty: slatedb_txn_obj::DirtyObject<crate::manifest::Manifest>,
-    ) {
-        let dirty_manifest = {
+    fn merge_remote_manifest(&self, remote_dirty: DirtyObject<Manifest>) {
+        let manifest = {
             let mut wguard_state = self.db.state.write();
             wguard_state.merge_remote_manifest(remote_dirty);
-            let cow = wguard_state.state();
-            self.update_stats_for_manifest(&cow);
-            cow.manifest.clone()
+            wguard_state.state().manifest.clone()
         };
-        self.db
-            .status_manager
-            .report_manifest(dirty_manifest.into());
+        self.update_stats_for_manifest(&manifest);
+        self.db.status_manager.report_manifest(manifest.into());
     }
 
-    fn update_stats_for_manifest(&self, cow: &COWDbState) {
+    fn update_stats_for_manifest(&self, manifest: &DirtyObject<Manifest>) {
         let mut l0_ssts = 0usize;
         let mut segment_max_l0_ssts = 0usize;
         let mut sorted_runs = 0usize;
         let mut sst_views = 0usize;
         let mut distinct_ssts: HashSet<SsTableId> = HashSet::new();
-        for tree in cow.core().trees() {
+        for tree in manifest.value.core.trees() {
             l0_ssts += tree.l0.len();
             // Track the largest single tree: backpressure is driven by `segment_max_l0_sst_count`
             // because `l0_max_ssts` is enforced per-tree.
@@ -705,7 +699,7 @@ impl ManifestWriterHandler {
         self.db
             .db_stats
             .external_db_count
-            .set(cow.manifest.value.external_dbs.len() as i64);
+            .set(manifest.value.external_dbs.len() as i64);
     }
 
     async fn write_checkpoint_safely(


### PR DESCRIPTION
## Summary

`merge_remote_manifest` called `update_stats_for_manifest` (six `GaugeFn::set` calls into the user-provided `MetricsRecorder`) while holding the `db.state` write lock. A recorder that blocks — e.g. the Node bindings recorder waiting on the JS event loop, which can itself be stuck in a synchronous FFI call waiting on this same lock — deadlocks the whole process. Full stacks and analysis in #2004.

Closes #2004

## Changes

- Take the `Arc<COWDbState>` snapshot under the write lock; set the gauges and report status after releasing it
- Regression test: block a gauge callback fired by the manifest poll and assert a concurrent `get()` still completes (times out in 5s against the old code)

## Notes for Reviewers

Validation in #2004: the Node metrics test hung 24/40 runs before this change, 0/40 after.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
