### PR TITLE
[rfc-30 4/N]: move max wal file flush check to wal trait

### DIFF
--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -334,7 +334,7 @@ pub trait WalWriter: Send {
     /// Returns true if the WAL implementation wants to request that the current in-memory
     /// writes be flushed to a new l0. WAL implementations can use this to (1) bound the range
     /// of writes that need to be replayed when SlateDB restarts, and (2) push data to L0s earlier
-    /// so that its available to readers which poll the latest manifest.
+    /// so that it's available to readers, which poll the latest manifest.
     ///
     /// ## Arguments
     /// - `replay_after_wal_id`: The WAL ID used as the replay point for the last memtable

--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -331,6 +331,18 @@ pub trait WalWriter: Send {
     /// future that receives the result of the flush once it completes.
     async fn flush(&mut self) -> Result<FlushResultFuture, WalError>;
 
+    /// Returns true if the WAL implementation wants to request that the current in-memory
+    /// writes be flushed to a new l0. WAL implementations can use this to (1) bound the range
+    /// of writes that need to be replayed when SlateDB restarts, and (2) push data to L0s earlier
+    /// so that its available to readers which poll the latest manifest.
+    ///
+    /// ## Arguments
+    /// - `replay_after_wal_id`: The WAL ID used as the replay point for the last memtable
+    ///   that was flushed to L0
+    fn should_flush_memtable(&self, _replay_after_wal_id: u64) -> bool {
+        false
+    }
+    
     /// Returns a `WalObserver` for reading [`WalStatus`] and subscribing to events.
     fn observer(&self) -> Box<dyn WalObserver>;
 
@@ -556,6 +568,10 @@ allowing custom WALs to apply backpressure.
 Memtable and Db flushing stay the same. The Batch Writer task annotates each immutable memtable 
 with a safe replay point using `WalStatus::last_flushed_wal_id`, and flushes the WAL using 
 `WalWriter::flush`.
+
+As part of this change we will move tracking of early memtable flush via
+`max_wal_flushes_before_l0_flush` to the native WAL implementation in the implementation of
+`WalWriter::should_flush_memtable`.
 
 #### Garbage Collection
 

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -32,8 +32,6 @@ use futures::{FutureExt, StreamExt};
 use std::sync::Arc;
 use tracing::instrument;
 
-use std::collections::BTreeSet;
-
 use crate::config::WriteOptions;
 use crate::db_state::DbState;
 use crate::db_transaction::DbTransaction;
@@ -45,6 +43,7 @@ use crate::wal::{FlushResultFuture, WalWriter};
 use crate::{batch::WriteBatch, db::DbInner, db::WriteHandle, error::SlateDBError};
 use bytes::Bytes;
 use parking_lot::RwLockWriteGuard;
+use std::collections::BTreeSet;
 use tokio::sync::oneshot;
 
 pub(crate) const WRITE_BATCH_TASK_NAME: &str = "writer";
@@ -121,9 +120,10 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
                 done,
                 txn,
             }) => {
+                let wal_writer = self.wal_writer.as_deref_mut();
                 let result = self
                     .db_inner
-                    .write_batch(batch, &options, txn.as_ref(), self.wal_writer.as_mut())
+                    .write_batch(batch, &options, txn.as_ref(), wal_writer)
                     .await;
                 match result {
                     Ok(write_result) => {
@@ -189,12 +189,12 @@ impl MessageHandler<BatchWriterMessage> for WriteBatchEventHandler {
 impl DbInner {
     #[allow(clippy::panic)]
     #[instrument(level = "trace", skip_all, fields(batch_size = batch.op_count()))]
-    async fn write_batch(
-        &self,
+    async fn write_batch<'a>(
+        &'a self,
         batch: WriteBatch,
         options: &WriteOptions,
         txn: Option<&DbTransaction>,
-        wal_writer: Option<&mut Box<dyn WalWriter>>,
+        mut wal_writer: Option<&mut (dyn WalWriter + 'static)>,
     ) -> Result<WriteBatchResult, SlateDBError> {
         let _options = options;
         #[cfg(not(dst))]
@@ -252,7 +252,7 @@ impl DbInner {
             return Ok(Err(error));
         }
 
-        if let Some(wal_writer) = wal_writer {
+        if let Some(wal_writer) = wal_writer.as_mut() {
             assert!(self.wal_enabled);
             // WAL entries must be appended to the wal buffer atomically. Otherwise,
             // the WAL buffer might flush the entries in the middle of the batch, which
@@ -303,7 +303,7 @@ impl DbInner {
         self.record_memtable_sequence(commit_seq);
 
         // maybe freeze the memtable.
-        self.maybe_freeze_current_memtable()?;
+        self.maybe_freeze_current_memtable(wal_writer.as_deref())?;
 
         let write_handle =
             WriteHandle::new_with_waiter(commit_seq, now, self.status_manager.durability_waiter());
@@ -311,7 +311,10 @@ impl DbInner {
         Ok(Ok(write_handle))
     }
 
-    fn maybe_freeze_current_memtable(&self) -> Result<(), SlateDBError> {
+    fn maybe_freeze_current_memtable(
+        &self,
+        wal_writer: Option<&dyn WalWriter>,
+    ) -> Result<(), SlateDBError> {
         let replay_after_wal_id = self.wal_observer.status()?.last_flushed_wal_id;
         let mut guard = self.state.write();
         let meta = guard.memtable().metadata();
@@ -327,13 +330,10 @@ impl DbInner {
             .table_store
             .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
 
-        let wal_id_gap = replay_after_wal_id
-            .checked_sub(last_freeze_wal_id)
-            .ok_or_else(|| SlateDBError::InvalidDBState)?;
+        let wal_should_flush_memtable = wal_writer
+            .is_some_and(|wal_writer| wal_writer.should_flush_memtable(last_freeze_wal_id));
 
-        if wal_id_gap < self.settings.max_wal_flushes_before_l0_flush
-            && l0_sst_size_est < self.settings.l0_sst_size_bytes
-        {
+        if !wal_should_flush_memtable && l0_sst_size_est < self.settings.l0_sst_size_bytes {
             return Ok(());
         }
         self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);

--- a/slatedb/src/batch_write.rs
+++ b/slatedb/src/batch_write.rs
@@ -315,20 +315,25 @@ impl DbInner {
         &self,
         wal_writer: Option<&dyn WalWriter>,
     ) -> Result<(), SlateDBError> {
-        let replay_after_wal_id = self.wal_observer.status()?.last_flushed_wal_id;
-        let mut guard = self.state.write();
-        let meta = guard.memtable().metadata();
+        // extract the information required to make a freeze decision under a read-lock first
+        // so we don't call into `WalWriter` while holding a lock
+        let (l0_sst_size_est, last_freeze_wal_id) = {
+            let guard = self.state.read();
+            let meta = guard.memtable().metadata();
 
-        let last_freeze_wal_id = guard
-            .state()
-            .imm_memtable
-            .front()
-            .map(|imm| imm.recent_flushed_wal_id())
-            .unwrap_or(guard.state().core().replay_after_wal_id);
+            let last_freeze_wal_id = guard
+                .state()
+                .imm_memtable
+                .front()
+                .map(|imm| imm.recent_flushed_wal_id())
+                .unwrap_or(guard.state().core().replay_after_wal_id);
 
-        let l0_sst_size_est = self
-            .table_store
-            .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
+            let l0_sst_size_est = self
+                .table_store
+                .estimate_encoded_size_compacted(meta.entry_num, meta.entries_size_in_bytes);
+
+            (l0_sst_size_est, last_freeze_wal_id)
+        };
 
         let wal_should_flush_memtable = wal_writer
             .is_some_and(|wal_writer| wal_writer.should_flush_memtable(last_freeze_wal_id));
@@ -336,6 +341,9 @@ impl DbInner {
         if !wal_should_flush_memtable && l0_sst_size_est < self.settings.l0_sst_size_bytes {
             return Ok(());
         }
+
+        let replay_after_wal_id = self.wal_observer.status()?.last_flushed_wal_id;
+        let mut guard = self.state.write();
         self.freeze_current_memtable_with_state_guard(&mut guard, replay_after_wal_id);
         Ok(())
     }

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -218,6 +218,18 @@ pub trait WalWriter: Send {
     /// future that receives the result of the flush once it completes.
     async fn flush(&mut self) -> Result<FlushResultFuture, WalError>;
 
+    /// Returns true if the WAL implementation wants to request that the current in-memory
+    /// writes be flushed to a new l0. WAL implementations can use this to (1) bound the range
+    /// of writes that need to be replayed when SlateDB restarts, and (2) push data to L0s earlier
+    /// so that its available to readers which poll the latest manifest.
+    ///
+    /// ## Arguments
+    /// - `replay_after_wal_id`: The WAL ID used as the replay point for the last memtable
+    ///   that was flushed to L0
+    fn should_flush_memtable(&self, _replay_after_wal_id: u64) -> bool {
+        false
+    }
+
     /// Returns a `WalObserver` for reading [`WalStatus`] and subscribing to events.
     fn observer(&self) -> Box<dyn WalObserver>;
 

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -221,7 +221,7 @@ pub trait WalWriter: Send {
     /// Returns true if the WAL implementation wants to request that the current in-memory
     /// writes be flushed to a new l0. WAL implementations can use this to (1) bound the range
     /// of writes that need to be replayed when SlateDB restarts, and (2) push data to L0s earlier
-    /// so that its available to readers which poll the latest manifest.
+    /// so that it's available to readers, which poll the latest manifest.
     ///
     /// ## Arguments
     /// - `replay_after_wal_id`: The WAL ID used as the replay point for the last memtable

--- a/slatedb/src/wal/writer_init.rs
+++ b/slatedb/src/wal/writer_init.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 #[derive(Clone, Copy)]
 pub(crate) struct WalWriterInitOptions {
     max_wal_bytes_size: usize,
+    max_wal_flushes_before_l0_flush: u64,
     max_flush_interval: Option<Duration>,
 }
 
@@ -25,6 +26,7 @@ impl From<&Settings> for WalWriterInitOptions {
     fn from(settings: &Settings) -> Self {
         Self {
             max_wal_bytes_size: settings.l0_sst_size_bytes,
+            max_wal_flushes_before_l0_flush: settings.max_wal_flushes_before_l0_flush,
             max_flush_interval: settings.flush_interval,
         }
     }
@@ -35,6 +37,7 @@ pub(crate) struct WalWriterInit {
     recorder: MetricsRecorderHelper,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
+    max_wal_flushes_before_l0_flush: u64,
     max_flush_interval: Option<Duration>,
     empty_wal_id: u64,
     task_executor: Arc<MessageHandlerExecutor>,
@@ -61,6 +64,7 @@ impl WalWriterInit {
             recorder,
             table_store,
             max_wal_bytes_size: options.max_wal_bytes_size,
+            max_wal_flushes_before_l0_flush: options.max_wal_flushes_before_l0_flush,
             max_flush_interval: options.max_flush_interval,
             empty_wal_id,
             task_executor,
@@ -135,6 +139,7 @@ impl wal::WriterInit for WalWriterInit {
                     empty_wal_id,
                     self.table_store.clone(),
                     self.max_wal_bytes_size,
+                    self.max_wal_flushes_before_l0_flush,
                     self.max_flush_interval,
                     self.task_executor.clone(),
                 )

--- a/slatedb/src/wal_buffer.rs
+++ b/slatedb/src/wal_buffer.rs
@@ -33,6 +33,8 @@ pub(crate) const WAL_BUFFER_TASK_NAME: &str = "wal_writer";
 ///
 /// - `max_wal_size`: Flushes when `max_wal_size` bytes is exceeded
 /// - `max_flush_interval`: Flushes after `max_flush_interval` elapses, if set
+/// - `max_wal_flushes_before_l0_flush`: Requests a memtable flush when this many WAL files have
+///   been flushed since the latest memtable replay point
 ///
 /// For strict durability requirements on synchronous writes, use [`WalBufferManager::flush()`] to explicitly
 /// trigger a flush operation and await the result. This will flush ALL the in memory WALs (including the
@@ -51,6 +53,7 @@ pub(crate) struct WalBufferManager {
     stats: Arc<WalBufferStats>,
     table_store: Arc<TableStore>,
     max_wal_bytes_size: usize,
+    max_wal_flushes_before_l0_flush: u64,
     /// The largest flush_epoch for which a size-triggered flush request has been
     /// sent. Compared against `flush_epoch` in the inner struct to avoid sending
     /// redundant flush requests for the same WAL.
@@ -111,6 +114,7 @@ impl WalBufferManager {
         last_flushed_wal_id: u64,
         table_store: Arc<TableStore>,
         max_wal_bytes_size: usize,
+        max_wal_flushes_before_l0_flush: u64,
         max_flush_interval: Option<Duration>,
         task_executor: Arc<MessageHandlerExecutor>,
     ) -> Result<Self, SlateDBError> {
@@ -147,6 +151,7 @@ impl WalBufferManager {
             stats,
             table_store,
             max_wal_bytes_size,
+            max_wal_flushes_before_l0_flush,
             last_flush_requested_epoch: AtomicU64::new(0),
             task_executor,
         })
@@ -208,6 +213,14 @@ impl WalWriter for WalBufferManager {
         self.inner.write().append(entries)?;
         self.maybe_trigger_flush()?;
         Ok(())
+    }
+
+    fn should_flush_memtable(&self, replay_after_wal_id: u64) -> bool {
+        let last_flushed_wal_id = self.inner.read().last_flushed_wal_id;
+        let Some(wal_id_gap) = last_flushed_wal_id.checked_sub(replay_after_wal_id) else {
+            return false;
+        };
+        wal_id_gap >= self.max_wal_flushes_before_l0_flush
     }
 
     fn observer(&self) -> Box<dyn wal::WalObserver> {
@@ -840,6 +853,7 @@ mod tests {
             0, // recent_flushed_wal_id
             table_store.clone(),
             1000,                 // max_wal_bytes_size
+            4096,                 // max_wal_flushes_before_l0_flush
             Some(flush_interval), // max_flush_interval
             task_executor.clone(),
         )
@@ -859,6 +873,19 @@ mod tests {
             .monitor_on(&Handle::current())
             .expect("failed to monitor executor");
         (wal_buffer, table_store, status_manager, recorder)
+    }
+
+    #[tokio::test]
+    async fn test_should_flush_memtable_at_max_wal_gap() {
+        let (wal_buffer, _, _, _) = setup_wal_buffer().await;
+        let max_wal_gap = wal_buffer.max_wal_flushes_before_l0_flush;
+        let last_flushed_wal_id = max_wal_gap + 10;
+        wal_buffer.inner.write().last_flushed_wal_id = last_flushed_wal_id;
+
+        assert!(!wal_buffer.should_flush_memtable(last_flushed_wal_id - max_wal_gap + 1));
+        assert!(wal_buffer.should_flush_memtable(last_flushed_wal_id - max_wal_gap));
+        assert!(wal_buffer.should_flush_memtable(last_flushed_wal_id - max_wal_gap - 1));
+        assert!(!wal_buffer.should_flush_memtable(last_flushed_wal_id + 1));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Adds a fn should_flush_memtable to WalWriter. The batch writer calls this to check whether it should flush the memtable before its reached its size threshold. WAL implementations can return true to limit how much of the WAL needs to be replayed when the db restarts. The native implementation implements this by checking the gap between the replay point from the last memtable flush and the current end of the wal and comparing it to max_wal_flushes_before_l0_flush

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
