### PR TITLE
Run nightly pprof on a Warp ARM runner

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -206,7 +206,7 @@ jobs:
           echo "Total diagrams: $(ls -1 target/bencher/transaction-results/mermaid/*.mermaid 2>/dev/null | wc -l)"
 
   microbenchmark-pprofs:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-latest-arm64-8x
     steps:
       - uses: actions/checkout@v4
 
@@ -234,10 +234,15 @@ jobs:
       # install instructions from https://github.com/polarsignals/pprofme/tree/main
       - name: Install pprofme
         run: |
-          curl -LO https://github.com/polarsignals/pprofme/releases/latest/download/pprofme_$(uname)_$(uname -m)
+          PPROFME_ARCH=$(uname -m)
+          if [ "$PPROFME_ARCH" = "aarch64" ]; then
+            PPROFME_ARCH=arm64
+          fi
+          PPROFME_BINARY="pprofme_$(uname)_${PPROFME_ARCH}"
+          curl -fLO "https://github.com/polarsignals/pprofme/releases/latest/download/${PPROFME_BINARY}"
           curl -sL https://github.com/polarsignals/pprofme/releases/latest/download/pprofme_checksums.txt | shasum --ignore-missing -a 256 --check
-          chmod a+x pprofme_$(uname)_$(uname -m)
-          sudo mv pprofme_$(uname)_$(uname -m) /usr/local/bin/pprofme
+          chmod a+x "${PPROFME_BINARY}"
+          sudo mv "${PPROFME_BINARY}" /usr/local/bin/pprofme
 
       - name: Upload pprofs and add links to summary
         run: |


### PR DESCRIPTION
## Summary

The nightly `microbenchmark-pprofs` job has been exiting with SIGTERM 143 while linking the benchmark binary on `ubuntu-latest`. Run it on Warp's smallest ARM runner with more memory so the build can finish.

## Changes

- Switch `microbenchmark-pprofs` to `warp-ubuntu-latest-arm64-8x`.
- Map Linux `aarch64` to the `arm64` suffix used by pprofme release assets.
- Fail the pprofme download on HTTP errors and reuse the resolved asset name during installation.

## Notes for Reviewers

None.
## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏