### PR TITLE
make close flush mode more explicit by using explicit flush type

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -959,6 +959,15 @@ func uniffiCheckChecksums() {
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_slatedb_uniffi_checksum_method_db_shutdown_with_options()
+		})
+		if checksum != 54951 {
+			// If this happens try cleaning and rebuilding your project
+			panic("slatedb: uniffi_slatedb_uniffi_checksum_method_db_shutdown_with_options: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_slatedb_uniffi_checksum_method_db_snapshot()
 		})
 		if checksum != 53137 {
@@ -3333,6 +3342,8 @@ type DbInterface interface {
 	ScanWithOptions(varRange KeyRange, options ScanOptions) (*DbIterator, error)
 	// Flushes outstanding work and closes the database.
 	Shutdown() error
+	// Performs the requested final flush and closes the database.
+	ShutdownWithOptions(options CloseOptions) error
 	// Creates a read-only snapshot representing a consistent point in time.
 	Snapshot() (*DbSnapshot, error)
 	// Returns the latest database status snapshot, including the segment
@@ -3994,6 +4005,38 @@ func (_self *Db) Shutdown() error {
 		func(_ struct{}) struct{} { return struct{}{} },
 		C.uniffi_slatedb_uniffi_fn_method_db_shutdown(
 			_pointer),
+		// pollFn
+		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
+		},
+		// freeFn
+		func(handle C.uint64_t) {
+			C.ffi_slatedb_uniffi_rust_future_free_void(handle)
+		},
+	)
+
+	if err == nil {
+		return nil
+	}
+
+	return err
+}
+
+// Performs the requested final flush and closes the database.
+func (_self *Db) ShutdownWithOptions(options CloseOptions) error {
+	_pointer := _self.ffiObject.incrementPointer("*Db")
+	defer _self.ffiObject.decrementPointer()
+	_, err := uniffiRustCallAsync[*Error](
+		FfiConverterErrorINSTANCE,
+		// completeFn
+		func(handle C.uint64_t, status *C.RustCallStatus) struct{} {
+			C.ffi_slatedb_uniffi_rust_future_complete_void(handle, status)
+			return struct{}{}
+		},
+		// liftFn
+		func(_ struct{}) struct{} { return struct{}{} },
+		C.uniffi_slatedb_uniffi_fn_method_db_shutdown_with_options(
+			_pointer, FfiConverterCloseOptionsINSTANCE.Lower(options)),
 		// pollFn
 		func(handle C.uint64_t, continuation C.UniffiRustFutureContinuationCallback, data C.uint64_t) {
 			C.ffi_slatedb_uniffi_rust_future_poll_void(handle, continuation, data)
@@ -9277,6 +9320,49 @@ func (_ FfiDestroyerCloneSourceSpec) Destroy(value CloneSourceSpec) {
 	value.Destroy()
 }
 
+// Options controlling how a database is shut down.
+type CloseOptions struct {
+	// The final flush to perform before shutdown. When `None`, no final flush is
+	// triggered and writes that are not durable may be lost.
+	FlushType *FlushType
+}
+
+func (r *CloseOptions) Destroy() {
+	FfiDestroyerOptionalFlushType{}.Destroy(r.FlushType)
+}
+
+type FfiConverterCloseOptions struct{}
+
+var FfiConverterCloseOptionsINSTANCE = FfiConverterCloseOptions{}
+
+func (c FfiConverterCloseOptions) Lift(rb RustBufferI) CloseOptions {
+	return LiftFromRustBuffer[CloseOptions](c, rb)
+}
+
+func (c FfiConverterCloseOptions) Read(reader io.Reader) CloseOptions {
+	return CloseOptions{
+		FfiConverterOptionalFlushTypeINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterCloseOptions) Lower(value CloseOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[CloseOptions](c, value)
+}
+
+func (c FfiConverterCloseOptions) LowerExternal(value CloseOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[CloseOptions](c, value))
+}
+
+func (c FfiConverterCloseOptions) Write(writer io.Writer, value CloseOptions) {
+	FfiConverterOptionalFlushTypeINSTANCE.Write(writer, value.FlushType)
+}
+
+type FfiDestroyerCloseOptions struct{}
+
+func (_ FfiDestroyerCloseOptions) Destroy(value CloseOptions) {
+	value.Destroy()
+}
+
 // Canonical compaction record.
 type Compaction struct {
 	// Compaction ULID string.
@@ -13735,6 +13821,47 @@ type FfiDestroyerOptionalFilterContext struct{}
 func (_ FfiDestroyerOptionalFilterContext) Destroy(value *FilterContext) {
 	if value != nil {
 		FfiDestroyerFilterContext{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalFlushType struct{}
+
+var FfiConverterOptionalFlushTypeINSTANCE = FfiConverterOptionalFlushType{}
+
+func (c FfiConverterOptionalFlushType) Lift(rb RustBufferI) *FlushType {
+	return LiftFromRustBuffer[*FlushType](c, rb)
+}
+
+func (_ FfiConverterOptionalFlushType) Read(reader io.Reader) *FlushType {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterFlushTypeINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalFlushType) Lower(value *FlushType) C.RustBuffer {
+	return LowerIntoRustBuffer[*FlushType](c, value)
+}
+
+func (c FfiConverterOptionalFlushType) LowerExternal(value *FlushType) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*FlushType](c, value))
+}
+
+func (_ FfiConverterOptionalFlushType) Write(writer io.Writer, value *FlushType) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterFlushTypeINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalFlushType struct{}
+
+func (_ FfiDestroyerOptionalFlushType) Destroy(value *FlushType) {
+	if value != nil {
+		FfiDestroyerFlushType{}.Destroy(*value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb.h
+++ b/bindings/go/uniffi/slatedb.h
@@ -1004,6 +1004,11 @@ uint64_t uniffi_slatedb_uniffi_fn_method_db_scan_with_options(uint64_t ptr, Rust
 uint64_t uniffi_slatedb_uniffi_fn_method_db_shutdown(uint64_t ptr
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SHUTDOWN_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SHUTDOWN_WITH_OPTIONS
+uint64_t uniffi_slatedb_uniffi_fn_method_db_shutdown_with_options(uint64_t ptr, RustBuffer options
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SNAPSHOT
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_FN_METHOD_DB_SNAPSHOT
 uint64_t uniffi_slatedb_uniffi_fn_method_db_snapshot(uint64_t ptr
@@ -2424,6 +2429,12 @@ uint16_t uniffi_slatedb_uniffi_checksum_method_db_scan_with_options(void
 #ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_SHUTDOWN
 #define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_SHUTDOWN
 uint16_t uniffi_slatedb_uniffi_checksum_method_db_shutdown(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_SHUTDOWN_WITH_OPTIONS
+#define UNIFFI_FFIDEF_UNIFFI_SLATEDB_UNIFFI_CHECKSUM_METHOD_DB_SHUTDOWN_WITH_OPTIONS
+uint16_t uniffi_slatedb_uniffi_checksum_method_db_shutdown_with_options(void
     
 );
 #endif

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -520,6 +520,38 @@ func TestDbLifecycleAndStatus(t *testing.T) {
 	}
 }
 
+func TestDbShutdownWithOptions(t *testing.T) {
+	wal := slatedb.FlushTypeWal
+	tests := []struct {
+		name      string
+		flushType *slatedb.FlushType
+	}{
+		{name: "wal", flushType: &wal},
+		{name: "none", flushType: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMemoryStore(t)
+			handle := openTestDB(t, store, nil)
+
+			if _, err := handle.db.Put([]byte("shutdown-options"), []byte("value")); err != nil {
+				t.Fatalf("Put(): %v", err)
+			}
+
+			if err := handle.db.ShutdownWithOptions(slatedb.CloseOptions{FlushType: tt.flushType}); err != nil {
+				t.Fatalf("ShutdownWithOptions(): %v", err)
+			}
+			handle.open = false
+
+			status := handle.db.Status()
+			if status.CloseReason == nil || *status.CloseReason != slatedb.CloseReasonClean {
+				t.Fatalf("Status() after ShutdownWithOptions(): got close reason %v, want %v", status.CloseReason, slatedb.CloseReasonClean)
+			}
+		})
+	}
+}
+
 type fixedThreeByteSegmentExtractor struct{}
 
 func (fixedThreeByteSegmentExtractor) Name() string { return "fixed_three_byte" }

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -366,6 +366,30 @@ impl From<FlushOptions> for slatedb::config::FlushOptions {
     }
 }
 
+/// Options controlling how a database is shut down.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct CloseOptions {
+    /// The final flush to perform before shutdown. When `None`, no final flush is
+    /// triggered and writes that are not durable may be lost.
+    pub flush_type: Option<FlushType>,
+}
+
+impl Default for CloseOptions {
+    fn default() -> Self {
+        Self {
+            flush_type: Some(FlushType::MemTable),
+        }
+    }
+}
+
+impl From<CloseOptions> for slatedb::config::CloseOptions {
+    fn from(value: CloseOptions) -> Self {
+        slatedb::config::CloseOptions {
+            flush_type: value.flush_type.map(Into::into),
+        }
+    }
+}
+
 /// Garbage collector options for one age-thresholded directory.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct GarbageCollectorDirectoryOptions {
@@ -519,7 +543,37 @@ impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions 
 
 #[cfg(test)]
 mod tests {
-    use super::{GarbageCollectorOptions, ReaderOptions};
+    use super::{CloseOptions, FlushType, GarbageCollectorOptions, ReaderOptions};
+
+    #[test]
+    fn close_options_default_flushes_memtable() {
+        let options: slatedb::config::CloseOptions = CloseOptions::default().into();
+
+        assert!(matches!(
+            options.flush_type,
+            Some(slatedb::config::FlushType::MemTable)
+        ));
+    }
+
+    #[test]
+    fn close_options_can_flush_wal_only() {
+        let options: slatedb::config::CloseOptions = CloseOptions {
+            flush_type: Some(FlushType::Wal),
+        }
+        .into();
+
+        assert!(matches!(
+            options.flush_type,
+            Some(slatedb::config::FlushType::Wal)
+        ));
+    }
+
+    #[test]
+    fn close_options_can_skip_final_flush() {
+        let options: slatedb::config::CloseOptions = CloseOptions { flush_type: None }.into();
+
+        assert!(options.flush_type.is_none());
+    }
 
     #[test]
     fn boundary_files_are_enabled_by_default() {

--- a/bindings/uniffi/src/db.rs
+++ b/bindings/uniffi/src/db.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::config::{
-    FlushOptions, IsolationLevel, MergeOptions, PutOptions, ReadOptions, ScanOptions, WriteOptions,
+    CloseOptions, FlushOptions, IsolationLevel, MergeOptions, PutOptions, ReadOptions, ScanOptions,
+    WriteOptions,
 };
 use crate::db_snapshot::DbSnapshot;
 use crate::db_transaction::DbTransaction;
@@ -41,6 +42,15 @@ impl Db {
     #[uniffi::method(name = "shutdown")]
     pub async fn close(&self) -> Result<(), Error> {
         self.inner.close().await.map_err(Into::into)
+    }
+
+    /// Performs the requested final flush and closes the database.
+    #[uniffi::method(name = "shutdown_with_options")]
+    pub async fn close_with_options(&self, options: CloseOptions) -> Result<(), Error> {
+        self.inner
+            .close_with_options(options.into())
+            .await
+            .map_err(Into::into)
     }
 
     /// Reads the current value for `key`.

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -24,7 +24,7 @@ mod write_handle;
 pub use admin::Admin;
 pub use builder::{AdminBuilder, CloneBuilder, DbBuilder, DbReaderBuilder};
 pub use config::{
-    DurabilityLevel, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
+    CloseOptions, DurabilityLevel, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
     GarbageCollectorOptions, GarbageCollectorScheduleOptions, IsolationLevel, IterationOrder,
     MergeOptions, PutOptions, ReadOptions, ReaderMode, ReaderOptions, ScanOptions, SstBlockSize,
     Ttl, WriteOptions,

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -435,7 +435,7 @@ impl ScanOptions {
 }
 
 /// Enum representing the type of flush to perform.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum FlushType {
     /// Freeze the active memtable [crate::mem_table::KVTable] and write
     /// all immutable memtable entries (including the formerly active
@@ -464,25 +464,28 @@ impl Default for FlushOptions {
 /// Options controlling how a database is closed.
 #[derive(Clone, Debug)]
 pub struct CloseOptions {
-    /// Whether to trigger a final flush of the active memtable before closing.
+    /// The type of flush to perform before closing.
     ///
-    /// When `false`, memtables already being flushed continue through the
-    /// existing shutdown pipeline. Defaults to `true`.
-    pub flush_memtables: bool,
+    /// When `None`, no final flush is triggered. Memtables already being
+    /// flushed continue through the existing shutdown pipeline, and writes
+    /// that are not durable may be lost. When set to `Some` flushes the
+    /// database in accordance with the specified [`FlushType`]
+    /// Defaults to `Some(FlushType::MemTable)`.
+    pub flush_type: Option<FlushType>,
 }
 
 impl Default for CloseOptions {
     fn default() -> Self {
         Self {
-            flush_memtables: true,
+            flush_type: Some(FlushType::MemTable),
         }
     }
 }
 
 impl CloseOptions {
-    /// Configure whether the active memtable is flushed before closing.
-    pub fn with_flush_memtables(mut self, flush_memtables: bool) -> Self {
-        self.flush_memtables = flush_memtables;
+    /// Configure the type of flush to perform before closing.
+    pub fn with_flush_type(mut self, flush_type: Option<FlushType>) -> Self {
+        self.flush_type = flush_type;
         self
     }
 }

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -686,36 +686,26 @@ impl Db {
 
     /// Close the database with custom options.
     ///
-    /// Setting [`CloseOptions::flush_memtables`] to `false` skips the final
-    /// active memtable flush. Memtables already being flushed are allowed to
-    /// finish, and writes that are not durable may be lost.
     pub async fn close_with_options(&self, options: CloseOptions) -> Result<(), crate::Error> {
-        let should_flush = match self.status().close_reason {
+        let flush_type = match self.status().close_reason {
             // If already closed, don't close again.
             Some(CloseReason::Clean) => return Err(SlateDBError::Closed.into()),
             // If in failed state, allow close, but don't flush since the database
             // might be in a bad state. Note that multiple close() calls will always
             // run when in a failed state (vs. a clean closure, which will return
             // Error::Closed(CloseReason::Clean) on subsequent calls).
-            Some(_) => false,
+            Some(_) => None,
             // Flush outstanding writes if the database is still open and the
-            // caller requested a final memtable flush.
-            None => options.flush_memtables,
+            // caller requested a final flush.
+            None => options.flush_type,
         };
 
         // Mark the database as closed before flushing.
         self.inner.status_manager.write_result(Ok(()));
 
-        let result = if should_flush {
-            // Flush memtables to L0 so that the WAL does not need to be
-            // replayed on the next startup.
+        let result = if let Some(flush_type) = flush_type {
             self.inner
-                .flush(
-                    FlushOptions {
-                        flush_type: FlushType::MemTable,
-                    },
-                    false,
-                )
+                .flush(FlushOptions { flush_type }, false)
                 .await
                 .map_err(Into::into)
                 .inspect_err(|e| warn!("failed to flush db during close [error={:?}]", e))
@@ -3512,6 +3502,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_close_with_options_flushes_wal_only() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut settings = test_db_options(0, 1024, None);
+        settings.flush_interval = None;
+        let path = "/tmp/test_close_with_options_flushes_wal_only";
+        let db = Db::builder(path, object_store.clone())
+            .with_settings(settings.clone())
+            .build()
+            .await
+            .unwrap();
+
+        db.put(b"test_key", b"test_value").await.unwrap();
+
+        db.close_with_options(CloseOptions::default().with_flush_type(Some(FlushType::Wal)))
+            .await
+            .unwrap();
+
+        let manifest = db.manifest();
+        assert!(
+            manifest.manifest.core.replay_after_wal_id + 1 < manifest.manifest.core.next_wal_sst_id,
+            "expected a data WAL after the replay watermark"
+        );
+        assert!(
+            manifest.manifest.core.tree.l0.is_empty(),
+            "expected no flushed memtables in the manifest"
+        );
+
+        let reopened = Db::builder(path, object_store)
+            .with_settings(settings)
+            .build()
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened.get(b"test_key").await.unwrap(),
+            Some(Bytes::from_static(b"test_value"))
+        );
+        reopened.close().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn test_close_with_options_skips_final_flush() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let mut settings = test_db_options(0, 1024, None);
@@ -3529,10 +3559,15 @@ mod tests {
 
         db.put(b"test_key", b"test_value").await.unwrap();
 
-        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+        db.close_with_options(CloseOptions::default().with_flush_type(None))
             .await
             .unwrap();
 
+        assert_eq!(
+            lookup_metric(&metrics_recorder, crate::wal_buffer::stats::WAL_FLUSH_BYTES)
+                .unwrap_or(0),
+            0
+        );
         assert_eq!(
             lookup_metric(&metrics_recorder, crate::db_stats::L0_FLUSH_BYTES).unwrap_or(0),
             0
@@ -3557,7 +3592,7 @@ mod tests {
 
         let handle = db.put(b"key", b"value").await.unwrap();
 
-        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+        db.close_with_options(CloseOptions::default().with_flush_type(None))
             .await
             .unwrap();
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -2827,9 +2827,7 @@ mod tests {
         // memtable flush does not flush the WAL, so an unawaited write would
         // race the flush interval and might never reach a WAL SST.
         let wal_only_key = b"wal_only_key";
-        db.put(wal_only_key, b"wal_only_value")
-            .await
-            .unwrap();
+        db.put(wal_only_key, b"wal_only_value").await.unwrap();
         db.close_with_options(CloseOptions::default().with_flush_type(Some(FlushType::Wal)))
             .await
             .unwrap();

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -2829,11 +2829,8 @@ mod tests {
         let wal_only_key = b"wal_only_key";
         db.put(wal_only_key, b"wal_only_value")
             .await
-            .unwrap()
-            .await_durable()
-            .await
             .unwrap();
-        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+        db.close_with_options(CloseOptions::default().with_flush_type(Some(FlushType::Wal)))
             .await
             .unwrap();
 
@@ -2918,7 +2915,7 @@ mod tests {
             .create_checkpoint(CheckpointScope::Durable, &CheckpointOptions::default())
             .await
             .unwrap();
-        db.close_with_options(CloseOptions::default().with_flush_memtables(false))
+        db.close_with_options(CloseOptions::default().with_flush_type(Some(FlushType::Wal)))
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary

Changes `flush_memtables` in `CloseOptions` to `flush_type: Option<FlushType>` so that the flush behaviour is:
(1) more flexible: previously, it was not possible to close with just a cheap WAL flush.
(2) more explicit: the flush behavior was somewhat misleading. Users might not expect that close with `flush_memtables: false` can lose acknowledged writes. Now they are expected to specify the specific flush type.

## Changes

- Change `CloseOptions::flush_memtables` to `CloseOptions::flush_type`
- Change `close_with_options` to honor the configured flush type
- Add a test for WAL-only flush

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
