### PR TITLE
fix(reader): don't permanently close DbReader on transient manifest-poll errors

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -829,9 +829,7 @@ impl MessageHandler<DbReaderMessage> for ManifestPoller {
                 // reader for good. Structural errors still propagate and close.
                 match self.poll_managed_checkpoint().await {
                     Err(error) if Self::is_transient_poll_error(&error) => {
-                        warn!(
-                            "failed to poll manifest; will retry on next tick [error={error:?}]"
-                        );
+                        warn!("failed to poll manifest; will retry on next tick [error={error:?}]");
                         Ok(())
                     }
                     result => result,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -766,6 +766,46 @@ struct ManifestPoller {
     inner: Arc<DbReaderInner>,
 }
 
+impl ManifestPoller {
+    /// One `ManagedCheckpoint` poll tick: load the latest manifest, reestablish
+    /// or refresh the checkpoint, and replay new WALs as needed.
+    async fn poll_managed_checkpoint(&self) -> Result<(), SlateDBError> {
+        let mut manifest = StoredManifest::load(
+            Arc::clone(&self.inner.manifest_store),
+            self.inner.system_clock.clone(),
+        )
+        .await?;
+
+        let latest_manifest = manifest.manifest();
+        if self
+            .inner
+            .should_reestablish_checkpoint(&latest_manifest.core)
+        {
+            let checkpoint = self.inner.replace_checkpoint(&mut manifest).await?;
+            self.inner.reestablish_checkpoint(checkpoint).await?;
+        } else {
+            self.inner.maybe_replay_new_wals().await?;
+        }
+
+        self.inner.maybe_refresh_checkpoint(&mut manifest).await
+    }
+
+    /// Whether a poll-tick error is a transient transport fault that the next
+    /// tick can plausibly succeed past. Structural errors (a missing object,
+    /// fencing, invariant violations) are not transient: retrying the same
+    /// poll cannot fix them, so they still fail the poller task and close the
+    /// reader.
+    fn is_transient_poll_error(error: &SlateDBError) -> bool {
+        match error {
+            SlateDBError::IoError(_) => true,
+            SlateDBError::ObjectStoreError(e) => {
+                !matches!(e.as_ref(), object_store::Error::NotFound { .. })
+            }
+            _ => false,
+        }
+    }
+}
+
 #[async_trait]
 impl MessageHandler<DbReaderMessage> for ManifestPoller {
     fn tickers(&mut self) -> Vec<MessageTickerDef<DbReaderMessage>> {
@@ -779,24 +819,23 @@ impl MessageHandler<DbReaderMessage> for ManifestPoller {
         assert!(matches!(message, DbReaderMessage::PollManifest));
         match self.inner.mode {
             DbReaderMode::ManagedCheckpoint => {
-                let mut manifest = StoredManifest::load(
-                    Arc::clone(&self.inner.manifest_store),
-                    self.inner.system_clock.clone(),
-                )
-                .await?;
-
-                let latest_manifest = manifest.manifest();
-                if self
-                    .inner
-                    .should_reestablish_checkpoint(&latest_manifest.core)
-                {
-                    let checkpoint = self.inner.replace_checkpoint(&mut manifest).await?;
-                    self.inner.reestablish_checkpoint(checkpoint).await?;
-                } else {
-                    self.inner.maybe_replay_new_wals().await?;
+                // A transient transport fault must not fail the poller task:
+                // that would record a closed result and permanently fail every
+                // subsequent read on this handle, turning a brief object-store
+                // brownout into a reader that never recovers (the FollowLatest
+                // arm below already warns and continues for the same reason).
+                // This matters most when `object_store_max_retries` bounds the
+                // retry layer: a single exhausted poll tick used to close the
+                // reader for good. Structural errors still propagate and close.
+                match self.poll_managed_checkpoint().await {
+                    Err(error) if Self::is_transient_poll_error(&error) => {
+                        warn!(
+                            "failed to poll manifest; will retry on next tick [error={error:?}]"
+                        );
+                        Ok(())
+                    }
+                    result => result,
                 }
-
-                self.inner.maybe_refresh_checkpoint(&mut manifest).await
             }
             DbReaderMode::FollowLatest => {
                 let result = self.inner.refresh_latest_manifest().await;
@@ -2574,7 +2613,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn should_fail_new_reads_if_manifest_poller_crashes() {
+    async fn should_keep_serving_reads_across_transient_poller_errors() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_kv_store");
         let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
@@ -2589,6 +2628,9 @@ mod tests {
             .await
             .unwrap();
 
+        // Inject a transient io error into the poller's WAL probing. The tick
+        // fails, but a transient transport fault must not close the reader —
+        // it warns and retries on the next tick instead.
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
             "probe-wal-ssts",
@@ -2596,9 +2638,17 @@ mod tests {
         )
         .unwrap();
         tokio::time::sleep(Duration::from_millis(20)).await;
-        let result = reader.get(b"key").await.unwrap_err();
-        dbg!(&result);
-        assert_eq!(result.to_string(), "Unavailable error: io error (oops)");
+        assert!(reader.get(b"key").await.is_ok());
+
+        // Clear the fault; a later tick succeeds and reads still work.
+        fail_parallel::cfg(
+            Arc::clone(&test_provider.fp_registry),
+            "probe-wal-ssts",
+            "off",
+        )
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(600)).await;
+        assert!(reader.get(b"key").await.is_ok());
     }
 
     #[tokio::test]

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -789,21 +789,6 @@ impl ManifestPoller {
 
         self.inner.maybe_refresh_checkpoint(&mut manifest).await
     }
-
-    /// Whether a poll-tick error is a transient transport fault that the next
-    /// tick can plausibly succeed past. Structural errors (a missing object,
-    /// fencing, invariant violations) are not transient: retrying the same
-    /// poll cannot fix them, so they still fail the poller task and close the
-    /// reader.
-    fn is_transient_poll_error(error: &SlateDBError) -> bool {
-        match error {
-            SlateDBError::IoError(_) => true,
-            SlateDBError::ObjectStoreError(e) => {
-                !matches!(e.as_ref(), object_store::Error::NotFound { .. })
-            }
-            _ => false,
-        }
-    }
 }
 
 #[async_trait]
@@ -828,7 +813,7 @@ impl MessageHandler<DbReaderMessage> for ManifestPoller {
                 // retry layer: a single exhausted poll tick used to close the
                 // reader for good. Structural errors still propagate and close.
                 match self.poll_managed_checkpoint().await {
-                    Err(error) if Self::is_transient_poll_error(&error) => {
+                    Err(error) if error.is_transient() => {
                         warn!("failed to poll manifest; will retry on next tick [error={error:?}]");
                         Ok(())
                     }

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -345,6 +345,22 @@ impl SlateDBError {
         matches!(self, Self::TransactionalObjectVersionExists)
     }
 
+    /// Returns true if this error is transient: the operation that produced it
+    /// could plausibly succeed if it were tried again. Callers use this to
+    /// decide whether to reissue work later instead of treating the failure as
+    /// final.
+    ///
+    /// Only transport-level faults qualify. Everything else — a definitive
+    /// answer from the store, fencing, or an invariant violation — returns the
+    /// same result no matter how often it is retried.
+    pub(crate) fn is_transient(&self) -> bool {
+        match self {
+            Self::IoError(_) => true,
+            Self::ObjectStoreError(err) => is_transient_object_store_error(err),
+            _ => false,
+        }
+    }
+
     /// Classifies this error as a recoverable SST validation failure to reissue
     /// the read with a [`RetryReason`], or `None` if it is not recoverable.
     ///
@@ -369,6 +385,25 @@ impl SlateDBError {
             _ => None,
         }
     }
+}
+
+/// Returns true if an object-store error is transient — i.e. retrying the same
+/// operation could plausibly succeed. The excluded variants are a definitive
+/// answer from the store, so a retry can only produce the same error.
+///
+/// Single source of truth for retryability: both the retry layer
+/// ([`crate::retrying_object_store`]) and callers deciding whether to reissue
+/// failed work classify errors through here.
+pub(crate) fn is_transient_object_store_error(err: &object_store::Error) -> bool {
+    !matches!(
+        err,
+        object_store::Error::AlreadyExists { .. }
+            | object_store::Error::Precondition { .. }
+            | object_store::Error::NotModified { .. }
+            | object_store::Error::NotFound { .. }
+            | object_store::Error::NotImplemented { .. }
+            | object_store::Error::NotSupported { .. }
+    )
 }
 
 impl From<TransactionalObjectError> for SlateDBError {

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -105,15 +105,7 @@ impl RetryingObjectStore {
 
     #[inline]
     fn should_retry(err: &object_store::Error) -> bool {
-        let retry = !matches!(
-            err,
-            object_store::Error::AlreadyExists { .. }
-                | object_store::Error::Precondition { .. }
-                | object_store::Error::NotModified { .. }
-                | object_store::Error::NotFound { .. }
-                | object_store::Error::NotImplemented { .. }
-                | object_store::Error::NotSupported { .. }
-        );
+        let retry = crate::error::is_transient_object_store_error(err);
         if !retry {
             debug!("not retrying object store operation [error={:?}]", err);
         }


### PR DESCRIPTION
## Problem

In `ManagedCheckpoint` mode (the default), `ManifestPoller::handle` propagates every error with `?`. A failed tick fails the poller task, which records a closed result, after which `check_closed()` fails **every subsequent read** on that handle — permanently, with no reopen API. `should_fail_new_reads_if_manifest_poller_crashes` codified this.

That is right for structural errors. For a transient transport fault it means a brief object-store brownout permanently stops a reader that still holds a perfectly serviceable checkpoint. The `FollowLatest` arm already warns and continues on the same error class, so the two modes disagree today.

It also makes `object_store_max_retries` (#1924) hard to use here: with unbounded retries the poller merely stalls through a brownout, but with a bound, one exhausted tick closes the reader for good.

## Change

- Extract the `ManagedCheckpoint` tick body into `poll_managed_checkpoint`.
- Transient errors (`SlateDBError::is_transient`) warn and retry on the next tick, matching `FollowLatest`. Everything else propagates and closes the reader, as before.
- Classification lives in `error.rs`: `is_transient_object_store_error` holds the object-store exclusion list, and `RetryingObjectStore::should_retry` now delegates to it, so retryability is defined once.

## Tests

`should_fail_new_reads_if_manifest_poller_crashes` → `should_keep_serving_reads_across_transient_poller_errors`: with the `probe-wal-ssts` failpoint active the reader keeps serving, and still serves after the fault clears. `db_reader` 44 / `retrying_object_store` 18 / `error` 3 pass.

## Why not just use `FollowLatest`?

It warns-and-continues because it has no checkpoint lease to lose — its documented contract already requires callers to tolerate missing objects, since it "provides no protection from garbage collection." For a reader against an actively-written database with GC running, that trades a rare brownout close for read failures during normal operation. `Checkpoint(uuid)` never advances. So `ManagedCheckpoint` is the only mode that both follows new data and is GC-safe, and it is the one that cannot survive a brownout — hence this change rather than a mode switch.

## Notes

Checkpoint-lease safety is unchanged: a poll stall beyond `checkpoint_lifetime/2` was already reachable with unbounded retries, and since #1900 a reaped checkpoint is re-established in-process.
