### PR TITLE
[rfc-30 5/N]: add WalAdmin trait for administrative wal operations

### DIFF
--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -424,12 +424,13 @@ pub trait WalAdmin: Send + Sync + 'static {
     /// `Ok(())` after the WAL has been deleted, or a [`WalError`] if deletion fails.
     async fn delete_wal(&self, path: &Path) -> Result<(), WalError>;
 
-    /// Given a path and manifest, returns true if the WAL referenced by the manifest at that path
-    /// is empty. A WAL is empty if it holds no records.
+    /// Given a path and WAL ID range, returns true if the WAL at that path is empty within the
+    /// specified range. A WAL is empty if it holds no records.
     ///
     /// ## Arguments
     /// - `path`: The database path containing the WAL.
-    /// - `manifest`: The source manifest that identifies the WAL state to inspect.
+    /// - `replay_after_wal_id`: The exclusive lower bound of the WAL range to inspect.
+    /// - `wal_id_last_seen`: The inclusive upper bound of the WAL range to inspect.
     ///
     /// ## Returns
     /// `Ok(true)` if the referenced WAL contains no records, `Ok(false)` if it contains records,
@@ -437,7 +438,8 @@ pub trait WalAdmin: Send + Sync + 'static {
     async fn is_empty(
         &self,
         path: &Path,
-        manifest: VersionedManifest,
+        replay_after_wal_id: u64,
+        wal_id_last_seen: u64,
     ) -> Result<bool, WalError>;
 
     /// Given a source path and manifest, copy the referenced WAL to a destination path and return

--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -402,6 +402,63 @@ pub trait WalGC {
         referenced_ranges: Vec<WalFileRange>,
     ) -> Result<(), WalError>;
 }
+
+/// Administrative operations for a WAL implementation.
+#[async_trait]
+pub trait WalAdmin: Send + Sync + 'static {
+    /// Creates a garbage collector scoped to the WAL at `path`.
+    ///
+    /// ## Arguments
+    /// - `path`: The database path whose WAL should be garbage collected.
+    ///
+    /// ## Returns
+    /// A garbage collector that can remove unreferenced WAL files at `path`.
+    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGC>;
+
+    /// Deletes the WAL at `path`.
+    ///
+    /// ## Arguments
+    /// - `path`: The database path whose WAL should be deleted.
+    ///
+    /// ## Returns
+    /// `Ok(())` after the WAL has been deleted, or a [`WalError`] if deletion fails.
+    async fn delete_wal(&self, path: &Path) -> Result<(), WalError>;
+
+    /// Given a path and manifest, returns true if the WAL referenced by the manifest at that path
+    /// is empty. A WAL is empty if it holds no records.
+    ///
+    /// ## Arguments
+    /// - `path`: The database path containing the WAL.
+    /// - `manifest`: The source manifest that identifies the WAL state to inspect.
+    ///
+    /// ## Returns
+    /// `Ok(true)` if the referenced WAL contains no records, `Ok(false)` if it contains records,
+    /// or a [`WalError`] if the WAL could not be inspected.
+    async fn is_empty(
+        &self,
+        path: &Path,
+        manifest: VersionedManifest,
+    ) -> Result<bool, WalError>;
+
+    /// Given a source path and manifest, copy the referenced WAL to a destination path and return
+    /// a replay range. This call must be idempotent (TODO: clarify)
+    ///
+    /// ## Arguments
+    /// - `from_path`: The db path that holds the source WAL range to be copied
+    /// - `from_manifest`: The source manifest that identifies the WAL to copy
+    /// - `to_path`: The db path of the clone that the WAL is being copied to.
+    ///
+    /// ## Returns
+    /// A (u64, u64) pair. The first item will be used as the replay start point (exclusive). The
+    /// second item should be the id of the last WAL file id in the copied WAL.
+    async fn clone_wal(
+        &self,
+        from_path: &Path,
+        from_manifest: VersionedManifest,
+        to_path: &Path,
+    ) -> Result<(u64, u64), WalError>;
+}
+
 ```
 
 Users can configure a custom WAL for the writer and reader using the db Builder:
@@ -617,6 +674,14 @@ impl WalReader for ObjectStoreWalReader {
     // ...
 }
 ```
+
+#### Clones
+
+Clone creation delegates to `WalAdmin::empty` to introspect source WALs to determine if they are
+empty when validating that unions/projections don't require copying the WAL.
+
+Clone creation delegates to `WalAdmin::clone_wal` to copy the WAL from the source db to the clone
+db.
 
 #### Error Handling
 

--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -393,7 +393,7 @@ pub trait WalReader {
 
 /// API for plugging into WAL GC
 #[async_trait]
-pub trait WalGC {
+pub trait WalGc {
     /// Hook for garbage collecting the WAL. Takes a list of ranges of WAL Files that are currently
     /// referenced by some active Manifest. The implementation may delete any WAL File that is not
     /// included in the ranges in this list.
@@ -413,7 +413,7 @@ pub trait WalAdmin: Send + Sync + 'static {
     ///
     /// ## Returns
     /// A garbage collector that can remove unreferenced WAL files at `path`.
-    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGC>;
+    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGc>;
 
     /// Deletes the WAL at `path`.
     ///

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -3,19 +3,16 @@ use crate::checkpoint::Checkpoint;
 use crate::config::CheckpointOptions;
 
 use crate::db::builder::CloneSourceSpec;
-use crate::db_state::SsTableId;
 use crate::error::SlateDBError;
 use crate::error::SlateDBError::CheckpointMissing;
 use crate::manifest::store::{ManifestStore, StoredManifest};
-use crate::manifest::{Manifest, ManifestCore, ProjectionConfig};
-use crate::object_stores::ObjectStoreType::{Main, Wal};
-use crate::object_stores::ObjectStores;
-use crate::paths::PathResolver;
+use crate::manifest::{Manifest, ProjectionConfig, VersionedManifest};
 use crate::utils::IdGenerator;
+use crate::wal::WalAdmin;
 use bytes::Bytes;
 use fail_parallel::{fail_point, FailPointRegistry};
 use object_store::path::Path;
-use object_store::{ObjectStore, ObjectStoreExt};
+use object_store::ObjectStore;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::DbRand;
 use std::ops::RangeBounds;
@@ -35,10 +32,22 @@ pub(crate) type SegmentFilterFn = Arc<dyn Fn(&[u8]) -> bool + Send + Sync>;
 pub(crate) type SegmentProjectionFn =
     Arc<dyn Fn(&[u8]) -> Result<BytesRange, SlateDBError> + Send + Sync>;
 
+struct CopyWalParams {
+    from_path: Path,
+    from_manifest: VersionedManifest,
+    to_path: Path,
+}
+
+struct CreateCloneManifestResult {
+    clone_manifest: StoredManifest,
+    copy_wal_params: Option<CopyWalParams>,
+}
+
 pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
     clone_sources: Vec<CloneSourceSpec<R>>,
     clone_path: P,
-    object_stores: ObjectStores,
+    object_store: Arc<dyn ObjectStore>,
+    wal_admin: Arc<dyn WalAdmin>,
     fp_registry: Arc<FailPointRegistry>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -48,40 +57,37 @@ pub(crate) async fn create_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
 ) -> Result<(), SlateDBError> {
     let clone_path = clone_path.into();
 
-    validate_clone_source_specs(clone_sources.clone(), clone_path.clone())?;
+    validate_clone_source_specs(&clone_sources, &clone_path)?;
 
-    let mut clone_manifest = create_clone_manifest(
+    let CreateCloneManifestResult {
+        mut clone_manifest,
+        copy_wal_params,
+    } = create_clone_manifest(
         clone_path.clone(),
-        clone_sources.clone(),
-        object_stores.store_of(Main).clone(),
-        object_stores.store_of(Wal).clone(),
+        clone_sources,
+        object_store,
         system_clock.clone(),
         rand,
         fp_registry.clone(),
         projection_range,
         segment_filter,
         segment_projection,
+        wal_admin.as_ref(),
     )
     .await?;
 
     if !clone_manifest.db_state().initialized {
-        // Copy WAL SSTs from all sources - WAL is only supported for single source
-        // this invariant is enforced in create_clone_manifest()
-        if clone_sources.len() == 1 {
-            for source in &clone_sources {
-                let parent_path = source.path.clone();
-                copy_wal_ssts(
-                    object_stores.store_of(Wal).clone(),
-                    clone_manifest.db_state(),
-                    &parent_path,
-                    &clone_path,
-                    fp_registry.clone(),
-                )
-                .await?;
-            }
-        }
+        let (replay_after_wal_id, wal_id_last_seen) = match copy_wal_params {
+            Some(params) => copy_wal(wal_admin.as_ref(), params).await?,
+            None => (0, 0),
+        };
+        let next_wal_sst_id = wal_id_last_seen
+            .checked_add(1)
+            .ok_or(SlateDBError::InvalidDBState)?;
 
         let mut dirty = clone_manifest.prepare_dirty()?;
+        dirty.value.core.replay_after_wal_id = replay_after_wal_id;
+        dirty.value.core.next_wal_sst_id = next_wal_sst_id;
         dirty.value.core.initialized = true;
         clone_manifest.update(dirty).await?;
     }
@@ -93,17 +99,17 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
     clone_path: Path,
     source_specs: Vec<CloneSourceSpec<R>>,
     object_store: Arc<dyn ObjectStore>,
-    wal_object_store: Arc<dyn ObjectStore>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
     #[allow(unused)] fp_registry: Arc<FailPointRegistry>,
     projection_range: Option<R>,
     segment_filter: Option<SegmentFilterFn>,
     segment_projection: Option<SegmentProjectionFn>,
-) -> Result<StoredManifest, SlateDBError> {
+    wal_admin: &dyn WalAdmin,
+) -> Result<CreateCloneManifestResult, SlateDBError> {
     let clone_manifest_store = Arc::new(ManifestStore::new(&clone_path, object_store.clone()));
 
-    let clone_manifest =
+    let (clone_manifest, copy_wal_params) =
         match StoredManifest::try_load(clone_manifest_store.clone(), system_clock.clone()).await? {
             Some(initialized_clone_manifest)
                 if initialized_clone_manifest.db_state().initialized =>
@@ -122,7 +128,10 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                     )
                     .await?;
                 }
-                return Ok(initialized_clone_manifest);
+                return Ok(CreateCloneManifestResult {
+                    clone_manifest: initialized_clone_manifest,
+                    copy_wal_params: None,
+                });
             }
             Some(uninitialized_clone_manifest) => {
                 for source_spec in &source_specs {
@@ -132,7 +141,24 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                         &uninitialized_clone_manifest,
                     )?;
                 }
-                uninitialized_clone_manifest
+                let copy_wal_params = match &source_specs[..] {
+                    [source_spec] => {
+                        let source = rebuild_source(
+                            source_spec,
+                            &uninitialized_clone_manifest,
+                            &object_store,
+                            &system_clock,
+                            &rand,
+                            &projection_range,
+                            segment_filter.as_ref(),
+                            segment_projection.as_ref(),
+                        )
+                        .await?;
+                        Some(copy_wal_params_for_source(&source, &clone_path))
+                    }
+                    _ => None,
+                };
+                (uninitialized_clone_manifest, copy_wal_params)
             }
             None => {
                 let sources = build_sources(
@@ -145,40 +171,48 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
                     segment_projection.as_ref(),
                 )
                 .await?;
+                let copy_wal_params = match &sources[..] {
+                    [source] => Some(copy_wal_params_for_source(source, &clone_path)),
+                    _ => None,
+                };
 
                 let projection_requested = projection_range.is_some()
                     || segment_filter.is_some()
                     || segment_projection.is_some()
                     || source_specs.iter().any(|s| s.projection_range.is_some());
 
-                let manifest: Manifest = match &sources[..] {
+                let mut manifest: Manifest = match &sources[..] {
                     [single_source] => {
                         // WAL SSTs are copied to the clone verbatim and replayed in full
                         // when the clone is opened, so entries outside the projected
                         // range would leak into the clone. So we reject projections if
                         // there are non-fence WALs to copy.
                         if projection_requested {
-                            validate_no_data_wal(&sources, &wal_object_store).await?;
+                            validate_no_data_wal(&sources, wal_admin).await?;
                         }
                         Manifest::cloned(
                             &single_source.manifest,
                             single_source.path.to_string(),
                             single_source.checkpoint.id,
-                            rand,
+                            rand.clone(),
                         )
                     }
                     [..] => {
-                        validate_no_data_wal(&sources, &wal_object_store).await?;
-                        Manifest::cloned_from_union(sources, rand)?
+                        validate_no_data_wal(&sources, wal_admin).await?;
+                        Manifest::cloned_from_union(sources, rand.clone())?
                     }
                 };
+                manifest.core.initialized = false;
 
-                StoredManifest::store_uninitialized_clone(
-                    clone_manifest_store,
-                    manifest,
-                    system_clock.clone(),
+                (
+                    StoredManifest::store_uninitialized_clone(
+                        clone_manifest_store,
+                        manifest,
+                        system_clock.clone(),
+                    )
+                    .await?,
+                    copy_wal_params,
                 )
-                .await?
             }
         };
 
@@ -224,7 +258,10 @@ async fn create_clone_manifest<R: RangeBounds<Bytes> + Clone>(
         }
     }
 
-    Ok(clone_manifest)
+    Ok(CreateCloneManifestResult {
+        clone_manifest,
+        copy_wal_params,
+    })
 }
 
 fn to_byte_range<T: RangeBounds<Bytes> + Clone>(bounds: &T) -> BytesRange {
@@ -236,6 +273,12 @@ pub(crate) struct CloneSource {
     pub path: Path,
     pub manifest: Manifest,
     pub checkpoint: Checkpoint,
+}
+
+impl CloneSource {
+    fn versioned_manifest(&self) -> VersionedManifest {
+        VersionedManifest::from_manifest(self.checkpoint.manifest_id, self.manifest.clone())
+    }
 }
 
 /// Builds a list of clone sources from the provided specifications. For each source spec, a
@@ -254,40 +297,115 @@ async fn build_sources<R: RangeBounds<Bytes> + Clone>(
 ) -> Result<Vec<CloneSource>, SlateDBError> {
     let mut result: Vec<CloneSource> = vec![];
     for source in source_specs {
-        let manifest_store = Arc::new(ManifestStore::new(&source.path, object_store.clone()));
-        let mut latest_manifest =
-            load_initialized_manifest(manifest_store.clone(), system_clock.clone()).await?;
-        let checkpoint =
-            get_or_create_parent_checkpoint(&mut latest_manifest, source.checkpoint, rand.clone())
-                .await?;
-        let mut manifest_at_checkpoint =
-            manifest_store.read_manifest(checkpoint.manifest_id).await?;
-
-        let range: Option<BytesRange> = match (source.projection_range.clone(), projection_range) {
-            (Some(l), Some(r)) => to_byte_range(&l).intersect(&to_byte_range(r)),
-            (Some(l), None) => Some(to_byte_range(&l)),
-            (None, Some(r)) => Some(to_byte_range(r)),
-            (None, None) => None,
-        };
-
-        let config = ProjectionConfig {
-            global_range: range,
-            segment_filter: segment_filter.cloned(),
-            segment_projection: segment_projection.cloned(),
-        };
-        manifest_at_checkpoint = if config.is_noop() {
-            manifest_at_checkpoint
-        } else {
-            Manifest::projected(&manifest_at_checkpoint, &config)?
-        };
-
-        result.push(CloneSource {
-            path: source.path.clone(),
-            manifest: manifest_at_checkpoint,
-            checkpoint,
-        });
+        result.push(
+            build_source(
+                source,
+                source.checkpoint,
+                object_store,
+                system_clock,
+                rand,
+                projection_range,
+                segment_filter,
+                segment_projection,
+            )
+            .await?,
+        );
     }
     Ok(result)
+}
+
+async fn build_source<R: RangeBounds<Bytes> + Clone>(
+    source: &CloneSourceSpec<R>,
+    checkpoint_id: Option<Uuid>,
+    object_store: &Arc<dyn ObjectStore>,
+    system_clock: &Arc<dyn SystemClock>,
+    rand: &Arc<DbRand>,
+    projection_range: &Option<R>,
+    segment_filter: Option<&SegmentFilterFn>,
+    segment_projection: Option<&SegmentProjectionFn>,
+) -> Result<CloneSource, SlateDBError> {
+    let manifest_store = Arc::new(ManifestStore::new(&source.path, object_store.clone()));
+    let mut latest_manifest =
+        load_initialized_manifest(manifest_store.clone(), system_clock.clone()).await?;
+    let checkpoint =
+        get_or_create_parent_checkpoint(&mut latest_manifest, checkpoint_id, rand.clone()).await?;
+    let mut manifest_at_checkpoint = manifest_store.read_manifest(checkpoint.manifest_id).await?;
+
+    let range: Option<BytesRange> = match (source.projection_range.clone(), projection_range) {
+        (Some(l), Some(r)) => to_byte_range(&l).intersect(&to_byte_range(r)),
+        (Some(l), None) => Some(to_byte_range(&l)),
+        (None, Some(r)) => Some(to_byte_range(r)),
+        (None, None) => None,
+    };
+
+    let config = ProjectionConfig {
+        global_range: range,
+        segment_filter: segment_filter.cloned(),
+        segment_projection: segment_projection.cloned(),
+    };
+    manifest_at_checkpoint = if config.is_noop() {
+        manifest_at_checkpoint
+    } else {
+        Manifest::projected(&manifest_at_checkpoint, &config)?
+    };
+
+    Ok(CloneSource {
+        path: source.path.clone(),
+        manifest: manifest_at_checkpoint,
+        checkpoint,
+    })
+}
+
+fn copy_wal_params_for_source(source: &CloneSource, to_path: &Path) -> CopyWalParams {
+    CopyWalParams {
+        from_path: source.path.clone(),
+        from_manifest: source.versioned_manifest(),
+        to_path: to_path.clone(),
+    }
+}
+
+async fn rebuild_source<R: RangeBounds<Bytes> + Clone>(
+    source_spec: &CloneSourceSpec<R>,
+    clone_manifest: &StoredManifest,
+    object_store: &Arc<dyn ObjectStore>,
+    system_clock: &Arc<dyn SystemClock>,
+    rand: &Arc<DbRand>,
+    projection_range: &Option<R>,
+    segment_filter: Option<&SegmentFilterFn>,
+    segment_projection: Option<&SegmentProjectionFn>,
+) -> Result<CloneSource, SlateDBError> {
+    // `Manifest::cloned` appends the direct parent after inherited external DBs. Search in reverse
+    // so a parent that also appears in its own ancestry still resolves to the direct source.
+    let source_path = source_spec.path.to_string();
+    let external_db = clone_manifest
+        .manifest()
+        .external_dbs
+        .iter()
+        .rev()
+        .find(|external_db| external_db.path == source_path)
+        .ok_or(SlateDBError::CloneExternalDbMissing)?;
+    let manifest_store = Arc::new(ManifestStore::new(&source_spec.path, object_store.clone()));
+    let latest_manifest = load_initialized_manifest(manifest_store, system_clock.clone()).await?;
+    let checkpoint_id = external_db
+        .final_checkpoint_id
+        .filter(|checkpoint_id| {
+            latest_manifest
+                .db_state()
+                .find_checkpoint(*checkpoint_id)
+                .is_some()
+        })
+        .unwrap_or(external_db.source_checkpoint_id);
+    build_source(
+        source_spec,
+        Some(checkpoint_id),
+        object_store,
+        system_clock,
+        rand,
+        projection_range,
+        segment_filter,
+        segment_projection,
+    )
+    .await
 }
 
 // Get a checkpoint and the corresponding manifest that will be used as the source
@@ -324,16 +442,16 @@ async fn get_or_create_parent_checkpoint(
 }
 
 fn validate_clone_source_specs<R: RangeBounds<Bytes> + Clone>(
-    specs: Vec<CloneSourceSpec<R>>,
-    clone_path: Path,
+    specs: &[CloneSourceSpec<R>],
+    clone_path: &Path,
 ) -> Result<(), SlateDBError> {
     if specs.is_empty() {
         return Err(SlateDBError::InvalidUnionSetEmpty());
     }
 
     let mut seen_paths = std::collections::HashSet::new();
-    for source in &specs {
-        if clone_path == source.path {
+    for source in specs {
+        if clone_path == &source.path {
             return Err(SlateDBError::IdenticalClonePaths(clone_path.clone()));
         }
         if !seen_paths.insert(source.path.to_string()) {
@@ -345,37 +463,14 @@ fn validate_clone_source_specs<R: RangeBounds<Bytes> + Clone>(
 
 async fn validate_no_data_wal(
     sources: &[CloneSource],
-    wal_object_store: &Arc<dyn ObjectStore>,
+    wal_admin: &dyn WalAdmin,
 ) -> Result<(), SlateDBError> {
     let mut parents_with_wal = vec![];
     for source in sources {
-        let core = &source.manifest.core;
-        // Cheap manifest check first: if the WAL range is empty there is
-        // nothing to inspect.
-        if core.next_wal_sst_id.saturating_sub(1) <= core.replay_after_wal_id {
-            continue;
-        }
-
-        let path_resolver = PathResolver::from_root(source.path.clone());
-        let mut has_data_wal = false;
-        for wal_id in (core.replay_after_wal_id + 1)..core.next_wal_sst_id {
-            let path = path_resolver.sst_path(&SsTableId::Wal(wal_id));
-            match wal_object_store.head(&path).await {
-                Ok(meta) => {
-                    // Fence WALs are zero-byte `SsTableId::Wal` objects (written via
-                    // `TableStore::write_wal_fence`). They contain no data, so dropping them loses
-                    // nothing and the source is allowed to participate in the union. We use the
-                    // same zero-size discriminator that fence garbage_collector/wal_gc.rs uses.
-                    if meta.size > 0 {
-                        has_data_wal = true;
-                        break;
-                    }
-                }
-                Err(e) => return Err(SlateDBError::from(e)),
-            }
-        }
-
-        if has_data_wal {
+        if !wal_admin
+            .is_empty(&source.path, source.versioned_manifest())
+            .await?
+        {
             parents_with_wal.push(source.path.clone());
         }
     }
@@ -467,36 +562,24 @@ async fn load_initialized_manifest(
     Ok(manifest)
 }
 
-async fn copy_wal_ssts(
-    object_store: Arc<dyn ObjectStore>,
-    parent_checkpoint_state: &ManifestCore,
-    parent_path: &Path,
-    clone_path: &Path,
-    #[allow(unused)] fp_registry: Arc<FailPointRegistry>,
-) -> Result<(), SlateDBError> {
-    let parent_path_resolver = PathResolver::from_root(parent_path.clone());
-    let clone_path_resolver = PathResolver::from_root(clone_path.clone());
-
-    let mut wal_id = parent_checkpoint_state.replay_after_wal_id + 1;
-    while wal_id < parent_checkpoint_state.next_wal_sst_id {
-        fail_point!(fp_registry.clone(), "copy-wal-ssts-io-error", |_| Err(
-            SlateDBError::from(std::io::Error::other("oops"))
-        ));
-
-        let id = SsTableId::Wal(wal_id);
-        let parent_path = parent_path_resolver.sst_path(&id);
-        let clone_path = clone_path_resolver.sst_path(&id);
-        object_store
-            .as_ref()
-            .copy(&parent_path, &clone_path)
-            .await?;
-        wal_id += 1;
-    }
-    Ok(())
+async fn copy_wal(
+    wal_admin: &dyn WalAdmin,
+    params: CopyWalParams,
+) -> Result<(u64, u64), SlateDBError> {
+    let CopyWalParams {
+        from_path,
+        from_manifest,
+        to_path,
+    } = params;
+    wal_admin
+        .clone_wal(&from_path, from_manifest, &to_path)
+        .await
+        .map_err(Into::into)
 }
 
 #[cfg(test)]
 mod tests {
+    use super::{SegmentFilterFn, SegmentProjectionFn};
     use crate::config::{
         CheckpointOptions, CheckpointScope, FlushOptions, FlushType, PutOptions, Settings,
         WriteOptions,
@@ -509,12 +592,15 @@ mod tests {
     use crate::iter::IterationOrder;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::Manifest;
-    use crate::manifest::ManifestCore;
+    use crate::manifest::{ManifestCore, VersionedManifest};
     use crate::object_stores::ObjectStores;
     use crate::paths::PathResolver;
     use crate::proptest_util::{rng, sample};
     use crate::test_utils;
     use crate::utils::IdGenerator;
+    use crate::wal::admin::SlateDbWalAdmin;
+    use crate::wal::{WalAdmin, WalError, WalFileRange, WalGC};
+    use async_trait::async_trait;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
     use object_store::memory::InMemory;
@@ -531,6 +617,85 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
+    struct RemappingWalAdmin {
+        replay_range: (u64, u64),
+        expected_manifest_id: Option<u64>,
+    }
+
+    struct NoopWalGc;
+
+    #[async_trait]
+    impl WalGC for NoopWalGc {
+        async fn collect(&self, _referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl WalAdmin for RemappingWalAdmin {
+        fn garbage_collector(&self, _path: &Path) -> Box<dyn WalGC> {
+            Box::new(NoopWalGc)
+        }
+
+        async fn delete_wal(&self, _path: &Path) -> Result<(), WalError> {
+            Ok(())
+        }
+
+        async fn is_empty(
+            &self,
+            _path: &Path,
+            _manifest: VersionedManifest,
+        ) -> Result<bool, WalError> {
+            Ok(true)
+        }
+
+        async fn clone_wal(
+            &self,
+            _from_path: &Path,
+            from_manifest: VersionedManifest,
+            _to_path: &Path,
+        ) -> Result<(u64, u64), WalError> {
+            if let Some(expected_manifest_id) = self.expected_manifest_id {
+                assert_eq!(from_manifest.id(), expected_manifest_id);
+            }
+            Ok(self.replay_range)
+        }
+    }
+
+    async fn create_native_clone<P: Into<Path>, R: RangeBounds<Bytes> + Clone>(
+        clone_sources: Vec<CloneSourceSpec<R>>,
+        clone_path: P,
+        object_stores: ObjectStores,
+        fp_registry: Arc<FailPointRegistry>,
+        system_clock: Arc<dyn SystemClock>,
+        rand: Arc<DbRand>,
+        projection_range: Option<R>,
+        segment_filter: Option<SegmentFilterFn>,
+        segment_projection: Option<SegmentProjectionFn>,
+    ) -> Result<(), SlateDBError> {
+        let wal_admin = Arc::new(SlateDbWalAdmin::new(
+            object_stores
+                .store_of(crate::object_stores::ObjectStoreType::Wal)
+                .clone(),
+            fp_registry.clone(),
+        ));
+        crate::clone::create_clone(
+            clone_sources,
+            clone_path,
+            object_stores
+                .store_of(crate::object_stores::ObjectStoreType::Main)
+                .clone(),
+            wal_admin,
+            fp_registry,
+            system_clock,
+            rand,
+            projection_range,
+            segment_filter,
+            segment_projection,
+        )
+        .await
+    }
+
     // helper method for tests that creates CloneSourceSpec
     async fn create_clone<P: Into<Path>>(
         clone_path: P,
@@ -546,7 +711,7 @@ mod tests {
             Some(cp) => CloneSourceSpec::with_checkpoint(parent_path, cp),
             None => CloneSourceSpec::new(parent_path),
         };
-        crate::clone::create_clone(
+        create_native_clone(
             vec![source],
             clone_path,
             ObjectStores::new(object_store, Some(wal_object_store)),
@@ -558,6 +723,105 @@ mod tests {
             None,
         )
         .await
+    }
+
+    #[tokio::test]
+    async fn should_stamp_wal_range_returned_by_wal_admin() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_path = Path::from("/tmp/test_parent_remapped_wal");
+        let clone_path = Path::from("/tmp/test_clone_remapped_wal");
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+
+        let mut parent_manifest = StoredManifest::create_new_db(
+            Arc::new(ManifestStore::new(&parent_path, object_store.clone())),
+            ManifestCore::new(),
+            system_clock.clone(),
+        )
+        .await
+        .unwrap();
+        let checkpoint = parent_manifest
+            .write_checkpoint(Uuid::new_v4(), &CheckpointOptions::default())
+            .await
+            .unwrap();
+
+        let wal_admin = RemappingWalAdmin {
+            replay_range: (41, 46),
+            expected_manifest_id: Some(checkpoint.manifest_id),
+        };
+        let source: CloneSourceSpec = CloneSourceSpec::with_checkpoint(parent_path, checkpoint.id);
+        crate::clone::create_clone(
+            vec![source],
+            clone_path.clone(),
+            object_store.clone(),
+            Arc::new(wal_admin),
+            Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
+            Arc::new(DbRand::default()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let manifest = StoredManifest::load(
+            Arc::new(ManifestStore::new(&clone_path, object_store)),
+            system_clock,
+        )
+        .await
+        .unwrap();
+        assert!(manifest.db_state().initialized);
+        assert_eq!(manifest.db_state().replay_after_wal_id, 41);
+        assert_eq!(manifest.db_state().next_wal_sst_id, 47);
+    }
+
+    #[tokio::test]
+    async fn should_reset_wal_range_when_clone_does_not_copy_wal() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let parent_paths = [
+            Path::from("/tmp/test_parent_no_wal_a"),
+            Path::from("/tmp/test_parent_no_wal_b"),
+        ];
+        let clone_path = Path::from("/tmp/test_clone_no_wal");
+        let system_clock: Arc<dyn SystemClock> = Arc::new(DefaultSystemClock::new());
+
+        for parent_path in &parent_paths {
+            StoredManifest::create_new_db(
+                Arc::new(ManifestStore::new(parent_path, object_store.clone())),
+                ManifestCore::new(),
+                system_clock.clone(),
+            )
+            .await
+            .unwrap();
+        }
+
+        crate::clone::create_clone(
+            parent_paths.into_iter().map(CloneSourceSpec::new).collect(),
+            clone_path.clone(),
+            object_store.clone(),
+            Arc::new(RemappingWalAdmin {
+                replay_range: (41, 47),
+                expected_manifest_id: None,
+            }),
+            Arc::new(FailPointRegistry::new()),
+            system_clock.clone(),
+            Arc::new(DbRand::default()),
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let manifest = StoredManifest::load(
+            Arc::new(ManifestStore::new(&clone_path, object_store)),
+            system_clock,
+        )
+        .await
+        .unwrap();
+        assert!(manifest.db_state().initialized);
+        assert_eq!(manifest.db_state().replay_after_wal_id, 0);
+        assert_eq!(manifest.db_state().next_wal_sst_id, 1);
     }
 
     #[tokio::test]
@@ -1097,7 +1361,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(err, SlateDBError::IoError(_)));
+        assert!(matches!(err, SlateDBError::WalUnavailable(_)));
 
         fail_parallel::cfg(Arc::clone(&fp_registry), "copy-wal-ssts-io-error", "off").unwrap();
         create_clone(
@@ -1358,10 +1622,11 @@ mod tests {
         .unwrap_err();
         assert!(matches!(
             err,
-            SlateDBError::ObjectStoreError(ref source)
+            SlateDBError::WalUnavailable(ref source)
                 if matches!(
-                    source.as_ref(),
-                    ObjectStoreError::NotFound { path, .. } if path == &expected_missing_wal_path
+                    source.downcast_ref::<ObjectStoreError>(),
+                    Some(ObjectStoreError::NotFound { path, .. })
+                        if path == &expected_missing_wal_path
                 )
         ));
     }
@@ -1442,7 +1707,7 @@ mod tests {
             Bound::Included(Bytes::from_static(b"aaa")),
             Bound::Excluded(Bytes::from_static(b"bbb")),
         );
-        let err = crate::clone::create_clone(
+        let err = create_native_clone(
             vec![CloneSourceSpec::new(parent_path.clone())],
             clone_path.clone(),
             ObjectStores::new(object_store.clone(), Some(object_store.clone())),
@@ -1475,7 +1740,7 @@ mod tests {
             .unwrap();
         parent_db.close().await.unwrap();
 
-        crate::clone::create_clone(
+        create_native_clone(
             vec![CloneSourceSpec::new(parent_path.clone())],
             clone_path.clone(),
             ObjectStores::new(object_store.clone(), Some(object_store.clone())),
@@ -1591,7 +1856,7 @@ mod tests {
         object_store: Arc<dyn ObjectStore>,
         projection: Option<R>,
     ) {
-        crate::clone::create_clone(
+        create_native_clone(
             sources,
             clone_path.clone(),
             ObjectStores::new(object_store.clone(), Some(object_store)),
@@ -2235,7 +2500,7 @@ mod tests {
         // Source B has no extra WAL.
         build_plain_wal_disabled_parent(&parent_path_b, object_store.clone(), &table_b).await;
 
-        crate::clone::create_clone(
+        create_native_clone(
             vec![
                 CloneSourceSpec::new(parent_path_a.clone()),
                 CloneSourceSpec::new(parent_path_b.clone()),
@@ -2298,7 +2563,7 @@ mod tests {
         .await;
         build_plain_wal_disabled_parent(&parent_path_b, object_store.clone(), &table_b).await;
 
-        let err = crate::clone::create_clone(
+        let err = create_native_clone(
             vec![
                 CloneSourceSpec::new(parent_path_a.clone()),
                 CloneSourceSpec::new(parent_path_b.clone()),
@@ -2367,7 +2632,7 @@ mod tests {
             }))
             .to_string();
 
-        let err = crate::clone::create_clone(
+        let err = create_native_clone(
             vec![
                 CloneSourceSpec::new(parent_path_a.clone()),
                 CloneSourceSpec::new(parent_path_b.clone()),
@@ -2387,10 +2652,10 @@ mod tests {
         assert!(
             matches!(
                 err,
-                SlateDBError::ObjectStoreError(ref source)
+                SlateDBError::WalUnavailable(ref source)
                     if matches!(
-                        source.as_ref(),
-                        ObjectStoreError::NotFound { path, .. }
+                        source.downcast_ref::<ObjectStoreError>(),
+                        Some(ObjectStoreError::NotFound { path, .. })
                             if path == &expected_missing_wal_path
                     )
             ),

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -467,8 +467,15 @@ async fn validate_no_data_wal(
 ) -> Result<(), SlateDBError> {
     let mut parents_with_wal = vec![];
     for source in sources {
+        let replay_after_wal_id = source.manifest.core.replay_after_wal_id;
+        let wal_id_last_seen = source
+            .manifest
+            .core
+            .next_wal_sst_id
+            .checked_sub(1)
+            .ok_or(SlateDBError::InvalidDBState)?;
         if !wal_admin
-            .is_empty(&source.path, source.versioned_manifest())
+            .is_empty(&source.path, replay_after_wal_id, wal_id_last_seen)
             .await?
         {
             parents_with_wal.push(source.path.clone());
@@ -644,7 +651,8 @@ mod tests {
         async fn is_empty(
             &self,
             _path: &Path,
-            _manifest: VersionedManifest,
+            _replay_after_wal_id: u64,
+            _wal_id_last_seen: u64,
         ) -> Result<bool, WalError> {
             Ok(true)
         }

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -606,7 +606,7 @@ mod tests {
     use crate::test_utils;
     use crate::utils::IdGenerator;
     use crate::wal::admin::SlateDbWalAdmin;
-    use crate::wal::{WalAdmin, WalError, WalFileRange, WalGC};
+    use crate::wal::{WalAdmin, WalError, WalFileRange, WalGc};
     use async_trait::async_trait;
     use bytes::Bytes;
     use fail_parallel::FailPointRegistry;
@@ -632,7 +632,7 @@ mod tests {
     struct NoopWalGc;
 
     #[async_trait]
-    impl WalGC for NoopWalGc {
+    impl WalGc for NoopWalGc {
         async fn collect(&self, _referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
             Ok(())
         }
@@ -640,7 +640,7 @@ mod tests {
 
     #[async_trait]
     impl WalAdmin for RemappingWalAdmin {
-        fn garbage_collector(&self, _path: &Path) -> Box<dyn WalGC> {
+        fn garbage_collector(&self, _path: &Path) -> Box<dyn WalGc> {
             Box::new(NoopWalGc)
         }
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -161,6 +161,7 @@ use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
 use crate::utils::WatchableOnceCell;
+use crate::wal::admin::SlateDbWalAdmin;
 use crate::wal::wal_disabled::DisabledWalObserver;
 use crate::wal::WalObserver;
 use slatedb_common::clock::DefaultSystemClock;
@@ -2054,11 +2055,17 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
 
     /// Build and execute the clone operation.
     pub async fn build(self) -> Result<(), crate::Error> {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        let wal_admin = Arc::new(SlateDbWalAdmin::new(
+            self.wal_object_store.unwrap_or(self.object_store.clone()),
+            fp_registry.clone(),
+        ));
         crate::clone::create_clone(
             self.sources,
             self.clone_path,
-            ObjectStores::new(self.object_store, self.wal_object_store),
-            Arc::new(FailPointRegistry::new()),
+            self.object_store,
+            wal_admin,
+            fp_registry,
             self.system_clock
                 .unwrap_or_else(|| Arc::new(DefaultSystemClock::new())),
             self.rand.unwrap_or_else(|| Arc::new(Default::default())),

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -2,7 +2,7 @@ use crate::manifest::Manifest;
 use crate::{
     error::SlateDBError,
     manifest::store::ManifestStore,
-    wal::{WalFileRange, WalGC},
+    wal::{WalFileRange, WalGc},
 };
 use chrono::{DateTime, Utc};
 use std::collections::BTreeMap;
@@ -14,7 +14,7 @@ use super::GcTask;
 #[derive(Clone)]
 pub(crate) struct WalGcTask {
     manifest_store: Arc<ManifestStore>,
-    wal_gc: Arc<dyn WalGC>,
+    wal_gc: Arc<dyn WalGc>,
     resource: &'static str,
 }
 
@@ -29,7 +29,7 @@ impl std::fmt::Debug for WalGcTask {
 impl WalGcTask {
     pub(super) fn new(
         manifest_store: Arc<ManifestStore>,
-        wal_gc: Arc<dyn WalGC>,
+        wal_gc: Arc<dyn WalGc>,
         resource: &'static str,
     ) -> Self {
         Self {
@@ -114,7 +114,7 @@ mod tests {
     }
 
     #[async_trait]
-    impl WalGC for RecordingWalGc {
+    impl WalGc for RecordingWalGc {
         async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
             self.calls.lock().unwrap().push(referenced_ranges);
             Ok(())

--- a/slatedb/src/wal/admin.rs
+++ b/slatedb/src/wal/admin.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub(crate) struct SlateDbWalAdmin {
     object_store: Arc<dyn ObjectStore>,
+    #[cfg_attr(not(test), allow(dead_code))]
     fp_registry: Arc<FailPointRegistry>,
 }
 

--- a/slatedb/src/wal/admin.rs
+++ b/slatedb/src/wal/admin.rs
@@ -90,7 +90,8 @@ impl WalAdmin for SlateDbWalAdmin {
 
     async fn delete_wal(&self, path: &Path) -> Result<(), WalError> {
         // Collect the paths first so listing is complete before objects are removed.
-        for object_path in self.paths_under(path).await? {
+        let wal_path = PathResolver::from_root(path.clone()).wal_path();
+        for object_path in self.paths_under(&wal_path).await? {
             self.object_store
                 .delete(&object_path)
                 .await
@@ -99,9 +100,12 @@ impl WalAdmin for SlateDbWalAdmin {
         Ok(())
     }
 
-    async fn is_empty(&self, path: &Path, manifest: VersionedManifest) -> Result<bool, WalError> {
-        let (replay_after_wal_id, wal_id_last_seen) = Self::replay_range(&manifest)?;
-
+    async fn is_empty(
+        &self,
+        path: &Path,
+        replay_after_wal_id: u64,
+        wal_id_last_seen: u64,
+    ) -> Result<bool, WalError> {
         // Avoid object-store requests when the manifest's WAL range contains no file IDs.
         if !Self::has_wal_file_ids(replay_after_wal_id, wal_id_last_seen) {
             return Ok(true);
@@ -162,15 +166,23 @@ mod tests {
     use object_store::memory::InMemory;
 
     #[tokio::test]
-    async fn delete_wal_deletes_only_objects_under_the_requested_path() {
+    async fn delete_wal_deletes_only_objects_under_the_wal_prefix() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let wal_admin =
             SlateDbWalAdmin::new(object_store.clone(), Arc::new(FailPointRegistry::new()));
-        let wal_path = Path::from("db/wal");
-        let wal_object = wal_path.clone().join("00000000000000000001.sst");
+        let db_path = Path::from("db");
+        let wal_object = PathResolver::from_root(db_path.clone()).sst_path(&SsTableId::Wal(1));
+        let non_wal_object = db_path
+            .clone()
+            .join("manifest")
+            .join("00000000000000000001");
         let sibling_object = Path::from("other/wal/00000000000000000002.sst");
         object_store
             .put(&wal_object, Bytes::from_static(b"wal").into())
+            .await
+            .unwrap();
+        object_store
+            .put(&non_wal_object, Bytes::from_static(b"keep").into())
             .await
             .unwrap();
         object_store
@@ -178,12 +190,13 @@ mod tests {
             .await
             .unwrap();
 
-        wal_admin.delete_wal(&wal_path).await.unwrap();
+        wal_admin.delete_wal(&db_path).await.unwrap();
 
         assert!(matches!(
             object_store.head(&wal_object).await,
             Err(object_store::Error::NotFound { .. })
         ));
+        assert!(object_store.head(&non_wal_object).await.is_ok());
         assert!(object_store.head(&sibling_object).await.is_ok());
     }
 

--- a/slatedb/src/wal/admin.rs
+++ b/slatedb/src/wal/admin.rs
@@ -7,7 +7,7 @@ use crate::object_stores::ObjectStores;
 use crate::paths::PathResolver;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::wal::gc::{SlateDbWalGc, WalGcMode};
-use crate::wal::{WalAdmin, WalError, WalGC};
+use crate::wal::{WalAdmin, WalError, WalGc};
 use crate::VersionedManifest;
 use async_trait::async_trait;
 use fail_parallel::{fail_point, FailPointRegistry};
@@ -69,7 +69,7 @@ impl SlateDbWalAdmin {
 
 #[async_trait]
 impl WalAdmin for SlateDbWalAdmin {
-    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGC> {
+    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGc> {
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(self.object_store.clone(), None),
             SsTableFormat::default(),

--- a/slatedb/src/wal/admin.rs
+++ b/slatedb/src/wal/admin.rs
@@ -1,0 +1,196 @@
+use crate::block_cache_policy::BlockCachePolicy;
+use crate::config::GarbageCollectorDirectoryOptions;
+use crate::db_state::SsTableId;
+use crate::format::sst::SsTableFormat;
+use crate::garbage_collector::stats::GcStats;
+use crate::object_stores::ObjectStores;
+use crate::paths::PathResolver;
+use crate::tablestore::{TableStore, TableStoreKind};
+use crate::wal::gc::{SlateDbWalGc, WalGcMode};
+use crate::wal::{WalAdmin, WalError, WalGC};
+use crate::VersionedManifest;
+use async_trait::async_trait;
+use fail_parallel::{fail_point, FailPointRegistry};
+use futures::StreamExt;
+use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt};
+use slatedb_common::clock::DefaultSystemClock;
+use slatedb_common::metrics::MetricsRecorderHelper;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub(crate) struct SlateDbWalAdmin {
+    object_store: Arc<dyn ObjectStore>,
+    fp_registry: Arc<FailPointRegistry>,
+}
+
+impl SlateDbWalAdmin {
+    pub(crate) fn new(
+        object_store: Arc<dyn ObjectStore>,
+        fp_registry: Arc<FailPointRegistry>,
+    ) -> Self {
+        Self {
+            object_store,
+            fp_registry,
+        }
+    }
+
+    fn replay_range(manifest: &VersionedManifest) -> Result<(u64, u64), WalError> {
+        let replay_after_wal_id = manifest.replay_after_wal_id();
+        let wal_id_last_seen = manifest
+            .next_wal_sst_id()
+            .checked_sub(1)
+            .ok_or_else(Self::invalid_manifest)?;
+        Ok((replay_after_wal_id, wal_id_last_seen))
+    }
+
+    fn invalid_manifest() -> WalError {
+        WalError::InternalError(Arc::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "source manifest must have a positive next WAL file ID",
+        )))
+    }
+
+    fn has_wal_file_ids(replay_after_wal_id: u64, wal_id_last_seen: u64) -> bool {
+        wal_id_last_seen > replay_after_wal_id
+    }
+
+    async fn paths_under(&self, path: &Path) -> Result<Vec<Path>, WalError> {
+        let mut objects = self.object_store.list(Some(path));
+        let mut paths = Vec::new();
+        while let Some(object) = objects.next().await {
+            let object = object.map_err(|err| WalError::Unavailable(Arc::new(err)))?;
+            paths.push(object.location);
+        }
+        Ok(paths)
+    }
+}
+
+#[async_trait]
+impl WalAdmin for SlateDbWalAdmin {
+    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGC> {
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(self.object_store.clone(), None),
+            SsTableFormat::default(),
+            path.clone(),
+            None,
+            TableStoreKind::GC,
+            BlockCachePolicy::default(),
+        ));
+        Box::new(SlateDbWalGc::new(
+            table_store,
+            Arc::new(GcStats::new(&MetricsRecorderHelper::noop())),
+            GarbageCollectorDirectoryOptions::default(),
+            WalGcMode::Regular,
+            None,
+            Arc::new(DefaultSystemClock::new()),
+        ))
+    }
+
+    async fn delete_wal(&self, path: &Path) -> Result<(), WalError> {
+        // Collect the paths first so listing is complete before objects are removed.
+        for object_path in self.paths_under(path).await? {
+            self.object_store
+                .delete(&object_path)
+                .await
+                .map_err(|err| WalError::Unavailable(Arc::new(err)))?;
+        }
+        Ok(())
+    }
+
+    async fn is_empty(&self, path: &Path, manifest: VersionedManifest) -> Result<bool, WalError> {
+        let (replay_after_wal_id, wal_id_last_seen) = Self::replay_range(&manifest)?;
+
+        // Avoid object-store requests when the manifest's WAL range contains no file IDs.
+        if !Self::has_wal_file_ids(replay_after_wal_id, wal_id_last_seen) {
+            return Ok(true);
+        }
+
+        let path_resolver = PathResolver::from_root(path.clone());
+        for wal_id in (replay_after_wal_id + 1)..=wal_id_last_seen {
+            let path = path_resolver.sst_path(&SsTableId::Wal(wal_id));
+            let metadata = self
+                .object_store
+                .head(&path)
+                .await
+                .map_err(|err| WalError::Unavailable(Arc::new(err)))?;
+
+            // Native SlateDB WAL fences are zero-byte WAL objects and contain no records.
+            if metadata.size > 0 {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    async fn clone_wal(
+        &self,
+        from_path: &Path,
+        from_manifest: VersionedManifest,
+        to_path: &Path,
+    ) -> Result<(u64, u64), WalError> {
+        let (replay_after_wal_id, wal_id_last_seen) = Self::replay_range(&from_manifest)?;
+        let from_path_resolver = PathResolver::from_root(from_path.clone());
+        let to_path_resolver = PathResolver::from_root(to_path.clone());
+
+        if Self::has_wal_file_ids(replay_after_wal_id, wal_id_last_seen) {
+            for wal_id in (replay_after_wal_id + 1)..=wal_id_last_seen {
+                fail_point!(self.fp_registry.clone(), "copy-wal-ssts-io-error", |_| Err(
+                    WalError::Unavailable(Arc::new(std::io::Error::other("oops")))
+                ));
+
+                let id = SsTableId::Wal(wal_id);
+                let source = from_path_resolver.sst_path(&id);
+                let destination = to_path_resolver.sst_path(&id);
+                self.object_store
+                    .as_ref()
+                    .copy(&source, &destination)
+                    .await
+                    .map_err(|err| WalError::Unavailable(Arc::new(err)))?;
+            }
+        }
+
+        Ok((replay_after_wal_id, wal_id_last_seen))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use object_store::memory::InMemory;
+
+    #[tokio::test]
+    async fn delete_wal_deletes_only_objects_under_the_requested_path() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wal_admin =
+            SlateDbWalAdmin::new(object_store.clone(), Arc::new(FailPointRegistry::new()));
+        let wal_path = Path::from("db/wal");
+        let wal_object = wal_path.clone().join("00000000000000000001.sst");
+        let sibling_object = Path::from("other/wal/00000000000000000002.sst");
+        object_store
+            .put(&wal_object, Bytes::from_static(b"wal").into())
+            .await
+            .unwrap();
+        object_store
+            .put(&sibling_object, Bytes::from_static(b"keep").into())
+            .await
+            .unwrap();
+
+        wal_admin.delete_wal(&wal_path).await.unwrap();
+
+        assert!(matches!(
+            object_store.head(&wal_object).await,
+            Err(object_store::Error::NotFound { .. })
+        ));
+        assert!(object_store.head(&sibling_object).await.is_ok());
+    }
+
+    #[test]
+    fn creates_a_path_scoped_garbage_collector() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let wal_admin = SlateDbWalAdmin::new(object_store, Arc::new(FailPointRegistry::new()));
+
+        let _collector = wal_admin.garbage_collector(&Path::from("db"));
+    }
+}

--- a/slatedb/src/wal/gc.rs
+++ b/slatedb/src/wal/gc.rs
@@ -3,7 +3,7 @@ use crate::db_state::SsTableId;
 use crate::garbage_collector::stats::GcStats;
 use crate::garbage_collector::{retain_allowed_by_gc_filter, GcFilter, GC_DELETE_CONCURRENCY};
 use crate::tablestore::TableStore;
-use crate::wal::{WalError, WalFileRange, WalGC};
+use crate::wal::{WalError, WalFileRange, WalGc};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
@@ -155,7 +155,7 @@ impl SlateDbWalGc {
 }
 
 #[async_trait]
-impl WalGC for SlateDbWalGc {
+impl WalGc for SlateDbWalGc {
     async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
         let utc_now = self.system_clock.now();
         let min_age = self.wal_sst_min_age();

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -3,11 +3,13 @@ use crate::manifest::store::FenceableManifest;
 use crate::{CloseReason, ErrorKind, RowEntry, VersionedManifest};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
+use object_store::path::Path;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::ops::{Bound, Range};
 use std::sync::Arc;
 
+pub(crate) mod admin;
 pub(crate) mod gc;
 #[cfg(test)]
 pub(crate) mod test_utils;
@@ -290,6 +292,58 @@ pub trait WalGC: Send + Sync + 'static {
     /// referenced by some active Manifest. The implementation may delete any WAL File that is not
     /// included in the ranges in this list.
     async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError>;
+}
+
+/// Administrative operations for a WAL implementation.
+#[async_trait]
+pub trait WalAdmin: Send + Sync + 'static {
+    /// Creates a garbage collector scoped to the WAL at `path`.
+    ///
+    /// ## Arguments
+    /// - `path`: The database path whose WAL should be garbage collected.
+    ///
+    /// ## Returns
+    /// A garbage collector that can remove unreferenced WAL files at `path`.
+    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGC>;
+
+    /// Deletes the WAL at `path`.
+    ///
+    /// ## Arguments
+    /// - `path`: The database path whose WAL should be deleted.
+    ///
+    /// ## Returns
+    /// `Ok(())` after the WAL has been deleted, or a [`WalError`] if deletion fails.
+    async fn delete_wal(&self, path: &Path) -> Result<(), WalError>;
+
+    /// Given a path and manifest, returns true if the WAL referenced by the manifest at that path
+    /// is empty. A WAL is empty if it holds no records.
+    ///
+    /// ## Arguments
+    /// - `path`: The database path containing the WAL.
+    /// - `manifest`: The source manifest that identifies the WAL state to inspect.
+    ///
+    /// ## Returns
+    /// `Ok(true)` if the referenced WAL contains no records, `Ok(false)` if it contains records,
+    /// or a [`WalError`] if the WAL could not be inspected.
+    async fn is_empty(&self, path: &Path, manifest: VersionedManifest) -> Result<bool, WalError>;
+
+    /// Given a source path and manifest, copy the referenced WAL to a destination path and return
+    /// a replay range. This call must be idempotent (TODO: clarify)
+    ///
+    /// ## Arguments
+    /// - `from_path`: The db path that holds the source WAL range to be copied
+    /// - `from_manifest`: The source manifest that identifies the WAL to copy
+    /// - `to_path`: The db path of the clone that the WAL is being copied to.
+    ///
+    /// ## Returns
+    /// A (u64, u64) pair. The first item will be used as the replay start point (exclusive). The
+    /// second item should be the id of the last WAL file id in the copied WAL.
+    async fn clone_wal(
+        &self,
+        from_path: &Path,
+        from_manifest: VersionedManifest,
+        to_path: &Path,
+    ) -> Result<(u64, u64), WalError>;
 }
 
 impl From<WalStatus> for WalError {

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -315,17 +315,23 @@ pub trait WalAdmin: Send + Sync + 'static {
     /// `Ok(())` after the WAL has been deleted, or a [`WalError`] if deletion fails.
     async fn delete_wal(&self, path: &Path) -> Result<(), WalError>;
 
-    /// Given a path and manifest, returns true if the WAL referenced by the manifest at that path
-    /// is empty. A WAL is empty if it holds no records.
+    /// Given a path and WAL ID range, returns true if the WAL at that path is empty within the
+    /// specified range. A WAL is empty if it holds no records.
     ///
     /// ## Arguments
     /// - `path`: The database path containing the WAL.
-    /// - `manifest`: The source manifest that identifies the WAL state to inspect.
+    /// - `replay_after_wal_id`: The exclusive lower bound of the WAL range to inspect.
+    /// - `wal_id_last_seen`: The inclusive upper bound of the WAL range to inspect.
     ///
     /// ## Returns
     /// `Ok(true)` if the referenced WAL contains no records, `Ok(false)` if it contains records,
     /// or a [`WalError`] if the WAL could not be inspected.
-    async fn is_empty(&self, path: &Path, manifest: VersionedManifest) -> Result<bool, WalError>;
+    async fn is_empty(
+        &self,
+        path: &Path,
+        replay_after_wal_id: u64,
+        wal_id_last_seen: u64,
+    ) -> Result<bool, WalError>;
 
     /// Given a source path and manifest, copy the referenced WAL to a destination path and return
     /// a replay range. This call must be idempotent (TODO: clarify)

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -284,10 +284,10 @@ pub trait WalReader {
 
 /// Trait that defines the contract between SlateDB's garbage collector and a custom WAL
 /// implementation. SlateDB tracks the set of currently referenced WAL ranges in its manifest.
-/// When the Garbage Collector runs, it computes this set and calls [`WalGC::collect`] so that
+/// When the Garbage Collector runs, it computes this set and calls [`WalGc::collect`] so that
 /// the implementation can clean up any un-referenced WAL storage.
 #[async_trait]
-pub trait WalGC: Send + Sync + 'static {
+pub trait WalGc: Send + Sync + 'static {
     /// Hook for garbage collecting the WAL. Takes a list of ranges of WAL Files that are currently
     /// referenced by some active Manifest. The implementation may delete any WAL File that is not
     /// included in the ranges in this list.
@@ -304,7 +304,7 @@ pub trait WalAdmin: Send + Sync + 'static {
     ///
     /// ## Returns
     /// A garbage collector that can remove unreferenced WAL files at `path`.
-    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGC>;
+    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGc>;
 
     /// Deletes the WAL at `path`.
     ///


### PR DESCRIPTION
## Summary

Adds a `WalAdmin` trait for admin operations and update the clone path to use it.

## Changes

Adds a WalAdmin trait for admin operations against the WAL. It has the following fns:
- is_empty: used on the clone path to check for non-empty WALs when doing project/union
- clone_wal: used to copy a wal to a clone db
- delete_wal: used by the admin api for deleting a db
- garbage_collector: used by the admin api when starting a gc

Updates the clone path to use the new trait (admin changes are in a later patch)

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
