### PR TITLE
[rfc-30 6/N]: wire custom WAL into builders

### DIFF
--- a/rfcs/0030-pluggable-wal.md
+++ b/rfcs/0030-pluggable-wal.md
@@ -389,6 +389,11 @@ pub trait WalReader {
         &self,
         wal_file_id_range: WalFileRange,
     ) -> Result<Box<dyn WalIterator>, WalError>;
+
+    /// Returns the ID of the last WAL file currently present after `replay_after_wal_id`, or
+    /// `replay_after_wal_id` if no later WAL file is present. Implementations may use
+    /// `replay_after_wal_id` as a known lower bound when locating the end of the WAL.
+    async fn last_wal_file_id(&self, replay_after_wal_id: u64) -> Result<u64, WalError>;
 }
 
 /// API for plugging into WAL GC

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -793,7 +793,6 @@ impl Admin {
             self.retrying_store(ObjectStoreType::Main),
         )
         .with_wal_admin(self.wal_admin.clone())
-        // TODO: make sure wal_admin uses retrying object store
     }
 
     /// Creates a new builder for an admin client at the given path.

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeSet};
 pub use crate::db::builder::CloneBuilder;
 pub use crate::db::builder::CloneSourceSpec;
 
@@ -36,6 +37,7 @@ use uuid::Uuid;
 pub use crate::db::builder::AdminBuilder;
 use crate::merge_operator::MergeOperatorType;
 use slatedb_txn_obj::TransactionalObject;
+use crate::wal::WalAdmin;
 
 /// An Admin struct for SlateDB administration operations.
 ///
@@ -57,6 +59,7 @@ pub struct Admin {
     pub(crate) compaction_filter_supplier:
         Option<Arc<dyn crate::compaction_filter::CompactionFilterSupplier>>,
     pub(crate) merge_operator: Option<MergeOperatorType>,
+    pub(crate) wal_admin: Arc<dyn WalAdmin>,
 }
 
 impl Admin {
@@ -284,6 +287,7 @@ impl Admin {
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
         )
         .with_system_clock(self.system_clock.clone())
+        .with_wal_gc(self.wal_admin.garbage_collector(&self.path))
         .with_wal_object_store(self.object_stores.store_of(ObjectStoreType::Wal).clone())
         .with_options(gc_opts)
         .with_seed(self.rand.rng().next_u64())
@@ -317,6 +321,7 @@ impl Admin {
             self.object_stores.store_of(ObjectStoreType::Main).clone(),
         )
         .with_system_clock(self.system_clock.clone())
+        .with_wal_gc(self.wal_admin.garbage_collector(&self.path))
         .with_wal_object_store(self.object_stores.store_of(ObjectStoreType::Wal).clone())
         .with_options(gc_opts)
         .with_seed(self.rand.rng().next_u64())
@@ -573,7 +578,7 @@ impl Admin {
     /// job. A `confirm` delete of a dir with neither a manifest nor a marker is
     /// refused, so a fat-fingered `--path` can't wipe an unrelated directory.
     /// Idempotent.
-    pub async fn delete_db(&self, confirm: bool) -> Result<Vec<Path>, crate::Error> {
+    pub async fn delete_db(&self, confirm: bool) -> Result<Vec<String>, crate::Error> {
         let main = self.retrying_store(ObjectStoreType::Main);
 
         if !confirm {
@@ -631,26 +636,28 @@ impl Admin {
         // Delete everything but the marker, then the marker last, so a crash in
         // between leaves the marker to prove a rerun should finish.
         let mut deleted = self.delete_prefix(&main, Some(&marker)).await?;
-        if self.object_stores.has_wal_object_store() {
-            deleted.extend(
-                self.delete_prefix(&self.retrying_store(ObjectStoreType::Wal), None)
-                    .await?,
-            );
-        }
+        deleted.extend(
+            self.wal_admin.delete_wal(
+                &self.path,
+                false
+            ).await.map_err(|e| SlateDBError::from(e))?
+        );
         main.delete(&marker).await.map_err(SlateDBError::from)?;
-        deleted.push(marker);
+        deleted.push(marker.to_string());
         Ok(deleted)
     }
 
     /// Lists every object under this db's path prefix across the main and WAL stores.
-    async fn list_prefix(&self, main: &Arc<dyn ObjectStore>) -> Result<Vec<Path>, crate::Error> {
-        let mut paths = collect_prefix(main, &self.path).await?;
-        if self.object_stores.has_wal_object_store() {
-            paths.extend(
-                collect_prefix(&self.retrying_store(ObjectStoreType::Wal), &self.path).await?,
-            );
+    async fn list_prefix(&self, main: &Arc<dyn ObjectStore>) -> Result<Vec<String>, crate::Error> {
+        let paths = collect_prefix(main, &self.path).await?;
+        // track the dry run paths in a set since the WAL and db may overlap
+        let mut paths = paths.iter().map(Path::to_string).collect::<BTreeSet<_>>();
+        let wal_paths = self.wal_admin.delete_wal(&self.path, true).await
+            .map_err(|e| SlateDBError::from(e))?;
+        for wp in wal_paths {
+            paths.insert(wp);
         }
-        Ok(paths)
+        Ok(paths.into_iter().collect())
     }
 
     /// Deletes every object under this db's path prefix in the given store,
@@ -659,7 +666,7 @@ impl Admin {
         &self,
         store: &Arc<dyn ObjectStore>,
         keep: Option<&Path>,
-    ) -> Result<Vec<Path>, crate::Error> {
+    ) -> Result<Vec<String>, crate::Error> {
         let mut deleted = Vec::new();
         for path in collect_prefix(store, &self.path).await? {
             if Some(&path) == keep {
@@ -668,7 +675,7 @@ impl Admin {
             store.delete(&path).await.map_err(SlateDBError::from)?;
             deleted.push(path);
         }
-        Ok(deleted)
+        Ok(deleted.into_iter().map(|p| p.to_string()).collect())
     }
 
     /// Returns the timestamp or sequence from the latest manifest's sequence tracker.
@@ -782,7 +789,8 @@ impl Admin {
             source,
             self.retrying_store(ObjectStoreType::Main),
         )
-        .with_wal_object_store(self.retrying_store(ObjectStoreType::Wal))
+        .with_wal_admin(self.wal_admin.clone())
+        // TODO: make sure wal_admin uses retrying object store
     }
 
     /// Creates a new builder for an admin client at the given path.

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -1,6 +1,6 @@
-use std::collections::{BTreeSet};
 pub use crate::db::builder::CloneBuilder;
 pub use crate::db::builder::CloneSourceSpec;
+use std::collections::BTreeSet;
 
 use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
 use crate::compactions_store::CompactionsStore;
@@ -36,8 +36,8 @@ use uuid::Uuid;
 
 pub use crate::db::builder::AdminBuilder;
 use crate::merge_operator::MergeOperatorType;
-use slatedb_txn_obj::TransactionalObject;
 use crate::wal::WalAdmin;
+use slatedb_txn_obj::TransactionalObject;
 
 /// An Admin struct for SlateDB administration operations.
 ///
@@ -637,10 +637,10 @@ impl Admin {
         // between leaves the marker to prove a rerun should finish.
         let mut deleted = self.delete_prefix(&main, Some(&marker)).await?;
         deleted.extend(
-            self.wal_admin.delete_wal(
-                &self.path,
-                false
-            ).await.map_err(|e| SlateDBError::from(e))?
+            self.wal_admin
+                .delete_wal(&self.path, false)
+                .await
+                .map_err(SlateDBError::from)?,
         );
         main.delete(&marker).await.map_err(SlateDBError::from)?;
         deleted.push(marker.to_string());
@@ -652,8 +652,11 @@ impl Admin {
         let paths = collect_prefix(main, &self.path).await?;
         // track the dry run paths in a set since the WAL and db may overlap
         let mut paths = paths.iter().map(Path::to_string).collect::<BTreeSet<_>>();
-        let wal_paths = self.wal_admin.delete_wal(&self.path, true).await
-            .map_err(|e| SlateDBError::from(e))?;
+        let wal_paths = self
+            .wal_admin
+            .delete_wal(&self.path, true)
+            .await
+            .map_err(SlateDBError::from)?;
         for wp in wal_paths {
             paths.insert(wp);
         }

--- a/slatedb/src/clone.rs
+++ b/slatedb/src/clone.rs
@@ -622,6 +622,7 @@ mod tests {
     use std::ops::Bound;
     use std::ops::RangeBounds;
     use std::sync::Arc;
+    use std::time::Duration;
     use uuid::Uuid;
 
     struct RemappingWalAdmin {
@@ -633,19 +634,24 @@ mod tests {
 
     #[async_trait]
     impl WalGc for NoopWalGc {
-        async fn collect(&self, _referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
+        async fn collect(
+            &self,
+            _referenced_ranges: Vec<WalFileRange>,
+            _min_age: Duration,
+            _dry_run: bool,
+        ) -> Result<(), WalError> {
             Ok(())
         }
     }
 
     #[async_trait]
     impl WalAdmin for RemappingWalAdmin {
-        fn garbage_collector(&self, _path: &Path) -> Box<dyn WalGc> {
-            Box::new(NoopWalGc)
+        fn garbage_collector(&self, _path: &Path) -> Arc<dyn WalGc> {
+            Arc::new(NoopWalGc)
         }
 
-        async fn delete_wal(&self, _path: &Path) -> Result<(), WalError> {
-            Ok(())
+        async fn delete_wal(&self, _path: &Path, _dry_run: bool) -> Result<Vec<String>, WalError> {
+            Ok(vec![])
         }
 
         async fn is_empty(

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -161,9 +161,10 @@ use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
 use crate::utils::WatchableOnceCell;
+use crate::{retrying_object_store, wal};
 use crate::wal::admin::SlateDbWalAdmin;
 use crate::wal::wal_disabled::DisabledWalObserver;
-use crate::wal::WalObserver;
+use crate::wal::{WalAdmin, WalGC, WalObserver};
 use slatedb_common::clock::DefaultSystemClock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorder;
@@ -195,6 +196,7 @@ pub struct DbBuilder<P: Into<Path>> {
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
     segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
+    wal_writer_init: Option<Box<dyn wal::WriterInit>>,
 }
 
 impl<P: Into<Path>> DbBuilder<P> {
@@ -224,6 +226,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             filter_policies: default_filter_policies(),
             metrics_recorder: Arc::new(NoopMetricsRecorder::new()),
             segment_extractor: None,
+            wal_writer_init: None,
         }
     }
 
@@ -262,6 +265,14 @@ impl<P: Into<Path>> DbBuilder<P> {
     /// durable and available enough for your use case.
     pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
         self.wal_object_store = Some(wal_object_store);
+        self
+    }
+
+    /// Sets the WAL writer initializer used to fence the WAL and create the writer.
+    /// Use this to plug in a custom WAL implementation. SlateDB's object-store-backed
+    /// WAL is used by default.
+    pub fn with_wal_writer(mut self, wal_writer_init: Box<dyn wal::WriterInit>) -> Self {
+        self.wal_writer_init = Some(wal_writer_init);
         self
     }
 
@@ -615,6 +626,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             &self.settings,
             system_clock.clone(),
             task_executor.clone(),
+            self.wal_writer_init,
         );
         let WriterFenceResult {
             manifest,
@@ -843,6 +855,7 @@ pub struct AdminBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
+    wal_admin: Option<Arc<dyn WalAdmin>>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
     object_store_max_retries: Option<u32>,
@@ -858,6 +871,7 @@ impl<P: Into<Path>> AdminBuilder<P> {
             path,
             main_object_store,
             wal_object_store: None,
+            wal_admin: None,
             system_clock: Arc::new(DefaultSystemClock::new()),
             rand: Arc::new(DbRand::default()),
             object_store_max_retries: None,
@@ -880,6 +894,13 @@ impl<P: Into<Path>> AdminBuilder<P> {
     /// main object store.
     pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
         self.wal_object_store = Some(wal_object_store);
+        self
+    }
+
+    /// Sets the WAL admin API implementation to use for admin operations like db deletion
+    /// and cloning. Users should set this if using a custom WAL implementation.
+    pub fn with_wal_admin(mut self, wal_admin: Arc<dyn WalAdmin>) -> Self {
+        self.wal_admin = Some(wal_admin);
         self
     }
 
@@ -915,9 +936,22 @@ impl<P: Into<Path>> AdminBuilder<P> {
         // rather than at build time, because several admin operations delegate
         // to sub-builders (compactor/GC) that add their own retry layer, and
         // wrapping here would double-wrap them.
+        let object_stores = ObjectStores::new(self.main_object_store, self.wal_object_store);
+        let wal_admin = self.wal_admin.unwrap_or_else(|| {
+            let retrying_object_store = Arc::new(RetryingObjectStore::new(
+                object_stores.store_of(ObjectStoreType::Wal).clone(),
+                self.rand.clone(),
+                self.system_clock.clone(),
+                self.object_store_max_retries,
+            ));
+            Arc::new(
+                SlateDbWalAdmin::new(retrying_object_store, Arc::new(FailPointRegistry::new()))
+            )
+        });
         Admin {
             path: self.path.into(),
-            object_stores: ObjectStores::new(self.main_object_store, self.wal_object_store),
+            object_stores,
+            wal_admin,
             system_clock: self.system_clock,
             rand: self.rand,
             object_store_max_retries: self.object_store_max_retries,
@@ -935,6 +969,7 @@ pub struct GarbageCollectorBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
+    wal_gc: Option<Arc<dyn WalGC>>,
     options: GarbageCollectorOptions,
     gc_filter: Option<Arc<dyn GcFilter>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
@@ -948,6 +983,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             path,
             main_object_store,
             wal_object_store: None,
+            wal_gc: None,
             options: GarbageCollectorOptions::default(),
             gc_filter: None,
             metrics_recorder: Arc::new(NoopMetricsRecorder::new()),
@@ -962,6 +998,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             path: self.path.into(),
             main_object_store: self.main_object_store,
             wal_object_store: self.wal_object_store,
+            wal_gc: self.wal_gc,
             options: self.options,
             gc_filter: self.gc_filter,
             metrics_recorder: self.metrics_recorder,
@@ -1009,6 +1046,11 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
         self
     }
 
+    pub fn with_wal_gc(mut self, wal_gc: Arc<dyn WalGC>) -> Self {
+        self.wal_gc = Some(wal_gc);
+        self
+    }
+
     /// Builds a GarbageCollector using pre-existing stores (used by DbBuilder).
     pub(crate) fn build_collector(
         self,
@@ -1030,6 +1072,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             &recorder,
             self.system_clock,
             self.gc_filter,
+            self.wal_gc,
         )
     }
 
@@ -1088,6 +1131,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
             &recorder,
             self.system_clock,
             self.gc_filter,
+            self.wal_gc,
         )
     }
 }
@@ -1617,6 +1661,7 @@ pub struct DbReaderBuilder<P: Into<Path>> {
     path: P,
     object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
+    wal_reader: Option<Arc<dyn wal::WalReader>>,
     db_cache: Option<Arc<dyn DbCache>>,
     mode: DbReaderMode,
     merge_operator: Option<MergeOperatorType>,
@@ -1636,6 +1681,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             path,
             object_store,
             wal_object_store: None,
+            wal_reader: None,
             db_cache: default_db_cache(),
             mode: DbReaderMode::default(),
             merge_operator: None,
@@ -1659,6 +1705,13 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
     /// Use this when the database was configured with a separate WAL object store.
     pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
         self.wal_object_store = Some(wal_object_store);
+        self
+    }
+
+    /// Sets the WAL reader used to replay WAL rows. Use this to plug in a custom
+    /// WAL implementation. SlateDB's object-store-backed WAL is used by default.
+    pub fn with_wal_reader(mut self, wal_reader: Arc<dyn wal::WalReader>) -> Self {
+        self.wal_reader = Some(wal_reader);
         self
     }
 
@@ -1868,6 +1921,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
             manifest_store,
             table_store,
             self.mode,
+            self.wal_reader,
             self.merge_operator,
             self.segment_extractor,
             self.options,
@@ -1955,6 +2009,7 @@ pub struct CloneBuilder<R: RangeBounds<Bytes> + Clone = (Bound<Bytes>, Bound<Byt
     sources: Vec<CloneSourceSpec<R>>,
     object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
+    wal_admin: Option<Arc<dyn WalAdmin>>,
     system_clock: Option<Arc<dyn SystemClock>>,
     rand: Option<Arc<DbRand>>,
     projection_range: Option<R>,
@@ -1973,6 +2028,7 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
             sources: vec![source],
             object_store,
             wal_object_store: None,
+            wal_admin: None,
             system_clock: None,
             rand: None,
             projection_range: None,
@@ -1998,6 +2054,11 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
 
     pub fn with_wal_object_store(mut self, wal_object_store: Arc<dyn ObjectStore>) -> Self {
         self.wal_object_store = Some(wal_object_store);
+        self
+    }
+
+    pub fn with_wal_admin(mut self, wal_admin: Arc<dyn WalAdmin>) -> Self {
+        self.wal_admin = Some(wal_admin);
         self
     }
 
@@ -2056,10 +2117,14 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     /// Build and execute the clone operation.
     pub async fn build(self) -> Result<(), crate::Error> {
         let fp_registry = Arc::new(FailPointRegistry::new());
-        let wal_admin = Arc::new(SlateDbWalAdmin::new(
-            self.wal_object_store.unwrap_or(self.object_store.clone()),
-            fp_registry.clone(),
-        ));
+        let wal_admin = if let Some(wal_admin) = self.wal_admin {
+            wal_admin
+        } else {
+            Arc::new(SlateDbWalAdmin::new(
+                self.wal_object_store.unwrap_or(self.object_store.clone()),
+                fp_registry.clone(),
+            ))
+        };
         crate::clone::create_clone(
             self.sources,
             self.clone_path,
@@ -2159,6 +2224,10 @@ mod tests {
     use crate::instrumented_object_store::stats::REQUEST_COUNT as OBJECT_STORE_REQUEST_COUNT;
     use crate::manifest::store::{ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
+    use crate::wal::test_utils::FakeWalWriter;
+    use crate::wal::{
+        WalError, WalIterator, WalRows, WriterInit, WriterInitResult, WriterManifest,
+    };
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::ObjectStore;
@@ -2166,7 +2235,37 @@ mod tests {
     use slatedb_common::metrics::{
         lookup_metric, lookup_metric_with_labels, DefaultMetricsRecorder, MetricsRecorderHelper,
     };
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    struct EmptyWalIterator;
+
+    #[async_trait::async_trait]
+    impl WalIterator for EmptyWalIterator {
+        async fn next(&mut self) -> Result<Option<WalRows>, WalError> {
+            Ok(None)
+        }
+    }
+
+    struct RecordingWriterInit {
+        called: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl WriterInit for RecordingWriterInit {
+        async fn fence_and_init(
+            &self,
+            manifest: &mut WriterManifest,
+        ) -> Result<WriterInitResult, WalError> {
+            self.called.store(true, Ordering::Relaxed);
+            Ok(WriterInitResult {
+                replay_iterator: Box::new(EmptyWalIterator),
+                wal_writer: Box::new(FakeWalWriter::new(manifest.replay_after_wal_id())),
+            })
+        }
+    }
 
     fn object_store_labels(
         component: &'static str,
@@ -2190,6 +2289,29 @@ mod tests {
         let counter = helper.counter(name).level(MetricLevel::Debug).register();
         counter.increment(1);
         assert_eq!(lookup_metric(recorder, name), Some(1));
+    }
+
+    #[tokio::test]
+    async fn test_db_builder_uses_custom_wal_writer_init() {
+        let called = Arc::new(AtomicBool::new(false));
+        let db = crate::Db::builder(
+            "test_db_builder_uses_custom_wal_writer_init",
+            Arc::new(InMemory::new()),
+        )
+        .with_settings(Settings {
+            compactor_options: None,
+            garbage_collector_options: None,
+            ..Settings::default()
+        })
+        .with_wal_writer(Box::new(RecordingWriterInit {
+            called: Arc::clone(&called),
+        }))
+        .build()
+        .await
+        .expect("failed to build db");
+
+        assert!(called.load(Ordering::Relaxed));
+        db.close().await.expect("failed to close db");
     }
 
     #[tokio::test]

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -161,7 +161,7 @@ use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
 use crate::utils::WatchableOnceCell;
-use crate::{retrying_object_store, wal};
+use crate::wal;
 use crate::wal::admin::SlateDbWalAdmin;
 use crate::wal::wal_disabled::DisabledWalObserver;
 use crate::wal::{WalAdmin, WalGC, WalObserver};
@@ -944,9 +944,10 @@ impl<P: Into<Path>> AdminBuilder<P> {
                 self.system_clock.clone(),
                 self.object_store_max_retries,
             ));
-            Arc::new(
-                SlateDbWalAdmin::new(retrying_object_store, Arc::new(FailPointRegistry::new()))
-            )
+            Arc::new(SlateDbWalAdmin::new(
+                retrying_object_store,
+                Arc::new(FailPointRegistry::new()),
+            ))
         });
         Admin {
             path: self.path.into(),

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -164,7 +164,7 @@ use crate::utils::WatchableOnceCell;
 use crate::wal;
 use crate::wal::admin::SlateDbWalAdmin;
 use crate::wal::wal_disabled::DisabledWalObserver;
-use crate::wal::{WalAdmin, WalGC, WalObserver};
+use crate::wal::{WalAdmin, WalGc, WalObserver};
 use slatedb_common::clock::DefaultSystemClock;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorder;
@@ -970,7 +970,7 @@ pub struct GarbageCollectorBuilder<P: Into<Path>> {
     path: P,
     main_object_store: Arc<dyn ObjectStore>,
     wal_object_store: Option<Arc<dyn ObjectStore>>,
-    wal_gc: Option<Arc<dyn WalGC>>,
+    wal_gc: Option<Arc<dyn WalGc>>,
     options: GarbageCollectorOptions,
     gc_filter: Option<Arc<dyn GcFilter>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
@@ -1047,7 +1047,7 @@ impl<P: Into<Path>> GarbageCollectorBuilder<P> {
         self
     }
 
-    pub fn with_wal_gc(mut self, wal_gc: Arc<dyn WalGC>) -> Self {
+    pub fn with_wal_gc(mut self, wal_gc: Arc<dyn WalGc>) -> Self {
         self.wal_gc = Some(wal_gc);
         self
     }

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -12,7 +12,6 @@ use {
         db_status::{ClosedResultWriter, DbStatus, DbStatusManager},
         dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef},
         error::SlateDBError,
-        iter::IterationOrder,
         manifest::{
             store::{ManifestStore, StoredManifest},
             Manifest, ManifestCore, VersionedManifest,
@@ -23,11 +22,11 @@ use {
         paths::PathResolver,
         prefix_extractor::PrefixExtractor,
         reader::{DbStateReader, Reader, ScanContext},
-        sst_iter::SstIteratorOptions,
         tablestore::TableStore,
         types::KeyValue,
         utils::IdGenerator,
-        wal_replay::{WalIteratorOptions, WalReplayIterator, WalReplayOptions},
+        wal::WalReader as WalReaderTrait,
+        wal_replay::{WalReplayIterator, WalReplayOptions},
         Checkpoint, DbCacheManagerOps, DbIterator, DbMetadataOps, DbReadOps,
     },
     async_trait::async_trait,
@@ -83,7 +82,7 @@ enum WalReplayEnd {
     /// the manifest itself records as durable.
     Manifest,
 
-    /// Probe the object store for the newest WAL file and replay through it,
+    /// Ask the configured WAL reader for the newest WAL file and replay through it,
     /// picking up writes made after the manifest was written.
     Latest,
 }
@@ -115,6 +114,7 @@ pub struct DbReader {
 struct DbReaderInner {
     manifest_store: Arc<ManifestStore>,
     table_store: Arc<TableStore>,
+    wal_reader: Arc<dyn WalReaderTrait>,
     options: DbReaderOptions,
     mode: DbReaderMode,
     state: RwLock<Arc<ReaderState>>,
@@ -172,6 +172,7 @@ impl DbReaderInner {
     async fn new(
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,
+        wal_reader: Option<Arc<dyn WalReaderTrait>>,
         options: DbReaderOptions,
         mode: DbReaderMode,
         merge_operator: Option<MergeOperatorType>,
@@ -181,6 +182,11 @@ impl DbReaderInner {
         recorder: slatedb_common::metrics::MetricsRecorderHelper,
         mut manifest: StoredManifest,
     ) -> Result<Self, SlateDBError> {
+        let wal_reader = wal_reader.unwrap_or_else(|| {
+            Arc::new(crate::wal::reader::SlateDbWalReader::new(Arc::clone(
+                &table_store,
+            )))
+        });
         let checkpoint =
             Self::get_or_create_checkpoint(&mut manifest, mode, &options, rand.clone()).await?;
         let (manifest_id, initial_manifest) = if let Some(checkpoint) = checkpoint.as_ref() {
@@ -199,6 +205,7 @@ impl DbReaderInner {
                 VecDeque::new(),
                 WalReplayEnd::for_reader(mode, &options),
                 Arc::clone(&table_store),
+                wal_reader.as_ref(),
                 &options,
                 segment_extractor.as_ref(),
             )
@@ -239,6 +246,7 @@ impl DbReaderInner {
         let inner = Self {
             manifest_store,
             table_store,
+            wal_reader,
             options,
             mode,
             state,
@@ -384,25 +392,20 @@ impl DbReaderInner {
         if self.options.skip_wal_replay {
             return Ok(());
         }
-        let last_replayed_wal_id = self.state.read().last_wal_id;
-        let last_seen_wal_id = self
-            .table_store
-            .last_seen_wal_id(last_replayed_wal_id)
-            .await?;
-        if last_seen_wal_id > last_replayed_wal_id {
-            let current_state = Arc::clone(&self.state.read());
-            let mut imm_memtable = current_state.imm_memtable().clone();
+        let current_state = Arc::clone(&self.state.read());
+        let mut imm_memtable = current_state.imm_memtable().clone();
+        let (last_wal_id, last_committed_seq) = Self::replay_wal_into(
+            Arc::clone(&self.table_store),
+            self.wal_reader.as_ref(),
+            &self.options,
+            current_state.core(),
+            &mut imm_memtable,
+            WalReplayEnd::Latest,
+            self.segment_extractor.as_ref(),
+        )
+        .await?;
 
-            let (last_wal_id, last_committed_seq) = Self::replay_wal_into(
-                Arc::clone(&self.table_store),
-                &self.options,
-                current_state.core(),
-                &mut imm_memtable,
-                WalReplayEnd::Latest,
-                self.segment_extractor.as_ref(),
-            )
-            .await?;
-
+        if last_wal_id > current_state.last_wal_id {
             self.oracle.advance_durable_seq(last_committed_seq);
             let mut write_guard = self.state.write();
             *write_guard = Arc::new(ReaderState {
@@ -470,6 +473,7 @@ impl DbReaderInner {
             imm_memtable,
             WalReplayEnd::for_reader(self.mode, &self.options),
             Arc::clone(&self.table_store),
+            self.wal_reader.as_ref(),
             &self.options,
             self.segment_extractor.as_ref(),
         )
@@ -483,6 +487,7 @@ impl DbReaderInner {
         mut imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
         replay_wals: Option<WalReplayEnd>,
         table_store: Arc<TableStore>,
+        wal_reader: &dyn WalReaderTrait,
         options: &DbReaderOptions,
         segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<ReaderState, SlateDBError> {
@@ -490,6 +495,7 @@ impl DbReaderInner {
             Some(replay_end) => {
                 Self::replay_wal_into(
                     Arc::clone(&table_store),
+                    wal_reader,
                     options,
                     &manifest.core,
                     &mut imm_memtable,
@@ -637,34 +643,30 @@ impl DbReaderInner {
 
     async fn replay_wal_into(
         table_store: Arc<TableStore>,
+        wal_reader: &dyn WalReaderTrait,
         reader_options: &DbReaderOptions,
         core: &ManifestCore,
         into_tables: &mut VecDeque<Arc<ImmutableMemtable>>,
         replay_end: WalReplayEnd,
         segment_extractor: Option<&Arc<dyn PrefixExtractor>>,
     ) -> Result<(u64, u64), SlateDBError> {
-        let sst_iter_options = SstIteratorOptions {
-            max_fetch_tasks: 1,
-            blocks_to_fetch: 256,
-            cache_blocks: true,
-            cache_metadata: false,
-            eager_spawn: true,
-            order: IterationOrder::Ascending,
-            prefix: None,
-            filter_context: None,
-        };
-
         let (mut replay_after_wal_id, mut last_committed_seq) =
             Self::replayed_watermark(core, into_tables);
+        let wal_id_start = replay_after_wal_id
+            .checked_add(1)
+            .ok_or(SlateDBError::InvalidDBState)?;
         let wal_id_end = match replay_end {
             WalReplayEnd::Manifest => core.next_wal_sst_id,
-            WalReplayEnd::Latest => table_store.last_seen_wal_id(replay_after_wal_id).await? + 1,
+            WalReplayEnd::Latest => wal_reader
+                .last_wal_file_id()
+                .await?
+                .checked_add(1)
+                .ok_or(SlateDBError::InvalidDBState)?,
         };
+        if wal_id_start >= wal_id_end {
+            return Ok((replay_after_wal_id, last_committed_seq));
+        }
 
-        let iterator_options = WalIteratorOptions {
-            sst_batch_size: 4,
-            sst_iter_options,
-        };
         let replay_options = WalReplayOptions {
             max_memtable_bytes: reader_options.max_memtable_bytes as usize,
             // Skip entries that we already have in `imm_memtable` (that might be above
@@ -672,10 +674,12 @@ impl DbReaderInner {
             min_seq: Some(last_committed_seq),
         };
 
-        let mut replay_iter = WalReplayIterator::range(
-            (replay_after_wal_id + 1)..wal_id_end,
+        let wal_iter = wal_reader
+            .iterator((wal_id_start..wal_id_end).into())
+            .await?;
+        let mut replay_iter = WalReplayIterator::for_wal_iterator(
+            wal_iter,
             core,
-            iterator_options,
             replay_options,
             Arc::clone(&table_store),
         )?;
@@ -945,6 +949,7 @@ impl DbReader {
         manifest_store: Arc<ManifestStore>,
         table_store: Arc<TableStore>,
         mode: DbReaderMode,
+        wal_reader: Option<Arc<dyn WalReaderTrait>>,
         merge_operator: Option<MergeOperatorType>,
         segment_extractor: Option<Arc<dyn PrefixExtractor>>,
         options: DbReaderOptions,
@@ -968,6 +973,7 @@ impl DbReader {
             DbReaderInner::new(
                 manifest_store,
                 table_store,
+                wal_reader,
                 options,
                 mode,
                 merge_operator,
@@ -1483,6 +1489,7 @@ mod tests {
             tablestore::{TableStore, TableStoreKind},
             test_utils,
             types::RowEntry,
+            wal::{WalError, WalFileRange, WalIterator, WalReader as WalReaderTrait, WalRows},
             CloseReason, Db,
         },
         bytes::Bytes,
@@ -1495,11 +1502,45 @@ mod tests {
         },
         std::{
             collections::{BTreeMap, VecDeque},
-            sync::Arc,
+            sync::{
+                atomic::{AtomicUsize, Ordering},
+                Arc,
+            },
             time::Duration,
         },
         uuid::Uuid,
     };
+
+    struct EmptyTestWalIterator;
+
+    #[async_trait::async_trait]
+    impl WalIterator for EmptyTestWalIterator {
+        async fn next(&mut self) -> Result<Option<WalRows>, WalError> {
+            Ok(None)
+        }
+    }
+
+    #[derive(Default)]
+    struct CountingWalReader {
+        iterator_calls: AtomicUsize,
+        last_wal_file_id_calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl WalReaderTrait for CountingWalReader {
+        async fn iterator(
+            &self,
+            _wal_file_id_range: WalFileRange,
+        ) -> Result<Box<dyn WalIterator>, WalError> {
+            self.iterator_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(Box::new(EmptyTestWalIterator))
+        }
+
+        async fn last_wal_file_id(&self) -> Result<u64, WalError> {
+            self.last_wal_file_id_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(10)
+        }
+    }
 
     #[tokio::test]
     async fn should_get_value_from_db() {
@@ -1532,6 +1573,32 @@ mod tests {
             reader.get(key).await.unwrap(),
             Some(Bytes::from_static(value))
         );
+    }
+
+    #[tokio::test]
+    async fn db_reader_builder_should_use_custom_wal_reader() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/tmp/test_custom_wal_reader");
+        let db = Db::open(path.clone(), Arc::clone(&object_store))
+            .await
+            .unwrap();
+        db.close().await.unwrap();
+
+        let wal_reader = Arc::new(CountingWalReader::default());
+        let reader = DbReader::builder(path, object_store)
+            .with_reader_mode(DbReaderMode::FollowLatest)
+            .with_wal_reader(wal_reader.clone())
+            .with_options(DbReaderOptions {
+                manifest_poll_interval: Duration::from_secs(60 * 60),
+                ..DbReaderOptions::default()
+            })
+            .build()
+            .await
+            .unwrap();
+
+        assert!(wal_reader.last_wal_file_id_calls.load(Ordering::Relaxed) > 0);
+        assert!(wal_reader.iterator_calls.load(Ordering::Relaxed) > 0);
+        reader.close().await.unwrap();
     }
 
     #[tokio::test]
@@ -1582,6 +1649,7 @@ mod tests {
             test_provider.manifest_store(),
             test_provider.table_store(),
             DbReaderMode::Checkpoint(checkpoint_result.id),
+            None,
             None,
             None,
             DbReaderOptions::default(),
@@ -1943,6 +2011,7 @@ mod tests {
             DbReaderMode::FollowLatest,
             None,
             None,
+            None,
             DbReaderOptions {
                 manifest_poll_interval: Duration::from_secs(60 * 60),
                 ..DbReaderOptions::default()
@@ -2136,6 +2205,7 @@ mod tests {
         let inner = DbReaderInner::new(
             Arc::clone(&manifest_store),
             table_store,
+            None,
             DbReaderOptions {
                 manifest_poll_interval: Duration::from_millis(100),
                 checkpoint_lifetime: Duration::from_millis(1000),
@@ -2231,6 +2301,7 @@ mod tests {
         let inner = DbReaderInner::new(
             Arc::clone(&manifest_store),
             table_store,
+            None,
             DbReaderOptions {
                 manifest_poll_interval: Duration::from_millis(100),
                 checkpoint_lifetime: Duration::from_millis(1000),
@@ -2347,6 +2418,7 @@ mod tests {
 
         let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
             Arc::clone(&table_store),
+            &native_wal_reader(&table_store),
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
@@ -2392,6 +2464,7 @@ mod tests {
 
         let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
             Arc::clone(&table_store),
+            &native_wal_reader(&table_store),
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
@@ -2447,6 +2520,7 @@ mod tests {
 
         let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
             Arc::clone(&table_store),
+            &native_wal_reader(&table_store),
             &reader_options,
             &core,
             &mut into_tables,
@@ -2483,6 +2557,7 @@ mod tests {
 
         let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
             Arc::clone(&table_store),
+            &native_wal_reader(&table_store),
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
@@ -2514,6 +2589,7 @@ mod tests {
 
         let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
             Arc::clone(&table_store),
+            &native_wal_reader(&table_store),
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
@@ -2560,6 +2636,7 @@ mod tests {
 
         let (last_wal_id, last_committed_seq) = DbReaderInner::replay_wal_into(
             Arc::clone(&table_store),
+            &native_wal_reader(&table_store),
             &DbReaderOptions::default(),
             &core,
             &mut into_tables,
@@ -2591,14 +2668,17 @@ mod tests {
 
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
-            "probe-wal-ssts",
+            "list-wal-ssts",
             "return",
         )
         .unwrap();
         tokio::time::sleep(Duration::from_millis(20)).await;
         let result = reader.get(b"key").await.unwrap_err();
         dbg!(&result);
-        assert_eq!(result.to_string(), "Unavailable error: io error (oops)");
+        assert_eq!(
+            result.to_string(),
+            "Unavailable error: wal unavailable (io error)"
+        );
     }
 
     #[tokio::test]
@@ -2714,14 +2794,14 @@ mod tests {
             .unwrap()
             .id;
 
-        // Inject a failpoint on WAL probing before flushing so it is active
+        // Inject a failpoint on WAL listing before flushing so it is active
         // when the poller fires. With the buggy replay_new_wals=true,
-        // reestablish_checkpoint calls last_seen_wal_id() which probes WAL SSTs
+        // reestablish_checkpoint resolves the last WAL file by listing WAL SSTs
         // and hits this failpoint. With the fix (replay_new_wals=false), the
-        // WAL probing is skipped entirely.
+        // WAL listing is skipped entirely.
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
-            "probe-wal-ssts",
+            "list-wal-ssts",
             "return",
         )
         .unwrap();
@@ -2987,6 +3067,7 @@ mod tests {
                 self.manifest_store(),
                 self.table_store(),
                 mode,
+                None,
                 merge_operator,
                 None,
                 options,
@@ -2996,6 +3077,10 @@ mod tests {
             )
             .await
         }
+    }
+
+    fn native_wal_reader(table_store: &Arc<TableStore>) -> crate::wal::reader::SlateDbWalReader {
+        crate::wal::reader::SlateDbWalReader::new(Arc::clone(table_store))
     }
 
     fn immutable_memtable(
@@ -3172,9 +3257,11 @@ mod tests {
             oracle.clone(),
             None,
         );
+        let wal_reader = Arc::new(native_wal_reader(&table_store));
         let inner = DbReaderInner {
             manifest_store,
             table_store,
+            wal_reader,
             options: DbReaderOptions {
                 skip_wal_replay: true,
                 ..DbReaderOptions::default()
@@ -3258,9 +3345,11 @@ mod tests {
             oracle.clone(),
             None,
         );
+        let wal_reader = Arc::new(native_wal_reader(&table_store));
         DbReaderInner {
             manifest_store,
             table_store,
+            wal_reader,
             options: DbReaderOptions::default(),
             mode: DbReaderMode::ManagedCheckpoint,
             state: parking_lot::RwLock::new(Arc::new(prior_state)),

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -658,7 +658,7 @@ impl DbReaderInner {
         let wal_id_end = match replay_end {
             WalReplayEnd::Manifest => core.next_wal_sst_id,
             WalReplayEnd::Latest => wal_reader
-                .last_wal_file_id()
+                .last_wal_file_id(replay_after_wal_id)
                 .await?
                 .checked_add(1)
                 .ok_or(SlateDBError::InvalidDBState)?,
@@ -1536,7 +1536,7 @@ mod tests {
             Ok(Box::new(EmptyTestWalIterator))
         }
 
-        async fn last_wal_file_id(&self) -> Result<u64, WalError> {
+        async fn last_wal_file_id(&self, _replay_after_wal_id: u64) -> Result<u64, WalError> {
             self.last_wal_file_id_calls.fetch_add(1, Ordering::Relaxed);
             Ok(10)
         }
@@ -2668,7 +2668,7 @@ mod tests {
 
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
-            "list-wal-ssts",
+            "probe-wal-ssts",
             "return",
         )
         .unwrap();
@@ -2794,14 +2794,14 @@ mod tests {
             .unwrap()
             .id;
 
-        // Inject a failpoint on WAL listing before flushing so it is active
+        // Inject a failpoint on WAL probing before flushing so it is active
         // when the poller fires. With the buggy replay_new_wals=true,
-        // reestablish_checkpoint resolves the last WAL file by listing WAL SSTs
+        // reestablish_checkpoint resolves the last WAL file by probing WAL SSTs
         // and hits this failpoint. With the fix (replay_new_wals=false), the
-        // WAL listing is skipped entirely.
+        // WAL probe is skipped entirely.
         fail_parallel::cfg(
             Arc::clone(&test_provider.fp_registry),
-            "list-wal-ssts",
+            "probe-wal-ssts",
             "return",
         )
         .unwrap();
@@ -2819,7 +2819,7 @@ mod tests {
 
         // Wait for the manifest poller to see the changed L0 state and
         // reestablish the checkpoint. Without the fix, the poller crashes
-        // on the WAL listing failpoint.
+        // on the WAL probing failpoint.
         let timeout = Duration::from_secs(5);
         let start = tokio::time::Instant::now();
         loop {

--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -20,6 +20,7 @@ pub(crate) struct WriterFencer {
     manifest_update_timeout: Duration,
     system_clock: Arc<dyn SystemClock>,
     task_executor: Arc<MessageHandlerExecutor>,
+    wal_writer_init: Option<Box<dyn WriterInit>>,
     #[cfg_attr(not(test), allow(dead_code))]
     fp_tx: FailPointTx,
 }
@@ -38,6 +39,7 @@ impl WriterFencer {
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
         task_executor: Arc<MessageHandlerExecutor>,
+        wal_writer_init: Option<Box<dyn WriterInit>>,
     ) -> Self {
         Self::new_with_fp_handle(
             closed_result_reader,
@@ -46,6 +48,7 @@ impl WriterFencer {
             settings,
             system_clock,
             task_executor,
+            wal_writer_init,
             FailPointTx::dummy(),
         )
     }
@@ -57,6 +60,7 @@ impl WriterFencer {
         settings: &Settings,
         system_clock: Arc<dyn SystemClock>,
         task_executor: Arc<MessageHandlerExecutor>,
+        wal_writer_init: Option<Box<dyn WriterInit>>,
         fp_tx: FailPointTx,
     ) -> Self {
         Self {
@@ -67,6 +71,7 @@ impl WriterFencer {
             manifest_update_timeout: settings.manifest_update_timeout,
             system_clock,
             task_executor,
+            wal_writer_init,
             fp_tx,
         }
     }
@@ -76,24 +81,28 @@ impl WriterFencer {
     }
 
     /// Fences all writers with an older epoch than the provided `stored_manifest` by (1) writing
-    /// a new `FenceableManifest` with a bumped epoch, and (2) writing an empty WAL file that acts
-    /// as a barrier. Any parallel old writers will fail with `SlateDBError::Fenced` when trying
-    /// to "re-write" this file. Returns a `WriterFence` with the `FenceableManifest` and iterator
-    /// that must be replayed to recover up to the current epoch.
+    /// a new `FenceableManifest` with a bumped epoch, and (2) delegating WAL fencing and recovery
+    /// to the configured [`WriterInit`]. Returns the fenced manifest, the initialized WAL writer,
+    /// and the iterator that must be replayed to recover up to the current epoch.
     pub(crate) async fn fence(
-        self,
+        mut self,
         stored_manifest: StoredManifest,
     ) -> Result<WriterFenceResult, SlateDBError> {
-        let wal_writer_init = WalWriterInit::load(
-            self.closed_result_reader.clone(),
-            self.recorder.clone(),
-            self.table_store.clone(),
-            self.wal_writer_init_options,
-            stored_manifest.manifest(),
-            self.task_executor.clone(),
-            self.fp_tx.clone(),
-        )
-        .await?;
+        let wal_writer_init = match self.wal_writer_init.take() {
+            Some(wal_writer_init) => wal_writer_init,
+            None => Box::new(
+                WalWriterInit::load(
+                    self.closed_result_reader.clone(),
+                    self.recorder.clone(),
+                    self.table_store.clone(),
+                    self.wal_writer_init_options,
+                    stored_manifest.manifest(),
+                    self.task_executor.clone(),
+                    self.fp_tx.clone(),
+                )
+                .await?,
+            ),
+        };
 
         let manifest = FenceableManifest::init_writer(
             stored_manifest,
@@ -205,6 +214,7 @@ mod tests {
                 &settings,
                 system_clock.clone(),
                 task_executor.clone(),
+                None,
                 fp_tx,
             );
             Self {
@@ -282,6 +292,7 @@ mod tests {
                 gc_opts,
                 &MetricsRecorderHelper::noop(),
                 Arc::new(DefaultSystemClock::new()),
+                None,
                 None,
             );
             gc.run_gc_once().await;

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -53,6 +53,7 @@ mod wal_gc;
 
 pub(crate) use filter::retain_allowed_by_gc_filter;
 pub use filter::GcFilter;
+use crate::wal::WalGC;
 
 pub(crate) const DEFAULT_MIN_AGE: Duration = Duration::from_secs(300);
 pub(crate) const DEFAULT_INTERVAL: Duration = Duration::from_secs(600);
@@ -235,8 +236,9 @@ impl GarbageCollector {
         recorder: &MetricsRecorderHelper,
         system_clock: Arc<dyn SystemClock>,
         gc_filter: Option<Arc<dyn GcFilter>>,
+        wal_gc: Option<Arc<dyn WalGC>>,
     ) -> Self {
-        let stats = Arc::new(GcStats::new(recorder));
+        let stats = Arc::new(GcStats::new(&recorder));
         // The standalone GC lifecycle does not surface a closed result yet, so the
         // task executor uses a throwaway sink.
         let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
@@ -245,30 +247,38 @@ impl GarbageCollector {
             system_clock.clone(),
         ));
         let wal_gc_task = options.wal_options.map(|wal_options| {
-            let wal_gc = Arc::new(SlateDbWalGc::new(
-                table_store.clone(),
-                stats.clone(),
-                wal_options,
-                WalGcMode::Regular,
-                gc_filter.clone(),
-                system_clock.clone(),
-            ));
+            let wal_gc = wal_gc.unwrap_or_else(||
+                Arc::new(SlateDbWalGc::new(
+                    table_store.clone(),
+                    stats.clone(),
+                    WalGcMode::Regular,
+                    gc_filter.clone(),
+                    system_clock.clone(),
+                ))
+            );
             WalGcTask::new(
                 manifest_store.clone(),
                 wal_gc,
                 WalGcMode::Regular.resource(),
+                wal_options.min_age,
+                wal_options.dry_run
             )
         });
         let wal_fence_gc_task = options.wal_fence_options.map(|wal_fence_options| {
             let wal_gc = Arc::new(SlateDbWalGc::new(
                 table_store.clone(),
                 stats.clone(),
-                wal_fence_options,
                 WalGcMode::Fence,
                 gc_filter.clone(),
                 system_clock.clone(),
             ));
-            WalGcTask::new(manifest_store.clone(), wal_gc, WalGcMode::Fence.resource())
+            WalGcTask::new(
+                manifest_store.clone(),
+                wal_gc,
+                WalGcMode::Fence.resource(),
+                wal_fence_options.min_age,
+                wal_fence_options.dry_run
+            )
         });
         let compacted_gc_task = options.compacted_options.map(|compacted_options| {
             CompactedGcTask::new(
@@ -1190,6 +1200,7 @@ mod tests {
             &MetricsRecorderHelper::noop(),
             Arc::new(DefaultSystemClock::default()),
             None,
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1260,6 +1271,7 @@ mod tests {
             &helper,
             Arc::new(DefaultSystemClock::default()),
             None,
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1324,6 +1336,7 @@ mod tests {
             gc_opts,
             &MetricsRecorderHelper::noop(),
             Arc::new(DefaultSystemClock::default()),
+            None,
             None,
         );
 
@@ -1404,6 +1417,7 @@ mod tests {
             gc_opts,
             &MetricsRecorderHelper::noop(),
             Arc::new(DefaultSystemClock::default()),
+            None,
             None,
         );
 
@@ -1869,6 +1883,7 @@ mod tests {
             recorder,
             Arc::new(DefaultSystemClock::default()),
             None,
+            None,
         );
 
         gc.run_gc_once().await;
@@ -1946,6 +1961,7 @@ mod tests {
             &recorder,
             Arc::new(DefaultSystemClock::default()),
             None,
+            None,
         );
 
         // Send a WAL GC message. Correct behavior: only WAL GC runs.
@@ -2018,6 +2034,7 @@ mod tests {
             &recorder,
             Arc::new(DefaultSystemClock::default()),
             None,
+            None,
         );
         gc.run_gc_once().await;
 
@@ -2068,6 +2085,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
             None,
         );
 
@@ -2123,6 +2141,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
             None,
         );
         gc.start().expect("failed to start garbage collector");
@@ -2457,6 +2476,7 @@ mod tests {
             Some(Arc::new(LocationGcFilter {
                 allowed_locations: HashSet::new(),
             })),
+            None,
         );
 
         // Run every directory GC task with candidates present for each task type.
@@ -2558,6 +2578,7 @@ mod tests {
             Some(Arc::new(LocationGcFilter {
                 allowed_locations: HashSet::from([path_resolver.sst_path(&allowed_wal_id)]),
             })),
+            None,
         );
 
         // Run WAL GC with a filter that permits only one of the eligible WALs.
@@ -2689,6 +2710,7 @@ mod tests {
             gc_opts,
             &recorder,
             Arc::new(DefaultSystemClock::default()),
+            None,
             None,
         );
 

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -51,7 +51,7 @@ mod manifest_gc;
 pub mod stats;
 mod wal_gc;
 
-use crate::wal::WalGC;
+use crate::wal::WalGc;
 pub(crate) use filter::retain_allowed_by_gc_filter;
 pub use filter::GcFilter;
 
@@ -236,7 +236,7 @@ impl GarbageCollector {
         recorder: &MetricsRecorderHelper,
         system_clock: Arc<dyn SystemClock>,
         gc_filter: Option<Arc<dyn GcFilter>>,
-        wal_gc: Option<Arc<dyn WalGC>>,
+        wal_gc: Option<Arc<dyn WalGc>>,
     ) -> Self {
         let stats = Arc::new(GcStats::new(recorder));
         // The standalone GC lifecycle does not surface a closed result yet, so the

--- a/slatedb/src/garbage_collector.rs
+++ b/slatedb/src/garbage_collector.rs
@@ -51,9 +51,9 @@ mod manifest_gc;
 pub mod stats;
 mod wal_gc;
 
+use crate::wal::WalGC;
 pub(crate) use filter::retain_allowed_by_gc_filter;
 pub use filter::GcFilter;
-use crate::wal::WalGC;
 
 pub(crate) const DEFAULT_MIN_AGE: Duration = Duration::from_secs(300);
 pub(crate) const DEFAULT_INTERVAL: Duration = Duration::from_secs(600);
@@ -238,7 +238,7 @@ impl GarbageCollector {
         gc_filter: Option<Arc<dyn GcFilter>>,
         wal_gc: Option<Arc<dyn WalGC>>,
     ) -> Self {
-        let stats = Arc::new(GcStats::new(&recorder));
+        let stats = Arc::new(GcStats::new(recorder));
         // The standalone GC lifecycle does not surface a closed result yet, so the
         // task executor uses a throwaway sink.
         let closed_result: Arc<dyn ClosedResultWriter> = Arc::new(WatchableOnceCell::new());
@@ -247,7 +247,7 @@ impl GarbageCollector {
             system_clock.clone(),
         ));
         let wal_gc_task = options.wal_options.map(|wal_options| {
-            let wal_gc = wal_gc.unwrap_or_else(||
+            let wal_gc = wal_gc.unwrap_or_else(|| {
                 Arc::new(SlateDbWalGc::new(
                     table_store.clone(),
                     stats.clone(),
@@ -255,13 +255,13 @@ impl GarbageCollector {
                     gc_filter.clone(),
                     system_clock.clone(),
                 ))
-            );
+            });
             WalGcTask::new(
                 manifest_store.clone(),
                 wal_gc,
                 WalGcMode::Regular.resource(),
                 wal_options.min_age,
-                wal_options.dry_run
+                wal_options.dry_run,
             )
         });
         let wal_fence_gc_task = options.wal_fence_options.map(|wal_fence_options| {
@@ -277,7 +277,7 @@ impl GarbageCollector {
                 wal_gc,
                 WalGcMode::Fence.resource(),
                 wal_fence_options.min_age,
-                wal_fence_options.dry_run
+                wal_fence_options.dry_run,
             )
         });
         let compacted_gc_task = options.compacted_options.map(|compacted_options| {

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::sync::Arc;
-
+use std::time::Duration;
 use super::GcTask;
 
 #[derive(Clone)]
@@ -16,6 +16,8 @@ pub(crate) struct WalGcTask {
     manifest_store: Arc<ManifestStore>,
     wal_gc: Arc<dyn WalGc>,
     resource: &'static str,
+    min_age: Duration,
+    dry_run: bool,
 }
 
 impl std::fmt::Debug for WalGcTask {
@@ -31,11 +33,15 @@ impl WalGcTask {
         manifest_store: Arc<ManifestStore>,
         wal_gc: Arc<dyn WalGc>,
         resource: &'static str,
+        min_age: Duration,
+        dry_run: bool,
     ) -> Self {
         Self {
             manifest_store,
             wal_gc,
             resource,
+            min_age,
+            dry_run,
         }
     }
 
@@ -77,7 +83,7 @@ impl GcTask for WalGcTask {
         let referenced_ranges = Self::referenced_wal_ranges(latest_manifest.id, &active_manifests);
 
         self.wal_gc
-            .collect(referenced_ranges)
+            .collect(referenced_ranges, self.min_age, self.dry_run)
             .await
             .map_err(Into::into)
     }
@@ -100,6 +106,7 @@ mod tests {
     use object_store::ObjectStore;
     use slatedb_common::clock::DefaultSystemClock;
     use std::sync::Mutex;
+    use std::time::Duration;
     use uuid::Uuid;
 
     #[derive(Default)]
@@ -115,7 +122,12 @@ mod tests {
 
     #[async_trait]
     impl WalGc for RecordingWalGc {
-        async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
+        async fn collect(
+            &self,
+            referenced_ranges: Vec<WalFileRange>,
+            _min_age: Duration,
+            _dry_run: bool,
+        ) -> Result<(), WalError> {
             self.calls.lock().unwrap().push(referenced_ranges);
             Ok(())
         }
@@ -178,7 +190,7 @@ mod tests {
         stored_manifest.update(dirty).await.unwrap();
 
         let wal_gc = Arc::new(RecordingWalGc::default());
-        let task = WalGcTask::new(manifest_store, wal_gc.clone(), "WAL");
+        let task = WalGcTask::new(manifest_store, wal_gc.clone(), "WAL", Duration::ZERO, false);
 
         task.collect(Utc::now()).await.unwrap();
 

--- a/slatedb/src/garbage_collector/wal_gc.rs
+++ b/slatedb/src/garbage_collector/wal_gc.rs
@@ -1,3 +1,4 @@
+use super::GcTask;
 use crate::manifest::Manifest;
 use crate::{
     error::SlateDBError,
@@ -9,7 +10,6 @@ use std::collections::BTreeMap;
 use std::ops::Bound;
 use std::sync::Arc;
 use std::time::Duration;
-use super::GcTask;
 
 #[derive(Clone)]
 pub(crate) struct WalGcTask {

--- a/slatedb/src/wal/admin.rs
+++ b/slatedb/src/wal/admin.rs
@@ -89,7 +89,7 @@ impl WalAdmin for SlateDbWalAdmin {
     async fn delete_wal(&self, path: &Path, dry_run: bool) -> Result<Vec<String>, WalError> {
         // Collect the paths first so listing is complete before objects are removed.
         let wal_path = PathResolver::from_root(path.clone()).wal_path();
-        let paths = self.paths_under(wal_path).await?;
+        let paths = self.paths_under(&wal_path).await?;
         if !dry_run {
             for object_path in &paths {
                 self.object_store

--- a/slatedb/src/wal/admin.rs
+++ b/slatedb/src/wal/admin.rs
@@ -1,5 +1,4 @@
 use crate::block_cache_policy::BlockCachePolicy;
-use crate::config::GarbageCollectorDirectoryOptions;
 use crate::db_state::SsTableId;
 use crate::format::sst::SsTableFormat;
 use crate::garbage_collector::stats::GcStats;
@@ -69,7 +68,7 @@ impl SlateDbWalAdmin {
 
 #[async_trait]
 impl WalAdmin for SlateDbWalAdmin {
-    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGc> {
+    fn garbage_collector(&self, path: &Path) -> Arc<dyn WalGc> {
         let table_store = Arc::new(TableStore::new(
             ObjectStores::new(self.object_store.clone(), None),
             SsTableFormat::default(),
@@ -78,26 +77,28 @@ impl WalAdmin for SlateDbWalAdmin {
             TableStoreKind::GC,
             BlockCachePolicy::default(),
         ));
-        Box::new(SlateDbWalGc::new(
+        Arc::new(SlateDbWalGc::new(
             table_store,
             Arc::new(GcStats::new(&MetricsRecorderHelper::noop())),
-            GarbageCollectorDirectoryOptions::default(),
             WalGcMode::Regular,
             None,
             Arc::new(DefaultSystemClock::new()),
         ))
     }
 
-    async fn delete_wal(&self, path: &Path) -> Result<(), WalError> {
+    async fn delete_wal(&self, path: &Path, dry_run: bool) -> Result<Vec<String>, WalError> {
         // Collect the paths first so listing is complete before objects are removed.
         let wal_path = PathResolver::from_root(path.clone()).wal_path();
-        for object_path in self.paths_under(&wal_path).await? {
-            self.object_store
-                .delete(&object_path)
-                .await
-                .map_err(|err| WalError::Unavailable(Arc::new(err)))?;
+        let paths = self.paths_under(wal_path).await?;
+        if !dry_run {
+            for object_path in &paths {
+                self.object_store
+                    .delete(object_path)
+                    .await
+                    .map_err(|err| WalError::Unavailable(Arc::new(err)))?;
+            }
         }
-        Ok(())
+        Ok(paths.iter().map(Path::to_string).collect())
     }
 
     async fn is_empty(
@@ -190,7 +191,7 @@ mod tests {
             .await
             .unwrap();
 
-        wal_admin.delete_wal(&db_path).await.unwrap();
+        wal_admin.delete_wal(&db_path, false).await.unwrap();
 
         assert!(matches!(
             object_store.head(&wal_object).await,

--- a/slatedb/src/wal/gc.rs
+++ b/slatedb/src/wal/gc.rs
@@ -292,13 +292,12 @@ mod tests {
             write_regular_wal(&table_store, wal_id).await;
         }
         make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
-        let collector = build_collector(
-            table_store.clone(),
-            clock,
-            WalGcMode::Regular,
-        );
+        let collector = build_collector(table_store.clone(), clock, WalGcMode::Regular);
 
-        collector.collect(protect_outer_wals(), Duration::ZERO, false).await.unwrap();
+        collector
+            .collect(protect_outer_wals(), Duration::ZERO, false)
+            .await
+            .unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![1, 4]);
     }
@@ -310,13 +309,12 @@ mod tests {
         write_regular_wal(&table_store, 1).await;
         write_fence_wal(&table_store, 2).await;
         make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
-        let collector = build_collector(
-            table_store.clone(),
-            clock,
-            WalGcMode::Regular,
-        );
+        let collector = build_collector(table_store.clone(), clock, WalGcMode::Regular);
 
-        collector.collect(vec![], Duration::ZERO, false).await.unwrap();
+        collector
+            .collect(vec![], Duration::ZERO, false)
+            .await
+            .unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![2]);
     }
@@ -332,11 +330,7 @@ mod tests {
             .unwrap()
             .last_modified;
         let min_age = Duration::from_secs(60 * 60);
-        let collector = build_collector(
-            table_store.clone(),
-            clock.clone(),
-            WalGcMode::Regular,
-        );
+        let collector = build_collector(table_store.clone(), clock.clone(), WalGcMode::Regular);
 
         clock.set((last_modified + chrono::Duration::minutes(30)).timestamp_millis());
         collector.collect(vec![], min_age, false).await.unwrap();
@@ -355,10 +349,12 @@ mod tests {
             write_fence_wal(&table_store, wal_id).await;
         }
         make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
-        let collector =
-            build_collector(table_store.clone(), clock, WalGcMode::Fence);
+        let collector = build_collector(table_store.clone(), clock, WalGcMode::Fence);
 
-        collector.collect(protect_outer_wals(), Duration::ZERO, false).await.unwrap();
+        collector
+            .collect(protect_outer_wals(), Duration::ZERO, false)
+            .await
+            .unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![1, 4]);
     }
@@ -370,10 +366,12 @@ mod tests {
         write_fence_wal(&table_store, 1).await;
         write_regular_wal(&table_store, 2).await;
         make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
-        let collector =
-            build_collector(table_store.clone(), clock, WalGcMode::Fence);
+        let collector = build_collector(table_store.clone(), clock, WalGcMode::Fence);
 
-        collector.collect(vec![], Duration::ZERO, false).await.unwrap();
+        collector
+            .collect(vec![], Duration::ZERO, false)
+            .await
+            .unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![2]);
     }
@@ -389,11 +387,7 @@ mod tests {
             .unwrap()
             .last_modified;
         let min_age = Duration::from_secs(60 * 60);
-        let collector = build_collector(
-            table_store.clone(),
-            clock.clone(),
-            WalGcMode::Fence,
-        );
+        let collector = build_collector(table_store.clone(), clock.clone(), WalGcMode::Fence);
 
         clock.set((last_modified + chrono::Duration::minutes(30)).timestamp_millis());
         collector.collect(vec![], min_age, false).await.unwrap();

--- a/slatedb/src/wal/gc.rs
+++ b/slatedb/src/wal/gc.rs
@@ -1,4 +1,3 @@
-use crate::config::GarbageCollectorDirectoryOptions;
 use crate::db_state::SsTableId;
 use crate::garbage_collector::stats::GcStats;
 use crate::garbage_collector::{retain_allowed_by_gc_filter, GcFilter, GC_DELETE_CONCURRENCY};
@@ -12,6 +11,7 @@ use slatedb_common::clock::SystemClock;
 use slatedb_common::object_metadata::IdentifiedObjectMetadata;
 use std::ops::Bound;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Selects which class of SlateDB WAL object is collected.
 ///
@@ -42,7 +42,6 @@ impl WalGcMode {
 pub(crate) struct SlateDbWalGc {
     table_store: Arc<TableStore>,
     stats: Arc<GcStats>,
-    wal_options: GarbageCollectorDirectoryOptions,
     mode: WalGcMode,
     gc_filter: Option<Arc<dyn GcFilter>>,
     system_clock: Arc<dyn SystemClock>,
@@ -51,7 +50,6 @@ pub(crate) struct SlateDbWalGc {
 impl std::fmt::Debug for SlateDbWalGc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SlateDbWalGc")
-            .field("wal_options", &self.wal_options)
             .field("mode", &self.mode)
             .finish()
     }
@@ -61,7 +59,6 @@ impl SlateDbWalGc {
     pub(crate) fn new(
         table_store: Arc<TableStore>,
         stats: Arc<GcStats>,
-        wal_options: GarbageCollectorDirectoryOptions,
         mode: WalGcMode,
         gc_filter: Option<Arc<dyn GcFilter>>,
         system_clock: Arc<dyn SystemClock>,
@@ -69,7 +66,6 @@ impl SlateDbWalGc {
         Self {
             table_store,
             stats,
-            wal_options,
             mode,
             gc_filter,
             system_clock,
@@ -106,15 +102,15 @@ impl SlateDbWalGc {
         after_start && before_end
     }
 
-    fn wal_sst_min_age(&self) -> chrono::Duration {
-        chrono::Duration::from_std(self.wal_options.min_age).expect("invalid duration")
+    fn wal_sst_min_age(&self, min_age: Duration) -> chrono::Duration {
+        chrono::Duration::from_std(min_age).expect("invalid duration")
     }
 
     /// Deletes the given WAL SSTs from the table store.
     ///
     /// In case of dryrun, the actual deletion doesn't happen.
-    async fn maybe_delete_wal_ssts(&self, sst_ids: Vec<SsTableId>) {
-        if self.wal_options.dry_run {
+    async fn maybe_delete_wal_ssts(&self, sst_ids: Vec<SsTableId>, dry_run: bool) {
+        if dry_run {
             if !sst_ids.is_empty() {
                 log::info!(
                     "dry run: skipping {} deletion [count={}]",
@@ -156,9 +152,14 @@ impl SlateDbWalGc {
 
 #[async_trait]
 impl WalGc for SlateDbWalGc {
-    async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError> {
+    async fn collect(
+        &self,
+        referenced_ranges: Vec<WalFileRange>,
+        min_age: Duration,
+        dry_run: bool,
+    ) -> Result<(), WalError> {
         let utc_now = self.system_clock.now();
-        let min_age = self.wal_sst_min_age();
+        let min_age = self.wal_sst_min_age(min_age);
         let ssts_to_delete = self
             .table_store
             .list_wal_ssts(..)
@@ -185,7 +186,7 @@ impl WalGc for SlateDbWalGc {
             .map(|wal_sst| wal_sst.id)
             .collect::<Vec<_>>();
 
-        self.maybe_delete_wal_ssts(sst_ids_to_delete).await;
+        self.maybe_delete_wal_ssts(sst_ids_to_delete, dry_run).await;
 
         Ok(())
     }
@@ -222,16 +223,10 @@ mod tests {
         table_store: Arc<TableStore>,
         clock: Arc<MockSystemClock>,
         mode: WalGcMode,
-        min_age: Duration,
     ) -> SlateDbWalGc {
         SlateDbWalGc::new(
             table_store,
             Arc::new(GcStats::new(&MetricsRecorderHelper::noop())),
-            GarbageCollectorDirectoryOptions {
-                interval: None,
-                min_age,
-                dry_run: false,
-            },
             mode,
             None,
             clock,
@@ -301,10 +296,9 @@ mod tests {
             table_store.clone(),
             clock,
             WalGcMode::Regular,
-            Duration::ZERO,
         );
 
-        collector.collect(protect_outer_wals()).await.unwrap();
+        collector.collect(protect_outer_wals(), Duration::ZERO, false).await.unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![1, 4]);
     }
@@ -320,10 +314,9 @@ mod tests {
             table_store.clone(),
             clock,
             WalGcMode::Regular,
-            Duration::ZERO,
         );
 
-        collector.collect(vec![]).await.unwrap();
+        collector.collect(vec![], Duration::ZERO, false).await.unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![2]);
     }
@@ -343,15 +336,14 @@ mod tests {
             table_store.clone(),
             clock.clone(),
             WalGcMode::Regular,
-            min_age,
         );
 
         clock.set((last_modified + chrono::Duration::minutes(30)).timestamp_millis());
-        collector.collect(vec![]).await.unwrap();
+        collector.collect(vec![], min_age, false).await.unwrap();
         assert_eq!(wal_ids(&table_store).await, vec![1]);
 
         clock.set((last_modified + chrono::Duration::minutes(61)).timestamp_millis());
-        collector.collect(vec![]).await.unwrap();
+        collector.collect(vec![], min_age, false).await.unwrap();
         assert!(wal_ids(&table_store).await.is_empty());
     }
 
@@ -364,9 +356,9 @@ mod tests {
         }
         make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
         let collector =
-            build_collector(table_store.clone(), clock, WalGcMode::Fence, Duration::ZERO);
+            build_collector(table_store.clone(), clock, WalGcMode::Fence);
 
-        collector.collect(protect_outer_wals()).await.unwrap();
+        collector.collect(protect_outer_wals(), Duration::ZERO, false).await.unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![1, 4]);
     }
@@ -379,9 +371,9 @@ mod tests {
         write_regular_wal(&table_store, 2).await;
         make_all_wals_older_than(&table_store, &clock, Duration::ZERO).await;
         let collector =
-            build_collector(table_store.clone(), clock, WalGcMode::Fence, Duration::ZERO);
+            build_collector(table_store.clone(), clock, WalGcMode::Fence);
 
-        collector.collect(vec![]).await.unwrap();
+        collector.collect(vec![], Duration::ZERO, false).await.unwrap();
 
         assert_eq!(wal_ids(&table_store).await, vec![2]);
     }
@@ -401,15 +393,14 @@ mod tests {
             table_store.clone(),
             clock.clone(),
             WalGcMode::Fence,
-            min_age,
         );
 
         clock.set((last_modified + chrono::Duration::minutes(30)).timestamp_millis());
-        collector.collect(vec![]).await.unwrap();
+        collector.collect(vec![], min_age, false).await.unwrap();
         assert_eq!(wal_ids(&table_store).await, vec![1]);
 
         clock.set((last_modified + chrono::Duration::minutes(61)).timestamp_millis());
-        collector.collect(vec![]).await.unwrap();
+        collector.collect(vec![], min_age, false).await.unwrap();
         assert!(wal_ids(&table_store).await.is_empty());
     }
 }

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -8,9 +8,11 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::ops::{Bound, Range};
 use std::sync::Arc;
+use std::time::Duration;
 
 pub(crate) mod admin;
 pub(crate) mod gc;
+pub(crate) mod reader;
 #[cfg(test)]
 pub(crate) mod test_utils;
 pub(crate) mod wal_disabled;
@@ -146,7 +148,7 @@ pub struct WriterInitResult {
 ///     rows in WAL files between [`WriterManifest::replay_after_wal_id`] (exclusive) and the
 ///     current end of the WAL.
 #[async_trait]
-pub trait WriterInit {
+pub trait WriterInit: Send + Sync + 'static {
     /// Fences the WAL and returns a [`WriterInitResult`] with a [`WalWriter`] and
     /// [`WalReplayIterator`] used to recover writes that have not yet been flushed to the tree.
     async fn fence_and_init(
@@ -271,7 +273,7 @@ pub trait WalIterator: Send + 'static {
 
 /// API for reading from the WAL. Used by the Reader/
 #[async_trait]
-pub trait WalReader {
+pub trait WalReader: Send + Sync + 'static {
     /// Returns an iterator over the specified range of WAL File IDs. The start of the range must
     /// not be `Unbounded`. If the end of the range is `Unbounded` then the returned iterator
     /// continues returning writes as new writes are appended to the WAL. Otherwise, it returns
@@ -280,6 +282,10 @@ pub trait WalReader {
         &self,
         wal_file_id_range: WalFileRange,
     ) -> Result<Box<dyn WalIterator>, WalError>;
+
+    /// Returns the ID of the last WAL file currently present in the WAL, or `0` if the WAL is
+    /// empty.
+    async fn last_wal_file_id(&self) -> Result<u64, WalError>;
 }
 
 /// Trait that defines the contract between SlateDB's garbage collector and a custom WAL
@@ -291,7 +297,12 @@ pub trait WalGc: Send + Sync + 'static {
     /// Hook for garbage collecting the WAL. Takes a list of ranges of WAL Files that are currently
     /// referenced by some active Manifest. The implementation may delete any WAL File that is not
     /// included in the ranges in this list.
-    async fn collect(&self, referenced_ranges: Vec<WalFileRange>) -> Result<(), WalError>;
+    async fn collect(
+        &self,
+        referenced_ranges: Vec<WalFileRange>,
+        min_age: Duration,
+        dry_run: bool,
+    ) -> Result<(), WalError>;
 }
 
 /// Administrative operations for a WAL implementation.
@@ -304,16 +315,20 @@ pub trait WalAdmin: Send + Sync + 'static {
     ///
     /// ## Returns
     /// A garbage collector that can remove unreferenced WAL files at `path`.
-    fn garbage_collector(&self, path: &Path) -> Box<dyn WalGc>;
+    fn garbage_collector(&self, path: &Path) -> Arc<dyn WalGc>;
 
     /// Deletes the WAL at `path`.
     ///
     /// ## Arguments
     /// - `path`: The database path whose WAL should be deleted.
+    /// - `dry_run`: If set to true, the implementation should just return the list of resources
+    ///              that would be deleted without actually deleting anything.
     ///
     /// ## Returns
-    /// `Ok(())` after the WAL has been deleted, or a [`WalError`] if deletion fails.
-    async fn delete_wal(&self, path: &Path) -> Result<(), WalError>;
+    /// `Ok(resources)` after the WAL has been deleted, or a [`WalError`] if deletion fails, where
+    /// `resources` is a list of descriptions of resources that were deleted by this fn. This
+    /// list is used to display the output of deleting the WAL (e.g. in logs or tool output)
+    async fn delete_wal(&self, path: &Path, dry_run: bool) -> Result<Vec<String>, WalError>;
 
     /// Given a path and WAL ID range, returns true if the WAL at that path is empty within the
     /// specified range. A WAL is empty if it holds no records.

--- a/slatedb/src/wal/mod.rs
+++ b/slatedb/src/wal/mod.rs
@@ -283,9 +283,10 @@ pub trait WalReader: Send + Sync + 'static {
         wal_file_id_range: WalFileRange,
     ) -> Result<Box<dyn WalIterator>, WalError>;
 
-    /// Returns the ID of the last WAL file currently present in the WAL, or `0` if the WAL is
-    /// empty.
-    async fn last_wal_file_id(&self) -> Result<u64, WalError>;
+    /// Returns the ID of the last WAL file currently present after `replay_after_wal_id`, or
+    /// `replay_after_wal_id` if no later WAL file is present. Implementations may use
+    /// `replay_after_wal_id` as a known lower bound when locating the end of the WAL.
+    async fn last_wal_file_id(&self, replay_after_wal_id: u64) -> Result<u64, WalError>;
 }
 
 /// Trait that defines the contract between SlateDB's garbage collector and a custom WAL

--- a/slatedb/src/wal/reader.rs
+++ b/slatedb/src/wal/reader.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::iter::IterationOrder;
+use crate::sst_iter::SstIteratorOptions;
+use crate::tablestore::TableStore;
+use crate::wal::{WalError, WalFileRange, WalIterator, WalReader};
+use crate::wal_replay::{WalIterator as WalReplayIterator, WalIteratorOptions};
+
+pub(crate) struct SlateDbWalReader {
+    table_store: Arc<TableStore>,
+}
+
+impl SlateDbWalReader {
+    pub(crate) fn new(table_store: Arc<TableStore>) -> Self {
+        Self { table_store }
+    }
+}
+
+#[async_trait]
+impl WalReader for SlateDbWalReader {
+    async fn iterator(
+        &self,
+        wal_file_id_range: WalFileRange,
+    ) -> Result<Box<dyn WalIterator>, WalError> {
+        let wal_id_range = wal_file_id_range.try_into().map_err(|()| {
+            WalError::InternalError(Arc::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "native WAL reader requires an included start and excluded end",
+            )))
+        })?;
+        let iterator = WalReplayIterator::range(
+            wal_id_range,
+            WalIteratorOptions {
+                sst_batch_size: 4,
+                sst_iter_options: SstIteratorOptions {
+                    max_fetch_tasks: 1,
+                    blocks_to_fetch: 256,
+                    cache_blocks: true,
+                    cache_metadata: false,
+                    eager_spawn: true,
+                    order: IterationOrder::Ascending,
+                    prefix: None,
+                    filter_context: None,
+                },
+            },
+            Arc::clone(&self.table_store),
+        )?;
+        Ok(Box::new(iterator))
+    }
+
+    async fn last_wal_file_id(&self) -> Result<u64, WalError> {
+        Ok(self
+            .table_store
+            .list_wal_ssts(..)
+            .await?
+            .last()
+            .map(|wal| wal.id.unwrap_wal_id())
+            .unwrap_or(0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::block_cache_policy::BlockCachePolicy;
+    use crate::config::{FlushOptions, FlushType};
+    use crate::format::sst::SsTableFormat;
+    use crate::object_stores::ObjectStores;
+    use crate::tablestore::TableStoreKind;
+    use crate::types::ValueDeletable;
+    use crate::Db;
+    use object_store::memory::InMemory;
+    use object_store::{path::Path, ObjectStore};
+
+    #[tokio::test]
+    async fn test_native_wal_reader_trait() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("/test_native_wal_reader_trait");
+        let db = Db::open(path.clone(), Arc::clone(&object_store))
+            .await
+            .unwrap();
+        db.put(b"key", b"value").await.unwrap();
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::Wal,
+        })
+        .await
+        .unwrap();
+
+        let table_store = Arc::new(TableStore::new(
+            ObjectStores::new(object_store, None),
+            SsTableFormat::default(),
+            path,
+            None,
+            TableStoreKind::Reader,
+            BlockCachePolicy::default(),
+        ));
+        let wal_reader = SlateDbWalReader::new(table_store);
+        let last_wal_id = wal_reader.last_wal_file_id().await.unwrap();
+        let mut iterator = wal_reader
+            .iterator((1..last_wal_id + 1).into())
+            .await
+            .unwrap();
+
+        let mut rows = Vec::new();
+        while let Some(wal_rows) = iterator.next().await.unwrap() {
+            rows.extend(wal_rows.rows);
+        }
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].key.as_ref(), b"key");
+        assert!(matches!(
+            &rows[0].value,
+            ValueDeletable::Value(value) if value.as_ref() == b"value"
+        ));
+    }
+}

--- a/slatedb/src/wal/reader.rs
+++ b/slatedb/src/wal/reader.rs
@@ -50,14 +50,11 @@ impl WalReader for SlateDbWalReader {
         Ok(Box::new(iterator))
     }
 
-    async fn last_wal_file_id(&self) -> Result<u64, WalError> {
+    async fn last_wal_file_id(&self, replay_after_wal_id: u64) -> Result<u64, WalError> {
         Ok(self
             .table_store
-            .list_wal_ssts(..)
-            .await?
-            .last()
-            .map(|wal| wal.id.unwrap_wal_id())
-            .unwrap_or(0))
+            .last_seen_wal_id(replay_after_wal_id)
+            .await?)
     }
 }
 
@@ -97,7 +94,7 @@ mod tests {
             BlockCachePolicy::default(),
         ));
         let wal_reader = SlateDbWalReader::new(table_store);
-        let last_wal_id = wal_reader.last_wal_file_id().await.unwrap();
+        let last_wal_id = wal_reader.last_wal_file_id(0).await.unwrap();
         let mut iterator = wal_reader
             .iterator((1..last_wal_id + 1).into())
             .await

--- a/slatedb/src/wal_replay.rs
+++ b/slatedb/src/wal_replay.rs
@@ -77,6 +77,7 @@ pub(crate) struct WalReplayIterator {
 }
 
 impl WalReplayIterator {
+    #[cfg(test)]
     pub(crate) fn range(
         wal_id_range: Range<u64>,
         db_state: &ManifestCore,

--- a/slatedb/tests/custom_wal.rs
+++ b/slatedb/tests/custom_wal.rs
@@ -1,0 +1,522 @@
+use std::collections::{BTreeMap, VecDeque};
+use std::ops::Bound;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use slatedb::admin::{Admin, CloneSourceSpec};
+use slatedb::config::{
+    CloseOptions, DbReaderOptions, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
+    GarbageCollectorOptions, Settings,
+};
+use slatedb::object_store::memory::InMemory;
+use slatedb::object_store::path::Path;
+use slatedb::object_store::ObjectStore;
+use slatedb::wal::{
+    FlushResultFuture, WalAdmin, WalError, WalEvent, WalFileRange, WalGC, WalIterator, WalObserver,
+    WalReader, WalRows, WalStatus, WalStatusListener, WalWriter, WriterInit, WriterInitResult,
+    WriterManifest,
+};
+use slatedb::{Db, DbReader, DbReaderMode, GarbageCollectorBuilder, RowEntry, VersionedManifest};
+
+/// A deliberately small WAL implementation used to exercise the public pluggable-WAL API.
+/// Every call to `WalWriter::append` inserts one write batch under a new WAL file ID.
+#[derive(Clone, Default)]
+struct BTreeMapWal {
+    files: Arc<Mutex<BTreeMap<u64, Vec<RowEntry>>>>,
+}
+
+impl BTreeMapWal {
+    fn file_ids(&self) -> Vec<u64> {
+        self.files.lock().keys().copied().collect()
+    }
+
+    fn snapshot(&self) -> BTreeMap<u64, Vec<RowEntry>> {
+        self.files.lock().clone()
+    }
+
+    fn open_status(&self) -> WalStatus {
+        let files = self.files.lock();
+        let last_flushed_wal_id = files.last_key_value().map(|(id, _)| *id).unwrap_or(0);
+        let last_flushed_seq = files
+            .last_key_value()
+            .and_then(|(_, batch)| batch.iter().map(|row| row.seq).max());
+        WalStatus {
+            closed_reason: None,
+            estimated_bytes: 0,
+            last_flushed_wal_id,
+            last_flushed_seq,
+            buffered_wal_entries_count: 0,
+        }
+    }
+}
+
+struct BTreeMapWalIterator {
+    batches: VecDeque<(u64, Vec<RowEntry>)>,
+}
+
+#[async_trait]
+impl WalIterator for BTreeMapWalIterator {
+    async fn next(&mut self) -> Result<Option<WalRows>, WalError> {
+        Ok(self.batches.pop_front().map(|(wal_file_id, rows)| WalRows {
+            rows,
+            last_consumed_wal_file_id: wal_file_id,
+        }))
+    }
+}
+
+#[async_trait]
+impl WalReader for BTreeMapWal {
+    async fn iterator(
+        &self,
+        wal_file_id_range: WalFileRange,
+    ) -> Result<Box<dyn WalIterator>, WalError> {
+        let WalFileRange(start, end) = wal_file_id_range;
+        let batches = self
+            .files
+            .lock()
+            .range((start, end))
+            .map(|(id, batch)| (*id, batch.clone()))
+            .collect();
+        Ok(Box::new(BTreeMapWalIterator { batches }))
+    }
+
+    async fn last_wal_file_id(&self) -> Result<u64, WalError> {
+        Ok(self
+            .files
+            .lock()
+            .last_key_value()
+            .map(|(id, _)| *id)
+            .unwrap_or(0))
+    }
+}
+
+struct ObserverState {
+    status: WalStatus,
+    listeners: Vec<WalStatusListener>,
+}
+
+#[derive(Clone)]
+struct BTreeMapWalObserver {
+    state: Arc<Mutex<ObserverState>>,
+}
+
+impl BTreeMapWalObserver {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        let status = self.state.lock().status.clone();
+        if status.closed_reason.is_some() {
+            Err(status)
+        } else {
+            Ok(status)
+        }
+    }
+}
+
+impl WalObserver for BTreeMapWalObserver {
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        self.status()
+    }
+
+    fn subscribe(&self, listener: WalStatusListener) -> Result<(), WalError> {
+        self.state.lock().listeners.push(listener);
+        Ok(())
+    }
+}
+
+struct BTreeMapWalWriter {
+    wal: BTreeMapWal,
+    observer: BTreeMapWalObserver,
+}
+
+impl BTreeMapWalWriter {
+    fn new(wal: BTreeMapWal) -> Self {
+        let observer = BTreeMapWalObserver {
+            state: Arc::new(Mutex::new(ObserverState {
+                status: wal.open_status(),
+                listeners: Vec::new(),
+            })),
+        };
+        Self { wal, observer }
+    }
+
+    fn publish(&self, event: WalEvent) {
+        let listeners = self.observer.state.lock().listeners.clone();
+        for listener in listeners {
+            listener(event.clone());
+        }
+    }
+}
+
+#[async_trait]
+impl WalWriter for BTreeMapWalWriter {
+    async fn append(&mut self, write_batch: &[RowEntry]) -> Result<(), WalError> {
+        if self.observer.state.lock().status.closed_reason.is_some() {
+            return Err(WalError::Closed);
+        }
+
+        let wal_file_id = {
+            let mut files = self.wal.files.lock();
+            let wal_file_id = match files.last_key_value() {
+                Some((last_id, _)) => last_id.checked_add(1).ok_or_else(|| {
+                    WalError::InternalError(Arc::new(std::io::Error::other("WAL file ID overflow")))
+                })?,
+                None => 1,
+            };
+            files.insert(wal_file_id, write_batch.to_vec());
+            wal_file_id
+        };
+
+        let status = {
+            let mut state = self.observer.state.lock();
+            state.status.last_flushed_wal_id = wal_file_id;
+            state.status.last_flushed_seq = write_batch.iter().map(|row| row.seq).max();
+            state.status.clone()
+        };
+        self.publish(WalEvent::WalFlushed(status));
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<FlushResultFuture, WalError> {
+        Ok(Box::pin(async { Ok(()) }))
+    }
+
+    fn observer(&self) -> Box<dyn WalObserver> {
+        Box::new(self.observer.clone())
+    }
+
+    fn status(&self) -> Result<WalStatus, WalStatus> {
+        self.observer.status()
+    }
+
+    async fn close(&mut self) -> Result<(), WalError> {
+        let status = {
+            let mut state = self.observer.state.lock();
+            if state.status.closed_reason.is_some() {
+                return Ok(());
+            }
+            state.status.closed_reason = Some(WalError::Closed);
+            state.status.clone()
+        };
+        self.publish(WalEvent::WalClosed(status));
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl WriterInit for BTreeMapWal {
+    async fn fence_and_init(
+        &self,
+        manifest: &mut WriterManifest,
+    ) -> Result<WriterInitResult, WalError> {
+        let start = manifest
+            .replay_after_wal_id()
+            .checked_add(1)
+            .ok_or_else(|| {
+                WalError::InternalError(Arc::new(std::io::Error::other(
+                    "WAL replay range overflow",
+                )))
+            })?;
+        let end = self
+            .last_wal_file_id()
+            .await?
+            .checked_add(1)
+            .ok_or_else(|| {
+                WalError::InternalError(Arc::new(std::io::Error::other(
+                    "WAL replay range overflow",
+                )))
+            })?;
+        let replay_iterator = self.iterator((start..end.max(start)).into()).await?;
+
+        Ok(WriterInitResult {
+            replay_iterator,
+            wal_writer: Box::new(BTreeMapWalWriter::new(self.clone())),
+        })
+    }
+}
+
+fn range_contains(range: &WalFileRange, wal_file_id: u64) -> bool {
+    let starts_before = match range.0 {
+        Bound::Included(start) => wal_file_id >= start,
+        Bound::Excluded(start) => wal_file_id > start,
+        Bound::Unbounded => true,
+    };
+    let ends_after = match range.1 {
+        Bound::Included(end) => wal_file_id <= end,
+        Bound::Excluded(end) => wal_file_id < end,
+        Bound::Unbounded => true,
+    };
+    starts_before && ends_after
+}
+
+#[async_trait]
+impl WalGC for BTreeMapWal {
+    async fn collect(
+        &self,
+        referenced_ranges: Vec<WalFileRange>,
+        _min_age: Duration,
+        dry_run: bool,
+    ) -> Result<(), WalError> {
+        if !dry_run {
+            self.files.lock().retain(|wal_file_id, _| {
+                referenced_ranges
+                    .iter()
+                    .any(|range| range_contains(range, *wal_file_id))
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Supplies a separate `BTreeMapWal` for each database path so clone administration can copy
+/// the source WAL into the clone's WAL namespace.
+#[derive(Clone, Default)]
+struct BTreeMapWalAdmin {
+    wals: Arc<Mutex<BTreeMap<String, BTreeMapWal>>>,
+}
+
+impl BTreeMapWalAdmin {
+    fn wal(&self, path: &Path) -> BTreeMapWal {
+        self.wals
+            .lock()
+            .entry(path.to_string())
+            .or_default()
+            .clone()
+    }
+}
+
+#[async_trait]
+impl WalAdmin for BTreeMapWalAdmin {
+    fn garbage_collector(&self, path: &Path) -> Arc<dyn WalGC> {
+        Arc::new(self.wal(path))
+    }
+
+    async fn delete_wal(&self, path: &Path, dry_run: bool) -> Result<Vec<String>, WalError> {
+        let key = path.to_string();
+        let exists = self.wals.lock().contains_key(&key);
+        if exists && !dry_run {
+            self.wals.lock().remove(&key);
+        }
+        Ok(exists
+            .then(|| format!("btree-map-wal:{key}"))
+            .into_iter()
+            .collect())
+    }
+
+    async fn is_empty(&self, path: &Path, _manifest: VersionedManifest) -> Result<bool, WalError> {
+        Ok(self.wal(path).files.lock().values().all(Vec::is_empty))
+    }
+
+    async fn clone_wal(
+        &self,
+        from_path: &Path,
+        from_manifest: VersionedManifest,
+        to_path: &Path,
+    ) -> Result<(u64, u64), WalError> {
+        let replay_after_wal_id = from_manifest.replay_after_wal_id();
+        let copied = self
+            .wal(from_path)
+            .files
+            .lock()
+            .range((Bound::Excluded(replay_after_wal_id), Bound::Unbounded))
+            .map(|(id, batch)| (*id, batch.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let last_wal_file_id = copied
+            .last_key_value()
+            .map(|(id, _)| *id)
+            .unwrap_or(replay_after_wal_id);
+        *self.wal(to_path).files.lock() = copied;
+        Ok((replay_after_wal_id, last_wal_file_id))
+    }
+}
+
+fn test_settings() -> Settings {
+    Settings {
+        flush_interval: None,
+        compactor_options: None,
+        garbage_collector_options: None,
+        ..Settings::default()
+    }
+}
+
+async fn open_db(path: Path, object_store: Arc<dyn ObjectStore>, wal: BTreeMapWal) -> Db {
+    Db::builder(path, object_store)
+        .with_settings(test_settings())
+        .with_wal_writer(Box::new(wal))
+        .build()
+        .await
+        .expect("failed to open database with custom WAL")
+}
+
+async fn close_without_memtable_flush(db: &Db) {
+    db.close_with_options(CloseOptions::default().with_flush_type(None))
+        .await
+        .expect("failed to close database")
+}
+
+#[tokio::test]
+async fn custom_wal_basic_write_and_recovery() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = Path::from("/custom-wal/basic-recovery");
+    let wal = BTreeMapWal::default();
+
+    let db = open_db(path.clone(), Arc::clone(&object_store), wal.clone()).await;
+    db.put(b"key-1", b"value-1").await.expect("put failed");
+    db.put(b"key-2", b"value-2").await.expect("put failed");
+
+    assert_eq!(wal.file_ids(), vec![1, 2]);
+    assert!(wal.snapshot().values().all(|batch| batch.len() == 1));
+    close_without_memtable_flush(&db).await;
+
+    let recovered = open_db(path, object_store, wal).await;
+    assert_eq!(
+        recovered
+            .get(b"key-1")
+            .await
+            .expect("get failed")
+            .as_deref(),
+        Some(b"value-1".as_slice())
+    );
+    assert_eq!(
+        recovered
+            .get(b"key-2")
+            .await
+            .expect("get failed")
+            .as_deref(),
+        Some(b"value-2".as_slice())
+    );
+    close_without_memtable_flush(&recovered).await;
+}
+
+#[tokio::test]
+async fn custom_wal_db_reader_serves_wal_data() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = Path::from("/custom-wal/db-reader");
+    let wal = BTreeMapWal::default();
+    let db = open_db(path.clone(), Arc::clone(&object_store), wal.clone()).await;
+    db.put(b"reader-key", b"reader-value")
+        .await
+        .expect("put failed");
+
+    let reader = DbReader::builder(path, object_store)
+        .with_reader_mode(DbReaderMode::FollowLatest)
+        .with_options(DbReaderOptions {
+            manifest_poll_interval: Duration::from_secs(60),
+            ..DbReaderOptions::default()
+        })
+        .with_wal_reader(Arc::new(wal))
+        .build()
+        .await
+        .expect("failed to open database reader");
+    assert_eq!(
+        reader
+            .get(b"reader-key")
+            .await
+            .expect("reader get failed")
+            .as_deref(),
+        Some(b"reader-value".as_slice())
+    );
+
+    reader.close().await.expect("failed to close reader");
+    close_without_memtable_flush(&db).await;
+}
+
+#[tokio::test]
+async fn custom_wal_garbage_collects_unused_ranges() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = Path::from("/custom-wal/gc");
+    let wal = BTreeMapWal::default();
+    let db = open_db(path.clone(), Arc::clone(&object_store), wal.clone()).await;
+
+    for id in 1..=3 {
+        db.put(
+            format!("key-{id}").as_bytes(),
+            format!("value-{id}").as_bytes(),
+        )
+        .await
+        .expect("put failed");
+    }
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .expect("memtable flush failed");
+    db.put(b"key-4", b"value-4").await.expect("put failed");
+    close_without_memtable_flush(&db).await;
+    assert_eq!(wal.file_ids(), vec![1, 2, 3, 4]);
+
+    let gc = GarbageCollectorBuilder::new(path, object_store)
+        .with_wal_gc(Arc::new(wal.clone()))
+        .with_options(GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: Some(GarbageCollectorDirectoryOptions {
+                interval: None,
+                min_age: Duration::ZERO,
+                dry_run: false,
+            }),
+            wal_fence_options: None,
+            compacted_options: None,
+            compactions_options: None,
+            detach_options: None,
+            ..GarbageCollectorOptions::default()
+        })
+        .build();
+    gc.run_gc_once().await;
+
+    // The latest manifest references the replay boundary (3) and everything after it.
+    assert_eq!(wal.file_ids(), vec![3, 4]);
+}
+
+#[tokio::test]
+async fn custom_wal_clone_has_the_same_data() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let source_path = Path::from("/custom-wal/clone-source");
+    let clone_path = Path::from("/custom-wal/clone-destination");
+    let wal_admin = BTreeMapWalAdmin::default();
+    let source_wal = wal_admin.wal(&source_path);
+
+    let source_db = open_db(
+        source_path.clone(),
+        Arc::clone(&object_store),
+        source_wal.clone(),
+    )
+    .await;
+    source_db
+        .put(b"clone-key-1", b"clone-value-1")
+        .await
+        .expect("put failed");
+    source_db
+        .put(b"clone-key-2", b"clone-value-2")
+        .await
+        .expect("put failed");
+    close_without_memtable_flush(&source_db).await;
+
+    Admin::builder(clone_path.clone(), Arc::clone(&object_store))
+        .with_wal_admin(Arc::new(wal_admin.clone()))
+        .build()
+        .create_clone_builder_from_source(CloneSourceSpec::new(source_path))
+        .build()
+        .await
+        .expect("failed to create clone");
+
+    let clone_wal = wal_admin.wal(&clone_path);
+    assert_eq!(clone_wal.snapshot(), source_wal.snapshot());
+    let clone_db = open_db(clone_path, object_store, clone_wal).await;
+    assert_eq!(
+        clone_db
+            .get(b"clone-key-1")
+            .await
+            .expect("get failed")
+            .as_deref(),
+        Some(b"clone-value-1".as_slice())
+    );
+    assert_eq!(
+        clone_db
+            .get(b"clone-key-2")
+            .await
+            .expect("get failed")
+            .as_deref(),
+        Some(b"clone-value-2".as_slice())
+    );
+    close_without_memtable_flush(&clone_db).await;
+}

--- a/slatedb/tests/custom_wal.rs
+++ b/slatedb/tests/custom_wal.rs
@@ -82,13 +82,14 @@ impl WalReader for BTreeMapWal {
         Ok(Box::new(BTreeMapWalIterator { batches }))
     }
 
-    async fn last_wal_file_id(&self) -> Result<u64, WalError> {
+    async fn last_wal_file_id(&self, replay_after_wal_id: u64) -> Result<u64, WalError> {
         Ok(self
             .files
             .lock()
-            .last_key_value()
+            .range((Bound::Excluded(replay_after_wal_id), Bound::Unbounded))
+            .next_back()
             .map(|(id, _)| *id)
-            .unwrap_or(0))
+            .unwrap_or(replay_after_wal_id))
     }
 }
 
@@ -209,16 +210,12 @@ impl WriterInit for BTreeMapWal {
         &self,
         manifest: &mut WriterManifest,
     ) -> Result<WriterInitResult, WalError> {
-        let start = manifest
-            .replay_after_wal_id()
-            .checked_add(1)
-            .ok_or_else(|| {
-                WalError::InternalError(Arc::new(std::io::Error::other(
-                    "WAL replay range overflow",
-                )))
-            })?;
+        let replay_after_wal_id = manifest.replay_after_wal_id();
+        let start = replay_after_wal_id.checked_add(1).ok_or_else(|| {
+            WalError::InternalError(Arc::new(std::io::Error::other("WAL replay range overflow")))
+        })?;
         let end = self
-            .last_wal_file_id()
+            .last_wal_file_id(replay_after_wal_id)
             .await?
             .checked_add(1)
             .ok_or_else(|| {

--- a/slatedb/tests/custom_wal.rs
+++ b/slatedb/tests/custom_wal.rs
@@ -14,7 +14,7 @@ use slatedb::object_store::memory::InMemory;
 use slatedb::object_store::path::Path;
 use slatedb::object_store::ObjectStore;
 use slatedb::wal::{
-    FlushResultFuture, WalAdmin, WalError, WalEvent, WalFileRange, WalGC, WalIterator, WalObserver,
+    FlushResultFuture, WalAdmin, WalError, WalEvent, WalFileRange, WalGc, WalIterator, WalObserver,
     WalReader, WalRows, WalStatus, WalStatusListener, WalWriter, WriterInit, WriterInitResult,
     WriterManifest,
 };
@@ -250,7 +250,7 @@ fn range_contains(range: &WalFileRange, wal_file_id: u64) -> bool {
 }
 
 #[async_trait]
-impl WalGC for BTreeMapWal {
+impl WalGc for BTreeMapWal {
     async fn collect(
         &self,
         referenced_ranges: Vec<WalFileRange>,
@@ -287,7 +287,7 @@ impl BTreeMapWalAdmin {
 
 #[async_trait]
 impl WalAdmin for BTreeMapWalAdmin {
-    fn garbage_collector(&self, path: &Path) -> Arc<dyn WalGC> {
+    fn garbage_collector(&self, path: &Path) -> Arc<dyn WalGc> {
         Arc::new(self.wal(path))
     }
 
@@ -303,7 +303,12 @@ impl WalAdmin for BTreeMapWalAdmin {
             .collect())
     }
 
-    async fn is_empty(&self, path: &Path, _manifest: VersionedManifest) -> Result<bool, WalError> {
+    async fn is_empty(
+        &self,
+        path: &Path,
+        _replay_after_wal_id: u64,
+        _wal_id_last_seen: u64,
+    ) -> Result<bool, WalError> {
         Ok(self.wal(path).files.lock().values().all(Vec::is_empty))
     }
 


### PR DESCRIPTION
## Summary

Adds the builder APIs for plugging in a custom WAL and adds an integration test

## Changes

- wires the custom WAL into the various builders
- updates Admin to use WalAdmin for wal admin operations
- one small tweak to WalReader to add an api for probing the current end of the WAL. Used by the reader to load the latest entries from its poll.
- adds an e2e integration test for custom WALs

## Notes for Reviewers

Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
