### PR TITLE
Select previous release tag dynamically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,18 @@ jobs:
         with:
           ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
           ref: ${{ github.ref }}
+          fetch-depth: 0
+
+      # Select the most recent stable release tag reachable from the release branch.
+      - name: Find previous release tag
+        id: previous_release
+        run: |
+          previous_tag="$(git describe \
+            --tags \
+            --abbrev=0 \
+            --match 'v[0-9]*.[0-9]*.[0-9]*' \
+            --exclude '*-*')"
+          echo "tag=${previous_tag}" >> "${GITHUB_OUTPUT}"
 
       # Set up Rust stable for installing cargo-edit
       - name: Setup Rust stable
@@ -67,6 +79,7 @@ jobs:
           tag: v${{ github.event.inputs.version }}
           name: v${{ github.event.inputs.version }}
           generateReleaseNotes: true
+          generateReleaseNotesPreviousTag: ${{ steps.previous_release.outputs.tag }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Publish crate chain to crates.io in dependency order


### PR DESCRIPTION
## Summary

- fetch the full Git history and tags in the release workflow
- select the nearest stable release tag reachable from the chosen release branch
- pass that tag explicitly to GitHub's generated release notes

## Why

GitHub's automatic previous-tag selection used `v0.13.1` for both the `v0.14.1` and `v0.15.0` release notes. The workflow did not provide an explicit base tag, so generated notes could include changes from multiple prior releases.

Resolving the tag from the checked-out branch keeps mainline releases and maintenance releases correct. Existing release descriptions are intentionally left unchanged.

## Validation

- parsed `.github/workflows/release.yaml` successfully with Ruby's YAML parser
- ran `git diff --check`
- verified the historical `v0.15.0` workflow commit selects `v0.14.1`
- verified the historical `v0.14.1` workflow commit selects `v0.14.0`