### PR TITLE
Enable clippy::absolute_paths and shorten deep paths at use sites

### DIFF
--- a/.config/clippy.toml
+++ b/.config/clippy.toml
@@ -97,3 +97,9 @@ disallowed-macros = [
     { path = "std::println", reason = "Use log::info instead" },
     { path = "std::print", reason = "Use log::info instead" },
 ]
+
+# Import items with `use` instead of spelling out deep paths at use sites. Only
+# the standard library stays exempt, where `std::fmt::Display` and friends read
+# fine fully qualified. `use` declarations themselves are never checked.
+absolute-paths-max-segments = 2
+absolute-paths-allowed-crates = ["std", "core", "alloc"]

--- a/bindings/uniffi/clippy.toml
+++ b/bindings/uniffi/clippy.toml
@@ -1,0 +1,1 @@
+../../.config/clippy.toml

--- a/bindings/uniffi/src/admin.rs
+++ b/bindings/uniffi/src/admin.rs
@@ -6,6 +6,7 @@ use crate::types::{
     CompactionSpec, CompactorStateView, VersionedCompactions, VersionedManifest,
 };
 use chrono::{DateTime, Utc};
+use slatedb::{admin, config};
 use std::ops::Bound;
 use std::sync::Arc;
 use std::time::Duration;
@@ -24,7 +25,7 @@ fn into_u64_bounds(
 /// Administrative read/query handle for SlateDB.
 #[derive(uniffi::Object)]
 pub struct Admin {
-    pub(crate) inner: slatedb::admin::Admin,
+    pub(crate) inner: admin::Admin,
 }
 
 #[uniffi::export(async_runtime = "tokio")]
@@ -110,10 +111,7 @@ impl Admin {
     ///
     /// When `options` is `None`, SlateDB's default garbage collector options are used.
     pub async fn run_gc_once(&self, options: Option<GarbageCollectorOptions>) -> Result<(), Error> {
-        let options = options.map_or_else(
-            slatedb::config::GarbageCollectorOptions::default,
-            Into::into,
-        );
+        let options = options.map_or_else(config::GarbageCollectorOptions::default, Into::into);
         self.inner.run_gc_once(options).await.map_err(Into::into)
     }
 
@@ -149,7 +147,7 @@ impl Admin {
     ) -> Result<CheckpointCreateResult, Error> {
         Ok(CheckpointCreateResult::from(
             self.inner
-                .create_detached_checkpoint(&slatedb::config::CheckpointOptions::try_from(options)?)
+                .create_detached_checkpoint(&config::CheckpointOptions::try_from(options)?)
                 .await?,
         ))
     }

--- a/bindings/uniffi/src/builder.rs
+++ b/bindings/uniffi/src/builder.rs
@@ -17,6 +17,7 @@ use crate::settings::Settings;
 use crate::types::{CloneSourceSpec, KeyRange};
 use crate::MetricsRecorder;
 use parking_lot::Mutex;
+use slatedb::admin;
 
 /// Builder for opening a writable [`crate::Db`].
 ///
@@ -260,15 +261,13 @@ impl DbReaderBuilder {
 /// Builders are single-use: calling [`AdminBuilder::build`] consumes the builder.
 #[derive(uniffi::Object)]
 pub struct AdminBuilder {
-    builder: Mutex<Option<slatedb::admin::AdminBuilder<String>>>,
+    builder: Mutex<Option<admin::AdminBuilder<String>>>,
 }
 
 impl AdminBuilder {
     fn update_builder(
         &self,
-        update: impl FnOnce(
-            slatedb::admin::AdminBuilder<String>,
-        ) -> slatedb::admin::AdminBuilder<String>,
+        update: impl FnOnce(admin::AdminBuilder<String>) -> admin::AdminBuilder<String>,
     ) -> Result<(), SlateDbError> {
         let mut guard = self.builder.lock();
         let builder = guard.take().ok_or(SlateDbError::BuilderConsumed)?;
@@ -276,7 +275,7 @@ impl AdminBuilder {
         Ok(())
     }
 
-    fn take_builder(&self) -> Result<slatedb::admin::AdminBuilder<String>, SlateDbError> {
+    fn take_builder(&self) -> Result<admin::AdminBuilder<String>, SlateDbError> {
         let mut guard = self.builder.lock();
         guard.take().ok_or(SlateDbError::BuilderConsumed)
     }
@@ -288,7 +287,7 @@ impl AdminBuilder {
     #[uniffi::constructor]
     pub fn new(path: String, object_store: Arc<ObjectStore>) -> Arc<Self> {
         Arc::new(Self {
-            builder: Mutex::new(Some(slatedb::admin::Admin::builder(
+            builder: Mutex::new(Some(admin::Admin::builder(
                 path,
                 object_store.inner.clone(),
             ))),
@@ -317,11 +316,11 @@ impl AdminBuilder {
 
 #[derive(uniffi::Object)]
 pub struct CloneBuilder {
-    builder: Mutex<Option<slatedb::admin::CloneBuilder>>,
+    builder: Mutex<Option<admin::CloneBuilder>>,
 }
 
 impl CloneBuilder {
-    pub(crate) fn new(inner: slatedb::admin::CloneBuilder) -> Arc<Self> {
+    pub(crate) fn new(inner: admin::CloneBuilder) -> Arc<Self> {
         Arc::new(Self {
             builder: Mutex::new(Some(inner)),
         })
@@ -329,7 +328,7 @@ impl CloneBuilder {
 
     fn update_builder(
         &self,
-        update: impl FnOnce(slatedb::admin::CloneBuilder) -> slatedb::admin::CloneBuilder,
+        update: impl FnOnce(admin::CloneBuilder) -> admin::CloneBuilder,
     ) -> Result<(), Error> {
         let mut guard = self.builder.lock();
         let builder = guard.take().ok_or(SlateDbError::BuilderConsumed)?;
@@ -337,7 +336,7 @@ impl CloneBuilder {
         Ok(())
     }
 
-    fn take_builder(&self) -> Result<slatedb::admin::CloneBuilder, SlateDbError> {
+    fn take_builder(&self) -> Result<admin::CloneBuilder, SlateDbError> {
         let mut guard = self.builder.lock();
         guard.take().ok_or(SlateDbError::BuilderConsumed)
     }

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, SlateDbError};
 use crate::filter_policy::FilterContext;
 use crate::types::try_checkpoint_id_from_str;
+use slatedb::config;
 use std::time::Duration;
 
 /// Minimum durability level required for data returned by reads and scans.
@@ -13,7 +14,7 @@ pub enum DurabilityLevel {
     Memory,
 }
 
-impl From<DurabilityLevel> for slatedb::config::DurabilityLevel {
+impl From<DurabilityLevel> for config::DurabilityLevel {
     fn from(value: DurabilityLevel) -> Self {
         match value {
             DurabilityLevel::Remote => Self::Remote,
@@ -32,7 +33,7 @@ pub enum FlushType {
     Wal,
 }
 
-impl From<FlushType> for slatedb::config::FlushType {
+impl From<FlushType> for config::FlushType {
     fn from(value: FlushType) -> Self {
         match value {
             FlushType::MemTable => Self::MemTable,
@@ -108,7 +109,7 @@ pub enum Ttl {
     ExpireAtMillis(i64),
 }
 
-impl From<Ttl> for slatedb::config::Ttl {
+impl From<Ttl> for config::Ttl {
     fn from(value: Ttl) -> Self {
         match value {
             Ttl::Default => Self::Default,
@@ -146,9 +147,9 @@ impl Default for ReadOptions {
     }
 }
 
-impl From<ReadOptions> for slatedb::config::ReadOptions {
+impl From<ReadOptions> for config::ReadOptions {
     fn from(value: ReadOptions) -> Self {
-        slatedb::config::ReadOptions {
+        config::ReadOptions {
             durability_filter: value.durability_filter.into(),
             dirty: value.dirty,
             cache_blocks: value.cache_blocks,
@@ -214,9 +215,9 @@ impl Default for ReaderOptions {
     }
 }
 
-impl From<ReaderOptions> for slatedb::config::DbReaderOptions {
+impl From<ReaderOptions> for config::DbReaderOptions {
     fn from(value: ReaderOptions) -> Self {
-        slatedb::config::DbReaderOptions {
+        config::DbReaderOptions {
             manifest_poll_interval: Duration::from_millis(value.manifest_poll_interval_ms),
             checkpoint_lifetime: Duration::from_millis(value.checkpoint_lifetime_ms),
             max_memtable_bytes: value.max_memtable_bytes,
@@ -281,11 +282,11 @@ impl Default for ScanOptions {
     }
 }
 
-impl TryFrom<ScanOptions> for slatedb::config::ScanOptions {
+impl TryFrom<ScanOptions> for config::ScanOptions {
     type Error = Error;
 
     fn try_from(value: ScanOptions) -> Result<Self, Self::Error> {
-        Ok(slatedb::config::ScanOptions {
+        Ok(config::ScanOptions {
             durability_filter: value.durability_filter.into(),
             dirty: value.dirty,
             read_ahead_bytes: usize::try_from(value.read_ahead_bytes).map_err(|_| {
@@ -313,9 +314,9 @@ pub struct WriteOptions {
     pub seqnum: u64,
 }
 
-impl From<WriteOptions> for slatedb::config::WriteOptions {
+impl From<WriteOptions> for config::WriteOptions {
     fn from(value: WriteOptions) -> Self {
-        slatedb::config::WriteOptions {
+        config::WriteOptions {
             seqnum: value.seqnum,
         }
     }
@@ -328,9 +329,9 @@ pub struct PutOptions {
     pub ttl: Ttl,
 }
 
-impl From<PutOptions> for slatedb::config::PutOptions {
+impl From<PutOptions> for config::PutOptions {
     fn from(value: PutOptions) -> Self {
-        slatedb::config::PutOptions {
+        config::PutOptions {
             ttl: value.ttl.into(),
         }
     }
@@ -343,9 +344,9 @@ pub struct MergeOptions {
     pub ttl: Ttl,
 }
 
-impl From<MergeOptions> for slatedb::config::MergeOptions {
+impl From<MergeOptions> for config::MergeOptions {
     fn from(value: MergeOptions) -> Self {
-        slatedb::config::MergeOptions {
+        config::MergeOptions {
             ttl: value.ttl.into(),
         }
     }
@@ -358,9 +359,9 @@ pub struct FlushOptions {
     pub flush_type: FlushType,
 }
 
-impl From<FlushOptions> for slatedb::config::FlushOptions {
+impl From<FlushOptions> for config::FlushOptions {
     fn from(value: FlushOptions) -> Self {
-        slatedb::config::FlushOptions {
+        config::FlushOptions {
             flush_type: value.flush_type.into(),
         }
     }
@@ -382,9 +383,9 @@ impl Default for CloseOptions {
     }
 }
 
-impl From<CloseOptions> for slatedb::config::CloseOptions {
+impl From<CloseOptions> for config::CloseOptions {
     fn from(value: CloseOptions) -> Self {
-        slatedb::config::CloseOptions {
+        config::CloseOptions {
             flush_type: value.flush_type.map(Into::into),
         }
     }
@@ -407,7 +408,7 @@ pub struct GarbageCollectorDirectoryOptions {
 
 impl Default for GarbageCollectorDirectoryOptions {
     fn default() -> Self {
-        let core = slatedb::config::GarbageCollectorDirectoryOptions::default();
+        let core = config::GarbageCollectorDirectoryOptions::default();
         Self {
             interval_ms: core.interval.map(|duration| duration.as_millis() as u64),
             min_age_ms: core.min_age.as_millis() as u64,
@@ -416,7 +417,7 @@ impl Default for GarbageCollectorDirectoryOptions {
     }
 }
 
-impl From<GarbageCollectorDirectoryOptions> for slatedb::config::GarbageCollectorDirectoryOptions {
+impl From<GarbageCollectorDirectoryOptions> for config::GarbageCollectorDirectoryOptions {
     fn from(value: GarbageCollectorDirectoryOptions) -> Self {
         Self {
             interval: value.interval_ms.map(Duration::from_millis),
@@ -438,14 +439,14 @@ pub struct GarbageCollectorScheduleOptions {
 
 impl Default for GarbageCollectorScheduleOptions {
     fn default() -> Self {
-        let core = slatedb::config::GarbageCollectorScheduleOptions::default();
+        let core = config::GarbageCollectorScheduleOptions::default();
         Self {
             interval_ms: core.interval.map(|duration| duration.as_millis() as u64),
         }
     }
 }
 
-impl From<GarbageCollectorScheduleOptions> for slatedb::config::GarbageCollectorScheduleOptions {
+impl From<GarbageCollectorScheduleOptions> for config::GarbageCollectorScheduleOptions {
     fn from(value: GarbageCollectorScheduleOptions) -> Self {
         Self {
             interval: value.interval_ms.map(Duration::from_millis),
@@ -493,7 +494,7 @@ pub struct GarbageCollectorOptions {
 
 impl Default for GarbageCollectorOptions {
     fn default() -> Self {
-        let core = slatedb::config::GarbageCollectorOptions::default();
+        let core = config::GarbageCollectorOptions::default();
         Self {
             manifest_options: core.manifest_options.map(Into::into),
             wal_options: core.wal_options.map(Into::into),
@@ -507,8 +508,8 @@ impl Default for GarbageCollectorOptions {
     }
 }
 
-impl From<slatedb::config::GarbageCollectorDirectoryOptions> for GarbageCollectorDirectoryOptions {
-    fn from(value: slatedb::config::GarbageCollectorDirectoryOptions) -> Self {
+impl From<config::GarbageCollectorDirectoryOptions> for GarbageCollectorDirectoryOptions {
+    fn from(value: config::GarbageCollectorDirectoryOptions) -> Self {
         Self {
             interval_ms: value.interval.map(|duration| duration.as_millis() as u64),
             min_age_ms: value.min_age.as_millis() as u64,
@@ -517,15 +518,15 @@ impl From<slatedb::config::GarbageCollectorDirectoryOptions> for GarbageCollecto
     }
 }
 
-impl From<slatedb::config::GarbageCollectorScheduleOptions> for GarbageCollectorScheduleOptions {
-    fn from(value: slatedb::config::GarbageCollectorScheduleOptions) -> Self {
+impl From<config::GarbageCollectorScheduleOptions> for GarbageCollectorScheduleOptions {
+    fn from(value: config::GarbageCollectorScheduleOptions) -> Self {
         Self {
             interval_ms: value.interval.map(|duration| duration.as_millis() as u64),
         }
     }
 }
 
-impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions {
+impl From<GarbageCollectorOptions> for config::GarbageCollectorOptions {
     fn from(value: GarbageCollectorOptions) -> Self {
         Self {
             manifest_options: value.manifest_options.map(Into::into),
@@ -543,49 +544,47 @@ impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions 
 
 #[cfg(test)]
 mod tests {
+    use slatedb::config;
+
     use super::{CloseOptions, FlushType, GarbageCollectorOptions, ReaderOptions};
 
     #[test]
     fn close_options_default_flushes_memtable() {
-        let options: slatedb::config::CloseOptions = CloseOptions::default().into();
+        let options: config::CloseOptions = CloseOptions::default().into();
 
         assert!(matches!(
             options.flush_type,
-            Some(slatedb::config::FlushType::MemTable)
+            Some(config::FlushType::MemTable)
         ));
     }
 
     #[test]
     fn close_options_can_flush_wal_only() {
-        let options: slatedb::config::CloseOptions = CloseOptions {
+        let options: config::CloseOptions = CloseOptions {
             flush_type: Some(FlushType::Wal),
         }
         .into();
 
-        assert!(matches!(
-            options.flush_type,
-            Some(slatedb::config::FlushType::Wal)
-        ));
+        assert!(matches!(options.flush_type, Some(config::FlushType::Wal)));
     }
 
     #[test]
     fn close_options_can_skip_final_flush() {
-        let options: slatedb::config::CloseOptions = CloseOptions { flush_type: None }.into();
+        let options: config::CloseOptions = CloseOptions { flush_type: None }.into();
 
         assert!(options.flush_type.is_none());
     }
 
     #[test]
     fn boundary_files_are_enabled_by_default() {
-        let gc: slatedb::config::GarbageCollectorOptions =
-            GarbageCollectorOptions::default().into();
+        let gc: config::GarbageCollectorOptions = GarbageCollectorOptions::default().into();
 
         assert!(gc.boundary_files_enabled);
     }
 
     #[test]
     fn boundary_files_can_be_disabled() {
-        let gc: slatedb::config::GarbageCollectorOptions = GarbageCollectorOptions {
+        let gc: config::GarbageCollectorOptions = GarbageCollectorOptions {
             disable_boundary_files: true,
             ..GarbageCollectorOptions::default()
         }
@@ -596,15 +595,14 @@ mod tests {
 
     #[test]
     fn gc_object_store_max_retries_defaults_to_unbounded() {
-        let gc: slatedb::config::GarbageCollectorOptions =
-            GarbageCollectorOptions::default().into();
+        let gc: config::GarbageCollectorOptions = GarbageCollectorOptions::default().into();
 
         assert_eq!(gc.object_store_max_retries, None);
     }
 
     #[test]
     fn gc_object_store_max_retries_threads_through() {
-        let gc: slatedb::config::GarbageCollectorOptions = GarbageCollectorOptions {
+        let gc: config::GarbageCollectorOptions = GarbageCollectorOptions {
             object_store_max_retries: Some(3),
             ..GarbageCollectorOptions::default()
         }
@@ -615,14 +613,14 @@ mod tests {
 
     #[test]
     fn reader_object_store_max_retries_defaults_to_unbounded() {
-        let reader: slatedb::config::DbReaderOptions = ReaderOptions::default().into();
+        let reader: config::DbReaderOptions = ReaderOptions::default().into();
 
         assert_eq!(reader.object_store_max_retries, None);
     }
 
     #[test]
     fn reader_object_store_max_retries_threads_through() {
-        let reader: slatedb::config::DbReaderOptions = ReaderOptions {
+        let reader: config::DbReaderOptions = ReaderOptions {
             object_store_max_retries: Some(5),
             ..ReaderOptions::default()
         }
@@ -649,13 +647,11 @@ pub struct CheckpointOptions {
     pub name: Option<String>,
 }
 
-impl TryFrom<&CheckpointOptions> for slatedb::config::CheckpointOptions {
+impl TryFrom<&CheckpointOptions> for config::CheckpointOptions {
     type Error = Error;
 
-    fn try_from(
-        value: &CheckpointOptions,
-    ) -> Result<slatedb::config::CheckpointOptions, Self::Error> {
-        Ok(slatedb::config::CheckpointOptions {
+    fn try_from(value: &CheckpointOptions) -> Result<config::CheckpointOptions, Self::Error> {
+        Ok(config::CheckpointOptions {
             lifetime: value.lifetime_ms.map(Duration::from_millis),
             source: value
                 .source

--- a/bindings/uniffi/src/db_cache.rs
+++ b/bindings/uniffi/src/db_cache.rs
@@ -1,4 +1,5 @@
 use crate::error::Error;
+use slatedb::db_cache;
 use slatedb::db_cache::{foyer, moka, SplitCache};
 use std::sync::Arc;
 use std::time::Duration;
@@ -40,7 +41,7 @@ impl From<MokaCacheOptions> for moka::MokaCacheOptions {
 /// Database cache used to store blocks in memory.
 #[derive(uniffi::Object)]
 pub struct DbCache {
-    pub(crate) inner: Arc<dyn slatedb::db_cache::DbCache>,
+    pub(crate) inner: Arc<dyn db_cache::DbCache>,
 }
 
 #[uniffi::export]
@@ -72,7 +73,7 @@ impl DbCache {
                 .with_block_cache(Some(block_cache.inner.clone()))
                 .with_meta_cache(Some(meta_cache.inner.clone()))
                 .build(),
-        ) as Arc<dyn slatedb::db_cache::DbCache>;
+        ) as Arc<dyn db_cache::DbCache>;
         Ok(Arc::new(Self { inner }))
     }
 }

--- a/bindings/uniffi/src/iterator.rs
+++ b/bindings/uniffi/src/iterator.rs
@@ -66,6 +66,7 @@ mod tests {
     use slatedb::object_store::memory::InMemory;
 
     use super::DbIterator;
+    use crate::types::KeyValue;
 
     const ROWS: u32 = 6;
 
@@ -87,7 +88,7 @@ mod tests {
     }
 
     /// Drains an iterator one row at a time; the oracle for the batch results.
-    async fn drain_rows(iter: &DbIterator) -> Vec<crate::types::KeyValue> {
+    async fn drain_rows(iter: &DbIterator) -> Vec<KeyValue> {
         let mut rows = Vec::new();
         while let Some(row) = iter.next().await.expect("next() failed") {
             rows.push(row);

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -1,3 +1,13 @@
+#![warn(clippy::absolute_paths)]
+#![cfg_attr(test, allow(clippy::absolute_paths))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::disallowed_macros,
+        clippy::disallowed_methods,
+        clippy::disallowed_types
+    )
+)]
 mod admin;
 mod builder;
 mod config;

--- a/bindings/uniffi/src/logging.rs
+++ b/bindings/uniffi/src/logging.rs
@@ -3,6 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 
 use log::LevelFilter as LogLevelFilter;
+use tracing::dispatcher;
+use tracing::field::{Field, Visit};
+use tracing::subscriber;
 use tracing::{Event, Subscriber};
 use tracing_log::LogTracer;
 use tracing_subscriber::filter::LevelFilter as TracingLevelFilter;
@@ -132,7 +135,7 @@ pub fn init_logging(level: LogLevel, callback: Option<Arc<dyn LogCallback>>) -> 
         return Err(logging_already_initialized_error());
     }
 
-    if tracing::dispatcher::has_been_set() {
+    if dispatcher::has_been_set() {
         return Err(invalid_logging_error(
             "global tracing subscriber already initialized by another library",
         ));
@@ -160,7 +163,7 @@ fn install_subscriber(
     if let Some(callback) = callback {
         let subscriber =
             tracing_subscriber::registry().with(LogCallbackLayer { callback }.with_filter(filter));
-        tracing::subscriber::set_global_default(subscriber).map_err(|_| {
+        subscriber::set_global_default(subscriber).map_err(|_| {
             invalid_logging_error(
                 "global tracing subscriber already initialized by another library",
             )
@@ -170,7 +173,7 @@ fn install_subscriber(
             .with_writer(std::io::stderr)
             .with_max_level(filter)
             .finish();
-        tracing::subscriber::set_global_default(subscriber).map_err(|_| {
+        subscriber::set_global_default(subscriber).map_err(|_| {
             invalid_logging_error(
                 "global tracing subscriber already initialized by another library",
             )
@@ -198,13 +201,13 @@ struct EventFieldVisitor {
 }
 
 impl EventFieldVisitor {
-    fn field_name(field: &tracing::field::Field) -> &str {
+    fn field_name(field: &Field) -> &str {
         field.name()
     }
 }
 
-impl tracing::field::Visit for EventFieldVisitor {
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+impl Visit for EventFieldVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
         match Self::field_name(field) {
             "message" => {
                 self.message.clear();
@@ -217,19 +220,19 @@ impl tracing::field::Visit for EventFieldVisitor {
         }
     }
 
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         if Self::field_name(field) == "message" {
             self.message = format!("{value:?}");
         }
     }
 
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+    fn record_u64(&mut self, field: &Field, value: u64) {
         if Self::field_name(field) == "log.line" {
             self.line = u32::try_from(value).ok();
         }
     }
 
-    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+    fn record_i64(&mut self, field: &Field, value: i64) {
         if Self::field_name(field) == "log.line" {
             self.line = u32::try_from(value).ok();
         }

--- a/bindings/uniffi/src/metrics.rs
+++ b/bindings/uniffi/src/metrics.rs
@@ -476,6 +476,8 @@ impl From<core_metrics::MetricValue> for MetricValue {
 
 #[cfg(test)]
 mod tests {
+    use slatedb::object_store;
+
     use std::collections::BTreeMap;
     use std::sync::{Arc, Mutex};
 
@@ -775,21 +777,15 @@ mod tests {
         reader.close().await.expect("failed to close reader");
     }
 
-    fn new_test_store() -> (
-        Arc<ObjectStore>,
-        Arc<dyn slatedb::object_store::ObjectStore>,
-    ) {
-        let inner: Arc<dyn slatedb::object_store::ObjectStore> = Arc::new(InMemory::new());
+    fn new_test_store() -> (Arc<ObjectStore>, Arc<dyn object_store::ObjectStore>) {
+        let inner: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
         let binding = Arc::new(ObjectStore {
             inner: inner.clone(),
         });
         (binding, inner)
     }
 
-    async fn seed_reader_data(
-        path: &str,
-        object_store: Arc<dyn slatedb::object_store::ObjectStore>,
-    ) {
+    async fn seed_reader_data(path: &str, object_store: Arc<dyn object_store::ObjectStore>) {
         let db = slatedb::Db::builder(path.to_owned(), object_store)
             .build()
             .await

--- a/bindings/uniffi/src/object_store.rs
+++ b/bindings/uniffi/src/object_store.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use slatedb::object_store;
 use slatedb::{admin, Db};
 
 use crate::error::Error;
@@ -7,7 +8,7 @@ use crate::error::Error;
 /// Object store handle used when opening databases, readers, and WAL readers.
 #[derive(uniffi::Object)]
 pub struct ObjectStore {
-    pub(crate) inner: Arc<dyn slatedb::object_store::ObjectStore>,
+    pub(crate) inner: Arc<dyn object_store::ObjectStore>,
 }
 
 #[uniffi::export]

--- a/bindings/uniffi/src/settings.rs
+++ b/bindings/uniffi/src/settings.rs
@@ -170,6 +170,8 @@ fn apply_dotted_json_path(root: &mut Value, key: &str, value: Value) -> Result<(
 
 #[cfg(test)]
 mod tests {
+    use slatedb::config::MetricLevel;
+
     use serde_json::json;
     use std::sync::Arc;
     use std::time::Duration;
@@ -355,10 +357,7 @@ flush_interval = "1s"
                 settings.inner().flush_interval,
                 Some(Duration::from_secs(1))
             );
-            assert_eq!(
-                settings.inner().metric_level,
-                slatedb::config::MetricLevel::Debug
-            );
+            assert_eq!(settings.inner().metric_level, MetricLevel::Debug);
 
             Ok(())
         });

--- a/slatedb-common/src/clock.rs
+++ b/slatedb-common/src/clock.rs
@@ -13,9 +13,12 @@ use crate::DbRand;
 use chrono::{DateTime, Utc};
 use rand::Rng;
 use std::{fmt::Debug, future::Future, ops::Range, pin::Pin, sync::Arc, time::Duration};
+use tokio::time;
 
 #[cfg(feature = "test-util")]
 use std::sync::atomic::{AtomicI64, Ordering};
+#[cfg(feature = "test-util")]
+use tokio::task;
 
 /// Defines the physical clock used to measure wall-clock time.
 pub trait SystemClock: Debug + Send + Sync {
@@ -133,14 +136,14 @@ impl<'a> SystemClockTicker<'a> {
 #[derive(Debug)]
 pub struct DefaultSystemClock {
     initial_ts: DateTime<Utc>,
-    initial_instant: tokio::time::Instant,
+    initial_instant: time::Instant,
 }
 
 impl DefaultSystemClock {
     pub fn new() -> Self {
         Self {
             initial_ts: Utc::now(),
-            initial_instant: tokio::time::Instant::now(),
+            initial_instant: time::Instant::now(),
         }
     }
 }
@@ -153,17 +156,17 @@ impl Default for DefaultSystemClock {
 
 impl SystemClock for DefaultSystemClock {
     fn now(&self) -> DateTime<Utc> {
-        let elapsed = tokio::time::Instant::now().duration_since(self.initial_instant);
+        let elapsed = time::Instant::now().duration_since(self.initial_instant);
         self.initial_ts + elapsed
     }
 
     #[cfg(feature = "test-util")]
     fn advance<'a>(&'a self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
-        Box::pin(tokio::time::advance(duration))
+        Box::pin(time::advance(duration))
     }
 
     fn sleep<'a>(&'a self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + 'a>> {
-        Box::pin(tokio::time::sleep(duration))
+        Box::pin(time::sleep(duration))
     }
 
     fn ticker<'a>(&'a self, duration: Duration) -> SystemClockTicker<'a> {
@@ -225,7 +228,7 @@ impl SystemClock for MockSystemClock {
             // the block can yield control to other tasks. Calling advance() in a tight loop
             // would prevent other tasks from running in this case. Yielding control to other
             // tasks explicitly so we avoid this issue.
-            tokio::task::yield_now().await;
+            task::yield_now().await;
         })
     }
 
@@ -236,7 +239,7 @@ impl SystemClock for MockSystemClock {
         Box::pin(async move {
             #[allow(clippy::while_immutable_condition)]
             while self.current_ts.load(Ordering::SeqCst) < end_time {
-                tokio::task::yield_now().await;
+                task::yield_now().await;
             }
         })
     }

--- a/slatedb-common/src/lib.rs
+++ b/slatedb-common/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::absolute_paths)]
+#![cfg_attr(test, allow(clippy::absolute_paths))]
 //! Common utilities shared across SlateDB crates.
 //!
 //! This crate contains utilities that are used by multiple SlateDB

--- a/slatedb-txn-obj/src/lib.rs
+++ b/slatedb-txn-obj/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::absolute_paths)]
+#![cfg_attr(test, allow(clippy::absolute_paths))]
 //! # SlateDB Transactional Object
 //!
 //! This module provides generic, reusable primitives for reading/writing an object in a durable

--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -3,11 +3,15 @@ pub use crate::db::builder::CloneSourceSpec;
 use std::collections::BTreeSet;
 
 use crate::checkpoint::{Checkpoint, CheckpointCreateResult};
+#[cfg(feature = "compaction_filters")]
+use crate::compaction_filter::CompactionFilterSupplier;
 use crate::compactions_store::CompactionsStore;
 use crate::compactor::{Compaction, CompactionSpec, Compactor, CompactorStateView};
 use crate::compactor_state::VersionedCompactions;
 use crate::compactor_state_protocols::CompactorStateReader;
-use crate::config::{CheckpointOptions, GarbageCollectorOptions};
+use crate::config::{
+    CheckpointOptions, CompactionWorkerOptions, CompactorOptions, GarbageCollectorOptions,
+};
 use crate::db::builder::GarbageCollectorBuilder;
 use crate::error::SlateDBError;
 use crate::manifest::store::{ManifestStore, StoredManifest};
@@ -21,6 +25,14 @@ use crate::utils::IdGenerator;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
+#[cfg(feature = "aws")]
+use object_store::aws::AmazonS3Builder;
+#[cfg(feature = "azure")]
+use object_store::azure::MicrosoftAzureBuilder;
+#[cfg(feature = "gcp")]
+use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::local::LocalFileSystem;
+use object_store::memory::InMemory;
 use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt};
 use rand::RngCore;
@@ -56,8 +68,7 @@ pub struct Admin {
     /// The retry policy applied to admin object-store operations.
     pub(crate) object_store_max_retries: Option<u32>,
     #[cfg(feature = "compaction_filters")]
-    pub(crate) compaction_filter_supplier:
-        Option<Arc<dyn crate::compaction_filter::CompactionFilterSupplier>>,
+    pub(crate) compaction_filter_supplier: Option<Arc<dyn CompactionFilterSupplier>>,
     pub(crate) merge_operator: Option<MergeOperatorType>,
     pub(crate) wal_admin: Arc<dyn WalAdmin>,
 }
@@ -348,11 +359,8 @@ impl Admin {
         &self,
         cancellation_token: CancellationToken,
     ) -> Result<(), crate::Error> {
-        self.run_compactor_with_options(
-            cancellation_token,
-            crate::config::CompactorOptions::default(),
-        )
-        .await
+        self.run_compactor_with_options(cancellation_token, CompactorOptions::default())
+            .await
     }
 
     /// Like [`Admin::run_compactor`] but accepts explicit [`crate::config::CompactorOptions`].
@@ -362,7 +370,7 @@ impl Admin {
     pub async fn run_compactor_with_options(
         &self,
         cancellation_token: CancellationToken,
-        options: crate::config::CompactorOptions,
+        options: CompactorOptions,
     ) -> Result<(), crate::Error> {
         #[allow(unused_mut)]
         let mut builder = crate::CompactorBuilder::new(
@@ -413,7 +421,7 @@ impl Admin {
     ) -> Result<(), crate::Error> {
         self.run_compaction_worker_with_options(
             cancellation_token,
-            crate::config::CompactionWorkerOptions::default(),
+            CompactionWorkerOptions::default(),
         )
         .await
     }
@@ -423,7 +431,7 @@ impl Admin {
     pub async fn run_compaction_worker_with_options(
         &self,
         cancellation_token: CancellationToken,
-        options: crate::config::CompactionWorkerOptions,
+        options: CompactionWorkerOptions,
     ) -> Result<(), crate::Error> {
         #[allow(unused_mut)]
         let mut builder = crate::CompactionWorkerBuilder::new(
@@ -876,19 +884,18 @@ pub fn load_object_store_from_env(
 /// | LOCAL_PATH | The path to the local directory where all data will be stored | Yes |
 pub fn load_local() -> Result<Arc<dyn ObjectStore>, crate::Error> {
     let local_path = get_env_variable("LOCAL_PATH")?;
-    let lfs =
-        object_store::local::LocalFileSystem::new_with_prefix(local_path).map_err(|error| {
-            SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
-                store: "local",
-                source: Box::new(error),
-            }))
-        })?;
+    let lfs = LocalFileSystem::new_with_prefix(local_path).map_err(|error| {
+        SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
+            store: "local",
+            source: Box::new(error),
+        }))
+    })?;
     Ok(Arc::new(lfs) as Arc<dyn ObjectStore>)
 }
 
 /// Loads an in-memory object store instance.
 pub fn load_memory() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    Ok(Arc::new(object_store::memory::InMemory::new()) as Arc<dyn ObjectStore>)
+    Ok(Arc::new(InMemory::new()) as Arc<dyn ObjectStore>)
 }
 
 /// Loads an AWS S3 Object store instance. The environment variables consumed are
@@ -897,7 +904,7 @@ pub fn load_memory() -> Result<Arc<dyn ObjectStore>, crate::Error> {
 /// <https://docs.rs/object_store/latest/object_store/aws/struct.AmazonS3Builder.html#method.with_config>
 #[cfg(feature = "aws")]
 pub fn load_aws() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    let builder = object_store::aws::AmazonS3Builder::from_env();
+    let builder = AmazonS3Builder::from_env();
 
     Ok(Arc::new(builder.build().map_err(|error| {
         SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
@@ -913,7 +920,7 @@ pub fn load_aws() -> Result<Arc<dyn ObjectStore>, crate::Error> {
 /// <https://docs.rs/object_store/latest/object_store/azure/struct.MicrosoftAzureBuilder.html#method.with_config>
 #[cfg(feature = "azure")]
 pub fn load_azure() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    let builder = object_store::azure::MicrosoftAzureBuilder::from_env();
+    let builder = MicrosoftAzureBuilder::from_env();
     Ok(Arc::new(builder.build().map_err(|error| {
         SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
             store: "MicrosoftAzure",
@@ -928,7 +935,7 @@ pub fn load_azure() -> Result<Arc<dyn ObjectStore>, crate::Error> {
 /// <https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html#method.with_config>
 #[cfg(feature = "gcp")]
 pub fn load_gcp() -> Result<Arc<dyn ObjectStore>, crate::Error> {
-    let builder = object_store::gcp::GoogleCloudStorageBuilder::from_env();
+    let builder = GoogleCloudStorageBuilder::from_env();
     Ok(Arc::new(builder.build().map_err(|error| {
         SlateDBError::ObjectStoreError(Arc::new(object_store::Error::Generic {
             store: "GoogleCloudStorage",

--- a/slatedb/src/batch.rs
+++ b/slatedb/src/batch.rs
@@ -17,6 +17,7 @@ use smallvec::{smallvec, SmallVec};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::iter::Peekable;
 use std::ops::RangeBounds;
+use tokio::task::coop;
 
 /// A batch of write operations (puts, deletes, and merges). All operations in
 /// the batch are applied atomically to the database. Put and delete operations
@@ -471,7 +472,7 @@ impl RowEntryIterator for WriteBatchIterator {
             } {
                 self.iter.next();
                 // Keep in-memory seeking cooperative.
-                tokio::task::coop::consume_budget().await;
+                coop::consume_budget().await;
             } else {
                 break;
             }

--- a/slatedb/src/block_iterator.rs
+++ b/slatedb/src/block_iterator.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::sync::Arc;
 
+use crate::block_iterator_v2::BlockIteratorV2;
 use crate::format::block::Block;
 use crate::format::row::SstRowCodecV0;
 use crate::iter::IterationOrder;
@@ -48,12 +49,12 @@ impl BlockLike for Arc<Block> {
 /// Type alias for the latest block iterator version.
 /// Note: B is constrained to BlockLike by BlockIteratorV2's definition.
 #[cfg(test)]
-pub(crate) type BlockIteratorLatest<B> = crate::block_iterator_v2::BlockIteratorV2<B>;
+pub(crate) type BlockIteratorLatest<B> = BlockIteratorV2<B>;
 
 /// Block iterator that dispatches on the SST format version.
 pub(crate) enum DataBlockIterator<B: BlockLike> {
     V1(BlockIterator<B>),
-    V2(crate::block_iterator_v2::BlockIteratorV2<B>),
+    V2(BlockIteratorV2<B>),
 }
 
 impl<B: BlockLike> DataBlockIterator<B> {
@@ -65,9 +66,7 @@ impl<B: BlockLike> DataBlockIterator<B> {
         use crate::format::sst::{SST_FORMAT_VERSION, SST_FORMAT_VERSION_V2};
         match sst_version {
             SST_FORMAT_VERSION => Ok(Self::V1(BlockIterator::new(block, order))),
-            SST_FORMAT_VERSION_V2 => Ok(Self::V2(crate::block_iterator_v2::BlockIteratorV2::new(
-                block, order,
-            ))),
+            SST_FORMAT_VERSION_V2 => Ok(Self::V2(BlockIteratorV2::new(block, order))),
             _ => Err(SlateDBError::InvalidVersion {
                 format_name: "SST",
                 supported_versions: vec![SST_FORMAT_VERSION, SST_FORMAT_VERSION_V2],

--- a/slatedb/src/cached_object_store/object_store.rs
+++ b/slatedb/src/cached_object_store/object_store.rs
@@ -8,7 +8,7 @@ use crate::cached_object_store::LocalCacheEntry;
 use crate::config::ObjectStoreCacheOptions;
 use crate::object_store_tag::ObjectStoreCallTag;
 use bytes::{Bytes, BytesMut};
-use futures::{future::BoxFuture, stream, stream::BoxStream, StreamExt};
+use futures::{future, future::BoxFuture, stream, stream::BoxStream, StreamExt};
 use object_store::{path::Path, GetOptions, GetResult, ObjectMeta, ObjectStore, ObjectStoreExt};
 use object_store::{
     Attributes, CopyOptions, Extensions, GetRange, GetResultPayload, PutMultipartOptions,
@@ -1075,7 +1075,7 @@ impl MultipartUpload for CachingMultipartUpload {
                     entry.save_part(part_number, chunk).await.ok();
                 }
             };
-            let (result, ()) = futures::future::join(inner_fut, cache_fut).await;
+            let (result, ()) = future::join(inner_fut, cache_fut).await;
             result
         })
     }

--- a/slatedb/src/cached_object_store/storage_fs.rs
+++ b/slatedb/src/cached_object_store/storage_fs.rs
@@ -16,7 +16,12 @@ use std::ops::Range;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::fs;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{Mutex, OnceCell};
+use tokio::task;
+use tokio::task::JoinHandle;
 use walkdir::WalkDir;
 
 use crate::cached_object_store::storage::{LocalCacheEntry, LocalCacheHead, LocalCacheStorage};
@@ -252,7 +257,7 @@ impl FsCacheEntry {
         // see https://github.com/slatedb/slatedb/pull/1342
         let invalidate_path = path.clone();
         #[allow(clippy::disallowed_methods)]
-        tokio::task::spawn_blocking(move || {
+        task::spawn_blocking(move || {
             let tmp_path = tmp_path.as_path();
             // ensure the parent folder exists
             if let Some(folder_path) = tmp_path.parent() {
@@ -355,7 +360,7 @@ impl LocalCacheEntry for FsCacheEntry {
         let file_cache = self.file_handle_cache.clone();
         let this_part_path = part_path.clone();
         #[allow(clippy::disallowed_methods)]
-        let result = tokio::task::spawn_blocking(move || {
+        let result = task::spawn_blocking(move || {
             let file = match file_cache.get_or_open(&this_part_path) {
                 Ok(Some(f)) => f,
                 Ok(None) => return Ok(None),
@@ -395,7 +400,7 @@ impl LocalCacheEntry for FsCacheEntry {
         };
 
         #[allow(clippy::disallowed_methods)]
-        tokio::task::spawn_blocking(move || {
+        task::spawn_blocking(move || {
             let target_prefix = "_part";
 
             let entries = match std::fs::read_dir(&directory_path) {
@@ -473,7 +478,7 @@ impl LocalCacheEntry for FsCacheEntry {
         let file_cache = self.file_handle_cache.clone();
         let this_head_path = head_path.clone();
         #[allow(clippy::disallowed_methods)]
-        let result = tokio::task::spawn_blocking(move || {
+        let result = task::spawn_blocking(move || {
             let file = match file_cache.get_or_open(&this_head_path) {
                 Ok(Some(f)) => f,
                 Ok(None) => return Ok(None),
@@ -551,13 +556,13 @@ struct FsCacheEvictor {
     root_folder: std::path::PathBuf,
     max_cache_size_bytes: usize,
     scan_interval: Option<Duration>,
-    tx: tokio::sync::mpsc::Sender<FsCacheEvictorWork>,
-    rx: Mutex<Option<tokio::sync::mpsc::Receiver<FsCacheEvictorWork>>>,
+    tx: mpsc::Sender<FsCacheEvictorWork>,
+    rx: Mutex<Option<mpsc::Receiver<FsCacheEvictorWork>>>,
     started: AtomicBool,
     queue_full_count: AtomicU64,
     last_queue_full_log_ms: AtomicI64,
-    background_evict_handle: OnceCell<tokio::task::JoinHandle<()>>,
-    background_scan_handle: OnceCell<tokio::task::JoinHandle<()>>,
+    background_evict_handle: OnceCell<JoinHandle<()>>,
+    background_scan_handle: OnceCell<JoinHandle<()>>,
     stats: Arc<CachedObjectStoreStats>,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -574,7 +579,7 @@ impl FsCacheEvictor {
         rand: Arc<DbRand>,
         file_handle_cache: FileHandleCache,
     ) -> Self {
-        let (tx, rx) = tokio::sync::mpsc::channel(100);
+        let (tx, rx) = mpsc::channel(100);
         Self {
             root_folder,
             scan_interval,
@@ -633,7 +638,7 @@ impl FsCacheEvictor {
 
     async fn background_evict(
         inner: Arc<FsCacheEvictorInner>,
-        mut rx: tokio::sync::mpsc::Receiver<FsCacheEvictorWork>,
+        mut rx: mpsc::Receiver<FsCacheEvictorWork>,
         system_clock: Arc<dyn SystemClock>,
     ) {
         loop {
@@ -684,7 +689,7 @@ impl FsCacheEvictor {
 
         match self.tx.try_send((path, access)) {
             Ok(()) => true,
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+            Err(TrySendError::Full(_)) => {
                 self.queue_full_count.fetch_add(1, Ordering::AcqRel);
                 let now_ms = self.system_clock.now().timestamp_millis();
                 let last_log_ms = self.last_queue_full_log_ms.load(Ordering::Acquire);
@@ -702,7 +707,7 @@ impl FsCacheEvictor {
                 }
                 false
             }
-            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => false,
+            Err(TrySendError::Closed(_)) => false,
         }
     }
 }
@@ -782,7 +787,7 @@ impl FsCacheEvictorInner {
         let root_folder = self.root_folder.clone();
 
         #[allow(clippy::disallowed_methods)]
-        let paths = tokio::task::spawn_blocking(move || {
+        let paths = task::spawn_blocking(move || {
             WalkDir::new(&root_folder)
                 .into_iter()
                 .filter_map(|e| e.ok())
@@ -794,7 +799,7 @@ impl FsCacheEvictorInner {
         .unwrap_or_default();
 
         for path in paths {
-            let metadata = match tokio::fs::metadata(&path).await {
+            let metadata = match fs::metadata(&path).await {
                 Ok(metadata) => metadata,
                 Err(err) => {
                     if err.kind() != std::io::ErrorKind::NotFound {
@@ -908,7 +913,7 @@ impl FsCacheEvictorInner {
             // if the file is not found, still try to remove it from the cache_entries, and decrease the cache_size_bytes.
             // this might happen when the file is removed by other processes, or due to a race between the background
             // scan (which collects paths then processes them) and eviction deleting files in between.
-            match tokio::fs::remove_file(&target).await {
+            match fs::remove_file(&target).await {
                 Ok(()) => {
                     debug!(
                         "evictor evicted cache file [path={:?}, bytes={}]",
@@ -1107,7 +1112,7 @@ async fn delete_cache_entry(
     // Run deletion as a single blocking task rather than jumping back and
     // forth to the same blocking thread pool tokio uses under the hood.
     #[allow(clippy::disallowed_methods)]
-    let result = tokio::task::spawn_blocking(move || {
+    let result = task::spawn_blocking(move || {
         let result = std::fs::read_dir(&path);
         match result {
             Ok(read_dir) => {

--- a/slatedb/src/clock.rs
+++ b/slatedb/src/clock.rs
@@ -28,6 +28,7 @@ use std::{
     },
     time::Duration,
 };
+use tokio::time;
 
 /// SlateDB uses MonotonicClock internally so that it can enforce that clock ticks
 /// from the underlying implementation are monotonically increasing.
@@ -63,7 +64,7 @@ impl MonotonicClock {
                     Sleeping {}ms to potentially resolve skew before returning InvalidClockTick.",
                     tick, last_tick, sync_millis
                 );
-                tokio::time::sleep(Duration::from_millis(sync_millis)).await;
+                time::sleep(Duration::from_millis(sync_millis)).await;
                 self.enforce_monotonic(self.delegate.now().timestamp_millis())
             }
             result => result,

--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::BufMut;
+use futures::future;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use log::{error, info};
@@ -10,6 +11,7 @@ use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt};
 use rand::RngCore;
 use tokio::runtime::Handle;
+use tokio::task;
 use tokio::task::JoinHandle;
 use ulid::Ulid;
 
@@ -198,7 +200,7 @@ impl CompactionExecuteBench {
                     .await
             }))
         }
-        let results = futures::future::join_all(del_tasks).await;
+        let results = future::join_all(del_tasks).await;
         for result in results {
             match result {
                 Ok(Ok(())) => {}
@@ -399,7 +401,7 @@ impl CompactionExecuteBench {
         let start = self.system_clock.now();
         info!("start compaction job");
         #[allow(clippy::disallowed_methods)]
-        tokio::task::spawn_blocking(move || executor.start_compaction_job(job));
+        task::spawn_blocking(move || executor.start_compaction_job(job));
         while let Ok(msg) = rx.recv().await {
             if let WorkerMessage::CompactionJobFinished { id: _, result } = msg {
                 match result {

--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -71,9 +71,11 @@ use ulid::Ulid;
 
 #[cfg(feature = "compaction_filters")]
 use crate::compaction_filter::CompactionFilterSupplier;
+use crate::compaction_worker;
 use crate::compaction_worker::CompactionWorkerHandler;
 use crate::compactions_store::{CompactionsStore, StoredCompactions};
 use crate::compactor::stats::CompactionStats;
+use crate::compactor_state::WorkerSpec;
 use crate::compactor_state_protocols::CompactorStateWriter;
 use crate::config::CompactorOptions;
 use crate::db_state::{SortedRun, SsTableView};
@@ -424,7 +426,7 @@ impl Compactor {
             );
             self.task_executor
                 .add_handler(
-                    crate::compaction_worker::COMPACTION_WORKER_TASK_NAME.to_string(),
+                    compaction_worker::COMPACTION_WORKER_TASK_NAME.to_string(),
                     Box::new(worker_handler),
                     worker_rx,
                     &Handle::current(),
@@ -443,7 +445,7 @@ impl Compactor {
             .map_err(Error::from)?;
         if self.options.worker.is_some() {
             self.task_executor
-                .join_task(crate::compaction_worker::COMPACTION_WORKER_TASK_NAME)
+                .join_task(compaction_worker::COMPACTION_WORKER_TASK_NAME)
                 .await
                 .map_err(Error::from)?;
         }
@@ -461,7 +463,7 @@ impl Compactor {
             .map_err(Error::from)?;
         if self.options.worker.is_some() {
             self.task_executor
-                .shutdown_task(crate::compaction_worker::COMPACTION_WORKER_TASK_NAME)
+                .shutdown_task(compaction_worker::COMPACTION_WORKER_TASK_NAME)
                 .await
                 .map_err(Error::from)?;
         }
@@ -806,7 +808,7 @@ impl CompactorEventHandler {
     fn update_distributed_compaction_metrics(&mut self) {
         use crate::compactor::stats::{WORKER_ID_LABEL, WORKER_LAST_HEARTBEAT_MS};
 
-        let claimed: Vec<(Ulid, crate::compactor_state::WorkerSpec)> = self
+        let claimed: Vec<(Ulid, WorkerSpec)> = self
             .state()
             .compactions_with_status(&[CompactionStatus::Running, CompactionStatus::Compacted])
             .filter_map(|c| c.worker().cloned().map(|w| (c.id(), w)))
@@ -1312,6 +1314,7 @@ pub mod stats {
     use crate::merge_operator::{
         MERGE_OPERATOR_COMPACT_PATH, MERGE_OPERATOR_OPERANDS_DESCRIPTION, MERGE_OPERATOR_PATH_LABEL,
     };
+    use crate::retention_iterator::RetentionMetrics;
 
     macro_rules! compactor_stat_name {
         ($suffix:expr) => {
@@ -1390,8 +1393,8 @@ pub mod stats {
             }
         }
 
-        pub(crate) fn retention_metrics(&self) -> crate::retention_iterator::RetentionMetrics {
-            crate::retention_iterator::RetentionMetrics {
+        pub(crate) fn retention_metrics(&self) -> RetentionMetrics {
+            RetentionMetrics {
                 expired_entries_purged_value: self.expired_entries_purged_value.clone(),
                 expired_entries_purged_merge: self.expired_entries_purged_merge.clone(),
             }

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -7,6 +7,9 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::future::{join, join_all};
 use parking_lot::Mutex;
+use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+use tokio::task::coop;
 use tokio::task::JoinHandle;
 use tokio_util::task::AbortOnDropHandle;
 
@@ -34,6 +37,7 @@ use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::subcompaction::{plan_subcompaction_ranges, Subcompaction};
 use crate::tablestore::TableStore;
+use crate::types::RowEntry;
 use slatedb_common::clock::SystemClock;
 use slatedb_common::DbRand;
 
@@ -183,7 +187,7 @@ impl<T: RowEntryIterator> RowEntryIterator for ResumingIterator<T> {
         self.iterator.init().await
     }
 
-    async fn next(&mut self) -> Result<Option<crate::types::RowEntry>, SlateDBError> {
+    async fn next(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         self.iterator.next().await
     }
 
@@ -215,7 +219,7 @@ pub(crate) trait CompactionExecutor {
 
 /// Options for creating a [`TokioCompactionExecutor`].
 pub(crate) struct TokioCompactionExecutorOptions {
-    pub handle: tokio::runtime::Handle,
+    pub handle: Handle,
     pub options: Arc<CompactionWorkerOptions>,
     pub worker_tx: async_channel::Sender<WorkerMessage>,
     pub table_store: Arc<TableStore>,
@@ -300,7 +304,7 @@ enum SubcompactionEvent {
 
 pub(crate) struct TokioCompactionExecutorInner {
     options: Arc<CompactionWorkerOptions>,
-    handle: tokio::runtime::Handle,
+    handle: Handle,
     worker_tx: async_channel::Sender<WorkerMessage>,
     table_store: Arc<TableStore>,
     tasks: Arc<Mutex<BTreeMap<Ulid, TokioCompactionTask>>>,
@@ -638,7 +642,7 @@ impl TokioCompactionExecutorInner {
             self.send_compaction_progress(id, 0, ctx.clone());
         }
 
-        let (sub_tx, mut sub_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (sub_tx, mut sub_rx) = mpsc::unbounded_channel();
         let mut sub_tasks = Vec::new();
         for args in subcompaction_args {
             // Each range runs as its own task, resuming from the output already
@@ -860,7 +864,7 @@ impl TokioCompactionExecutorInner {
             }
 
             // Keep cached compaction work cooperative.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
         }
 
         // Drain the in-flight close, then flush the final partial SST. Order
@@ -1456,7 +1460,7 @@ mod tests {
         #[case] merge_operator: Option<MergeOperatorType>,
         #[case] expected_rows: Vec<RowEntry>,
     ) {
-        let handle = tokio::runtime::Handle::current();
+        let handle = Handle::current();
         let options = Arc::new(CompactionWorkerOptions::default());
         let (tx, _rx) = async_channel::unbounded::<WorkerMessage>();
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -1675,7 +1679,7 @@ mod tests {
                     Some(0)
                 };
 
-                let handle = tokio::runtime::Handle::current();
+                let handle = Handle::current();
                 let options = CompactionWorkerOptions {
                     max_sst_size: MAX_SST_SIZE,
                     ..Default::default()
@@ -1936,7 +1940,7 @@ mod tests {
             .unwrap();
         let (tx, rx) = async_channel::unbounded::<WorkerMessage>();
         let executor = TokioCompactionExecutor::new(TokioCompactionExecutorOptions {
-            handle: tokio::runtime::Handle::current(),
+            handle: Handle::current(),
             options: Arc::new(CompactionWorkerOptions {
                 max_sst_size: SUBCOMPACTION_SST_SIZE,
                 ..CompactionWorkerOptions::default()
@@ -2469,7 +2473,7 @@ mod tests {
     async fn should_stop_single_compaction_job_without_stopping_executor() {
         // given: an executor writing through a gated object store, with a tiny
         // max_sst_size so the first compaction parks while flushing output.
-        let handle = tokio::runtime::Handle::current();
+        let handle = Handle::current();
         let options = Arc::new(CompactionWorkerOptions {
             max_sst_size: 1,
             ..CompactionWorkerOptions::default()
@@ -2603,7 +2607,7 @@ mod tests {
         // given: an executor writing through a gated object store, with a tiny
         // max_sst_size so each finished block rolls into a new output SST
         // (guaranteeing several SST boundaries, and thus background closes).
-        let handle = tokio::runtime::Handle::current();
+        let handle = Handle::current();
         let options = Arc::new(CompactionWorkerOptions {
             max_sst_size: 1,
             ..CompactionWorkerOptions::default()
@@ -2807,7 +2811,7 @@ mod tests {
         }
 
         async fn build(self) -> TestContext {
-            let handle = tokio::runtime::Handle::current();
+            let handle = Handle::current();
             let options = Arc::new(CompactionWorkerOptions::default());
             let (tx, rx) = async_channel::unbounded();
             let os = Arc::new(InMemory::new());

--- a/slatedb/src/compactor_state.rs
+++ b/slatedb/src/compactor_state.rs
@@ -10,8 +10,10 @@ use ulid::Ulid;
 
 use crate::db_state::{SortedRun, SsTableHandle, SsTableView};
 use crate::error::SlateDBError;
+use crate::manifest;
 use crate::manifest::{Manifest, ManifestCore};
 use crate::subcompaction::Subcompaction;
+use crate::utils;
 use slatedb_txn_obj::DirtyObject;
 
 /// Identifier for a compaction input source.
@@ -634,7 +636,7 @@ impl Display for Compaction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.spec)?;
         if self.bytes_processed > 0 {
-            let human_bytes_processed = crate::utils::format_bytes_si(self.bytes_processed);
+            let human_bytes_processed = utils::format_bytes_si(self.bytes_processed);
             write!(f, " ({} processed)", human_bytes_processed)?;
         }
         // TODO: fix me by implementing Display for CompactionJob
@@ -979,7 +981,7 @@ impl CompactorState {
         let remote = &remote_manifest.value.core;
         let tree = my_db_state.tree.merge_from_writer(&remote.tree);
         let segments =
-            crate::manifest::merge_segments_from_writer(&my_db_state.segments, &remote.segments);
+            manifest::merge_segments_from_writer(&my_db_state.segments, &remote.segments);
         // Segment configuration is stable; the writer is the source of truth.
         let merged = ManifestCore {
             initialized: remote_manifest.value.core.initialized,
@@ -1804,7 +1806,7 @@ mod tests {
         let mut state = CompactorState::new(manifest, compactions);
         let stale_id = SsTableId::Compacted(Ulid::new());
         let mut remote = new_dirty_manifest();
-        remote.value.external_dbs = vec![crate::manifest::ExternalDb {
+        remote.value.external_dbs = vec![manifest::ExternalDb {
             path: "/parent/db".to_string(),
             source_checkpoint_id: uuid::Uuid::new_v4(),
             final_checkpoint_id: Some(uuid::Uuid::new_v4()),
@@ -2065,8 +2067,7 @@ mod tests {
                 compacted: vec![],
             }),
         }];
-        let v1_segments =
-            crate::manifest::merge_segments_from_writer(&compactor_post_drain, &writer_v0);
+        let v1_segments = manifest::merge_segments_from_writer(&compactor_post_drain, &writer_v0);
         assert_eq!(v1_segments.len(), 1);
 
         // V2: writer reads V1 (compactor's manifest). Writer's local view
@@ -2081,7 +2082,7 @@ mod tests {
         // V3: compactor reads writer's V2 (no segments). Compactor's local
         // still holds the marker from V1. The compactor-side merge follows
         // the writer's prune and drops the segment.
-        let v3_segments = crate::manifest::merge_segments_from_writer(&v1_segments, &v2_segments);
+        let v3_segments = manifest::merge_segments_from_writer(&v1_segments, &v2_segments);
         assert!(
             v3_segments.is_empty(),
             "compactor should follow the writer's prune"

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -198,7 +198,8 @@
 use crate::filter_policy::FilterContext;
 use crate::iter::IterationOrder;
 use duration_str::{deserialize_duration, deserialize_option_duration};
-use figment::providers::{Env, Format, Json, Toml, Yaml};
+use figment::providers::{Env, Format, Json, Serialized, Toml, Yaml};
+use figment::value::{Dict, Map};
 use figment::{Figment, Metadata, Provider};
 use log::warn;
 use serde::{Deserialize, Serialize, Serializer};
@@ -1056,10 +1057,8 @@ impl Provider for Settings {
         Metadata::named("SlateDb configuration options")
     }
 
-    fn data(
-        &self,
-    ) -> Result<figment::value::Map<figment::Profile, figment::value::Dict>, figment::Error> {
-        figment::providers::Serialized::defaults(self.clone()).data()
+    fn data(&self) -> Result<Map<figment::Profile, Dict>, figment::Error> {
+        Serialized::defaults(self.clone()).data()
     }
 }
 

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -47,6 +47,7 @@ use crate::batch_write::{BatchWriterMessage, WriteBatchRequest, WRITE_BATCH_TASK
 use crate::bytes_range::{ByteRangeBounds, BytesRange};
 use crate::cached_object_store::CachedObjectStore;
 use crate::clock::MonotonicClock;
+use crate::compaction_worker;
 use crate::config::{
     CloseOptions, FlushOptions, FlushType, MergeOptions, PutOptions, ReadOptions, ScanOptions,
     Settings, WriteOptions,
@@ -69,6 +70,7 @@ use crate::snapshot_manager::SnapshotManager;
 use crate::tablestore::TableStore;
 use crate::transaction_manager::TransactionManager;
 use crate::types::KeyValue;
+use crate::utils;
 use crate::utils::{format_bytes_si, SafeSender, WatchableOnceCellReader};
 use crate::wal_replay::{WalReplayIterator, WalReplayOptions};
 use crate::{DbCacheManagerOps, DbMetadataOps, DbReadOps, DbWriteOps};
@@ -76,6 +78,7 @@ use slatedb_common::clock::SystemClock;
 use slatedb_common::metrics::MetricsRecorderHelper;
 use slatedb_common::DbRand;
 use slatedb_txn_obj::DirtyObject;
+use tokio::sync::{oneshot, watch};
 
 use crate::db_status::{ClosedResultWriter, DbStatusManager, DurabilityWaiter};
 use crate::wal::{WalEvent, WalIterator, WalObserver, WalStatus};
@@ -288,7 +291,7 @@ impl DbInner {
             return Err(SlateDBError::EmptyBatch);
         }
 
-        let (tx, rx) = tokio::sync::oneshot::channel();
+        let (tx, rx) = oneshot::channel();
         let batch_msg = BatchWriterMessage::WriteBatch(WriteBatchRequest {
             batch,
             options: options.clone(),
@@ -552,7 +555,7 @@ impl DbInner {
     ) -> Result<(), SlateDBError> {
         let state = self.state.read().state();
         let cache_opts = &self.settings.object_store_cache_options;
-        crate::utils::preload_cache_from_manifest(
+        utils::preload_cache_from_manifest(
             &state.manifest.value.core,
             cached_obj_store,
             path_resolver,
@@ -721,7 +724,7 @@ impl Db {
 
         if let Err(e) = self
             .task_executor
-            .shutdown_task(crate::compaction_worker::COMPACTION_WORKER_TASK_NAME)
+            .shutdown_task(compaction_worker::COMPACTION_WORKER_TASK_NAME)
             .await
         {
             warn!("failed to shutdown compaction worker task [error={:?}]", e);
@@ -1954,7 +1957,7 @@ impl DbMetadataOps for Db {
         self.inner.manifest()
     }
 
-    fn subscribe(&self) -> tokio::sync::watch::Receiver<DbStatus> {
+    fn subscribe(&self) -> watch::Receiver<DbStatus> {
         self.inner.status_manager.subscribe()
     }
 
@@ -2031,7 +2034,7 @@ impl Db {
     }
 
     /// See [`DbMetadataOps::subscribe`].
-    pub fn subscribe(&self) -> tokio::sync::watch::Receiver<DbStatus> {
+    pub fn subscribe(&self) -> watch::Receiver<DbStatus> {
         <Self as DbMetadataOps>::subscribe(self)
     }
 
@@ -2142,7 +2145,7 @@ impl WriteHandle {
 /// via a [`tokio::sync::watch`] channel.
 #[derive(Clone)]
 pub(crate) struct DbWalObserver {
-    status_rx: tokio::sync::watch::Receiver<Result<WalStatus, WalStatus>>,
+    status_rx: watch::Receiver<Result<WalStatus, WalStatus>>,
     closed_reader: WatchableOnceCellReader<Result<(), SlateDBError>>,
     wrapped: Arc<dyn WalObserver>,
 }
@@ -2154,7 +2157,7 @@ impl DbWalObserver {
         db_state: Arc<RwLock<DbState>>,
         closed_writer: Arc<dyn ClosedResultWriter>,
     ) -> Self {
-        let (status_tx, status_rx) = tokio::sync::watch::channel(wrapped.status());
+        let (status_tx, status_rx) = watch::channel(wrapped.status());
         let closed_reader = closed_writer.result_reader();
         wrapped
             .subscribe(Arc::new(move |event| {

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -118,7 +118,9 @@ use crate::admin::Admin;
 use crate::batch_write::WriteBatchEventHandler;
 use crate::batch_write::WRITE_BATCH_TASK_NAME;
 use crate::block_cache_policy::BlockCachePolicy;
+use crate::bytes_range::BytesRange;
 use crate::cached_object_store::CachedObjectStore;
+use crate::clone;
 use crate::clone::{SegmentFilterFn, SegmentProjectionFn};
 #[cfg(feature = "compaction_filters")]
 use crate::compaction_filter::CompactionFilterSupplier;
@@ -138,6 +140,12 @@ use crate::config::{CompactionWorkerOptions, CompactorOptions};
 use crate::config::{Settings, SstBlockSize};
 use crate::db::Db;
 use crate::db::DbInner;
+#[cfg(any(feature = "foyer", feature = "moka"))]
+use crate::db_cache;
+#[cfg(feature = "foyer")]
+use crate::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
+#[cfg(feature = "moka")]
+use crate::db_cache::moka::{MokaCache, MokaCacheOptions};
 use crate::db_cache::SplitCache;
 use crate::db_cache::{DbCache, DbCacheWrapper, UnownedDbCache};
 use crate::db_reader::{DbReader, DbReaderMode};
@@ -157,6 +165,7 @@ use crate::merge_operator::MergeOperatorType;
 use crate::object_stores::ObjectStoreType;
 use crate::object_stores::ObjectStores;
 use crate::paths::PathResolver;
+use crate::prefix_extractor::PrefixExtractor;
 use crate::retrying_object_store::RetryingObjectStore;
 use crate::tablestore::{TableStore, TableStoreKind};
 use crate::utils::SafeSender;
@@ -195,7 +204,7 @@ pub struct DbBuilder<P: Into<Path>> {
     block_transformer: Option<Arc<dyn BlockTransformer>>,
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
     metrics_recorder: Arc<dyn MetricsRecorder>,
-    segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     wal_writer_init: Option<Box<dyn wal::WriterInit>>,
 }
 
@@ -238,10 +247,7 @@ impl<P: Into<Path>> DbBuilder<P> {
     /// routing for all existing key schemas and keeps segment prefixes across
     /// schema versions an antichain (no prefix may be a proper prefix of
     /// another).
-    pub fn with_segment_extractor(
-        mut self,
-        extractor: Arc<dyn crate::prefix_extractor::PrefixExtractor>,
-    ) -> Self {
+    pub fn with_segment_extractor(mut self, extractor: Arc<dyn PrefixExtractor>) -> Self {
         self.segment_extractor = Some(extractor);
         self
     }
@@ -1668,7 +1674,7 @@ pub struct DbReaderBuilder<P: Into<Path>> {
     merge_operator: Option<MergeOperatorType>,
     block_transformer: Option<Arc<dyn BlockTransformer>>,
     filter_policies: Vec<Arc<dyn FilterPolicy>>,
-    segment_extractor: Option<Arc<dyn crate::prefix_extractor::PrefixExtractor>>,
+    segment_extractor: Option<Arc<dyn PrefixExtractor>>,
     options: DbReaderOptions,
     system_clock: Arc<dyn SystemClock>,
     rand: Arc<DbRand>,
@@ -1726,10 +1732,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
     /// re-derives each WAL-replayed entry's segment prefix so that in-memory
     /// segments are reported via [`DbReader::subscribe`]. Must match the
     /// extractor the database was created with.
-    pub fn with_segment_extractor(
-        mut self,
-        extractor: Arc<dyn crate::prefix_extractor::PrefixExtractor>,
-    ) -> Self {
+    pub fn with_segment_extractor(mut self, extractor: Arc<dyn PrefixExtractor>) -> Self {
         self.segment_extractor = Some(extractor);
         self
     }
@@ -2093,13 +2096,11 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
     {
         self.segment_projection = Some(Arc::new(move |prefix| {
             let r = f(prefix);
-            crate::bytes_range::BytesRange::try_new(
-                r.start_bound().cloned(),
-                r.end_bound().cloned(),
-            )
-            .ok_or_else(|| SlateDBError::InvalidProjection {
-                prefix: Bytes::copy_from_slice(prefix),
-                reason: "empty range".into(),
+            BytesRange::try_new(r.start_bound().cloned(), r.end_bound().cloned()).ok_or_else(|| {
+                SlateDBError::InvalidProjection {
+                    prefix: Bytes::copy_from_slice(prefix),
+                    reason: "empty range".into(),
+                }
             })
         }));
         self
@@ -2126,7 +2127,7 @@ impl<R: RangeBounds<Bytes> + Clone> CloneBuilder<R> {
                 fp_registry.clone(),
             ))
         };
-        crate::clone::create_clone(
+        clone::create_clone(
             self.sources,
             self.clone_path,
             self.object_store,
@@ -2171,22 +2172,18 @@ fn instrumented_retrying_object_store(
 pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "foyer")]
     {
-        return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
-            crate::db_cache::foyer::FoyerCacheOptions {
-                max_capacity: crate::db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
-                ..Default::default()
-            },
-        )));
+        return Some(Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
+            max_capacity: db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
+            ..Default::default()
+        })));
     }
     #[cfg(feature = "moka")]
     {
-        return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
-            crate::db_cache::moka::MokaCacheOptions {
-                max_capacity: crate::db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
-                time_to_live: None,
-                time_to_idle: None,
-            },
-        )));
+        return Some(Arc::new(MokaCache::new_with_opts(MokaCacheOptions {
+            max_capacity: db_cache::DEFAULT_BLOCK_CACHE_CAPACITY,
+            time_to_live: None,
+            time_to_idle: None,
+        })));
     }
     None
 }
@@ -2195,22 +2192,18 @@ pub(crate) fn default_block_cache() -> Option<Arc<dyn DbCache>> {
 pub(crate) fn default_meta_cache() -> Option<Arc<dyn DbCache>> {
     #[cfg(feature = "foyer")]
     {
-        return Some(Arc::new(crate::db_cache::foyer::FoyerCache::new_with_opts(
-            crate::db_cache::foyer::FoyerCacheOptions {
-                max_capacity: crate::db_cache::DEFAULT_META_CACHE_CAPACITY,
-                ..Default::default()
-            },
-        )));
+        return Some(Arc::new(FoyerCache::new_with_opts(FoyerCacheOptions {
+            max_capacity: db_cache::DEFAULT_META_CACHE_CAPACITY,
+            ..Default::default()
+        })));
     }
     #[cfg(feature = "moka")]
     {
-        return Some(Arc::new(crate::db_cache::moka::MokaCache::new_with_opts(
-            crate::db_cache::moka::MokaCacheOptions {
-                max_capacity: crate::db_cache::DEFAULT_META_CACHE_CAPACITY,
-                time_to_live: None,
-                time_to_idle: None,
-            },
-        )));
+        return Some(Arc::new(MokaCache::new_with_opts(MokaCacheOptions {
+            max_capacity: db_cache::DEFAULT_META_CACHE_CAPACITY,
+            time_to_live: None,
+            time_to_idle: None,
+        })));
     }
     None
 }

--- a/slatedb/src/db_cache/moka.rs
+++ b/slatedb/src/db_cache/moka.rs
@@ -31,6 +31,7 @@
 //!
 use crate::db_cache::{CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
 use async_trait::async_trait;
+use moka::future::Cache;
 use std::time::Duration;
 
 /// The options for the Moka cache.
@@ -67,7 +68,7 @@ impl Default for MokaCacheOptions {
 /// including settings for capacity, time-to-live (TTL), and time-to-idle (TTI).
 /// It uses a custom weigher to account for the size of cached blocks.
 pub struct MokaCache {
-    inner: moka::future::Cache<CachedKey, CachedEntry>,
+    inner: Cache<CachedKey, CachedEntry>,
 }
 
 impl MokaCache {
@@ -76,7 +77,7 @@ impl MokaCache {
     }
 
     pub fn new_with_opts(options: MokaCacheOptions) -> Self {
-        let mut builder = moka::future::Cache::builder()
+        let mut builder = Cache::builder()
             .weigher(|_, v: &CachedEntry| v.size() as u32)
             .max_capacity(options.max_capacity);
 

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -15,6 +15,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::VecDeque;
 use std::ops::RangeBounds;
+use tokio::task::coop;
 
 /// [`DbIteratorRangeTracker`] records the *requested* scan range of a
 /// [`DbIterator`] so that the transaction manager can detect read-write
@@ -284,7 +285,7 @@ impl DbIterator {
             let result = loop {
                 let next = self.iter.next().await;
                 // Keep cached iteration cooperative.
-                tokio::task::coop::consume_budget().await;
+                coop::consume_budget().await;
                 match next {
                     Ok(Some(entry)) => match entry.value {
                         ValueDeletable::Tombstone => continue,
@@ -425,7 +426,7 @@ impl DbRecencyIterator {
 
             let next = iter.next().await;
             // Keep cached iteration cooperative.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
             match next {
                 Ok(Some(entry)) => return Ok(Some(entry)),
                 Ok(None) => {

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -4,6 +4,7 @@ use {
         cached_object_store::CachedObjectStore,
         clock::MonotonicClock,
         config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions},
+        db::builder::DbReaderBuilder,
         db_cache::CacheTarget,
         db_cache_manager,
         db_common::extract_segment_prefix,
@@ -24,7 +25,8 @@ use {
         reader::{DbStateReader, Reader, ScanContext},
         tablestore::TableStore,
         types::KeyValue,
-        utils::IdGenerator,
+        utils::{self, IdGenerator},
+        wal::reader::SlateDbWalReader,
         wal::WalReader as WalReaderTrait,
         wal_replay::{WalReplayIterator, WalReplayOptions},
         Checkpoint, DbCacheManagerOps, DbIterator, DbMetadataOps, DbReadOps,
@@ -35,13 +37,13 @@ use {
     log::{info, warn},
     object_store::{path::Path, ObjectStore},
     parking_lot::RwLock,
-    slatedb_common::{clock::SystemClock, DbRand},
+    slatedb_common::{clock::SystemClock, metrics::MetricsRecorderHelper, DbRand},
     std::{
         collections::{BTreeSet, VecDeque},
         ops::Sub,
         sync::{Arc, LazyLock},
     },
-    tokio::runtime::Handle,
+    tokio::{runtime::Handle, sync::watch},
     uuid::Uuid,
 };
 
@@ -128,7 +130,7 @@ struct DbReaderInner {
     /// metric handles in `DbStats` (and other stats structs) are still in use.
     /// See: https://github.com/slatedb/slatedb/issues/1469
     #[allow(dead_code)]
-    recorder: slatedb_common::metrics::MetricsRecorderHelper,
+    recorder: MetricsRecorderHelper,
 }
 
 #[derive(Debug)]
@@ -179,14 +181,11 @@ impl DbReaderInner {
         segment_extractor: Option<Arc<dyn PrefixExtractor>>,
         system_clock: Arc<dyn SystemClock>,
         rand: Arc<DbRand>,
-        recorder: slatedb_common::metrics::MetricsRecorderHelper,
+        recorder: MetricsRecorderHelper,
         mut manifest: StoredManifest,
     ) -> Result<Self, SlateDBError> {
-        let wal_reader = wal_reader.unwrap_or_else(|| {
-            Arc::new(crate::wal::reader::SlateDbWalReader::new(Arc::clone(
-                &table_store,
-            )))
-        });
+        let wal_reader =
+            wal_reader.unwrap_or_else(|| Arc::new(SlateDbWalReader::new(Arc::clone(&table_store))));
         let checkpoint =
             Self::get_or_create_checkpoint(&mut manifest, mode, &options, rand.clone()).await?;
         let (manifest_id, initial_manifest) = if let Some(checkpoint) = checkpoint.as_ref() {
@@ -877,7 +876,7 @@ impl DbReader {
         let external_ssts = state.manifest.external_ssts();
         let path_resolver = PathResolver::new_with_external_ssts(path, external_ssts);
         let cache_opts = &self.inner.options.object_store_cache_options;
-        crate::utils::preload_cache_from_manifest(
+        utils::preload_cache_from_manifest(
             &state.manifest.core,
             cached_obj_store,
             &path_resolver,
@@ -941,8 +940,8 @@ impl DbReader {
     pub fn builder<P: Into<Path>>(
         path: P,
         object_store: Arc<dyn ObjectStore>,
-    ) -> crate::db::builder::DbReaderBuilder<P> {
-        crate::db::builder::DbReaderBuilder::new(path, object_store)
+    ) -> DbReaderBuilder<P> {
+        DbReaderBuilder::new(path, object_store)
     }
 
     pub(crate) async fn open_internal(
@@ -955,7 +954,7 @@ impl DbReader {
         options: DbReaderOptions,
         system_clock: Arc<dyn SystemClock>,
         rand: Arc<DbRand>,
-        recorder: slatedb_common::metrics::MetricsRecorderHelper,
+        recorder: MetricsRecorderHelper,
     ) -> Result<Self, SlateDBError> {
         Self::validate_options(mode, &options)?;
 
@@ -1412,7 +1411,7 @@ impl DbMetadataOps for DbReader {
         VersionedManifest::from(state.as_ref())
     }
 
-    fn subscribe(&self) -> tokio::sync::watch::Receiver<DbStatus> {
+    fn subscribe(&self) -> watch::Receiver<DbStatus> {
         self.inner.status_manager.subscribe()
     }
 
@@ -1428,7 +1427,7 @@ impl DbReader {
     }
 
     /// See [`DbMetadataOps::subscribe`].
-    pub fn subscribe(&self) -> tokio::sync::watch::Receiver<DbStatus> {
+    pub fn subscribe(&self) -> watch::Receiver<DbStatus> {
         <Self as DbMetadataOps>::subscribe(self)
     }
 

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -1,6 +1,7 @@
 use crate::bytes_range::BytesRange;
 use crate::config::CompressionCodec;
 use crate::error::SlateDBError;
+use crate::manifest;
 use crate::manifest::{Manifest, ManifestCore};
 use crate::mem_table::{ImmutableMemtable, KVTable, WritableKVTable};
 use crate::reader::DbStateReader;
@@ -823,7 +824,7 @@ impl<'a> StateModifier<'a> {
         let remote = &remote_manifest.value.core;
         let tree = my_db_state.tree.merge_from_compactor(&remote.tree);
         let segments =
-            crate::manifest::merge_segments_from_compactor(&my_db_state.segments, &remote.segments);
+            manifest::merge_segments_from_compactor(&my_db_state.segments, &remote.segments);
         remote_manifest.value.core = ManifestCore {
             initialized: my_db_state.initialized,
             tree: Arc::new(tree),

--- a/slatedb/src/dispatcher.rs
+++ b/slatedb/src/dispatcher.rs
@@ -124,7 +124,7 @@ use crossbeam_skiplist::SkipMap;
 use fail_parallel::{fail_point, FailPointRegistry};
 use futures::{
     future::BoxFuture,
-    stream::{BoxStream, FuturesUnordered},
+    stream::{self, BoxStream, FuturesUnordered},
     FutureExt, StreamExt,
 };
 use log::error;
@@ -394,7 +394,7 @@ impl<T: Send + std::fmt::Debug> MessageDispatcher<T> {
             Err(SlateDBError::Fenced)
         });
         self.rx.close();
-        let messages = futures::stream::unfold(&mut self.rx, |rx| async move {
+        let messages = stream::unfold(&mut self.rx, |rx| async move {
             rx.recv().await.ok().map(|message| (message, rx))
         });
         self.handler.cleanup(Box::pin(messages), result).await

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -4,9 +4,12 @@ use std::ops::Bound;
 use std::time::Duration;
 use std::{path::PathBuf, sync::Arc};
 use thiserror::Error as ThisError;
+use tokio::sync::oneshot::error::RecvError;
 use uuid::Uuid;
 
 use crate::bytes_range::BytesRange;
+#[cfg(feature = "compaction_filters")]
+use crate::compaction_filter::CompactionFilterError;
 use crate::error::SlateDBError::{
     LatestTransactionalObjectVersionMissing, TransactionalObjectVersionExists,
 };
@@ -156,7 +159,7 @@ pub(crate) enum SlateDBError {
     },
 
     #[error("read channel error")]
-    ReadChannelError(#[from] tokio::sync::oneshot::error::RecvError),
+    ReadChannelError(#[from] RecvError),
 
     #[error("background task panicked. name=`{0}`")]
     BackgroundTaskPanic(String),
@@ -290,7 +293,7 @@ pub(crate) enum SlateDBError {
 
     #[cfg(feature = "compaction_filters")]
     #[error("compaction filter error: {0}")]
-    CompactionFilterError(Arc<crate::compaction_filter::CompactionFilterError>),
+    CompactionFilterError(Arc<CompactionFilterError>),
 
     #[error("invalid sequence number ordering during merge. expected sequence numbers in descending order, but found {current_seq} followed by {next_seq}")]
     InvalidSequenceOrder { current_seq: u64, next_seq: u64 },
@@ -419,8 +422,8 @@ impl From<foyer::Error> for SlateDBError {
 }
 
 #[cfg(feature = "compaction_filters")]
-impl From<crate::compaction_filter::CompactionFilterError> for SlateDBError {
-    fn from(value: crate::compaction_filter::CompactionFilterError) -> Self {
+impl From<CompactionFilterError> for SlateDBError {
+    fn from(value: CompactionFilterError) -> Self {
         Self::CompactionFilterError(Arc::new(value))
     }
 }

--- a/slatedb/src/filter_iterator.rs
+++ b/slatedb/src/filter_iterator.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use tokio::task::coop;
 
 use crate::error::SlateDBError;
 use crate::iter::RowEntryIterator;
@@ -42,7 +43,7 @@ impl<T: RowEntryIterator> RowEntryIterator for FilterIterator<T> {
                 return Ok(Some(entry));
             }
             // Keep filtered scans cooperative.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
         }
         Ok(None)
     }

--- a/slatedb/src/flatbuffer_types.rs
+++ b/slatedb/src/flatbuffer_types.rs
@@ -12,6 +12,7 @@ use ulid::Ulid;
 
 use crate::bytes_range::BytesRange;
 use crate::checkpoint;
+use crate::compactor_state;
 use crate::compactor_state::{
     Compaction as CompactorCompaction, CompactionContext as CompactorCompactionContext,
     CompactionSpec as CompactorCompactionSpec, CompactionStatus,
@@ -654,14 +655,12 @@ impl FlatBufferCompactionsCodec {
         CompactorSubcompaction::new(range).with_output_ssts(output_ssts)
     }
 
-    fn worker_spec(
-        worker: root_generated::WorkerSpec,
-    ) -> Option<crate::compactor_state::WorkerSpec> {
+    fn worker_spec(worker: root_generated::WorkerSpec) -> Option<compactor_state::WorkerSpec> {
         // worker_id is the discriminator for "claimed" vs "unclaimed"; treat a
         // missing string as unclaimed even if the table itself was emitted.
-        worker.worker_id().map(|id| {
-            crate::compactor_state::WorkerSpec::new(id.to_string(), worker.last_heartbeat_ms())
-        })
+        worker
+            .worker_id()
+            .map(|id| compactor_state::WorkerSpec::new(id.to_string(), worker.last_heartbeat_ms()))
     }
 
     fn compaction_spec(
@@ -1167,7 +1166,7 @@ impl<'b> DbFlatBufferBuilder<'b> {
 
     fn add_worker_spec(
         &mut self,
-        worker: &crate::compactor_state::WorkerSpec,
+        worker: &compactor_state::WorkerSpec,
     ) -> WIPOffset<root_generated::WorkerSpec<'b>> {
         let worker_id = self.builder.create_string(&worker.worker_id);
         root_generated::WorkerSpec::create(

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -11,6 +11,7 @@ use crate::reader::DbStateReader;
 use crate::retention_iterator::RetentionIterator;
 use bytes::Bytes;
 use std::sync::Arc;
+use tokio::task::coop;
 
 /// One encoded-but-not-yet-uploaded SST from a memtable flush, tagged with
 /// the segment it belongs to (RFC-0024). Mirrors the shape of post-upload
@@ -38,7 +39,7 @@ impl DbInner {
             sst_builder.add(entry).await?;
             any = true;
             // Keep cached flush work cooperative.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
         }
         if !any {
             return Ok(None);
@@ -134,7 +135,7 @@ impl DbInner {
             current_builder.add(entry).await?;
             current_has_entry = true;
             // Keep cached flush work cooperative.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
         }
         if current_has_entry {
             out.push(EncodedSegmentSst {

--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -1,6 +1,7 @@
 use crate::blob::ReadOnlyBlob;
 use crate::config::CompressionCodec;
 use crate::db_state::{FilterFormat, SsTableInfo, SsTableInfoCodec, SstType};
+use crate::error::Error;
 use crate::error::SlateDBError;
 use crate::filter_policy::{BloomFilterPolicy, FilterPolicy, NamedFilter};
 use crate::flatbuffer_types::{
@@ -9,12 +10,22 @@ use crate::flatbuffer_types::{
 use crate::format::block::{Block, BlockBuilderV1};
 use crate::format::block_v2::BlockBuilderV2;
 use crate::format::row;
+use crate::sst_builder::BlockFormat;
 use crate::sst_stats::{BlockStats, SstStats};
+use crate::types::{RowEntry, ValueDeletable};
 use async_trait::async_trait;
 use bytes::{Buf, BufMut, Bytes};
 use flatbuffers::DefaultAllocator;
+#[cfg(feature = "zlib")]
+use flate2::read::ZlibDecoder;
+#[cfg(feature = "zlib")]
+use flate2::write::ZlibEncoder;
 use futures::future::try_join_all;
 use log::warn;
+#[cfg(feature = "lz4")]
+use lz4_flex::block;
+#[cfg(feature = "snappy")]
+use snap::raw::{Decoder, Encoder};
 use std::collections::VecDeque;
 #[cfg(feature = "zlib")]
 use std::io::Read;
@@ -22,6 +33,11 @@ use std::io::Read;
 use std::io::Write;
 use std::ops::Range;
 use std::sync::Arc;
+use tokio::task::coop;
+#[cfg(feature = "zstd")]
+use zstd::bulk;
+#[cfg(feature = "zstd")]
+use zstd::stream;
 
 // 8 bytes for the metadata offset + 2 bytes for the version
 const NUM_FOOTER_BYTES: usize = 10;
@@ -62,14 +78,14 @@ impl BlockBuilder {
         ))
     }
 
-    pub(crate) fn would_fit(&self, entry: &crate::types::RowEntry) -> bool {
+    pub(crate) fn would_fit(&self, entry: &RowEntry) -> bool {
         match self {
             Self::V1(builder) => builder.would_fit(entry),
             Self::V2(builder) => builder.would_fit(entry),
         }
     }
 
-    pub(crate) fn add(&mut self, entry: crate::types::RowEntry) -> Result<bool, SlateDBError> {
+    pub(crate) fn add(&mut self, entry: RowEntry) -> Result<bool, SlateDBError> {
         match self {
             Self::V1(builder) => builder.add(entry),
             Self::V2(builder) => builder.add(entry),
@@ -118,15 +134,15 @@ impl BlockBuilderWithStats {
         }
     }
 
-    pub(crate) fn would_fit(&self, entry: &crate::types::RowEntry) -> bool {
+    pub(crate) fn would_fit(&self, entry: &RowEntry) -> bool {
         self.builder.would_fit(entry)
     }
 
-    pub(crate) fn add(&mut self, entry: crate::types::RowEntry) -> Result<bool, SlateDBError> {
+    pub(crate) fn add(&mut self, entry: RowEntry) -> Result<bool, SlateDBError> {
         match &entry.value {
-            crate::types::ValueDeletable::Value(_) => self.stats.num_puts += 1,
-            crate::types::ValueDeletable::Merge(_) => self.stats.num_merges += 1,
-            crate::types::ValueDeletable::Tombstone => self.stats.num_deletes += 1,
+            ValueDeletable::Value(_) => self.stats.num_puts += 1,
+            ValueDeletable::Merge(_) => self.stats.num_merges += 1,
+            ValueDeletable::Tombstone => self.stats.num_deletes += 1,
         }
         self.builder.add(entry)
     }
@@ -185,10 +201,10 @@ pub(crate) const VERSION_SIZE: usize = SIZEOF_U16;
 #[async_trait]
 pub trait BlockTransformer: Send + Sync {
     /// Encode (transform) block data before storage.
-    async fn encode(&self, data: Bytes) -> Result<Bytes, crate::error::Error>;
+    async fn encode(&self, data: Bytes) -> Result<Bytes, Error>;
 
     /// Decode (inverse transform) block data after retrieval.
-    async fn decode(&self, data: Bytes) -> Result<Bytes, crate::error::Error>;
+    async fn decode(&self, data: Bytes) -> Result<Bytes, Error>;
 }
 
 impl SsTableInfo {
@@ -533,7 +549,7 @@ pub(crate) async fn compress_and_transform(
         Some(c) => {
             let compressed = compress(data, c)?;
             // Account for CPU-only compression work.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
             compressed
         }
     };
@@ -561,15 +577,14 @@ pub(crate) fn compress(
     match c {
         #[cfg(feature = "snappy")]
         CompressionCodec::Snappy => {
-            let compressed = snap::raw::Encoder::new()
+            let compressed = Encoder::new()
                 .compress_vec(&data)
                 .map_err(|_| SlateDBError::BlockCompressionError)?;
             Ok(Bytes::from(compressed))
         }
         #[cfg(feature = "zlib")]
         CompressionCodec::Zlib => {
-            let mut encoder =
-                flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+            let mut encoder = ZlibEncoder::new(Vec::new(), flate2::Compression::default());
             encoder
                 .write_all(&data)
                 .map_err(|_| SlateDBError::BlockCompressionError)?;
@@ -581,13 +596,13 @@ pub(crate) fn compress(
         }
         #[cfg(feature = "lz4")]
         CompressionCodec::Lz4 => {
-            let compressed = lz4_flex::block::compress_prepend_size(&data);
+            let compressed = block::compress_prepend_size(&data);
             Ok(Bytes::from(compressed))
         }
         #[cfg(feature = "zstd")]
         CompressionCodec::Zstd => {
             let compressed =
-                zstd::bulk::compress(&data, 3).map_err(|_| SlateDBError::BlockCompressionError)?;
+                bulk::compress(&data, 3).map_err(|_| SlateDBError::BlockCompressionError)?;
             Ok(Bytes::from(compressed))
         }
     }
@@ -605,7 +620,7 @@ pub(crate) async fn transform(
                 .await
                 .map_err(|_| SlateDBError::BlockTransformError)?;
             // Account for CPU-only transformation work.
-            tokio::task::coop::consume_budget().await;
+            coop::consume_budget().await;
             transformed
         }
         None => data,
@@ -625,7 +640,7 @@ pub(crate) struct SsTableFormat {
     pub(crate) filter_policies: Vec<Arc<dyn FilterPolicy>>,
     pub(crate) compression_codec: Option<CompressionCodec>,
     pub(crate) block_transformer: Option<Arc<dyn BlockTransformer>>,
-    pub(crate) block_format: Option<crate::sst_builder::BlockFormat>,
+    pub(crate) block_format: Option<BlockFormat>,
 }
 
 impl Default for SsTableFormat {
@@ -888,13 +903,13 @@ impl SsTableFormat {
         match compression_option {
             #[cfg(feature = "snappy")]
             CompressionCodec::Snappy => Ok(Bytes::from(
-                snap::raw::Decoder::new()
+                Decoder::new()
                     .decompress_vec(&compressed_data)
                     .map_err(|_| SlateDBError::BlockDecompressionError)?,
             )),
             #[cfg(feature = "zlib")]
             CompressionCodec::Zlib => {
-                let mut decoder = flate2::read::ZlibDecoder::new(&compressed_data[..]);
+                let mut decoder = ZlibDecoder::new(&compressed_data[..]);
                 let mut decompressed = Vec::new();
                 decoder
                     .read_to_end(&mut decompressed)
@@ -903,13 +918,13 @@ impl SsTableFormat {
             }
             #[cfg(feature = "lz4")]
             CompressionCodec::Lz4 => {
-                let decompressed = lz4_flex::block::decompress_size_prepended(&compressed_data)
+                let decompressed = block::decompress_size_prepended(&compressed_data)
                     .map_err(|_| SlateDBError::BlockDecompressionError)?;
                 Ok(Bytes::from(decompressed))
             }
             #[cfg(feature = "zstd")]
             CompressionCodec::Zstd => {
-                let decompressed = zstd::stream::decode_all(&compressed_data[..])
+                let decompressed = stream::decode_all(&compressed_data[..])
                     .map_err(|_| SlateDBError::BlockDecompressionError)?;
                 Ok(Bytes::from(decompressed))
             }

--- a/slatedb/src/garbage_collector/compacted_gc.rs
+++ b/slatedb/src/garbage_collector/compacted_gc.rs
@@ -9,6 +9,7 @@ use crate::{
     tablestore::TableStore,
 };
 use chrono::{DateTime, Utc};
+use futures::stream;
 use futures::StreamExt;
 use log::error;
 use std::collections::HashSet;
@@ -126,7 +127,7 @@ impl CompactedGcTask {
             return;
         }
 
-        futures::stream::iter(sst_ids)
+        stream::iter(sst_ids)
             .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
                 log::info!("deleting SST [id={:?}]", id);
                 if let Err(e) = self.table_store.delete_sst(&id).await {

--- a/slatedb/src/garbage_collector/compactions_gc.rs
+++ b/slatedb/src/garbage_collector/compactions_gc.rs
@@ -23,6 +23,7 @@ use crate::{
     error::SlateDBError,
 };
 use chrono::{DateTime, Utc};
+use futures::stream;
 use futures::StreamExt;
 use log::error;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -93,7 +94,7 @@ impl CompactionsGcTask {
         }
 
         let deleted_count = AtomicU64::new(0);
-        futures::stream::iter(compactions_ids)
+        stream::iter(compactions_ids)
             .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| {
                 let deleted_count = &deleted_count;
                 async move {

--- a/slatedb/src/garbage_collector/manifest_gc.rs
+++ b/slatedb/src/garbage_collector/manifest_gc.rs
@@ -2,6 +2,7 @@ use crate::{
     config::GarbageCollectorDirectoryOptions, error::SlateDBError, manifest::store::ManifestStore,
 };
 use chrono::{DateTime, Utc};
+use futures::stream;
 use futures::StreamExt;
 use log::error;
 use std::collections::HashSet;
@@ -70,7 +71,7 @@ impl ManifestGcTask {
         }
 
         let deleted_count = AtomicU64::new(0);
-        futures::stream::iter(manifest_ids)
+        stream::iter(manifest_ids)
             .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| {
                 let deleted_count = &deleted_count;
                 async move {

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(test, allow(clippy::unwrap_used))]
+#![warn(clippy::absolute_paths)]
+#![cfg_attr(test, allow(clippy::absolute_paths))]
 #![warn(clippy::panic)]
 #![cfg_attr(test, allow(clippy::panic))]
 #![allow(clippy::result_large_err, clippy::too_many_arguments)]

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -8,10 +8,12 @@ use crate::bytes_range::BytesRange;
 use crate::checkpoint::Checkpoint;
 use crate::clone::{CloneSource, SegmentFilterFn, SegmentProjectionFn};
 use crate::error::SlateDBError;
+use crate::prefix_extractor::{PrefixExtractor, PrefixTarget};
 use crate::seq_tracker::SequenceTracker;
 use crate::utils::IdGenerator;
 use bytes::Bytes;
 use log::{debug, warn};
+use object_store::path::Path;
 use serde::Serialize;
 use slatedb_common::DbRand;
 use slatedb_txn_obj::DirtyObject;
@@ -596,7 +598,7 @@ impl ManifestCore {
     /// - both `Some` but `name()` differs → reject.
     pub(crate) fn validate_extractor_configuration(
         &self,
-        configured: Option<&dyn crate::prefix_extractor::PrefixExtractor>,
+        configured: Option<&dyn PrefixExtractor>,
     ) -> Result<(), SlateDBError> {
         let persisted = self.segment_extractor_name.as_deref();
         let configured_name = configured.map(|e| e.name());
@@ -619,12 +621,10 @@ impl ManifestCore {
     /// no longer assign `p`-keys to the segment they currently live in.
     fn validate_segment_prefixes_recognized(
         &self,
-        extractor: &dyn crate::prefix_extractor::PrefixExtractor,
+        extractor: &dyn PrefixExtractor,
     ) -> Result<(), SlateDBError> {
         for segment in &self.segments {
-            let n = extractor.prefix_len(&crate::prefix_extractor::PrefixTarget::Prefix(
-                segment.prefix.clone(),
-            ));
+            let n = extractor.prefix_len(&PrefixTarget::Prefix(segment.prefix.clone()));
             if n != Some(segment.prefix.len()) {
                 return Err(SlateDBError::SegmentPrefixNotRecognized {
                     prefix: segment.prefix.clone(),
@@ -935,7 +935,7 @@ impl VersionedManifest {
         &self.manifest.core
     }
 
-    pub(crate) fn external_ssts(&self) -> HashMap<SsTableId, object_store::path::Path> {
+    pub(crate) fn external_ssts(&self) -> HashMap<SsTableId, Path> {
         self.manifest.external_ssts()
     }
 
@@ -1517,7 +1517,7 @@ pub struct ExternalDb {
 
 impl Manifest {
     /// Returns a map from SST ID to the external DB path for all external SSTs.
-    pub(crate) fn external_ssts(&self) -> HashMap<SsTableId, object_store::path::Path> {
+    pub(crate) fn external_ssts(&self) -> HashMap<SsTableId, Path> {
         let mut external_ssts = HashMap::new();
         for external_db in &self.external_dbs {
             for id in &external_db.sst_ids {

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::Ordering::SeqCst;
 
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
+use tokio::task::coop;
 
 use crate::db_common::extract_segment_prefix;
 use crate::error::SlateDBError;
@@ -213,7 +214,7 @@ impl RowEntryIterator for MemTableIterator {
             if front.is_some_and(|record| record.key < next_key) {
                 self.next_sync();
                 // Keep in-memory seeking cooperative.
-                tokio::task::coop::consume_budget().await;
+                coop::consume_budget().await;
             } else {
                 return Ok(());
             }

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -20,7 +20,9 @@ use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
 use crate::db_state::{collect_touched_segments, DbState, SsTableId, SsTableView};
+use crate::db_status::{ClosedResultWriter, DbStatus};
 use crate::dispatcher::MessageHandler;
+use crate::dispatcher::{MessageHandlerExecutor, MessageTickerDef, Notifier};
 use crate::error::SlateDBError;
 use crate::manifest::store::FenceableManifest;
 use crate::manifest::Manifest;
@@ -107,8 +109,8 @@ impl ManifestWriter {
         db: Arc<DbInner>,
         manifest: FenceableManifest,
         manifest_poll_interval: Duration,
-        closed_result: &dyn crate::db_status::ClosedResultWriter,
-        executor: &crate::dispatcher::MessageHandlerExecutor,
+        closed_result: &dyn ClosedResultWriter,
+        executor: &MessageHandlerExecutor,
         tokio_handle: &Handle,
         tracker_tx: SafeSender<TrackerMessage>,
     ) -> Result<Self, SlateDBError> {
@@ -192,7 +194,7 @@ impl ManifestWriter {
         )
     }
 
-    pub(crate) async fn shutdown(executor: &crate::dispatcher::MessageHandlerExecutor) {
+    pub(crate) async fn shutdown(executor: &MessageHandlerExecutor) {
         if let Err(e) = executor.shutdown_task(MANIFEST_WRITER_TASK_NAME).await {
             log::warn!("failed to shutdown l0 manifest writer [error={:?}]", e);
         }
@@ -210,7 +212,7 @@ struct ManifestWriterHandler {
     durable_seq: u64,
     /// Watches the database status so the manifest write can wait for
     /// WAL durability without blocking uploads.
-    db_status_rx: watch::Receiver<crate::db_status::DbStatus>,
+    db_status_rx: watch::Receiver<DbStatus>,
     pending_flushes: Vec<PendingFlush>,
     pending_checkpoints: Vec<PendingCheckpoint>,
     pending_manifest_refreshes: Vec<oneshot::Sender<Result<(), SlateDBError>>>,
@@ -218,14 +220,14 @@ struct ManifestWriterHandler {
 
 #[async_trait]
 impl MessageHandler<ManifestWriterCommand> for ManifestWriterHandler {
-    fn tickers(&mut self) -> Vec<crate::dispatcher::MessageTickerDef<ManifestWriterCommand>> {
-        vec![crate::dispatcher::MessageTickerDef::new(
+    fn tickers(&mut self) -> Vec<MessageTickerDef<ManifestWriterCommand>> {
+        vec![MessageTickerDef::new(
             self.manifest_poll_interval,
             Box::new(|| ManifestWriterCommand::PollManifest { done: None }),
         )]
     }
 
-    fn notifiers(&mut self) -> Vec<Box<dyn crate::dispatcher::Notifier<ManifestWriterCommand>>> {
+    fn notifiers(&mut self) -> Vec<Box<dyn Notifier<ManifestWriterCommand>>> {
         vec![Box::new(DurableSeqNotifier {
             rx: self.db_status_rx.clone(),
         })]
@@ -869,11 +871,11 @@ struct PendingCheckpoint {
 /// that produces [ManifestWriterCommand::DurableSeqAdvanced] whenever the
 /// database status changes (which includes WAL durable sequence advances).
 struct DurableSeqNotifier {
-    rx: watch::Receiver<crate::db_status::DbStatus>,
+    rx: watch::Receiver<DbStatus>,
 }
 
 #[async_trait]
-impl crate::dispatcher::Notifier<ManifestWriterCommand> for DurableSeqNotifier {
+impl Notifier<ManifestWriterCommand> for DurableSeqNotifier {
     async fn notify(&mut self) -> ManifestWriterCommand {
         // changed() returns Err only when the sender is dropped. In that case
         // the database is shutting down and the dispatcher's cancellation token

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -21,6 +21,7 @@ use slatedb_common::metrics::{CounterFn, MetricsRecorderHelper};
 use crate::checkpoint::CheckpointCreateResult;
 use crate::config::CheckpointOptions;
 use crate::db::DbInner;
+use crate::db_state;
 use crate::dispatcher::MessageHandler;
 use crate::error::SlateDBError;
 use crate::mem_table::ImmutableMemtable;
@@ -284,7 +285,7 @@ impl FlushTracker {
                 core.trees().fold((0_usize, 0_usize), |(len, peak), tree| {
                     (
                         len.max(tree.l0.len()),
-                        peak.max(crate::db_state::max_l0_overlap(&tree.l0)),
+                        peak.max(db_state::max_l0_overlap(&tree.l0)),
                     )
                 });
             let reserved = self.frontier.reserved_l0_slots();
@@ -310,7 +311,7 @@ impl FlushTracker {
                 match core.segments.binary_search_by(|s| s.prefix.cmp(prefix)) {
                     Ok(idx) => {
                         let tree = &core.segments[idx].tree;
-                        (tree.l0.len(), crate::db_state::max_l0_overlap(&tree.l0))
+                        (tree.l0.len(), db_state::max_l0_overlap(&tree.l0))
                     }
                     Err(_) => (0, 0),
                 };

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -22,6 +22,7 @@ use crate::mem_table::ImmutableMemtable;
 use crate::utils::SafeSender;
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::future;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use log::{info, warn};
@@ -208,7 +209,7 @@ impl UploadHandler {
         // on the first fatal error and drops the remaining futures; sibling
         // uploads that already landed before the abort are left for the
         // garbage collector to reclaim.
-        let segments = futures::future::try_join_all(built.iter().map(|sst| {
+        let segments = future::try_join_all(built.iter().map(|sst| {
             // Ids are pre-allocated at dispatch keyed by segment prefix. Every
             // built prefix is a subset of the dispatched touched set, so a
             // missing id is an internal invariant violation.

--- a/slatedb/src/merge_iterator.rs
+++ b/slatedb/src/merge_iterator.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::future;
 
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator, TrackedRowEntryIterator};
@@ -222,7 +223,7 @@ impl RowEntryIterator for MergeIterator<'_> {
             seek_futures.push_back(iterator.0.seek(next_key));
         }
 
-        for seek_result in futures::future::join_all(seek_futures).await {
+        for seek_result in future::join_all(seek_futures).await {
             if let Some(seeked_iterator) = seek_result? {
                 self.iterators.push(Reverse(seeked_iterator));
             }

--- a/slatedb/src/merge_operator.rs
+++ b/slatedb/src/merge_operator.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use slatedb_common::metrics::CounterFn;
 use thiserror::Error;
+use tokio::task::coop;
 
 use crate::{
     error::SlateDBError,
@@ -404,7 +405,7 @@ impl<T: RowEntryIterator> MergeOperatorIterator<T> {
 
                 next = self.delegate.next().await?;
                 // Keep cached operand scans cooperative.
-                tokio::task::coop::consume_budget().await;
+                coop::consume_budget().await;
             } else {
                 break None;
             }

--- a/slatedb/src/ops.rs
+++ b/slatedb/src/ops.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use tokio::sync::watch;
 use uuid::Uuid;
 
 use crate::batch::WriteBatch;
@@ -621,7 +622,7 @@ pub trait DbMetadataOps {
     /// let status = rx.borrow();
     /// some_async_fn(status.durable_seq).await; // deadlock!
     /// ```
-    fn subscribe(&self) -> tokio::sync::watch::Receiver<DbStatus>;
+    fn subscribe(&self) -> watch::Receiver<DbStatus>;
 
     /// Returns the latest database status.
     ///

--- a/slatedb/src/paths.rs
+++ b/slatedb/src/paths.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::db_state::SsTableId;
 use crate::db_state::SsTableId::{Compacted, Wal};
 use crate::error::SlateDBError;
+use crate::manifest::VersionedManifest;
 use object_store::path::Path;
 use ulid::Ulid;
 
@@ -32,7 +33,7 @@ impl PathResolver {
     /// Creates a resolver for the database rooted at `root_path`, resolving
     /// the external SSTs referenced by `manifest` to their owning database's
     /// path.
-    pub fn new<P: Into<Path>>(root_path: P, manifest: &crate::manifest::VersionedManifest) -> Self {
+    pub fn new<P: Into<Path>>(root_path: P, manifest: &VersionedManifest) -> Self {
         Self::new_with_external_ssts(root_path.into(), manifest.external_ssts())
     }
 

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -7,6 +7,7 @@ use std::collections::VecDeque;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, Range, RangeBounds};
 use std::sync::Arc;
+use tokio::task::JoinError;
 use tokio::task::JoinHandle;
 
 use crate::block_iterator::DataBlockIterator;
@@ -1067,7 +1068,7 @@ impl RowEntryIterator for SstIterator<'_> {
 /// A fetch task is cancelled when the runtime it was spawned on shuts down,
 /// so the iterator reports the cancellation to its caller instead of panicking
 /// the task that is awaiting the fetch.
-fn block_fetch_join_error(join_err: tokio::task::JoinError, sst_id: SsTableId) -> SlateDBError {
+fn block_fetch_join_error(join_err: JoinError, sst_id: SsTableId) -> SlateDBError {
     let task_name = format!("sst_block_fetch[{:?}]", sst_id);
     match join_err.try_into_panic() {
         Ok(panic_err) => {

--- a/slatedb/src/utils.rs
+++ b/slatedb/src/utils.rs
@@ -11,14 +11,19 @@ use crate::manifest::ManifestCore;
 use crate::paths::PathResolver;
 use crate::tablestore::TableStore;
 use bytes::{Buf, BufMut, Bytes};
+use futures::stream;
 use futures::FutureExt;
 use log::{error, warn};
+use object_store::path::Path;
 use rand::{Rng, RngCore};
 use slatedb_common::clock::SystemClock;
 use std::any::Any;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
+use tokio::runtime::Handle;
+use tokio::sync::watch;
+use tokio::task::{JoinError, JoinHandle};
 use ulid::Ulid;
 use uuid::Uuid;
 
@@ -29,18 +34,18 @@ static EMPTY_KEY: Bytes = Bytes::new();
 
 #[derive(Clone, Debug)]
 pub(crate) struct WatchableOnceCell<T: Clone> {
-    rx: tokio::sync::watch::Receiver<Option<T>>,
-    tx: tokio::sync::watch::Sender<Option<T>>,
+    rx: watch::Receiver<Option<T>>,
+    tx: watch::Sender<Option<T>>,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct WatchableOnceCellReader<T: Clone> {
-    rx: tokio::sync::watch::Receiver<Option<T>>,
+    rx: watch::Receiver<Option<T>>,
 }
 
 impl<T: Clone> WatchableOnceCell<T> {
     pub(crate) fn new() -> Self {
-        let (tx, rx) = tokio::sync::watch::channel(None);
+        let (tx, rx) = watch::channel(None);
         Self { rx, tx }
     }
 
@@ -83,10 +88,10 @@ impl<T: Clone> WatchableOnceCellReader<T> {
 /// result. If the task panics, the cleanup fn is called with Err(BackgroundTaskPanic).
 pub(crate) fn spawn_bg_task<F, T, C>(
     name: String,
-    handle: &tokio::runtime::Handle,
+    handle: &Handle,
     cleanup_fn: C,
     future: F,
-) -> tokio::task::JoinHandle<Result<T, SlateDBError>>
+) -> JoinHandle<Result<T, SlateDBError>>
 where
     F: Future<Output = Result<T, SlateDBError>> + Send + 'static,
     T: Send + 'static,
@@ -458,7 +463,7 @@ where
 {
     let mut out = VecDeque::new();
 
-    let results = futures::stream::iter(inputs.into_iter().map(move |it| f(it)))
+    let results = stream::iter(inputs.into_iter().map(move |it| f(it)))
         .buffer_unordered(max_parallel.max(1))
         .collect::<Vec<_>>()
         .await;
@@ -548,7 +553,7 @@ pub(crate) fn split_unwind_result(
 /// - (Err(SlateDBError::BackgroundTaskPanic), Some(payload)) if the task panicked
 pub(crate) fn split_join_result(
     name: String,
-    join_result: Result<Result<(), SlateDBError>, tokio::task::JoinError>,
+    join_result: Result<Result<(), SlateDBError>, JoinError>,
 ) -> (Result<(), SlateDBError>, Option<Box<dyn Any + Send>>) {
     match join_result {
         Ok(task_result) => (task_result, None),
@@ -654,7 +659,7 @@ pub(crate) async fn preload_cache_from_manifest(
 ) -> Result<(), SlateDBError> {
     match preload_level {
         Some(PreloadLevel::AllSst) => {
-            let all_sst_paths: Vec<object_store::path::Path> = core
+            let all_sst_paths: Vec<Path> = core
                 .all_sst_views()
                 .map(|view| path_resolver.sst_path(&view.sst.id))
                 .collect();
@@ -668,7 +673,7 @@ pub(crate) async fn preload_cache_from_manifest(
             }
         }
         Some(PreloadLevel::L0Sst) => {
-            let l0_sst_paths: Vec<object_store::path::Path> = core
+            let l0_sst_paths: Vec<Path> = core
                 .trees()
                 .flat_map(|tree| tree.l0.iter())
                 .map(|view| path_resolver.sst_path(&view.sst.id))

--- a/slatedb/src/wal/gc.rs
+++ b/slatedb/src/wal/gc.rs
@@ -5,6 +5,7 @@ use crate::tablestore::TableStore;
 use crate::wal::{WalError, WalFileRange, WalGc};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use futures::stream;
 use futures::StreamExt;
 use log::error;
 use slatedb_common::clock::SystemClock;
@@ -135,7 +136,7 @@ impl SlateDbWalGc {
             return;
         }
 
-        futures::stream::iter(sst_ids)
+        stream::iter(sst_ids)
             .for_each_concurrent(GC_DELETE_CONCURRENCY, |id| async move {
                 if let Err(e) = self.table_store.delete_sst(&id).await {
                     error!("error deleting WAL SST [id={:?}, error={}]", id, e);

--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -73,6 +73,7 @@ use object_store::ObjectStore;
 
 use crate::block_cache_policy::BlockCachePolicy;
 use crate::db_state::SsTableId;
+use crate::error::SlateDBError;
 use crate::format::sst::SsTableFormat;
 use crate::iter::{EmptyIterator, RowEntryIterator};
 use crate::manifest::SsTableView;
@@ -142,7 +143,7 @@ impl WalFile {
     pub async fn iterator(&self) -> Result<WalFileIterator, crate::Error> {
         let sst = match self.table_store.open_sst(&SsTableId::Wal(self.id)).await {
             Ok(sst) => sst,
-            Err(crate::error::SlateDBError::EmptySSTable) => {
+            Err(SlateDBError::EmptySSTable) => {
                 // Zero-byte WAL files are fencing markers, not corrupt WALs.
                 return Ok(WalFileIterator::new(Box::new(EmptyIterator::new())));
             }


### PR DESCRIPTION
## Summary

Follow-up to #2020. Both review comments that started that work were deep paths written inline where
the item could just be imported — `crate::mem_table::KVTableMetadata` (#1939) and
`crate::manifest::Manifest` (#2006).

`clippy::absolute_paths` with `absolute-paths-max-segments = 2` bounds depth at the use site: `Error`
and `crate::Error` are fine, `crate::error::SlateDBError` is not. `use` declarations are never checked,
so items can still be imported from any depth, and relative paths such as `fmt::Display` are never
examined.

## Changes

- `.config/clippy.toml` gains `absolute-paths-max-segments = 2` and
  `absolute-paths-allowed-crates = ["std", "core", "alloc"]`.
- The lint is enabled per crate root, not workspace-wide. clippy reads its config from each crate's
  manifest directory: `slatedb`, `slatedb-common` and `slatedb-txn-obj` already symlink
  `.config/clippy.toml`, and `bindings/uniffi` gets the symlink here. `examples`, `slatedb-cli`,
  `slatedb-bencher` and `slatedb-dst` have never read that config — handing it to them would also
  subject them to `disallowed-macros` and friends (90 unrelated violations, mostly `println!` in a CLI
  and in examples, where printing is the point), so they stay out. Happy to bring them in separately if
  you'd like.
- Test code is exempt, matching the five other lints already exempted in `slatedb/src/lib.rs`.
- Shorten 232 paths in production code. Each takes one of the two forms already dominant here: import
  the item (`crate::types::RowEntry` → `RowEntry`), or import the module and keep one segment where the
  short name is taken or the item is a free function or constant (`tokio::time::sleep` →
  `time::sleep`; `slatedb::config::WriteOptions` → `config::WriteOptions`, since the uniffi wrapper
  types share their names with the upstream ones). No site needed an `as` alias.

## Notes for Reviewers

Imports only, no behaviour changes. This lint has no machine-applicable suggestions, so unlike #2020
nothing could be applied with `cargo fix`. The first commit enables the rule, the second fixes it.
Imports for `cfg`-gated code carry the same `#[cfg(...)]` as their use site, so every feature
combination still builds clean.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
