### PR TITLE
configure sst iterator read ahead using bytes

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -338,9 +338,7 @@ impl TokioCompactionExecutorInner {
         };
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: self.options.max_fetch_tasks,
-            blocks_to_fetch: self
-                .table_store
-                .bytes_to_blocks(self.options.bytes_to_fetch),
+            target_bytes_to_fetch: self.options.bytes_to_fetch,
             cache_blocks: false, // don't clobber the cache
             cache_metadata: false,
             eager_spawn: true,

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -350,9 +350,10 @@ pub struct ScanOptions {
     /// Whether to include dirty data in the scan. "dirty" means that the data is not considered
     /// as "committed" yet, whose seq number is greater than the last committed seq number.
     pub dirty: bool,
-    /// The number of bytes to read ahead. The value is rounded up to the nearest
-    /// block size when fetching from object storage. The default is 1, which
-    /// rounds up to one block.
+    /// The target number of bytes to fetch in a single request while iterating over SSTs.
+    /// Each fetch will read the minimum number of blocks such that the resulting read is at least
+    /// this size or reaches the end of the file. The default is 1, which results in each fetch
+    /// reading one block.
     pub read_ahead_bytes: usize,
     /// Whether or not fetched data blocks should be cached. SST indexes,
     /// filters, and stats are cached independently of this setting.
@@ -1321,9 +1322,10 @@ pub struct CompactionWorkerOptions {
     /// compaction. Higher values can improve throughput but use more resources.
     pub max_fetch_tasks: usize,
 
-    /// Number of bytes to fetch in a single read-ahead request while iterating
-    /// over input SSTs during compaction. The value is rounded up to the nearest
-    /// block size when fetching from object storage. The default is 2MiB.
+    /// The target number of bytes to fetch in a single request while iterating over
+    /// input SSTs during compaction. Each fetch will read the minimum number of blocks
+    /// such that the resulting read is at least this size or reaches the end of the file.
+    /// The default is 2MiB.
     ///
     /// This pairs with [`CompactionWorkerOptions::max_fetch_tasks`]:
     /// `bytes_to_fetch` is the size of each read-ahead request while

--- a/slatedb/src/format/sst.rs
+++ b/slatedb/src/format/sst.rs
@@ -916,13 +916,17 @@ impl SsTableFormat {
         }
     }
 
-    fn block_range(
+    pub(crate) fn block_range(
         &self,
         blocks: Range<usize>,
         info: &SsTableInfo,
         index: &SsTableIndex,
     ) -> Range<u64> {
-        let mut end_offset = info.filter_offset;
+        let mut end_offset = if info.filter_len > 0 {
+            info.filter_offset
+        } else {
+            info.index_offset
+        };
         if blocks.end < index.block_meta().len() {
             let next_block_meta = index.block_meta().get(blocks.end);
             end_offset = next_block_meta.offset();

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -280,11 +280,10 @@ impl Reader {
     ) -> Result<DbIterator, SlateDBError> {
         self.db_stats.scan_requests.increment(1);
         let max_seq = self.prepare_max_seq(ctx.max_seq, options.durability_filter, options.dirty);
-        let read_ahead_blocks = self.table_store.bytes_to_blocks(options.read_ahead_bytes);
 
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: options.max_fetch_tasks,
-            blocks_to_fetch: read_ahead_blocks,
+            target_bytes_to_fetch: options.read_ahead_bytes,
             cache_blocks: options.cache_blocks,
             cache_metadata: true,
             eager_spawn: true,
@@ -342,12 +341,11 @@ impl Reader {
     ) -> Result<DbRecencyIterator, SlateDBError> {
         self.db_stats.scan_requests.increment(1);
         let max_seq = self.prepare_max_seq(None, options.durability_filter, options.dirty);
-        let read_ahead_blocks = self.table_store.bytes_to_blocks(options.read_ahead_bytes);
 
         let range = BytesRange::from_prefix(prefix.as_ref());
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: options.max_fetch_tasks,
-            blocks_to_fetch: read_ahead_blocks,
+            target_bytes_to_fetch: options.read_ahead_bytes,
             cache_blocks: options.cache_blocks,
             cache_metadata: true,
             // Recency scans are designed for early-stop. Eager spawning would

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -2,7 +2,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use log::error;
 use slatedb_common::metrics::CounterFn;
-use std::cmp::min;
 use std::collections::VecDeque;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, Range, RangeBounds};
@@ -34,7 +33,7 @@ enum FetchTask {
 #[derive(Clone, Debug)]
 pub(crate) struct SstIteratorOptions {
     pub(crate) max_fetch_tasks: usize,
-    pub(crate) blocks_to_fetch: usize,
+    pub(crate) target_bytes_to_fetch: usize,
     pub(crate) cache_blocks: bool,
     pub(crate) cache_metadata: bool,
     pub(crate) eager_spawn: bool,
@@ -47,7 +46,7 @@ impl Default for SstIteratorOptions {
     fn default() -> Self {
         SstIteratorOptions {
             max_fetch_tasks: 1,
-            blocks_to_fetch: 1,
+            target_bytes_to_fetch: 1,
             cache_blocks: true,
             cache_metadata: true,
             eager_spawn: false,
@@ -293,7 +292,7 @@ impl<'a> InternalSstIterator<'a> {
         options: SstIteratorOptions,
     ) -> Result<Self, SlateDBError> {
         assert!(options.max_fetch_tasks > 0);
-        assert!(options.blocks_to_fetch > 0);
+        assert!(options.target_bytes_to_fetch > 0);
 
         let descending_buffer = match options.order {
             IterationOrder::Descending => Some(VecDeque::new()),
@@ -381,25 +380,23 @@ impl<'a> InternalSstIterator<'a> {
                 while self.fetch_tasks.len() < self.options.max_fetch_tasks
                     && self.block_idx_range.contains(&self.next_block_idx_to_fetch)
                 {
-                    let blocks_to_fetch = min(
-                        self.options.blocks_to_fetch,
-                        self.block_idx_range.end - self.next_block_idx_to_fetch,
-                    );
                     let table = self.view.table_as_ref().sst.clone();
+                    let mut blocks = self.table_store.block_range_for_target_bytes(
+                        &table,
+                        index,
+                        self.next_block_idx_to_fetch,
+                        self.options.target_bytes_to_fetch,
+                        IterationOrder::Ascending,
+                    );
+                    blocks.end = blocks.end.min(self.block_idx_range.end);
                     let table_store = self.table_store.clone();
-                    let blocks_start = self.next_block_idx_to_fetch;
-                    let blocks_end = self.next_block_idx_to_fetch + blocks_to_fetch;
                     let index = index.clone();
                     let cache_blocks = self.options.cache_blocks;
+                    let blocks_end = blocks.end;
                     self.fetch_tasks
                         .push_back(FetchTask::InFlight(tokio::spawn(async move {
                             table_store
-                                .read_blocks_using_index(
-                                    &table,
-                                    index,
-                                    blocks_start..blocks_end,
-                                    cache_blocks,
-                                )
+                                .read_blocks_using_index(&table, index, blocks, cache_blocks)
                                 .await
                         })));
                     self.next_block_idx_to_fetch = blocks_end;
@@ -410,25 +407,23 @@ impl<'a> InternalSstIterator<'a> {
                 while self.fetch_tasks.len() < self.options.max_fetch_tasks
                     && self.next_block_idx_to_fetch > self.block_idx_range.start
                 {
-                    let blocks_to_fetch = min(
-                        self.options.blocks_to_fetch,
-                        self.next_block_idx_to_fetch - self.block_idx_range.start,
-                    );
                     let table = self.view.table_as_ref().sst.clone();
+                    let mut blocks = self.table_store.block_range_for_target_bytes(
+                        &table,
+                        index,
+                        self.next_block_idx_to_fetch - 1,
+                        self.options.target_bytes_to_fetch,
+                        IterationOrder::Descending,
+                    );
+                    blocks.start = blocks.start.max(self.block_idx_range.start);
                     let table_store = self.table_store.clone();
-                    let blocks_end = self.next_block_idx_to_fetch;
-                    let blocks_start = blocks_end - blocks_to_fetch;
                     let index = index.clone();
                     let cache_blocks = self.options.cache_blocks;
+                    let blocks_start = blocks.start;
                     self.fetch_tasks
                         .push_back(FetchTask::InFlight(tokio::spawn(async move {
                             table_store
-                                .read_blocks_using_index(
-                                    &table,
-                                    index,
-                                    blocks_start..blocks_end,
-                                    cache_blocks,
-                                )
+                                .read_blocks_using_index(&table, index, blocks, cache_blocks)
                                 .await
                         })));
                     self.next_block_idx_to_fetch = blocks_start;
@@ -1616,7 +1611,7 @@ mod tests {
 
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 3,
-            blocks_to_fetch: 3,
+            target_bytes_to_fetch: 3 * 4096,
             cache_blocks: true,
             order,
             ..SstIteratorOptions::default()
@@ -1900,7 +1895,7 @@ mod tests {
             table_store.clone(),
             SstIteratorOptions {
                 max_fetch_tasks: 32,
-                blocks_to_fetch: 256,
+                target_bytes_to_fetch: 256 * 128,
                 cache_blocks: true,
                 cache_metadata: true,
                 eager_spawn: false,
@@ -1919,7 +1914,7 @@ mod tests {
             table_store.clone(),
             SstIteratorOptions {
                 max_fetch_tasks: 1,
-                blocks_to_fetch: 1,
+                target_bytes_to_fetch: 1,
                 cache_blocks: true,
                 cache_metadata: true,
                 eager_spawn: false,
@@ -2506,7 +2501,7 @@ mod tests {
 
         let sst_iter_options = SstIteratorOptions {
             max_fetch_tasks: 3,
-            blocks_to_fetch: 3,
+            target_bytes_to_fetch: 3 * 128,
             cache_blocks: true,
             cache_metadata: true,
             eager_spawn: false,
@@ -2799,7 +2794,7 @@ mod tests {
             table_store.clone(),
             SstIteratorOptions {
                 max_fetch_tasks: 1,
-                blocks_to_fetch: 1,
+                target_bytes_to_fetch: 1,
                 cache_blocks: true,
                 cache_metadata: true,
                 eager_spawn: false,

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -26,6 +26,7 @@ use crate::filter_policy::NamedFilter;
 use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::format::block::Block;
 use crate::format::sst::{EncodedSsTable, EncodedSsTableBlock, SsTableFormat};
+use crate::iter::IterationOrder;
 use crate::object_store_tag::ObjectStoreCallTag;
 pub(crate) use crate::object_store_tag::TableStoreKind;
 use crate::object_stores::{ObjectStoreType, ObjectStores};
@@ -159,12 +160,6 @@ impl TableStore {
             block_cache_policy,
             kind,
         }
-    }
-
-    /// Get the number of blocks for a size specified in bytes.
-    /// The returned value will be rounded down to the nearest block.
-    pub(crate) fn bytes_to_blocks(&self, bytes: usize) -> usize {
-        bytes.div_ceil(self.sst_format.block_size)
     }
 
     /// Find the highest WAL SST id present in the object store at or above
@@ -870,6 +865,57 @@ impl TableStore {
         .await
     }
 
+    /// Returns the smallest contiguous block range, starting at `first_block` in
+    /// `order`, whose encoded size is at least `target_bytes`. If the SST boundary
+    /// is reached first, all remaining blocks in that direction are returned.
+    pub(crate) fn block_range_for_target_bytes(
+        &self,
+        handle: &SsTableHandle,
+        index: &SsTableIndexOwned,
+        first_block: usize,
+        target_bytes: usize,
+        order: IterationOrder,
+    ) -> Range<usize> {
+        assert!(target_bytes > 0);
+
+        let index = index.borrow();
+        let block_meta = index.block_meta();
+        let num_blocks = block_meta.len();
+        assert!(first_block < num_blocks);
+
+        let target_bytes = u64::try_from(target_bytes).unwrap_or(u64::MAX);
+        match order {
+            IterationOrder::Ascending => {
+                let mut blocks = first_block..first_block + 1;
+                loop {
+                    let byte_range =
+                        self.sst_format
+                            .block_range(blocks.clone(), &handle.info, &index);
+                    if byte_range.end.saturating_sub(byte_range.start) >= target_bytes
+                        || blocks.end == num_blocks
+                    {
+                        return blocks;
+                    }
+                    blocks.end += 1;
+                }
+            }
+            IterationOrder::Descending => {
+                let mut blocks = first_block..first_block + 1;
+                loop {
+                    let byte_range =
+                        self.sst_format
+                            .block_range(blocks.clone(), &handle.info, &index);
+                    if byte_range.end.saturating_sub(byte_range.start) >= target_bytes
+                        || blocks.start == 0
+                    {
+                        return blocks;
+                    }
+                    blocks.start -= 1;
+                }
+            }
+        }
+    }
+
     /// Reads specified blocks from an SSTable using the provided index.
     ///
     /// This function attempts to read blocks from the cache if available
@@ -1311,10 +1357,9 @@ mod tests {
     use futures::future;
     use futures::StreamExt;
     use object_store::{memory::InMemory, path::Path, ObjectStore, ObjectStoreExt};
-    use proptest::prelude::any;
-    use proptest::proptest;
     use rstest::rstest;
     use std::collections::VecDeque;
+    use std::ops::Range;
     use std::sync::Arc;
 
     use crate::block_cache_policy::BlockCachePolicy;
@@ -1322,9 +1367,14 @@ mod tests {
     use crate::db_cache::CacheTarget;
     use crate::db_cache::SplitCache;
     use crate::db_cache::{CachedKey, DbCache, DbCacheWrapper};
+    use crate::db_state::{SsTableHandle, SsTableInfo};
     use crate::error;
+    use crate::flatbuffer_types::{
+        BlockMeta, BlockMetaArgs, SsTableIndex, SsTableIndexArgs, SsTableIndexOwned,
+    };
     use crate::format::block::Block;
-    use crate::format::sst::SsTableFormat;
+    use crate::format::sst::{SsTableFormat, SST_FORMAT_VERSION_LATEST};
+    use crate::iter::IterationOrder;
     use crate::manifest::SsTableView;
     use crate::object_stores::ObjectStores;
     use crate::retrying_object_store::RetryingObjectStore;
@@ -1429,6 +1479,33 @@ mod tests {
 
     fn make_store() -> Arc<dyn ObjectStore> {
         Arc::new(InMemory::new())
+    }
+
+    fn build_index(offsets: &[u64]) -> SsTableIndexOwned {
+        let mut builder = flatbuffers::FlatBufferBuilder::new();
+        let block_meta = offsets
+            .iter()
+            .enumerate()
+            .map(|(block, offset)| {
+                let first_key = builder.create_vector(block.to_string().as_bytes());
+                BlockMeta::create(
+                    &mut builder,
+                    &BlockMetaArgs {
+                        offset: *offset,
+                        first_key: Some(first_key),
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        let block_meta = builder.create_vector(&block_meta);
+        let index = SsTableIndex::create(
+            &mut builder,
+            &SsTableIndexArgs {
+                block_meta: Some(block_meta),
+            },
+        );
+        builder.finish(index, None);
+        SsTableIndexOwned::new(Bytes::copy_from_slice(builder.finished_data())).unwrap()
     }
 
     async fn count_ssts_in(store: &Arc<dyn ObjectStore>) -> usize {
@@ -2926,20 +3003,91 @@ mod tests {
         assert_eq!(metadata.location, path);
     }
 
-    proptest! {
-        #[test]
-        fn convert_bytes_to_blocks_precise_when_aligned_with_block_size(
-            block_size in any::<usize>(),
-            num_blocks in any::<usize>(),
-        ) {
-            let os = Arc::new(InMemory::new());
-            let format = SsTableFormat { block_size, ..SsTableFormat::default() };
-            let ts = Arc::new(TableStore::new(ObjectStores::new(os, None),
-                format, Path::from(ROOT), None, TableStoreKind::Main, BlockCachePolicy::default()));
-            if let Some(bytes) = block_size.checked_mul(num_blocks) {
-                assert_eq!(num_blocks, ts.bytes_to_blocks(bytes));
-            }
-        }
+    #[rstest]
+    #[case::ascending_one_block(IterationOrder::Ascending, 0, 100, 0..1)]
+    #[case::ascending_crosses_boundary(IterationOrder::Ascending, 0, 101, 0..2)]
+    #[case::ascending_exact_boundary(IterationOrder::Ascending, 0, 250, 0..2)]
+    #[case::ascending_exhausts_sst(IterationOrder::Ascending, 1, 1_000, 1..4)]
+    #[case::descending_one_block(IterationOrder::Descending, 3, 200, 3..4)]
+    #[case::descending_crosses_boundary(IterationOrder::Descending, 3, 201, 2..4)]
+    #[case::descending_exact_boundary(IterationOrder::Descending, 3, 250, 2..4)]
+    #[case::descending_exhausts_sst(IterationOrder::Descending, 2, 1_000, 0..3)]
+    fn block_range_for_target_bytes_is_minimal(
+        #[case] order: IterationOrder,
+        #[case] first_block: usize,
+        #[case] target_bytes: usize,
+        #[case] expected: Range<usize>,
+    ) {
+        let table_store = TableStore::new(
+            ObjectStores::new(make_store(), None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+            TableStoreKind::Main,
+            BlockCachePolicy::default(),
+        );
+        let handle = SsTableHandle::new(
+            SsTableId::Compacted(ulid::Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                index_offset: 500,
+                filter_offset: 500,
+                ..SsTableInfo::default()
+            },
+        );
+        // Encoded block sizes are 100, 150, 50, and 200 bytes.
+        let index = build_index(&[0, 100, 250, 300]);
+
+        let actual = table_store.block_range_for_target_bytes(
+            &handle,
+            &index,
+            first_block,
+            target_bytes,
+            order,
+        );
+
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case::filter_precedes_index(1, 500, 700)]
+    #[case::index_follows_data_without_filter(0, 700, 500)]
+    fn block_range_for_target_bytes_uses_format_for_last_block_end(
+        #[case] filter_len: u64,
+        #[case] filter_offset: u64,
+        #[case] index_offset: u64,
+    ) {
+        let table_store = TableStore::new(
+            ObjectStores::new(make_store(), None),
+            SsTableFormat::default(),
+            Path::from(ROOT),
+            None,
+            TableStoreKind::Main,
+            BlockCachePolicy::default(),
+        );
+        let handle = SsTableHandle::new(
+            SsTableId::Compacted(ulid::Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                index_offset,
+                filter_offset,
+                filter_len,
+                ..SsTableInfo::default()
+            },
+        );
+        let index = build_index(&[0, 100, 250, 300]);
+
+        let actual = table_store.block_range_for_target_bytes(
+            &handle,
+            &index,
+            3,
+            201,
+            IterationOrder::Descending,
+        );
+
+        // The last block ends at byte 500 and is 200 bytes, so one preceding
+        // block is required to meet a 201-byte target.
+        assert_eq!(actual, 2..4);
     }
 
     /// End-to-end test: concurrent index reads through `TableStore` issue a single

--- a/slatedb/src/wal/slatedb/reader.rs
+++ b/slatedb/src/wal/slatedb/reader.rs
@@ -47,13 +47,11 @@ impl Default for SlateDbWalReaderOptions {
 
 impl From<SlateDbWalReaderOptions> for SlateDbWalIteratorOptions {
     fn from(options: SlateDbWalReaderOptions) -> Self {
-        let format = SsTableFormat::default();
-        let blocks_to_fetch = options.read_ahead_bytes.div_ceil(format.block_size);
         Self {
             sst_batch_size: options.sst_batch_size,
             sst_iter_options: SstIteratorOptions {
                 max_fetch_tasks: options.max_fetch_tasks,
-                blocks_to_fetch,
+                target_bytes_to_fetch: options.read_ahead_bytes,
                 cache_blocks: false,
                 cache_metadata: false,
                 eager_spawn: true,

--- a/slatedb/src/wal/slatedb/reader.rs
+++ b/slatedb/src/wal/slatedb/reader.rs
@@ -30,8 +30,9 @@ pub struct SlateDbWalReaderOptions {
     /// pending while the current data is being consumed.
     pub max_fetch_tasks: usize,
 
-    /// The number of bytes to read ahead in each sst. The value is rounded up to the nearest
-    /// block size when fetching from object storage. The default is 1MB
+    /// The target number of bytes to fetch in a single request while iterating over WAL SSTs.
+    /// Each fetch will read the minimum number of blocks such that the resulting read is at least
+    /// this size or reaches the end of the file. The default is 1MiB.
     pub read_ahead_bytes: usize,
 }
 

--- a/slatedb/src/wal/slatedb/writer_init.rs
+++ b/slatedb/src/wal/slatedb/writer_init.rs
@@ -125,7 +125,7 @@ impl wal::WriterInit for SlateDbWalWriterInit {
                         sst_batch_size: 4,
                         sst_iter_options: SstIteratorOptions {
                             max_fetch_tasks: 2,
-                            blocks_to_fetch: 256,
+                            target_bytes_to_fetch: 1024 * 1024,
                             cache_blocks: false,
                             cache_metadata: false,
                             eager_spawn: true,

--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -153,8 +153,8 @@ impl WalFile {
             SsTableView::identity(sst),
             Arc::clone(&self.table_store),
             SstIteratorOptions {
-                // Optimize for throughput. Go for 256MiB per-fetch (4096 bytes/block default).
-                blocks_to_fetch: 65_536,
+                // Optimize for throughput. Go for 256MiB per fetch.
+                target_bytes_to_fetch: 256 * 1024 * 1024,
                 ..Default::default()
             },
         )


### PR DESCRIPTION
## Summary

Before this patch sst iterator read ahead was configured by specifying a number of blocks that each fetch should read. This has a couple problems. Callers typically want to configure a read size in bytes and so have to convert bytes to blocks using the sst format. This isn't done consistently in all places. Db supports configuring the format to use for the conversion, but DbReader doesn't. That format may not be the same format the particular sst was written with. And blocks don't necessarily align with the format size anyway. This patch changes the option to a target number of bytes for each read, and has the iterator compute the read size in blocks using the index.

The patch is a Sol one-shot.

## Changes

- Replaces SstIteratorOptions::blocks_to_fetch with SstIteratorOptions::target_bytes_to_fetch. This value represents a goal for the size of each read. The iterator reads the minimum number of blocks required to get this read size.
- Adds a helper fn to TableStore for computing the blocks that must be read to get the target read size.
- SstIterator calls this fn to decide the bounds of each fetch task.
- Updates SstIterator callers to use the new option

## Notes for Reviewers

Fixees #2036 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
