### PR TITLE
perf(wal): read a whole WAL SST per request during replay (#2003)

### DIFF
--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -204,7 +204,12 @@ impl DbReaderInner {
                     Arc::clone(&table_store),
                     &status_manager,
                     Arc::clone(&system_clock),
-                    SlateDbWalReaderOptions::default(),
+                    // Read a whole WAL SST per request. A reader can't see the writer's
+                    // l0_sst_size_bytes, so use max_memtable_bytes as the equivalent budget.
+                    SlateDbWalReaderOptions {
+                        read_ahead_bytes: options.max_memtable_bytes as usize,
+                        ..SlateDbWalReaderOptions::default()
+                    },
                 ),
             )
         });
@@ -2973,6 +2978,55 @@ mod tests {
         assert_eq!(
             reader.get(flushed_key).await.unwrap(),
             Some(Bytes::from_static(flushed_value))
+        );
+    }
+
+    /// Regression test for #2003: read-ahead was a fixed 1MiB, so a large WAL took one
+    /// GET per MiB. It now covers a whole WAL SST, so reads for one file stay a small
+    /// constant instead of growing with size.
+    #[tokio::test]
+    async fn replay_reads_a_large_wal_sst_in_a_bounded_number_of_requests() {
+        let recording_store = Arc::new(test_utils::RecordingObjectStore::new(Arc::new(
+            InMemory::new(),
+        )));
+        let object_store: Arc<dyn ObjectStore> = recording_store.clone();
+        let path = Path::from("/tmp/test_kv_store");
+        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
+        let table_store = test_provider.table_store();
+
+        // One 16MiB WAL SST, far over the old 1MiB window. The old window read it in
+        // ~16 data GETs; the fix reads it in one.
+        let value = vec![b'x'; 4096];
+        let entries: Vec<RowEntry> = (0..4096u32)
+            .map(|i| RowEntry::new_value(format!("key-{i:08}").as_bytes(), &value, i as u64 + 1))
+            .collect();
+        write_wal_sst(Arc::clone(&table_store), 1, entries)
+            .await
+            .unwrap();
+
+        let mut core = ManifestCore::new();
+        core.next_wal_sst_id = 2;
+        let status_manager = status_manager_for_core(&core);
+        let wal_reader = native_wal_reader(&table_store, &status_manager);
+
+        recording_store.clear();
+        let mut iterator = wal_reader.iterator((1..2).into()).await.unwrap();
+        let mut rows = 0;
+        while let Some(batch) = iterator.next().await.unwrap() {
+            rows += batch.rows.len();
+        }
+        assert_eq!(rows, 4096, "replay should return every WAL row");
+
+        let wal_reads = recording_store
+            .get_sst_types(false)
+            .into_iter()
+            .filter(|sst_type| *sst_type == Some(SstType::Wal))
+            .count();
+        // Footer, index, and one data read. The old 1MiB window needed ~16 data reads
+        // for this file, so the bound is the regression.
+        assert!(
+            wal_reads <= 4,
+            "expected a bounded number of WAL reads for one file, got {wal_reads}"
         );
     }
 

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -204,8 +204,6 @@ impl DbReaderInner {
                     Arc::clone(&table_store),
                     &status_manager,
                     Arc::clone(&system_clock),
-                    // Read a whole WAL SST per request. A reader can't see the writer's
-                    // l0_sst_size_bytes, so use max_memtable_bytes as the equivalent budget.
                     SlateDbWalReaderOptions {
                         read_ahead_bytes: options.max_memtable_bytes as usize,
                         ..SlateDbWalReaderOptions::default()

--- a/slatedb/src/wal/slatedb/reader.rs
+++ b/slatedb/src/wal/slatedb/reader.rs
@@ -31,8 +31,9 @@ pub struct SlateDbWalReaderOptions {
     pub max_fetch_tasks: usize,
 
     /// The target number of bytes to fetch in a single request while iterating over WAL SSTs.
-    /// Each fetch will read the minimum number of blocks such that the resulting read is at least
-    /// this size or reaches the end of the file. The default is 1MiB.
+    /// Each fetch reads the minimum number of blocks such that the resulting read is at least
+    /// this size or reaches the end of the file. Callers size this to a whole WAL SST
+    /// (`l0_sst_size_bytes`) so replay reads each file in one request; the default is a fallback.
     pub read_ahead_bytes: usize,
 }
 
@@ -41,7 +42,7 @@ impl Default for SlateDbWalReaderOptions {
         Self {
             sst_batch_size: 4,
             max_fetch_tasks: 2,
-            read_ahead_bytes: 1024 * 1024,
+            read_ahead_bytes: 64 * 1024 * 1024,
         }
     }
 }

--- a/slatedb/src/wal/slatedb/reader.rs
+++ b/slatedb/src/wal/slatedb/reader.rs
@@ -33,7 +33,7 @@ pub struct SlateDbWalReaderOptions {
     /// The target number of bytes to fetch in a single request while iterating over WAL SSTs.
     /// Each fetch reads the minimum number of blocks such that the resulting read is at least
     /// this size or reaches the end of the file. Callers size this to a whole WAL SST
-    /// (`l0_sst_size_bytes`) so replay reads each file in one request; the default is a fallback.
+    /// (`l0_sst_size_bytes`) so replay reads each file in one request.
     pub read_ahead_bytes: usize,
 }
 

--- a/slatedb/src/wal/slatedb/writer_init.rs
+++ b/slatedb/src/wal/slatedb/writer_init.rs
@@ -115,8 +115,6 @@ impl wal::WriterInit for SlateDbWalWriterInit {
                 // older writers would have failed with a stale epoch
                 let replay_after_wal_id = manifest.core().replay_after_wal_id;
                 assert!(empty_wal_id > replay_after_wal_id);
-                // Read a whole WAL SST per request. A WAL SST is bounded by
-                // max_wal_bytes_size (= l0_sst_size_bytes), so one window covers a file.
                 let replay_iterator = SlateDbWalIterator::range(
                     replay_after_wal_id + 1,
                     WalIteratorEndBound::Exclusive(empty_wal_id + 1),

--- a/slatedb/src/wal/slatedb/writer_init.rs
+++ b/slatedb/src/wal/slatedb/writer_init.rs
@@ -1,13 +1,10 @@
 use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
-use crate::iter::IterationOrder;
 use crate::manifest::Manifest;
-use crate::sst_iter::SstIteratorOptions;
 use crate::tablestore::TableStore;
 use crate::utils::WatchableOnceCellReader;
-use crate::wal::slatedb::iterator::{
-    SlateDbWalIterator, SlateDbWalIteratorOptions, WalIteratorEndBound,
-};
+use crate::wal::slatedb::iterator::{SlateDbWalIterator, WalIteratorEndBound};
+use crate::wal::slatedb::reader::SlateDbWalReaderOptions;
 use crate::wal::slatedb::writer::SlateDbWalWriter;
 use crate::wal::{WalError, WriterInitResult, WriterManifest};
 use crate::{wal, Settings};
@@ -118,22 +115,16 @@ impl wal::WriterInit for SlateDbWalWriterInit {
                 // older writers would have failed with a stale epoch
                 let replay_after_wal_id = manifest.core().replay_after_wal_id;
                 assert!(empty_wal_id > replay_after_wal_id);
+                // Read a whole WAL SST per request. A WAL SST is bounded by
+                // max_wal_bytes_size (= l0_sst_size_bytes), so one window covers a file.
                 let replay_iterator = SlateDbWalIterator::range(
                     replay_after_wal_id + 1,
                     WalIteratorEndBound::Exclusive(empty_wal_id + 1),
-                    SlateDbWalIteratorOptions {
-                        sst_batch_size: 4,
-                        sst_iter_options: SstIteratorOptions {
-                            max_fetch_tasks: 2,
-                            target_bytes_to_fetch: 1024 * 1024,
-                            cache_blocks: false,
-                            cache_metadata: false,
-                            eager_spawn: true,
-                            order: IterationOrder::Ascending,
-                            prefix: None,
-                            filter_context: None,
-                        },
-                    },
+                    SlateDbWalReaderOptions {
+                        read_ahead_bytes: self.max_wal_bytes_size,
+                        ..SlateDbWalReaderOptions::default()
+                    }
+                    .into(),
                     self.table_store.clone(),
                 )?;
                 let wal_writer = SlateDbWalWriter::start_new(


### PR DESCRIPTION
Closes #2003

## Summary

fixes the slow half of #2003. part 1 (`skip_wal_replay`) was already fixed by #2005

WAL replay at open (both `Db::open` and `DbReader::open`) fetched ~1 MiB per GET so a large live WAL took one serialized round trip per megabyte. the fetch size was hardcoded in two places and never matched the throughput choice the standalone `WalReader` already made

the fix sizes read-ahead to a whole WAL SST, which a single GET can cover since `read_blocks_using_index` issues one request per contiguous block run

## Changes

- reader path reads ahead by `max_memtable_bytes` (a reader cant see the writer's `l0_sst_size_bytes`)
- writer path reads ahead by `max_wal_bytes_size` (= `l0_sst_size_bytes`)
- `blocks_to_fetch` derives from the store's configured `block_size` instead of assuming 4 KiB, via [`to_iterator_options`](https://github.com/bit2swaz/slatedb/blob/ad6dd01567fd01973f2cc6041a72e7b527b89eba/slatedb/src/wal/slatedb/reader.rs#L52-L66)
- both open paths share that method now so the duplicated fetch literals in `writer_init.rs` are gone
- no new config

## Notes for Reviewers

one open question: `max_memtable_bytes` is the reader's proxy for WAL file size since it cant see `l0_sst_size_bytes`. happy to read from smth else if thats wrong

the regression test drives the reader's WAL path against a recording object store and counts non-HEAD WAL reads. a 16 MiB WAL SST goes from 19 reads to 4 at open; the reads for one file stay a small constant regardless of size, which is the regression. footer and index reads share the WAL tag, so it asserts a bound rather than an exact GET count

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏