### PR TITLE
Scale SsTableView::estimate_size by the visible_range fraction

### DIFF
--- a/slatedb/src/compactor.rs
+++ b/slatedb/src/compactor.rs
@@ -717,8 +717,8 @@ impl CompactorEventHandler {
             .iter()
             .try_fold(0, |total, source| {
                 let source_bytes = match source {
-                    SourceId::SstView(id) => views_by_id.get(id)?.estimate_size(),
-                    SourceId::SortedRun(id) => srs_by_id.get(id)?.estimate_size(),
+                    SourceId::SstView(id) => views_by_id.get(id)?.estimate_visible_size(),
+                    SourceId::SortedRun(id) => srs_by_id.get(id)?.estimate_visible_size(),
                 };
                 Some(total + source_bytes)
             })
@@ -1444,6 +1444,7 @@ pub mod stats {
 mod tests {
     use std::collections::{HashMap, VecDeque};
     use std::future::Future;
+    use std::ops::Bound::{Excluded, Included};
     use std::ops::Range;
     use std::sync::Arc;
     use std::time::{Duration, SystemTime};
@@ -1460,6 +1461,7 @@ mod tests {
     use super::*;
     use crate::batch::WriteBatch;
     use crate::block_cache_policy::BlockCachePolicy;
+    use crate::bytes_range::BytesRange;
     use crate::compaction_worker::WorkerMessage;
     use crate::compactions_store::{FenceableCompactions, StoredCompactions};
     use crate::compactor::stats::CompactionStats;
@@ -3871,9 +3873,51 @@ mod tests {
             ),
         );
 
-        let expected = segment_l0.estimate_size() + segment_sr.estimate_size();
+        let expected = segment_l0.estimate_visible_size() + segment_sr.estimate_visible_size();
         let actual = CompactorEventHandler::calculate_estimated_source_bytes(&compaction, &core);
         assert_eq!(actual, Some(expected));
+    }
+
+    #[test]
+    fn test_calculate_estimated_source_bytes_uses_visible_size_for_borrowed_views() {
+        let raw_size = 1_000_000u64;
+        let l0_view = SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo {
+                first_entry: Some(Bytes::from_static(b"seg/a")),
+                last_entry: Some(Bytes::from_static(b"seg/z")),
+                index_offset: raw_size,
+                ..SsTableInfo::default()
+            },
+        ))
+        .with_visible_range(BytesRange::new(
+            Included(Bytes::from_static(b"seg/a")),
+            Excluded(Bytes::from_static(b"seg/m")),
+        ));
+
+        let mut core = ManifestCore::new();
+        core.segments = vec![Segment {
+            prefix: Bytes::from_static(b"seg"),
+            tree: Arc::new(LsmTreeState {
+                l0: VecDeque::from(vec![l0_view.clone()]),
+                ..LsmTreeState::default()
+            }),
+        }];
+
+        let compaction = Compaction::new(
+            Ulid::new(),
+            CompactionSpec::for_segment(
+                Bytes::from_static(b"seg"),
+                vec![SourceId::SstView(l0_view.id)],
+                9,
+            ),
+        );
+
+        let expected = l0_view.estimate_visible_size();
+        let actual = CompactorEventHandler::calculate_estimated_source_bytes(&compaction, &core);
+        assert_eq!(actual, Some(expected));
+        assert!(expected < raw_size);
     }
 
     #[test]

--- a/slatedb/src/db_state.rs
+++ b/slatedb/src/db_state.rs
@@ -254,6 +254,94 @@ impl SsTableView {
     pub fn estimate_size(&self) -> u64 {
         self.sst.estimate_size()
     }
+
+    pub(crate) fn estimate_visible_size(&self) -> u64 {
+        const MIN_ESTIMATED_SIZE_BYTES: f64 = 1.0;
+
+        let raw_size = self.sst.estimate_size();
+        if self.visible_range.is_none() {
+            return raw_size;
+        }
+        let fraction = self.visible_fraction();
+        ((raw_size as f64) * fraction)
+            .round()
+            .max(MIN_ESTIMATED_SIZE_BYTES) as u64
+    }
+
+    /// This function finds the size of the visible part of a file:
+    /// - Compares the start and end keys of the file and the view.
+    /// - Skips the bytes that are equal and reads the bytes after them.
+    /// - Uses these bytes to find the fraction of the full file size.
+    fn visible_fraction(&self) -> f64 {
+        const FULL_VISIBLE_FRACTION: f64 = 1.0;
+        const MIN_VISIBLE_FRACTION: f64 = 1e-6;
+
+        if self.sst.info.last_entry.is_none() {
+            return FULL_VISIBLE_FRACTION;
+        }
+
+        let physical_range = self.physical_range();
+        if self.effective_range == physical_range {
+            return FULL_VISIBLE_FRACTION;
+        }
+
+        let skip = common_prefix_len(physical_range.start_bound(), physical_range.end_bound());
+
+        let (phys_start, phys_end) = Self::range_span(&physical_range, skip);
+        let (vis_start, vis_end) = Self::range_span(&self.effective_range, skip);
+
+        let phys_len = (phys_end - phys_start).max(f64::EPSILON);
+        let vis_len = vis_end - vis_start;
+        if vis_len == 0.0 {
+            return FULL_VISIBLE_FRACTION;
+        }
+
+        (vis_len / phys_len).clamp(MIN_VISIBLE_FRACTION, FULL_VISIBLE_FRACTION)
+    }
+
+    /// This function finds a position number for the start and end of a range:
+    /// - Skips the bytes given by `skip`, then reads the bytes after them.
+    /// - Turns these bytes into a number between 0 and 1.
+    /// - Uses 0 for an open start and 1 for an open end.
+    fn range_span(range: &BytesRange, skip: usize) -> (f64, f64) {
+        const KEYSPACE_START: f64 = 0.0;
+        const KEYSPACE_END: f64 = 1.0;
+
+        fn key_fraction(key: &[u8], skip: usize) -> f64 {
+            const BYTE_VALUE_RANGE: f64 = 256.0;
+            const FRACTION_WINDOW_BYTES: usize = 8;
+
+            let key = key.get(skip..).unwrap_or(&[]);
+            let mut frac = 0.0_f64;
+            let mut scale = 1.0_f64 / BYTE_VALUE_RANGE;
+            // The code reads up to 8 bytes after the skip point, which gives a fine result for almost all keys.
+            // Checking more bytes adds little value, but costs a little more time.
+            for &byte in key.iter().take(FRACTION_WINDOW_BYTES) {
+                frac += byte as f64 * scale;
+                scale /= BYTE_VALUE_RANGE;
+            }
+            frac
+        }
+
+        let start = match range.start_bound() {
+            Unbounded => KEYSPACE_START,
+            Included(k) | Excluded(k) => key_fraction(k, skip),
+        };
+        let end = match range.end_bound() {
+            Unbounded => KEYSPACE_END,
+            Included(k) | Excluded(k) => key_fraction(k, skip),
+        };
+        (start, end)
+    }
+}
+
+fn common_prefix_len(a: Bound<&Bytes>, b: Bound<&Bytes>) -> usize {
+    match (a, b) {
+        (Included(a) | Excluded(a), Included(b) | Excluded(b)) => {
+            a.iter().zip(b.iter()).take_while(|(x, y)| x == y).count()
+        }
+        _ => 0,
+    }
 }
 
 /// Maximum number of L0 SST views whose effective ranges cover any single key.
@@ -516,6 +604,13 @@ impl SortedRun {
     /// Estimate the total size of all SSTables in this sorted run.
     pub fn estimate_size(&self) -> u64 {
         self.sst_views.iter().map(|sst| sst.estimate_size()).sum()
+    }
+
+    pub(crate) fn estimate_visible_size(&self) -> u64 {
+        self.sst_views
+            .iter()
+            .map(|sst| sst.estimate_visible_size())
+            .sum()
     }
 
     /// Cheap O(1) check: does the run's overall key span overlap `range`?
@@ -1271,6 +1366,154 @@ mod tests {
             first_entry,
             ..Default::default()
         }
+    }
+
+    fn create_compacted_sst_view_with_size(
+        first_entry: &[u8],
+        last_entry: &[u8],
+        raw_size: u64,
+    ) -> SsTableView {
+        let sst_info = SsTableInfo {
+            first_entry: Some(Bytes::copy_from_slice(first_entry)),
+            last_entry: Some(Bytes::copy_from_slice(last_entry)),
+            index_offset: raw_size,
+            ..Default::default()
+        };
+        let sst_id = SsTableId::Compacted(ulid::Ulid::new());
+        let handle = SsTableHandle::new(sst_id, SST_FORMAT_VERSION_LATEST, sst_info);
+        SsTableView::identity(handle)
+    }
+
+    #[test]
+    fn estimate_size_unprojected_view_returns_raw_physical_size() {
+        let view = create_compacted_sst_view_with_size(b"a", b"z", 1_000_000);
+        assert_eq!(view.estimate_size(), 1_000_000);
+    }
+
+    #[test]
+    fn estimate_visible_size_scales_projected_views_by_visible_fraction() {
+        let raw_size = 1_000_000u64;
+        let base = create_compacted_sst_view_with_size(b"a", b"z", raw_size);
+
+        let a = Bytes::copy_from_slice(b"a");
+        let m = Bytes::copy_from_slice(b"m");
+        let z = Bytes::copy_from_slice(b"z");
+
+        let first_half = base.with_visible_range(BytesRange::new(Included(a), Excluded(m.clone())));
+        let second_half = base.with_visible_range(BytesRange::new(Included(m), Included(z)));
+
+        let first_size = first_half.estimate_visible_size();
+        let second_size = second_half.estimate_visible_size();
+
+        assert!(
+            first_size < raw_size && second_size < raw_size,
+            "projected views must not report the full physical size: \
+             first={first_size}, second={second_size}, raw={raw_size}"
+        );
+
+        let summed = first_size + second_size;
+        let lower = (raw_size as f64 * 0.8) as u64;
+        let upper = (raw_size as f64 * 1.2) as u64;
+        assert!(
+            (lower..=upper).contains(&summed),
+            "sibling views over disjoint halves of one physical SST should \
+             sum to ~raw_size, got {summed} (raw={raw_size})"
+        );
+    }
+
+    #[test]
+    fn estimate_visible_size_single_key_visible_range_falls_back_to_raw_size() {
+        let raw_size = 1_000_000u64;
+        let prefix = b"tenant00";
+        let low = [prefix.as_slice(), &[0]].concat();
+        let high = [prefix.as_slice(), &[200]].concat();
+        let base = create_compacted_sst_view_with_size(&low, &high, raw_size);
+
+        let point = base.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(&low)),
+            Included(Bytes::copy_from_slice(&low)),
+        ));
+        assert_eq!(point.estimate_visible_size(), raw_size);
+    }
+
+    #[test]
+    fn estimate_visible_size_single_key_sst_fully_visible_returns_raw_size() {
+        let raw_size = 1_000_000u64;
+        let key = b"tenant0000000";
+        let base = create_compacted_sst_view_with_size(key, key, raw_size);
+
+        let projected = base.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(key)),
+            Included(Bytes::copy_from_slice(key)),
+        ));
+        assert_eq!(projected.estimate_visible_size(), raw_size);
+    }
+
+    #[test]
+    fn estimate_visible_size_shared_prefix_does_not_collapse() {
+        let raw_size = 1_000_000u64;
+        let prefix = b"tenant00";
+        let phys_low = [prefix.as_slice(), &[0]].concat();
+        let phys_high = [prefix.as_slice(), &[200]].concat();
+        let base = create_compacted_sst_view_with_size(&phys_low, &phys_high, raw_size);
+
+        let vis_low = [prefix.as_slice(), &[0]].concat();
+        let vis_high = [prefix.as_slice(), &[2]].concat();
+        let slice = base.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(&vis_low)),
+            Excluded(Bytes::copy_from_slice(&vis_high)),
+        ));
+
+        let size = slice.estimate_visible_size();
+        assert_ne!(
+            size, 1,
+            "shared long prefix must not collapse the estimate to the 1-byte floor"
+        );
+        assert!(
+            (1_000..100_000).contains(&size),
+            "expected roughly a 1% slice of raw_size, got {size} (raw={raw_size})"
+        );
+    }
+
+    #[test]
+    fn estimate_visible_size_ambiguous_deep_divergence_falls_back_to_raw_size() {
+        let raw_size = 1_000_000u64;
+        let phys_low = vec![0x10u8];
+        let phys_high = vec![0xF0u8];
+        let base = create_compacted_sst_view_with_size(&phys_low, &phys_high, raw_size);
+
+        let vis_low = vec![0x50u8, 0, 0, 0, 0, 0, 0, 0, 0x00];
+        let vis_high = vec![0x50u8, 0, 0, 0, 0, 0, 0, 0, 0xFF];
+        let view = base.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(&vis_low)),
+            Included(Bytes::copy_from_slice(&vis_high)),
+        ));
+
+        assert_eq!(view.estimate_visible_size(), raw_size);
+    }
+
+    #[test]
+    fn estimate_visible_size_missing_last_entry_falls_back_to_raw_size() {
+        let raw_size = 1_000_000u64;
+        let sst_info = SsTableInfo {
+            first_entry: Some(Bytes::copy_from_slice(&[0x00])),
+            last_entry: None,
+            index_offset: raw_size,
+            ..Default::default()
+        };
+        let handle = SsTableHandle::new(
+            SsTableId::Compacted(ulid::Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            sst_info,
+        );
+        let base = SsTableView::identity(handle);
+
+        let view = base.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(&[0x00])),
+            Included(Bytes::copy_from_slice(&[0x01])),
+        ));
+
+        assert_eq!(view.estimate_visible_size(), raw_size);
     }
 
     #[test]

--- a/slatedb/src/size_tiered_compaction.rs
+++ b/slatedb/src/size_tiered_compaction.rs
@@ -443,7 +443,7 @@ fn compaction_sources(tree: &LsmTreeState) -> (Vec<CompactionSource>, Vec<Compac
         .iter()
         .map(|view| CompactionSource {
             source: SourceId::SstView(view.id),
-            size: view.estimate_size(),
+            size: view.estimate_visible_size(),
         })
         .collect();
     let srs: Vec<CompactionSource> = tree
@@ -451,7 +451,7 @@ fn compaction_sources(tree: &LsmTreeState) -> (Vec<CompactionSource>, Vec<Compac
         .iter()
         .map(|sr| CompactionSource {
             source: SourceId::SortedRun(sr.id),
-            size: sr.estimate_size(),
+            size: sr.estimate_visible_size(),
         })
         .collect();
     (l0, srs)
@@ -508,6 +508,7 @@ mod tests {
 
     use crate::compactor::{CompactionScheduler, CompactionSchedulerSupplier};
 
+    use crate::bytes_range::BytesRange;
     use crate::compactor_state::{
         Compaction, CompactionSpec, CompactionStatus, Compactions, CompactorState, SourceId,
     };
@@ -517,6 +518,7 @@ mod tests {
     use crate::manifest::store::test_utils::new_dirty_manifest;
     use crate::manifest::{LsmTreeState, ManifestCore, Segment};
     use crate::seq_tracker::SequenceTracker;
+    use crate::size_tiered_compaction::CompactionSource;
     use crate::size_tiered_compaction::{
         SizeTieredCompactionScheduler, SizeTieredCompactionSchedulerSupplier,
     };
@@ -525,6 +527,7 @@ mod tests {
     use slatedb_common::clock::DefaultSystemClock;
     use slatedb_common::DbRand;
     use slatedb_txn_obj::test_utils::new_dirty_object;
+    use std::ops::Bound::{Excluded, Included};
     use std::sync::Arc;
 
     #[test]
@@ -1012,6 +1015,110 @@ mod tests {
     fn create_sr(id: u32, sst_size: u64, num_ssts: usize) -> SortedRun {
         let ssts: Vec<SsTableView> = (0..num_ssts).map(|_| create_sst_view(sst_size)).collect();
         SortedRun::new(id, ssts)
+    }
+
+    fn create_sst_view_with_bounds(first: &[u8], last: &[u8], size: u64) -> SsTableView {
+        let info = SsTableInfo {
+            first_entry: Some(Bytes::copy_from_slice(first)),
+            last_entry: Some(Bytes::copy_from_slice(last)),
+            index_offset: size,
+            index_len: 0,
+            filter_offset: 0,
+            filter_len: 0,
+            compression_codec: None,
+            ..Default::default()
+        };
+        SsTableView::identity(SsTableHandle::new(
+            SsTableId::Compacted(ulid::Ulid::new()),
+            SST_FORMAT_VERSION_LATEST,
+            info,
+        ))
+    }
+
+    #[test]
+    fn test_borrowed_sst_views_join_compactable_run() {
+        let parent = create_sst_view_with_bounds(b"a", b"z", 4_000_000);
+        let borrowed_first_half = parent.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(b"a")),
+            Excluded(Bytes::copy_from_slice(b"m")),
+        ));
+        let borrowed_second_half = parent.with_visible_range(BytesRange::new(
+            Included(Bytes::copy_from_slice(b"m")),
+            Included(Bytes::copy_from_slice(b"z")),
+        ));
+        let peer = create_sst_view_with_bounds(b"aa", b"az", 600_000);
+
+        let sources = vec![
+            CompactionSource {
+                source: SourceId::SstView(peer.id),
+                size: peer.estimate_visible_size(),
+            },
+            CompactionSource {
+                source: SourceId::SstView(borrowed_first_half.id),
+                size: borrowed_first_half.estimate_visible_size(),
+            },
+            CompactionSource {
+                source: SourceId::SstView(borrowed_second_half.id),
+                size: borrowed_second_half.estimate_visible_size(),
+            },
+        ];
+
+        let run = SizeTieredCompactionScheduler::build_compactable_run(4.0, &sources, 0, None);
+
+        assert_eq!(
+            run.len(),
+            3,
+            "borrowed halves should scale down enough to join the peer's \
+             compactable run within the 4.0x size threshold, got sizes {:?}",
+            sources.iter().map(|s| s.size).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_propose_compacts_sorted_run_mixing_borrowed_and_plain_views() {
+        let scheduler = SizeTieredCompactionScheduler::default();
+
+        let plain_view = create_sst_view_with_bounds(b"a", b"z", 50_000);
+
+        let prefix = b"tenant00";
+        let phys_low = [prefix.as_slice(), &[0]].concat();
+        let phys_high = [prefix.as_slice(), &[200]].concat();
+        let vis_low = [prefix.as_slice(), &[0]].concat();
+        let vis_high = [prefix.as_slice(), &[10]].concat();
+        let borrowed_view = create_sst_view_with_bounds(&phys_low, &phys_high, 1_000_000)
+            .with_visible_range(BytesRange::new(
+                Included(Bytes::copy_from_slice(&vis_low)),
+                Excluded(Bytes::copy_from_slice(&vis_high)),
+            ));
+
+        let mixed_sr = SortedRun::new(0, [plain_view, borrowed_view]);
+        let mixed_sr_size = mixed_sr.estimate_visible_size();
+        assert!(
+            (80_000..120_000).contains(&mixed_sr_size),
+            "expected the mixed sorted run's aggregate to land near \
+             plain (50KB) + borrowed-visible (~50KB) = ~100KB, got {mixed_sr_size}"
+        );
+
+        let state = &create_compactor_state(create_db_state(
+            VecDeque::new(),
+            vec![
+                mixed_sr,
+                create_sr(1, 100_000, 1),
+                create_sr(2, 100_000, 1),
+                create_sr(3, 100_000, 1),
+            ],
+        ));
+
+        let compactions = scheduler.propose(&state.into());
+
+        assert_eq!(
+            compactions.len(),
+            1,
+            "the mixed sorted run's sane aggregate should let it join a compactable run with its peers"
+        );
+        let compaction = compactions.first().unwrap();
+        let expected_compaction = create_sr_compaction(vec![0, 1, 2, 3]);
+        assert_eq!(compaction.clone(), expected_compaction);
     }
 
     fn create_db_state(l0: VecDeque<SsTableView>, srs: Vec<SortedRun>) -> ManifestCore {


### PR DESCRIPTION
## Summary

- A view can show all of a file, or only a part of it. The old code always used the size of the full file, even for a partial view.
- This made a small view look big and as a result, the compactor could not match it with other small files. 
- The file then stayed unused for a long time, fragmenting the LSM tree. This was also confirmed by looking into the DB files for one of our jobs. 
- The new code adds a way to find the size of the visible part only.

## Changes

- We added a new function, `estimate_visible_size()`. The old function, `estimate_size()`, stays the same and is not affected.
- The new function checks the key range. It gives a size based on how much of the file the view can see. We use this new function only in the compactor's grouping step only. Later if required this can be extended to other callers. But for now keeping the scope focused only on compactor. 
- The new function never gives a size of zero. If it cannot find a good number, it uses the full file size instead of a very small number. This is like a fallback which keeps the behaiour same as now.  
- Added tests for all these cases.

## Notes for Reviewers

- The size from the new function is an estimate. It is not an exact count of bytes.
- The estimate can still be wrong in rare cases. In these cases, the code now falls back to the full file size. This stops the code from giving a size that is too small.
- We ran the tests and checks for the files we changed. 

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
