### PR TITLE
add tracing options to read path

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -10354,6 +10354,8 @@ type ReadOptions struct {
 	// Optional context forwarded to custom filter policies; ignored by
 	// built-in filters.
 	FilterContext *FilterContext
+	// Optional caller-supplied tracing settings.
+	TracingOptions *TracingOptions
 }
 
 func (r *ReadOptions) Destroy() {
@@ -10361,6 +10363,7 @@ func (r *ReadOptions) Destroy() {
 	FfiDestroyerBool{}.Destroy(r.Dirty)
 	FfiDestroyerBool{}.Destroy(r.CacheBlocks)
 	FfiDestroyerOptionalFilterContext{}.Destroy(r.FilterContext)
+	FfiDestroyerOptionalTracingOptions{}.Destroy(r.TracingOptions)
 }
 
 type FfiConverterReadOptions struct{}
@@ -10377,6 +10380,7 @@ func (c FfiConverterReadOptions) Read(reader io.Reader) ReadOptions {
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterOptionalFilterContextINSTANCE.Read(reader),
+		FfiConverterOptionalTracingOptionsINSTANCE.Read(reader),
 	}
 }
 
@@ -10393,6 +10397,7 @@ func (c FfiConverterReadOptions) Write(writer io.Writer, value ReadOptions) {
 	FfiConverterBoolINSTANCE.Write(writer, value.Dirty)
 	FfiConverterBoolINSTANCE.Write(writer, value.CacheBlocks)
 	FfiConverterOptionalFilterContextINSTANCE.Write(writer, value.FilterContext)
+	FfiConverterOptionalTracingOptionsINSTANCE.Write(writer, value.TracingOptions)
 }
 
 type FfiDestroyerReadOptions struct{}
@@ -10551,6 +10556,8 @@ type ScanOptions struct {
 	// Optional context forwarded to custom filter policies; ignored by
 	// built-in filters. Only consulted for prefix scans.
 	FilterContext *FilterContext
+	// Optional caller-supplied tracing settings.
+	TracingOptions *TracingOptions
 }
 
 func (r *ScanOptions) Destroy() {
@@ -10561,6 +10568,7 @@ func (r *ScanOptions) Destroy() {
 	FfiDestroyerUint64{}.Destroy(r.MaxFetchTasks)
 	FfiDestroyerOptionalIterationOrder{}.Destroy(r.Order)
 	FfiDestroyerOptionalFilterContext{}.Destroy(r.FilterContext)
+	FfiDestroyerOptionalTracingOptions{}.Destroy(r.TracingOptions)
 }
 
 type FfiConverterScanOptions struct{}
@@ -10580,6 +10588,7 @@ func (c FfiConverterScanOptions) Read(reader io.Reader) ScanOptions {
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterOptionalIterationOrderINSTANCE.Read(reader),
 		FfiConverterOptionalFilterContextINSTANCE.Read(reader),
+		FfiConverterOptionalTracingOptionsINSTANCE.Read(reader),
 	}
 }
 
@@ -10599,6 +10608,7 @@ func (c FfiConverterScanOptions) Write(writer io.Writer, value ScanOptions) {
 	FfiConverterUint64INSTANCE.Write(writer, value.MaxFetchTasks)
 	FfiConverterOptionalIterationOrderINSTANCE.Write(writer, value.Order)
 	FfiConverterOptionalFilterContextINSTANCE.Write(writer, value.FilterContext)
+	FfiConverterOptionalTracingOptionsINSTANCE.Write(writer, value.TracingOptions)
 }
 
 type FfiDestroyerScanOptions struct{}
@@ -11010,6 +11020,47 @@ func (c FfiConverterSsTableView) Write(writer io.Writer, value SsTableView) {
 type FfiDestroyerSsTableView struct{}
 
 func (_ FfiDestroyerSsTableView) Destroy(value SsTableView) {
+	value.Destroy()
+}
+
+// Options for tracing a read operation.
+type TracingOptions struct {
+	TraceId string
+}
+
+func (r *TracingOptions) Destroy() {
+	FfiDestroyerString{}.Destroy(r.TraceId)
+}
+
+type FfiConverterTracingOptions struct{}
+
+var FfiConverterTracingOptionsINSTANCE = FfiConverterTracingOptions{}
+
+func (c FfiConverterTracingOptions) Lift(rb RustBufferI) TracingOptions {
+	return LiftFromRustBuffer[TracingOptions](c, rb)
+}
+
+func (c FfiConverterTracingOptions) Read(reader io.Reader) TracingOptions {
+	return TracingOptions{
+		FfiConverterStringINSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterTracingOptions) Lower(value TracingOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[TracingOptions](c, value)
+}
+
+func (c FfiConverterTracingOptions) LowerExternal(value TracingOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[TracingOptions](c, value))
+}
+
+func (c FfiConverterTracingOptions) Write(writer io.Writer, value TracingOptions) {
+	FfiConverterStringINSTANCE.Write(writer, value.TraceId)
+}
+
+type FfiDestroyerTracingOptions struct{}
+
+func (_ FfiDestroyerTracingOptions) Destroy(value TracingOptions) {
 	value.Destroy()
 }
 
@@ -13551,6 +13602,47 @@ type FfiDestroyerOptionalMetric struct{}
 func (_ FfiDestroyerOptionalMetric) Destroy(value *Metric) {
 	if value != nil {
 		FfiDestroyerMetric{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalTracingOptions struct{}
+
+var FfiConverterOptionalTracingOptionsINSTANCE = FfiConverterOptionalTracingOptions{}
+
+func (c FfiConverterOptionalTracingOptions) Lift(rb RustBufferI) *TracingOptions {
+	return LiftFromRustBuffer[*TracingOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalTracingOptions) Read(reader io.Reader) *TracingOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterTracingOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalTracingOptions) Lower(value *TracingOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*TracingOptions](c, value)
+}
+
+func (c FfiConverterOptionalTracingOptions) LowerExternal(value *TracingOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*TracingOptions](c, value))
+}
+
+func (_ FfiConverterOptionalTracingOptions) Write(writer io.Writer, value *TracingOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterTracingOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalTracingOptions struct{}
+
+func (_ FfiDestroyerOptionalTracingOptions) Destroy(value *TracingOptions) {
+	if value != nil {
+		FfiDestroyerTracingOptions{}.Destroy(*value)
 	}
 }
 

--- a/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/TestSupport.java
+++ b/bindings/java/slatedb-uniffi/src/test/java/io/slatedb/uniffi/TestSupport.java
@@ -346,7 +346,7 @@ final class TestSupport {
     }
 
     static ReadOptions readOptions() {
-        return new ReadOptions(DurabilityLevel.MEMORY, false, true, null);
+        return new ReadOptions(DurabilityLevel.MEMORY, false, true, null, null);
     }
 
     static ScanOptions scanOptions(long readAheadBytes, boolean cacheBlocks, long maxFetchTasks) {
@@ -356,6 +356,7 @@ final class TestSupport {
                 readAheadBytes,
                 cacheBlocks,
                 maxFetchTasks,
+                null,
                 null,
                 null);
     }

--- a/bindings/python/tests/conftest.py
+++ b/bindings/python/tests/conftest.py
@@ -53,6 +53,7 @@ def read_options() -> ReadOptions:
         durability_filter=DurabilityLevel.MEMORY,
         dirty=False,
         cache_blocks=True,
+        tracing_options=None,
     )
 
 
@@ -65,6 +66,7 @@ def scan_options(
         read_ahead_bytes=read_ahead_bytes,
         cache_blocks=cache_blocks,
         max_fetch_tasks=max_fetch_tasks,
+        tracing_options=None,
     )
 
 

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -119,6 +119,20 @@ impl From<Ttl> for slatedb::config::Ttl {
     }
 }
 
+/// Options for tracing a read operation.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct TracingOptions {
+    pub trace_id: String,
+}
+
+impl From<TracingOptions> for slatedb::config::TracingOptions {
+    fn from(value: TracingOptions) -> Self {
+        Self {
+            trace_id: value.trace_id,
+        }
+    }
+}
+
 /// Options that control a point read.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct ReadOptions {
@@ -133,6 +147,9 @@ pub struct ReadOptions {
     /// built-in filters.
     #[uniffi(default = None)]
     pub filter_context: Option<FilterContext>,
+    /// Optional caller-supplied tracing settings.
+    #[uniffi(default = None)]
+    pub tracing_options: Option<TracingOptions>,
 }
 
 impl Default for ReadOptions {
@@ -142,6 +159,7 @@ impl Default for ReadOptions {
             dirty: false,
             cache_blocks: true,
             filter_context: None,
+            tracing_options: None,
         }
     }
 }
@@ -153,6 +171,7 @@ impl From<ReadOptions> for slatedb::config::ReadOptions {
             dirty: value.dirty,
             cache_blocks: value.cache_blocks,
             filter_context: value.filter_context.map(Into::into),
+            tracing_options: value.tracing_options.map(Into::into),
         }
     }
 }
@@ -265,6 +284,9 @@ pub struct ScanOptions {
     /// built-in filters. Only consulted for prefix scans.
     #[uniffi(default = None)]
     pub filter_context: Option<FilterContext>,
+    /// Optional caller-supplied tracing settings.
+    #[uniffi(default = None)]
+    pub tracing_options: Option<TracingOptions>,
 }
 
 impl Default for ScanOptions {
@@ -277,6 +299,7 @@ impl Default for ScanOptions {
             max_fetch_tasks: 1,
             order: None,
             filter_context: None,
+            tracing_options: None,
         }
     }
 }
@@ -301,6 +324,7 @@ impl TryFrom<ScanOptions> for slatedb::config::ScanOptions {
             })?,
             order: value.order.unwrap_or_default().into(),
             filter_context: value.filter_context.map(Into::into),
+            tracing_options: value.tracing_options.map(Into::into),
         })
     }
 }

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -27,7 +27,7 @@ pub use config::{
     CloseOptions, DurabilityLevel, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
     GarbageCollectorOptions, GarbageCollectorScheduleOptions, IsolationLevel, IterationOrder,
     MergeOptions, PutOptions, ReadOptions, ReaderMode, ReaderOptions, ScanOptions, SstBlockSize,
-    Ttl, WriteOptions,
+    TracingOptions, Ttl, WriteOptions,
 };
 pub use db::Db;
 pub use db_reader::DbReader;

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -281,6 +281,20 @@ pub enum DurabilityLevel {
     Memory,
 }
 
+/// Options for tracing a read operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TracingOptions {
+    pub trace_id: String,
+}
+
+impl TracingOptions {
+    pub fn new(trace_id: impl Into<String>) -> Self {
+        Self {
+            trace_id: trace_id.into(),
+        }
+    }
+}
+
 /// Configuration for client read operations. `ReadOptions` is supplied for each
 /// read call and controls the behavior of the read.
 #[derive(Clone, Debug)]
@@ -298,6 +312,8 @@ pub struct ReadOptions {
     /// Optional context forwarded to custom filter policies; ignored by
     /// built-in filters. See [`FilterContext`].
     pub filter_context: Option<FilterContext>,
+    /// Optional caller-provided tracing settings.
+    pub tracing_options: Option<TracingOptions>,
 }
 
 impl Default for ReadOptions {
@@ -307,6 +323,7 @@ impl Default for ReadOptions {
             dirty: false,
             cache_blocks: true,
             filter_context: None,
+            tracing_options: None,
         }
     }
 }
@@ -340,6 +357,13 @@ impl ReadOptions {
             ..self
         }
     }
+
+    pub fn with_tracing_options(self, tracing_options: Option<TracingOptions>) -> Self {
+        Self {
+            tracing_options,
+            ..self
+        }
+    }
 }
 #[derive(Clone, Debug)]
 pub struct ScanOptions {
@@ -369,6 +393,8 @@ pub struct ScanOptions {
     /// Only consulted for `scan_prefix` today. Plain range scans do not
     /// evaluate SST filters, so this field has no effect on `scan`.
     pub filter_context: Option<FilterContext>,
+    /// Optional caller-provided tracing settings.
+    pub tracing_options: Option<TracingOptions>,
 }
 
 impl Default for ScanOptions {
@@ -382,6 +408,7 @@ impl Default for ScanOptions {
             max_fetch_tasks: 1,
             order: IterationOrder::Ascending,
             filter_context: None,
+            tracing_options: None,
         }
     }
 }
@@ -430,6 +457,13 @@ impl ScanOptions {
     pub fn with_filter_context(self, filter_context: Option<FilterContext>) -> Self {
         Self {
             filter_context,
+            ..self
+        }
+    }
+
+    pub fn with_tracing_options(self, tracing_options: Option<TracingOptions>) -> Self {
+        Self {
+            tracing_options,
             ..self
         }
     }
@@ -1995,6 +2029,12 @@ object_store_cache_options:
     }
 
     #[test]
+    fn test_default_tracing_options_are_none() {
+        assert!(ReadOptions::default().tracing_options.is_none());
+        assert!(ScanOptions::default().tracing_options.is_none());
+    }
+
+    #[test]
     fn test_scan_options_with_max_fetch_tasks() {
         let options = ScanOptions::default().with_max_fetch_tasks(4);
         assert_eq!(options.max_fetch_tasks, 4);
@@ -2004,6 +2044,32 @@ object_store_cache_options:
         assert!(!options.dirty);
         assert_eq!(options.read_ahead_bytes, 1);
         assert!(!options.cache_blocks);
+    }
+
+    #[test]
+    fn test_read_options_with_tracing_options() {
+        let options =
+            ReadOptions::default().with_tracing_options(Some(TracingOptions::new("read-trace")));
+        assert_eq!(
+            options
+                .tracing_options
+                .as_ref()
+                .map(|tracing_options| tracing_options.trace_id.as_str()),
+            Some("read-trace")
+        );
+    }
+
+    #[test]
+    fn test_scan_options_with_tracing_options() {
+        let options =
+            ScanOptions::default().with_tracing_options(Some(TracingOptions::new("scan-trace")));
+        assert_eq!(
+            options
+                .tracing_options
+                .as_ref()
+                .map(|tracing_options| tracing_options.trace_id.as_str()),
+            Some("scan-trace")
+        );
     }
 
     #[test]

--- a/slatedb/src/db.rs
+++ b/slatedb/src/db.rs
@@ -3155,6 +3155,7 @@ mod tests {
                                         dirty: false,
                                         cache_blocks: true,
                                         filter_context: None,
+                                        tracing_options: None,
                                     }
                                 )
                                 .await


### PR DESCRIPTION
## Summary

This is the first PR for RFC-0033: SlateDB Query Tracing.
The PR introduces type `TracingOptions` and adds an optional field of it to
`ReadOptions` and `ScanOptions`.

Part of the fix for https://github.com/slatedb/slatedb/issues/400 and https://github.com/slatedb/slatedb/issues/797

## Changes

- Introduces `TracingOptions`
- Adds optional field `tracing_options: TracingOptions` to `ReadOptions` and `ScanOptions`
- Adds the bindings for other languages.
- Adds unit tests. 

## Notes for Reviewers

N/A

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
