### PR TITLE
Tolerate manifests GCed during admin.list_manifests

### DIFF
--- a/slatedb/src/admin.rs
+++ b/slatedb/src/admin.rs
@@ -107,11 +107,21 @@ impl Admin {
             .map_err(crate::Error::from)?;
         let mut manifests = Vec::with_capacity(manifest_metadata.len());
         for metadata in manifest_metadata {
-            let manifest = manifest_store
-                .read_manifest(metadata.id)
+            match manifest_store
+                .try_read_manifest(metadata.id)
                 .await
-                .map_err(crate::Error::from)?;
-            manifests.push(VersionedManifest::from_manifest(metadata.id, manifest));
+                .map_err(crate::Error::from)?
+            {
+                Some(manifest) => {
+                    manifests.push(VersionedManifest::from_manifest(metadata.id, manifest))
+                }
+                // Deleted after LIST by a concurrent GC
+                // See https://github.com/slatedb/slatedb/issues/1215 for more details.
+                None => log::warn!(
+                    "listed manifest missing on read, skipping [id={}]",
+                    metadata.id
+                ),
+            }
         }
         Ok(manifests)
     }
@@ -1976,5 +1986,63 @@ mod tests {
                 "pinned checkpoint should be removed from every parent"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod gc_tolerant_list_manifests_tests {
+    use crate::admin::AdminBuilder;
+    use crate::manifest::store::{ManifestStore, StoredManifest};
+    use crate::manifest::ManifestCore;
+    use crate::test_utils::FlakyObjectStore;
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::ObjectStore;
+    use slatedb_common::clock::DefaultSystemClock;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_list_manifests_skips_manifest_gced_between_list_and_read() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let flaky = Arc::new(FlakyObjectStore::new(inner, 0));
+        let store: Arc<dyn ObjectStore> = flaky.clone();
+        let path = Path::from("/tmp/test_gc_tolerant_list_manifests");
+
+        let manifest_store = Arc::new(ManifestStore::new(&path, store.clone()));
+        let mut sm = StoredManifest::create_new_db(
+            manifest_store,
+            ManifestCore::new(),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        sm.update(sm.prepare_dirty().unwrap()).await.unwrap();
+        sm.update(sm.prepare_dirty().unwrap()).await.unwrap();
+
+        let admin = AdminBuilder::new(path.clone(), store.clone()).build();
+        let ids: Vec<u64> = admin
+            .list_manifests(..)
+            .await
+            .unwrap()
+            .iter()
+            .map(|vm| vm.id())
+            .collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+
+        // manifest 1 is listed, but missing on read
+        flaky.with_get_not_found_failures(1);
+
+        let ids: Vec<u64> = admin
+            .list_manifests(..)
+            .await
+            .unwrap()
+            .iter()
+            .map(|vm| vm.id())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![2, 3],
+            "a manifest GC'd mid-listing should be skipped, not fail the operation"
+        );
     }
 }

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -573,6 +573,8 @@ pub(crate) struct FlakyObjectStore {
     // get_range: truncate response body to this many bytes on first N attempts (0 = no truncation)
     truncate_get_range_bytes: AtomicUsize,
     truncate_get_range_count: AtomicUsize,
+    // Get: return NotFound on the next N GETs
+    fail_first_get_not_found: AtomicUsize,
 }
 
 impl FlakyObjectStore {
@@ -598,7 +600,12 @@ impl FlakyObjectStore {
             get_range_attempts: AtomicUsize::new(0),
             truncate_get_range_bytes: AtomicUsize::new(0),
             truncate_get_range_count: AtomicUsize::new(0),
+            fail_first_get_not_found: AtomicUsize::new(0),
         }
+    }
+
+    pub(crate) fn with_get_not_found_failures(&self, n: usize) {
+        self.fail_first_get_not_found.store(n, Ordering::SeqCst);
     }
 
     pub(crate) fn with_put_precondition_always(self) -> Self {
@@ -726,6 +733,25 @@ impl ObjectStore for FlakyObjectStore {
         location: &Path,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
+        if self
+            .fail_first_get_not_found
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |v| {
+                if v > 0 {
+                    Some(v - 1)
+                } else {
+                    None
+                }
+            })
+            .is_ok()
+        {
+            return Err(object_store::Error::NotFound {
+                path: location.to_string(),
+                source: Box::new(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "injected not-found (deleted between LIST and GET)",
+                )),
+            });
+        }
         if options.head {
             self.head_attempts.fetch_add(1, Ordering::SeqCst);
             if self


### PR DESCRIPTION
## Summary

During down scales (union cloning) we've sporadically observed `failed to find manifest with id. id=1` errors failing the restore, appearing to be a race by GC deleting manifest 1 of the clone after `create_clone` rewritten manifest 2, and `admin.list_manifests` doing `LIST` + `GET` each

The issue can be reproduced by setting `garbage_collector_options.manifest_options.min_age` to `1s` + slow union cloning, and solved here by skipping read of manifests that couldn't be found after listed
Alternatively we could retry the LIST+GET as in https://github.com/slatedb/slatedb/pull/1230

## Changes

- Skip reading GCed manifests during admin.list_manifests + a test

## Notes for Reviewers

Related to https://github.com/slatedb/slatedb/issues/1215

## Checklist

- [X] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [X] Self-reviewed the diff; added comments for tricky parts
- [X] Tests added/updated and passing locally
- [X] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [X] Called out any breaking changes and provided migration notes
- [X] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
