### PR TITLE
add tracing spans slatedb.read and slatedb.read.memtable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,8 @@ dependencies = [
  "object_store",
  "slatedb",
  "tokio",
+ "tracing",
+ "tracing-chrome",
  "tracing-subscriber",
 ]
 
@@ -3880,6 +3882,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -111,12 +111,20 @@ path = "src/standalone_garbage_collector.rs"
 test = false
 bench = false
 
+[[bin]]
+name = "read_tracing"
+path = "src/read_tracing.rs"
+test = false
+bench = false
+
 [dependencies]
 anyhow.workspace = true
 object_store = { workspace = true, features = ["azure", "gcp"] }
 slatedb.workspace = true
 tokio = { workspace = true, features = ["macros", "signal"] }
 tracing-subscriber.workspace = true
+tracing-chrome = "0.7.2"
+tracing = "0.1.44"
 
 [lints]
 workspace = true

--- a/examples/src/read_tracing.rs
+++ b/examples/src/read_tracing.rs
@@ -1,0 +1,46 @@
+use slatedb::{bytes::Bytes, object_store::memory::InMemory, Db};
+use std::sync::Arc;
+use tracing_chrome::{ChromeLayerBuilder, TraceStyle};
+use tracing_subscriber::layer::SubscriberExt;
+use slatedb::config::{ReadOptions, TracingOptions};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+
+    // Setup
+    let object_store = Arc::new(InMemory::new());
+    let db = Db::open("/tmp/slatedb_tracing_subscriber", object_store).await?;
+
+    // Put
+    let key = b"test_key";
+    let value = b"test_value";
+    db.put(key, value).await?;
+
+    // Create tracing options with a custom trace ID
+    let tracing_options = TracingOptions::new("my-trace-id");
+
+    // Pass it to the read operation
+    let read_options = ReadOptions::default()
+        .with_tracing_options(Some(tracing_options));
+
+    // Register tracing-chrome subscriber.
+    // Subscriber tracing-chrome outputs traces in Chrome’s trace viewer format.
+    // The generated file `trace-<unix timestamp>` with the traces can be found in
+    // the root directory of the project. Dump that file into
+    // https://ui.perfetto.dev/ to visualize the spans.
+    let (chrome_layer, _chrome_guard) = ChromeLayerBuilder::new()
+        .include_args(true)
+        .trace_style(TraceStyle::Async)
+        .build();
+    let subscriber = tracing_subscriber::registry().with(chrome_layer);
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    //Get
+    let result = db.get_with_options(key, &read_options).await?;
+    assert_eq!(result, Some(Bytes::from_static(value)));
+
+    // Close
+    db.close().await?;
+
+    Ok(())
+}

--- a/examples/src/read_tracing.rs
+++ b/examples/src/read_tracing.rs
@@ -1,12 +1,11 @@
+use slatedb::config::{ReadOptions, TracingOptions};
 use slatedb::{bytes::Bytes, object_store::memory::InMemory, Db};
 use std::sync::Arc;
 use tracing_chrome::{ChromeLayerBuilder, TraceStyle};
 use tracing_subscriber::layer::SubscriberExt;
-use slatedb::config::{ReadOptions, TracingOptions};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-
     // Setup
     let object_store = Arc::new(InMemory::new());
     let db = Db::open("/tmp/slatedb_tracing_subscriber", object_store).await?;
@@ -20,8 +19,7 @@ async fn main() -> anyhow::Result<()> {
     let tracing_options = TracingOptions::new("my-trace-id");
 
     // Pass it to the read operation
-    let read_options = ReadOptions::default()
-        .with_tracing_options(Some(tracing_options));
+    let read_options = ReadOptions::default().with_tracing_options(Some(tracing_options));
 
     // Register tracing-chrome subscriber.
     // Subscriber tracing-chrome outputs traces in Chrome’s trace viewer format.

--- a/examples/src/read_tracing.rs
+++ b/examples/src/read_tracing.rs
@@ -2,7 +2,9 @@ use slatedb::config::{ReadOptions, TracingOptions};
 use slatedb::{bytes::Bytes, object_store::memory::InMemory, Db};
 use std::sync::Arc;
 use tracing_chrome::{ChromeLayerBuilder, TraceStyle};
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Layer;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -30,7 +32,8 @@ async fn main() -> anyhow::Result<()> {
         .include_args(true)
         .trace_style(TraceStyle::Async)
         .build();
-    let subscriber = tracing_subscriber::registry().with(chrome_layer);
+    let subscriber =
+        tracing_subscriber::registry().with(chrome_layer.with_filter(LevelFilter::DEBUG));
     let _subscriber_guard = tracing::subscriber::set_default(subscriber);
 
     //Get

--- a/rfcs/0033-query_tracing.md
+++ b/rfcs/0033-query_tracing.md
@@ -152,9 +152,12 @@ Both get a `with_tracing_options(TracingOptions) -> Self` builder method. Defaul
 
 The read path spans are structured hierarchically. The root span for the read path is named `slatedb.read`.
 All others are direct children of `slatedb.read`. All spans carry the trace ID
-(`trace_id`) as field. The spans are constructed at `info` level, except for `slatedb.read.memtable` which is 
+(`trace_id`) as field. Spans instrumented on a future are entered each time the future is polled by the runtime.
+
+The spans are constructed at `info` level, except for `slatedb.read.memtable` which is
 constructed at `debug` level.
-Spans instrumented on a future are entered each time the future is polled by the runtime.
+The reason for putting `slatedb.read.memtable` on a lower tracing level is the potential huge number of
+`slatedb.read.memtable` spans during scan operations since a span is constructed per key lookup in the memtables.
 
 The root span `slatedb.read` traces the entire read operation, which includes all stages of the read path
 covered by the child spans and common operations over all sources needed for reading, such as setting up

--- a/rfcs/0033-query_tracing.md
+++ b/rfcs/0033-query_tracing.md
@@ -152,7 +152,8 @@ Both get a `with_tracing_options(TracingOptions) -> Self` builder method. Defaul
 
 The read path spans are structured hierarchically. The root span for the read path is named `slatedb.read`.
 All others are direct children of `slatedb.read`. All spans carry the trace ID
-(`trace_id`) as field. The spans are all constructed at debug level.
+(`trace_id`) as field. The spans are constructed at `info` level, except for `slatedb.read.memtable` which is 
+constructed at `debug` level.
 Spans instrumented on a future are entered each time the future is polled by the runtime.
 
 The root span `slatedb.read` traces the entire read operation, which includes all stages of the read path

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -8,6 +8,7 @@ use crate::merge_iterator::MergeIterator;
 use crate::merge_operator::{
     MergeOperatorIterator, MergeOperatorRequiredIterator, MergeOperatorType,
 };
+use crate::reader::ReadTrace;
 use crate::segment_iterator::{build_l0_point_iters, build_sr_point_iters, SegmentScanContext};
 use crate::types::{KeyValue, RowEntry, ValueDeletable};
 
@@ -15,6 +16,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use std::collections::VecDeque;
 use std::ops::RangeBounds;
+use tracing::Instrument;
 
 /// [`DbIteratorRangeTracker`] records the *requested* scan range of a
 /// [`DbIterator`] so that the transaction manager can detect read-write
@@ -183,6 +185,7 @@ pub struct DbIterator {
     iter: Box<dyn RowEntryIterator + 'static>,
     invalidated_error: Option<SlateDBError>,
     last_key: Option<Bytes>,
+    read_span: Option<tracing::Span>,
 }
 
 impl DbIterator {
@@ -194,7 +197,12 @@ impl DbIterator {
         max_seq: Option<u64>,
         merge_operator: Option<MergeOperatorType>,
         order: IterationOrder,
+        read_trace: Option<ReadTrace>,
     ) -> Result<Self, SlateDBError> {
+        let read_span = read_trace
+            .as_ref()
+            .map(|read_trace| read_trace.read_span().clone());
+
         // The write_batch iterator is provided only when operating within a Transaction. It represents the uncommitted
         // writes made during the transaction. We do not need to apply the max_seq filter to them, because they do
         // not have an real committed sequence number yet.
@@ -246,13 +254,18 @@ impl DbIterator {
             iter = Box::new(MergeOperatorRequiredIterator::new(iter));
         }
 
-        iter.init().await?;
+        if let Some(span) = read_span.clone() {
+            iter.init().instrument(span).await?;
+        } else {
+            iter.init().await?;
+        }
 
         Ok(DbIterator {
             range,
             iter,
             invalidated_error: None,
             last_key: None,
+            read_span,
         })
     }
 
@@ -278,6 +291,15 @@ impl DbIterator {
     }
 
     pub(crate) async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
+        let read_span = self.read_span.clone();
+        if let Some(read_span) = read_span {
+            self.next_entry_inner().instrument(read_span).await
+        } else {
+            self.next_entry_inner().await
+        }
+    }
+
+    async fn next_entry_inner(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         if let Some(error) = self.invalidated_error.clone() {
             Err(error)
         } else {
@@ -390,14 +412,19 @@ pub struct DbRecencyIterator {
     /// returns it instead of advancing, since after a failure the
     /// iterator's underlying state is unsafe to keep using.
     invalidated_error: Option<SlateDBError>,
+    read_span: Option<tracing::Span>,
 }
 
 impl DbRecencyIterator {
-    pub(crate) fn new(iters: VecDeque<Box<dyn RowEntryIterator + 'static>>) -> Self {
+    pub(crate) fn new(
+        iters: VecDeque<Box<dyn RowEntryIterator + 'static>>,
+        read_span: Option<tracing::Span>,
+    ) -> Self {
         Self {
             iters,
             current_initialized: false,
             invalidated_error: None,
+            read_span,
         }
     }
 
@@ -406,6 +433,15 @@ impl DbRecencyIterator {
     /// operands are not filtered. See [`crate::Db::scan_prefix_by_recency`]
     /// for the full contract.
     pub async fn next_entry(&mut self) -> Result<Option<RowEntry>, crate::Error> {
+        let read_span = self.read_span.clone();
+        if let Some(read_span) = read_span {
+            self.next_entry_inner().instrument(read_span).await
+        } else {
+            self.next_entry_inner().await
+        }
+    }
+
+    async fn next_entry_inner(&mut self) -> Result<Option<RowEntry>, crate::Error> {
         if let Some(error) = &self.invalidated_error {
             return Err(error.clone().into());
         }
@@ -463,6 +499,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();
@@ -503,6 +540,7 @@ mod tests {
             Some(100),
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();
@@ -533,6 +571,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();
@@ -582,6 +621,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
+            None,
         )
         .await
         .unwrap();

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -185,7 +185,7 @@ pub struct DbIterator {
     iter: Box<dyn RowEntryIterator + 'static>,
     invalidated_error: Option<SlateDBError>,
     last_key: Option<Bytes>,
-    read_span: Option<tracing::Span>,
+    read_span: tracing::Span,
 }
 
 impl DbIterator {
@@ -197,11 +197,9 @@ impl DbIterator {
         max_seq: Option<u64>,
         merge_operator: Option<MergeOperatorType>,
         order: IterationOrder,
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> Result<Self, SlateDBError> {
-        let read_span = read_trace
-            .as_ref()
-            .map(|read_trace| read_trace.read_span().clone());
+        let read_span = read_trace.read_span();
 
         // The write_batch iterator is provided only when operating within a Transaction. It represents the uncommitted
         // writes made during the transaction. We do not need to apply the max_seq filter to them, because they do
@@ -254,11 +252,7 @@ impl DbIterator {
             iter = Box::new(MergeOperatorRequiredIterator::new(iter));
         }
 
-        if let Some(span) = read_span.clone() {
-            iter.init().instrument(span).await?;
-        } else {
-            iter.init().await?;
-        }
+        iter.init().instrument(read_span.clone()).await?;
 
         Ok(DbIterator {
             range,
@@ -292,11 +286,7 @@ impl DbIterator {
 
     pub(crate) async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
         let read_span = self.read_span.clone();
-        if let Some(read_span) = read_span {
-            self.next_entry_inner().instrument(read_span).await
-        } else {
-            self.next_entry_inner().await
-        }
+        self.next_entry_inner().instrument(read_span).await
     }
 
     async fn next_entry_inner(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
@@ -412,13 +402,13 @@ pub struct DbRecencyIterator {
     /// returns it instead of advancing, since after a failure the
     /// iterator's underlying state is unsafe to keep using.
     invalidated_error: Option<SlateDBError>,
-    read_span: Option<tracing::Span>,
+    read_span: tracing::Span,
 }
 
 impl DbRecencyIterator {
     pub(crate) fn new(
         iters: VecDeque<Box<dyn RowEntryIterator + 'static>>,
-        read_span: Option<tracing::Span>,
+        read_span: tracing::Span,
     ) -> Self {
         Self {
             iters,
@@ -434,11 +424,7 @@ impl DbRecencyIterator {
     /// for the full contract.
     pub async fn next_entry(&mut self) -> Result<Option<RowEntry>, crate::Error> {
         let read_span = self.read_span.clone();
-        if let Some(read_span) = read_span {
-            self.next_entry_inner().instrument(read_span).await
-        } else {
-            self.next_entry_inner().await
-        }
+        self.next_entry_inner().instrument(read_span).await
     }
 
     async fn next_entry_inner(&mut self) -> Result<Option<RowEntry>, crate::Error> {
@@ -484,6 +470,7 @@ mod tests {
     use crate::db_iter::DbIterator;
     use crate::error::SlateDBError;
     use crate::iter::{EmptyIterator, IterationOrder, RowEntryIterator};
+    use crate::reader::ReadTrace;
     use crate::test_utils::TestIterator;
     use bytes::Bytes;
     use std::collections::VecDeque;
@@ -499,7 +486,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
-            None,
+            ReadTrace::new(None),
         )
         .await
         .unwrap();
@@ -540,7 +527,7 @@ mod tests {
             Some(100),
             None,
             IterationOrder::Ascending,
-            None,
+            ReadTrace::new(None),
         )
         .await
         .unwrap();
@@ -571,7 +558,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
-            None,
+            ReadTrace::new(None),
         )
         .await
         .unwrap();
@@ -621,7 +608,7 @@ mod tests {
             None,
             None,
             IterationOrder::Ascending,
-            None,
+            ReadTrace::new(None),
         )
         .await
         .unwrap();

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -18,6 +18,7 @@ use crate::db_common::extract_segment_prefix;
 use crate::error::SlateDBError;
 use crate::iter::{IterationOrder, RowEntryIterator};
 use crate::prefix_extractor::PrefixExtractor;
+use crate::reader::ReadTrace;
 use crate::seq_tracker::{SequenceTracker, TrackedSeq};
 use crate::types::RowEntry;
 use crate::utils::{WatchableOnceCell, WatchableOnceCellReader};
@@ -194,6 +195,7 @@ pub(crate) struct MemTableIteratorInner<T: RangeBounds<SequencedKey>> {
     /// in seq-ascending order. Pushing them onto this stack and popping gives
     /// seq-descending order, which is what the merge iterator needs for dedup.
     descending_stack: Vec<RowEntry>,
+    read_trace: Option<ReadTrace>,
 }
 pub(crate) type MemTableIterator = MemTableIteratorInner<KVTableInternalKeyRange>;
 
@@ -222,7 +224,16 @@ impl RowEntryIterator for MemTableIterator {
 }
 
 impl MemTableIterator {
+    fn read_trace(&self) -> Option<ReadTrace> {
+        self.borrow_read_trace().clone()
+    }
+
     pub(crate) fn next_sync(&mut self) -> Option<RowEntry> {
+        let span = self
+            .read_trace()
+            .as_ref()
+            .map(|read_trace| read_trace.new_memtable_span());
+        let _guard = span.as_ref().map(|span| span.enter());
         match self.borrow_ordering() {
             IterationOrder::Ascending => self.next_ascending(),
             IterationOrder::Descending => self.next_descending(),
@@ -500,13 +511,14 @@ impl KVTable {
     }
 
     pub(crate) fn range_ascending<T: RangeBounds<Bytes>>(&self, range: T) -> MemTableIterator {
-        self.range(range, IterationOrder::Ascending)
+        self.range(range, IterationOrder::Ascending, None)
     }
 
     pub(crate) fn range<T: RangeBounds<Bytes>>(
         &self,
         range: T,
         ordering: IterationOrder,
+        read_trace: Option<ReadTrace>,
     ) -> MemTableIterator {
         let internal_range = KVTableInternalKeyRange::from(range);
         let mut iterator = MemTableIteratorInnerBuilder {
@@ -515,6 +527,7 @@ impl KVTable {
             ordering,
             item: None,
             descending_stack: Vec::new(),
+            read_trace,
         }
         .build();
         iterator.next_sync();
@@ -860,7 +873,7 @@ mod tests {
             .run(
                 &(arbitrary::nonempty_range(10), arbitrary::iteration_order()),
                 |(range, ordering)| {
-                    let mut kv_iter = kv_table.table.range(range.clone(), ordering);
+                    let mut kv_iter = kv_table.table.range(range.clone(), ordering, None);
 
                     runtime.block_on(test_utils::assert_ranged_kv_scan(
                         &sample_table,
@@ -1076,7 +1089,7 @@ mod tests {
         table.put(RowEntry::new_value(b"bbbb", b"new", 2));
         table.put(RowEntry::new_value(b"cccc", b"v3", 3));
 
-        let mut iter = table.table().range(.., IterationOrder::Descending);
+        let mut iter = table.table().range(.., IterationOrder::Descending, None);
 
         // In descending order, for key "bbbb" the newest version (seq 2) must
         // come before the older version (seq 1) so that dedup works correctly.

--- a/slatedb/src/mem_table.rs
+++ b/slatedb/src/mem_table.rs
@@ -195,7 +195,7 @@ pub(crate) struct MemTableIteratorInner<T: RangeBounds<SequencedKey>> {
     /// in seq-ascending order. Pushing them onto this stack and popping gives
     /// seq-descending order, which is what the merge iterator needs for dedup.
     descending_stack: Vec<RowEntry>,
-    read_trace: Option<ReadTrace>,
+    read_trace: ReadTrace,
 }
 pub(crate) type MemTableIterator = MemTableIteratorInner<KVTableInternalKeyRange>;
 
@@ -224,16 +224,9 @@ impl RowEntryIterator for MemTableIterator {
 }
 
 impl MemTableIterator {
-    fn read_trace(&self) -> Option<ReadTrace> {
-        self.borrow_read_trace().clone()
-    }
-
     pub(crate) fn next_sync(&mut self) -> Option<RowEntry> {
-        let span = self
-            .read_trace()
-            .as_ref()
-            .map(|read_trace| read_trace.new_memtable_span());
-        let _guard = span.as_ref().map(|span| span.enter());
+        let span = self.borrow_read_trace().new_memtable_span();
+        let _guard = span.enter();
         match self.borrow_ordering() {
             IterationOrder::Ascending => self.next_ascending(),
             IterationOrder::Descending => self.next_descending(),
@@ -511,14 +504,14 @@ impl KVTable {
     }
 
     pub(crate) fn range_ascending<T: RangeBounds<Bytes>>(&self, range: T) -> MemTableIterator {
-        self.range(range, IterationOrder::Ascending, None)
+        self.range(range, IterationOrder::Ascending, ReadTrace::new(None))
     }
 
     pub(crate) fn range<T: RangeBounds<Bytes>>(
         &self,
         range: T,
         ordering: IterationOrder,
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> MemTableIterator {
         let internal_range = KVTableInternalKeyRange::from(range);
         let mut iterator = MemTableIteratorInnerBuilder {
@@ -873,7 +866,10 @@ mod tests {
             .run(
                 &(arbitrary::nonempty_range(10), arbitrary::iteration_order()),
                 |(range, ordering)| {
-                    let mut kv_iter = kv_table.table.range(range.clone(), ordering, None);
+                    let mut kv_iter =
+                        kv_table
+                            .table
+                            .range(range.clone(), ordering, ReadTrace::new(None));
 
                     runtime.block_on(test_utils::assert_ranged_kv_scan(
                         &sample_table,
@@ -1089,7 +1085,9 @@ mod tests {
         table.put(RowEntry::new_value(b"bbbb", b"new", 2));
         table.put(RowEntry::new_value(b"cccc", b"v3", 3));
 
-        let mut iter = table.table().range(.., IterationOrder::Descending, None);
+        let mut iter = table
+            .table()
+            .range(.., IterationOrder::Descending, ReadTrace::new(None));
 
         // In descending order, for key "bbbb" the newest version (seq 2) must
         // come before the older version (seq 1) so that dedup works correctly.

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -1,10 +1,10 @@
 use crate::batch::WriteBatchIterator;
 use crate::bytes_range::BytesRange;
 use crate::clock::MonotonicClock;
-use crate::config::{DurabilityLevel, ReadOptions, ScanOptions};
+use crate::config::{DurabilityLevel, ReadOptions, ScanOptions, TracingOptions};
 use crate::db_iter::{apply_filters, DbRecencyIterator};
 use crate::db_stats::DbStats;
-use crate::iter::RowEntryIterator;
+use crate::iter::{IterationOrder, RowEntryIterator};
 use crate::manifest::{ManifestCore, Segment};
 use crate::mem_table::{ImmutableMemtable, KVTable};
 use crate::merge_operator::{instrument_merge_operator, MergeOperatorType};
@@ -19,6 +19,7 @@ use crate::{error::SlateDBError, DbIterator};
 use bytes::Bytes;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use tracing::Instrument;
 
 pub(crate) trait DbStateReader {
     fn memtable(&self) -> Arc<KVTable>;
@@ -34,6 +35,39 @@ struct IteratorSources {
     /// `SegmentRangeIterator`); the top-level scan path treats the
     /// chain as one merge arm alongside `mem_iters` and `write_batch_iter`.
     segment_iter: Box<dyn RowEntryIterator + 'static>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ReadTrace {
+    tracing_options: TracingOptions,
+    read_span: tracing::Span,
+}
+
+impl ReadTrace {
+    pub(crate) fn new(tracing_options: TracingOptions) -> Self {
+        let read_span =
+            tracing::debug_span!("slatedb.read", trace_id = tracing_options.trace_id.as_str(),);
+        Self {
+            tracing_options,
+            read_span,
+        }
+    }
+
+    pub(crate) fn read_span(&self) -> &tracing::Span {
+        &self.read_span
+    }
+
+    fn trace_id(&self) -> &str {
+        self.tracing_options.trace_id.as_str()
+    }
+
+    pub(crate) fn new_memtable_span(&self) -> tracing::Span {
+        tracing::debug_span!(
+            parent: &self.read_span,
+            "slatedb.read.memtable",
+            trace_id = self.trace_id(),
+        )
+    }
 }
 
 /// Context for [`Reader::scan_with_options`].
@@ -130,6 +164,31 @@ impl Reader {
         max_seq
     }
 
+    fn read_trace(tracing_options: Option<&TracingOptions>) -> Option<ReadTrace> {
+        tracing_options.map(|tracing_options| ReadTrace::new(tracing_options.clone()))
+    }
+
+    fn build_memtable_iters(
+        range: &BytesRange,
+        db_state: &(dyn DbStateReader + Sync),
+        order: IterationOrder,
+        read_trace: Option<ReadTrace>,
+    ) -> Vec<Box<dyn RowEntryIterator + 'static>> {
+        let mut memtables = VecDeque::new();
+        memtables.push_back(db_state.memtable());
+        for memtable in db_state.imm_memtable() {
+            memtables.push_back(memtable.table());
+        }
+
+        memtables
+            .iter()
+            .map(|table| {
+                Box::new(table.range(range.clone(), order, read_trace.clone()))
+                    as Box<dyn RowEntryIterator + 'static>
+            })
+            .collect()
+    }
+
     async fn build_iterator_sources(
         &self,
         range: &BytesRange,
@@ -138,19 +197,10 @@ impl Reader {
         sst_iter_options: &SstIteratorOptions,
         point_lookup_stats: Option<DbStats>,
         max_seq: Option<u64>,
+        read_trace: Option<ReadTrace>,
     ) -> Result<IteratorSources, SlateDBError> {
-        let mut memtables = VecDeque::new();
-        memtables.push_back(db_state.memtable());
-        for memtable in db_state.imm_memtable() {
-            memtables.push_back(memtable.table());
-        }
-        let mem_iters = memtables
-            .iter()
-            .map(|table| {
-                Box::new(table.range(range.clone(), sst_iter_options.order))
-                    as Box<dyn RowEntryIterator + 'static>
-            })
-            .collect::<Vec<_>>();
+        let mem_iters =
+            Self::build_memtable_iters(range, db_state, sst_iter_options.order, read_trace);
 
         let default_seg;
         let segments: &[Segment] = match db_state.core().select_segments(range) {
@@ -208,6 +258,31 @@ impl Reader {
         write_batch_iter: Option<WriteBatchIterator>,
         max_seq: Option<u64>,
     ) -> Result<Option<KeyValue>, SlateDBError> {
+        let read_trace = Self::read_trace(options.tracing_options.as_ref());
+        let read = self.get_key_value_with_options_inner(
+            key,
+            options,
+            db_state,
+            write_batch_iter,
+            max_seq,
+            read_trace.clone(),
+        );
+        if let Some(read_trace) = read_trace {
+            read.instrument(read_trace.read_span().clone()).await
+        } else {
+            read.await
+        }
+    }
+
+    async fn get_key_value_with_options_inner<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+        options: &ReadOptions,
+        db_state: &(dyn DbStateReader + Sync + Send),
+        write_batch_iter: Option<WriteBatchIterator>,
+        max_seq: Option<u64>,
+        read_trace: Option<ReadTrace>,
+    ) -> Result<Option<KeyValue>, SlateDBError> {
         self.db_stats.get_requests.increment(1);
         let max_seq = self.prepare_max_seq(max_seq, options.durability_filter, options.dirty);
         let key_slice = key.as_ref();
@@ -232,6 +307,7 @@ impl Reader {
                 &sst_iter_options,
                 Some(self.db_stats.clone()),
                 max_seq,
+                read_trace.clone(),
             )
             .await?;
 
@@ -243,6 +319,7 @@ impl Reader {
             max_seq,
             self.read_merge_operator.clone(),
             sst_iter_options.order,
+            read_trace,
         )
         .await?;
 
@@ -278,6 +355,22 @@ impl Reader {
         options: &ScanOptions,
         ctx: ScanContext<'_>,
     ) -> Result<DbIterator, SlateDBError> {
+        let read_trace = Self::read_trace(options.tracing_options.as_ref());
+        let read = self.scan_with_options_inner(range, options, ctx, read_trace.clone());
+        if let Some(read_trace) = read_trace {
+            read.instrument(read_trace.read_span().clone()).await
+        } else {
+            read.await
+        }
+    }
+
+    async fn scan_with_options_inner(
+        &self,
+        range: BytesRange,
+        options: &ScanOptions,
+        ctx: ScanContext<'_>,
+        read_trace: Option<ReadTrace>,
+    ) -> Result<DbIterator, SlateDBError> {
         self.db_stats.scan_requests.increment(1);
         let max_seq = self.prepare_max_seq(ctx.max_seq, options.durability_filter, options.dirty);
 
@@ -304,6 +397,7 @@ impl Reader {
                 &sst_iter_options,
                 None,
                 max_seq,
+                read_trace.clone(),
             )
             .await?;
 
@@ -315,6 +409,7 @@ impl Reader {
             max_seq,
             self.read_merge_operator.clone(),
             options.order,
+            read_trace,
         )
         .await
     }
@@ -338,6 +433,27 @@ impl Reader {
         prefix: Bytes,
         options: &ScanOptions,
         db_state: &(dyn DbStateReader + Sync),
+    ) -> Result<DbRecencyIterator, SlateDBError> {
+        let read_trace = Self::read_trace(options.tracing_options.as_ref());
+        let read = self.scan_prefix_by_recency_with_options_inner(
+            prefix,
+            options,
+            db_state,
+            read_trace.clone(),
+        );
+        if let Some(read_trace) = read_trace {
+            read.instrument(read_trace.read_span().clone()).await
+        } else {
+            read.await
+        }
+    }
+
+    async fn scan_prefix_by_recency_with_options_inner(
+        &self,
+        prefix: Bytes,
+        options: &ScanOptions,
+        db_state: &(dyn DbStateReader + Sync),
+        read_trace: Option<ReadTrace>,
     ) -> Result<DbRecencyIterator, SlateDBError> {
         self.db_stats.scan_requests.increment(1);
         let max_seq = self.prepare_max_seq(None, options.durability_filter, options.dirty);
@@ -371,21 +487,13 @@ impl Reader {
             None => Some(db_state.core().default_segment()),
         };
 
-        let mut all_iters: Vec<Box<dyn RowEntryIterator + 'static>> = Vec::new();
-
         // Memtables drain first (newest data, always in memory).
-        all_iters.push(Box::new(
-            db_state
-                .memtable()
-                .range(range.clone(), sst_iter_options.order),
-        ));
-        for memtable in db_state.imm_memtable() {
-            all_iters.push(Box::new(
-                memtable
-                    .table()
-                    .range(range.clone(), sst_iter_options.order),
-            ));
-        }
+        let mut all_iters = Self::build_memtable_iters(
+            &range,
+            db_state,
+            sst_iter_options.order,
+            read_trace.clone(),
+        );
 
         // Single-segment chain: L0 newest-first, then sorted runs newest-first.
         // SST and SortedRun iterators are constructed without `init`, so the
@@ -424,7 +532,10 @@ impl Reader {
         }
 
         let filtered = apply_filters(all_iters, max_seq);
-        Ok(DbRecencyIterator::new(VecDeque::from(filtered)))
+        Ok(DbRecencyIterator::new(
+            VecDeque::from(filtered),
+            read_trace.map(|read_trace| read_trace.read_span().clone()),
+        ))
     }
 }
 
@@ -479,7 +590,11 @@ mod tests {
         MetricsRecorderHelper,
     };
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::fmt;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::registry::LookupSpan;
+    use tracing_subscriber::Layer;
     use ulid::Ulid;
 
     /// A simple merge operator for testing that concatenates byte strings
@@ -500,6 +615,74 @@ mod tests {
                 }
                 None => Ok(operand),
             }
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecordedSpan {
+        name: String,
+        level: String,
+        parent_name: Option<String>,
+        fields: HashMap<String, String>,
+    }
+
+    #[derive(Clone, Default)]
+    struct SpanRecorder {
+        spans: Arc<Mutex<Vec<RecordedSpan>>>,
+    }
+
+    impl SpanRecorder {
+        fn spans(&self) -> Vec<RecordedSpan> {
+            self.spans.lock().expect("span recorder poisoned").clone()
+        }
+    }
+
+    struct FieldRecorder<'a> {
+        fields: &'a mut HashMap<String, String>,
+    }
+
+    impl tracing::field::Visit for FieldRecorder<'_> {
+        fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn fmt::Debug) {
+            self.fields
+                .insert(field.name().to_string(), format!("{value:?}"));
+        }
+    }
+
+    impl<S> Layer<S> for SpanRecorder
+    where
+        S: tracing::Subscriber + for<'lookup> LookupSpan<'lookup>,
+    {
+        fn on_new_span(
+            &self,
+            attrs: &tracing::span::Attributes<'_>,
+            _id: &tracing::Id,
+            ctx: Context<'_, S>,
+        ) {
+            let mut fields = HashMap::new();
+            attrs.record(&mut FieldRecorder {
+                fields: &mut fields,
+            });
+
+            let explicit_parent = attrs.parent().and_then(|id| ctx.span(id));
+            let contextual_parent = ctx.current_span().id().and_then(|id| ctx.span(id));
+            let parent_name = explicit_parent
+                .or(contextual_parent)
+                .map(|span| span.metadata().name().to_string());
+
+            self.spans
+                .lock()
+                .expect("span recorder poisoned")
+                .push(RecordedSpan {
+                    name: attrs.metadata().name().to_string(),
+                    level: attrs.metadata().level().to_string(),
+                    parent_name,
+                    fields,
+                });
         }
     }
 
@@ -1799,6 +1982,237 @@ mod tests {
             oracle,
             merge_operator,
         )
+    }
+
+    fn build_span_test_reader() -> (TestDbState, Reader) {
+        let mut test_db_state = tokio_test::block_on(TestDbState::new());
+        test_db_state.add_to_memtable(vec![TestEntry::value(b"key1", b"value1", 1).to_row_entry()]);
+
+        let recorder = MetricsRecorderHelper::noop();
+        let db_stats = DbStats::new(&recorder);
+        let reader = tokio_test::block_on(build_reader(&test_db_state, db_stats, false));
+
+        (test_db_state, reader)
+    }
+
+    fn assert_recorded_memtable_read_spans(recorder: &SpanRecorder, trace_id: &str) {
+        let spans = recorder.spans();
+        let read_span = spans
+            .iter()
+            .find(|span| span.name == "slatedb.read")
+            .expect("missing slatedb.read span");
+        assert_eq!(read_span.level, "DEBUG");
+        assert_eq!(
+            read_span.fields.get("trace_id").map(String::as_str),
+            Some(trace_id)
+        );
+
+        let memtable_span = spans
+            .iter()
+            .find(|span| span.name == "slatedb.read.memtable")
+            .expect("missing slatedb.read.memtable span");
+        assert_eq!(memtable_span.level, "DEBUG");
+        assert_eq!(memtable_span.parent_name.as_deref(), Some("slatedb.read"));
+        assert_eq!(
+            memtable_span.fields.get("trace_id").map(String::as_str),
+            Some(trace_id)
+        );
+    }
+
+    fn assert_no_read_spans(recorder: &SpanRecorder) {
+        let spans = recorder.spans();
+        assert!(
+            spans
+                .iter()
+                .all(|span| span.name != "slatedb.read" && span.name != "slatedb.read.memtable"),
+            "read spans should not be created without tracing options: {spans:?}"
+        );
+    }
+
+    #[test]
+    fn should_record_memtable_read_spans_for_get_with_tracing_options() -> Result<(), SlateDBError>
+    {
+        let (test_db_state, reader) = build_span_test_reader();
+        let span_recorder = SpanRecorder::default();
+        let subscriber = tracing_subscriber::registry().with(span_recorder.clone());
+        let trace_id = "get-trace";
+        let read_options =
+            ReadOptions::default().with_tracing_options(Some(TracingOptions::new(trace_id)));
+
+        let result = tracing::subscriber::with_default(subscriber, || {
+            tokio_test::block_on(reader.get_key_value_with_options(
+                b"key1",
+                &read_options,
+                &test_db_state,
+                None,
+                None,
+            ))
+        })?;
+
+        assert_eq!(
+            result.map(|kv| kv.value),
+            Some(Bytes::from_static(b"value1"))
+        );
+        assert_recorded_memtable_read_spans(&span_recorder, trace_id);
+        Ok(())
+    }
+
+    #[test]
+    fn should_record_memtable_read_spans_for_scan_with_tracing_options() -> Result<(), SlateDBError>
+    {
+        let (test_db_state, reader) = build_span_test_reader();
+        let span_recorder = SpanRecorder::default();
+        let subscriber = tracing_subscriber::registry().with(span_recorder.clone());
+        let trace_id = "scan-trace";
+        let scan_options =
+            ScanOptions::default().with_tracing_options(Some(TracingOptions::new(trace_id)));
+        let range = BytesRange::from_slice(b"key1".as_slice()..=b"key1".as_slice());
+
+        tracing::subscriber::with_default(subscriber, || {
+            tokio_test::block_on(async {
+                let mut iter = reader
+                    .scan_with_options(
+                        range.clone(),
+                        &scan_options,
+                        ScanContext {
+                            db_state: &test_db_state,
+                            write_batch_iter: None,
+                            max_seq: None,
+                            prefix: None,
+                        },
+                    )
+                    .await?;
+                assert_eq!(
+                    iter.next_entry().await?.map(|entry| entry.value),
+                    Some(ValueDeletable::Value(Bytes::from_static(b"value1")))
+                );
+                Ok::<_, SlateDBError>(())
+            })
+        })?;
+
+        assert_recorded_memtable_read_spans(&span_recorder, trace_id);
+        Ok(())
+    }
+
+    #[test]
+    fn should_record_memtable_read_spans_for_recency_scan_with_tracing_options(
+    ) -> Result<(), SlateDBError> {
+        let (test_db_state, reader) = build_span_test_reader();
+        let span_recorder = SpanRecorder::default();
+        let subscriber = tracing_subscriber::registry().with(span_recorder.clone());
+        let trace_id = "recency-scan-trace";
+        let scan_options =
+            ScanOptions::default().with_tracing_options(Some(TracingOptions::new(trace_id)));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tokio_test::block_on(async {
+                let mut iter = reader
+                    .scan_prefix_by_recency_with_options(
+                        Bytes::from_static(b"key"),
+                        &scan_options,
+                        &test_db_state,
+                    )
+                    .await?;
+                assert_eq!(
+                    iter.next_entry()
+                        .await
+                        .expect("recency scan next should succeed")
+                        .map(|entry| entry.value),
+                    Some(ValueDeletable::Value(Bytes::from_static(b"value1")))
+                );
+                Ok::<_, SlateDBError>(())
+            })
+        })?;
+
+        assert_recorded_memtable_read_spans(&span_recorder, trace_id);
+        Ok(())
+    }
+
+    #[test]
+    fn should_not_record_memtable_read_spans_without_tracing_options() -> Result<(), SlateDBError> {
+        let (test_db_state, reader) = build_span_test_reader();
+        let span_recorder = SpanRecorder::default();
+        let subscriber = tracing_subscriber::registry().with(span_recorder.clone());
+
+        let _result = tracing::subscriber::with_default(subscriber, || {
+            tokio_test::block_on(reader.get_key_value_with_options(
+                b"key1",
+                &ReadOptions::default(),
+                &test_db_state,
+                None,
+                None,
+            ))
+        })?;
+
+        assert_no_read_spans(&span_recorder);
+        Ok(())
+    }
+
+    #[test]
+    fn should_not_record_memtable_read_spans_for_scan_without_tracing_options(
+    ) -> Result<(), SlateDBError> {
+        let (test_db_state, reader) = build_span_test_reader();
+        let span_recorder = SpanRecorder::default();
+        let subscriber = tracing_subscriber::registry().with(span_recorder.clone());
+        let scan_options = ScanOptions::default();
+        let range = BytesRange::from_slice(b"key1".as_slice()..=b"key1".as_slice());
+
+        tracing::subscriber::with_default(subscriber, || {
+            tokio_test::block_on(async {
+                let mut iter = reader
+                    .scan_with_options(
+                        range,
+                        &scan_options,
+                        ScanContext {
+                            db_state: &test_db_state,
+                            write_batch_iter: None,
+                            max_seq: None,
+                            prefix: None,
+                        },
+                    )
+                    .await?;
+                assert_eq!(
+                    iter.next_entry().await?.map(|entry| entry.value),
+                    Some(ValueDeletable::Value(Bytes::from_static(b"value1")))
+                );
+                Ok::<_, SlateDBError>(())
+            })
+        })?;
+
+        assert_no_read_spans(&span_recorder);
+        Ok(())
+    }
+
+    #[test]
+    fn should_not_record_memtable_read_spans_for_recency_scan_without_tracing_options(
+    ) -> Result<(), SlateDBError> {
+        let (test_db_state, reader) = build_span_test_reader();
+        let span_recorder = SpanRecorder::default();
+        let subscriber = tracing_subscriber::registry().with(span_recorder.clone());
+        let scan_options = ScanOptions::default();
+
+        tracing::subscriber::with_default(subscriber, || {
+            tokio_test::block_on(async {
+                let mut iter = reader
+                    .scan_prefix_by_recency_with_options(
+                        Bytes::from_static(b"key"),
+                        &scan_options,
+                        &test_db_state,
+                    )
+                    .await?;
+                assert_eq!(
+                    iter.next_entry()
+                        .await
+                        .expect("recency scan next should succeed")
+                        .map(|entry| entry.value),
+                    Some(ValueDeletable::Value(Bytes::from_static(b"value1")))
+                );
+                Ok::<_, SlateDBError>(())
+            })
+        })?;
+
+        assert_no_read_spans(&span_recorder);
+        Ok(())
     }
 
     #[tokio::test]

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -39,34 +39,38 @@ struct IteratorSources {
 
 #[derive(Clone)]
 pub(crate) struct ReadTrace {
-    tracing_options: TracingOptions,
+    tracing_options: Option<TracingOptions>,
     read_span: tracing::Span,
 }
 
 impl ReadTrace {
-    pub(crate) fn new(tracing_options: TracingOptions) -> Self {
-        let read_span =
-            tracing::debug_span!("slatedb.read", trace_id = tracing_options.trace_id.as_str(),);
+    pub(crate) fn new(tracing_options: Option<TracingOptions>) -> Self {
+        let read_span = tracing_options
+            .as_ref()
+            .map(|tracing_options| {
+                tracing::debug_span!("slatedb.read", trace_id = tracing_options.trace_id.as_str(),)
+            })
+            .unwrap_or_else(tracing::Span::none);
         Self {
             tracing_options,
             read_span,
         }
     }
 
-    pub(crate) fn read_span(&self) -> &tracing::Span {
-        &self.read_span
-    }
-
-    fn trace_id(&self) -> &str {
-        self.tracing_options.trace_id.as_str()
+    pub(crate) fn read_span(&self) -> tracing::Span {
+        self.read_span.clone()
     }
 
     pub(crate) fn new_memtable_span(&self) -> tracing::Span {
-        tracing::debug_span!(
-            parent: &self.read_span,
-            "slatedb.read.memtable",
-            trace_id = self.trace_id(),
-        )
+        if let Some(tracing_options) = self.tracing_options.as_ref() {
+            tracing::debug_span!(
+                parent: &self.read_span,
+                "slatedb.read.memtable",
+                trace_id = tracing_options.trace_id.as_str(),
+            )
+        } else {
+            tracing::Span::none()
+        }
     }
 }
 
@@ -164,15 +168,15 @@ impl Reader {
         max_seq
     }
 
-    fn read_trace(tracing_options: Option<&TracingOptions>) -> Option<ReadTrace> {
-        tracing_options.map(|tracing_options| ReadTrace::new(tracing_options.clone()))
+    fn read_trace(tracing_options: Option<&TracingOptions>) -> ReadTrace {
+        ReadTrace::new(tracing_options.cloned())
     }
 
     fn build_memtable_iters(
         range: &BytesRange,
         db_state: &(dyn DbStateReader + Sync),
         order: IterationOrder,
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> Vec<Box<dyn RowEntryIterator + 'static>> {
         let mut memtables = VecDeque::new();
         memtables.push_back(db_state.memtable());
@@ -197,7 +201,7 @@ impl Reader {
         sst_iter_options: &SstIteratorOptions,
         point_lookup_stats: Option<DbStats>,
         max_seq: Option<u64>,
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> Result<IteratorSources, SlateDBError> {
         let mem_iters =
             Self::build_memtable_iters(range, db_state, sst_iter_options.order, read_trace);
@@ -267,11 +271,7 @@ impl Reader {
             max_seq,
             read_trace.clone(),
         );
-        if let Some(read_trace) = read_trace {
-            read.instrument(read_trace.read_span().clone()).await
-        } else {
-            read.await
-        }
+        read.instrument(read_trace.read_span()).await
     }
 
     async fn get_key_value_with_options_inner<K: AsRef<[u8]>>(
@@ -281,7 +281,7 @@ impl Reader {
         db_state: &(dyn DbStateReader + Sync + Send),
         write_batch_iter: Option<WriteBatchIterator>,
         max_seq: Option<u64>,
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> Result<Option<KeyValue>, SlateDBError> {
         self.db_stats.get_requests.increment(1);
         let max_seq = self.prepare_max_seq(max_seq, options.durability_filter, options.dirty);
@@ -357,11 +357,7 @@ impl Reader {
     ) -> Result<DbIterator, SlateDBError> {
         let read_trace = Self::read_trace(options.tracing_options.as_ref());
         let read = self.scan_with_options_inner(range, options, ctx, read_trace.clone());
-        if let Some(read_trace) = read_trace {
-            read.instrument(read_trace.read_span().clone()).await
-        } else {
-            read.await
-        }
+        read.instrument(read_trace.read_span()).await
     }
 
     async fn scan_with_options_inner(
@@ -369,7 +365,7 @@ impl Reader {
         range: BytesRange,
         options: &ScanOptions,
         ctx: ScanContext<'_>,
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> Result<DbIterator, SlateDBError> {
         self.db_stats.scan_requests.increment(1);
         let max_seq = self.prepare_max_seq(ctx.max_seq, options.durability_filter, options.dirty);
@@ -441,11 +437,7 @@ impl Reader {
             db_state,
             read_trace.clone(),
         );
-        if let Some(read_trace) = read_trace {
-            read.instrument(read_trace.read_span().clone()).await
-        } else {
-            read.await
-        }
+        read.instrument(read_trace.read_span()).await
     }
 
     async fn scan_prefix_by_recency_with_options_inner(
@@ -453,7 +445,7 @@ impl Reader {
         prefix: Bytes,
         options: &ScanOptions,
         db_state: &(dyn DbStateReader + Sync),
-        read_trace: Option<ReadTrace>,
+        read_trace: ReadTrace,
     ) -> Result<DbRecencyIterator, SlateDBError> {
         self.db_stats.scan_requests.increment(1);
         let max_seq = self.prepare_max_seq(None, options.durability_filter, options.dirty);
@@ -534,7 +526,7 @@ impl Reader {
         let filtered = apply_filters(all_iters, max_seq);
         Ok(DbRecencyIterator::new(
             VecDeque::from(filtered),
-            read_trace.map(|read_trace| read_trace.read_span().clone()),
+            read_trace.read_span(),
         ))
     }
 }

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -48,7 +48,7 @@ impl ReadTrace {
         let read_span = tracing_options
             .as_ref()
             .map(|tracing_options| {
-                tracing::debug_span!("slatedb.read", trace_id = tracing_options.trace_id.as_str(),)
+                tracing::info_span!("slatedb.read", trace_id = tracing_options.trace_id.as_str(),)
             })
             .unwrap_or_else(tracing::Span::none);
         Self {
@@ -1993,7 +1993,7 @@ mod tests {
             .iter()
             .find(|span| span.name == "slatedb.read")
             .expect("missing slatedb.read span");
-        assert_eq!(read_span.level, "DEBUG");
+        assert_eq!(read_span.level, "INFO");
         assert_eq!(
             read_span.fields.get("trace_id").map(String::as_str),
             Some(trace_id)

--- a/website/src/content/docs/docs/operations/logging.mdx
+++ b/website/src/content/docs/docs/operations/logging.mdx
@@ -13,3 +13,37 @@ SlateDB uses the [`tracing`](https://github.com/tokio-rs/tracing) library for lo
 Here's a basic example showing how to consume tracing logs with `tracing_subscriber` and SlateDB:
 
 <Code code={tracingSubscriber} lang="rust" title="main.rs" />
+
++## Tracing Read Operation
++
++SlateDB provides structured tracing spans for read operations, allowing you to track and measure the performance of individual reads. When enabled, SlateDB creates a hierarchy of spans that wrap different parts of the read path:
++
++- `slatedb.read` — The root span that wraps the entire read operation (get, scan, or scan_prefix_by_recency)
++- `slatedb.read.memtable` — A child span that wraps memtable lookups
++
++These spans are only created when you provide `TracingOptions` to the read operation.
++
++### Configuring TracingOptions
++
++Read operations (`get`, `scan`, `scan_prefix_by_recency`) can be traced by passing `TracingOptions` via the corresponding options struct. Use `ReadOptions::with_tracing_options()` for point reads and `ScanOptions::with_tracing_options()` for scans.
++
++The `trace_id` field in `TracingOptions` allows you to correlate spans of the read operation.
++
++Here's an example of enabling tracing for a get operation:
++
++```rust
++use slatedb::{ReadOptions, TracingOptions};
++
++// Create tracing options with a custom trace ID
++let tracing_options = TracingOptions::new("my-trace-id");
++
++// Pass it to the read operation
++let read_options = ReadOptions::default()
++    .with_tracing_options(Some(tracing_options));
++
++let value = db.get_with_options(b"key", &read_options).await?;
++```
++
++:::note
++These are the first spans introduced as part of [RFC-0033](https://github.com/slatedb/slatedb/blob/main/rfcs/0033-query-tracing.md). More spans covering additional parts of the read path will be added in future releases.
++:::

--- a/website/src/content/docs/docs/operations/logging.mdx
+++ b/website/src/content/docs/docs/operations/logging.mdx
@@ -5,6 +5,7 @@ description: Learn how to configure logging and tracing in SlateDB
 
 import { Code } from '@astrojs/starlight/components';
 import tracingSubscriber from '/../examples/src/tracing_subscriber.rs?raw'
+import readTracing from '/../examples/src/read_tracing.rs?raw'
 
 ## Tracing in SlateDB
 
@@ -14,36 +15,25 @@ Here's a basic example showing how to consume tracing logs with `tracing_subscri
 
 <Code code={tracingSubscriber} lang="rust" title="main.rs" />
 
-+## Tracing Read Operation
-+
-+SlateDB provides structured tracing spans for read operations, allowing you to track and measure the performance of individual reads. When enabled, SlateDB creates a hierarchy of spans that wrap different parts of the read path:
-+
-+- `slatedb.read` — The root span that wraps the entire read operation (get, scan, or scan_prefix_by_recency)
-+- `slatedb.read.memtable` — A child span that wraps memtable lookups
-+
-+These spans are only created when you provide `TracingOptions` to the read operation.
-+
-+### Configuring TracingOptions
-+
-+Read operations (`get`, `scan`, `scan_prefix_by_recency`) can be traced by passing `TracingOptions` via the corresponding options struct. Use `ReadOptions::with_tracing_options()` for point reads and `ScanOptions::with_tracing_options()` for scans.
-+
-+The `trace_id` field in `TracingOptions` allows you to correlate spans of the read operation.
-+
-+Here's an example of enabling tracing for a get operation:
-+
-+```rust
-+use slatedb::{ReadOptions, TracingOptions};
-+
-+// Create tracing options with a custom trace ID
-+let tracing_options = TracingOptions::new("my-trace-id");
-+
-+// Pass it to the read operation
-+let read_options = ReadOptions::default()
-+    .with_tracing_options(Some(tracing_options));
-+
-+let value = db.get_with_options(b"key", &read_options).await?;
-+```
-+
-+:::note
-+These are the first spans introduced as part of [RFC-0033](https://github.com/slatedb/slatedb/blob/main/rfcs/0033-query-tracing.md). More spans covering additional parts of the read path will be added in future releases.
-+:::
+## Tracing Read Operation
+
+SlateDB provides structured tracing spans for read operations, allowing you to track and measure the performance of individual reads. When enabled, SlateDB creates a hierarchy of spans that wrap different parts of the read path:
+
+- `slatedb.read` — The root span that wraps the entire read operation (get, scan, or scan_prefix_by_recency)
+- `slatedb.read.memtable` — A child span that wraps memtable lookups
+
+These spans are only created when you provide `TracingOptions` to the read operation.
+
+### Configuring TracingOptions
+
+Read operations (`get`, `scan`, `scan_prefix_by_recency`) can be traced by passing `TracingOptions` via the corresponding options struct. Use `ReadOptions::with_tracing_options()` for point reads and `ScanOptions::with_tracing_options()` for scans.
+
+The `trace_id` field in `TracingOptions` allows you to correlate spans of the same read operation.
+
+Here's an example of enabling tracing for a get operation:
+
+<Code code={readTracing} lang="rust" title="main.rs" />
+
+:::note
+These are the first spans introduced as part of [RFC-0033](https://github.com/slatedb/slatedb/blob/main/rfcs/0033-query_tracing.md). More spans covering additional parts of the read path will be added in future releases.
+:::

--- a/website/src/content/docs/docs/operations/logging.mdx
+++ b/website/src/content/docs/docs/operations/logging.mdx
@@ -20,9 +20,12 @@ Here's a basic example showing how to consume tracing logs with `tracing_subscri
 SlateDB provides structured tracing spans for read operations, allowing you to track and measure the performance of individual reads. When enabled, SlateDB creates a hierarchy of spans that wrap different parts of the read path:
 
 - `slatedb.read` — The root span that wraps the entire read operation (get, scan, or scan_prefix_by_recency)
-- `slatedb.read.memtable` — A child span that wraps memtable lookups
+- `slatedb.read.memtable` — A child span that wraps each memtable lookup
 
 These spans are only created when you provide `TracingOptions` to the read operation.
+
+The spans `slatedb.read` are created at tracing level `INFO`.
+Due to the potential huge number of spans `slatedb.read.memtable` created during scan operations, spans `slatedb.read.memtable` are created at tracing level `DEBUG`.
 
 ### Configuring TracingOptions
 


### PR DESCRIPTION
## Summary

This is the second PR for RFC-0033: SlateDB Query Tracing.
The PR adds the root span `slatedb.read` and its first child span
`slatedb.read.memtable`. Span `slatedb.read` wraps the entire
read operation whereas span `slatedb.read.memtable` wraps
the memtable lookups. 

Part of the fix for https://github.com/slatedb/slatedb/issues/400 and https://github.com/slatedb/slatedb/issues/797

## Changes

- Add root span `slatedb.read`
- Enter `slatedb.read` when starting the read operation
- Add span `slatedb.read.memtable`
- Enter `slatedb.read.memtable` when during memtable lookups
- Add corresponding unit tests

## Notes for Reviewers

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
