### PR TITLE
add lixray as adopter

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ See who's using SlateDB.
 - [Volga](https://github.com/volga-project/volga)
 - [WombatKV](https://github.com/Venkat2811/wombatkv)
 - [ZeroFS](https://zerofs.net)
+- [LixRay](https://lixray.com)
 
 ## Talks
 


### PR DESCRIPTION
## Summary

Add [lixray.com](https://lixray.com) as adopter of SlateDB.  
