### PR TITLE
fix: preserve sequence tracker interval after deserialization

### DIFF
--- a/slatedb/src/seq_tracker.rs
+++ b/slatedb/src/seq_tracker.rs
@@ -289,6 +289,7 @@ fn decode_sequence_tracker(buf: &[u8]) -> Result<SequenceTracker, String> {
     let mut tracker = SequenceTracker::with_config(DEFAULT_CAPACITY, DEFAULT_INTERVAL_SECS);
     tracker.sequence_numbers = sequence_numbers;
     tracker.timestamps = timestamps;
+    tracker.last_recorded_ts = tracker.timestamps.last().copied();
 
     Ok(tracker)
 }
@@ -777,6 +778,23 @@ mod tests {
         // then
         assert_eq!(decoded.sequence_numbers, tracker.sequence_numbers);
         assert_eq!(decoded.timestamps, tracker.timestamps);
+    }
+
+    #[test]
+    fn deserialize_preserves_the_recording_interval() {
+        let mut tracker = SequenceTracker::new();
+        tracker.insert(TrackedSeq {
+            seq: 0,
+            ts: DateTime::from_timestamp(1_600_000_060, 0).unwrap(),
+        });
+
+        let mut decoded = SequenceTracker::from_bytes(&tracker.to_bytes()).unwrap();
+        decoded.insert(TrackedSeq {
+            seq: 1,
+            ts: DateTime::from_timestamp(1_600_000_061, 0).unwrap(),
+        });
+
+        assert_eq!(decoded.sequence_numbers, vec![0]);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

`SequenceTracker` did not restore `last_recorded_ts` when decoding its serialized state. The first insert after deserialization therefore skipped the normal 60-second recording interval. The decoder now restores that state from the final decoded timestamp.

Fixes #2051.

## Changes

- Restore `last_recorded_ts` from the final timestamp during decoding.
- Add a regression test that tries to insert a sequence one second after a round trip.

## Notes for Reviewers

The version 1 serialization format is unchanged. The decoder uses a timestamp that is already present in the payload, so existing manifests stay compatible.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏