### PR TITLE
perf(wal): pipeline replay reads with shared limits

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -11137,16 +11137,16 @@ func (_ FfiDestroyerSegmentPrefix) Destroy(value SegmentPrefix) {
 
 // Options controlling how the native SlateDB WAL reader fetches WAL SSTs.
 type SlateDbWalReaderOptions struct {
-	// Number of WAL SSTs to preload.
-	SstBatchSize uint64
-	// Number of concurrent fetch tasks per WAL SST.
+	// Shared soft limit on bytes buffered across WAL SSTs.
+	MaxBufferedBytes uint64
+	// Shared limit on concurrent WAL SST fetch tasks.
 	MaxFetchTasks uint64
-	// Number of bytes to read ahead from each WAL SST.
+	// Target number of bytes in each WAL SST fetch.
 	ReadAheadBytes uint64
 }
 
 func (r *SlateDbWalReaderOptions) Destroy() {
-	FfiDestroyerUint64{}.Destroy(r.SstBatchSize)
+	FfiDestroyerUint64{}.Destroy(r.MaxBufferedBytes)
 	FfiDestroyerUint64{}.Destroy(r.MaxFetchTasks)
 	FfiDestroyerUint64{}.Destroy(r.ReadAheadBytes)
 }
@@ -11176,7 +11176,7 @@ func (c FfiConverterSlateDbWalReaderOptions) LowerExternal(value SlateDbWalReade
 }
 
 func (c FfiConverterSlateDbWalReaderOptions) Write(writer io.Writer, value SlateDbWalReaderOptions) {
-	FfiConverterUint64INSTANCE.Write(writer, value.SstBatchSize)
+	FfiConverterUint64INSTANCE.Write(writer, value.MaxBufferedBytes)
 	FfiConverterUint64INSTANCE.Write(writer, value.MaxFetchTasks)
 	FfiConverterUint64INSTANCE.Write(writer, value.ReadAheadBytes)
 }

--- a/bindings/uniffi/src/wal_reader.rs
+++ b/bindings/uniffi/src/wal_reader.rs
@@ -11,13 +11,13 @@ use crate::types::RowEntry;
 /// Options controlling how the native SlateDB WAL reader fetches WAL SSTs.
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct SlateDbWalReaderOptions {
-    /// Number of WAL SSTs to preload.
-    #[uniffi(default = 4)]
-    pub sst_batch_size: u64,
-    /// Number of concurrent fetch tasks per WAL SST.
+    /// Shared soft limit on bytes buffered across WAL SSTs.
+    #[uniffi(default = 4096)]
+    pub max_buffered_bytes: u64,
+    /// Shared limit on concurrent WAL SST fetch tasks.
     #[uniffi(default = 2)]
     pub max_fetch_tasks: u64,
-    /// Number of bytes to read ahead from each WAL SST.
+    /// Target number of bytes in each WAL SST fetch.
     #[uniffi(default = 1048576)]
     pub read_ahead_bytes: u64,
 }
@@ -25,7 +25,7 @@ pub struct SlateDbWalReaderOptions {
 impl Default for SlateDbWalReaderOptions {
     fn default() -> Self {
         Self {
-            sst_batch_size: 4,
+            max_buffered_bytes: 4 * 1024,
             max_fetch_tasks: 2,
             read_ahead_bytes: 1024 * 1024,
         }
@@ -37,7 +37,7 @@ impl TryFrom<SlateDbWalReaderOptions> for slatedb::wal::SlateDbWalReaderOptions 
 
     fn try_from(options: SlateDbWalReaderOptions) -> Result<Self, Self::Error> {
         Ok(Self {
-            sst_batch_size: positive_usize(options.sst_batch_size, "sst_batch_size")?,
+            max_buffered_bytes: positive_usize(options.max_buffered_bytes, "max_buffered_bytes")?,
             max_fetch_tasks: positive_usize(options.max_fetch_tasks, "max_fetch_tasks")?,
             read_ahead_bytes: positive_usize(options.read_ahead_bytes, "read_ahead_bytes")?,
         })
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn rejects_zero_reader_options() {
         let options = SlateDbWalReaderOptions {
-            sst_batch_size: 0,
+            max_buffered_bytes: 0,
             ..SlateDbWalReaderOptions::default()
         };
         assert!(matches!(

--- a/bindings/uniffi/src/wal_reader.rs
+++ b/bindings/uniffi/src/wal_reader.rs
@@ -12,13 +12,13 @@ use crate::types::RowEntry;
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct SlateDbWalReaderOptions {
     /// Shared soft limit on bytes buffered across WAL SSTs.
-    #[uniffi(default = 4096)]
+    #[uniffi(default = 134217728)]
     pub max_buffered_bytes: u64,
     /// Shared limit on concurrent WAL SST fetch tasks.
-    #[uniffi(default = 2)]
+    #[uniffi(default = 128)]
     pub max_fetch_tasks: u64,
     /// Target number of bytes in each WAL SST fetch.
-    #[uniffi(default = 1048576)]
+    #[uniffi(default = 4194304)]
     pub read_ahead_bytes: u64,
 }
 

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -497,8 +497,9 @@ impl<P: Into<Path>> DbBuilder<P> {
         // producing the same layering as a caller-built
         // [`CachedObjectStore`] passed to [`DbBuilder::new`]: the cache sits
         // under the retry and instrumentation layers, so the same cache
-        // instance can be shared with the compactor and GC below while each
-        // component keeps its own layers.
+        // instance can be shared with the WAL store, compactor, and GC below
+        // while each component keeps its own layers. WAL calls carry a WAL tag,
+        // so the cache wrapper applies its WAL bypass/skip policy.
         let cached_object_store = CachedObjectStore::from_config(
             self.main_object_store.clone(),
             &self.settings.object_store_cache_options,
@@ -513,7 +514,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         };
 
         let retrying_main_object_store = wrap_object_store(
-            maybe_cached_main_object_store,
+            maybe_cached_main_object_store.clone(),
             ObjectStoreComponent::Db,
             ObjectStoreType::Main,
         );
@@ -1899,7 +1900,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
         };
 
         let retrying_object_store = instrumented_retrying_object_store(
-            maybe_cached_object_store,
+            maybe_cached_object_store.clone(),
             &recorder,
             ObjectStoreComponent::Reader,
             ObjectStoreType::Main,

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -497,9 +497,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         // producing the same layering as a caller-built
         // [`CachedObjectStore`] passed to [`DbBuilder::new`]: the cache sits
         // under the retry and instrumentation layers, so the same cache
-        // instance can be shared with the WAL store, compactor, and GC below
-        // while each component keeps its own layers. WAL calls carry a WAL tag,
-        // so the cache wrapper applies its WAL bypass/skip policy.
+        // instance can be shared with the WAL store, compactor, and GC.
         let cached_object_store = CachedObjectStore::from_config(
             self.main_object_store.clone(),
             &self.settings.object_store_cache_options,
@@ -514,7 +512,7 @@ impl<P: Into<Path>> DbBuilder<P> {
         };
 
         let retrying_main_object_store = wrap_object_store(
-            maybe_cached_main_object_store.clone(),
+            maybe_cached_main_object_store,
             ObjectStoreComponent::Db,
             ObjectStoreType::Main,
         );
@@ -1900,7 +1898,7 @@ impl<P: Into<Path>> DbReaderBuilder<P> {
         };
 
         let retrying_object_store = instrumented_retrying_object_store(
-            maybe_cached_object_store.clone(),
+            maybe_cached_object_store,
             &recorder,
             ObjectStoreComponent::Reader,
             ObjectStoreType::Main,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -206,10 +206,7 @@ impl DbReaderInner {
                     wal_store,
                     &status_manager,
                     Arc::clone(&system_clock),
-                    SlateDbWalReaderOptions {
-                        read_ahead_bytes: options.max_memtable_bytes as usize,
-                        ..SlateDbWalReaderOptions::default()
-                    },
+                    SlateDbWalReaderOptions::default(),
                 ),
             )
         });
@@ -3000,55 +2997,6 @@ mod tests {
         assert_eq!(
             reader.get(flushed_key).await.unwrap(),
             Some(Bytes::from_static(flushed_value))
-        );
-    }
-
-    /// Regression test for #2003: read-ahead was a fixed 1MiB, so a large WAL took one
-    /// GET per MiB. It now covers a whole WAL SST, so reads for one file stay a small
-    /// constant instead of growing with size.
-    #[tokio::test]
-    async fn replay_reads_a_large_wal_sst_in_a_bounded_number_of_requests() {
-        let recording_store = Arc::new(test_utils::RecordingObjectStore::new(Arc::new(
-            InMemory::new(),
-        )));
-        let object_store: Arc<dyn ObjectStore> = recording_store.clone();
-        let path = Path::from("/tmp/test_kv_store");
-        let test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
-        let wal_store = test_provider.wal_store();
-
-        // One 16MiB WAL SST, far over the old 1MiB window. The old window read it in
-        // ~16 data GETs; the fix reads it in one.
-        let value = vec![b'x'; 4096];
-        let entries: Vec<RowEntry> = (0..4096u32)
-            .map(|i| RowEntry::new_value(format!("key-{i:08}").as_bytes(), &value, i as u64 + 1))
-            .collect();
-        write_wal_sst(Arc::clone(&wal_store), 1, entries)
-            .await
-            .unwrap();
-
-        let mut core = ManifestCore::new();
-        core.next_wal_sst_id = 2;
-        let status_manager = status_manager_for_core(&core);
-        let wal_reader = native_wal_reader(&wal_store, &status_manager);
-
-        recording_store.clear();
-        let mut iterator = wal_reader.iterator((1..2).into()).await.unwrap();
-        let mut rows = 0;
-        while let Some(batch) = iterator.next().await.unwrap() {
-            rows += batch.rows.len();
-        }
-        assert_eq!(rows, 4096, "replay should return every WAL row");
-
-        let wal_reads = recording_store
-            .get_sst_types(false)
-            .into_iter()
-            .filter(|sst_type| *sst_type == Some(SstType::Wal))
-            .count();
-        // Footer, index, and one data read. The old 1MiB window needed ~16 data reads
-        // for this file, so the bound is the regression.
-        assert!(
-            wal_reads <= 4,
-            "expected a bounded number of WAL reads for one file, got {wal_reads}"
         );
     }
 

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -242,9 +242,6 @@ pub(crate) enum SlateDBError {
         interval: Duration,
     },
 
-    #[error("invalid sst batch size. size=`{0}`")]
-    InvalidSSTBatchSize(usize),
-
     #[error("invalid configuration: {0}")]
     InvalidConfiguration(String),
 
@@ -666,7 +663,6 @@ impl From<SlateDBError> for Error {
             }
             SlateDBError::InvalidObjectStorePath(_) => Error::invalid(msg),
             SlateDBError::UnknownConfigurationFormat(_) => Error::invalid(msg),
-            SlateDBError::InvalidSSTBatchSize(_) => Error::invalid(msg),
             SlateDBError::InvalidConfiguration(_) => Error::invalid(msg),
             SlateDBError::InvalidCheckpointLifetime(_) => Error::invalid(msg),
             SlateDBError::InvalidManifestPollInterval(_) => Error::invalid(msg),

--- a/slatedb/src/sst_builder.rs
+++ b/slatedb/src/sst_builder.rs
@@ -595,7 +595,7 @@ mod tests {
             "wal",
             format.estimate_encoded_size_wal(num_entries, estimated_entries_size),
             wal_actual_size,
-            2993,
+            3917,
         );
     }
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -16,8 +16,9 @@ use futures::stream::BoxStream;
 use futures::{stream, StreamExt};
 use object_store::path::Path;
 use object_store::{
-    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions as OS_PutOptions, PutPayload, PutResult, RenameOptions,
+    CopyOptions, GetOptions, GetRange, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOptions, PutOptions as OS_PutOptions, PutPayload, PutResult,
+    RenameOptions,
 };
 use rand::{Rng, RngCore};
 use std::cmp::Ordering as CmpOrdering;
@@ -1731,6 +1732,7 @@ mod tests {
 pub(crate) enum RecordedCall {
     Get {
         head: bool,
+        range: Option<GetRange>,
         kind: Option<TableStoreKind>,
         sst_type: Option<SstType>,
         retry: Option<RetryReason>,
@@ -1811,6 +1813,20 @@ impl RecordingObjectStore {
                 RecordedCall::Get {
                     head: h, segment, ..
                 } if *h == head => Some(segment.clone()),
+            })
+            .collect()
+    }
+
+    pub(crate) fn recorded_get_ranges(&self, head: bool) -> Vec<Option<GetRange>> {
+        self.calls
+            .lock()
+            .iter()
+            .filter_map(|call| match call {
+                RecordedCall::Get {
+                    head: is_head,
+                    range,
+                    ..
+                } if *is_head == head => Some(range.clone()),
                 _ => None,
             })
             .collect()
@@ -1871,10 +1887,17 @@ impl ObjectStore for RecordingObjectStore {
         let tag = ObjectStoreCallTag::from_extensions(&options.extensions);
         self.calls.lock().push(RecordedCall::Get {
             head: options.head,
+<<<<<<< HEAD
             kind: tag.as_ref().map(|t| t.kind),
             sst_type: tag.as_ref().map(|t| t.sst_type),
             retry: tag.as_ref().and_then(|t| t.retry),
             segment: tag.as_ref().and_then(|t| t.segment.clone()),
+=======
+            range: options.range.clone(),
+            kind: tag.map(|t| t.kind),
+            sst_type: tag.map(|t| t.sst_type),
+            retry: tag.and_then(|t| t.retry),
+>>>>>>> 2b487a29 (perf(wal): pipeline replay reads with shared limits)
         });
         self.inner.get_opts(location, options).await
     }

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -1813,6 +1813,7 @@ impl RecordingObjectStore {
                 RecordedCall::Get {
                     head: h, segment, ..
                 } if *h == head => Some(segment.clone()),
+                _ => None,
             })
             .collect()
     }
@@ -1887,17 +1888,11 @@ impl ObjectStore for RecordingObjectStore {
         let tag = ObjectStoreCallTag::from_extensions(&options.extensions);
         self.calls.lock().push(RecordedCall::Get {
             head: options.head,
-<<<<<<< HEAD
+            range: options.range.clone(),
             kind: tag.as_ref().map(|t| t.kind),
             sst_type: tag.as_ref().map(|t| t.sst_type),
             retry: tag.as_ref().and_then(|t| t.retry),
             segment: tag.as_ref().and_then(|t| t.segment.clone()),
-=======
-            range: options.range.clone(),
-            kind: tag.map(|t| t.kind),
-            sst_type: tag.map(|t| t.sst_type),
-            retry: tag.and_then(|t| t.retry),
->>>>>>> 2b487a29 (perf(wal): pipeline replay reads with shared limits)
         });
         self.inner.get_opts(location, options).await
     }

--- a/slatedb/src/wal/slatedb/admin.rs
+++ b/slatedb/src/wal/slatedb/admin.rs
@@ -1,7 +1,7 @@
 use crate::format::sst::SsTableFormat;
 use crate::garbage_collector::stats::GcStats;
-use crate::object_store_tag::TableStoreKind;
 use crate::paths::PathResolver;
+use crate::tablestore::TableStoreKind;
 use crate::wal::slatedb::gc::{SlateDbWalGc, WalGcMode};
 use crate::wal::slatedb::store::{WalFileId, WalTableStore};
 use crate::wal::{WalAdmin, WalError, WalGc};

--- a/slatedb/src/wal/slatedb/gc.rs
+++ b/slatedb/src/wal/slatedb/gc.rs
@@ -195,7 +195,7 @@ impl WalGc for SlateDbWalGc {
 mod tests {
     use super::*;
     use crate::format::sst::SsTableFormat;
-    use crate::object_store_tag::TableStoreKind;
+    use crate::tablestore::TableStoreKind;
     use crate::RowEntry;
     use object_store::memory::InMemory;
     use object_store::path::Path;

--- a/slatedb/src/wal/slatedb/iterator.rs
+++ b/slatedb/src/wal/slatedb/iterator.rs
@@ -18,7 +18,8 @@ use crate::utils::panic_string;
 use crate::wal::{WalError, WalIterator as WalIteratorTrait, WalRows};
 use crate::RowEntry;
 
-use super::sst_iterator::{WalSstIterator, WalSstIteratorOptions};
+use super::resource_limiter::ResourceLimiter;
+use super::sst_iterator::{SpawnFetchResult, WalSstIterator, WalSstIteratorOptions};
 use super::store::{WalFileId, WalTableStore};
 
 #[async_trait]
@@ -41,22 +42,25 @@ impl ManifestReader for ManifestStore {
 }
 
 pub(crate) struct SlateDbWalIteratorOptions {
-    /// The number of WAL SSTs to preload while replaying.
-    pub(crate) sst_batch_size: usize,
-
-    /// Options to pass through to the underlying WAL SST iterators.
-    pub(crate) sst_iter_options: WalSstIteratorOptions,
+    /// Target bytes per block-fetch request.
+    pub(crate) target_bytes_to_fetch: usize,
+    /// Shared soft limit on bytes reserved by all WAL SST iterators.
+    pub(crate) max_buffered_bytes: usize,
+    /// Shared soft limit on in-flight fetch tasks across all WAL SST iterators.
+    pub(crate) max_fetch_tasks: usize,
 }
 
 impl Default for SlateDbWalIteratorOptions {
     fn default() -> Self {
         Self {
-            sst_batch_size: 4,
-            sst_iter_options: WalSstIteratorOptions::default(),
+            target_bytes_to_fetch: 4 * 1024 * 1024,
+            max_buffered_bytes: 128 * 1024 * 1024,
+            max_fetch_tasks: 128,
         }
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum WalFileIterator {
     Empty(EmptyIterator),
     Sst(Box<WalSstIterator>),
@@ -67,6 +71,13 @@ impl WalFileIterator {
         match self {
             Self::Empty(iter) => iter.next().await,
             Self::Sst(iter) => iter.next().await,
+        }
+    }
+
+    fn spawn_fetches(&mut self) -> SpawnFetchResult {
+        match self {
+            Self::Empty(_) => SpawnFetchResult::default(),
+            Self::Sst(iter) => iter.spawn_fetches(),
         }
     }
 }
@@ -86,6 +97,10 @@ impl WalRowsCollector {
             rows: vec![],
             drained: false,
         }
+    }
+
+    fn spawn_fetches(&mut self) -> SpawnFetchResult {
+        self.iter.spawn_fetches()
     }
 
     async fn collect(&mut self) -> Result<(), WalError> {
@@ -157,20 +172,23 @@ impl CurrentWalFile {
     }
 }
 
-/// Iterates over the writes in a range of WAL files, preloading up to
-/// `sst_batch_size` WAL SST handles concurrently. Returns the rows of one WAL
+/// Iterates over the writes in a range of WAL files. Returns the rows of one WAL
 /// file per [`WalRows`], and verifies that files carry strictly increasing seq
 /// ranges — the ordering callers rely on to split and tag memtables safely.
 ///
-/// A file's rows are read sequentially only when it is returned from
-/// [`Self::next`], so at most one file's rows are materialized at a time. For an
-/// unbounded end, open tasks poll their assigned future WAL IDs until the files
-/// appear or the manifest proves that a missing file was truncated.
+/// Preloading opens each WAL SST and loads its index, then schedules block
+/// fetches under one shared task and byte budget. A file's rows are read out
+/// only when it is returned from [`Self::next`], so at most one file's rows are
+/// materialized at a time. For an unbounded end, open tasks poll their assigned
+/// future WAL IDs until the files appear or the manifest proves that a missing
+/// file was truncated.
 pub(crate) struct SlateDbWalIterator {
-    options: SlateDbWalIteratorOptions,
+    sst_iter_options: WalSstIteratorOptions,
+    preload_limit: usize,
     end_bound: WalIteratorEndBound,
     wal_store: Arc<WalTableStore>,
     next_files: VecDeque<JoinHandle<Result<WalRowsCollector, WalError>>>,
+    loading_files: VecDeque<Result<WalRowsCollector, WalError>>,
     next_wal_id: Option<u64>,
     /// The greatest seq returned so far, used to verify that WAL files arrive
     /// with strictly increasing seq ranges.
@@ -219,15 +237,20 @@ impl SlateDbWalIterator {
         options: SlateDbWalIteratorOptions,
         wal_store: Arc<WalTableStore>,
     ) -> Result<Self, SlateDBError> {
-        if options.sst_batch_size < 1 {
-            return Err(SlateDBError::InvalidSSTBatchSize(options.sst_batch_size));
-        }
+        let preload_limit = options.max_fetch_tasks.max(1);
+        let sst_iter_options = WalSstIteratorOptions {
+            target_bytes_to_fetch: options.target_bytes_to_fetch,
+            fetch_limiter: ResourceLimiter::new(options.max_fetch_tasks),
+            buffer_limiter: ResourceLimiter::new(options.max_buffered_bytes),
+        };
 
         Ok(Self {
-            options,
+            sst_iter_options,
+            preload_limit,
             end_bound: to_bound,
             wal_store,
             next_files: VecDeque::new(),
+            loading_files: VecDeque::new(),
             next_wal_id: Some(from_wal_id),
             last_seq: None,
             terminal_result: None,
@@ -244,7 +267,7 @@ impl SlateDbWalIterator {
             return false;
         };
         if !self.end_bound.contains(next_wal_id)
-            || self.next_files.len() >= self.options.sst_batch_size
+            || self.next_files.len() + self.loading_files.len() >= self.preload_limit
         {
             return false;
         }
@@ -311,7 +334,7 @@ impl SlateDbWalIterator {
 
         let handle = task::spawn(open_file_iter(
             next_wal_id,
-            self.options.sst_iter_options.clone(),
+            self.sst_iter_options.clone(),
             Arc::clone(&self.wal_store),
             self.end_bound.clone(),
         ));
@@ -343,27 +366,71 @@ impl SlateDbWalIterator {
         }
     }
 
-    /// Opens WAL handles in the background and promotes the oldest file when a
-    /// current file is needed.
-    async fn load_next_file(&mut self) -> Result<(), WalError> {
-        if self.current_file.initialized() {
-            return Ok(());
+    /// Moves every completed open from the task queue into the metadata-loaded queue without
+    /// waiting for an unfinished open.
+    async fn move_finished_files(&mut self) {
+        while self.next_files.front().is_some_and(JoinHandle::is_finished) {
+            let result = self
+                .next_files
+                .pop_front()
+                .expect("a finished open must exist")
+                .await;
+            self.loading_files
+                .push_back(Self::open_task_result(&self.end_bound, result));
         }
+    }
 
-        // Populate the pre-load queue first to handle the case where it's initially empty
-        self.spawn_opens();
-        // await a mutable ref to the task so that next remains cancel-safe
-        // see https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html#cancel-safety
+    /// Waits for the oldest open while preserving `next` cancellation safety.
+    async fn await_next_file(&mut self) -> bool {
+        // Await a mutable reference so cancellation leaves the handle in the queue.
+        // See https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html#cancel-safety.
         let Some(join_handle) = self.next_files.front_mut() else {
-            self.current_file.finish();
-            return Ok(());
+            return false;
         };
         let result = join_handle.await;
         self.next_files.pop_front();
-        // Refill the preload queue before returning so the iterator starts loading the next file
+        self.loading_files
+            .push_back(Self::open_task_result(&self.end_bound, result));
+        true
+    }
+
+    fn spawn_loading_file_fetches(&mut self) {
+        for file in &mut self.loading_files {
+            let Ok(file) = file else {
+                break;
+            };
+            if file.spawn_fetches().resource_exhausted {
+                break;
+            }
+        }
+    }
+
+    /// Advances completed opens through metadata loading and speculative block fetching, then
+    /// promotes the oldest file when a current file is needed.
+    async fn load_next_file(&mut self) -> Result<(), WalError> {
         self.spawn_opens();
-        self.current_file
-            .advance(Self::open_task_result(&self.end_bound, result)?);
+        self.move_finished_files().await;
+
+        if !self.current_file.initialized() && self.loading_files.is_empty() {
+            if !self.await_next_file().await {
+                self.current_file.finish();
+                return Ok(());
+            }
+            self.spawn_opens();
+            self.move_finished_files().await;
+        }
+
+        self.spawn_loading_file_fetches();
+
+        if !self.current_file.initialized() {
+            let Some(file) = self.loading_files.pop_front() else {
+                self.current_file.finish();
+                return Ok(());
+            };
+            self.current_file.advance(file?);
+        }
+
+        self.spawn_opens();
         Ok(())
     }
 
@@ -375,6 +442,7 @@ impl SlateDbWalIterator {
         for task in self.next_files.drain(..) {
             task.abort();
         }
+        self.loading_files.clear();
         self.current_file.collector = None;
         result
     }
@@ -451,12 +519,17 @@ mod tests {
     use object_store::ObjectStore;
     use slatedb_common::clock::DefaultSystemClock;
 
-    use super::{SlateDbWalIterator, SlateDbWalIteratorOptions, WalIteratorEndBound};
+    use super::{
+        SlateDbWalIterator, SlateDbWalIteratorOptions, WalFileIterator, WalIteratorEndBound,
+        WalRowsCollector,
+    };
     use crate::db_status::DbStatusManager;
     use crate::format::sst::SsTableFormat;
+    use crate::iter::EmptyIterator;
     use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
     use crate::object_store_tag::TableStoreKind;
     use crate::types::RowEntry;
+    use crate::wal::slatedb::sst_iterator::WalSstIterator;
     use crate::wal::slatedb::store::WalTableStore;
     use crate::wal::{WalError, WalIterator as _};
 
@@ -527,6 +600,62 @@ mod tests {
         assert_eq!(batch.last_consumed_wal_file_id, 1);
         assert!(batch.rows.is_empty());
         assert!(wal_iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn should_continue_spawning_fetches_after_an_empty_wal() {
+        let table_store = test_table_store();
+        let mut builder = table_store.table_builder();
+        builder
+            .add(RowEntry::new_value(b"key", b"value", 1))
+            .await
+            .unwrap();
+        let encoded_sst = builder.build().await.unwrap();
+        let table = table_store.write_sst(2.into(), &encoded_sst).await.unwrap();
+        let mut wal_iter = SlateDbWalIterator::range(
+            1,
+            WalIteratorEndBound::Exclusive(3),
+            SlateDbWalIteratorOptions {
+                target_bytes_to_fetch: usize::MAX,
+                max_buffered_bytes: usize::MAX,
+                max_fetch_tasks: 2,
+            },
+            Arc::clone(&table_store),
+        )
+        .unwrap();
+        let sst_iter = WalSstIterator::new(table, table_store, wal_iter.sst_iter_options.clone())
+            .await
+            .unwrap();
+        wal_iter.loading_files.push_back(Ok(WalRowsCollector::new(
+            1,
+            WalFileIterator::Empty(EmptyIterator::new()),
+        )));
+        wal_iter.loading_files.push_back(Ok(WalRowsCollector::new(
+            2,
+            WalFileIterator::Sst(Box::new(sst_iter)),
+        )));
+
+        let empty_result = wal_iter
+            .loading_files
+            .front_mut()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .spawn_fetches();
+        assert_eq!(empty_result.spawned, 0);
+        assert!(!empty_result.resource_exhausted);
+
+        wal_iter.spawn_loading_file_fetches();
+
+        let already_scheduled = wal_iter
+            .loading_files
+            .back_mut()
+            .unwrap()
+            .as_mut()
+            .unwrap()
+            .spawn_fetches();
+        assert_eq!(already_scheduled.spawned, 0);
+        assert!(!already_scheduled.resource_exhausted);
     }
 
     #[tokio::test(start_paused = true)]
@@ -716,6 +845,74 @@ mod tests {
             .collect();
         assert_eq!(returned_rows, expected_returned_rows);
         assert_eq!(last_consumed_wal_file_id, wal_file_count);
+    }
+
+    #[tokio::test]
+    async fn should_share_fetch_and_buffer_limits_across_loading_files() {
+        let table_store = test_table_store();
+        let mut handles = Vec::new();
+        for wal_id in 1..=2 {
+            let mut builder = table_store.table_builder();
+            builder
+                .add(RowEntry::new_value(
+                    format!("key_{wal_id}").as_bytes(),
+                    &[b'x'; 128],
+                    wal_id,
+                ))
+                .await
+                .unwrap();
+            let encoded_sst = builder.build().await.unwrap();
+            handles.push(
+                table_store
+                    .write_sst(wal_id.into(), &encoded_sst)
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let mut block_fetch_sizes = Vec::new();
+        for handle in &handles {
+            let index = table_store.read_index(handle).await.unwrap();
+            let blocks = table_store.block_range_for_target_bytes(handle, &index, 0, 1);
+            block_fetch_sizes.push(table_store.block_range_size(handle, &index, blocks));
+        }
+        let one_file_buffer_limit = *block_fetch_sizes.iter().max().unwrap();
+        let mut wal_iter = SlateDbWalIterator::range(
+            1,
+            WalIteratorEndBound::Exclusive(3),
+            SlateDbWalIteratorOptions {
+                target_bytes_to_fetch: 1,
+                max_buffered_bytes: one_file_buffer_limit,
+                max_fetch_tasks: 2,
+            },
+            table_store,
+        )
+        .unwrap();
+        let fetch_limiter = wal_iter.sst_iter_options.fetch_limiter.clone();
+        let buffer_limiter = wal_iter.sst_iter_options.buffer_limiter.clone();
+
+        wal_iter.spawn_opens();
+        assert_eq!(wal_iter.next_files.len(), 2);
+        assert!(wal_iter.await_next_file().await);
+        assert!(wal_iter.await_next_file().await);
+        assert_eq!(wal_iter.loading_files.len(), 2);
+
+        wal_iter.spawn_loading_file_fetches();
+        assert!(
+            buffer_limiter.allocate(1, false).is_none(),
+            "one loading file should consume the shared byte limit"
+        );
+        let spare_fetch = fetch_limiter
+            .allocate(1, false)
+            .expect("the byte limit should stop the second loading file before the task limit");
+        assert!(fetch_limiter.allocate(1, false).is_none());
+        drop(spare_fetch);
+
+        drop(wal_iter);
+        assert!(fetch_limiter.allocate(2, false).is_some());
+        assert!(buffer_limiter
+            .allocate(one_file_buffer_limit, false)
+            .is_some());
     }
 
     fn test_table_store() -> Arc<WalTableStore> {

--- a/slatedb/src/wal/slatedb/iterator.rs
+++ b/slatedb/src/wal/slatedb/iterator.rs
@@ -921,22 +921,18 @@ mod tests {
     async fn should_not_pop_completed_file_until_await_returns() {
         use futures::FutureExt;
 
+        let table_store = test_table_store();
+        for wal_id in 1..=3 {
+            table_store.write_wal_fence(wal_id.into()).await.unwrap();
+        }
         let mut iter = SlateDbWalIterator::range(
             1,
-            WalIteratorEndBound::Exclusive(3),
+            WalIteratorEndBound::Exclusive(4),
             SlateDbWalIteratorOptions::default(),
-            test_table_store(),
+            table_store,
         )
         .unwrap();
-        iter.next_wal_id = Some(3);
-        for wal_id in 1..=2 {
-            iter.next_files.push_back(tokio::spawn(async move {
-                Ok(WalRowsCollector::new(
-                    wal_id,
-                    WalFileIterator::Empty(EmptyIterator::new()),
-                ))
-            }));
-        }
+        iter.spawn_opens();
         // wait for all the file waits to finish
         while !iter
             .next_files

--- a/slatedb/src/wal/slatedb/iterator.rs
+++ b/slatedb/src/wal/slatedb/iterator.rs
@@ -372,9 +372,10 @@ impl SlateDbWalIterator {
         while self.next_files.front().is_some_and(JoinHandle::is_finished) {
             let result = self
                 .next_files
-                .pop_front()
+                .front_mut()
                 .expect("a finished open must exist")
                 .await;
+            self.next_files.pop_front();
             self.loading_files
                 .push_back(Self::open_task_result(&self.end_bound, result));
         }
@@ -913,6 +914,49 @@ mod tests {
         assert!(buffer_limiter
             .allocate(one_file_buffer_limit, false)
             .is_some());
+    }
+
+    #[tokio::test]
+    // tests cancellation-safety of moving completed pre-fetches to the ready files queue
+    async fn should_not_pop_completed_file_until_await_returns() {
+        use futures::FutureExt;
+
+        let mut iter = SlateDbWalIterator::range(
+            1,
+            WalIteratorEndBound::Exclusive(3),
+            SlateDbWalIteratorOptions::default(),
+            test_table_store(),
+        )
+        .unwrap();
+        iter.next_wal_id = Some(3);
+        for wal_id in 1..=2 {
+            iter.next_files.push_back(tokio::spawn(async move {
+                Ok(WalRowsCollector::new(
+                    wal_id,
+                    WalFileIterator::Empty(EmptyIterator::new()),
+                ))
+            }));
+        }
+        // wait for all the file waits to finish
+        while !iter
+            .next_files
+            .iter()
+            .all(tokio::task::JoinHandle::is_finished)
+        {
+            tokio::task::yield_now().await;
+        }
+        // exhaust the current tasks's budget and ensure the future is pending even though
+        // all the file waits are finished
+        while tokio::task::coop::has_budget_remaining() {
+            tokio::task::consume_budget().await;
+        }
+        assert!(iter.next().now_or_never().is_none());
+        // clear the budget
+        tokio::task::yield_now().await;
+
+        let first = iter.next().await.unwrap().unwrap();
+
+        assert_eq!(first.last_consumed_wal_file_id, 1);
     }
 
     fn test_table_store() -> Arc<WalTableStore> {

--- a/slatedb/src/wal/slatedb/mod.rs
+++ b/slatedb/src/wal/slatedb/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod admin;
 pub(crate) mod gc;
 pub(crate) mod iterator;
 pub(crate) mod reader;
+pub(crate) mod resource_limiter;
 pub(crate) mod sst_builder;
 pub(crate) mod sst_iterator;
 pub(crate) mod store;

--- a/slatedb/src/wal/slatedb/reader.rs
+++ b/slatedb/src/wal/slatedb/reader.rs
@@ -20,10 +20,12 @@ use crate::wal::{WalError, WalFileRange, WalIterator, WalReader};
 
 #[derive(Clone, Debug)]
 pub struct SlateDbWalReaderOptions {
-    /// The number of WAL SST handles to preload while replaying.
-    pub sst_batch_size: usize,
+    /// The shared soft limit on bytes buffered across all WAL SST iterators. A fetch needed to
+    /// make forward progress may temporarily exceed this limit. The default is 4 KiB.
+    pub max_buffered_bytes: usize,
 
-    /// Retained for compatibility with the existing WAL reader configuration.
+    /// The speculative fetch-task limit shared by all WAL SST iterators. An SST may temporarily
+    /// exceed this budget when it must fetch a block to make progress. Defaults to 2.
     pub max_fetch_tasks: usize,
 
     /// The target number of bytes to fetch in a single request while iterating over WAL SSTs.
@@ -35,9 +37,9 @@ pub struct SlateDbWalReaderOptions {
 impl Default for SlateDbWalReaderOptions {
     fn default() -> Self {
         Self {
-            sst_batch_size: 4,
-            max_fetch_tasks: 2,
-            read_ahead_bytes: 64 * 1024 * 1024,
+            max_buffered_bytes: 128 * 1024 * 1024,
+            max_fetch_tasks: 128,
+            read_ahead_bytes: 4 * 1024 * 1024,
         }
     }
 }
@@ -45,10 +47,9 @@ impl Default for SlateDbWalReaderOptions {
 impl From<SlateDbWalReaderOptions> for SlateDbWalIteratorOptions {
     fn from(options: SlateDbWalReaderOptions) -> Self {
         Self {
-            sst_batch_size: options.sst_batch_size,
-            sst_iter_options: super::sst_iterator::WalSstIteratorOptions {
-                target_bytes_to_fetch: options.read_ahead_bytes,
-            },
+            target_bytes_to_fetch: options.read_ahead_bytes,
+            max_buffered_bytes: options.max_buffered_bytes,
+            max_fetch_tasks: options.max_fetch_tasks,
         }
     }
 }

--- a/slatedb/src/wal/slatedb/reader.rs
+++ b/slatedb/src/wal/slatedb/reader.rs
@@ -21,16 +21,16 @@ use crate::wal::{WalError, WalFileRange, WalIterator, WalReader};
 #[derive(Clone, Debug)]
 pub struct SlateDbWalReaderOptions {
     /// The shared soft limit on bytes buffered across all WAL SST iterators. A fetch needed to
-    /// make forward progress may temporarily exceed this limit. The default is 4 KiB.
+    /// make forward progress may temporarily exceed this limit. The default is 128 MiB.
     pub max_buffered_bytes: usize,
 
     /// The speculative fetch-task limit shared by all WAL SST iterators. An SST may temporarily
-    /// exceed this budget when it must fetch a block to make progress. Defaults to 2.
+    /// exceed this budget when it must fetch a block to make progress. Defaults to 128.
     pub max_fetch_tasks: usize,
 
     /// The target number of bytes to fetch in a single request while iterating over WAL SSTs.
     /// Each fetch reads enough whole blocks to meet this target or reach the end of the file.
-    /// The default is 1 MiB.
+    /// The default is 4 MiB.
     pub read_ahead_bytes: usize,
 }
 

--- a/slatedb/src/wal/slatedb/resource_limiter.rs
+++ b/slatedb/src/wal/slatedb/resource_limiter.rs
@@ -1,0 +1,102 @@
+use std::sync::{Arc, Mutex};
+
+/// A cloneable, shared budget whose usage is released by dropping allocation guards.
+///
+/// Forced allocations may take usage above the configured limit. This is useful for
+/// operations that must reserve resources to make forward progress.
+#[derive(Clone, Debug)]
+pub(crate) struct ResourceLimiter {
+    inner: Arc<Mutex<ResourceLimiterInner>>,
+}
+
+impl ResourceLimiter {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ResourceLimiterInner { limit, usage: 0 })),
+        }
+    }
+
+    pub(crate) fn allocate(&self, usage: usize, force: bool) -> Option<ResourceGuard> {
+        let mut inner = self.inner.lock().expect("lock poisoned");
+        inner.allocate(usage, force).then(|| ResourceGuard {
+            usage,
+            inner: self.inner.clone(),
+        })
+    }
+}
+
+pub(crate) struct ResourceGuard {
+    usage: usize,
+    inner: Arc<Mutex<ResourceLimiterInner>>,
+}
+
+impl Drop for ResourceGuard {
+    fn drop(&mut self) {
+        self.inner
+            .lock()
+            .expect("lock poisoned")
+            .release(self.usage);
+    }
+}
+
+#[derive(Debug)]
+struct ResourceLimiterInner {
+    limit: usize,
+    usage: usize,
+}
+
+impl ResourceLimiterInner {
+    fn can_allocate(&self, usage: usize) -> bool {
+        self.usage
+            .checked_add(usage)
+            .is_some_and(|new_usage| new_usage <= self.limit)
+    }
+
+    fn allocate(&mut self, usage: usize, force: bool) -> bool {
+        if !force && !self.can_allocate(usage) {
+            return false;
+        }
+
+        let Some(new_usage) = self.usage.checked_add(usage) else {
+            return false;
+        };
+        self.usage = new_usage;
+        true
+    }
+
+    fn release(&mut self, usage: usize) {
+        self.usage = self
+            .usage
+            .checked_sub(usage)
+            .expect("released more resources than were allocated");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_enforce_limit_and_release_on_drop() {
+        let limiter = ResourceLimiter::new(2);
+
+        let first = limiter.allocate(2, false).expect("allocation should fit");
+        assert!(limiter.allocate(1, false).is_none());
+
+        drop(first);
+        assert!(limiter.allocate(2, false).is_some());
+    }
+
+    #[test]
+    fn should_allow_forced_allocation_over_limit() {
+        let limiter = ResourceLimiter::new(1);
+
+        let forced = limiter
+            .allocate(2, true)
+            .expect("forced allocation should exceed the limit");
+        assert!(limiter.allocate(1, false).is_none());
+
+        drop(forced);
+        assert!(limiter.allocate(1, false).is_some());
+    }
+}

--- a/slatedb/src/wal/slatedb/sst_builder.rs
+++ b/slatedb/src/wal/slatedb/sst_builder.rs
@@ -65,9 +65,13 @@ use crate::types::RowEntry;
 use bytes::Bytes;
 use flatbuffers::DefaultAllocator;
 
+// use as large of a block size as possible for the WAL. We don't need to support random seeks,
+// so the size is optimized to minimize overhead.
+const WAL_BLOCK_SIZE: usize = u16::MAX as usize;
+
 impl SsTableFormat {
     pub(crate) fn wal_table_builder(&self) -> EncodedWalSsTableBuilder {
-        let mut builder = EncodedWalSsTableBuilder::new(self.block_size, self.sst_codec.clone());
+        let mut builder = EncodedWalSsTableBuilder::new(WAL_BLOCK_SIZE, self.sst_codec.clone());
         if let Some(codec) = self.compression_codec {
             builder = builder.with_compression_codec(codec);
         }

--- a/slatedb/src/wal/slatedb/sst_iterator.rs
+++ b/slatedb/src/wal/slatedb/sst_iterator.rs
@@ -1,6 +1,10 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
+use log::error;
+use tokio::task::{JoinError, JoinHandle};
+
+use super::resource_limiter::{ResourceGuard, ResourceLimiter};
 use super::store::{WalFileHandle, WalTableStore};
 use crate::block_iterator::DataBlockIterator;
 use crate::config::SstBlockSize;
@@ -9,32 +13,58 @@ use crate::flatbuffer_types::SsTableIndexOwned;
 use crate::format::block::Block;
 use crate::iter::IterationOrder;
 use crate::types::RowEntry;
+use crate::utils::panic_string;
+
+enum FetchTask {
+    InFlight {
+        join_handle: JoinHandle<Result<VecDeque<Arc<Block>>, SlateDBError>>,
+        _fetch_guard: ResourceGuard,
+        _buffer_guard: ResourceGuard,
+    },
+    Finished {
+        blocks: VecDeque<Arc<Block>>,
+        _buffer_guard: ResourceGuard,
+    },
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct WalSstIteratorOptions {
     /// Target encoded bytes per block-fetch request.
     pub(crate) target_bytes_to_fetch: usize,
+    /// Shared limit on in-flight WAL block fetches.
+    pub(crate) fetch_limiter: ResourceLimiter,
+    /// Shared limit on bytes reserved by queued WAL block fetches.
+    pub(crate) buffer_limiter: ResourceLimiter,
 }
 
 impl Default for WalSstIteratorOptions {
     fn default() -> Self {
         Self {
-            target_bytes_to_fetch: SstBlockSize::default().as_bytes(),
+            target_bytes_to_fetch: 1,
+            fetch_limiter: ResourceLimiter::new(1),
+            buffer_limiter: ResourceLimiter::new(SstBlockSize::default().as_bytes()),
         }
     }
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub(crate) struct SpawnFetchResult {
+    pub(crate) spawned: usize,
+    pub(crate) resource_exhausted: bool,
 }
 
 /// Iterates all rows in one WAL SST in ascending sequence order.
 ///
 /// WAL replay only performs whole-file scans, so this iterator deliberately has
-/// no range/view abstraction, filters, cache controls, descending mode, seek,
-/// or speculative fetch scheduling.
+/// no range/view abstraction, filters, cache controls, descending mode, or seek
+/// operation. Construction loads metadata without fetching data blocks, and
+/// replay can speculatively spawn those block fetches under shared limits.
 pub(crate) struct WalSstIterator {
     table: WalFileHandle,
     index: Arc<SsTableIndexOwned>,
     block_iter: Option<DataBlockIterator<Arc<Block>>>,
     next_block_idx_to_fetch: usize,
-    fetched_blocks: VecDeque<Arc<Block>>,
+    fetch_tasks: VecDeque<FetchTask>,
     table_store: Arc<WalTableStore>,
     options: WalSstIteratorOptions,
 }
@@ -52,10 +82,17 @@ impl WalSstIterator {
             index,
             block_iter: None,
             next_block_idx_to_fetch: 0,
-            fetched_blocks: VecDeque::new(),
+            fetch_tasks: VecDeque::new(),
             table_store,
             options,
         })
+    }
+
+    /// Starts as many speculative block fetches as the shared allocators permit.
+    /// An empty or fully scheduled SST returns zero spawned tasks without
+    /// reporting resource exhaustion.
+    pub(crate) fn spawn_fetches(&mut self) -> SpawnFetchResult {
+        self.do_spawn_fetches(false)
     }
 
     /// Returns the next WAL row in ascending sequence order.
@@ -73,38 +110,144 @@ impl WalSstIterator {
     }
 
     async fn load_next_block(&mut self) -> Result<bool, SlateDBError> {
-        loop {
-            if let Some(block) = self.fetched_blocks.pop_front() {
-                self.block_iter = Some(DataBlockIterator::new(
-                    block,
-                    self.table.format_version,
-                    IterationOrder::Ascending,
-                )?);
-                return Ok(true);
-            }
+        self.block_iter = self.next_block_iter(true).await?;
+        Ok(self.block_iter.is_some())
+    }
 
-            let num_blocks = self.index.borrow().block_meta().len();
-            if self.next_block_idx_to_fetch == num_blocks {
-                self.block_iter = None;
-                return Ok(false);
-            }
+    fn allocate_fetch_resources(
+        &self,
+        buffer_usage: usize,
+        force: bool,
+    ) -> Option<(ResourceGuard, ResourceGuard)> {
+        let fetch_guard = self.options.fetch_limiter.allocate(1, force)?;
+        let buffer_guard = self.options.buffer_limiter.allocate(buffer_usage, force)?;
+        Some((fetch_guard, buffer_guard))
+    }
 
+    fn do_spawn_fetches(&mut self, force_progress: bool) -> SpawnFetchResult {
+        let index = Arc::clone(&self.index);
+        let num_blocks = index.borrow().block_meta().len();
+        let mut result = SpawnFetchResult::default();
+
+        while self.next_block_idx_to_fetch < num_blocks {
             let blocks = self.table_store.block_range_for_target_bytes(
                 &self.table,
-                &self.index,
+                &index,
                 self.next_block_idx_to_fetch,
                 self.options.target_bytes_to_fetch,
             );
+            let buffer_usage =
+                self.table_store
+                    .block_range_size(&self.table, &index, blocks.clone());
+            let resources = match self.allocate_fetch_resources(buffer_usage, false) {
+                Some(resources) => Some(resources),
+                None => {
+                    result.resource_exhausted = true;
+                    if force_progress && self.fetch_tasks.is_empty() {
+                        let resources = self.allocate_fetch_resources(buffer_usage, true);
+                        assert!(resources.is_some(), "forced allocation must make progress");
+                        resources
+                    } else {
+                        None
+                    }
+                }
+            };
+            let Some((fetch_guard, buffer_guard)) = resources else {
+                break;
+            };
+
+            let table_store = Arc::clone(&self.table_store);
+            let table = self.table.clone();
+            let index = Arc::clone(&index);
             let next_block_idx_to_fetch = blocks.end;
-            let fetched_blocks = self
-                .table_store
-                .read_blocks_using_index(&self.table, Arc::clone(&self.index), blocks)
-                .await?;
-            // Commit the cursor only after the read succeeds so cancelling the
-            // read future cannot cause the next call to skip these blocks.
+            let join_handle = tokio::spawn(async move {
+                table_store
+                    .read_blocks_using_index(&table, index, blocks)
+                    .await
+            });
+            self.fetch_tasks.push_back(FetchTask::InFlight {
+                join_handle,
+                _fetch_guard: fetch_guard,
+                _buffer_guard: buffer_guard,
+            });
             self.next_block_idx_to_fetch = next_block_idx_to_fetch;
-            self.fetched_blocks = fetched_blocks;
+            result.spawned += 1;
         }
+
+        result
+    }
+
+    async fn next_block_iter(
+        &mut self,
+        spawn_fetches: bool,
+    ) -> Result<Option<DataBlockIterator<Arc<Block>>>, SlateDBError> {
+        let num_blocks = self.index.borrow().block_meta().len();
+
+        loop {
+            if spawn_fetches {
+                self.do_spawn_fetches(true);
+            }
+
+            let fetched_blocks = match self.fetch_tasks.front_mut() {
+                Some(FetchTask::InFlight { join_handle, .. }) => Some(
+                    join_handle
+                        .await
+                        .map_err(|error| block_fetch_join_error(error, self.table.id.value()))??,
+                ),
+                _ => None,
+            };
+            if let Some(blocks) = fetched_blocks {
+                let buffer_guard = match self.fetch_tasks.pop_front().expect("task must exist") {
+                    FetchTask::InFlight {
+                        _fetch_guard: fetch_guard,
+                        _buffer_guard,
+                        ..
+                    } => {
+                        drop(fetch_guard);
+                        _buffer_guard
+                    }
+                    FetchTask::Finished { .. } => unreachable!("task state changed unexpectedly"),
+                };
+                self.fetch_tasks.push_front(FetchTask::Finished {
+                    blocks,
+                    _buffer_guard: buffer_guard,
+                });
+                continue;
+            }
+
+            if let Some(FetchTask::Finished { blocks, .. }) = self.fetch_tasks.front_mut() {
+                if let Some(block) = blocks.pop_front() {
+                    return Ok(Some(DataBlockIterator::new(
+                        block,
+                        self.table.format_version,
+                        IterationOrder::Ascending,
+                    )?));
+                }
+                self.fetch_tasks.pop_front();
+                continue;
+            }
+
+            assert!(self.fetch_tasks.is_empty());
+            if spawn_fetches {
+                assert_eq!(self.next_block_idx_to_fetch, num_blocks);
+            }
+            return Ok(None);
+        }
+    }
+}
+
+fn block_fetch_join_error(error: JoinError, wal_id: u64) -> SlateDBError {
+    let task_name = format!("wal_sst_block_fetch[{wal_id}]");
+    match error.try_into_panic() {
+        Ok(panic_error) => {
+            error!(
+                "WAL SST block fetch task panicked unexpectedly. [task_name={}, panic={}]",
+                task_name,
+                panic_string(&panic_error),
+            );
+            SlateDBError::BackgroundTaskPanic(task_name)
+        }
+        Err(_) => SlateDBError::BackgroundTaskCancelled(task_name),
     }
 }
 
@@ -130,10 +273,8 @@ mod tests {
         ))
     }
 
-    #[tokio::test]
-    async fn should_iterate_the_whole_wal_sequentially() {
-        let store = test_store();
-        let rows: Vec<_> = (1..=6)
+    fn test_rows() -> Vec<RowEntry> {
+        (1..=6)
             .map(|seq| {
                 RowEntry::new_value(
                     format!("key-{seq}").as_bytes(),
@@ -141,23 +282,56 @@ mod tests {
                     seq,
                 )
             })
-            .collect();
+            .collect()
+    }
+
+    async fn write_test_wal(
+        store: &WalTableStore,
+        wal_id: u64,
+        rows: &[RowEntry],
+    ) -> WalFileHandle {
         let mut builder =
             EncodedWalSsTableBuilder::new(32, Box::new(FlatBufferSsTableInfoCodec {}));
         for row in rows.iter().cloned() {
             builder.add(row).await.unwrap();
         }
         let encoded = builder.build().await.unwrap();
-        let table = store.write_sst(1.into(), &encoded).await.unwrap();
+        assert!(encoded.index.borrow().block_meta().len() > 1);
+        store.write_sst(wal_id.into(), &encoded).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn preloads_metadata_and_iterates_the_whole_wal() {
+        let store = test_store();
+        let rows = test_rows();
+        let table = write_test_wal(&store, 1, &rows).await;
         let mut iter = WalSstIterator::new(
             table,
-            store,
+            Arc::clone(&store),
             WalSstIteratorOptions {
                 target_bytes_to_fetch: 1,
+                fetch_limiter: ResourceLimiter::new(1),
+                buffer_limiter: ResourceLimiter::new(usize::MAX),
             },
         )
         .await
         .unwrap();
+
+        assert!(iter.fetch_tasks.is_empty());
+        assert_eq!(
+            iter.spawn_fetches(),
+            SpawnFetchResult {
+                spawned: 1,
+                resource_exhausted: true,
+            }
+        );
+        assert_eq!(
+            iter.spawn_fetches(),
+            SpawnFetchResult {
+                spawned: 0,
+                resource_exhausted: true,
+            }
+        );
 
         let mut actual = Vec::new();
         while let Some(row) = iter.next().await.unwrap() {
@@ -165,5 +339,78 @@ mod tests {
         }
         assert_eq!(actual, rows);
         assert!(iter.next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn forces_a_fetch_when_required_for_progress() {
+        let store = test_store();
+        let rows = test_rows();
+        let table = write_test_wal(&store, 1, &rows).await;
+        let mut iter = WalSstIterator::new(
+            table,
+            store,
+            WalSstIteratorOptions {
+                target_bytes_to_fetch: 1,
+                fetch_limiter: ResourceLimiter::new(0),
+                buffer_limiter: ResourceLimiter::new(0),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            iter.spawn_fetches(),
+            SpawnFetchResult {
+                spawned: 0,
+                resource_exhausted: true,
+            }
+        );
+
+        let mut actual = Vec::new();
+        while let Some(row) = iter.next().await.unwrap() {
+            actual.push(row);
+        }
+        assert_eq!(actual, rows);
+    }
+
+    #[tokio::test]
+    async fn releases_fetch_capacity_before_buffer_capacity() {
+        let store = test_store();
+        let rows = test_rows();
+        let table = write_test_wal(&store, 1, &rows).await;
+        let index = store.read_index(&table).await.unwrap();
+        let blocks = store.block_range_for_target_bytes(&table, &index, 0, 1);
+        let buffer_usage = store.block_range_size(&table, &index, blocks);
+        let fetch_limiter = ResourceLimiter::new(1);
+        let buffer_limiter = ResourceLimiter::new(buffer_usage);
+        let mut iter = WalSstIterator::new(
+            table,
+            store,
+            WalSstIteratorOptions {
+                target_bytes_to_fetch: 1,
+                fetch_limiter: fetch_limiter.clone(),
+                buffer_limiter: buffer_limiter.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            iter.spawn_fetches(),
+            SpawnFetchResult {
+                spawned: 1,
+                resource_exhausted: true,
+            }
+        );
+        assert!(iter.next().await.unwrap().is_some());
+
+        let fetch_probe = fetch_limiter
+            .allocate(1, false)
+            .expect("fetch guard should be released once the task finishes");
+        assert!(buffer_limiter.allocate(1, false).is_none());
+        drop(fetch_probe);
+
+        drop(iter);
+        assert!(buffer_limiter.allocate(buffer_usage, false).is_some());
     }
 }

--- a/slatedb/src/wal/slatedb/store.rs
+++ b/slatedb/src/wal/slatedb/store.rs
@@ -7,11 +7,12 @@ use fail_parallel::{fail_point, FailPointRegistry};
 use futures::{future::join_all, StreamExt};
 use log::{debug, warn};
 use object_store::path::Path;
-use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions};
+use object_store::{GetOptions, GetRange, ObjectStore, ObjectStoreExt, PutMode, PutOptions};
 use serde::Serialize;
 use slatedb_common::object_metadata::IdentifiedObjectMetadata;
 use slatedb_common::ObjectMetadata;
 
+use crate::blob::ReadOnlyBlob;
 use crate::db_state::{SsTableInfo, SstType};
 use crate::error::SlateDBError;
 use crate::flatbuffer_types::SsTableIndexOwned;
@@ -19,8 +20,10 @@ use crate::format::block::Block;
 use crate::format::sst::{EncodedSsTable, SsTableFormat};
 use crate::object_store_tag::{ObjectStoreCallTag, TableStoreKind};
 use crate::paths::PathResolver;
-use crate::sst_io::{read_obj, read_with_validation_retry, ReadOnlyObject};
+use crate::sst_io::{read_with_validation_retry, ReadOnlyObject};
 use crate::wal::slatedb::sst_builder::EncodedWalSsTableBuilder;
+
+const WAL_SST_CACHED_FOOTER_SIZE: u64 = 128 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub(crate) struct WalFileId(u64);
@@ -43,11 +46,78 @@ impl From<WalFileId> for u64 {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize)]
+#[derive(Clone, Debug)]
+struct CachedFooter {
+    offset: u64,
+    data: Bytes,
+}
+
+impl CachedFooter {
+    fn from_object_size(object_size: u64, data: Bytes) -> Result<Self, SlateDBError> {
+        let data_len = u64::try_from(data.len()).map_err(|_| SlateDBError::InvalidDBState)?;
+        let offset = object_size
+            .checked_sub(data_len)
+            .ok_or(SlateDBError::InvalidDBState)?;
+        Ok(Self { offset, data })
+    }
+
+    fn object_size(&self) -> u64 {
+        self.offset
+            .checked_add(u64::try_from(self.data.len()).expect("footer size must fit in u64"))
+            .expect("cached footer cannot extend beyond u64::MAX")
+    }
+
+    fn read_range(&self, range: &Range<u64>) -> Option<Bytes> {
+        if range.start < self.offset || range.end > self.object_size() {
+            return None;
+        }
+
+        let start = usize::try_from(range.start - self.offset).ok()?;
+        let end = usize::try_from(range.end - self.offset).ok()?;
+        Some(self.data.slice(start..end))
+    }
+}
+
+struct WalReadOnlyObject {
+    inner: ReadOnlyObject,
+    cached_footer: Option<CachedFooter>,
+}
+
+impl ReadOnlyBlob for WalReadOnlyObject {
+    async fn len(&self) -> Result<u64, SlateDBError> {
+        match &self.cached_footer {
+            Some(cached_footer) => Ok(cached_footer.object_size()),
+            None => self.inner.len().await,
+        }
+    }
+
+    async fn read_range(&self, range: Range<u64>) -> Result<Bytes, SlateDBError> {
+        if let Some(data) = self
+            .cached_footer
+            .as_ref()
+            .and_then(|cached_footer| cached_footer.read_range(&range))
+        {
+            return Ok(data);
+        }
+        self.inner.read_range(range).await
+    }
+
+    async fn read(&self) -> Result<Bytes, SlateDBError> {
+        if let Some(cached_footer) = &self.cached_footer {
+            if cached_footer.offset == 0 {
+                return Ok(cached_footer.data.clone());
+            }
+        }
+        self.inner.read().await
+    }
+}
+
+#[derive(Clone, Debug)]
 pub(crate) struct WalFileHandle {
     pub(crate) id: WalFileId,
     pub(crate) format_version: u16,
     pub(crate) info: SsTableInfo,
+    cached_footer: Option<CachedFooter>,
 }
 
 impl WalFileHandle {
@@ -56,14 +126,22 @@ impl WalFileHandle {
             id,
             format_version,
             info,
+            cached_footer: None,
         }
+    }
+
+    fn with_cached_footer(mut self, offset: u64, data: Bytes) -> Self {
+        self.cached_footer = Some(CachedFooter { offset, data });
+        self
     }
 }
 
-/// Cacheless storage adapter for SlateDB's object-store-backed WAL files.
+/// Storage adapter for SlateDB's object-store-backed WAL files.
 ///
 /// WALs continue to use the shared SST format and builders. This type owns only
 /// WAL object-store operations and deliberately has no `DbCache` integration.
+/// Its object store may be a [`CachedObjectStore`](crate::cached_object_store::CachedObjectStore);
+/// WAL calls carry [`SstType::Wal`] so that wrapper can apply its WAL policy.
 pub(crate) struct WalTableStore {
     object_store: Arc<dyn ObjectStore>,
     sst_format: SsTableFormat,
@@ -162,14 +240,81 @@ impl WalTableStore {
     }
 
     pub(crate) async fn open_sst(&self, wal_id: WalFileId) -> Result<WalFileHandle, SlateDBError> {
-        let (info, version) = read_obj!(
-            Arc::clone(&self.object_store),
-            self.path(wal_id),
-            ObjectStoreCallTag::new(self.kind, SstType::Wal),
-            |obj| self.sst_format.read_info_and_version(&obj)
-        )
-        .await?;
-        Ok(WalFileHandle::new(wal_id, version, info))
+        let path = self.path(wal_id);
+        let (info, version, cached_footer) =
+            read_with_validation_retry(ObjectStoreCallTag::new(self.kind, SstType::Wal), |tag| {
+                let path = path.clone();
+                async move {
+                    let cached_footer = self.read_cached_footer(&path, tag).await?;
+                    let obj = WalReadOnlyObject {
+                        inner: ReadOnlyObject {
+                            object_store: Arc::clone(&self.object_store),
+                            path: path.clone(),
+                            tag,
+                        },
+                        cached_footer: Some(cached_footer.clone()),
+                    };
+                    let (info, version) = self
+                        .sst_format
+                        .read_info_and_version(&obj)
+                        .await
+                        .map_err(|error| error.with_path(&path))?;
+                    Ok((info, version, cached_footer))
+                }
+            })
+            .await?;
+        Ok(WalFileHandle::new(wal_id, version, info)
+            .with_cached_footer(cached_footer.offset, cached_footer.data))
+    }
+
+    async fn read_cached_footer(
+        &self,
+        path: &Path,
+        tag: ObjectStoreCallTag,
+    ) -> Result<CachedFooter, SlateDBError> {
+        // Determine the object size before requesting the footer instead of using a suffix
+        // range directly. S3 responds to a suffix-range request for a zero-byte object with
+        // HTTP 200 and no Content-Range header. object_store rejects that response as the
+        // private GetResultError::NotPartial, wraps it in Error::Generic, and SlateDB's object
+        // store retry layer retries Generic errors indefinitely by default. A HEAD lets us
+        // recognize zero-byte WAL fence files without issuing the problematic range request.
+        let head_options = GetOptions {
+            head: true,
+            extensions: tag.into(),
+            ..GetOptions::default()
+        };
+        let object_size = self
+            .object_store
+            .get_opts(path, head_options)
+            .await?
+            .meta
+            .size;
+        if object_size == 0 {
+            return CachedFooter::from_object_size(0, Bytes::new());
+        }
+
+        let offset = object_size.saturating_sub(WAL_SST_CACHED_FOOTER_SIZE);
+        let (returned_object_size, data) = self
+            .read_footer_range(path, GetRange::Bounded(offset..object_size), tag)
+            .await?;
+        CachedFooter::from_object_size(returned_object_size, data)
+    }
+
+    async fn read_footer_range(
+        &self,
+        path: &Path,
+        range: GetRange,
+        tag: ObjectStoreCallTag,
+    ) -> object_store::Result<(u64, Bytes)> {
+        let options = GetOptions {
+            range: Some(range),
+            extensions: tag.into(),
+            ..GetOptions::default()
+        };
+        let result = self.object_store.get_opts(path, options).await?;
+        let object_size = result.meta.size;
+        let data = result.bytes().await?;
+        Ok((object_size, data))
     }
 
     pub(crate) async fn list_wal_ssts<R: RangeBounds<WalFileId>>(
@@ -215,8 +360,14 @@ impl WalTableStore {
     }
 
     pub(crate) async fn metadata(&self, wal_id: WalFileId) -> Result<ObjectMetadata, SlateDBError> {
+        let path = self.path(wal_id);
+        let options = GetOptions {
+            head: true,
+            extensions: ObjectStoreCallTag::new(self.kind, SstType::Wal).into(),
+            ..GetOptions::default()
+        };
         Ok(ObjectMetadata::new(
-            self.object_store.head(&self.path(wal_id)).await?,
+            self.object_store.get_opts(&path, options).await?.meta,
         ))
     }
 
@@ -224,13 +375,29 @@ impl WalTableStore {
         &self,
         handle: &WalFileHandle,
     ) -> Result<Arc<SsTableIndexOwned>, SlateDBError> {
-        let index = read_obj!(
-            Arc::clone(&self.object_store),
-            self.path(handle.id),
-            ObjectStoreCallTag::new(self.kind, SstType::Wal),
-            |obj| self.sst_format.read_index(&handle.info, &obj)
-        )
-        .await?;
+        let path = self.path(handle.id);
+        let index =
+            read_with_validation_retry(ObjectStoreCallTag::new(self.kind, SstType::Wal), |tag| {
+                let obj = WalReadOnlyObject {
+                    inner: ReadOnlyObject {
+                        object_store: Arc::clone(&self.object_store),
+                        path: path.clone(),
+                        tag,
+                    },
+                    cached_footer: if tag.retry.is_none() {
+                        handle.cached_footer.clone()
+                    } else {
+                        None
+                    },
+                };
+                async move {
+                    self.sst_format
+                        .read_index(&handle.info, &obj)
+                        .await
+                        .map_err(|error| error.with_path(&obj.inner.path))
+                }
+            })
+            .await?;
         Ok(Arc::new(index))
     }
 
@@ -290,17 +457,24 @@ impl WalTableStore {
         let index = &index;
         let blocks =
             read_with_validation_retry(ObjectStoreCallTag::new(self.kind, SstType::Wal), |tag| {
-                let obj = ReadOnlyObject {
-                    object_store: Arc::clone(&object_store),
-                    path: path.clone(),
-                    tag,
+                let obj = WalReadOnlyObject {
+                    inner: ReadOnlyObject {
+                        object_store: Arc::clone(&object_store),
+                        path: path.clone(),
+                        tag,
+                    },
+                    cached_footer: if tag.retry.is_none() {
+                        handle.cached_footer.clone()
+                    } else {
+                        None
+                    },
                 };
                 let blocks = blocks.clone();
                 async move {
                     self.sst_format
                         .read_blocks(&handle.info, index, blocks, &obj)
                         .await
-                        .map_err(|error| error.with_path(&obj.path))
+                        .map_err(|error| error.with_path(&obj.inner.path))
                 }
             })
             .await?;
@@ -422,7 +596,9 @@ fn slatedb_io_error() -> SlateDBError {
 mod tests {
     use super::*;
     use crate::block_iterator::DataBlockIterator;
+    use crate::error::RetryReason;
     use crate::iter::IterationOrder;
+    use crate::test_utils::{FlakyObjectStore, RecordingObjectStore};
     use crate::types::RowEntry;
     use object_store::memory::InMemory;
     use object_store::ObjectStoreExt;
@@ -436,6 +612,148 @@ mod tests {
             Path::from("test-db"),
             TableStoreKind::Main,
         )
+    }
+
+    #[tokio::test]
+    async fn open_sst_caches_last_500kb() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let observed = Arc::new(FlakyObjectStore::new(inner, 0));
+        let recording = Arc::new(RecordingObjectStore::new(observed.clone()));
+        let object_store: Arc<dyn ObjectStore> = recording.clone();
+        let store = WalTableStore::new(
+            object_store,
+            SsTableFormat::default(),
+            Path::from("cached-footer"),
+            TableStoreKind::Main,
+        );
+
+        let value = vec![b'x'; 4096];
+        let mut builder =
+            EncodedWalSsTableBuilder::new(32 * 1024, store.sst_format.sst_codec.clone());
+        for seq in 0..300 {
+            builder
+                .add(RowEntry::new_value(b"key", &value, seq))
+                .await
+                .unwrap();
+        }
+        let encoded = builder.build().await.unwrap();
+        let encoded_bytes = encoded.remaining_as_bytes();
+        assert!(encoded_bytes.len() > WAL_SST_CACHED_FOOTER_SIZE as usize);
+        store.write_sst(1.into(), &encoded).await.unwrap();
+
+        let handle = store.open_sst(1.into()).await.unwrap();
+        let cached_footer = handle.cached_footer.as_ref().unwrap();
+        assert_eq!(
+            cached_footer.data.len(),
+            WAL_SST_CACHED_FOOTER_SIZE as usize
+        );
+        assert_eq!(
+            cached_footer.offset,
+            encoded_bytes.len() as u64 - WAL_SST_CACHED_FOOTER_SIZE
+        );
+        assert_eq!(
+            cached_footer.data,
+            encoded_bytes.slice(cached_footer.offset as usize..)
+        );
+        assert_eq!(observed.get_range_attempts(), 1);
+        assert_eq!(observed.head_attempts(), 1);
+        assert_eq!(
+            recording.recorded_get_ranges(false),
+            vec![Some(GetRange::Bounded(
+                encoded_bytes.len() as u64 - WAL_SST_CACHED_FOOTER_SIZE..encoded_bytes.len() as u64
+            ))]
+        );
+
+        let index = store.read_index(&handle).await.unwrap();
+        let last_block = index.borrow().block_meta().len() - 1;
+        store
+            .read_blocks_using_index(&handle, index, last_block..last_block + 1)
+            .await
+            .unwrap();
+
+        // The index and final data block are both covered by the cached tail.
+        assert_eq!(observed.get_range_attempts(), 1);
+        assert_eq!(observed.head_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn open_sst_caches_entire_small_sst_with_bounded_range() {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let observed = Arc::new(FlakyObjectStore::new(inner, 0));
+        let recording = Arc::new(RecordingObjectStore::new(observed.clone()));
+        let object_store: Arc<dyn ObjectStore> = recording.clone();
+        let store = WalTableStore::new(
+            object_store,
+            SsTableFormat::default(),
+            Path::from("cached-footer-fallback"),
+            TableStoreKind::Main,
+        );
+
+        let mut builder = store.table_builder();
+        builder
+            .add(RowEntry::new_value(b"key", b"value", 1))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
+        let encoded_bytes = encoded.remaining_as_bytes();
+        store.write_sst(1.into(), &encoded).await.unwrap();
+
+        let handle = store.open_sst(1.into()).await.unwrap();
+        let cached_footer = handle.cached_footer.as_ref().unwrap();
+        assert_eq!(cached_footer.offset, 0);
+        assert_eq!(cached_footer.data, encoded_bytes);
+        assert_eq!(observed.get_range_attempts(), 1);
+        assert_eq!(observed.head_attempts(), 1);
+        assert_eq!(
+            recording.recorded_get_ranges(false),
+            vec![Some(GetRange::Bounded(0..encoded_bytes.len() as u64))]
+        );
+
+        let index = store.read_index(&handle).await.unwrap();
+        store
+            .read_blocks_using_index(&handle, index, 0..1)
+            .await
+            .unwrap();
+
+        // One HEAD and one bounded GET were enough to open and read the small WAL SST.
+        assert_eq!(observed.get_range_attempts(), 1);
+        assert_eq!(observed.head_attempts(), 1);
+    }
+
+    #[tokio::test]
+    async fn validation_retry_bypasses_the_cached_footer() {
+        let recording = Arc::new(RecordingObjectStore::new(Arc::new(InMemory::new())));
+        let object_store: Arc<dyn ObjectStore> = recording.clone();
+        let store = WalTableStore::new(
+            object_store,
+            SsTableFormat::default(),
+            Path::from("cached-footer-validation-retry"),
+            TableStoreKind::Main,
+        );
+
+        let mut builder = store.table_builder();
+        builder
+            .add(RowEntry::new_value(b"key", b"value", 1))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
+        store.write_sst(1.into(), &encoded).await.unwrap();
+
+        let mut handle = store.open_sst(1.into()).await.unwrap();
+        recording.clear();
+
+        let cached_footer = handle.cached_footer.as_mut().unwrap();
+        let index_offset =
+            usize::try_from(handle.info.index_offset - cached_footer.offset).unwrap();
+        let mut corrupted = cached_footer.data.to_vec();
+        corrupted[index_offset] ^= 0xff;
+        cached_footer.data = Bytes::from(corrupted);
+
+        store.read_index(&handle).await.unwrap();
+        assert_eq!(
+            recording.get_retries(false),
+            vec![Some(RetryReason::CrcMismatch)]
+        );
     }
 
     #[tokio::test]
@@ -455,7 +773,9 @@ mod tests {
         let written = store.write_sst(1.into(), &encoded).await.unwrap();
         let opened = store.open_sst(1.into()).await.unwrap();
 
-        assert_eq!(written, opened);
+        assert_eq!(written.id, opened.id);
+        assert_eq!(written.info, opened.info);
+        assert_eq!(written.format_version, opened.format_version);
         assert_eq!(opened.id.value(), 1);
 
         let index = store.read_index(&opened).await.unwrap();
@@ -548,5 +868,56 @@ mod tests {
                 .value(),
             start_after + n_above
         );
+    }
+
+    #[tokio::test]
+    async fn object_store_calls_carry_wal_tag() {
+        let recording = Arc::new(RecordingObjectStore::new(Arc::new(InMemory::new())));
+        let object_store: Arc<dyn ObjectStore> = recording.clone();
+        let store = WalTableStore::new(
+            object_store,
+            SsTableFormat::default(),
+            Path::from("tagged-wal-store"),
+            TableStoreKind::Reader,
+        );
+
+        let mut builder = store.table_builder();
+        builder
+            .add(RowEntry::new_value(b"key", b"value", 1))
+            .await
+            .unwrap();
+        let encoded = builder.build().await.unwrap();
+        store.write_sst(1.into(), &encoded).await.unwrap();
+
+        assert_eq!(recording.write_kinds(), vec![Some(TableStoreKind::Reader)]);
+        assert_eq!(recording.write_sst_types(), vec![Some(SstType::Wal)]);
+
+        recording.clear();
+        store.metadata(1.into()).await.unwrap();
+        let handle = store.open_sst(1.into()).await.unwrap();
+        let index = store.read_index(&handle).await.unwrap();
+        store
+            .read_blocks_using_index(&handle, index, 0..1)
+            .await
+            .unwrap();
+
+        let read_kinds = recording.get_kinds(false);
+        let read_sst_types = recording.get_sst_types(false);
+        let head_kinds = recording.get_kinds(true);
+        let head_sst_types = recording.get_sst_types(true);
+        assert!(!head_kinds.is_empty());
+        assert!(head_kinds
+            .iter()
+            .all(|kind| *kind == Some(TableStoreKind::Reader)));
+        assert!(head_sst_types
+            .iter()
+            .all(|sst_type| *sst_type == Some(SstType::Wal)));
+        assert!(!read_kinds.is_empty());
+        assert!(read_kinds
+            .iter()
+            .all(|kind| *kind == Some(TableStoreKind::Reader)));
+        assert!(read_sst_types
+            .iter()
+            .all(|sst_type| *sst_type == Some(SstType::Wal)));
     }
 }

--- a/slatedb/src/wal/slatedb/store.rs
+++ b/slatedb/src/wal/slatedb/store.rs
@@ -430,7 +430,6 @@ impl WalTableStore {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn block_range_size(
         &self,
         handle: &WalFileHandle,

--- a/slatedb/src/wal/slatedb/store.rs
+++ b/slatedb/src/wal/slatedb/store.rs
@@ -245,7 +245,7 @@ impl WalTableStore {
             read_with_validation_retry(ObjectStoreCallTag::new(self.kind, SstType::Wal), |tag| {
                 let path = path.clone();
                 async move {
-                    let cached_footer = self.read_cached_footer(&path, tag).await?;
+                    let cached_footer = self.read_cached_footer(&path, tag.clone()).await?;
                     let obj = WalReadOnlyObject {
                         inner: ReadOnlyObject {
                             object_store: Arc::clone(&self.object_store),
@@ -280,7 +280,7 @@ impl WalTableStore {
         // recognize zero-byte WAL fence files without issuing the problematic range request.
         let head_options = GetOptions {
             head: true,
-            extensions: tag.into(),
+            extensions: tag.clone().into(),
             ..GetOptions::default()
         };
         let object_size = self
@@ -382,7 +382,7 @@ impl WalTableStore {
                     inner: ReadOnlyObject {
                         object_store: Arc::clone(&self.object_store),
                         path: path.clone(),
-                        tag,
+                        tag: tag.clone(),
                     },
                     cached_footer: if tag.retry.is_none() {
                         handle.cached_footer.clone()
@@ -460,7 +460,7 @@ impl WalTableStore {
                     inner: ReadOnlyObject {
                         object_store: Arc::clone(&object_store),
                         path: path.clone(),
-                        tag,
+                        tag: tag.clone(),
                     },
                     cached_footer: if tag.retry.is_none() {
                         handle.cached_footer.clone()

--- a/slatedb/src/wal/slatedb/writer_init.rs
+++ b/slatedb/src/wal/slatedb/writer_init.rs
@@ -2,8 +2,9 @@ use crate::dispatcher::MessageHandlerExecutor;
 use crate::error::SlateDBError;
 use crate::manifest::Manifest;
 use crate::utils::WatchableOnceCellReader;
-use crate::wal::slatedb::iterator::{SlateDbWalIterator, WalIteratorEndBound};
-use crate::wal::slatedb::reader::SlateDbWalReaderOptions;
+use crate::wal::slatedb::iterator::{
+    SlateDbWalIterator, SlateDbWalIteratorOptions, WalIteratorEndBound,
+};
 use crate::wal::slatedb::writer::SlateDbWalWriter;
 use crate::wal::{WalError, WriterInitResult, WriterManifest};
 use crate::{wal, Settings};
@@ -121,11 +122,11 @@ impl wal::WriterInit for SlateDbWalWriterInit {
                 let replay_iterator = SlateDbWalIterator::range(
                     replay_after_wal_id + 1,
                     WalIteratorEndBound::Exclusive(empty_wal_id + 1),
-                    SlateDbWalReaderOptions {
-                        read_ahead_bytes: self.max_wal_bytes_size,
-                        ..SlateDbWalReaderOptions::default()
-                    }
-                    .into(),
+                    SlateDbWalIteratorOptions {
+                        target_bytes_to_fetch: 1024 * 1024,
+                        max_buffered_bytes: 4 * 1024,
+                        max_fetch_tasks: 2,
+                    },
                     self.table_store.clone(),
                 )?;
                 let wal_writer = SlateDbWalWriter::start_new(

--- a/slatedb/src/wal/slatedb/writer_init.rs
+++ b/slatedb/src/wal/slatedb/writer_init.rs
@@ -122,11 +122,7 @@ impl wal::WriterInit for SlateDbWalWriterInit {
                 let replay_iterator = SlateDbWalIterator::range(
                     replay_after_wal_id + 1,
                     WalIteratorEndBound::Exclusive(empty_wal_id + 1),
-                    SlateDbWalIteratorOptions {
-                        target_bytes_to_fetch: 1024 * 1024,
-                        max_buffered_bytes: 4 * 1024,
-                        max_fetch_tasks: 2,
-                    },
+                    SlateDbWalIteratorOptions::default(),
                     self.table_store.clone(),
                 )?;
                 let wal_writer = SlateDbWalWriter::start_new(

--- a/slatedb/src/wal_reader.rs
+++ b/slatedb/src/wal_reader.rs
@@ -73,7 +73,7 @@ use object_store::ObjectStore;
 
 use crate::format::sst::SsTableFormat;
 use crate::iter::{EmptyIterator, RowEntryIterator};
-use crate::object_store_tag::TableStoreKind;
+use crate::tablestore::TableStoreKind;
 use crate::types::RowEntry;
 use crate::wal::slatedb::sst_iterator::{WalSstIterator, WalSstIteratorOptions};
 use crate::wal::slatedb::store::{WalFileId, WalTableStore};
@@ -161,6 +161,7 @@ impl WalFile {
             WalSstIteratorOptions {
                 // Optimize for throughput. Go for 256MiB per fetch.
                 target_bytes_to_fetch: 256 * 1024 * 1024,
+                ..Default::default()
             },
         )
         .await?;


### PR DESCRIPTION
## Summary

Improve WAL replay performance to strike a good balance when replaying small vs large WAL files

## Changes

- When opening a WAL SST, read the last 100KB of the file and stash it in WalFileHandle::cached_footer. Then, when reading data from the WAL, use the cached footer when possible. This gets WAL file reads down to a HEAD+GET for each WAL file. We had to use a HEAD +GET rather than 1 suffix-range for 2 reasons. First, suffix-gets are not supported on Azure. The object store crate returns NotSupported in this case, so we _could_ handle that by falling back to GET+HEAD just when NotSupported is return. Unfortunately on S3, object_store expects a 206 but for the 0-byte fence files, and S3 returns a 200 which causes object_store to return a Generic error. This error is not distinguishable from other retryable errors so the retrying object store retries these (indefinitely if so configured).
- Support externally-driven pre-fetching with configured limits from WalSstIterator. We add a ResourceLimiter type that tracks resource usage against some limit. WalSstIterator takes a ResourceLimiter to track global buffer and fetch concurrency, and consults it before spawning new fetches. SlateDbWalIterator eagerly spawns fetches on all open iterators until the resource limit is hit.
- Change SlateDbWalIterator to concurrently open up to 128 iterators and eagerly spawn fetches up to the configured buffer and fetch limits.

After these patches we see that restarting a db that's accumulated thousands of small (~4KB) wal files goes from minutes to ~10 seconds, while still seeing restarts of a db with large (4MB) wal files take < 1 second.

## Checklist

- [ ] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [ ] Linked related issue(s) or added context in the description
- [ ] Self-reviewed the diff; added comments for tricky parts
- [ ] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
