### PR TITLE
feat(compactor): configure checkpoint lifetime

### DIFF
--- a/slatedb-dst/src/utils.rs
+++ b/slatedb-dst/src/utils.rs
@@ -143,6 +143,7 @@ pub fn build_settings_compactor(rng: &mut impl Rng) -> CompactorOptions {
         metric_level: None,
         commit_compacted_interval: rng
             .random_range(Duration::from_millis(1)..Duration::from_secs(5)),
+        checkpoint_lifetime: CompactorOptions::default().checkpoint_lifetime,
         worker_heartbeat_timeout,
         object_store_max_retries: None,
     }

--- a/slatedb/src/compactor_state_protocols.rs
+++ b/slatedb/src/compactor_state_protocols.rs
@@ -110,6 +110,8 @@ pub(crate) struct CompactorStateWriter {
     manifest: FenceableManifest,
     /// Fenceable compactions handle used for refresh/update with fencing.
     compactions: FenceableCompactions,
+    /// Lifetime of checkpoints that protect compaction inputs during manifest updates.
+    checkpoint_lifetime: Duration,
     /// RNG for checkpoint ids.
     rand: Arc<DbRand>,
 }
@@ -170,6 +172,7 @@ impl CompactorStateWriter {
             state,
             manifest,
             compactions,
+            checkpoint_lifetime: options.checkpoint_lifetime,
             rand,
         })
     }
@@ -240,10 +243,9 @@ impl CompactorStateWriter {
 
     /// Persists the updated manifest after a compaction finishes.
     ///
-    /// A checkpoint with a 15-minute lifetime is written first to prevent GC from
-    /// deleting SSTs that are about to be removed. This is to keep them around for a
-    /// while in case any in-flight operations (such as iterator scans) are still using
-    /// them.
+    /// A checkpoint is written first to prevent GC from deleting SSTs that are about
+    /// to be removed. Its configured lifetime keeps them available to in-flight
+    /// operations such as iterator scans.
     async fn write_manifest(&mut self) -> Result<(), SlateDBError> {
         // write the checkpoint first so that it points to the manifest with the ssts
         // being removed
@@ -252,13 +254,7 @@ impl CompactorStateWriter {
             .write_checkpoint(
                 checkpoint_id,
                 &CheckpointOptions {
-                    // TODO(rohan): for now, just write a checkpoint with 15-minute expiry
-                    //              so that it's extremely unlikely for the gc to delete ssts
-                    //              out from underneath the writer. In a follow up, we'll write
-                    //              a checkpoint with no expiry and with metadata indicating its
-                    //              a compactor checkpoint. Then, the gc will delete the checkpoint
-                    //              based on a configurable timeout
-                    lifetime: Some(Duration::from_secs(900)),
+                    lifetime: Some(self.checkpoint_lifetime),
                     ..CheckpointOptions::default()
                 },
             )
@@ -1058,6 +1054,55 @@ mod tests {
             .unwrap()
             .id;
         assert_eq!(final_id, start_id + 3);
+    }
+
+    #[tokio::test]
+    async fn test_write_manifest_uses_configured_checkpoint_lifetime() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_store = Arc::new(ManifestStore::new(
+            &Path::from(ROOT),
+            Arc::clone(&object_store),
+        ));
+        let compactions_store = Arc::new(CompactionsStore::new(&Path::from(ROOT), object_store));
+        let clock = Arc::new(MockSystemClock::with_time(1_000));
+        let system_clock: Arc<dyn SystemClock> = clock.clone();
+
+        StoredManifest::create_new_db(
+            manifest_store.clone(),
+            ManifestCore::new(),
+            system_clock.clone(),
+        )
+        .await
+        .unwrap();
+
+        let checkpoint_lifetime = Duration::from_secs(42);
+        let options = CompactorOptions {
+            checkpoint_lifetime,
+            ..CompactorOptions::default()
+        };
+        let mut writer = CompactorStateWriter::new(
+            manifest_store.clone(),
+            compactions_store,
+            system_clock.clone(),
+            &options,
+            Arc::new(DbRand::new(7)),
+        )
+        .await
+        .unwrap();
+
+        writer.write_manifest_safely().await.unwrap();
+
+        let latest = manifest_store.read_latest_manifest().await.unwrap();
+        let checkpoint = latest
+            .manifest
+            .core
+            .checkpoints
+            .last()
+            .expect("missing compactor checkpoint");
+        assert_eq!(
+            Some(system_clock.now() + checkpoint_lifetime),
+            checkpoint.expire_time
+        );
     }
 
     #[tokio::test]

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1455,7 +1455,7 @@ fn default_compaction_worker_options() -> Option<CompactionWorkerOptions> {
 }
 
 fn default_compactor_checkpoint_lifetime() -> Duration {
-    Duration::from_secs(15 * 60)
+    Duration::from_mins(15)
 }
 
 /// Options for the Size-Tiered Compaction Scheduler
@@ -1898,7 +1898,7 @@ mod tests {
 
     #[test]
     fn test_compactor_checkpoint_lifetime_config() {
-        let default_lifetime = Duration::from_secs(15 * 60);
+        let default_lifetime = Duration::from_mins(15);
         assert_eq!(
             default_lifetime,
             CompactorOptions::default().checkpoint_lifetime

--- a/slatedb/src/config.rs
+++ b/slatedb/src/config.rs
@@ -1276,6 +1276,23 @@ pub struct CompactorOptions {
     #[serde(serialize_with = "serialize_duration")]
     pub commit_compacted_interval: Duration,
 
+    /// How long the compactor checkpoint protects input SSTs while publishing a
+    /// manifest that replaces them with compacted output.
+    ///
+    /// A scan, get, snapshot, or transaction that began before the manifest update
+    /// and still needs an input SST must finish within this duration. If it runs
+    /// longer, garbage collection may delete the SST, causing the operation to fail
+    /// with a [`crate::ErrorKind::Data`] error backed by
+    /// [`object_store::Error::NotFound`]. Shorter lifetimes reduce retained storage;
+    /// longer lifetimes give in-flight reads more time to finish. Defaults to 15
+    /// minutes.
+    #[serde(
+        default = "default_compactor_checkpoint_lifetime",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "serialize_duration"
+    )]
+    pub checkpoint_lifetime: Duration,
+
     /// How long the coordinator will wait without a heartbeat before reclaiming
     /// a `Running` compaction from its worker and resetting it to `Submitted`.
     /// A worker that crashes or stalls will have its jobs reclaimed after this
@@ -1293,8 +1310,9 @@ pub struct CompactorOptions {
 /// Default options for the compactor. Currently, only a
 /// `SizeTieredCompactionScheduler` compaction strategy is implemented.
 impl Default for CompactorOptions {
-    /// Returns a `CompactorOptions` with a 5 second poll interval and an embedded
-    /// worker enabled with default [`CompactionWorkerOptions`].
+    /// Returns a `CompactorOptions` with a 5 second poll interval, a 15 minute
+    /// checkpoint lifetime, and an embedded worker enabled with default
+    /// [`CompactionWorkerOptions`].
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(5),
@@ -1305,6 +1323,7 @@ impl Default for CompactorOptions {
             worker: Some(CompactionWorkerOptions::default()),
             metric_level: None,
             commit_compacted_interval: Duration::from_secs(1),
+            checkpoint_lifetime: default_compactor_checkpoint_lifetime(),
             worker_heartbeat_timeout: Duration::from_secs(30),
             object_store_max_retries: None,
         }
@@ -1326,6 +1345,7 @@ impl std::fmt::Debug for CompactorOptions {
             .field("worker", &self.worker)
             .field("metric_level", &self.metric_level)
             .field("commit_compacted_interval", &self.commit_compacted_interval)
+            .field("checkpoint_lifetime", &self.checkpoint_lifetime)
             .field("worker_heartbeat_timeout", &self.worker_heartbeat_timeout)
             .field("object_store_max_retries", &self.object_store_max_retries)
             .finish()
@@ -1432,6 +1452,10 @@ impl Default for CompactionWorkerOptions {
 /// disabling it.)
 fn default_compaction_worker_options() -> Option<CompactionWorkerOptions> {
     Some(CompactionWorkerOptions::default())
+}
+
+fn default_compactor_checkpoint_lifetime() -> Duration {
+    Duration::from_secs(15 * 60)
 }
 
 /// Options for the Size-Tiered Compaction Scheduler
@@ -1870,6 +1894,27 @@ mod tests {
     fn test_db_options_default_metric_level() {
         let options = Settings::default();
         assert_eq!(MetricLevel::default(), options.metric_level);
+    }
+
+    #[test]
+    fn test_compactor_checkpoint_lifetime_config() {
+        let default_lifetime = Duration::from_secs(15 * 60);
+        assert_eq!(
+            default_lifetime,
+            CompactorOptions::default().checkpoint_lifetime
+        );
+
+        let mut value = serde_json::to_value(CompactorOptions::default()).unwrap();
+        value.as_object_mut().unwrap().insert(
+            "checkpoint_lifetime".to_string(),
+            serde_json::Value::String("42s".to_string()),
+        );
+        let configured: CompactorOptions = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(Duration::from_secs(42), configured.checkpoint_lifetime);
+
+        value.as_object_mut().unwrap().remove("checkpoint_lifetime");
+        let omitted: CompactorOptions = serde_json::from_value(value).unwrap();
+        assert_eq!(default_lifetime, omitted.checkpoint_lifetime);
     }
 
     #[test]

--- a/website/src/content/docs/docs/design/checkpoints.mdx
+++ b/website/src/content/docs/docs/design/checkpoints.mdx
@@ -39,7 +39,7 @@ A new checkpoint can also be created from an existing checkpoint through [`Check
 
 [`DbReaderOptions::checkpoint_lifetime`](https://docs.rs/slatedb/latest/slatedb/config/struct.DbReaderOptions.html#structfield.checkpoint_lifetime) controls how long a `ManagedCheckpoint` reader's checkpoint lives before it must be refreshed.
 
-SlateDB also uses short-lived internal checkpoints during some background transitions. For example, the compactor writes a temporary checkpoint before publishing a manifest that drops obsolete SST references. That keeps recently replaced SSTs readable until GC can safely remove them.
+SlateDB also uses short-lived internal checkpoints during some background transitions. For example, the compactor writes a temporary checkpoint before publishing a manifest that drops obsolete SST references. The checkpoint's lifetime is configurable via [`CompactorOptions::checkpoint_lifetime`](https://docs.rs/slatedb/latest/slatedb/config/struct.CompactorOptions.html#structfield.checkpoint_lifetime) and defaults to 15 minutes. Shorter lifetimes reduce retained storage; longer lifetimes give in-flight reads more time to complete before GC deletes their SSTs. If a read operation runs longer than the configured lifetime, it may fail with a data error when GC removes the SST.
 
 ## Clones
 


### PR DESCRIPTION
First step toward RFC34 and ObjectStoreMirror.

## Summary

- add `CompactorOptions::checkpoint_lifetime` with the existing 15-minute behavior as its default
- use the configured lifetime for checkpoints that protect compaction input SSTs
- preserve compatibility when the field is omitted and document the read-duration/storage tradeoff

## Tests

- `cargo check -p slatedb -p slatedb-dst`
- `cargo test -p slatedb checkpoint_lifetime`