### PR TITLE
Stream L0 flush blocks instead of building the whole SST in memory

### DIFF
--- a/slatedb/src/compaction_execute_bench.rs
+++ b/slatedb/src/compaction_execute_bench.rs
@@ -177,7 +177,7 @@ impl CompactionExecuteBench {
             let row_entry = RowEntry::new(key, ValueDeletable::Value(val.into()), 0, None, None);
             sst_writer.add(row_entry).await?;
         }
-        let sst = sst_writer.close().await?;
+        let (sst, _) = sst_writer.close().await?;
         let elapsed_ms = system_clock
             .now()
             .signed_duration_since(start)

--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -860,7 +860,7 @@ impl TokioCompactionExecutorInner {
                     format!("compactor_sst_close:{:?}", finished_writer.id()),
                     &self.handle,
                     |_| {},
-                    async move { finished_writer.close().await },
+                    async move { finished_writer.close().await.map(|(sst, _)| sst) },
                 )));
                 bytes_written = 0;
                 let total_bytes = start_bytes_processed + all_iter.bytes_processed();
@@ -877,7 +877,7 @@ impl TokioCompactionExecutorInner {
             self.collect_close(pending, &mut output_ssts).await?;
         }
         if !current_writer.is_drained() {
-            let sst = current_writer.close().await?;
+            let (sst, _) = current_writer.close().await?;
 
             self.worker_stats
                 .bytes_compacted
@@ -1064,7 +1064,7 @@ mod tests {
             }
 
             if bytes_written > max_sst_size {
-                output_ssts.push(writer.close().await.unwrap());
+                output_ssts.push(writer.close().await.unwrap().0);
                 bytes_written = 0;
 
                 if index + 1 < entries.len() {
@@ -1076,7 +1076,7 @@ mod tests {
             }
         }
 
-        output_ssts.push(writer.close().await.unwrap());
+        output_ssts.push(writer.close().await.unwrap().0);
         output_ssts
     }
 

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -126,7 +126,7 @@ impl DbInner {
         if !any {
             return Ok(None);
         }
-        Ok(Some(writer.close_and_count_bytes().await?))
+        Ok(Some(writer.close().await?))
     }
 
     /// Write one SST per touched segment, block by block.
@@ -175,8 +175,7 @@ impl DbInner {
             // to the next prefix.
             while !entry.key.starts_with(current_prefix.as_ref()) {
                 if current_has_entry {
-                    let (sst_handle, encoded_bytes) =
-                        current_writer.close_and_count_bytes().await?;
+                    let (sst_handle, encoded_bytes) = current_writer.close().await?;
                     out.push(SegmentedSstHandle {
                         prefix: current_prefix,
                         sst_handle,
@@ -204,7 +203,7 @@ impl DbInner {
             tokio::task::coop::consume_budget().await;
         }
         if current_has_entry {
-            let (sst_handle, encoded_bytes) = current_writer.close_and_count_bytes().await?;
+            let (sst_handle, encoded_bytes) = current_writer.close().await?;
             out.push(SegmentedSstHandle {
                 prefix: current_prefix,
                 sst_handle,

--- a/slatedb/src/flush.rs
+++ b/slatedb/src/flush.rs
@@ -1,7 +1,7 @@
 use crate::db::DbInner;
-use crate::db_state;
-use crate::db_state::SsTableHandle;
+use crate::db_state::{SsTableHandle, SsTableId};
 use crate::error::SlateDBError;
+#[cfg(test)]
 use crate::format::sst::EncodedSsTable;
 use crate::iter::RowEntryIterator;
 use crate::mem_table::KVTable;
@@ -9,137 +9,206 @@ use crate::merge_operator::{MergeOperatorIterator, MergeOperatorRequiredIterator
 use crate::oracle::Oracle;
 use crate::reader::DbStateReader;
 use crate::retention_iterator::RetentionIterator;
+use crate::tablestore::EncodedSsTableWriter;
 use bytes::Bytes;
+use log::warn;
+use std::collections::BTreeMap;
 use std::sync::Arc;
+use ulid::Ulid;
 
-/// One encoded-but-not-yet-uploaded SST from a memtable flush, tagged with
-/// the segment it belongs to (RFC-0024). Mirrors the shape of post-upload
-/// [`crate::memtable_flusher::uploader::SegmentedSstHandle`].
-pub(crate) struct EncodedSegmentSst {
+/// Best-effort cleanup after a writer fails partway through.
+///
+/// Tells object storage to discard any part of this SST already
+/// uploaded. If the abort call itself fails, only logs a warning. The
+/// caller returns its original error either way.
+async fn abort_writer(writer: &mut EncodedSsTableWriter) {
+    if let Err(e) = writer.abort().await {
+        warn!("failed to abort sst writer after error [error={:?}]", e);
+    }
+}
+
+/// One uploaded SST from a memtable flush, tagged with the segment it
+/// belongs to (RFC-0024). An empty `prefix` denotes the compatibility-encoded
+/// `prefix=""` segment whose state lives in the manifest's top-level tree.
+#[derive(Clone)]
+pub(crate) struct SegmentedSstHandle {
     pub(crate) prefix: Bytes,
-    pub(crate) encoded: EncodedSsTable,
+    pub(crate) sst_handle: SsTableHandle,
+    pub(crate) encoded_bytes: u64,
 }
 
 impl DbInner {
-    /// Build a single SST from an immutable memtable, ignoring any segment
-    /// extractor. Returns `None` when the post-retention iterator yields
-    /// zero entries — callers that want a real blob (e.g. the WAL fence)
-    /// should construct one explicitly rather than relying on this path.
-    /// For L0 flushes use [`Self::build_imm_ssts`] instead, which routes
-    /// entries through segment-aware builders.
-    async fn build_imm_sst(
+    /// Write this memtable's post-retention entries to object storage.
+    ///
+    /// Hands the SST to the writer one block at a time, so peak memory
+    /// is bounded by the writer's buffer (10 MiB) rather than the whole
+    /// encoded SST. An SST that fits in that buffer still stays fully
+    /// buffered until close; the saving is for SSTs larger than it.
+    ///
+    /// With no segment extractor configured, writes one SST. With one
+    /// configured, writes one SST per segment prefix that received at
+    /// least one entry.
+    pub(crate) async fn stream_imm_ssts(
         &self,
         imm_table: Arc<KVTable>,
-    ) -> Result<Option<EncodedSsTable>, SlateDBError> {
-        let mut sst_builder = self.table_store.table_builder();
-        let mut iter = self.iter_imm_table(imm_table).await?;
-        let mut any = false;
-        while let Some(entry) = iter.next().await? {
-            sst_builder.add(entry).await?;
-            any = true;
-            // Keep cached flush work cooperative.
-            tokio::task::coop::consume_budget().await;
-        }
-        if !any {
-            return Ok(None);
-        }
-        Ok(Some(sst_builder.build().await?))
-    }
-
-    /// Build one or more L0 SSTs from a single immutable memtable, grouping
-    /// entries by the segment prefix derived from the configured extractor.
-    ///
-    /// Returns one `(prefix, EncodedSsTable)` per segment that received at
-    /// least one post-retention entry, sorted ascending by `prefix`. The
-    /// memtable iterator yields keys in sorted order and segments own
-    /// disjoint key intervals, so all entries for a given prefix arrive
-    /// consecutively — the implementation streams one open builder at a
-    /// time, finalizing on prefix transitions.
-    ///
-    /// The touched-segment set is read from
-    /// [`KVTable::touched_segments`], populated by the write and
-    /// WAL-replay paths. A non-empty memtable with an empty set is
-    /// an invariant violation surfaced as `InvalidDBState`.
-    ///
-    /// If retention prunes every entry the result is an empty Vec
-    /// — per-memtable progress in the manifest (`last_l0_seq`,
-    /// `replay_after_wal_id`) advances independently of whether any
-    /// SST landed.
-    pub(crate) async fn build_imm_ssts(
-        &self,
-        imm_table: Arc<KVTable>,
-    ) -> Result<Vec<EncodedSegmentSst>, SlateDBError> {
+        min_retention_seq: Option<u64>,
+        segment_sst_ids: &BTreeMap<Bytes, Ulid>,
+    ) -> Result<Vec<SegmentedSstHandle>, SlateDBError> {
         if self.segment_extractor.is_none() {
+            let sst_id = segment_sst_ids
+                .get(&Bytes::new())
+                .copied()
+                .map(SsTableId::from)
+                .ok_or(SlateDBError::InvalidDBState)?;
             return Ok(self
-                .build_imm_sst(imm_table)
+                .stream_imm_sst(imm_table, min_retention_seq, sst_id)
                 .await?
                 .into_iter()
-                .map(|encoded| EncodedSegmentSst {
+                .map(|(sst_handle, encoded_bytes)| SegmentedSstHandle {
                     prefix: Bytes::new(),
-                    encoded,
+                    sst_handle,
+                    encoded_bytes,
                 })
                 .collect());
         }
         let touched = imm_table.touched_segments();
         if touched.is_empty() {
-            // An empty memtable is fine; a non-empty memtable with
-            // no recorded prefixes is an invariant violation.
             if imm_table.is_empty() {
                 return Ok(Vec::new());
             }
             return Err(SlateDBError::InvalidDBState);
         }
-        self.build_imm_segment_ssts(imm_table, touched).await
+        self.stream_imm_segment_ssts(imm_table, touched, min_retention_seq, segment_sst_ids)
+            .await
     }
 
-    /// Sorted-merge walk over the precomputed touched-segment set.
-    /// Both inputs are sorted (`BTreeSet` iter is ascending; the
-    /// memtable yields keys in order). For each entry, advance the
-    /// segment cursor until `entry.key.starts_with(current_prefix)`
-    /// holds, then add to that segment's builder. Finalizes builders
-    /// only when entries actually landed in them, so post-retention
-    /// pruning that empties a segment yields no SST for it.
-    async fn build_imm_segment_ssts(
+    /// Write one SST for the whole memtable, with no segment extractor.
+    ///
+    /// Each finished block is handed to the writer as it is produced.
+    /// The writer buffers blocks and only starts uploading once its
+    /// buffer fills, so a small SST is held in memory until close.
+    ///
+    /// On any error, aborts this SST's upload before returning the
+    /// error. This discards any blocks already sent to object storage
+    /// for this attempt.
+    async fn stream_imm_sst(
+        &self,
+        imm_table: Arc<KVTable>,
+        min_retention_seq: Option<u64>,
+        sst_id: SsTableId,
+    ) -> Result<Option<(SsTableHandle, u64)>, SlateDBError> {
+        let mut writer = self.table_store.table_writer(sst_id, Some(Bytes::new()));
+        let mut iter = match self.iter_imm_table(imm_table, min_retention_seq).await {
+            Ok(iter) => iter,
+            Err(e) => {
+                abort_writer(&mut writer).await;
+                return Err(e);
+            }
+        };
+        let mut any = false;
+        loop {
+            match iter.next().await {
+                Ok(Some(entry)) => {
+                    if let Err(e) = writer.add(entry).await {
+                        abort_writer(&mut writer).await;
+                        return Err(e);
+                    }
+                    any = true;
+                    tokio::task::coop::consume_budget().await;
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    abort_writer(&mut writer).await;
+                    return Err(e);
+                }
+            }
+        }
+        if !any {
+            return Ok(None);
+        }
+        Ok(Some(writer.close_and_count_bytes().await?))
+    }
+
+    /// Write one SST per touched segment, block by block.
+    ///
+    /// Walks the memtable's entries and the segment prefixes together.
+    /// Both are sorted, so every entry for one prefix arrives before
+    /// the next prefix starts. Closes the current segment's SST and
+    /// opens the next one each time an entry's key no longer matches
+    /// the current prefix.
+    ///
+    /// On error, aborts only the segment being written when the error
+    /// happened. Segments already closed and uploaded earlier in this
+    /// call stay uploaded.
+    async fn stream_imm_segment_ssts(
         &self,
         imm_table: Arc<KVTable>,
         touched_segments: std::collections::BTreeSet<Bytes>,
-    ) -> Result<Vec<EncodedSegmentSst>, SlateDBError> {
-        let mut entries = self.iter_imm_table(imm_table).await?;
+        min_retention_seq: Option<u64>,
+        segment_sst_ids: &BTreeMap<Bytes, Ulid>,
+    ) -> Result<Vec<SegmentedSstHandle>, SlateDBError> {
+        let mut entries = self.iter_imm_table(imm_table, min_retention_seq).await?;
         let mut seg_iter = touched_segments.into_iter();
         let mut current_prefix = seg_iter
             .next()
             .expect("touched_segments non-empty in this branch");
-        let mut current_builder = self.table_store.table_builder();
+        let mut current_id = segment_sst_ids
+            .get(&current_prefix)
+            .copied()
+            .ok_or(SlateDBError::InvalidDBState)?;
+        let mut current_writer = self
+            .table_store
+            .table_writer(SsTableId::from(current_id), Some(current_prefix.clone()));
         let mut current_has_entry = false;
-        let mut out: Vec<EncodedSegmentSst> = Vec::new();
-        while let Some(entry) = entries.next().await? {
-            // Advance the segment cursor until the entry fits the
-            // current prefix. The validation contract guarantees a
-            // match; an exhausted iterator means the extractor's
-            // output diverges from the recorded set.
+        let mut out: Vec<SegmentedSstHandle> = Vec::new();
+        loop {
+            let entry = match entries.next().await {
+                Ok(Some(entry)) => entry,
+                Ok(None) => break,
+                Err(e) => {
+                    abort_writer(&mut current_writer).await;
+                    return Err(e);
+                }
+            };
+            // entry's key no longer matches current_prefix: close this
+            // segment's SST (if it received any entries) and move on
+            // to the next prefix.
             while !entry.key.starts_with(current_prefix.as_ref()) {
                 if current_has_entry {
-                    out.push(EncodedSegmentSst {
+                    let (sst_handle, encoded_bytes) =
+                        current_writer.close_and_count_bytes().await?;
+                    out.push(SegmentedSstHandle {
                         prefix: current_prefix,
-                        encoded: current_builder.build().await?,
+                        sst_handle,
+                        encoded_bytes,
                     });
                 }
                 current_prefix = seg_iter.next().expect(
                     "entry key has no matching prefix in touched_segments — \
                          extractor output inconsistent with recorded set",
                 );
-                current_builder = self.table_store.table_builder();
+                current_id = segment_sst_ids
+                    .get(&current_prefix)
+                    .copied()
+                    .ok_or(SlateDBError::InvalidDBState)?;
+                current_writer = self
+                    .table_store
+                    .table_writer(SsTableId::from(current_id), Some(current_prefix.clone()));
                 current_has_entry = false;
             }
-            current_builder.add(entry).await?;
+            if let Err(e) = current_writer.add(entry).await {
+                abort_writer(&mut current_writer).await;
+                return Err(e);
+            }
             current_has_entry = true;
-            // Keep cached flush work cooperative.
             tokio::task::coop::consume_budget().await;
         }
         if current_has_entry {
-            out.push(EncodedSegmentSst {
+            let (sst_handle, encoded_bytes) = current_writer.close_and_count_bytes().await?;
+            out.push(SegmentedSstHandle {
                 prefix: current_prefix,
-                encoded: current_builder.build().await?,
+                sst_handle,
+                encoded_bytes,
             });
         }
         Ok(out)
@@ -147,9 +216,10 @@ impl DbInner {
 
     /// Write `encoded_sst` to object storage at `id` and advance the
     /// monotonic durable tick from `imm_table`.
+    #[cfg(test)]
     pub(crate) async fn upload_sst(
         &self,
-        id: &db_state::SsTableId,
+        id: &SsTableId,
         encoded_sst: &EncodedSsTable,
         segment: Bytes,
     ) -> Result<SsTableHandle, SlateDBError> {
@@ -161,7 +231,7 @@ impl DbInner {
     }
 
     /// Test helper: build L0 SSTs from `imm_table` via the segment-aware
-    /// path ([`Self::build_imm_ssts`]) and upload each one with a freshly
+    /// path ([`Self::stream_imm_ssts`]) and upload each one with a freshly
     /// allocated [`db_state::SsTableId`]. Returns the resulting
     /// handles in the same order as the segments. Without an extractor the
     /// result is at most one handle; an empty Vec means retention pruned
@@ -175,44 +245,60 @@ impl DbInner {
         // Tests that construct an `imm_table` outside the write path
         // must call `KVTable::record_touched_segments` themselves
         // before dispatching here.
-        let built = self.build_imm_ssts(imm_table.clone()).await?;
-        let mut handles = Vec::with_capacity(built.len());
-        for sst in built {
-            let id =
-                db_state::SsTableId::from(self.rand.rng().gen_ulid(self.system_clock.as_ref()));
-            let handle = self
-                .upload_sst(&id, &sst.encoded, sst.prefix.clone())
-                .await?;
-            handles.push(handle);
+        let mut prefixes = imm_table.touched_segments();
+        if prefixes.is_empty() {
+            prefixes.insert(Bytes::new());
         }
-        Ok(handles)
+        let segment_sst_ids: BTreeMap<Bytes, Ulid> = prefixes
+            .into_iter()
+            .map(|p| (p, self.rand.rng().gen_ulid(self.system_clock.as_ref())))
+            .collect();
+        let min_retention_seq = self.compute_min_retention_seq();
+        let segments = self
+            .stream_imm_ssts(imm_table, min_retention_seq, &segment_sst_ids)
+            .await?;
+        Ok(segments.into_iter().map(|s| s.sst_handle).collect())
     }
 
-    async fn iter_imm_table(
-        &self,
-        imm_table: Arc<KVTable>,
-    ) -> Result<RetentionIterator<Box<dyn RowEntryIterator>>, SlateDBError> {
-        let state = self.state.read().view();
-
-        // Compute retention boundary using the minimum active sequences from active snapshots AND
-        // active transactions AND durable watermark. This does not need to be atomic as even if a
-        // new snapshot is created/dropped or a new transaction is created/dropped between reading
-        // both snapshot_manager and txn_manager we will always have the min so any race here is
-        // acceptable.
-        //
-        // Remote readers (DurabilityLevel::Remote) cap visibility at last_remote_persisted_seq,
-        // so we must retain at least one version at or below that boundary for each key.
-        // Otherwise, if we only keep a newer non-durable version, remote readers would skip
-        // it and incorrectly fall back to an even older value.
+    /// Compute the retention boundary for this flush.
+    ///
+    /// The boundary is the lowest sequence number this flush must keep
+    /// a version for. It is the minimum of three values: the durable
+    /// watermark, the oldest open snapshot's sequence, and the oldest
+    /// open transaction's sequence.
+    ///
+    /// Remote readers (`DurabilityLevel::Remote`) cap visibility at the
+    /// durable watermark, so at least one version at or below the
+    /// boundary must survive for each key. Otherwise a remote reader
+    /// skips a newer non-durable version and falls back to an even
+    /// older value.
+    ///
+    /// The read is not atomic. A snapshot or transaction may open or
+    /// close between the reads of the three inputs. Taking the minimum
+    /// still yields a safe boundary, so the race is acceptable.
+    ///
+    /// Call this once per flush attempt. Reuse the same value on every
+    /// retry of that attempt. The three inputs can change between
+    /// retries; reading a fresh value on each retry could make each
+    /// retry keep a different set of entries.
+    pub(crate) fn compute_min_retention_seq(&self) -> Option<u64> {
         let durable_seq = self.oracle.last_remote_persisted_seq();
-        let min_retention_seq = [
+        [
             Some(durable_seq),
             self.snapshot_manager.min_active_seq(),
             self.txn_manager.min_active_seq(),
         ]
         .into_iter()
         .flatten()
-        .min();
+        .min()
+    }
+
+    async fn iter_imm_table(
+        &self,
+        imm_table: Arc<KVTable>,
+        min_retention_seq: Option<u64>,
+    ) -> Result<RetentionIterator<Box<dyn RowEntryIterator>>, SlateDBError> {
+        let state = self.state.read().view();
 
         let merge_iter = if let Some(merge_operator) = self.flush_merge_operator.clone() {
             Box::new(MergeOperatorIterator::new(
@@ -245,7 +331,7 @@ impl DbInner {
 mod tests {
     use crate::block_iterator::BlockIteratorLatest;
     use crate::db::Db;
-    use crate::db_state::{SsTableHandle, SsTableId};
+    use crate::db_state::SsTableHandle;
     use crate::error::SlateDBError;
     use crate::error::SlateDBError::MergeOperatorMissing;
     use crate::iter::RowEntryIterator;
@@ -259,8 +345,13 @@ mod tests {
     use bytes::Bytes;
     use rstest::rstest;
     use slatedb_common::metrics::test_recorder_helper;
+    use std::collections::BTreeMap;
     use std::sync::Arc;
     use ulid::Ulid;
+
+    fn preallocate_ids(prefixes: impl IntoIterator<Item = Bytes>) -> BTreeMap<Bytes, Ulid> {
+        prefixes.into_iter().map(|p| (p, Ulid::new())).collect()
+    }
 
     async fn setup_test_db_with_merge_operator() -> Db {
         setup_test_db(true).await
@@ -702,6 +793,86 @@ mod tests {
         db.close().await.unwrap();
     }
 
+    #[tokio::test]
+    async fn stream_imm_ssts_reuses_a_pinned_retention_boundary() {
+        let db = setup_test_db_with_merge_operator().await;
+        db.inner.oracle.advance_durable_seq(4);
+
+        let table = WritableKVTable::new();
+        table.put(RowEntry::new_value(&Bytes::from("key"), b"value1", 1));
+        table.put(RowEntry::new_value(&Bytes::from("key"), b"value2", 2));
+        table.put(RowEntry::new_value(&Bytes::from("key"), b"value3", 3));
+        table.put(RowEntry::new_value(&Bytes::from("key"), b"value4", 4));
+
+        let pinned = db.inner.compute_min_retention_seq();
+        assert_eq!(pinned, Some(4));
+
+        // Opening a snapshot lowers the live boundary. A flush that reuses
+        // its pinned boundary must ignore this change.
+        let (_, snapshot_seq) = db.inner.snapshot_manager.new_snapshot(Some(1));
+        assert_eq!(snapshot_seq, 1);
+        assert_eq!(db.inner.compute_min_retention_seq(), Some(1));
+
+        for _ in 0..2 {
+            let ids = preallocate_ids([Bytes::new()]);
+            let segments = db
+                .inner
+                .stream_imm_ssts(table.table().clone(), pinned, &ids)
+                .await
+                .unwrap();
+            let handle = segments.into_iter().next().unwrap().sst_handle;
+            verify_sst(
+                &db,
+                &handle,
+                &[(
+                    Bytes::from("key"),
+                    4,
+                    ValueDeletable::Value(Bytes::from("value4")),
+                )],
+            )
+            .await;
+        }
+
+        // Streaming with the live boundary (1) keeps every version.
+        let live = db.inner.compute_min_retention_seq();
+        let ids = preallocate_ids([Bytes::new()]);
+        let segments = db
+            .inner
+            .stream_imm_ssts(table.table().clone(), live, &ids)
+            .await
+            .unwrap();
+        let handle = segments.into_iter().next().unwrap().sst_handle;
+        verify_sst(
+            &db,
+            &handle,
+            &[
+                (
+                    Bytes::from("key"),
+                    4,
+                    ValueDeletable::Value(Bytes::from("value4")),
+                ),
+                (
+                    Bytes::from("key"),
+                    3,
+                    ValueDeletable::Value(Bytes::from("value3")),
+                ),
+                (
+                    Bytes::from("key"),
+                    2,
+                    ValueDeletable::Value(Bytes::from("value2")),
+                ),
+                (
+                    Bytes::from("key"),
+                    1,
+                    ValueDeletable::Value(Bytes::from("value1")),
+                ),
+            ],
+        )
+        .await;
+
+        db.close().await.unwrap();
+    }
+
     async fn setup_test_db_with_extractor(
         path: &str,
         extractor: Arc<dyn crate::prefix_extractor::PrefixExtractor>,
@@ -715,16 +886,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_imm_ssts_without_extractor_emits_single_empty_prefix() {
+    async fn stream_imm_ssts_without_extractor_emits_single_empty_prefix() {
         let db = setup_test_db_without_merge_operator().await;
         db.inner.oracle.advance_durable_seq(u64::MAX);
         let table = WritableKVTable::new();
         table.put(RowEntry::new_value(b"k1", b"v1", 1));
         table.put(RowEntry::new_value(b"k2", b"v2", 2));
+        let segment_sst_ids = preallocate_ids([Bytes::new()]);
 
         let ssts = db
             .inner
-            .build_imm_ssts(table.table().clone())
+            .stream_imm_ssts(table.table().clone(), None, &segment_sst_ids)
             .await
             .unwrap();
 
@@ -734,21 +906,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_imm_ssts_with_extractor_yields_empty_vec_when_no_entries() {
+    async fn stream_imm_ssts_with_extractor_yields_empty_vec_when_no_entries() {
         // With an extractor configured, an empty memtable produces no
-        // entries and therefore opens no builders — the result is an
+        // entries and therefore opens no writers — the result is an
         // empty Vec.
         let db = setup_test_db_with_extractor(
-            "/tmp/test_build_imm_ssts_empty",
+            "/tmp/test_stream_imm_ssts_empty",
             Arc::new(FixedThreeBytePrefixExtractor),
         )
         .await;
         db.inner.oracle.advance_durable_seq(u64::MAX);
         let table = WritableKVTable::new();
+        let segment_sst_ids = preallocate_ids([]);
 
         let ssts = db
             .inner
-            .build_imm_ssts(table.table().clone())
+            .stream_imm_ssts(table.table().clone(), None, &segment_sst_ids)
             .await
             .unwrap();
 
@@ -757,17 +930,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_imm_ssts_without_extractor_yields_empty_vec_when_no_entries() {
+    async fn stream_imm_ssts_without_extractor_yields_empty_vec_when_no_entries() {
         // Without an extractor configured, an empty memtable also yields
         // an empty Vec — symmetric with the extractor case. Manifest
         // progress (last_l0_seq, replay frontier) advances independently.
         let db = setup_test_db_without_merge_operator().await;
         db.inner.oracle.advance_durable_seq(u64::MAX);
         let table = WritableKVTable::new();
+        let segment_sst_ids = preallocate_ids([Bytes::new()]);
 
         let ssts = db
             .inner
-            .build_imm_ssts(table.table().clone())
+            .stream_imm_ssts(table.table().clone(), None, &segment_sst_ids)
             .await
             .unwrap();
 
@@ -776,9 +950,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_imm_ssts_with_extractor_groups_by_prefix() {
+    async fn stream_imm_ssts_with_extractor_groups_by_prefix() {
         let db = setup_test_db_with_extractor(
-            "/tmp/test_build_imm_ssts_groups",
+            "/tmp/test_stream_imm_ssts_groups",
             Arc::new(FixedThreeBytePrefixExtractor),
         )
         .await;
@@ -798,17 +972,22 @@ mod tests {
             Bytes::from_static(b"bbb"),
             Bytes::from_static(b"ccc"),
         ]));
+        let segment_sst_ids = preallocate_ids([
+            Bytes::from_static(b"aaa"),
+            Bytes::from_static(b"bbb"),
+            Bytes::from_static(b"ccc"),
+        ]);
 
         let ssts = db
             .inner
-            .build_imm_ssts(table.table().clone())
+            .stream_imm_ssts(table.table().clone(), None, &segment_sst_ids)
             .await
             .unwrap();
 
         let prefixes: Vec<&[u8]> = ssts.iter().map(|s| s.prefix.as_ref()).collect();
         assert_eq!(prefixes, vec![&b"aaa"[..], &b"bbb"[..], &b"ccc"[..]]);
 
-        // Upload each SST and verify it carries exactly its prefix's entries.
+        // Each SST is already uploaded; verify it carries exactly its prefix's entries.
         let expected: Vec<Vec<(Bytes, u64, ValueDeletable)>> = vec![
             vec![
                 (
@@ -841,21 +1020,15 @@ mod tests {
             ],
         ];
         for (sst, entries) in ssts.into_iter().zip(expected.into_iter()) {
-            let id = SsTableId::from(Ulid::new());
-            let handle = db
-                .inner
-                .upload_sst(&id, &sst.encoded, sst.prefix.clone())
-                .await
-                .unwrap();
-            verify_sst(&db, &handle, &entries).await;
+            verify_sst(&db, &sst.sst_handle, &entries).await;
         }
         db.close().await.unwrap();
     }
 
     #[tokio::test]
-    async fn build_imm_ssts_with_extractor_single_segment_yields_one() {
+    async fn stream_imm_ssts_with_extractor_single_segment_yields_one() {
         let db = setup_test_db_with_extractor(
-            "/tmp/test_build_imm_ssts_single",
+            "/tmp/test_stream_imm_ssts_single",
             Arc::new(FixedThreeBytePrefixExtractor),
         )
         .await;
@@ -866,10 +1039,11 @@ mod tests {
         table.record_touched_segments(std::collections::BTreeSet::from([Bytes::from_static(
             b"aaa",
         )]));
+        let segment_sst_ids = preallocate_ids([Bytes::from_static(b"aaa")]);
 
         let ssts = db
             .inner
-            .build_imm_ssts(table.table().clone())
+            .stream_imm_ssts(table.table().clone(), None, &segment_sst_ids)
             .await
             .unwrap();
 
@@ -878,14 +1052,14 @@ mod tests {
         db.close().await.unwrap();
     }
 
-    /// `build_imm_ssts` rejects the invariant violation where an
+    /// `stream_imm_ssts` rejects the invariant violation where an
     /// extractor is configured but the memtable has entries with no
     /// recorded prefix set — surfacing what would otherwise be a
     /// silent inconsistency.
     #[tokio::test]
-    async fn build_imm_ssts_rejects_missing_touched_segments() {
+    async fn stream_imm_ssts_rejects_missing_touched_segments() {
         let db = setup_test_db_with_extractor(
-            "/tmp/test_build_imm_ssts_invariant",
+            "/tmp/test_stream_imm_ssts_invariant",
             Arc::new(FixedThreeBytePrefixExtractor),
         )
         .await;
@@ -893,8 +1067,13 @@ mod tests {
         let table = WritableKVTable::new();
         table.put(RowEntry::new_value(b"aaa-1", b"v1", 1));
         // Deliberately do NOT call record_touched_segments.
+        let segment_sst_ids = preallocate_ids([]);
 
-        let err = match db.inner.build_imm_ssts(table.table().clone()).await {
+        let err = match db
+            .inner
+            .stream_imm_ssts(table.table().clone(), None, &segment_sst_ids)
+            .await
+        {
             Ok(_) => panic!("expected InvalidDBState for missing touched_segments"),
             Err(e) => e,
         };

--- a/slatedb/src/memtable_flusher/manifest_writer.rs
+++ b/slatedb/src/memtable_flusher/manifest_writer.rs
@@ -893,10 +893,11 @@ mod tests {
     use crate::db::DbInner;
     use crate::db_status::{ClosedResultWriter, DbStatusManager};
     use crate::error::SlateDBError;
+    use crate::flush::SegmentedSstHandle;
     use crate::format::sst::SsTableFormat;
     use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
-    use crate::memtable_flusher::uploader::{SegmentedSstHandle, UploadedMemtable};
+    use crate::memtable_flusher::uploader::UploadedMemtable;
     use crate::paths::PathResolver;
     use crate::tablestore::{TableStore, TableStoreKind};
     use crate::types::RowEntry;
@@ -1834,6 +1835,7 @@ mod tests {
             segments.push(SegmentedSstHandle {
                 prefix: Bytes::copy_from_slice(prefix),
                 sst_handle,
+                encoded_bytes: encoded_sst.remaining_len() as u64,
             });
         }
         inner.oracle.advance_durable_seq(last_seq);

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -13,11 +13,12 @@
 
 use super::tracker::TrackerMessage;
 use crate::db::DbInner;
-use crate::db_state::{SsTableHandle, SsTableId};
+#[cfg(test)]
+use crate::db_state::SsTableHandle;
 use crate::db_status::ClosedResultWriter;
 use crate::dispatcher::{MessageHandler, MessageHandlerExecutor};
 use crate::error::SlateDBError;
-use crate::flush::EncodedSegmentSst;
+use crate::flush::SegmentedSstHandle;
 use crate::mem_table::ImmutableMemtable;
 use crate::utils::SafeSender;
 use async_trait::async_trait;
@@ -63,15 +64,6 @@ impl UploadJob {
     }
 }
 
-/// One uploaded SST from a memtable flush, tagged with the segment it
-/// belongs to (RFC-0024). An empty `prefix` denotes the compatibility-encoded
-/// `prefix=""` segment whose state lives in the manifest's top-level tree.
-#[derive(Clone)]
-pub(crate) struct SegmentedSstHandle {
-    pub(crate) prefix: Bytes,
-    pub(crate) sst_handle: SsTableHandle,
-}
-
 #[derive(Clone)]
 /// Result of a successfully uploaded immutable memtable. A flush produces
 /// one [`SegmentedSstHandle`] per segment that received at least one
@@ -105,6 +97,7 @@ impl UploadedMemtable {
             segments: vec![SegmentedSstHandle {
                 prefix: Bytes::new(),
                 sst_handle,
+                encoded_bytes: 0,
             }],
             first_seq,
             last_seq,
@@ -189,10 +182,10 @@ impl UploadHandler {
     }
 
     async fn upload_with_retry(&self, job: &UploadJob) -> Result<UploadedMemtable, SlateDBError> {
-        // Build once, retry only the upload. `write_sst` takes
-        // `&EncodedSsTable`, so the encoded SSTs stay alive for retries —
-        // no need to rebuild from the memtable on transient upload errors.
-        let built = self.db.build_imm_ssts(job.imm_memtable.table()).await?;
+        // Read the retention boundary once, before the first attempt
+        // below. Every retry reuses this same value, so every attempt
+        // keeps the same entries.
+        let min_retention_seq = self.db.compute_min_retention_seq();
         let first_seq = job
             .imm_memtable
             .table()
@@ -204,25 +197,36 @@ impl UploadHandler {
             .last_seq()
             .expect("flush of l0 with no entries");
 
-        // Upload all segment SSTs concurrently. `try_join_all` short-circuits
-        // on the first fatal error and drops the remaining futures; sibling
-        // uploads that already landed before the abort are left for the
-        // garbage collector to reclaim.
-        let segments = futures::future::try_join_all(built.iter().map(|sst| {
-            // Ids are pre-allocated at dispatch keyed by segment prefix. Every
-            // built prefix is a subset of the dispatched touched set, so a
-            // missing id is an internal invariant violation.
-            let sst_id = job
-                .segment_sst_ids
-                .get(&sst.prefix)
-                .copied()
-                .map(SsTableId::from);
-            async move {
-                let sst_id = sst_id.ok_or(SlateDBError::InvalidDBState)?;
-                self.upload_segment_sst(sst, sst_id).await
+        let segments = loop {
+            match self
+                .db
+                .stream_imm_ssts(
+                    job.imm_memtable.table(),
+                    min_retention_seq,
+                    &job.segment_sst_ids,
+                )
+                .await
+            {
+                Ok(segments) => break segments,
+                // Only a storage-layer error is worth retrying. Any
+                // other error is a logic error that retrying cannot
+                // fix, so it is returned right away below.
+                Err(e @ (SlateDBError::IoError(_) | SlateDBError::ObjectStoreError(_))) => {
+                    // When the WAL is enabled and the database is shutting
+                    // down, give up immediately. The data is already durable
+                    // in the WAL and will be recovered on the next startup.
+                    if self.db.wal_enabled && self.db.check_closed().is_err() {
+                        info!("skipping l0 flush retry during shutdown [error={:?}]", e);
+                        return Err(e);
+                    }
+                    self.db.system_clock.sleep(self.retry_backoff).await;
+                }
+                Err(e) => return Err(e),
             }
-        }))
-        .await?;
+        };
+
+        let written_bytes: u64 = segments.iter().map(|s| s.encoded_bytes).sum();
+        self.db.db_stats.l0_flush_bytes.increment(written_bytes);
 
         Ok(UploadedMemtable {
             imm_memtable: Arc::clone(&job.imm_memtable),
@@ -230,46 +234,6 @@ impl UploadHandler {
             first_seq,
             last_seq,
         })
-    }
-
-    /// Upload a single segment SST with retry, writing it to the id
-    /// pre-allocated for its segment at dispatch. Each retry reuses the
-    /// already-encoded SST so the upload loop never rebuilds from the
-    /// memtable.
-    async fn upload_segment_sst(
-        &self,
-        sst: &EncodedSegmentSst,
-        sst_id: SsTableId,
-    ) -> Result<SegmentedSstHandle, SlateDBError> {
-        let written_bytes = sst.encoded.remaining_len() as u64;
-        loop {
-            match self
-                .db
-                .upload_sst(&sst_id, &sst.encoded, sst.prefix.clone())
-                .await
-            {
-                Ok(sst_handle) => {
-                    self.db.db_stats.l0_flush_bytes.increment(written_bytes);
-                    return Ok(SegmentedSstHandle {
-                        prefix: sst.prefix.clone(),
-                        sst_handle,
-                    });
-                }
-                Err(e) => {
-                    // When the WAL is enabled and the database is shutting
-                    // down, give up immediately. The data is already durable
-                    // in the WAL and will be recovered on the next startup.
-                    if self.db.wal_enabled && self.db.check_closed().is_err() {
-                        info!(
-                            "skipping l0 upload retry during shutdown [sst_id={:?}, error={:?}]",
-                            sst_id, e
-                        );
-                        return Err(e);
-                    }
-                    self.db.system_clock.sleep(self.retry_backoff).await;
-                }
-            }
-        }
     }
 }
 
@@ -620,11 +584,75 @@ mod tests {
         fail_parallel::cfg(
             Arc::clone(&fp_registry),
             "write-compacted-sst-io-error",
-            "1*off->return",
+            "1*return->off",
         )
         .unwrap();
         let db = setup_db("/tmp/test_parallel_l0_flush_uploader_retry", fp_registry).await;
         let job = next_upload_job(&db, b"key", b"value", 1);
+
+        let test = start_test_uploader(&db);
+        let started = std::time::Instant::now();
+        test.submit(job).unwrap();
+
+        let msg = timeout(Duration::from_secs(5), test.tracker_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            started.elapsed() >= db.settings.manifest_poll_interval,
+            "expected the job to wait out at least one retry backoff before succeeding"
+        );
+        let TrackerMessage::UploadComplete(event) = msg else {
+            panic!("expected UploadComplete");
+        };
+        assert_eq!(event.first_seq, 1);
+        assert_eq!(event.last_seq, 1);
+
+        test.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn should_retry_the_whole_job_when_a_later_segment_fails() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        // First segment's write succeeds; second segment's write fails once;
+        // every write after that succeeds, including the retried first
+        // segment.
+        fail_parallel::cfg(
+            Arc::clone(&fp_registry),
+            "write-compacted-sst-io-error",
+            "1*off->1*return->off",
+        )
+        .unwrap();
+        let db = setup_db_with_extractor(
+            "/tmp/test_parallel_l0_flush_uploader_multi_segment_retry",
+            fp_registry,
+            Some(Arc::new(FixedThreeBytePrefixExtractor)),
+        )
+        .await;
+        {
+            let mut guard = db.state.write();
+            for (key, value, seq) in [(&b"aaa-1"[..], b"v1", 1), (&b"bbb-1"[..], b"v2", 2)] {
+                guard.memtable().put(RowEntry::new_value(key, value, seq));
+            }
+            guard
+                .memtable()
+                .table()
+                .record_touched_segments(std::collections::BTreeSet::from([
+                    Bytes::from_static(b"aaa"),
+                    Bytes::from_static(b"bbb"),
+                ]));
+            guard.freeze_memtable(0);
+        }
+        let imm_memtable = db
+            .state
+            .read()
+            .state()
+            .imm_memtable
+            .front()
+            .cloned()
+            .unwrap();
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        let job = UploadJob::new(imm_memtable, segment_sst_ids);
 
         let test = start_test_uploader(&db);
         test.submit(job).unwrap();
@@ -636,8 +664,97 @@ mod tests {
         let TrackerMessage::UploadComplete(event) = msg else {
             panic!("expected UploadComplete");
         };
+        let prefixes: Vec<&[u8]> = event.segments.iter().map(|s| s.prefix.as_ref()).collect();
+        assert_eq!(prefixes, vec![&b"aaa"[..], &b"bbb"[..]]);
+        for segment in &event.segments {
+            db.table_store
+                .open_sst(&segment.sst_handle.id, Some(segment.prefix.clone()))
+                .await
+                .expect("uploaded SST should be readable");
+        }
+
+        test.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn should_rebuild_from_memtable_when_a_mid_sst_block_write_fails() {
+        let fp_registry = Arc::new(FailPointRegistry::new());
+        fail_parallel::cfg(
+            Arc::clone(&fp_registry),
+            "write-compacted-sst-io-error",
+            "1*off->1*return->off",
+        )
+        .unwrap();
+        let db = setup_db(
+            "/tmp/test_parallel_l0_flush_uploader_mid_block_retry",
+            fp_registry,
+        )
+        .await;
+
+        let value = vec![b'x'; 1024];
+        let entry_count = 32u64;
+        {
+            let mut guard = db.state.write();
+            for seq in 1..=entry_count {
+                let key = format!("key-{seq:04}");
+                guard
+                    .memtable()
+                    .put(RowEntry::new_value(key.as_bytes(), &value, seq));
+            }
+            guard.freeze_memtable(0);
+        }
+        let imm_memtable = db
+            .state
+            .read()
+            .state()
+            .imm_memtable
+            .front()
+            .cloned()
+            .unwrap();
+        let segment_sst_ids = preallocate_ids(&imm_memtable);
+        let job = UploadJob::new(imm_memtable, segment_sst_ids);
+
+        let test = start_test_uploader(&db);
+        let started = std::time::Instant::now();
+        test.submit(job).unwrap();
+
+        let msg = timeout(Duration::from_secs(5), test.tracker_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            started.elapsed() >= db.settings.manifest_poll_interval,
+            "expected a mid-SST block write to fail and force one retry backoff"
+        );
+        let TrackerMessage::UploadComplete(event) = msg else {
+            panic!("expected UploadComplete");
+        };
         assert_eq!(event.first_seq, 1);
-        assert_eq!(event.last_seq, 1);
+        assert_eq!(event.last_seq, entry_count);
+        assert_eq!(event.segments.len(), 1);
+
+        let sst_view = SsTableView::identity(
+            db.table_store
+                .open_sst(&event.segments[0].sst_handle.id, Some(Bytes::new()))
+                .await
+                .expect("rebuilt SST should be readable"),
+        );
+        let mut iter = SstIterator::new_owned_initialized(
+            ..,
+            sst_view,
+            Arc::clone(&db.table_store),
+            SstIteratorOptions::default(),
+        )
+        .await
+        .unwrap()
+        .expect("expected non-empty SST");
+        let mut seen = 0u64;
+        while let Some(entry) = iter.next().await.unwrap() {
+            seen += 1;
+            assert_eq!(entry.key.as_ref(), format!("key-{seen:04}").as_bytes());
+            assert_eq!(entry.seq, seen);
+        }
+        assert_eq!(seen, entry_count);
 
         test.shutdown().await;
     }
@@ -868,13 +985,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_abort_concurrent_segment_uploads_on_shutdown_when_wal_enabled() {
-        // With multiple segments uploading concurrently via try_join_all,
-        // every per-segment retry loop must independently observe the
-        // shutdown signal and bail out — otherwise one stuck upload would
-        // hold the worker open. Configure the fail point to fail every
-        // upload and verify the worker reports an error after the db is
-        // closed.
+    async fn should_stop_retrying_multi_segment_job_on_shutdown_when_wal_enabled() {
+        // A multi-segment job streams and uploads all of its segments as one
+        // unit, retried as a whole on failure. Configure the fail point to
+        // fail every write and verify the single retry loop still observes
+        // the shutdown signal and gives up, rather than retrying forever.
         let fp_registry = Arc::new(FailPointRegistry::new());
         fail_parallel::cfg(
             Arc::clone(&fp_registry),

--- a/slatedb/src/memtable_flusher/uploader.rs
+++ b/slatedb/src/memtable_flusher/uploader.rs
@@ -20,6 +20,7 @@ use crate::dispatcher::{MessageHandler, MessageHandlerExecutor};
 use crate::error::SlateDBError;
 use crate::flush::SegmentedSstHandle;
 use crate::mem_table::ImmutableMemtable;
+use crate::retrying_object_store::RetryingObjectStore;
 use crate::utils::SafeSender;
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -33,6 +34,32 @@ use tokio::runtime::Handle;
 use ulid::Ulid;
 
 const UPLOADER_TASK_NAME: &str = "l0_sst_uploader";
+
+// `BufWriter` wraps an `object_store::Error` inside `std::io::Error` through
+// `AsyncWrite`. Find the original error before applying the shared retry rule.
+// Without this step, `NotSupported` can retry forever.
+fn should_retry_upload_error(error: &SlateDBError) -> bool {
+    match error {
+        SlateDBError::ObjectStoreError(error) => RetryingObjectStore::should_retry(error),
+        SlateDBError::IoError(error) => {
+            let Some(source) = error.get_ref() else {
+                return true;
+            };
+            let mut source: Option<&(dyn std::error::Error + 'static)> = Some(source);
+            while let Some(error) = source {
+                if let Some(error) = error.downcast_ref::<object_store::Error>() {
+                    return RetryingObjectStore::should_retry(error);
+                }
+                if let Some(error) = error.downcast_ref::<Arc<object_store::Error>>() {
+                    return RetryingObjectStore::should_retry(error);
+                }
+                source = error.source();
+            }
+            true
+        }
+        _ => false,
+    }
+}
 
 /// One immutable-memtable upload request submitted to the uploader. Physical
 /// SST ids are allocated at dispatch (in sequence order) and carried here, so
@@ -208,10 +235,7 @@ impl UploadHandler {
                 .await
             {
                 Ok(segments) => break segments,
-                // Only a storage-layer error is worth retrying. Any
-                // other error is a logic error that retrying cannot
-                // fix, so it is returned right away below.
-                Err(e @ (SlateDBError::IoError(_) | SlateDBError::ObjectStoreError(_))) => {
+                Err(e) if should_retry_upload_error(&e) => {
                     // When the WAL is enabled and the database is shutting
                     // down, give up immediately. The data is already durable
                     // in the WAL and will be recovered on the next startup.
@@ -265,7 +289,7 @@ impl MessageHandler<UploadJob> for UploadHandler {
 
 #[cfg(test)]
 mod tests {
-    use super::{TrackerMessage, UploadJob, Uploader};
+    use super::{should_retry_upload_error, TrackerMessage, UploadJob, Uploader};
     use crate::block_cache_policy::BlockCachePolicy;
     use crate::config::Settings;
     use crate::db::DbInner;
@@ -302,6 +326,27 @@ mod tests {
     use tokio::runtime::Handle;
     use tokio::time::timeout;
     use ulid::Ulid;
+
+    fn not_supported_error() -> object_store::Error {
+        object_store::Error::NotSupported {
+            source: Box::new(std::io::Error::other("not supported")),
+        }
+    }
+
+    #[test]
+    fn should_not_retry_not_supported_upload_error() {
+        let direct = SlateDBError::from(not_supported_error());
+        assert!(!should_retry_upload_error(&direct));
+
+        let wrapped = SlateDBError::from(std::io::Error::from(not_supported_error()));
+        assert!(!should_retry_upload_error(&wrapped));
+    }
+
+    #[test]
+    fn should_retry_io_error_without_object_store_source() {
+        let error = SlateDBError::from(std::io::Error::other("temporary failure"));
+        assert!(should_retry_upload_error(&error));
+    }
 
     /// Build a pre-allocated id map for a test job, mirroring dispatch-time
     /// allocation: one id per segment prefix, falling back to the empty prefix

--- a/slatedb/src/retrying_object_store.rs
+++ b/slatedb/src/retrying_object_store.rs
@@ -104,7 +104,7 @@ impl RetryingObjectStore {
     }
 
     #[inline]
-    fn should_retry(err: &object_store::Error) -> bool {
+    pub(crate) fn should_retry(err: &object_store::Error) -> bool {
         let retry = !matches!(
             err,
             object_store::Error::AlreadyExists { .. }

--- a/slatedb/src/sorted_run_iterator.rs
+++ b/slatedb/src/sorted_run_iterator.rs
@@ -712,7 +712,7 @@ mod tests {
                     RowEntry::new_value(key_gen.next().as_ref(), val_gen.next().as_ref(), 0);
                 writer.add(entry).await.unwrap();
             }
-            let sst = writer.close().await.unwrap();
+            let (sst, _) = writer.close().await.unwrap();
             ssts.push(SsTableView::identity(sst));
         }
         SortedRun::new(0, ssts)

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -2059,7 +2059,7 @@ mod tests {
             writer.add(entry).await.unwrap();
             nkeys += 1;
         }
-        let sst = writer.close().await.unwrap();
+        let (sst, _) = writer.close().await.unwrap();
         (SsTableView::identity(sst), nkeys)
     }
 
@@ -2840,7 +2840,7 @@ mod tests {
             .add(RowEntry::new_value(b"key_c", b"value_50", 50))
             .await
             .unwrap();
-        let handle = writer.close().await.unwrap();
+        let (handle, _) = writer.close().await.unwrap();
 
         let mut iter = SstIterator::new_owned_initialized(
             ..,
@@ -2924,7 +2924,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let sst_handle = writer.close().await.unwrap();
+        let (sst_handle, _) = writer.close().await.unwrap();
         let sst = SsTableView::identity(sst_handle);
 
         // Minimal prefetch: 1 block at a time, 1 task max.

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1019,10 +1019,6 @@ impl EncodedSsTableWriter {
         Ok(block_size)
     }
 
-    pub(crate) async fn close(self) -> Result<SsTableHandle, SlateDBError> {
-        self.close_and_count_bytes().await.map(|(handle, _)| handle)
-    }
-
     /// Finish this SST: write the last block, write the footer, close
     /// the upload.
     ///
@@ -1032,56 +1028,49 @@ impl EncodedSsTableWriter {
     /// On failure, aborts the upload before returning the error. This
     /// discards any blocks already sent to object storage for this
     /// SST.
-    pub(crate) async fn close_and_count_bytes(
-        mut self,
-    ) -> Result<(SsTableHandle, u64), SlateDBError> {
-        match self.close_inner().await {
-            Ok(result) => Ok(result),
-            Err(e) => {
-                if let Err(abort_err) = self.abort().await {
-                    warn!(
-                        "failed to abort sst writer after error [id={:?}, error={:?}]",
-                        self.id, abort_err
-                    );
-                }
-                Err(e)
+    pub(crate) async fn close(mut self) -> Result<(SsTableHandle, u64), SlateDBError> {
+        let result = async {
+            fail_point!(
+                self.table_store.fp_registry.clone(),
+                "write-compacted-sst-io-error",
+                |_| Err(slatedb_io_error())
+            );
+            let builder = std::mem::replace(&mut self.builder, self.table_store.table_builder());
+            let encoded_sst = builder.build().await?;
+            for block in &encoded_sst.unconsumed_blocks {
+                self.writer.write_all(block.encoded_bytes.as_ref()).await?;
+                self.bytes_written += block.encoded_bytes.len();
+            }
+            self.writer.write_all(encoded_sst.footer.as_ref()).await?;
+            self.bytes_written += encoded_sst.footer.len();
+            self.shutdown_started = true;
+            self.writer.shutdown().await?;
+
+            // Cache inserts happen after writer shutdown so an SST whose upload
+            // fails contributes no metadata entries.
+            //
+            // Blocks drained while entries were added are cached by `write_block`,
+            // so the only data block left for `cache_on_sst_write` is the tail
+            // block that `build` finished.
+            self.table_store
+                .cache_on_sst_write(self.id, &encoded_sst)
+                .await;
+            Ok((
+                SsTableHandle::new(self.id, encoded_sst.format_version, encoded_sst.info),
+                self.bytes_written as u64,
+            ))
+        }
+        .await;
+
+        if result.is_err() {
+            if let Err(abort_err) = self.abort().await {
+                warn!(
+                    "failed to abort sst writer after error [id={:?}, error={:?}]",
+                    self.id, abort_err
+                );
             }
         }
-    }
-
-    /// Build the final block, write every block and the footer to
-    /// object storage, then record this SST's blocks in the read
-    /// cache.
-    async fn close_inner(&mut self) -> Result<(SsTableHandle, u64), SlateDBError> {
-        fail_point!(
-            self.table_store.fp_registry.clone(),
-            "write-compacted-sst-io-error",
-            |_| Err(slatedb_io_error())
-        );
-        let builder = std::mem::replace(&mut self.builder, self.table_store.table_builder());
-        let encoded_sst = builder.build().await?;
-        for block in &encoded_sst.unconsumed_blocks {
-            self.writer.write_all(block.encoded_bytes.as_ref()).await?;
-            self.bytes_written += block.encoded_bytes.len();
-        }
-        self.writer.write_all(encoded_sst.footer.as_ref()).await?;
-        self.bytes_written += encoded_sst.footer.len();
-        self.shutdown_started = true;
-        self.writer.shutdown().await?;
-
-        // Cache inserts happen after writer shutdown so an SST whose upload
-        // fails contributes no metadata entries.
-        //
-        // Blocks drained while entries were added are cached by `write_block`,
-        // so the only data block left for `cache_on_sst_write` is the tail
-        // block that `build` finished.
-        self.table_store
-            .cache_on_sst_write(self.id, &encoded_sst)
-            .await;
-        Ok((
-            SsTableHandle::new(self.id, encoded_sst.format_version, encoded_sst.info),
-            self.bytes_written as u64,
-        ))
+        result
     }
 
     /// Tell object storage to discard this SST's upload.
@@ -1368,7 +1357,7 @@ mod tests {
             .add(RowEntry::new_value(&[b'd'; 16], &[4u8; 16], 0))
             .await
             .unwrap();
-        let sst = writer.close().await.unwrap();
+        let (sst, _) = writer.close().await.unwrap();
 
         let sst_iter_options = SstIteratorOptions {
             eager_spawn: true,
@@ -1469,7 +1458,7 @@ mod tests {
             .add(RowEntry::new_value(&[b'a'; 16], &[1u8; 16], 0))
             .await
             .unwrap();
-        let result = writer.close_and_count_bytes().await;
+        let result = writer.close().await;
         assert!(
             result.is_err(),
             "a failed shutdown must surface as an error, not a panic"
@@ -1587,7 +1576,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let handle = writer.close().await.unwrap();
+        let (handle, _) = writer.close().await.unwrap();
 
         // Read the index
         let index = ts
@@ -2067,7 +2056,7 @@ mod tests {
                 .unwrap();
         }
 
-        let handle = writer.close().await.unwrap();
+        let (handle, _) = writer.close().await.unwrap();
         let index_key: CachedKey = (id, handle.info.index_offset).into();
         let filter_key: CachedKey = (id, handle.info.filter_offset).into();
         let stats_key: CachedKey = (id, handle.info.stats_offset).into();
@@ -2166,7 +2155,7 @@ mod tests {
                 .unwrap();
         }
 
-        let handle = writer.close().await.unwrap();
+        let (handle, _) = writer.close().await.unwrap();
 
         let index_key: CachedKey = (id, handle.info.index_offset).into();
         let index = cache
@@ -2208,7 +2197,7 @@ mod tests {
             .await
             .unwrap();
 
-        let handle = writer.close().await.unwrap();
+        let (handle, _) = writer.close().await.unwrap();
 
         assert_eq!(cache.entry_count(), 2);
         assert!(cache

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -114,6 +114,8 @@ impl TableStore {
                 ObjectStoreCallTag::new_with_segment(self.kind, SstType::from(&id), segment),
             ),
             table_store: self.clone(),
+            bytes_written: 0,
+            shutdown_started: false,
             #[cfg(test)]
             blocks_written: 0,
         }
@@ -125,6 +127,7 @@ impl TableStore {
 
     /// Writes an SST. `segment` is a hint attached to the
     /// [`ObjectStoreCallTag`] for object-store routing.
+    #[cfg(test)]
     pub(crate) async fn write_sst(
         &self,
         id: &SsTableId,
@@ -971,6 +974,7 @@ fn tagged_buf_writer(
     BufWriter::new(object_store, path).with_extensions(tag.into())
 }
 
+#[cfg(test)]
 async fn write_sst_streaming_in_object_store(
     object_store: Arc<dyn ObjectStore>,
     path: &Path,
@@ -991,6 +995,8 @@ pub(crate) struct EncodedSsTableWriter {
     builder: EncodedSsTableBuilder,
     writer: BufWriter,
     table_store: Arc<TableStore>,
+    bytes_written: usize,
+    shutdown_started: bool,
     #[cfg(test)]
     blocks_written: usize,
 }
@@ -1005,12 +1011,54 @@ impl EncodedSsTableWriter {
         Ok(block_size)
     }
 
-    pub(crate) async fn close(mut self) -> Result<SsTableHandle, SlateDBError> {
-        let encoded_sst = self.builder.build().await?;
+    pub(crate) async fn close(self) -> Result<SsTableHandle, SlateDBError> {
+        self.close_and_count_bytes().await.map(|(handle, _)| handle)
+    }
+
+    /// Finish this SST: write the last block, write the footer, close
+    /// the upload.
+    ///
+    /// On success, returns the finished SST handle and the exact
+    /// number of bytes written.
+    ///
+    /// On failure, aborts the upload before returning the error. This
+    /// discards any blocks already sent to object storage for this
+    /// SST.
+    pub(crate) async fn close_and_count_bytes(
+        mut self,
+    ) -> Result<(SsTableHandle, u64), SlateDBError> {
+        match self.close_inner().await {
+            Ok(result) => Ok(result),
+            Err(e) => {
+                if let Err(abort_err) = self.abort().await {
+                    warn!(
+                        "failed to abort sst writer after error [id={:?}, error={:?}]",
+                        self.id, abort_err
+                    );
+                }
+                Err(e)
+            }
+        }
+    }
+
+    /// Build the final block, write every block and the footer to
+    /// object storage, then record this SST's blocks in the read
+    /// cache.
+    async fn close_inner(&mut self) -> Result<(SsTableHandle, u64), SlateDBError> {
+        fail_point!(
+            self.table_store.fp_registry.clone(),
+            "write-compacted-sst-io-error",
+            |_| Err(slatedb_io_error())
+        );
+        let builder = std::mem::replace(&mut self.builder, self.table_store.table_builder());
+        let encoded_sst = builder.build().await?;
         for block in &encoded_sst.unconsumed_blocks {
             self.writer.write_all(block.encoded_bytes.as_ref()).await?;
+            self.bytes_written += block.encoded_bytes.len();
         }
         self.writer.write_all(encoded_sst.footer.as_ref()).await?;
+        self.bytes_written += encoded_sst.footer.len();
+        self.shutdown_started = true;
         self.writer.shutdown().await?;
 
         // Cache inserts happen after writer shutdown so an SST whose upload
@@ -1022,11 +1070,30 @@ impl EncodedSsTableWriter {
         self.table_store
             .cache_on_sst_write(self.id, &encoded_sst)
             .await;
-        Ok(SsTableHandle::new(
-            self.id,
-            encoded_sst.format_version,
-            encoded_sst.info,
+        Ok((
+            SsTableHandle::new(self.id, encoded_sst.format_version, encoded_sst.info),
+            self.bytes_written as u64,
         ))
+    }
+
+    /// Tell object storage to discard this SST's upload.
+    ///
+    /// If the upload never grew past the small in-memory buffer,
+    /// nothing reached object storage yet, so this is a no-op.
+    /// Otherwise this cancels the multipart upload and asks object
+    /// storage to delete the parts already stored.
+    ///
+    /// Once shutdown has started this is a no-op: the underlying
+    /// `BufWriter` panics if aborted after shutdown, and a failed
+    /// shutdown leaves nothing this can usefully cancel.
+    pub(crate) async fn abort(&mut self) -> Result<(), SlateDBError> {
+        if self.shutdown_started {
+            return Ok(());
+        }
+        self.writer
+            .abort()
+            .await
+            .map_err(|e| SlateDBError::ObjectStoreError(Arc::new(e)))
     }
 
     async fn drain_blocks(&mut self) -> Result<(), SlateDBError> {
@@ -1041,7 +1108,13 @@ impl EncodedSsTableWriter {
     }
 
     async fn write_block(&mut self, block: EncodedSsTableBlock) -> Result<(), SlateDBError> {
+        fail_point!(
+            self.table_store.fp_registry.clone(),
+            "write-compacted-sst-io-error",
+            |_| Err(slatedb_io_error())
+        );
         self.writer.write_all(block.encoded_bytes.as_ref()).await?;
+        self.bytes_written += block.encoded_bytes.len();
         if let (Some(cache), Some(key_span)) = (&self.table_store.cache, &block.key_span) {
             let targets = self.table_store.targets_to_cache(&self.id);
             if should_cache_data_block(targets, key_span) {
@@ -1359,6 +1432,47 @@ mod tests {
         // then:
         assert_eq!(os.put_attempts(), 0);
         assert_eq!(os.multipart_attempts(), 1);
+        ts.open_sst(&id, Some(Bytes::new())).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn close_surfaces_error_instead_of_panicking_when_shutdown_fails() {
+        // A small SST flushes as a single put during shutdown. Failing
+        // that put must come back as an error the caller can retry, not a
+        // panic from aborting a BufWriter that has already shut down.
+        let os = Arc::new(FlakyObjectStore::new(Arc::new(InMemory::new()), 1));
+        let format = SsTableFormat {
+            block_size: 32,
+            min_filter_keys: 1,
+            ..SsTableFormat::default()
+        };
+        let ts = Arc::new(TableStore::new(
+            os.clone(),
+            format,
+            Path::from(ROOT),
+            None,
+            TableStoreKind::Main,
+            BlockCachePolicy::default(),
+        ));
+        let id = SsTableId::from(ulid::Ulid::new());
+
+        let mut writer = ts.table_writer(id, Some(Bytes::new()));
+        writer
+            .add(RowEntry::new_value(&[b'a'; 16], &[1u8; 16], 0))
+            .await
+            .unwrap();
+        let result = writer.close_and_count_bytes().await;
+        assert!(
+            result.is_err(),
+            "a failed shutdown must surface as an error, not a panic"
+        );
+
+        let mut writer = ts.table_writer(id, Some(Bytes::new()));
+        writer
+            .add(RowEntry::new_value(&[b'a'; 16], &[1u8; 16], 0))
+            .await
+            .unwrap();
+        writer.close().await.unwrap();
         ts.open_sst(&id, Some(Bytes::new())).await.unwrap();
     }
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -437,7 +437,7 @@ pub(crate) async fn write_ssts(
         }
 
         if bytes_written > max_sst_size {
-            output_ssts.push(writer.close().await.unwrap());
+            output_ssts.push(writer.close().await.unwrap().0);
             bytes_written = 0;
 
             if index + 1 < entries.len() {
@@ -448,7 +448,7 @@ pub(crate) async fn write_ssts(
         }
     }
 
-    output_ssts.push(writer.close().await.unwrap());
+    output_ssts.push(writer.close().await.unwrap().0);
     output_ssts
 }
 


### PR DESCRIPTION
## Summary

An L0 flush writes an immutable memtable into one or more sorted string table (SST) files.

Before this change, the flush path encoded each full SST in memory before it sent the file to object storage. This required an encoded copy beside the memtable.

This change gives completed blocks to `EncodedSsTableWriter` as the builder makes them. The object store writer buffers up to 10 MiB. An SST below this limit remains in the buffer until the writer closes.

A retry must build the SST again from the immutable memtable. The flush reads the retention boundary once and uses it for all attempts. Thus, all attempts keep the same key versions.

## Changes

- Stream L0 SST blocks through `EncodedSsTableWriter`.
- Use the same low-level table writer that the compaction path uses.
- Calculate the minimum retention sequence before the first upload attempt.
- Use the same retention sequence and preallocated SST identifiers for each retry.
- Process segment SSTs in prefix order.
- Retry the full flush job when one segment upload fails.
- Count the encoded bytes from successful SST uploads.
- Prevent `BufWriter::abort` calls after shutdown starts.
- Return the upload error when shutdown fails instead of causing a panic.
- Move `SegmentedSstHandle` to `flush.rs`, where the streaming path creates it.
- Remove the old test-only batch builders and their duplicate logic.
- Update tests to use the streaming path.

## AI Assistance

| Model | Effort |
| --- | --- |
| GPT-5 (Codex) | High |

## Notes for Reviewers

Please examine the upload error path and the use of the retention boundary during retries.

Segment uploads remain sequential within one memtable. This bounds active writer memory, but upload time increases with the number of segments. A failure in a later segment causes the full job to start again.

The object store writer has a 10 MiB buffer. This change removes the full encoded SST copy, but it does not limit memory to one block.

The compaction path uses the same table writer. Compaction also uses background SST close tasks and parallel subcompactions. This pull request does not add those forms of concurrency to L0 flushes.

Tests cover streaming, segment grouping, empty output, retry behavior, retention behavior, shutdown errors, and upload cleanup.

This change does not modify the public API.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant