### PR TITLE
feat(uniffi): expose object_store_cache_options on ReaderOptions

### DIFF
--- a/bindings/go/uniffi/slatedb.go
+++ b/bindings/go/uniffi/slatedb.go
@@ -10300,6 +10300,85 @@ func (_ FfiDestroyerObjectMetadata) Destroy(value ObjectMetadata) {
 	value.Destroy()
 }
 
+// Options for the local-disk cache that sits in front of the object store.
+type ObjectStoreCacheOptions struct {
+	// Root folder where cache files are stored. `None` (default) disables the cache.
+	RootFolder *string
+	// Limit of the cache size in bytes. `None` means unbounded.
+	MaxCacheSizeBytes *uint64
+	// Size of each cached part file in bytes; expected to be aligned to 1 KiB.
+	PartSizeBytes uint64
+	// Whether SSTs produced by memtable flushes are written to the cache.
+	CacheOnFlush bool
+	// Whether SSTs produced by compaction are written to the cache.
+	CacheOnCompaction bool
+	// Which SSTs to preload into the cache on startup, up to the cache size limit.
+	// `None` (default) preloads nothing.
+	PreloadDiskCacheOnStartup *PreloadLevel
+	// How often the cache directory is rescanned to rebuild the evictor's in-memory
+	// map, in milliseconds. `None` scans only once on startup.
+	ScanIntervalMs *uint64
+	// Maximum number of file handles kept open by the file handle cache.
+	MaxOpenFileHandles uint64
+}
+
+func (r *ObjectStoreCacheOptions) Destroy() {
+	FfiDestroyerOptionalString{}.Destroy(r.RootFolder)
+	FfiDestroyerOptionalUint64{}.Destroy(r.MaxCacheSizeBytes)
+	FfiDestroyerUint64{}.Destroy(r.PartSizeBytes)
+	FfiDestroyerBool{}.Destroy(r.CacheOnFlush)
+	FfiDestroyerBool{}.Destroy(r.CacheOnCompaction)
+	FfiDestroyerOptionalPreloadLevel{}.Destroy(r.PreloadDiskCacheOnStartup)
+	FfiDestroyerOptionalUint64{}.Destroy(r.ScanIntervalMs)
+	FfiDestroyerUint64{}.Destroy(r.MaxOpenFileHandles)
+}
+
+type FfiConverterObjectStoreCacheOptions struct{}
+
+var FfiConverterObjectStoreCacheOptionsINSTANCE = FfiConverterObjectStoreCacheOptions{}
+
+func (c FfiConverterObjectStoreCacheOptions) Lift(rb RustBufferI) ObjectStoreCacheOptions {
+	return LiftFromRustBuffer[ObjectStoreCacheOptions](c, rb)
+}
+
+func (c FfiConverterObjectStoreCacheOptions) Read(reader io.Reader) ObjectStoreCacheOptions {
+	return ObjectStoreCacheOptions{
+		FfiConverterOptionalStringINSTANCE.Read(reader),
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterBoolINSTANCE.Read(reader),
+		FfiConverterOptionalPreloadLevelINSTANCE.Read(reader),
+		FfiConverterOptionalUint64INSTANCE.Read(reader),
+		FfiConverterUint64INSTANCE.Read(reader),
+	}
+}
+
+func (c FfiConverterObjectStoreCacheOptions) Lower(value ObjectStoreCacheOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[ObjectStoreCacheOptions](c, value)
+}
+
+func (c FfiConverterObjectStoreCacheOptions) LowerExternal(value ObjectStoreCacheOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[ObjectStoreCacheOptions](c, value))
+}
+
+func (c FfiConverterObjectStoreCacheOptions) Write(writer io.Writer, value ObjectStoreCacheOptions) {
+	FfiConverterOptionalStringINSTANCE.Write(writer, value.RootFolder)
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.MaxCacheSizeBytes)
+	FfiConverterUint64INSTANCE.Write(writer, value.PartSizeBytes)
+	FfiConverterBoolINSTANCE.Write(writer, value.CacheOnFlush)
+	FfiConverterBoolINSTANCE.Write(writer, value.CacheOnCompaction)
+	FfiConverterOptionalPreloadLevelINSTANCE.Write(writer, value.PreloadDiskCacheOnStartup)
+	FfiConverterOptionalUint64INSTANCE.Write(writer, value.ScanIntervalMs)
+	FfiConverterUint64INSTANCE.Write(writer, value.MaxOpenFileHandles)
+}
+
+type FfiDestroyerObjectStoreCacheOptions struct{}
+
+func (_ FfiDestroyerObjectStoreCacheOptions) Destroy(value ObjectStoreCacheOptions) {
+	value.Destroy()
+}
+
 // Options applied to a put operation.
 type PutOptions struct {
 	// TTL policy for the inserted value.
@@ -10421,6 +10500,9 @@ type ReaderOptions struct {
 	// `None` (default) retries transient errors indefinitely; `Some(n)` gives
 	// up after `n` retries and surfaces the underlying error.
 	ObjectStoreMaxRetries *uint32
+	// Optional local-disk object-store cache settings. `None` (default) uses
+	// the core defaults, which leave the cache disabled.
+	ObjectStoreCacheOptions *ObjectStoreCacheOptions
 }
 
 func (r *ReaderOptions) Destroy() {
@@ -10429,6 +10511,7 @@ func (r *ReaderOptions) Destroy() {
 	FfiDestroyerUint64{}.Destroy(r.MaxMemtableBytes)
 	FfiDestroyerBool{}.Destroy(r.SkipWalReplay)
 	FfiDestroyerOptionalUint32{}.Destroy(r.ObjectStoreMaxRetries)
+	FfiDestroyerOptionalObjectStoreCacheOptions{}.Destroy(r.ObjectStoreCacheOptions)
 }
 
 type FfiConverterReaderOptions struct{}
@@ -10446,6 +10529,7 @@ func (c FfiConverterReaderOptions) Read(reader io.Reader) ReaderOptions {
 		FfiConverterUint64INSTANCE.Read(reader),
 		FfiConverterBoolINSTANCE.Read(reader),
 		FfiConverterOptionalUint32INSTANCE.Read(reader),
+		FfiConverterOptionalObjectStoreCacheOptionsINSTANCE.Read(reader),
 	}
 }
 
@@ -10463,6 +10547,7 @@ func (c FfiConverterReaderOptions) Write(writer io.Writer, value ReaderOptions) 
 	FfiConverterUint64INSTANCE.Write(writer, value.MaxMemtableBytes)
 	FfiConverterBoolINSTANCE.Write(writer, value.SkipWalReplay)
 	FfiConverterOptionalUint32INSTANCE.Write(writer, value.ObjectStoreMaxRetries)
+	FfiConverterOptionalObjectStoreCacheOptionsINSTANCE.Write(writer, value.ObjectStoreCacheOptions)
 }
 
 type FfiDestroyerReaderOptions struct{}
@@ -12581,6 +12666,45 @@ func (_ FfiDestroyerPrefixTarget) Destroy(value PrefixTarget) {
 	value.Destroy()
 }
 
+// Which SSTs to preload into the local disk cache when a database or reader opens.
+type PreloadLevel uint
+
+const (
+	// Preload only L0 SSTs (the most recently written files).
+	PreloadLevelL0Sst PreloadLevel = 1
+	// Preload all SSTs (both L0 and compacted levels).
+	PreloadLevelAllSst PreloadLevel = 2
+)
+
+type FfiConverterPreloadLevel struct{}
+
+var FfiConverterPreloadLevelINSTANCE = FfiConverterPreloadLevel{}
+
+func (c FfiConverterPreloadLevel) Lift(rb RustBufferI) PreloadLevel {
+	return LiftFromRustBuffer[PreloadLevel](c, rb)
+}
+
+func (c FfiConverterPreloadLevel) Lower(value PreloadLevel) C.RustBuffer {
+	return LowerIntoRustBuffer[PreloadLevel](c, value)
+}
+
+func (c FfiConverterPreloadLevel) LowerExternal(value PreloadLevel) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[PreloadLevel](c, value))
+}
+func (FfiConverterPreloadLevel) Read(reader io.Reader) PreloadLevel {
+	id := readInt32(reader)
+	return PreloadLevel(id)
+}
+
+func (FfiConverterPreloadLevel) Write(writer io.Writer, value PreloadLevel) {
+	writeInt32(writer, int32(value))
+}
+
+type FfiDestroyerPreloadLevel struct{}
+
+func (_ FfiDestroyerPreloadLevel) Destroy(value PreloadLevel) {
+}
+
 // Determines how a [`crate::DbReader`] chooses and refreshes database state.
 type ReaderMode interface {
 	Destroy()
@@ -13573,6 +13697,47 @@ func (_ FfiDestroyerOptionalMetric) Destroy(value *Metric) {
 	}
 }
 
+type FfiConverterOptionalObjectStoreCacheOptions struct{}
+
+var FfiConverterOptionalObjectStoreCacheOptionsINSTANCE = FfiConverterOptionalObjectStoreCacheOptions{}
+
+func (c FfiConverterOptionalObjectStoreCacheOptions) Lift(rb RustBufferI) *ObjectStoreCacheOptions {
+	return LiftFromRustBuffer[*ObjectStoreCacheOptions](c, rb)
+}
+
+func (_ FfiConverterOptionalObjectStoreCacheOptions) Read(reader io.Reader) *ObjectStoreCacheOptions {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterObjectStoreCacheOptionsINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalObjectStoreCacheOptions) Lower(value *ObjectStoreCacheOptions) C.RustBuffer {
+	return LowerIntoRustBuffer[*ObjectStoreCacheOptions](c, value)
+}
+
+func (c FfiConverterOptionalObjectStoreCacheOptions) LowerExternal(value *ObjectStoreCacheOptions) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*ObjectStoreCacheOptions](c, value))
+}
+
+func (_ FfiConverterOptionalObjectStoreCacheOptions) Write(writer io.Writer, value *ObjectStoreCacheOptions) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterObjectStoreCacheOptionsINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalObjectStoreCacheOptions struct{}
+
+func (_ FfiDestroyerOptionalObjectStoreCacheOptions) Destroy(value *ObjectStoreCacheOptions) {
+	if value != nil {
+		FfiDestroyerObjectStoreCacheOptions{}.Destroy(*value)
+	}
+}
+
 type FfiConverterOptionalTracingOptions struct{}
 
 var FfiConverterOptionalTracingOptionsINSTANCE = FfiConverterOptionalTracingOptions{}
@@ -13939,6 +14104,47 @@ type FfiDestroyerOptionalIterationOrder struct{}
 func (_ FfiDestroyerOptionalIterationOrder) Destroy(value *IterationOrder) {
 	if value != nil {
 		FfiDestroyerIterationOrder{}.Destroy(*value)
+	}
+}
+
+type FfiConverterOptionalPreloadLevel struct{}
+
+var FfiConverterOptionalPreloadLevelINSTANCE = FfiConverterOptionalPreloadLevel{}
+
+func (c FfiConverterOptionalPreloadLevel) Lift(rb RustBufferI) *PreloadLevel {
+	return LiftFromRustBuffer[*PreloadLevel](c, rb)
+}
+
+func (_ FfiConverterOptionalPreloadLevel) Read(reader io.Reader) *PreloadLevel {
+	if readInt8(reader) == 0 {
+		return nil
+	}
+	temp := FfiConverterPreloadLevelINSTANCE.Read(reader)
+	return &temp
+}
+
+func (c FfiConverterOptionalPreloadLevel) Lower(value *PreloadLevel) C.RustBuffer {
+	return LowerIntoRustBuffer[*PreloadLevel](c, value)
+}
+
+func (c FfiConverterOptionalPreloadLevel) LowerExternal(value *PreloadLevel) ExternalCRustBuffer {
+	return RustBufferFromC(LowerIntoRustBuffer[*PreloadLevel](c, value))
+}
+
+func (_ FfiConverterOptionalPreloadLevel) Write(writer io.Writer, value *PreloadLevel) {
+	if value == nil {
+		writeInt8(writer, 0)
+	} else {
+		writeInt8(writer, 1)
+		FfiConverterPreloadLevelINSTANCE.Write(writer, *value)
+	}
+}
+
+type FfiDestroyerOptionalPreloadLevel struct{}
+
+func (_ FfiDestroyerOptionalPreloadLevel) Destroy(value *PreloadLevel) {
+	if value != nil {
+		FfiDestroyerPreloadLevel{}.Destroy(*value)
 	}
 }
 

--- a/bindings/go/uniffi/slatedb_test.go
+++ b/bindings/go/uniffi/slatedb_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"sync"
@@ -1580,6 +1581,87 @@ func TestDbReaderWalReplayBehavior(t *testing.T) {
 		}
 		if value == nil || !bytes.Equal(*value, []byte("wal-only-value")) {
 			t.Fatalf("DbReader.Get(wal-only-key) after memtable flush: got %v, want %q", value, "wal-only-value")
+		}
+	})
+}
+
+func TestDbReaderObjectStoreCache(t *testing.T) {
+	t.Run("default options leave the disk cache disabled", func(t *testing.T) {
+		store := newMemoryStore(t)
+		dbHandle := openTestDB(t, store, nil)
+
+		if _, err := dbHandle.db.Put([]byte("cached-key"), []byte("cached-value")); err != nil {
+			t.Fatalf("Put(cached-key): %v", err)
+		}
+		if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+			t.Fatalf("FlushWithOptions(MemTable): %v", err)
+		}
+
+		readerHandle := openTestReader(t, store, func(t *testing.T, builder *slatedb.DbReaderBuilder) {
+			t.Helper()
+			if err := builder.WithOptions(slatedb.ReaderOptions{
+				ManifestPollIntervalMs: 100,
+				CheckpointLifetimeMs:   1000,
+				MaxMemtableBytes:       64 * 1024 * 1024,
+				SkipWalReplay:          true,
+			}); err != nil {
+				t.Fatalf("DbReaderBuilder.WithOptions(): %v", err)
+			}
+		})
+
+		value, err := readerHandle.reader.Get([]byte("cached-key"))
+		if err != nil {
+			t.Fatalf("DbReader.Get(cached-key): %v", err)
+		}
+		if value == nil || !bytes.Equal(*value, []byte("cached-value")) {
+			t.Fatalf("DbReader.Get(cached-key): got %v, want %q", value, "cached-value")
+		}
+	})
+
+	t.Run("root folder enables the disk cache and reads populate it", func(t *testing.T) {
+		store := newMemoryStore(t)
+		dbHandle := openTestDB(t, store, nil)
+
+		if _, err := dbHandle.db.Put([]byte("cached-key"), []byte("cached-value")); err != nil {
+			t.Fatalf("Put(cached-key): %v", err)
+		}
+		if err := dbHandle.db.FlushWithOptions(slatedb.FlushOptions{FlushType: slatedb.FlushTypeMemTable}); err != nil {
+			t.Fatalf("FlushWithOptions(MemTable): %v", err)
+		}
+
+		cacheDir := t.TempDir()
+		readerHandle := openTestReader(t, store, func(t *testing.T, builder *slatedb.DbReaderBuilder) {
+			t.Helper()
+			rootFolder := cacheDir
+			if err := builder.WithOptions(slatedb.ReaderOptions{
+				ManifestPollIntervalMs: 100,
+				CheckpointLifetimeMs:   1000,
+				MaxMemtableBytes:       64 * 1024 * 1024,
+				SkipWalReplay:          true,
+				ObjectStoreCacheOptions: &slatedb.ObjectStoreCacheOptions{
+					RootFolder:         &rootFolder,
+					PartSizeBytes:      1024,
+					MaxOpenFileHandles: 16,
+				},
+			}); err != nil {
+				t.Fatalf("DbReaderBuilder.WithOptions(): %v", err)
+			}
+		})
+
+		value, err := readerHandle.reader.Get([]byte("cached-key"))
+		if err != nil {
+			t.Fatalf("DbReader.Get(cached-key): %v", err)
+		}
+		if value == nil || !bytes.Equal(*value, []byte("cached-value")) {
+			t.Fatalf("DbReader.Get(cached-key): got %v, want %q", value, "cached-value")
+		}
+
+		entries, err := os.ReadDir(cacheDir)
+		if err != nil {
+			t.Fatalf("os.ReadDir(%q): %v", cacheDir, err)
+		}
+		if len(entries) == 0 {
+			t.Fatalf("expected disk cache directory %q to be populated after read", cacheDir)
 		}
 	})
 }

--- a/bindings/python/tests/test_reader.py
+++ b/bindings/python/tests/test_reader.py
@@ -22,7 +22,9 @@ from slatedb.uniffi import (
     FlushOptions,
     FlushType,
     KeyRange,
+    ObjectStoreCacheOptions,
     ReaderMode,
+    ReaderOptions,
 )
 
 
@@ -236,6 +238,55 @@ async def test_reader_skip_wal_replay_ignores_wal_only_data() -> None:
             configure=lambda builder: builder.with_options(reader_options(True)),
         ) as reader:
             assert await reader.get(b"wal-only-key") == b"wal-only-value"
+
+
+@pytest.mark.asyncio
+async def test_reader_options_without_object_store_cache_still_open() -> None:
+    store = new_memory_store()
+
+    async with open_db(store) as db:
+        await db.put(b"cached-key", b"cached-value")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        async with open_reader(
+            store,
+            configure=lambda builder: builder.with_options(reader_options(True)),
+        ) as reader:
+            assert await reader.get(b"cached-key") == b"cached-value"
+
+
+@pytest.mark.asyncio
+async def test_reader_object_store_cache_populates_root_folder(tmp_path) -> None:
+    store = new_memory_store()
+    cache_dir = tmp_path / "reader-cache"
+    cache_dir.mkdir()
+
+    async with open_db(store) as db:
+        await db.put(b"cached-key", b"cached-value")
+        await db.flush_with_options(FlushOptions(flush_type=FlushType.MEM_TABLE))
+
+        options = ReaderOptions(
+            manifest_poll_interval_ms=100,
+            checkpoint_lifetime_ms=1_000,
+            max_memtable_bytes=64 * 1024 * 1024,
+            skip_wal_replay=True,
+            object_store_cache_options=ObjectStoreCacheOptions(
+                root_folder=str(cache_dir),
+                max_cache_size_bytes=None,
+                part_size_bytes=1024,
+                cache_on_flush=False,
+                cache_on_compaction=False,
+                scan_interval_ms=None,
+                max_open_file_handles=16,
+            ),
+        )
+        async with open_reader(
+            store,
+            configure=lambda builder: builder.with_options(options),
+        ) as reader:
+            assert await reader.get(b"cached-key") == b"cached-value"
+
+    assert list(cache_dir.iterdir()) != []
 
 
 @pytest.mark.asyncio

--- a/bindings/uniffi/src/builder.rs
+++ b/bindings/uniffi/src/builder.rs
@@ -206,7 +206,7 @@ impl DbReaderBuilder {
 
     /// Applies custom reader options.
     pub fn with_options(&self, options: ReaderOptions) -> Result<(), Error> {
-        let options = options.into();
+        let options = options.try_into()?;
         self.update_builder(|builder| builder.with_options(options))
             .map_err(Into::into)
     }

--- a/bindings/uniffi/src/config.rs
+++ b/bindings/uniffi/src/config.rs
@@ -202,6 +202,99 @@ impl TryFrom<ReaderMode> for slatedb::DbReaderMode {
     }
 }
 
+/// Which SSTs to preload into the local disk cache when a database or reader opens.
+#[derive(Clone, Copy, Debug, uniffi::Enum)]
+pub enum PreloadLevel {
+    /// Preload only L0 SSTs (the most recently written files).
+    L0Sst,
+    /// Preload all SSTs (both L0 and compacted levels).
+    AllSst,
+}
+
+impl From<PreloadLevel> for slatedb::config::PreloadLevel {
+    fn from(value: PreloadLevel) -> Self {
+        match value {
+            PreloadLevel::L0Sst => Self::L0Sst,
+            PreloadLevel::AllSst => Self::AllSst,
+        }
+    }
+}
+
+/// Options for the local-disk cache that sits in front of the object store.
+#[derive(Clone, Debug, uniffi::Record)]
+pub struct ObjectStoreCacheOptions {
+    /// Root folder where cache files are stored. `None` (default) disables the cache.
+    #[uniffi(default = None)]
+    pub root_folder: Option<String>,
+    /// Limit of the cache size in bytes. `None` means unbounded.
+    pub max_cache_size_bytes: Option<u64>,
+    /// Size of each cached part file in bytes; expected to be aligned to 1 KiB.
+    pub part_size_bytes: u64,
+    /// Whether SSTs produced by memtable flushes are written to the cache.
+    pub cache_on_flush: bool,
+    /// Whether SSTs produced by compaction are written to the cache.
+    pub cache_on_compaction: bool,
+    /// Which SSTs to preload into the cache on startup, up to the cache size limit.
+    /// `None` (default) preloads nothing.
+    #[uniffi(default = None)]
+    pub preload_disk_cache_on_startup: Option<PreloadLevel>,
+    /// How often the cache directory is rescanned to rebuild the evictor's in-memory
+    /// map, in milliseconds. `None` scans only once on startup.
+    pub scan_interval_ms: Option<u64>,
+    /// Maximum number of file handles kept open by the file handle cache.
+    pub max_open_file_handles: u64,
+}
+
+impl Default for ObjectStoreCacheOptions {
+    fn default() -> Self {
+        let core = slatedb::config::ObjectStoreCacheOptions::default();
+        Self {
+            root_folder: None,
+            max_cache_size_bytes: core.max_cache_size_bytes.map(|v| v as u64),
+            part_size_bytes: core.part_size_bytes as u64,
+            cache_on_flush: core.cache_on_flush,
+            cache_on_compaction: core.cache_on_compaction,
+            preload_disk_cache_on_startup: None,
+            scan_interval_ms: core.scan_interval.map(|d| d.as_millis() as u64),
+            max_open_file_handles: core.max_open_file_handles as u64,
+        }
+    }
+}
+
+impl TryFrom<ObjectStoreCacheOptions> for slatedb::config::ObjectStoreCacheOptions {
+    type Error = Error;
+
+    fn try_from(value: ObjectStoreCacheOptions) -> Result<Self, Self::Error> {
+        Ok(slatedb::config::ObjectStoreCacheOptions {
+            root_folder: value.root_folder.map(std::path::PathBuf::from),
+            max_cache_size_bytes: value
+                .max_cache_size_bytes
+                .map(|v| {
+                    usize::try_from(v).map_err(|_| {
+                        Error::from(SlateDbError::ValueTooLargeForUsize {
+                            field: "max_cache_size_bytes",
+                        })
+                    })
+                })
+                .transpose()?,
+            part_size_bytes: usize::try_from(value.part_size_bytes).map_err(|_| {
+                Error::from(SlateDbError::ValueTooLargeForUsize {
+                    field: "part_size_bytes",
+                })
+            })?,
+            cache_on_flush: value.cache_on_flush,
+            cache_on_compaction: value.cache_on_compaction,
+            preload_disk_cache_on_startup: value.preload_disk_cache_on_startup.map(Into::into),
+            scan_interval: value.scan_interval_ms.map(Duration::from_millis),
+            max_open_file_handles: usize::try_from(value.max_open_file_handles).map_err(|_| {
+                Error::from(SlateDbError::ValueTooLargeForUsize {
+                    field: "max_open_file_handles",
+                })
+            })?,
+        })
+    }
+}
+
 /// Options for opening a [`crate::DbReader`].
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct ReaderOptions {
@@ -219,6 +312,10 @@ pub struct ReaderOptions {
     /// up after `n` retries and surfaces the underlying error.
     #[uniffi(default = None)]
     pub object_store_max_retries: Option<u32>,
+    /// Optional local-disk object-store cache settings. `None` (default) uses
+    /// the core defaults, which leave the cache disabled.
+    #[uniffi(default = None)]
+    pub object_store_cache_options: Option<ObjectStoreCacheOptions>,
 }
 
 impl Default for ReaderOptions {
@@ -229,20 +326,28 @@ impl Default for ReaderOptions {
             max_memtable_bytes: 64 * 1024 * 1024,
             skip_wal_replay: false,
             object_store_max_retries: None,
+            object_store_cache_options: None,
         }
     }
 }
 
-impl From<ReaderOptions> for slatedb::config::DbReaderOptions {
-    fn from(value: ReaderOptions) -> Self {
-        slatedb::config::DbReaderOptions {
+impl TryFrom<ReaderOptions> for slatedb::config::DbReaderOptions {
+    type Error = Error;
+
+    fn try_from(value: ReaderOptions) -> Result<Self, Self::Error> {
+        Ok(slatedb::config::DbReaderOptions {
             manifest_poll_interval: Duration::from_millis(value.manifest_poll_interval_ms),
             checkpoint_lifetime: Duration::from_millis(value.checkpoint_lifetime_ms),
             max_memtable_bytes: value.max_memtable_bytes,
             skip_wal_replay: value.skip_wal_replay,
             object_store_max_retries: value.object_store_max_retries,
+            object_store_cache_options: value
+                .object_store_cache_options
+                .map(TryInto::try_into)
+                .transpose()?
+                .unwrap_or_default(),
             ..Default::default()
-        }
+        })
     }
 }
 
@@ -567,7 +672,11 @@ impl From<GarbageCollectorOptions> for slatedb::config::GarbageCollectorOptions 
 
 #[cfg(test)]
 mod tests {
-    use super::{CloseOptions, FlushType, GarbageCollectorOptions, ReaderOptions};
+    use super::{
+        CloseOptions, FlushType, GarbageCollectorOptions, ObjectStoreCacheOptions, PreloadLevel,
+        ReaderOptions,
+    };
+    use std::time::Duration;
 
     #[test]
     fn close_options_default_flushes_memtable() {
@@ -639,7 +748,7 @@ mod tests {
 
     #[test]
     fn reader_object_store_max_retries_defaults_to_unbounded() {
-        let reader: slatedb::config::DbReaderOptions = ReaderOptions::default().into();
+        let reader: slatedb::config::DbReaderOptions = ReaderOptions::default().try_into().unwrap();
 
         assert_eq!(reader.object_store_max_retries, None);
     }
@@ -650,9 +759,88 @@ mod tests {
             object_store_max_retries: Some(5),
             ..ReaderOptions::default()
         }
-        .into();
+        .try_into()
+        .unwrap();
 
         assert_eq!(reader.object_store_max_retries, Some(5));
+    }
+
+    #[test]
+    fn reader_object_store_cache_options_default_to_core_defaults() {
+        let reader: slatedb::config::DbReaderOptions = ReaderOptions::default().try_into().unwrap();
+        let core = slatedb::config::ObjectStoreCacheOptions::default();
+
+        assert_eq!(reader.object_store_cache_options.root_folder, None);
+        assert_eq!(
+            reader.object_store_cache_options.part_size_bytes,
+            core.part_size_bytes
+        );
+        assert_eq!(
+            reader.object_store_cache_options.max_cache_size_bytes,
+            core.max_cache_size_bytes
+        );
+        assert_eq!(
+            reader.object_store_cache_options.scan_interval,
+            core.scan_interval
+        );
+        assert_eq!(
+            reader.object_store_cache_options.max_open_file_handles,
+            core.max_open_file_handles
+        );
+    }
+
+    #[test]
+    fn object_store_cache_options_default_mirrors_core_defaults() {
+        let converted: slatedb::config::ObjectStoreCacheOptions =
+            ObjectStoreCacheOptions::default().try_into().unwrap();
+        let core = slatedb::config::ObjectStoreCacheOptions::default();
+
+        assert_eq!(converted.root_folder, core.root_folder);
+        assert_eq!(converted.max_cache_size_bytes, core.max_cache_size_bytes);
+        assert_eq!(converted.part_size_bytes, core.part_size_bytes);
+        assert_eq!(converted.cache_on_flush, core.cache_on_flush);
+        assert_eq!(converted.cache_on_compaction, core.cache_on_compaction);
+        assert_eq!(
+            converted.preload_disk_cache_on_startup,
+            core.preload_disk_cache_on_startup
+        );
+        assert_eq!(converted.scan_interval, core.scan_interval);
+        assert_eq!(converted.max_open_file_handles, core.max_open_file_handles);
+    }
+
+    #[test]
+    fn reader_object_store_cache_options_thread_through() {
+        let reader: slatedb::config::DbReaderOptions = ReaderOptions {
+            object_store_cache_options: Some(ObjectStoreCacheOptions {
+                root_folder: Some("/tmp/slatedb-cache".to_string()),
+                max_cache_size_bytes: None,
+                part_size_bytes: 1024,
+                cache_on_flush: true,
+                cache_on_compaction: true,
+                preload_disk_cache_on_startup: Some(PreloadLevel::AllSst),
+                scan_interval_ms: Some(5_000),
+                max_open_file_handles: 16,
+            }),
+            ..ReaderOptions::default()
+        }
+        .try_into()
+        .unwrap();
+        let cache = reader.object_store_cache_options;
+
+        assert_eq!(
+            cache.root_folder,
+            Some(std::path::PathBuf::from("/tmp/slatedb-cache"))
+        );
+        assert_eq!(cache.max_cache_size_bytes, None);
+        assert_eq!(cache.part_size_bytes, 1024);
+        assert!(cache.cache_on_flush);
+        assert!(cache.cache_on_compaction);
+        assert_eq!(
+            cache.preload_disk_cache_on_startup,
+            Some(slatedb::config::PreloadLevel::AllSst)
+        );
+        assert_eq!(cache.scan_interval, Some(Duration::from_secs(5)));
+        assert_eq!(cache.max_open_file_handles, 16);
     }
 }
 

--- a/bindings/uniffi/src/lib.rs
+++ b/bindings/uniffi/src/lib.rs
@@ -26,8 +26,8 @@ pub use builder::{AdminBuilder, CloneBuilder, DbBuilder, DbReaderBuilder};
 pub use config::{
     CloseOptions, DurabilityLevel, FlushOptions, FlushType, GarbageCollectorDirectoryOptions,
     GarbageCollectorOptions, GarbageCollectorScheduleOptions, IsolationLevel, IterationOrder,
-    MergeOptions, PutOptions, ReadOptions, ReaderMode, ReaderOptions, ScanOptions, SstBlockSize,
-    TracingOptions, Ttl, WriteOptions,
+    MergeOptions, ObjectStoreCacheOptions, PreloadLevel, PutOptions, ReadOptions, ReaderMode,
+    ReaderOptions, ScanOptions, SstBlockSize, TracingOptions, Ttl, WriteOptions,
 };
 pub use db::Db;
 pub use db_reader::DbReader;


### PR DESCRIPTION
## Problem

`DbReader` in Rust honors `DbReaderOptions.object_store_cache_options` (local-disk cache in front of the object store), but the UniFFI `ReaderOptions` record has no equivalent field and its `From` impl fills the core field with `..Default::default()`. Users of the Python / Go / other bindings therefore cannot enable a reader's disk cache at all.

## Change

- `bindings/uniffi/src/config.rs`
  - New `PreloadLevel` uniffi enum (`L0Sst`, `AllSst`) with a `From` into `slatedb::config::PreloadLevel`.
  - New `ObjectStoreCacheOptions` uniffi record mirroring the core struct with binding-friendly scalars: `root_folder: Option<String>`, `max_cache_size_bytes: Option<u64>`, `part_size_bytes: u64`, `cache_on_flush`, `cache_on_compaction`, `preload_disk_cache_on_startup: Option<PreloadLevel>`, `scan_interval_ms: Option<u64>`, `max_open_file_handles: u64`. Its `Default` is derived from `slatedb::config::ObjectStoreCacheOptions::default()` so the two cannot drift.
  - `TryFrom<ObjectStoreCacheOptions>` into the core type; the `u64 -> usize` fields are bounds-checked with the existing `ValueTooLargeForUsize` error, the same way `ScanOptions` does it.
  - `ReaderOptions` gains `#[uniffi(default = None)] object_store_cache_options: Option<ObjectStoreCacheOptions>`; `None` keeps the core default (cache disabled). Because of the bounds check, `ReaderOptions -> DbReaderOptions` becomes a `TryFrom`; `DbReaderBuilder::with_options` already returned `Result`, so no API change there.
- `bindings/uniffi/src/lib.rs`: re-export the two new types.
- `bindings/go/uniffi/slatedb.go`: regenerated with `uniffi-bindgen-go v0.7.0+v0.31.0` via `scripts/generate-go-uniffi.sh` (no header changes).

## Testing

- `cargo test -p slatedb-uniffi`: 42 passed (3 new: default-mirrors-core, reader-default-is-core-default, full field thread-through). `cargo clippy -p slatedb-uniffi --all-targets -D warnings` and `cargo fmt --check` clean.
- Python (`bindings/python`, `maturin develop` + pytest): 49 passed. New: `test_reader_object_store_cache_populates_root_folder` opens a reader with `root_folder` set to a tmp dir, reads a key written by `Db`, and asserts the cache dir is non-empty; `test_reader_options_without_object_store_cache_still_open` covers the field being omitted.
- Go (`bindings/go`, `go test ./...`): ok, `TestDbReaderObjectStoreCache` adds the same two cases (`t.TempDir()` populated after a read; options without the field still open). `go vet` clean.

Independent of #2070 (branched from `main`).
