### PR TITLE
test(db_cache): pin the bincode variant index for V3 cache keys

### DIFF
--- a/slatedb/src/db_cache/serde.rs
+++ b/slatedb/src/db_cache/serde.rs
@@ -306,12 +306,15 @@ mod tests {
         ))
         .unwrap();
 
-        // Bincode writes the variant index as a little-endian u32 prefix.
-        let variant_index = u32::from_le_bytes(
-            encoded[..4]
-                .try_into()
-                .expect("bincode writes a 4 byte variant index"),
-        );
+        // Bincode writes the variant index as a little-endian u32 prefix. Read it
+        // through `get` so a shorter encoding reports that the prefix is missing,
+        // rather than panicking on the slice before the assertion below runs.
+        let prefix: [u8; 4] = encoded
+            .get(..4)
+            .expect("bincode writes a 4 byte variant index prefix")
+            .try_into()
+            .expect("a 4 byte slice converts to a 4 byte array");
+        let variant_index = u32::from_le_bytes(prefix);
 
         assert_eq!(
             variant_index, 2,

--- a/slatedb/src/db_cache/serde.rs
+++ b/slatedb/src/db_cache/serde.rs
@@ -284,6 +284,42 @@ mod tests {
         V2(u64, LegacySerializedSsTableOrWalId, u64),
     }
 
+    /// Bincode identifies an enum variant by its position, so the index of every
+    /// `SerializedCachedKey` variant is part of the on-disk cache format. Removing
+    /// or reordering one shifts every variant after it: drop `V1` or `V2` and a key
+    /// written as `V3` decodes as a different variant, against a payload that was
+    /// never encoded for it.
+    ///
+    /// The enum comment says to append new versions. This pins it as a test, so the
+    /// mistake fails here instead of in someone's disk cache.
+    ///
+    /// The assertion deliberately names `V3` and builds it from the current types
+    /// only. Removing `V2` also removes the legacy mirror the other tests encode
+    /// with, so a check written in terms of `V1`/`V2` would be deleted alongside
+    /// the thing it was meant to guard.
+    #[test]
+    fn test_v3_cached_key_stays_at_its_bincode_variant_index() {
+        let encoded = bincode::serialize(&SerializedCachedKey::V3(
+            5,
+            SerializedSsTableId(Ulid::from((123, 456))),
+            99,
+        ))
+        .unwrap();
+
+        // Bincode writes the variant index as a little-endian u32 prefix.
+        let variant_index = u32::from_le_bytes(
+            encoded[..4]
+                .try_into()
+                .expect("bincode writes a 4 byte variant index"),
+        );
+
+        assert_eq!(
+            variant_index, 2,
+            "V3 keys on disk are encoded at variant index 2. Changing this \
+             silently invalidates every cached key already written."
+        );
+    }
+
     #[test]
     fn test_should_serialize_deserialize_compacted_sst_key() {
         let key = CachedKey {


### PR DESCRIPTION
## Summary

`SerializedCachedKey` is encoded with bincode, which identifies an enum variant by its position, so each index is part of the on-disk cache format. #2061 asks about removing the V2 key type. I went to do that and found removing a variant is not a free cleanup: dropping V1 or V2 shifts V3 down a slot, and a key already written as V3 then decodes as a different variant, against a payload that was never encoded for it.

Reordering the enum to simulate that, three tests do fail, but none of them says the on disk format changed. One is an unwrap panic, one is a string match on an error message.

The comment above the enum already says new versions must be appended. This says the same thing in a way CI can enforce.

## Changes

- a test asserting the V3 cache key encodes at bincode variant index 2

## Notes for Reviewers

The assertion names V3 and builds it from the current types only. Removing V2 also removes `LegacySerializedCachedKey`, which the other tests encode with, so a guard written in terms of V1 or V2 would get deleted alongside the thing it is meant to protect.

On #2061 itself, the bit i could not work out from reading is what should happen to keys still encoded as V1 or V2 if the type does get removed. `foyer::HybridCache<CachedKey, CachedEntry>` deserializes keys off disk, and `FoyerHybridCache::get` maps a foyer error through `SlateDBError`, so it looks like a stale key surfaces as an error rather than a miss. if those keys should just be dropped and refilled from the object store, should that live in the serde layer or in foyer_hybrid? happy to write that follow up once you say which.

Written with AI assistance (Claude Code, Opus 5). I reviewed the change and confirmed the test fails without the guard.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); 36 lines, all test
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally; verified the test fails when the enum is reordered
- [x] Ran `cargo fmt` and `cargo clippy --all-targets`; ran `cargo test -p slatedb --lib` rather than `cargo nextest run --all-features` (7 GB box, the full workspace run OOMs)
- [x] Called out any breaking changes and provided migration notes — none, test only
- [x] Considered performance impact; added notes or benchmarks if relevant — none, test only

Thank you for the review! 🙏
