### PR TITLE
Add AI disclosure and enum guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,15 @@ What is being changed and why?
 
 -
 
+## AI-generated Code
+
+If you used AI to generate code, add one row for each model and effort level that you used.
+If you did not use AI, enter `N/A` in both columns.
+
+| Model | Effort |
+| --- | --- |
+|  |  |
+
 ## Notes for Reviewers
 
 Any hints on how to best review this PR? Anything you’d like reviewers to focus on? Any follow-ups planned?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,10 @@ What is being changed and why?
 
 -
 
-## AI-generated Code
+## AI Assistance
 
-If you used AI to generate code, add one row for each model and effort level that you used.
+If you used AI for any part of this pull request, add one row for each model and effort level.
+Include code, tests, documentation, and pull request text.
 If you did not use AI, enter `N/A` in both columns.
 
 | Model | Effort |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,8 @@ If the user requests a text review, read `.agents/skills/simple-english/referenc
 Follow the skill rules in every chat reply.
 Do not edit an existing comment only to apply the skill.
 Apply the skill to each new comment that you add.
+
+# API design
+
+Do not add `#[non_exhaustive]` to an enum only to avoid a future breaking change.
+Prefer exhaustive enum matches, even when a new variant causes a breaking API change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,15 +24,3 @@ a CLA and decorate the PR appropriately (e.g., status check, comment). Simply fo
 provided by the bot. You will only need to do this once across all repos using our CLA.
 
 The CLA text is also available [here](https://gist.github.com/criccomini/5ea2c60fe2ec791d91aa05d165060b9c).
-
-## AI Generated Pull Requests
-
-AI-generated (or largerly generated) pull requests are welcome, provided that you:
-
-- Disclose that the pull request is largely AI generated.
-- Specify which tool and model you used.
-- Understand the changes in the PR.
-- Keep PR descriptions and review replies human.
-- Review the code change yourself before submitting the PR.
-- Run `/review` locally in the `codex` or `claude` CLI before submitting the PR.
-- Follow the guidelines in the PR template (the checkboxes at the bottom).


### PR DESCRIPTION
## Summary

This change moves AI assistance details into pull request descriptions.
It removes the older AI guidance from `CONTRIBUTING.md`.
It also adds guidance for exhaustive enums.

## Changes

- Added a table for each AI model and effort level used in a pull request.
- Allowed contributors to add rows for multiple model and effort combinations.
- Included AI use for code, tests, documentation, and pull request text.
- Removed the AI-generated pull request section from `CONTRIBUTING.md`.
- Added repository guidance that favors exhaustive enums over `#[non_exhaustive]`.

## AI Assistance

| Model | Effort |
| --- | --- |
| `gpt-5.6-sol` | `xhigh` |

## Notes for Reviewers

This change updates documentation only. No tests were run.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests)
- [x] Added context in the description
- [x] Self-reviewed the diff
- [x] Tests are not needed for this documentation-only change
- [x] Rust checks are not needed for this documentation-only change
- [x] This change does not break an API
- [x] This change does not affect performance

Thank you for the review! 🙏
