### PR TITLE
feat(manifest): enforce the L0 ULID cutoff invariant

### DIFF
--- a/slatedb/src/manifest/invariants.rs
+++ b/slatedb/src/manifest/invariants.rs
@@ -1,4 +1,4 @@
-//! RFC-0026 "GC cutoff rule enforcement" invariants for the `.manifest` object.
+//! RFC-0029 GC cutoff invariants for the `.manifest` object.
 //!
 //! Each invariant is a plain [`Invariant<Manifest>`] predicate attached once to
 //! the [`StoredManifest`](super::store::StoredManifest)'s transactional object, so
@@ -49,7 +49,6 @@ use crate::manifest::Manifest;
 /// watermark timestamp as `last_tick` and the offending ULID timestamp as
 /// `next_tick`. The txn-obj layer wraps the boxed error in `CallbackError`, which
 /// maps back to `SlateDBError::InvalidClockTick` for the caller.
-#[allow(dead_code)]
 pub(crate) fn l0_ulid_cutoff(
     dirty: &Manifest,
     current: &Manifest,
@@ -84,10 +83,7 @@ pub(crate) fn l0_ulid_cutoff(
     Ok(())
 }
 
-/// The invariants enforced on every `.manifest` update (RFC-0026 GC cutoff
-/// rules). Will be attached once at [`StoredManifest`](super::store::StoredManifest)
-/// construction via `with_invariants` in the follow-up wiring PR.
-#[allow(dead_code)]
+/// The RFC-0029 invariants that run before each `.manifest` update.
 pub(crate) fn manifest_invariants() -> Vec<Invariant<Manifest>> {
     vec![Arc::new(l0_ulid_cutoff)]
 }

--- a/slatedb/src/manifest/mod.rs
+++ b/slatedb/src/manifest/mod.rs
@@ -539,10 +539,6 @@ impl ManifestCore {
     /// and every segment. Returned as a `Ulid` (not a raw timestamp) so the L0
     /// cutoff invariant ([`l0_ulid_cutoff`](crate::manifest::invariants::l0_ulid_cutoff))
     /// and the open-time skew check share one definition of the watermark.
-    // TODO: Wire this into the manifest update path in a follow-up PR for
-    // https://github.com/slatedb/slatedb/issues/1707
-    // until then unit-tested via `l0_ulid_cutoff`.
-    #[allow(dead_code)]
     pub(crate) fn max_l0_ulid_timestamp_across_trees(&self) -> Option<ulid::Ulid> {
         self.trees()
             .filter_map(|tree| {

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -5,6 +5,7 @@ use crate::error::SlateDBError::{
     CheckpointMissing, InvalidDBState, LatestTransactionalObjectVersionMissing, ManifestMissing,
 };
 use crate::flatbuffer_types::FlatBufferManifestCodec;
+use crate::manifest::invariants::manifest_invariants;
 use crate::manifest::{Manifest, ManifestCore, VersionedManifest};
 use log::debug;
 use object_store::path::Path;
@@ -175,6 +176,13 @@ pub(crate) struct StoredManifest {
 }
 
 impl StoredManifest {
+    fn new(inner: SimpleTransactionalObject<Manifest>, clock: Arc<dyn SystemClock>) -> Self {
+        Self {
+            inner: inner.with_invariants(manifest_invariants()),
+            clock,
+        }
+    }
+
     async fn init(
         store: Arc<ManifestStore>,
         manifest: Manifest,
@@ -187,7 +195,7 @@ impl StoredManifest {
             manifest.clone(),
         )
         .await?;
-        Ok(Self { inner, clock })
+        Ok(Self::new(inner, clock))
     }
 
     /// Create the initial manifest for a new database.
@@ -222,7 +230,7 @@ impl StoredManifest {
         else {
             return Ok(None);
         };
-        Ok(Some(Self { inner, clock }))
+        Ok(Some(Self::new(inner, clock)))
     }
 
     /// Load the current manifest from the supplied manifest store. If successful,
@@ -232,11 +240,9 @@ impl StoredManifest {
         store: Arc<ManifestStore>,
         clock: Arc<dyn SystemClock>,
     ) -> Result<Self, SlateDBError> {
-        SimpleTransactionalObject::<Manifest>::try_load(Arc::clone(&store.inner)
-            as Arc<dyn TransactionalStorageProtocol<Manifest, MonotonicId>>)
-        .await?
-        .map(|inner| Self { inner, clock })
-        .ok_or(LatestTransactionalObjectVersionMissing)
+        Self::try_load(store, clock)
+            .await?
+            .ok_or(LatestTransactionalObjectVersionMissing)
     }
 
     #[allow(dead_code)]
@@ -588,7 +594,7 @@ mod tests {
     use crate::manifest::store::{FenceableManifest, ManifestStore, StoredManifest};
     use crate::manifest::ManifestCore;
     use crate::retrying_object_store::RetryingObjectStore;
-    use crate::test_utils::FlakyObjectStore;
+    use crate::test_utils::{bounded_sst_view, FlakyObjectStore};
     use chrono::Timelike;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -641,6 +647,39 @@ mod tests {
         let version = ms.read_latest_manifest().await.unwrap().id;
 
         assert_eq!(version, 2);
+    }
+
+    #[tokio::test]
+    async fn test_should_enforce_manifest_invariants_after_create() {
+        let ms = new_memory_manifest_store();
+        let mut sm = StoredManifest::create_new_db(
+            ms.clone(),
+            core_with_l0(100),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+
+        assert_l0_invariant_rejects_update(&mut sm).await;
+        assert_eq!(ms.read_latest_manifest().await.unwrap().id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_should_enforce_manifest_invariants_after_load() {
+        let ms = new_memory_manifest_store();
+        StoredManifest::create_new_db(
+            ms.clone(),
+            core_with_l0(100),
+            Arc::new(DefaultSystemClock::new()),
+        )
+        .await
+        .unwrap();
+        let mut sm = StoredManifest::load(ms.clone(), Arc::new(DefaultSystemClock::new()))
+            .await
+            .unwrap();
+
+        assert_l0_invariant_rejects_update(&mut sm).await;
+        assert_eq!(ms.read_latest_manifest().await.unwrap().id, 1);
     }
 
     #[tokio::test]
@@ -1057,6 +1096,31 @@ mod tests {
     fn new_memory_manifest_store() -> Arc<ManifestStore> {
         let os = Arc::new(InMemory::new());
         Arc::new(ManifestStore::new(&Path::from(ROOT), os))
+    }
+
+    fn core_with_l0(timestamp_ms: u64) -> ManifestCore {
+        let mut core = ManifestCore::new();
+        Arc::make_mut(&mut core.tree)
+            .l0
+            .push_front(bounded_sst_view(timestamp_ms, b"a", b"z"));
+        core
+    }
+
+    async fn assert_l0_invariant_rejects_update(sm: &mut StoredManifest) {
+        let mut dirty = sm.prepare_dirty().unwrap();
+        Arc::make_mut(&mut dirty.value.core.tree)
+            .l0
+            .push_front(bounded_sst_view(50, b"a", b"z"));
+
+        let result = sm.update(dirty).await;
+
+        assert!(matches!(
+            result,
+            Err(SlateDBError::InvalidClockTick {
+                last_tick: 100,
+                next_tick: 50
+            })
+        ));
     }
 
     fn new_checkpoint(manifest_id: u64) -> Checkpoint {

--- a/slatedb/src/memtable_flusher/tracker.rs
+++ b/slatedb/src/memtable_flusher/tracker.rs
@@ -713,13 +713,18 @@ mod tests {
         manifest.manifest.core.checkpoints.len()
     }
 
-    fn seeded_l0_handle(first_key: &[u8]) -> SsTableHandle {
-        seeded_l0_handle_with_bounds(first_key, None)
+    fn seeded_l0_handle(seed: u128, first_key: &[u8]) -> SsTableHandle {
+        seeded_l0_handle_with_bounds(seed, first_key, None)
     }
 
-    fn seeded_l0_handle_with_bounds(first_key: &[u8], last_key: Option<&[u8]>) -> SsTableHandle {
+    fn seeded_l0_handle_with_bounds(
+        seed: u128,
+        first_key: &[u8],
+        last_key: Option<&[u8]>,
+    ) -> SsTableHandle {
+        // Seed test L0s with an old timestamp so live uploads are always newer.
         SsTableHandle::new(
-            SsTableId::from(ulid::Ulid::new()),
+            SsTableId::from(ulid::Ulid::from_parts(0, seed)),
             SST_FORMAT_VERSION_LATEST,
             SsTableInfo {
                 first_entry: Some(Bytes::copy_from_slice(first_key)),
@@ -749,12 +754,12 @@ mod tests {
                 .unwrap();
         let mut dirty = stored_manifest.prepare_dirty().unwrap();
         Arc::make_mut(&mut dirty.value.core.tree).l0.clear();
-        for (first, last) in ranges {
+        for (seed, (first, last)) in ranges.iter().enumerate() {
             Arc::make_mut(&mut dirty.value.core.tree)
                 .l0
                 .push_back(SsTableView::new(
                     ulid::Ulid::new(),
-                    seeded_l0_handle_with_bounds(first, Some(last)),
+                    seeded_l0_handle_with_bounds(seed as u128, first, Some(last)),
                 ));
         }
         stored_manifest.update(dirty).await.unwrap();
@@ -766,12 +771,12 @@ mod tests {
             Arc::make_mut(&mut modifier.state.manifest.value.core.tree)
                 .l0
                 .clear();
-            for (first, last) in ranges {
+            for (seed, (first, last)) in ranges.iter().enumerate() {
                 Arc::make_mut(&mut modifier.state.manifest.value.core.tree)
                     .l0
                     .push_back(SsTableView::new(
                         ulid::Ulid::new(),
-                        seeded_l0_handle_with_bounds(first, Some(last)),
+                        seeded_l0_handle_with_bounds(seed as u128, first, Some(last)),
                     ));
             }
         });
@@ -790,7 +795,7 @@ mod tests {
                 .l0
                 .push_back(SsTableView::new(
                     ulid::Ulid::new(),
-                    seeded_l0_handle(format!("seed-{idx}").as_bytes()),
+                    seeded_l0_handle(idx as u128, format!("seed-{idx}").as_bytes()),
                 ));
         }
         stored_manifest.update(dirty).await.unwrap();
@@ -804,7 +809,7 @@ mod tests {
             for idx in 0..l0_len {
                 l0.push_back(SsTableView::new(
                     ulid::Ulid::new(),
-                    seeded_l0_handle(format!("local-segment-seed-{idx}").as_bytes()),
+                    seeded_l0_handle(idx as u128, format!("local-segment-seed-{idx}").as_bytes()),
                 ));
             }
             modifier.state.manifest.value.core.segments = vec![Segment {
@@ -830,7 +835,7 @@ mod tests {
                     .l0
                     .push_back(SsTableView::new(
                         ulid::Ulid::new(),
-                        seeded_l0_handle(format!("local-seed-{idx}").as_bytes()),
+                        seeded_l0_handle(idx as u128, format!("local-seed-{idx}").as_bytes()),
                     ));
             }
         });


### PR DESCRIPTION
## Summary

This PR enables the manifest invariant from [RFC 0029](https://github.com/slatedb/slatedb/blob/main/rfcs/0029-gc-safe-sst-ulid-timestamps.md). It prevents new L0 SSTs from using a ULID timestamp older than the current manifest cutoff.

## Changes

- Register the RFC 0029 invariant when a stored manifest is created or loaded
- Reject L0 SSTs whose ULID timestamp is below the manifest cutoff
- Add tests for both new and reloaded manifests
- Remove stale dead-code annotations and update related documentation

## AI Assistance

| Model | Effort |
| ----- | ------ |
| GPT-5.6 Sol | High |

## Notes for Reviewers

Please focus on whether the invariant is installed on every `StoredManifest` construction path. This PR has no expected breaking changes or performance impact, and the remaining RFC work will stay in separate PRs.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant


Thank you for the review! 🙏