### PR TITLE
feat(compactions): enforce RFC 0029 ULID invariants

### DIFF
--- a/slatedb/src/compactions_store.rs
+++ b/slatedb/src/compactions_store.rs
@@ -1,3 +1,6 @@
+mod invariants;
+
+use self::invariants::compactions_invariants;
 use crate::compactor_state::{Compactions, VersionedCompactions};
 use crate::error::SlateDBError;
 #[allow(dead_code)]
@@ -25,6 +28,12 @@ pub(crate) struct StoredCompactions {
 }
 
 impl StoredCompactions {
+    fn new(inner: SimpleTransactionalObject<Compactions>) -> Self {
+        Self {
+            inner: inner.with_invariants(compactions_invariants()),
+        }
+    }
+
     async fn init(
         store: Arc<CompactionsStore>,
         compactions: Compactions,
@@ -35,7 +44,7 @@ impl StoredCompactions {
             compactions.clone(),
         )
         .await?;
-        Ok(Self { inner })
+        Ok(Self::new(inner))
     }
 
     /// Create a new compactions record with the supplied compactor epoch and no compactions.
@@ -60,7 +69,7 @@ impl StoredCompactions {
         else {
             return Ok(None);
         };
-        Ok(Some(Self { inner }))
+        Ok(Some(Self::new(inner)))
     }
 
     /// Load the current compactions state from the supplied compactions store. If successful,
@@ -68,11 +77,9 @@ impl StoredCompactions {
     /// If no compactions could be found, the error [`LatestTransactionalObjectVersionMissing`] is returned.
     #[cfg(test)]
     pub(crate) async fn load(store: Arc<CompactionsStore>) -> Result<Self, SlateDBError> {
-        SimpleTransactionalObject::<Compactions>::try_load(Arc::clone(&store.inner)
-            as Arc<dyn TransactionalStorageProtocol<Compactions, MonotonicId>>)
-        .await?
-        .map(|inner| Self { inner })
-        .ok_or(LatestTransactionalObjectVersionMissing)
+        Self::try_load(store)
+            .await?
+            .ok_or(LatestTransactionalObjectVersionMissing)
     }
 
     #[allow(dead_code)]
@@ -276,6 +283,8 @@ impl CompactionsStore {
 mod tests {
     use super::*;
     use crate::compactor_state::{Compaction, CompactionSpec, SourceId};
+    use crate::db_state::{SsTableHandle, SsTableId, SsTableInfo};
+    use crate::format::sst::SST_FORMAT_VERSION_LATEST;
     use crate::retrying_object_store::RetryingObjectStore;
     use crate::test_utils::FlakyObjectStore;
     use object_store::memory::InMemory;
@@ -345,6 +354,25 @@ mod tests {
         sc.update(dirty).await.unwrap();
 
         assert!(sc.compactions().contains(&compaction.id()));
+    }
+
+    #[tokio::test]
+    async fn test_should_enforce_compactions_invariants_after_create() {
+        let store = new_memory_compactions_store();
+        let mut sc = create_compactions_with_job(store.clone(), 100).await;
+
+        assert_compactions_invariants_reject_updates(&mut sc).await;
+        assert_eq!(store.read_latest_compactions().await.unwrap().id, 2);
+    }
+
+    #[tokio::test]
+    async fn test_should_enforce_compactions_invariants_after_load() {
+        let store = new_memory_compactions_store();
+        create_compactions_with_job(store.clone(), 100).await;
+        let mut sc = StoredCompactions::load(store.clone()).await.unwrap();
+
+        assert_compactions_invariants_reject_updates(&mut sc).await;
+        assert_eq!(store.read_latest_compactions().await.unwrap().id, 2);
     }
 
     #[tokio::test]
@@ -522,6 +550,63 @@ mod tests {
         Compaction::new(
             Ulid::new(),
             CompactionSpec::new(vec![SourceId::SortedRun(0)], 0),
+        )
+    }
+
+    async fn create_compactions_with_job(
+        store: Arc<CompactionsStore>,
+        timestamp_ms: u64,
+    ) -> StoredCompactions {
+        let mut sc = StoredCompactions::create(store, 0).await.unwrap();
+        let mut dirty = sc.prepare_dirty().unwrap();
+        dirty.value.insert(compaction_at(timestamp_ms));
+        sc.update(dirty).await.unwrap();
+        sc
+    }
+
+    async fn assert_compactions_invariants_reject_updates(sc: &mut StoredCompactions) {
+        let mut dirty = sc.prepare_dirty().unwrap();
+        dirty.value.insert(compaction_at(50));
+        let result = sc.update(dirty).await;
+        assert!(matches!(
+            result,
+            Err(SlateDBError::InvalidClockTick {
+                last_tick: 100,
+                next_tick: 50,
+            })
+        ));
+
+        let job_id = Ulid::from_parts(100, 0);
+        let mut dirty = sc.prepare_dirty().unwrap();
+        let updated = dirty
+            .value
+            .get(&job_id)
+            .unwrap()
+            .clone()
+            .with_output_ssts(vec![output_sst_at(50)]);
+        dirty.value.insert(updated);
+        let result = sc.update(dirty).await;
+        assert!(matches!(
+            result,
+            Err(SlateDBError::InvalidClockTick {
+                last_tick: 100,
+                next_tick: 50,
+            })
+        ));
+    }
+
+    fn compaction_at(timestamp_ms: u64) -> Compaction {
+        Compaction::new(
+            Ulid::from_parts(timestamp_ms, 0),
+            CompactionSpec::new(vec![SourceId::SortedRun(0)], 0),
+        )
+    }
+
+    fn output_sst_at(timestamp_ms: u64) -> SsTableHandle {
+        SsTableHandle::new(
+            SsTableId::from(Ulid::from_parts(timestamp_ms, 0)),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo::default(),
         )
     }
 

--- a/slatedb/src/compactions_store/invariants.rs
+++ b/slatedb/src/compactions_store/invariants.rs
@@ -1,0 +1,184 @@
+//! RFC-0029 invariants for the `.compactions` object.
+
+use std::error::Error;
+use std::sync::Arc;
+
+use slatedb_txn_obj::Invariant;
+use ulid::Ulid;
+
+use crate::compactor_state::{Compaction, Compactions};
+use crate::error::SlateDBError;
+
+/// Rejects a new job with a timestamp below the current job watermark.
+pub(crate) fn compaction_job_id_cutoff(
+    dirty: &Compactions,
+    current: &Compactions,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let Some(watermark) = current.iter().map(|job| job.id().timestamp_ms()).max() else {
+        return Ok(());
+    };
+
+    for job in dirty.iter() {
+        let job_id = job.id();
+        if current.get(&job_id).is_none() && job_id.timestamp_ms() < watermark {
+            return Err(Box::new(SlateDBError::InvalidClockTick {
+                last_tick: watermark as i64,
+                next_tick: job_id.timestamp_ms() as i64,
+            }));
+        }
+    }
+    Ok(())
+}
+
+/// Rejects an output SST with a timestamp below its compaction job timestamp.
+/// This covers final and partial outputs. Final sorted-run views use the same ID as their physical SST.
+pub(crate) fn sorted_run_ulid_cutoff(
+    dirty: &Compactions,
+    _current: &Compactions,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    for job in dirty.iter() {
+        let watermark = job.id().timestamp_ms();
+        for output_id in output_sst_ids(job) {
+            if output_id.timestamp_ms() < watermark {
+                return Err(Box::new(SlateDBError::InvalidClockTick {
+                    last_tick: watermark as i64,
+                    next_tick: output_id.timestamp_ms() as i64,
+                }));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Returns final and partial output SST IDs for one compaction job.
+fn output_sst_ids(job: &Compaction) -> Vec<Ulid> {
+    let mut output_ids = job
+        .output_ssts()
+        .into_iter()
+        .map(|sst| sst.id.value())
+        .collect::<Vec<_>>();
+    output_ids.extend(
+        job.subcompactions()
+            .iter()
+            .flat_map(|subcompaction| subcompaction.output_ssts())
+            .map(|sst| sst.id.value()),
+    );
+    output_ids
+}
+
+/// The RFC-0029 invariants that run before each `.compactions` update.
+pub(crate) fn compactions_invariants() -> Vec<Invariant<Compactions>> {
+    vec![
+        Arc::new(compaction_job_id_cutoff),
+        Arc::new(sorted_run_ulid_cutoff),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bytes_range::BytesRange;
+    use crate::compactor_state::{CompactionContext, CompactionSpec};
+    use crate::db_state::{SsTableHandle, SsTableId, SsTableInfo};
+    use crate::format::sst::SST_FORMAT_VERSION_LATEST;
+    use crate::subcompaction::Subcompaction;
+
+    #[test]
+    fn compaction_job_id_cutoff_rejects_an_older_new_job() {
+        let current_job = compaction(100, 0);
+        let current = compactions([current_job.clone()]);
+        let dirty = compactions([current_job, compaction(50, 0)]);
+
+        assert_invalid_clock_tick(compaction_job_id_cutoff(&dirty, &current), 100, 50);
+    }
+
+    #[test]
+    fn compaction_job_id_cutoff_allows_the_same_millisecond() {
+        let current_job = compaction(100, 1);
+        let current = compactions([current_job.clone()]);
+        let dirty = compactions([current_job, compaction(100, 0)]);
+
+        compaction_job_id_cutoff(&dirty, &current).unwrap();
+    }
+
+    #[test]
+    fn compaction_job_id_cutoff_allows_an_older_existing_job() {
+        let older_job = compaction(50, 0);
+        let newest_job = compaction(100, 0);
+        let current = compactions([older_job.clone(), newest_job.clone()]);
+        let dirty = compactions([older_job, newest_job, compaction(101, 0)]);
+
+        compaction_job_id_cutoff(&dirty, &current).unwrap();
+    }
+
+    #[test]
+    fn sorted_run_ulid_cutoff_rejects_an_older_final_output() {
+        let job = compaction(100, 0).with_output_ssts(vec![output_sst(50, 0)]);
+        let dirty = compactions([job]);
+
+        assert_invalid_clock_tick(
+            sorted_run_ulid_cutoff(&dirty, &Compactions::new(0)),
+            100,
+            50,
+        );
+    }
+
+    #[test]
+    fn sorted_run_ulid_cutoff_rejects_an_older_partial_output() {
+        let context = CompactionContext::new(
+            vec![Subcompaction::new(BytesRange::unbounded())
+                .with_output_ssts(vec![output_sst(50, 0)])],
+            None,
+        );
+        let job = compaction(100, 0).with_ctx(Some(context));
+        let dirty = compactions([job]);
+
+        assert_invalid_clock_tick(
+            sorted_run_ulid_cutoff(&dirty, &Compactions::new(0)),
+            100,
+            50,
+        );
+    }
+
+    #[test]
+    fn sorted_run_ulid_cutoff_allows_the_same_millisecond() {
+        let job = compaction(100, 1).with_output_ssts(vec![output_sst(100, 0)]);
+        let dirty = compactions([job]);
+
+        sorted_run_ulid_cutoff(&dirty, &Compactions::new(0)).unwrap();
+    }
+
+    fn compactions(jobs: impl IntoIterator<Item = Compaction>) -> Compactions {
+        Compactions::new(0).with_compactions(jobs.into_iter().collect())
+    }
+
+    fn compaction(timestamp_ms: u64, random: u128) -> Compaction {
+        Compaction::new(
+            Ulid::from_parts(timestamp_ms, random),
+            CompactionSpec::new(vec![], 0),
+        )
+    }
+
+    fn output_sst(timestamp_ms: u64, random: u128) -> SsTableHandle {
+        SsTableHandle::new(
+            SsTableId::from(Ulid::from_parts(timestamp_ms, random)),
+            SST_FORMAT_VERSION_LATEST,
+            SsTableInfo::default(),
+        )
+    }
+
+    fn assert_invalid_clock_tick(
+        result: Result<(), Box<dyn Error + Send + Sync>>,
+        last_tick: i64,
+        next_tick: i64,
+    ) {
+        let error = result.unwrap_err().downcast::<SlateDBError>().unwrap();
+        assert!(matches!(
+            *error,
+            SlateDBError::InvalidClockTick {
+                last_tick: actual_last,
+                next_tick: actual_next,
+            } if actual_last == last_tick && actual_next == next_tick
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds the `.compactions` timestamp invariants from RFC 0029. The checks stop unsafe compaction IDs before storage writes.

## Changes

- The compaction job invariant rejects a new job timestamp below the current job timestamp watermark.
- The output invariant rejects final and partial SST timestamps below their compaction job timestamp.
- `StoredCompactions` registers both invariants after creation and loading.
- Tests cover rejected older timestamps, accepted equal timestamps, and both registration paths.

## AI Assistance

| Model | Effort |
| --- | --- |
| GPT-5 | High |

## Notes for Reviewers

Please focus on the two timestamp boundaries and the central registration path. A sorted-run view uses the same ID as its physical SST. The checks scan in-memory compaction records before each update. They do not add storage I/O or breaking changes.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏