### PR TITLE
[2021] Add DbBuilder::with_write_runtime to place the batch-writer on the caller's runtime

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -117,6 +117,12 @@ path = "src/read_tracing.rs"
 test = false
 bench = false
 
+[[bin]]
+name = "write-runtime"
+path = "src/write_runtime.rs"
+test = false
+bench = false
+
 [dependencies]
 anyhow.workspace = true
 object_store = { workspace = true, features = ["azure", "gcp"] }

--- a/examples/src/write_runtime.rs
+++ b/examples/src/write_runtime.rs
@@ -1,0 +1,45 @@
+//! `DbBuilder::with_write_runtime` puts the batch-writer on a current-thread runtime the writing
+//! thread drives, so a write is a task switch rather than a cross-thread wake-up. The caller then
+//! drives that runtime for everything that goes through the batch-writer — writes, `flush`,
+//! `close`, `create_checkpoint` — or the call hangs. Reads can run anywhere.
+
+use slatedb::config::{CheckpointOptions, CheckpointScope};
+use slatedb::object_store::local::LocalFileSystem;
+use slatedb::Db;
+use std::sync::Arc;
+use tokio::runtime::{Builder, Runtime};
+
+fn main() -> anyhow::Result<()> {
+    let local_root = std::env::temp_dir().join("slatedb-write-runtime-tutorial");
+    std::fs::create_dir_all(&local_root)?;
+    let object_store = Arc::new(LocalFileSystem::new_with_prefix(local_root)?);
+
+    // Opens the Db, serves reads, and hosts the flusher, compactor and GC.
+    let background = Runtime::new()?;
+
+    // Hosts the batch-writer. Timer on for the monotonic clock; no IO driver, which a
+    // current-thread runtime would poll on every write.
+    let writer = Builder::new_current_thread().enable_time().build()?;
+
+    let db = background.block_on(
+        Db::builder("db", object_store)
+            .with_write_runtime(writer.handle().clone())
+            .build(),
+    )?;
+
+    // Write path — on the write runtime.
+    writer.block_on(db.put(b"hello", b"world"))?;
+    writer.block_on(db.flush())?;
+    let checkpoint = writer
+        .block_on(db.create_checkpoint(CheckpointScope::All, &CheckpointOptions::default()))?;
+    println!("created checkpoint {}", checkpoint.id);
+
+    // Reads — anywhere.
+    let value = background.block_on(db.get(b"hello"))?;
+    assert_eq!(value.as_deref(), Some(b"world".as_ref()));
+
+    // close goes through the batch-writer, so it too uses the write runtime.
+    writer.block_on(db.close())?;
+
+    Ok(())
+}

--- a/slatedb/src/db/builder.rs
+++ b/slatedb/src/db/builder.rs
@@ -186,6 +186,7 @@ pub struct DbBuilder<P: Into<Path>> {
     block_cache_policy: BlockCachePolicy,
     system_clock: Option<Arc<dyn SystemClock>>,
     gc_runtime: Option<Handle>,
+    write_runtime: Option<Handle>,
     compactor_builder: Option<CompactorBuilder<Path>>,
     gc_builder: Option<GarbageCollectorBuilder<Path>>,
     fp_registry: Arc<FailPointRegistry>,
@@ -216,6 +217,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             block_cache_policy: BlockCachePolicy::default(),
             system_clock: None,
             gc_runtime: None,
+            write_runtime: None,
             compactor_builder: None,
             gc_builder: None,
             fp_registry: Arc::new(FailPointRegistry::new()),
@@ -321,6 +323,20 @@ impl<P: Into<Path>> DbBuilder<P> {
     /// Sets the garbage collection runtime to use for the database.
     pub fn with_gc_runtime(mut self, gc_runtime: Handle) -> Self {
         self.gc_runtime = Some(gc_runtime);
+        self
+    }
+
+    /// Runs the batch-writer task on `runtime` instead of the one the database is built on; all
+    /// other components stay put. On a current-thread runtime the writing threads drive
+    /// themselves, a write becomes a task switch rather than a cross-thread wake-up.
+    ///
+    /// The caller must drive `runtime` for every write, [`Db::flush`], [`Db::close`] and
+    /// [`Db::create_checkpoint`] — they go through the batch-writer and otherwise hang; reads do
+    /// not. Build it with [`enable_time`] and no IO driver, which would cost a syscall per write.
+    ///
+    /// [`enable_time`]: tokio::runtime::Builder::enable_time
+    pub fn with_write_runtime(mut self, runtime: Handle) -> Self {
+        self.write_runtime = Some(runtime);
         self
     }
 
@@ -701,7 +717,7 @@ impl<P: Into<Path>> DbBuilder<P> {
             WRITE_BATCH_TASK_NAME.to_string(),
             Box::new(WriteBatchEventHandler::new(inner.clone(), wal_writer)),
             write_rx,
-            &tokio_handle,
+            self.write_runtime.as_ref().unwrap_or(&tokio_handle),
         )?;
 
         // Selects the store a background component (compactor, GC) reads and
@@ -2294,6 +2310,8 @@ mod tests {
         atomic::{AtomicBool, Ordering},
         Arc,
     };
+    // Aliased because `tempfile::Builder` is also used below.
+    use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 
     struct EmptyWalIterator;
 
@@ -2658,6 +2676,61 @@ mod tests {
         assert!(cached_compacted > 0);
         assert!(!cached_db_path.join("manifest").exists());
 
+        assert_eq!(
+            db.get(b"k1").await.expect("failed to get").as_deref(),
+            Some(b"v1".as_ref())
+        );
+        db.close().await.expect("failed to close db");
+    }
+
+    // Not a `#[tokio::test]`: the caller has to own both runtimes.
+    #[test]
+    fn test_write_runtime_serves_writes_and_close() {
+        let background = Runtime::new().expect("failed to build background runtime");
+        let writer = RuntimeBuilder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("failed to build writer runtime");
+
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = background
+            .block_on(
+                crate::Db::builder(
+                    Path::from("test_write_runtime_serves_writes_and_close"),
+                    object_store,
+                )
+                .with_write_runtime(writer.handle().clone())
+                .build(),
+            )
+            .expect("failed to build db");
+
+        writer
+            .block_on(db.put(b"k1", b"v1"))
+            .expect("failed to put");
+
+        // Reads do not go through the batch-writer.
+        let value = background
+            .block_on(db.get(b"k1"))
+            .expect("failed to get")
+            .expect("expected the written value");
+        assert_eq!(value.as_ref(), b"v1");
+
+        // Close flushes through the batch-writer and joins it.
+        writer.block_on(db.close()).expect("failed to close db");
+    }
+
+    #[tokio::test]
+    async fn test_write_runtime_defaults_to_the_build_runtime() {
+        let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let db = crate::Db::builder(
+            Path::from("test_write_runtime_defaults_to_the_build_runtime"),
+            object_store,
+        )
+        .build()
+        .await
+        .expect("failed to build db");
+
+        db.put(b"k1", b"v1").await.expect("failed to put");
         assert_eq!(
             db.get(b"k1").await.expect("failed to get").as_deref(),
             Some(b"v1".as_ref())

--- a/website/src/content/docs/docs/operations/tuning.mdx
+++ b/website/src/content/docs/docs/operations/tuning.mdx
@@ -48,6 +48,8 @@ SlateDB provides several configuration options to tune performance. See [slatedb
 * **`max_unflushed_bytes`**: The total amount of unflushed WAL and memtable data allowed in memory before SlateDB applies backpressure to writers.
 * **`l0_max_ssts`**: The maximum number of L0 SSTs SlateDB allows before it stops flushing memtables and waits for compaction to catch up.
 
+Writes go through a single batch-writer task, which by default runs on a worker thread, so a write from another thread pays a cross-thread hand-off. **`DbBuilder::with_write_runtime(...)`** places that task on a current-thread runtime the writing thread also drives, turning the hand-off into a task switch — a large win for single- or low-concurrency writers, with no regression as concurrency rises. See [`examples/write_runtime.rs`](https://github.com/slatedb/slatedb/blob/main/examples/src/write_runtime.rs).
+
 ### Read Performance
 
 * **`min_filter_keys`**: SlateDB only builds filters for SSTs with at least this many keys. Raising it avoids filter overhead on small SSTs.


### PR DESCRIPTION
## Summary

Closes #2021.

Every write is handed to a single resident batch-writer task and the caller awaits a reply. The
caller's future runs on the calling thread via `block_on` while `spawn` puts the writer task on a
worker, so the two sit on different OS threads and every write pays a cross-thread wake-up. Many
concurrent writers amortize that; one writer pays it on every write for nothing.

`DbBuilder::with_write_runtime(Handle)` registers only the batch-writer on a given runtime; the
flusher, compactor, GC and task monitor are unaffected. Pointed at a current-thread runtime the
writing threads drive themselves, the wake-up becomes a task switch. Unset, nothing changes.

## Results

Writer-thread scaling, N OS threads writing to one `Db` (Apple M5 Max arm64, WAL disabled, single
run). Benchmark: https://github.com/1996fanrui/slatedb/commit/b0b79922c15a428379b7f74a4f83c5848b4aee58

| threads | native | with_write_runtime | change |
|---|---|---|---|
| 1 | 95 k ops/s | **778 k ops/s** | **8.1x** |
| 2 | 203 k ops/s | **491 k ops/s** | **2.4x** |
| 3 | 367 k ops/s | 376 k ops/s | +2.4% |
| 4 | 341 k ops/s | 361 k ops/s | +6.0% |
| 5 | 367 k ops/s | 384 k ops/s | +4.8% |
| 6 | 362 k ops/s | 379 k ops/s | +4.9% |

No regression at any thread count; the gain is concentrated at low write concurrency.

## Notes for Reviewers

Three requirements, all on the method's doc comment:

- The runtime must be built with `enable_time()`, not `enable_all()` — with the IO driver on, a
  current-thread runtime pays a syscall per write and is slower than doing nothing.
- The caller must drive it for every write, `flush`, `close` and `create_checkpoint`, which all go
  through the batch-writer. Reads are unaffected.
- Nothing on that runtime performs I/O; object-store writes stay on the build-time runtime.

