### PR TITLE
Return cache hit or miss results from DbCache fetch methods

### DIFF
--- a/slatedb/src/db_cache/foyer.rs
+++ b/slatedb/src/db_cache/foyer.rs
@@ -31,7 +31,10 @@
 //! ```
 //!
 
-use crate::db_cache::{CacheLoader, CachedEntry, CachedKey, DbCache, DEFAULT_MAX_CAPACITY};
+use crate::db_cache::{
+    instrumented_loader, CacheFetch, CacheLoader, CacheLookup, CachedEntry, CachedKey, DbCache,
+    DEFAULT_MAX_CAPACITY,
+};
 use crate::error::SlateDBError;
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -131,7 +134,7 @@ impl DbCache for FoyerCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 
@@ -139,7 +142,7 @@ impl DbCache for FoyerCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 
@@ -147,7 +150,7 @@ impl DbCache for FoyerCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 
@@ -155,7 +158,7 @@ impl DbCache for FoyerCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 }
@@ -172,13 +175,57 @@ impl FoyerCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
+        let (loader, loader_ran) = instrumented_loader(loader);
         let fetch = self
             .inner
             .get_or_fetch(&key, move || async move { loader().await });
         match fetch.await {
-            Ok(entry) => Ok(entry.value().clone()),
+            Ok(entry) => Ok(CacheFetch {
+                entry: entry.value().clone(),
+                lookup: if loader_ran.was_called() {
+                    CacheLookup::Miss
+                } else {
+                    CacheLookup::Hit
+                },
+            }),
             Err(err) => Err(SlateDBError::FoyerError(Arc::new(err)).into()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db_state::SsTableId;
+    use crate::format::sst::BlockBuilder;
+    use crate::types::RowEntry;
+    use ulid::Ulid;
+
+    #[tokio::test]
+    async fn test_fetch_lookup_from_memory() {
+        let cache = FoyerCache::new();
+        let key = CachedKey::from((SsTableId::new(Ulid::new()), 0));
+        let mut builder = BlockBuilder::new_latest(4096);
+        assert!(builder
+            .add(RowEntry::new_value(b"key", b"value", 0))
+            .unwrap());
+        let block = Arc::new(builder.build().unwrap());
+        let entry = CachedEntry::with_block(block.clone());
+        let loader: CacheLoader = Box::new(move || Box::pin(async move { Ok(entry) }));
+
+        let first = cache.fetch_block(key.clone(), loader).await.unwrap();
+        assert_eq!(first.lookup, CacheLookup::Miss);
+        assert!(Arc::ptr_eq(&first.entry.block().unwrap(), &block));
+        let second = cache
+            .fetch_block(
+                key,
+                Box::new(|| panic!("A cache hit must not run the loader.")),
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.lookup, CacheLookup::Hit);
+        assert!(Arc::ptr_eq(&second.entry.block().unwrap(), &block));
+        cache.close().await.unwrap();
     }
 }

--- a/slatedb/src/db_cache/foyer_hybrid.rs
+++ b/slatedb/src/db_cache/foyer_hybrid.rs
@@ -71,7 +71,9 @@
 //!
 
 use crate::{
-    db_cache::{CacheLoader, CachedEntry, CachedKey, DbCache},
+    db_cache::{
+        instrumented_loader, CacheFetch, CacheLoader, CacheLookup, CachedEntry, CachedKey, DbCache,
+    },
     error::SlateDBError,
     utils::format_bytes_si,
 };
@@ -171,7 +173,7 @@ impl DbCache for FoyerHybridCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 
@@ -179,7 +181,7 @@ impl DbCache for FoyerHybridCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 
@@ -187,7 +189,7 @@ impl DbCache for FoyerHybridCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 
@@ -195,7 +197,7 @@ impl DbCache for FoyerHybridCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.dedup_fetch(key, loader).await
     }
 }
@@ -208,12 +210,20 @@ impl FoyerHybridCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
+        let (loader, loader_ran) = instrumented_loader(loader);
         let fetch = self
             .inner
             .get_or_fetch(&key, move || async move { loader().await });
         match fetch.await {
-            Ok(entry) => Ok(entry.value().clone()),
+            Ok(entry) => Ok(CacheFetch {
+                entry: entry.value().clone(),
+                lookup: if loader_ran.was_called() {
+                    CacheLookup::Miss
+                } else {
+                    CacheLookup::Hit
+                },
+            }),
             Err(err) => Err(SlateDBError::FoyerError(Arc::new(err)).into()),
         }
     }
@@ -281,6 +291,25 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let cache = open_cache(tempdir.path()).await;
         (cache, tempdir)
+    }
+
+    #[tokio::test]
+    async fn test_fetch_lookup_from_memory_and_disk() {
+        use crate::db_cache::{CacheLoader, CacheLookup};
+
+        let (cache, _tempdir) = setup().await;
+        let key = CachedKey::from((SsTableId::new(Ulid::new()), 0));
+        let loader = || -> CacheLoader { Box::new(|| Box::pin(async { Ok(build_block()) })) };
+        let first = cache.fetch_block(key.clone(), loader()).await.unwrap();
+        assert_eq!(first.lookup, CacheLookup::Miss);
+        let second = cache.fetch_block(key.clone(), loader()).await.unwrap();
+        assert_eq!(second.lookup, CacheLookup::Hit);
+        cache.flush_scope(0).await.unwrap();
+        assert!(cache.inner.memory().get(&key).is_none());
+        let third = cache.fetch_block(key, loader()).await.unwrap();
+        assert_eq!(third.lookup, CacheLookup::Hit);
+        assert_eq!(third.entry.size(), first.entry.size());
+        cache.close().await.unwrap();
     }
 
     async fn open_cache(path: &std::path::Path) -> FoyerHybridCache {

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -12,6 +12,7 @@
 //! To use the cache, you need to configure the [DbOptions](crate::config::DbOptions) with the desired cache implementation.
 
 use std::ops::{Bound, RangeBounds};
+#[cfg(feature = "foyer")]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -51,6 +52,24 @@ pub const DEFAULT_META_CACHE_CAPACITY: u64 = 128 * 1024 * 1024;
 /// receive the same result.
 pub type CacheLoader =
     Box<dyn FnOnce() -> BoxFuture<'static, Result<CachedEntry, crate::Error>> + Send + 'static>;
+
+/// The result of a cache lookup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CacheLookup {
+    /// The fetch loaded the entry from object storage.
+    Miss,
+    /// The cache supplied the entry, including through a concurrent fetch.
+    Hit,
+}
+
+/// A fetched entry and the result of its cache lookup.
+#[derive(Clone)]
+pub struct CacheFetch {
+    /// The entry that the fetch returned.
+    pub entry: CachedEntry,
+    /// Whether the cache supplied the entry or the fetch loaded it.
+    pub lookup: CacheLookup,
+}
 
 /// A trait for slatedb's in-memory cache.
 ///
@@ -195,13 +214,19 @@ pub trait DbCache: Send + Sync {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_block(&key).await? {
-            return Ok(entry);
+            return Ok(CacheFetch {
+                entry,
+                lookup: CacheLookup::Hit,
+            });
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(entry)
+        Ok(CacheFetch {
+            entry,
+            lookup: CacheLookup::Miss,
+        })
     }
 
     /// Fetch an index entry, invoking `loader` on cache miss. See [`Self::fetch_block`].
@@ -209,13 +234,19 @@ pub trait DbCache: Send + Sync {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_index(&key).await? {
-            return Ok(entry);
+            return Ok(CacheFetch {
+                entry,
+                lookup: CacheLookup::Hit,
+            });
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(entry)
+        Ok(CacheFetch {
+            entry,
+            lookup: CacheLookup::Miss,
+        })
     }
 
     /// Fetch a filter entry, invoking `loader` on cache miss. See [`Self::fetch_block`].
@@ -223,13 +254,19 @@ pub trait DbCache: Send + Sync {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_filter(&key).await? {
-            return Ok(entry);
+            return Ok(CacheFetch {
+                entry,
+                lookup: CacheLookup::Hit,
+            });
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(entry)
+        Ok(CacheFetch {
+            entry,
+            lookup: CacheLookup::Miss,
+        })
     }
 
     /// Fetch a stats entry, invoking `loader` on cache miss. See [`Self::fetch_block`].
@@ -237,13 +274,19 @@ pub trait DbCache: Send + Sync {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_stats(&key).await? {
-            return Ok(entry);
+            return Ok(CacheFetch {
+                entry,
+                lookup: CacheLookup::Hit,
+            });
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(entry)
+        Ok(CacheFetch {
+            entry,
+            lookup: CacheLookup::Miss,
+        })
     }
 }
 
@@ -621,11 +664,14 @@ impl DbCache for SplitCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(cache) = &self.block_cache {
             cache.fetch_block(key, loader).await
         } else {
-            loader().await
+            loader().await.map(|entry| CacheFetch {
+                entry,
+                lookup: CacheLookup::Miss,
+            })
         }
     }
 
@@ -633,11 +679,14 @@ impl DbCache for SplitCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(cache) = &self.meta_cache {
             cache.fetch_index(key, loader).await
         } else {
-            loader().await
+            loader().await.map(|entry| CacheFetch {
+                entry,
+                lookup: CacheLookup::Miss,
+            })
         }
     }
 
@@ -645,11 +694,14 @@ impl DbCache for SplitCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(cache) = &self.meta_cache {
             cache.fetch_filter(key, loader).await
         } else {
-            loader().await
+            loader().await.map(|entry| CacheFetch {
+                entry,
+                lookup: CacheLookup::Miss,
+            })
         }
     }
 
@@ -657,11 +709,14 @@ impl DbCache for SplitCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         if let Some(cache) = &self.meta_cache {
             cache.fetch_stats(key, loader).await
         } else {
-            loader().await
+            loader().await.map(|entry| CacheFetch {
+                entry,
+                lookup: CacheLookup::Miss,
+            })
         }
     }
 }
@@ -719,15 +774,12 @@ impl DbCacheWrapper {
         key.with_scope(self.db_cache_id)
     }
 
-    fn record_fetch_outcome(
-        &self,
-        block_type: &str,
-        loader_ran: bool,
-        result: &Result<CachedEntry, crate::Error>,
-    ) {
+    fn record_fetch_outcome(&self, block_type: &str, result: &Result<CacheFetch, crate::Error>) {
         match result {
-            Ok(_) if loader_ran => self.record_miss(block_type),
-            Ok(_) => self.record_hit(block_type),
+            Ok(fetch) => match fetch.lookup {
+                CacheLookup::Miss => self.record_miss(block_type),
+                CacheLookup::Hit => self.record_hit(block_type),
+            },
             Err(err) => self.record_get_err(block_type, err),
         }
     }
@@ -879,11 +931,10 @@ impl DbCache for DbCacheWrapper {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         let scoped_key = self.scoped_key(&key);
-        let (loader, loader_ran) = instrumented_loader(loader);
         let result = self.cache.fetch_block(scoped_key, loader).await;
-        self.record_fetch_outcome("block", loader_ran.was_called(), &result);
+        self.record_fetch_outcome("block", &result);
         result
     }
 
@@ -891,11 +942,10 @@ impl DbCache for DbCacheWrapper {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         let scoped_key = self.scoped_key(&key);
-        let (loader, loader_ran) = instrumented_loader(loader);
         let result = self.cache.fetch_index(scoped_key, loader).await;
-        self.record_fetch_outcome("index", loader_ran.was_called(), &result);
+        self.record_fetch_outcome("index", &result);
         result
     }
 
@@ -903,11 +953,10 @@ impl DbCache for DbCacheWrapper {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         let scoped_key = self.scoped_key(&key);
-        let (loader, loader_ran) = instrumented_loader(loader);
         let result = self.cache.fetch_filter(scoped_key, loader).await;
-        self.record_fetch_outcome("filter", loader_ran.was_called(), &result);
+        self.record_fetch_outcome("filter", &result);
         result
     }
 
@@ -915,11 +964,10 @@ impl DbCache for DbCacheWrapper {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         let scoped_key = self.scoped_key(&key);
-        let (loader, loader_ran) = instrumented_loader(loader);
         let result = self.cache.fetch_stats(scoped_key, loader).await;
-        self.record_fetch_outcome("stats", loader_ran.was_called(), &result);
+        self.record_fetch_outcome("stats", &result);
         result
     }
 }
@@ -991,7 +1039,7 @@ impl DbCache for UnownedDbCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.inner.fetch_block(key, loader).await
     }
 
@@ -999,7 +1047,7 @@ impl DbCache for UnownedDbCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.inner.fetch_index(key, loader).await
     }
 
@@ -1007,7 +1055,7 @@ impl DbCache for UnownedDbCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.inner.fetch_filter(key, loader).await
     }
 
@@ -1015,23 +1063,24 @@ impl DbCache for UnownedDbCache {
         &self,
         key: CachedKey,
         loader: CacheLoader,
-    ) -> Result<CachedEntry, crate::Error> {
+    ) -> Result<CacheFetch, crate::Error> {
         self.inner.fetch_stats(key, loader).await
     }
 }
 
-/// Tracks whether the loader closure was actually invoked. Used by `DbCacheWrapper`
-/// to attribute fetches as hits (loader skipped, value served from cache or a
-/// concurrent fetch) or misses (this caller's loader ran).
+/// Tracks whether this caller ran the loader.
+#[cfg(feature = "foyer")]
 #[derive(Clone)]
 struct LoaderRan(Arc<AtomicBool>);
 
+#[cfg(feature = "foyer")]
 impl LoaderRan {
     fn was_called(&self) -> bool {
         self.0.load(Ordering::Relaxed)
     }
 }
 
+#[cfg(feature = "foyer")]
 fn instrumented_loader(loader: CacheLoader) -> (CacheLoader, LoaderRan) {
     let flag = Arc::new(AtomicBool::new(false));
     let flag_for_closure = flag.clone();
@@ -1237,7 +1286,10 @@ pub(crate) mod test_utils {
 #[cfg(test)]
 mod tests {
 
-    use crate::db_cache::{CachedEntry, CachedKey, DbCache, DbCacheWrapper, SplitCache};
+    use crate::db_cache::{
+        CacheFetch, CacheLoader, CacheLookup, CachedEntry, CachedKey, DbCache, DbCacheWrapper,
+        SplitCache,
+    };
     use crate::db_state::SsTableId;
     use crate::filter_policy::{BloomFilterPolicy, FilterPolicy, NamedFilter};
     use crate::format::sst::BlockBuilder;
@@ -1257,6 +1309,102 @@ mod tests {
     use ulid::Ulid;
 
     const SST_ID: SsTableId = SsTableId::new(Ulid::from_parts(0u64, 0u128));
+
+    #[tokio::test]
+    async fn test_fetch_lookup_outcomes() {
+        let mut caches: Vec<(Arc<dyn DbCache>, bool)> = vec![
+            (Arc::new(TestCache::new()), true),
+            (Arc::new(SplitCache::new()), false),
+            (
+                Arc::new(
+                    SplitCache::new()
+                        .with_block_cache(Some(Arc::new(TestCache::new())))
+                        .with_meta_cache(Some(Arc::new(TestCache::new()))),
+                ),
+                true,
+            ),
+        ];
+        #[cfg(feature = "foyer")]
+        caches.push((Arc::new(super::foyer::FoyerCache::new()), true));
+        #[cfg(feature = "moka")]
+        caches.push((Arc::new(super::moka::MokaCache::new()), true));
+
+        for (cache, retains_entries) in caches {
+            for method in 0..4 {
+                let key = CachedKey::from((SST_ID, method));
+                let mut builder = BlockBuilder::new_latest(4096);
+                assert!(builder
+                    .add(RowEntry::new_value(b"key", b"value", 0))
+                    .unwrap());
+                let block = Arc::new(builder.build().unwrap());
+                for attempt in 0..2 {
+                    let entry = CachedEntry::with_block(block.clone());
+                    let loader: CacheLoader = Box::new(move || Box::pin(async move { Ok(entry) }));
+                    let fetch = match method {
+                        0 => cache.fetch_block(key.clone(), loader).await,
+                        1 => cache.fetch_index(key.clone(), loader).await,
+                        2 => cache.fetch_filter(key.clone(), loader).await,
+                        _ => cache.fetch_stats(key.clone(), loader).await,
+                    }
+                    .unwrap();
+                    assert_eq!(
+                        fetch.lookup,
+                        if attempt == 0 || !retains_entries {
+                            CacheLookup::Miss
+                        } else {
+                            CacheLookup::Hit
+                        }
+                    );
+                    assert_eq!(fetch.entry.block().unwrap().size(), block.size());
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "foyer")]
+    #[tokio::test]
+    async fn test_concurrent_fetch_lookup() {
+        let cache = super::foyer::FoyerCache::new();
+        let key = CachedKey::from((SST_ID, 0));
+        let loader_started = Arc::new(tokio::sync::Notify::new());
+        let release_loader = Arc::new(tokio::sync::Notify::new());
+        let loader: CacheLoader = {
+            let loader_started = loader_started.clone();
+            let release_loader = release_loader.clone();
+            Box::new(move || {
+                Box::pin(async move {
+                    loader_started.notify_one();
+                    release_loader.notified().await;
+                    let mut builder = BlockBuilder::new_latest(4096);
+                    assert!(builder
+                        .add(RowEntry::new_value(b"key", b"value", 0))
+                        .unwrap());
+                    Ok(CachedEntry::with_block(Arc::new(builder.build().unwrap())))
+                })
+            })
+        };
+        let first = cache.fetch_block(key.clone(), loader);
+        tokio::pin!(first);
+        assert!(futures::poll!(&mut first).is_pending());
+        loader_started.notified().await;
+
+        let second = cache.fetch_block(
+            key,
+            Box::new(|| panic!("The concurrent fetch must share the first loader.")),
+        );
+        tokio::pin!(second);
+        assert!(futures::poll!(&mut second).is_pending());
+        release_loader.notify_one();
+
+        let first = first.await.unwrap();
+        let second = second.await.unwrap();
+        assert_eq!(first.lookup, CacheLookup::Miss);
+        assert_eq!(second.lookup, CacheLookup::Hit);
+        assert!(Arc::ptr_eq(
+            &first.entry.block().unwrap(),
+            &second.entry.block().unwrap()
+        ));
+    }
 
     #[rstest]
     #[tokio::test]
@@ -1869,29 +2017,41 @@ mod tests {
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
-            ) -> Result<CachedEntry, crate::Error> {
-                Ok(self.marker.clone())
+            ) -> Result<CacheFetch, crate::Error> {
+                Ok(CacheFetch {
+                    entry: self.marker.clone(),
+                    lookup: CacheLookup::Hit,
+                })
             }
             async fn fetch_index(
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
-            ) -> Result<CachedEntry, crate::Error> {
-                Ok(self.marker.clone())
+            ) -> Result<CacheFetch, crate::Error> {
+                Ok(CacheFetch {
+                    entry: self.marker.clone(),
+                    lookup: CacheLookup::Hit,
+                })
             }
             async fn fetch_filter(
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
-            ) -> Result<CachedEntry, crate::Error> {
-                Ok(self.marker.clone())
+            ) -> Result<CacheFetch, crate::Error> {
+                Ok(CacheFetch {
+                    entry: self.marker.clone(),
+                    lookup: CacheLookup::Hit,
+                })
             }
             async fn fetch_stats(
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
-            ) -> Result<CachedEntry, crate::Error> {
-                Ok(self.marker.clone())
+            ) -> Result<CacheFetch, crate::Error> {
+                Ok(CacheFetch {
+                    entry: self.marker.clone(),
+                    lookup: CacheLookup::Hit,
+                })
             }
         }
 
@@ -1917,7 +2077,7 @@ mod tests {
         ];
         for entry in fetched {
             assert!(
-                Arc::ptr_eq(&entry.block().unwrap(), &marker_block),
+                Arc::ptr_eq(&entry.entry.block().unwrap(), &marker_block),
                 "fetch was not forwarded to the inner cache's override"
             );
         }

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -71,6 +71,24 @@ pub struct CacheFetch {
     pub lookup: CacheLookup,
 }
 
+impl CacheFetch {
+    /// Create a result for an entry that the cache supplied.
+    pub fn hit(entry: CachedEntry) -> Self {
+        Self {
+            entry,
+            lookup: CacheLookup::Hit,
+        }
+    }
+
+    /// Create a result for an entry that the fetch loaded.
+    pub fn miss(entry: CachedEntry) -> Self {
+        Self {
+            entry,
+            lookup: CacheLookup::Miss,
+        }
+    }
+}
+
 /// A trait for slatedb's in-memory cache.
 ///
 /// This trait defines the interface for an in-memory cache,
@@ -205,6 +223,13 @@ pub trait DbCache: Send + Sync {
 
     /// Fetch a data-block entry, invoking `loader` on cache miss.
     ///
+    /// Custom implementations must report the lookup result in [`CacheFetch::lookup`].
+    /// Return [`CacheLookup::Miss`] when this fetch loads the entry from object storage.
+    /// Return [`CacheLookup::Hit`] when memory, disk, or a concurrent fetch supplies the entry.
+    /// The cache wrapper uses this result to update hit and miss counters.
+    /// It does not track whether the supplied loader runs.
+    /// This contract also applies to [`Self::fetch_index`], [`Self::fetch_filter`], and [`Self::fetch_stats`].
+    ///
     /// Implementations should deduplicate concurrent fetches: if multiple callers request the
     /// same key while it is being loaded, only one should run `loader` and the rest should
     /// share its result. The default implementation does **not** dedup; it simply does a
@@ -216,17 +241,11 @@ pub trait DbCache: Send + Sync {
         loader: CacheLoader,
     ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_block(&key).await? {
-            return Ok(CacheFetch {
-                entry,
-                lookup: CacheLookup::Hit,
-            });
+            return Ok(CacheFetch::hit(entry));
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(CacheFetch {
-            entry,
-            lookup: CacheLookup::Miss,
-        })
+        Ok(CacheFetch::miss(entry))
     }
 
     /// Fetch an index entry, invoking `loader` on cache miss. See [`Self::fetch_block`].
@@ -236,17 +255,11 @@ pub trait DbCache: Send + Sync {
         loader: CacheLoader,
     ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_index(&key).await? {
-            return Ok(CacheFetch {
-                entry,
-                lookup: CacheLookup::Hit,
-            });
+            return Ok(CacheFetch::hit(entry));
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(CacheFetch {
-            entry,
-            lookup: CacheLookup::Miss,
-        })
+        Ok(CacheFetch::miss(entry))
     }
 
     /// Fetch a filter entry, invoking `loader` on cache miss. See [`Self::fetch_block`].
@@ -256,17 +269,11 @@ pub trait DbCache: Send + Sync {
         loader: CacheLoader,
     ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_filter(&key).await? {
-            return Ok(CacheFetch {
-                entry,
-                lookup: CacheLookup::Hit,
-            });
+            return Ok(CacheFetch::hit(entry));
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(CacheFetch {
-            entry,
-            lookup: CacheLookup::Miss,
-        })
+        Ok(CacheFetch::miss(entry))
     }
 
     /// Fetch a stats entry, invoking `loader` on cache miss. See [`Self::fetch_block`].
@@ -276,17 +283,11 @@ pub trait DbCache: Send + Sync {
         loader: CacheLoader,
     ) -> Result<CacheFetch, crate::Error> {
         if let Some(entry) = self.get_stats(&key).await? {
-            return Ok(CacheFetch {
-                entry,
-                lookup: CacheLookup::Hit,
-            });
+            return Ok(CacheFetch::hit(entry));
         }
         let entry = loader().await?;
         self.insert(key, entry.clone()).await;
-        Ok(CacheFetch {
-            entry,
-            lookup: CacheLookup::Miss,
-        })
+        Ok(CacheFetch::miss(entry))
     }
 }
 
@@ -668,10 +669,7 @@ impl DbCache for SplitCache {
         if let Some(cache) = &self.block_cache {
             cache.fetch_block(key, loader).await
         } else {
-            loader().await.map(|entry| CacheFetch {
-                entry,
-                lookup: CacheLookup::Miss,
-            })
+            loader().await.map(CacheFetch::miss)
         }
     }
 
@@ -683,10 +681,7 @@ impl DbCache for SplitCache {
         if let Some(cache) = &self.meta_cache {
             cache.fetch_index(key, loader).await
         } else {
-            loader().await.map(|entry| CacheFetch {
-                entry,
-                lookup: CacheLookup::Miss,
-            })
+            loader().await.map(CacheFetch::miss)
         }
     }
 
@@ -698,10 +693,7 @@ impl DbCache for SplitCache {
         if let Some(cache) = &self.meta_cache {
             cache.fetch_filter(key, loader).await
         } else {
-            loader().await.map(|entry| CacheFetch {
-                entry,
-                lookup: CacheLookup::Miss,
-            })
+            loader().await.map(CacheFetch::miss)
         }
     }
 
@@ -713,10 +705,7 @@ impl DbCache for SplitCache {
         if let Some(cache) = &self.meta_cache {
             cache.fetch_stats(key, loader).await
         } else {
-            loader().await.map(|entry| CacheFetch {
-                entry,
-                lookup: CacheLookup::Miss,
-            })
+            loader().await.map(CacheFetch::miss)
         }
     }
 }
@@ -776,10 +765,14 @@ impl DbCacheWrapper {
 
     fn record_fetch_outcome(&self, block_type: &str, result: &Result<CacheFetch, crate::Error>) {
         match result {
-            Ok(fetch) => match fetch.lookup {
-                CacheLookup::Miss => self.record_miss(block_type),
-                CacheLookup::Hit => self.record_hit(block_type),
-            },
+            Ok(CacheFetch {
+                lookup: CacheLookup::Miss,
+                ..
+            }) => self.record_miss(block_type),
+            Ok(CacheFetch {
+                lookup: CacheLookup::Hit,
+                ..
+            }) => self.record_hit(block_type),
             Err(err) => self.record_get_err(block_type, err),
         }
     }
@@ -1311,6 +1304,116 @@ mod tests {
     const SST_ID: SsTableId = SsTableId::new(Ulid::from_parts(0u64, 0u128));
 
     #[tokio::test]
+    async fn test_wrapper_counts_reported_fetch_lookup() {
+        struct ReportedLookupCache {
+            lookup: CacheLookup,
+            entry: CachedEntry,
+        }
+
+        #[async_trait::async_trait]
+        impl DbCache for ReportedLookupCache {
+            async fn get_block(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                panic!("The wrapper must call fetch_block.");
+            }
+            async fn get_index(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                panic!("The wrapper must call fetch_index.");
+            }
+            async fn get_filter(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                panic!("The wrapper must call fetch_filter.");
+            }
+            async fn get_stats(&self, _: &CachedKey) -> Result<Option<CachedEntry>, crate::Error> {
+                panic!("The wrapper must call fetch_stats.");
+            }
+            async fn insert(&self, _: CachedKey, _: CachedEntry) {}
+            async fn remove(&self, _: &CachedKey) {}
+            fn entry_count(&self) -> u64 {
+                0
+            }
+            async fn fetch_block(
+                &self,
+                _: CachedKey,
+                _: CacheLoader,
+            ) -> Result<CacheFetch, crate::Error> {
+                Ok(CacheFetch {
+                    entry: self.entry.clone(),
+                    lookup: self.lookup,
+                })
+            }
+            async fn fetch_index(
+                &self,
+                key: CachedKey,
+                loader: CacheLoader,
+            ) -> Result<CacheFetch, crate::Error> {
+                self.fetch_block(key, loader).await
+            }
+            async fn fetch_filter(
+                &self,
+                key: CachedKey,
+                loader: CacheLoader,
+            ) -> Result<CacheFetch, crate::Error> {
+                self.fetch_block(key, loader).await
+            }
+            async fn fetch_stats(
+                &self,
+                key: CachedKey,
+                loader: CacheLoader,
+            ) -> Result<CacheFetch, crate::Error> {
+                self.fetch_block(key, loader).await
+            }
+        }
+
+        for lookup in [CacheLookup::Miss, CacheLookup::Hit] {
+            for method in ["data_block", "index", "filter", "stats"] {
+                let recorder = Arc::new(DefaultMetricsRecorder::new());
+                let helper = MetricsRecorderHelper::new(recorder.clone(), MetricLevel::default());
+                let mut builder = BlockBuilder::new_latest(4096);
+                assert!(builder
+                    .add(RowEntry::new_value(b"key", b"value", 0))
+                    .unwrap());
+                let block = Arc::new(builder.build().unwrap());
+                let cache = DbCacheWrapper::new(
+                    Arc::new(ReportedLookupCache {
+                        lookup,
+                        entry: CachedEntry::with_block(block.clone()),
+                    }),
+                    &helper,
+                    Arc::new(DefaultSystemClock::default()),
+                    1,
+                );
+                let key = CachedKey::from((SST_ID, 0));
+                let loader: CacheLoader =
+                    Box::new(|| panic!("This cache supplies its own result."));
+                let fetch = match method {
+                    "data_block" => cache.fetch_block(key, loader).await,
+                    "index" => cache.fetch_index(key, loader).await,
+                    "filter" => cache.fetch_filter(key, loader).await,
+                    "stats" => cache.fetch_stats(key, loader).await,
+                    _ => unreachable!(),
+                }
+                .unwrap();
+                assert_eq!(fetch.lookup, lookup);
+                assert!(Arc::ptr_eq(&fetch.entry.block().unwrap(), &block));
+                for entry_kind in ["data_block", "index", "filter", "stats"] {
+                    for (result, expected_lookup) in
+                        [("hit", CacheLookup::Hit), ("miss", CacheLookup::Miss)]
+                    {
+                        let expected = i64::from(entry_kind == method && lookup == expected_lookup);
+                        assert_eq!(
+                            lookup_metric_with_labels(
+                                &recorder,
+                                super::stats::ACCESS_COUNT,
+                                &[("entry_kind", entry_kind), ("result", result)],
+                            ),
+                            Some(expected),
+                            "method={method}, lookup={lookup:?}, entry_kind={entry_kind}, result={result}",
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
     async fn test_fetch_lookup_outcomes() {
         let mut caches: Vec<(Arc<dyn DbCache>, bool)> = vec![
             (Arc::new(TestCache::new()), true),
@@ -1330,8 +1433,11 @@ mod tests {
         caches.push((Arc::new(super::moka::MokaCache::new()), true));
 
         for (cache, retains_entries) in caches {
-            for method in 0..4 {
-                let key = CachedKey::from((SST_ID, method));
+            for (offset, method) in ["data_block", "index", "filter", "stats"]
+                .into_iter()
+                .enumerate()
+            {
+                let key = CachedKey::from((SST_ID, offset as u64));
                 let mut builder = BlockBuilder::new_latest(4096);
                 assert!(builder
                     .add(RowEntry::new_value(b"key", b"value", 0))
@@ -1341,10 +1447,11 @@ mod tests {
                     let entry = CachedEntry::with_block(block.clone());
                     let loader: CacheLoader = Box::new(move || Box::pin(async move { Ok(entry) }));
                     let fetch = match method {
-                        0 => cache.fetch_block(key.clone(), loader).await,
-                        1 => cache.fetch_index(key.clone(), loader).await,
-                        2 => cache.fetch_filter(key.clone(), loader).await,
-                        _ => cache.fetch_stats(key.clone(), loader).await,
+                        "data_block" => cache.fetch_block(key.clone(), loader).await,
+                        "index" => cache.fetch_index(key.clone(), loader).await,
+                        "filter" => cache.fetch_filter(key.clone(), loader).await,
+                        "stats" => cache.fetch_stats(key.clone(), loader).await,
+                        _ => unreachable!(),
                     }
                     .unwrap();
                     assert_eq!(
@@ -2018,40 +2125,28 @@ mod tests {
                 _: CachedKey,
                 _: CacheLoader,
             ) -> Result<CacheFetch, crate::Error> {
-                Ok(CacheFetch {
-                    entry: self.marker.clone(),
-                    lookup: CacheLookup::Hit,
-                })
+                Ok(CacheFetch::hit(self.marker.clone()))
             }
             async fn fetch_index(
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
             ) -> Result<CacheFetch, crate::Error> {
-                Ok(CacheFetch {
-                    entry: self.marker.clone(),
-                    lookup: CacheLookup::Hit,
-                })
+                Ok(CacheFetch::hit(self.marker.clone()))
             }
             async fn fetch_filter(
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
             ) -> Result<CacheFetch, crate::Error> {
-                Ok(CacheFetch {
-                    entry: self.marker.clone(),
-                    lookup: CacheLookup::Hit,
-                })
+                Ok(CacheFetch::hit(self.marker.clone()))
             }
             async fn fetch_stats(
                 &self,
                 _: CachedKey,
                 _: CacheLoader,
             ) -> Result<CacheFetch, crate::Error> {
-                Ok(CacheFetch {
-                    entry: self.marker.clone(),
-                    lookup: CacheLookup::Hit,
-                })
+                Ok(CacheFetch::hit(self.marker.clone()))
             }
         }
 

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -410,6 +410,7 @@ impl TableStore {
                     )
                     .await
                     .ok()
+                    .map(|fetch| fetch.entry)
             } else {
                 cache.get_filter(&cache_key).await.unwrap_or(None)
             };
@@ -463,6 +464,7 @@ impl TableStore {
                     )
                     .await
                     .ok()
+                    .map(|fetch| fetch.entry)
             } else {
                 cache.get_stats(&cache_key).await.unwrap_or(None)
             };
@@ -503,6 +505,7 @@ impl TableStore {
                     )
                     .await
                     .ok()
+                    .map(|fetch| fetch.entry)
             } else {
                 cache.get_index(&cache_key).await.unwrap_or(None)
             };
@@ -734,8 +737,8 @@ impl TableStore {
                 let offset = index.borrow().block_meta().get(block_num).offset();
                 let cache_key: CachedKey = (handle.id, offset).into();
                 let loader = self.block_loader(handle, index.clone(), block_num, segment.clone());
-                if let Ok(entry) = cache.fetch_block(cache_key, loader).await {
-                    if let Some(block) = entry.block() {
+                if let Ok(fetch) = cache.fetch_block(cache_key, loader).await {
+                    if let Some(block) = fetch.entry.block() {
                         let mut result = VecDeque::with_capacity(1);
                         result.push_back(block);
                         return Ok(result);


### PR DESCRIPTION
## Summary

This PR changes the return type of the `fetch*` methods in trait `DbCache`. Instead of only returning the entry, now those methods return the entry and whether the lookup was a cache hit or miss.  

This change is needed by [RFC-33: SlateDB Query Tracing](https://github.com/slatedb/slatedb/blob/main/rfcs/0033-query_tracing.md)

This change breaks the DbCache public API that is used for custom cache implementations.

## Changes

- Introduced return type `CacheFetch` that contains the entry and whether the lookup was a hit or miss
- Introduced enum `CacheLookup` with variants `Hit` and `Miss`
- Adapted method definitions and call sites.
- Added unit tests  

## AI Assistance

| Model | Effort |
| ------ | ---- |
| gpt-6-astra | low |

## Notes for Reviewers

Nothing special

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
