### PR TITLE
fix: retain managed scan files across checkpoint replacement

### DIFF
--- a/slatedb/src/compactor_executor.rs
+++ b/slatedb/src/compactor_executor.rs
@@ -342,6 +342,7 @@ impl TokioCompactionExecutorInner {
             None => None,
         };
         let sst_iter_options = SstIteratorOptions {
+            snapshot_lease: None,
             max_fetch_tasks: self.options.max_fetch_tasks,
             target_bytes_to_fetch: self.options.bytes_to_fetch,
             cache_blocks: false, // don't clobber the cache

--- a/slatedb/src/db_iter.rs
+++ b/slatedb/src/db_iter.rs
@@ -10,6 +10,7 @@ use crate::merge_operator::{
 };
 use crate::reader::ReadTrace;
 use crate::segment_iterator::{build_l0_point_iters, build_sr_point_iters, SegmentScanContext};
+use crate::snapshot_lease::SnapshotLease;
 use crate::types::{KeyValue, RowEntry, ValueDeletable};
 
 use async_trait::async_trait;
@@ -18,6 +19,7 @@ use futures::stream::{self, BoxStream, StreamExt};
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::ops::RangeBounds;
+use std::sync::Arc;
 use tracing::Instrument;
 
 /// [`DbIteratorRangeTracker`] records the *requested* scan range of a
@@ -245,6 +247,7 @@ impl RowEntryIterator for ScanIterator {
 }
 
 pub struct DbIterator {
+    snapshot_lease: Option<Arc<SnapshotLease>>,
     range: BytesRange,
     iter: Box<dyn RowEntryIterator + 'static>,
     invalidated_error: Option<SlateDBError>,
@@ -262,6 +265,7 @@ impl DbIterator {
         merge_operator: Option<MergeOperatorType>,
         order: IterationOrder,
         read_trace: ReadTrace,
+        snapshot_lease: Option<Arc<SnapshotLease>>,
     ) -> Result<Self, SlateDBError> {
         let read_span = read_trace.read_span();
 
@@ -316,9 +320,14 @@ impl DbIterator {
             iter = Box::new(MergeOperatorRequiredIterator::new(iter));
         }
 
-        iter.init().instrument(read_span.clone()).await?;
+        SnapshotLease::protect(
+            snapshot_lease.clone(),
+            iter.init().instrument(read_span.clone()),
+        )
+        .await?;
 
         Ok(DbIterator {
+            snapshot_lease,
             range,
             iter,
             invalidated_error: None,
@@ -349,33 +358,36 @@ impl DbIterator {
     }
 
     pub(crate) async fn next_entry(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
+        if let Some(error) = self.invalidated_error.clone() {
+            return Err(error);
+        }
         let read_span = self.read_span.clone();
-        self.next_entry_inner().instrument(read_span).await
+        let result = SnapshotLease::protect(
+            self.snapshot_lease.clone(),
+            self.next_entry_inner().instrument(read_span),
+        )
+        .await;
+        self.maybe_invalidate(result)
     }
 
     async fn next_entry_inner(&mut self) -> Result<Option<RowEntry>, SlateDBError> {
-        if let Some(error) = self.invalidated_error.clone() {
-            Err(error)
-        } else {
-            let result = loop {
-                let next = self.iter.next().await;
-                // Keep cached iteration cooperative.
-                tokio::task::coop::consume_budget().await;
-                match next {
-                    Ok(Some(entry)) => match entry.value {
-                        ValueDeletable::Tombstone => continue,
-                        _ => break Ok(Some(entry)),
-                    },
-                    Ok(None) => break Ok(None),
-                    Err(e) => break Err(e),
-                }
-            };
-            let result = self.maybe_invalidate(result);
-            if let Ok(Some(ref entry)) = result {
-                self.last_key = Some(entry.key.clone());
+        let result = loop {
+            let next = self.iter.next().await;
+            // Keep cached iteration cooperative.
+            tokio::task::coop::consume_budget().await;
+            match next {
+                Ok(Some(entry)) => match entry.value {
+                    ValueDeletable::Tombstone => continue,
+                    _ => break Ok(Some(entry)),
+                },
+                Ok(None) => break Ok(None),
+                Err(error) => break Err(error),
             }
-            result
+        };
+        if let Ok(Some(ref entry)) = result {
+            self.last_key = Some(entry.key.clone());
         }
+        result
     }
 
     fn maybe_invalidate<T: Clone>(
@@ -407,8 +419,14 @@ impl DbIterator {
     pub async fn seek<K: AsRef<[u8]>>(&mut self, next_key: K) -> Result<(), crate::Error> {
         let next_key = next_key.as_ref();
         if let Some(error) = self.invalidated_error.clone() {
-            Err(error.into())
-        } else if !self.range.contains(&next_key) {
+            return Err(error.into());
+        }
+        let validity = self
+            .snapshot_lease
+            .as_ref()
+            .map_or(Ok(()), |lease| lease.check());
+        self.maybe_invalidate(validity)?;
+        if !self.range.contains(&next_key) {
             Err(SlateDBError::SeekKeyOutOfRange {
                 key: next_key.to_vec(),
                 range: self.range.clone(),
@@ -421,7 +439,8 @@ impl DbIterator {
         {
             Err(SlateDBError::SeekKeyLessThanLastReturnedKey.into())
         } else {
-            let result = self.iter.seek(next_key).await;
+            let result =
+                SnapshotLease::protect(self.snapshot_lease.clone(), self.iter.seek(next_key)).await;
             self.maybe_invalidate(result).map_err(Into::into)
         }
     }
@@ -683,6 +702,7 @@ mod tests {
             None,
             IterationOrder::Ascending,
             ReadTrace::new(None),
+            None,
         )
         .await
         .unwrap();
@@ -724,6 +744,7 @@ mod tests {
             None,
             IterationOrder::Ascending,
             ReadTrace::new(None),
+            None,
         )
         .await
         .unwrap();
@@ -755,6 +776,7 @@ mod tests {
             None,
             IterationOrder::Ascending,
             ReadTrace::new(None),
+            None,
         )
         .await
         .unwrap();
@@ -805,6 +827,7 @@ mod tests {
             None,
             IterationOrder::Ascending,
             ReadTrace::new(None),
+            None,
         )
         .await
         .unwrap();

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -807,7 +807,13 @@ impl MessageHandler<DbReaderMessage> for ManifestPoller {
             Some(retention) => tokio::select! {
                 biased;
                 _ = retention.stopped.cancelled() => Ok(()),
-                result = self.poll() => result,
+                result = self.poll() => match result {
+                    // Close can invalidate a lease after select checked cancellation.
+                    // Only a recorded clean shutdown makes that Closed result expected.
+                    Err(SlateDBError::Closed)
+                        if matches!(self.inner.status_manager.result_reader().read(), Some(Ok(()))) => Ok(()),
+                    result => result,
+                },
             },
             None => self.poll().await,
         }
@@ -3963,6 +3969,136 @@ mod tests {
 
         db.close().await.unwrap();
     }
+
+    #[rstest]
+    #[case::clean_shutdown(true, true, None)]
+    #[case::wal_failure(
+        true,
+        false,
+        Some(SlateDBError::WalUnavailable(Arc::new(std::io::Error::other("probe failed"))))
+    )]
+    #[case::lease_failure(false, true, Some(SlateDBError::SnapshotLeaseLost { checkpoint_id: Uuid::nil(), manifest_id: 1 }))]
+    #[case::prior_lease_failure(true, true, Some(SlateDBError::SnapshotLeaseLost { checkpoint_id: Uuid::nil(), manifest_id: 1 }))]
+    #[case::unmarked_closed(false, true, Some(SlateDBError::Closed))]
+    #[tokio::test]
+    async fn managed_close_during_manifest_poll_preserves_task_result(
+        #[case] clean_shutdown: bool,
+        #[case] reestablish: bool,
+        #[case] expected_error: Option<SlateDBError>,
+    ) {
+        type ProbeAction = Box<dyn FnOnce() -> Result<u64, WalError> + Send>;
+        #[derive(Default)]
+        struct ProbeWalReader(parking_lot::Mutex<Option<ProbeAction>>);
+
+        #[async_trait::async_trait]
+        impl WalReaderTrait for ProbeWalReader {
+            async fn iterator(&self, _: WalFileRange) -> Result<Box<dyn WalIterator>, WalError> {
+                Ok(Box::new(EmptyTestWalIterator))
+            }
+
+            async fn last_wal_file_id(&self, _: u64) -> Result<u64, WalError> {
+                let action = self.0.lock().take();
+                action.map_or(Ok(0), |action| action())
+            }
+        }
+
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let provider = TestProvider::new(Path::from("close-during-manifest-poll"), store);
+        let manifest = StoredManifest::create_new_db(
+            provider.manifest_store(),
+            ManifestCore::new(),
+            provider.system_clock.clone(),
+        )
+        .await
+        .unwrap();
+        let wal_reader = Arc::new(ProbeWalReader::default());
+        let inner = Arc::new(
+            DbReaderInner::new(
+                provider.manifest_store(),
+                provider.table_store(),
+                provider.wal_store(),
+                Some(wal_reader.clone()),
+                DbReaderOptions::default(),
+                DbReaderMode::ManagedCheckpoint,
+                None,
+                None,
+                provider.system_clock.clone(),
+                provider.rand.clone(),
+                slatedb_common::metrics::MetricsRecorderHelper::noop(),
+                manifest,
+            )
+            .await
+            .unwrap(),
+        );
+        let task_executor = crate::dispatcher::MessageHandlerExecutor::new(
+            Arc::new(inner.status_manager.clone()),
+            provider.system_clock.clone(),
+        );
+        let reader = Arc::new(DbReader {
+            inner,
+            task_executor,
+        });
+        if reestablish {
+            let mut manifest =
+                StoredManifest::load(provider.manifest_store(), provider.system_clock.clone())
+                    .await
+                    .unwrap();
+            let mut dirty = manifest.prepare_dirty().unwrap();
+            dirty.value.core.last_l0_seq = 1;
+            manifest.update(dirty).await.unwrap();
+        }
+        *wal_reader.0.lock() = Some(Box::new({
+            let reader = reader.clone();
+            let error = expected_error.clone();
+            move || {
+                if clean_shutdown {
+                    if let Some(error) = error.as_ref().filter(|_| reestablish) {
+                        reader.inner.retention.as_ref().unwrap().stop(error.clone());
+                    }
+                    // Stop inside the poll branch, after select has already checked
+                    // its cancellation branch. The task cannot join itself yet.
+                    let mut close = Box::pin(reader.close());
+                    let mut context =
+                        std::task::Context::from_waker(futures::task::noop_waker_ref());
+                    assert!(std::future::Future::poll(close.as_mut(), &mut context).is_pending());
+                } else {
+                    reader
+                        .inner
+                        .retention
+                        .as_ref()
+                        .unwrap()
+                        .stop(error.clone().unwrap());
+                }
+                if reestablish {
+                    Ok(0)
+                } else {
+                    Err(error.unwrap().into())
+                }
+            }
+        }));
+        reader
+            .inner
+            .spawn_manifest_poller(&reader.task_executor)
+            .unwrap();
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            reader.task_executor.join_task(super::DB_READER_TASK_NAME),
+        )
+        .await
+        .unwrap();
+        assert!(wal_reader.0.lock().is_none());
+        match expected_error {
+            Some(error) => {
+                assert_eq!(result.unwrap_err().to_string(), error.to_string());
+                assert!(reader.close().await.is_err());
+            }
+            None => {
+                result.unwrap();
+                reader.close().await.unwrap();
+            }
+        }
+    }
+
     async fn gated_managed_reader() -> (
         DbReader,
         Arc<test_utils::GatedObjectStore>,

--- a/slatedb/src/db_reader.rs
+++ b/slatedb/src/db_reader.rs
@@ -1,10 +1,11 @@
+use crate::snapshot_lease::{SnapshotLease, SnapshotLeaseManager, SNAPSHOT_LEASE_TASK_NAME};
 use crate::wal::slatedb::reader::SlateDbWalReaderOptions;
 use {
     crate::{
         bytes_range::{ByteRangeBounds, BytesRange},
         cached_object_store::CachedObjectStore,
         clock::MonotonicClock,
-        config::{CheckpointOptions, DbReaderOptions, ReadOptions, ScanOptions},
+        config::{DbReaderOptions, ReadOptions, ScanOptions},
         db_cache::CacheTarget,
         db_cache_manager,
         db_common::extract_segment_prefix,
@@ -40,7 +41,6 @@ use {
     slatedb_common::{clock::SystemClock, DbRand},
     std::{
         collections::{BTreeSet, VecDeque},
-        ops::Sub,
         sync::{Arc, LazyLock},
     },
     tokio::runtime::Handle,
@@ -57,6 +57,11 @@ pub enum DbReaderMode {
     /// The reader will automatically create a checkpoint and refresh it periodically to ensure
     /// that the reader can continue to read the latest database state without being affected by
     /// garbage collection.
+    ///
+    /// Existing scans retain their original checkpoint until release or reader close.
+    /// Reads fail if protection expires or its checkpoint disappears.
+    /// Initial construction must finish before the first lease deadline.
+    /// Managed expiration rounds upward to whole seconds in the manifest.
     #[default]
     ManagedCheckpoint,
 
@@ -120,6 +125,7 @@ struct DbReaderInner {
     options: DbReaderOptions,
     mode: DbReaderMode,
     state: RwLock<Arc<ReaderState>>,
+    retention: Option<Arc<SnapshotLeaseManager>>,
     system_clock: Arc<dyn SystemClock>,
     oracle: Arc<DbReaderOracle>,
     reader: Reader,
@@ -140,8 +146,8 @@ enum DbReaderMessage {
 
 #[derive(Clone)]
 struct ReaderState {
+    snapshot_lease: Option<Arc<SnapshotLease>>,
     manifest_id: u64,
-    checkpoint: Option<Checkpoint>,
     manifest: Manifest,
     imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
     last_wal_id: u64,
@@ -151,6 +157,9 @@ struct ReaderState {
 static EMPTY_TABLE: LazyLock<Arc<KVTable>> = LazyLock::new(|| Arc::new(KVTable::new()));
 
 impl DbStateReader for ReaderState {
+    fn snapshot_lease(&self) -> Option<Arc<SnapshotLease>> {
+        self.snapshot_lease.clone()
+    }
     fn memtable(&self) -> Arc<KVTable> {
         Arc::clone(&EMPTY_TABLE)
     }
@@ -185,12 +194,32 @@ impl DbReaderInner {
         recorder: slatedb_common::metrics::MetricsRecorderHelper,
         mut manifest: StoredManifest,
     ) -> Result<Self, SlateDBError> {
-        let checkpoint =
-            Self::get_or_create_checkpoint(&mut manifest, mode, &options, rand.clone()).await?;
+        let retention = (mode == DbReaderMode::ManagedCheckpoint).then(|| {
+            SnapshotLeaseManager::new(
+                manifest_store.clone(),
+                system_clock.clone(),
+                options.checkpoint_lifetime,
+            )
+        });
+        let snapshot_lease = match &retention {
+            Some(retention) => {
+                let id = rand.rng().gen_uuid();
+                Some(retention.create(&mut manifest, id).await?)
+            }
+            None => None,
+        };
+        let checkpoint = match &snapshot_lease {
+            Some(lease) => Some(lease.checkpoint()),
+            None => Self::get_checkpoint(&manifest, mode)?,
+        };
         let (manifest_id, initial_manifest) = if let Some(checkpoint) = checkpoint.as_ref() {
             (
                 checkpoint.manifest_id,
-                manifest_store.read_manifest(checkpoint.manifest_id).await?,
+                SnapshotLease::protect(
+                    snapshot_lease.clone(),
+                    manifest_store.read_manifest(checkpoint.manifest_id),
+                )
+                .await?,
             )
         } else {
             (manifest.id(), manifest.manifest().clone())
@@ -215,16 +244,19 @@ impl DbReaderInner {
         });
 
         let initial_state = Arc::new(
-            Self::build_reader_state(
-                checkpoint,
-                manifest_id,
-                initial_manifest,
-                VecDeque::new(),
-                WalReplayEnd::for_reader(mode, &options),
-                Arc::clone(&table_store),
-                wal_reader.as_ref(),
-                &options,
-                segment_extractor.as_ref(),
+            SnapshotLease::protect(
+                snapshot_lease.clone(),
+                Self::build_reader_state(
+                    snapshot_lease.clone(),
+                    manifest_id,
+                    initial_manifest,
+                    VecDeque::new(),
+                    WalReplayEnd::for_reader(mode, &options),
+                    Arc::clone(&table_store),
+                    wal_reader.as_ref(),
+                    &options,
+                    segment_extractor.as_ref(),
+                ),
             )
             .await?,
         );
@@ -269,6 +301,7 @@ impl DbReaderInner {
             options,
             mode,
             state,
+            retention,
             system_clock,
             oracle,
             reader,
@@ -280,33 +313,22 @@ impl DbReaderInner {
         Ok(inner)
     }
 
-    async fn get_or_create_checkpoint(
-        manifest: &mut StoredManifest,
+    fn get_checkpoint(
+        manifest: &StoredManifest,
         mode: DbReaderMode,
-        options: &DbReaderOptions,
-        rand: Arc<DbRand>,
     ) -> Result<Option<Checkpoint>, SlateDBError> {
         match mode {
-            DbReaderMode::Checkpoint(checkpoint_id) => Ok(Some(
+            DbReaderMode::Checkpoint(id) => Ok(Some(
                 manifest
                     .db_state()
-                    .find_checkpoint(checkpoint_id)
-                    .ok_or(SlateDBError::CheckpointMissing(checkpoint_id))?
+                    .find_checkpoint(id)
+                    .ok_or(SlateDBError::CheckpointMissing(id))?
                     .clone(),
             )),
-            DbReaderMode::ManagedCheckpoint => {
-                let checkpoint_options = CheckpointOptions {
-                    lifetime: Some(options.checkpoint_lifetime),
-                    ..CheckpointOptions::default()
-                };
-                let checkpoint_id = rand.rng().gen_uuid();
-                Ok(Some(
-                    manifest
-                        .write_checkpoint(checkpoint_id, &checkpoint_options)
-                        .await?,
-                ))
-            }
             DbReaderMode::FollowLatest => Ok(None),
+            DbReaderMode::ManagedCheckpoint => {
+                unreachable!("managed checkpoint creation uses a lease")
+            }
         }
     }
 
@@ -368,29 +390,22 @@ impl DbReaderInner {
             || latest.segments != current_state.segments
     }
 
-    async fn replace_checkpoint(
+    async fn reestablish_checkpoint(
         &self,
         stored_manifest: &mut StoredManifest,
-    ) -> Result<Checkpoint, SlateDBError> {
-        let current_checkpoint_id = self
-            .state
-            .read()
-            .checkpoint
+    ) -> Result<(), SlateDBError> {
+        let id = self.rand.rng().gen_uuid();
+        let lease = self
+            .retention
             .as_ref()
-            .expect("managed reader must have a checkpoint")
-            .id;
-        let options = CheckpointOptions {
-            lifetime: Some(self.options.checkpoint_lifetime),
-            ..CheckpointOptions::default()
-        };
-        let new_checkpoint_id = self.rand.rng().gen_uuid();
-        stored_manifest
-            .replace_checkpoint(current_checkpoint_id, new_checkpoint_id, &options)
-            .await
-    }
-
-    async fn reestablish_checkpoint(&self, checkpoint: Checkpoint) -> Result<(), SlateDBError> {
-        let new_state = self.rebuild_checkpoint_state(checkpoint).await?;
+            .expect("managed lease manager")
+            .create(stored_manifest, id)
+            .await?;
+        let new_state = SnapshotLease::protect(
+            Some(lease.clone()),
+            self.rebuild_checkpoint_state(lease.checkpoint(), Some(lease.clone())),
+        )
+        .await?;
         self.install_state(new_state);
         Ok(())
     }
@@ -428,8 +443,8 @@ impl DbReaderInner {
             self.oracle.advance_durable_seq(last_committed_seq);
             let mut write_guard = self.state.write();
             *write_guard = Arc::new(ReaderState {
+                snapshot_lease: current_state.snapshot_lease.clone(),
                 manifest_id: current_state.manifest_id,
-                checkpoint: current_state.checkpoint.clone(),
                 manifest: current_state.manifest.clone(),
                 imm_memtable,
                 last_wal_id,
@@ -445,16 +460,17 @@ impl DbReaderInner {
     async fn rebuild_checkpoint_state(
         &self,
         new_checkpoint: Checkpoint,
+        snapshot_lease: Option<Arc<SnapshotLease>>,
     ) -> Result<ReaderState, SlateDBError> {
         let manifest_id = new_checkpoint.manifest_id;
         let manifest = self.manifest_store.read_manifest(manifest_id).await?;
-        self.rebuild_state(Some(new_checkpoint), manifest_id, manifest)
+        self.rebuild_state(snapshot_lease, manifest_id, manifest)
             .await
     }
 
     async fn rebuild_state(
         &self,
-        checkpoint: Option<Checkpoint>,
+        snapshot_lease: Option<Arc<SnapshotLease>>,
         manifest_id: u64,
         manifest: Manifest,
     ) -> Result<ReaderState, SlateDBError> {
@@ -486,7 +502,7 @@ impl DbReaderInner {
         }
 
         Self::build_reader_state(
-            checkpoint,
+            snapshot_lease,
             manifest_id,
             manifest,
             imm_memtable,
@@ -500,7 +516,7 @@ impl DbReaderInner {
     }
 
     async fn build_reader_state(
-        checkpoint: Option<Checkpoint>,
+        snapshot_lease: Option<Arc<SnapshotLease>>,
         manifest_id: u64,
         manifest: Manifest,
         mut imm_memtable: VecDeque<Arc<ImmutableMemtable>>,
@@ -529,8 +545,8 @@ impl DbReaderInner {
         };
 
         Ok(ReaderState {
+            snapshot_lease,
             manifest_id,
-            checkpoint,
             manifest,
             imm_memtable,
             last_wal_id,
@@ -560,72 +576,6 @@ impl DbReaderInner {
         Ok(())
     }
 
-    async fn maybe_refresh_checkpoint(
-        &self,
-        stored_manifest: &mut StoredManifest,
-    ) -> Result<(), SlateDBError> {
-        let checkpoint = self
-            .state
-            .read()
-            .checkpoint
-            .clone()
-            .expect("managed reader must have a checkpoint");
-        let half_lifetime = self
-            .options
-            .checkpoint_lifetime
-            .checked_div(2)
-            .expect("Failed to divide checkpoint lifetime");
-        let refresh_deadline = checkpoint
-            .expire_time
-            .expect("Expected checkpoint expiration time to be set")
-            .sub(half_lifetime);
-        if self.system_clock.now() > refresh_deadline {
-            let refreshed_checkpoint = match stored_manifest
-                .refresh_checkpoint(checkpoint.id, self.options.checkpoint_lifetime)
-                .await
-            {
-                Ok(refreshed_checkpoint) => refreshed_checkpoint,
-                Err(SlateDBError::CheckpointMissing(id)) => {
-                    // Our self-established checkpoint lapsed (e.g. a stalled poll tick
-                    // outlived the lease during an object-store outage) and the writer's
-                    // GC reaped it. Re-establish a fresh checkpoint against the latest
-                    // manifest instead of failing the reader permanently.
-                    warn!("reader checkpoint missing, re-establishing [checkpoint_id={id}]");
-                    let checkpoint = self.replace_checkpoint(stored_manifest).await?;
-                    self.reestablish_checkpoint(checkpoint).await?;
-                    return Ok(());
-                }
-                Err(e) => return Err(e),
-            };
-
-            // Update our local checkpoint copy so we know the latest expiration time
-            // and can calculate future refresh deadlines correctly.
-            {
-                let mut write_guard = self.state.write();
-                let current_state = write_guard.as_ref();
-                // Defensively, only update checkpoint if the id and expiry still match.
-                if current_state
-                    .checkpoint
-                    .as_ref()
-                    .is_some_and(|current_checkpoint| {
-                        current_checkpoint.id == checkpoint.id
-                            && current_checkpoint.expire_time == checkpoint.expire_time
-                    })
-                {
-                    let mut updated_state = current_state.clone();
-                    updated_state.checkpoint = Some(refreshed_checkpoint.clone());
-                    *write_guard = Arc::new(updated_state);
-                }
-            }
-
-            info!(
-                "refreshed checkpoint [checkpoint_id={}, expire_time={:?}]",
-                checkpoint.id, refreshed_checkpoint.expire_time
-            )
-        }
-        Ok(())
-    }
-
     fn spawn_manifest_poller(
         self: &Arc<Self>,
         task_executor: &MessageHandlerExecutor,
@@ -634,6 +584,9 @@ impl DbReaderInner {
             inner: Arc::clone(self),
         };
         let (_tx, rx) = async_channel::unbounded();
+        if let Some(retention) = &self.retention {
+            retention.spawn(task_executor)?;
+        }
         let result = task_executor.add_handler(
             DB_READER_TASK_NAME.to_string(),
             Box::new(poller),
@@ -789,17 +742,8 @@ struct ManifestPoller {
     inner: Arc<DbReaderInner>,
 }
 
-#[async_trait]
-impl MessageHandler<DbReaderMessage> for ManifestPoller {
-    fn tickers(&mut self) -> Vec<MessageTickerDef<DbReaderMessage>> {
-        vec![MessageTickerDef::new(
-            self.inner.options.manifest_poll_interval,
-            Box::new(|| DbReaderMessage::PollManifest),
-        )]
-    }
-
-    async fn handle(&mut self, message: DbReaderMessage) -> Result<(), SlateDBError> {
-        assert!(matches!(message, DbReaderMessage::PollManifest));
+impl ManifestPoller {
+    async fn poll(&self) -> Result<(), SlateDBError> {
         match self.inner.mode {
             DbReaderMode::ManagedCheckpoint => {
                 let mut manifest = StoredManifest::load(
@@ -809,17 +753,31 @@ impl MessageHandler<DbReaderMessage> for ManifestPoller {
                 .await?;
 
                 let latest_manifest = manifest.manifest();
-                if self
+                let lease = self
                     .inner
-                    .should_reestablish_checkpoint(&latest_manifest.core)
+                    .state
+                    .read()
+                    .snapshot_lease
+                    .clone()
+                    .expect("managed snapshot lease");
+                if latest_manifest
+                    .core
+                    .find_checkpoint(lease.checkpoint().id)
+                    .is_none()
                 {
-                    let checkpoint = self.inner.replace_checkpoint(&mut manifest).await?;
-                    self.inner.reestablish_checkpoint(checkpoint).await?;
+                    lease.invalidate_missing();
+                }
+                if lease.check().is_err()
+                    || self
+                        .inner
+                        .should_reestablish_checkpoint(&latest_manifest.core)
+                {
+                    self.inner.reestablish_checkpoint(&mut manifest).await?;
                 } else {
                     self.inner.maybe_replay_new_wals().await?;
                 }
 
-                self.inner.maybe_refresh_checkpoint(&mut manifest).await
+                Ok(())
             }
             DbReaderMode::FollowLatest => {
                 let result = self.inner.refresh_latest_manifest().await;
@@ -832,33 +790,37 @@ impl MessageHandler<DbReaderMessage> for ManifestPoller {
             DbReaderMode::Checkpoint(_) => Ok(()),
         }
     }
+}
+
+#[async_trait]
+impl MessageHandler<DbReaderMessage> for ManifestPoller {
+    fn tickers(&mut self) -> Vec<MessageTickerDef<DbReaderMessage>> {
+        vec![MessageTickerDef::new(
+            self.inner.options.manifest_poll_interval,
+            Box::new(|| DbReaderMessage::PollManifest),
+        )]
+    }
+
+    async fn handle(&mut self, message: DbReaderMessage) -> Result<(), SlateDBError> {
+        assert!(matches!(message, DbReaderMessage::PollManifest));
+        match &self.inner.retention {
+            Some(retention) => tokio::select! {
+                biased;
+                _ = retention.stopped.cancelled() => Ok(()),
+                result = self.poll() => result,
+            },
+            None => self.poll().await,
+        }
+    }
 
     async fn cleanup(
         &mut self,
-        _messages: BoxStream<'async_trait, DbReaderMessage>,
-        _result: Result<(), SlateDBError>,
+        _: BoxStream<'async_trait, DbReaderMessage>,
+        result: Result<(), SlateDBError>,
     ) -> Result<(), SlateDBError> {
-        if self.inner.mode != DbReaderMode::ManagedCheckpoint {
-            return Ok(());
+        if let Some(retention) = &self.inner.retention {
+            retention.stop(result.err().unwrap_or(SlateDBError::Closed));
         }
-        let mut manifest = StoredManifest::load(
-            Arc::clone(&self.inner.manifest_store),
-            self.inner.system_clock.clone(),
-        )
-        .await?;
-        let checkpoint_id = self
-            .inner
-            .state
-            .read()
-            .checkpoint
-            .as_ref()
-            .expect("managed reader must have a checkpoint")
-            .id;
-        info!(
-            "deleting reader established checkpoint for shutdown [checkpoint_id={}]",
-            checkpoint_id
-        );
-        manifest.delete_checkpoint(checkpoint_id).await?;
         Ok(())
     }
 }
@@ -1339,6 +1301,8 @@ impl DbReader {
 
     /// Close the database reader.
     ///
+    /// Closing invalidates managed scans and cancels their pending storage tasks.
+    ///
     /// ## Returns
     /// - `Result<(), Error>`: if there was an error closing the reader
     ///
@@ -1371,16 +1335,32 @@ impl DbReader {
     /// }
     /// ```
     pub async fn close(&self) -> Result<(), crate::Error> {
-        self.task_executor
-            .shutdown_task(DB_READER_TASK_NAME)
-            .await
-            .map_err(Into::<crate::Error>::into)?;
+        self.inner.status_manager.write_result(Ok(()));
+        if let Some(retention) = &self.inner.retention {
+            retention.stop(SlateDBError::Closed);
+        }
+        self.task_executor.cancel_task(DB_READER_TASK_NAME);
+        self.task_executor.cancel_task(SNAPSHOT_LEASE_TASK_NAME);
+        let poller_result = self.task_executor.join_task(DB_READER_TASK_NAME).await;
+        let retention_result = self.task_executor.join_task(SNAPSHOT_LEASE_TASK_NAME).await;
 
         if let Err(e) = self.inner.table_store.close_cache().await {
             warn!("failed to close block cache [error={:?}]", e);
         }
 
+        poller_result?;
+        retention_result?;
         Ok(())
+    }
+}
+
+impl Drop for DbReader {
+    fn drop(&mut self) {
+        if let Some(retention) = &self.inner.retention {
+            retention.stop(SlateDBError::Closed);
+        }
+        self.task_executor.cancel_task(DB_READER_TASK_NAME);
+        self.task_executor.cancel_task(SNAPSHOT_LEASE_TASK_NAME);
     }
 }
 
@@ -2235,7 +2215,7 @@ mod tests {
         let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
 
         // Build DbReaderInner directly instead of DbReader so no spawned poller
-        // can race the manual calls to maybe_refresh_checkpoint below.
+        // can race the manual maintenance calls.
         let inner = DbReaderInner::new(
             Arc::clone(&manifest_store),
             table_store,
@@ -2270,29 +2250,15 @@ mod tests {
         // at t=0 with a 1000ms lifetime, so checkpoint_lifetime / 2 is 500ms.
         // This refresh is expected and should write exactly one new manifest.
         clock.advance(Duration::from_millis(501)).await;
-        let mut stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
-            .await
-            .unwrap();
-        inner
-            .maybe_refresh_checkpoint(&mut stored_manifest)
-            .await
-            .unwrap();
+        inner.retention.as_ref().unwrap().maintain().await.unwrap();
 
         let manifests_after_first_refresh = manifest_store.list_manifests(..).await.unwrap();
         assert_eq!(3, manifests_after_first_refresh.len());
 
-        // Simulate the next manifest poll 100ms later. Because the first
-        // refresh extended the checkpoint lifetime to t=1501ms, the next
-        // refresh deadline should be t=1001ms. A second manifest here shows
-        // the in-memory checkpoint expiry was not updated after the refresh.
+        // The renewed expiration rounds up to 2000ms in durable storage.
+        // Its next renewal starts at 1500ms, so this poll must not write.
         clock.advance(Duration::from_millis(100)).await;
-        let mut stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
-            .await
-            .unwrap();
-        inner
-            .maybe_refresh_checkpoint(&mut stored_manifest)
-            .await
-            .unwrap();
+        inner.retention.as_ref().unwrap().maintain().await.unwrap();
 
         // Correct behavior keeps the manifest count at 3.
         let manifests_after_second_poll = manifest_store.list_manifests(..).await.unwrap();
@@ -2332,7 +2298,7 @@ mod tests {
         let recorder = slatedb_common::metrics::MetricsRecorderHelper::noop();
 
         // Build DbReaderInner directly so no spawned poller can race the
-        // manual call to maybe_refresh_checkpoint below.
+        // manual maintenance call.
         let inner = DbReaderInner::new(
             Arc::clone(&manifest_store),
             table_store,
@@ -2353,7 +2319,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let reader_checkpoint_id = inner.state.read().checkpoint.as_ref().unwrap().id;
+        let reader_checkpoint_id = inner
+            .state
+            .read()
+            .snapshot_lease
+            .as_ref()
+            .unwrap()
+            .checkpoint()
+            .id;
 
         // Simulate the writer's GC reaping the expired checkpoint.
         let mut stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
@@ -2366,16 +2339,24 @@ mod tests {
 
         // Move past the refresh deadline (checkpoint_lifetime / 2) and poll.
         clock.advance(Duration::from_millis(501)).await;
-        let mut stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
-            .await
-            .unwrap();
-        inner
-            .maybe_refresh_checkpoint(&mut stored_manifest)
-            .await
-            .unwrap();
+        inner.retention.as_ref().unwrap().maintain().await.unwrap();
 
         // The reader should have replaced the reaped checkpoint with a new one.
-        let new_checkpoint_id = inner.state.read().checkpoint.as_ref().unwrap().id;
+        let inner = Arc::new(inner);
+        ManifestPoller {
+            inner: inner.clone(),
+        }
+        .handle(DbReaderMessage::PollManifest)
+        .await
+        .unwrap();
+        let new_checkpoint_id = inner
+            .state
+            .read()
+            .snapshot_lease
+            .as_ref()
+            .unwrap()
+            .checkpoint()
+            .id;
         assert_ne!(reader_checkpoint_id, new_checkpoint_id);
         let latest_manifest = manifest_store.read_latest_manifest().await.unwrap();
         let checkpoints = &latest_manifest.manifest.core.checkpoints;
@@ -3332,11 +3313,8 @@ mod tests {
         // Seed the prior checkpoint state with IMMs.
         let input_tables: Vec<_> = case.tables.iter().map(InputMemtable::build).collect();
         let prior_state = ReaderState {
+            snapshot_lease: None,
             manifest_id: stored_manifest.id(),
-            checkpoint: Some(test_checkpoint(
-                stored_manifest.id(),
-                test_provider.system_clock.clone(),
-            )),
             manifest: stored_manifest.manifest().clone(),
             imm_memtable: input_tables.iter().cloned().collect(),
             last_wal_id: 0,
@@ -3385,6 +3363,7 @@ mod tests {
             },
             mode: DbReaderMode::ManagedCheckpoint,
             state: parking_lot::RwLock::new(Arc::new(prior_state)),
+            retention: None,
             system_clock: test_provider.system_clock.clone(),
             oracle,
             reader,
@@ -3395,10 +3374,10 @@ mod tests {
         };
 
         let rebuilt_state = inner
-            .rebuild_checkpoint_state(test_checkpoint(
-                new_manifest_id,
-                test_provider.system_clock.clone(),
-            ))
+            .rebuild_checkpoint_state(
+                test_checkpoint(new_manifest_id, test_provider.system_clock.clone()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -3441,8 +3420,8 @@ mod tests {
         let status_manager = status_manager_for_core(current_core);
 
         let prior_state = ReaderState {
+            snapshot_lease: None,
             manifest_id: 1,
-            checkpoint: Some(test_checkpoint(1, test_provider.system_clock.clone())),
             manifest: Manifest::initial(current_core.clone()),
             imm_memtable: VecDeque::from([immutable_memtable(
                 1,
@@ -3472,6 +3451,7 @@ mod tests {
             options: DbReaderOptions::default(),
             mode: DbReaderMode::ManagedCheckpoint,
             state: parking_lot::RwLock::new(Arc::new(prior_state)),
+            retention: None,
             system_clock: test_provider.system_clock.clone(),
             oracle,
             reader,
@@ -3731,7 +3711,7 @@ mod tests {
     async fn db_reader_get_returns_correct_merge_result_after_reestablish_from_l0() {
         let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let path = Path::from("/tmp/test_db_reader_merge_reestablish_from_l0");
-        let clock = Arc::new(MockSystemClock::new());
+        let clock = Arc::new(DefaultSystemClock::new());
 
         let mut test_provider = TestProvider::new(path.clone(), Arc::clone(&object_store));
         test_provider.system_clock = clock.clone();
@@ -3802,9 +3782,6 @@ mod tests {
             "reader should have replayed WAL data into immutable memtables"
         );
 
-        // Let the reader's immediate first ticker fire and settle before phase B.
-        tokio::task::yield_now().await;
-
         // Phase B: write newer merge operands and flush the writer memtable to L0.
         db.merge_with_options(
             key,
@@ -3857,15 +3834,13 @@ mod tests {
             if reader.inner.state.read().manifest.core.tree.l0.len() == 1 {
                 break;
             }
-            // The reader poller may observe the pre-flush manifest on one tick and
-            // only see the new L0 on a later poll. Keep advancing the mock clock
-            // until the reader reestablishes from the updated manifest.
-            clock.advance(Duration::from_millis(100)).await;
+            // Wait for the background poller without advancing lease time faster
+            // than its checkpoint operations can complete.
             assert!(
                 start.elapsed() < timeout,
                 "timed out waiting for reader to reestablish from the new manifest"
             );
-            tokio::task::yield_now().await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         // Correct behavior: the reader should return the full merged value after reestablish.
@@ -3988,4 +3963,530 @@ mod tests {
 
         db.close().await.unwrap();
     }
+    async fn gated_managed_reader() -> (
+        DbReader,
+        Arc<test_utils::GatedObjectStore>,
+        Arc<MockSystemClock>,
+    ) {
+        gated_managed_reader_with_cache(None).await
+    }
+
+    async fn gated_managed_reader_with_cache(
+        cache: Option<Arc<dyn crate::db_cache::DbCache>>,
+    ) -> (
+        DbReader,
+        Arc<test_utils::GatedObjectStore>,
+        Arc<MockSystemClock>,
+    ) {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let clock = Arc::new(MockSystemClock::new());
+        let mut provider = TestProvider::new(Path::from("managed-reader-lifecycle"), store.clone());
+        provider.system_clock = clock.clone();
+        let tables = provider.table_store();
+        let mut builder = tables.table_builder();
+        for index in 0..128 {
+            builder
+                .add(RowEntry::new_value(
+                    format!("key-{index:03}").as_bytes(),
+                    &[b'x'; 512],
+                    1,
+                ))
+                .await
+                .unwrap();
+        }
+        let table = builder.build().await.unwrap();
+        let table = tables
+            .write_sst(
+                &crate::db_state::SsTableId::new(ulid::Ulid::new()),
+                &table,
+                Some(Bytes::new()),
+            )
+            .await
+            .unwrap();
+        let mut core = ManifestCore::new();
+        Arc::make_mut(&mut core.tree)
+            .l0
+            .push_back(crate::db_state::SsTableView::identity(table));
+        core.last_l0_seq = 1;
+        StoredManifest::create_new_db(provider.manifest_store(), core, clock.clone())
+            .await
+            .unwrap();
+        let gated = Arc::new(test_utils::GatedObjectStore::new(store));
+        let gated_provider = TestProvider::new(provider.path.clone(), gated.clone());
+        let reader = DbReader::open_internal(
+            provider.manifest_store(),
+            Arc::new(TableStore::new(
+                gated.clone(),
+                SsTableFormat::default(),
+                gated_provider.path,
+                cache,
+                TableStoreKind::Reader,
+                BlockCachePolicy::default(),
+            )),
+            provider.wal_store(),
+            DbReaderMode::ManagedCheckpoint,
+            None,
+            None,
+            None,
+            DbReaderOptions {
+                skip_wal_replay: true,
+                checkpoint_lifetime: Duration::from_secs(60),
+                manifest_poll_interval: Duration::from_secs(1),
+                ..DbReaderOptions::default()
+            },
+            clock.clone(),
+            provider.rand.clone(),
+            slatedb_common::metrics::MetricsRecorderHelper::noop(),
+        )
+        .await
+        .unwrap();
+        (reader, gated, clock)
+    }
+
+    #[rstest]
+    #[case::uncached(None)]
+    #[cfg_attr(
+        feature = "foyer",
+        case::foyer(Some(Arc::new(crate::db_cache::foyer::FoyerCache::new()) as Arc<dyn crate::db_cache::DbCache>))
+    )]
+    #[tokio::test]
+    async fn managed_close_completes_with_a_retained_pending_next(
+        #[case] cache: Option<Arc<dyn crate::db_cache::DbCache>>,
+    ) {
+        let (reader, gated, _) = gated_managed_reader_with_cache(cache).await;
+        let mut scan = reader
+            .scan_with_options(
+                ..,
+                &crate::config::ScanOptions {
+                    cache_blocks: true,
+                    max_fetch_tasks: 1,
+                    read_ahead_bytes: 1,
+                    ..crate::config::ScanOptions::default()
+                },
+            )
+            .await
+            .unwrap();
+        let arrivals = gated.get_opts_gate.arrivals();
+        gated.get_opts_gate.close();
+        let retained = async {
+            while scan.next().await?.is_some() {}
+            Ok::<_, crate::Error>(())
+        };
+        tokio::pin!(retained);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while gated.get_opts_gate.arrivals() == arrivals {
+                assert!(futures::poll!(&mut retained).is_pending());
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(futures::poll!(&mut retained).is_pending());
+        tokio::time::timeout(Duration::from_secs(1), reader.close())
+            .await
+            .unwrap()
+            .unwrap();
+        let arrivals_after_close = gated.get_opts_gate.arrivals();
+        assert!(retained.await.unwrap_err().to_string().contains("closed"));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while gated.get_opts_gate.active_calls() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        gated.get_opts_gate.release();
+        tokio::task::yield_now().await;
+        assert_eq!(arrivals_after_close, gated.get_opts_gate.arrivals());
+        assert!(reader
+            .inner
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core
+            .checkpoints
+            .is_empty());
+    }
+
+    #[rstest]
+    #[case::completed(false)]
+    #[case::cancelled(true)]
+    #[tokio::test]
+    async fn managed_scan_constructor_retains_the_acquired_generation_during_refresh(
+        #[case] cancel: bool,
+    ) {
+        let (reader, gated, clock) = gated_managed_reader().await;
+        let old_id = reader
+            .inner
+            .state
+            .read()
+            .snapshot_lease
+            .as_ref()
+            .unwrap()
+            .checkpoint()
+            .id;
+        gated.get_opts_gate.close();
+        let mut scan = Box::pin(reader.scan(..));
+        assert!(futures::poll!(&mut scan).is_pending());
+        let mut manifest = StoredManifest::load(reader.inner.manifest_store.clone(), clock)
+            .await
+            .unwrap();
+        let mut dirty = manifest.prepare_dirty().unwrap();
+        dirty.value.core.last_l0_seq = 2;
+        manifest.update(dirty).await.unwrap();
+        ManifestPoller {
+            inner: reader.inner.clone(),
+        }
+        .handle(DbReaderMessage::PollManifest)
+        .await
+        .unwrap();
+        reader
+            .inner
+            .retention
+            .as_ref()
+            .unwrap()
+            .maintain()
+            .await
+            .unwrap();
+        let latest = reader
+            .inner
+            .manifest_store
+            .read_latest_manifest()
+            .await
+            .unwrap();
+        assert!(latest.manifest.core.find_checkpoint(old_id).is_some());
+        assert_ne!(
+            old_id,
+            reader
+                .inner
+                .state
+                .read()
+                .snapshot_lease
+                .as_ref()
+                .unwrap()
+                .checkpoint()
+                .id
+        );
+        if cancel {
+            drop(scan);
+            gated.get_opts_gate.release();
+        } else {
+            gated.get_opts_gate.release();
+            let mut scan = scan.await.unwrap();
+            assert_eq!(
+                scan.next().await.unwrap().unwrap().key,
+                Bytes::from_static(b"key-000")
+            );
+        }
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                reader
+                    .inner
+                    .retention
+                    .as_ref()
+                    .unwrap()
+                    .maintain()
+                    .await
+                    .unwrap();
+                let latest = reader
+                    .inner
+                    .manifest_store
+                    .read_latest_manifest()
+                    .await
+                    .unwrap();
+                if latest.manifest.core.find_checkpoint(old_id).is_none() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        reader.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn managed_reader_drop_invalidates_scans_and_retires_checkpoints() {
+        let (reader, _, _) = gated_managed_reader().await;
+        let store = reader.inner.manifest_store.clone();
+        let weak = Arc::downgrade(&reader.inner);
+        let mut scan = reader.scan(..).await.unwrap();
+        drop(reader);
+        assert!(scan
+            .next()
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("closed"));
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+            while !store
+                .read_latest_manifest()
+                .await
+                .unwrap()
+                .manifest
+                .core
+                .checkpoints
+                .is_empty()
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+    #[tokio::test]
+    async fn managed_seek_invalidation_stops_storage_and_remains_terminal() {
+        let (reader, gated, _) = gated_managed_reader().await;
+        let mut scan = reader
+            .scan_with_options(
+                ..,
+                &crate::config::ScanOptions {
+                    cache_blocks: false,
+                    max_fetch_tasks: 1,
+                    read_ahead_bytes: 1,
+                    ..crate::config::ScanOptions::default()
+                },
+            )
+            .await
+            .unwrap();
+        let mut argument_scan = reader.scan("key-000".."key-128").await.unwrap();
+        assert!(argument_scan.seek(b"zzz").await.is_err());
+        assert!(argument_scan.next().await.unwrap().is_some());
+        gated.get_opts_gate.close();
+        let error = {
+            let seek = scan.seek(b"key-120");
+            tokio::pin!(seek);
+            assert!(futures::poll!(&mut seek).is_pending());
+            reader
+                .inner
+                .state
+                .read()
+                .snapshot_lease
+                .as_ref()
+                .unwrap()
+                .invalidate_missing();
+            seek.await.unwrap_err().to_string()
+        };
+        assert_eq!(
+            argument_scan.seek(b"zzz").await.unwrap_err().to_string(),
+            error
+        );
+        let arrivals = gated.get_opts_gate.arrivals();
+        gated.get_opts_gate.release();
+        assert_eq!(scan.next().await.unwrap_err().to_string(), error);
+        assert_eq!(scan.seek(b"key-121").await.unwrap_err().to_string(), error);
+        tokio::task::yield_now().await;
+        assert_eq!(gated.get_opts_gate.arrivals(), arrivals);
+        reader.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn managed_wal_state_copies_share_renewed_expiration() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let clock = Arc::new(MockSystemClock::new());
+        let mut provider = TestProvider::new(Path::from("managed-wal-generation"), store);
+        provider.system_clock = clock.clone();
+        let manifest = StoredManifest::create_new_db(
+            provider.manifest_store(),
+            ManifestCore::new(),
+            clock.clone(),
+        )
+        .await
+        .unwrap();
+        let inner = DbReaderInner::new(
+            provider.manifest_store(),
+            provider.table_store(),
+            provider.wal_store(),
+            None,
+            DbReaderOptions {
+                checkpoint_lifetime: Duration::from_secs(1),
+                ..DbReaderOptions::default()
+            },
+            DbReaderMode::ManagedCheckpoint,
+            None,
+            None,
+            clock.clone(),
+            provider.rand.clone(),
+            slatedb_common::metrics::MetricsRecorderHelper::noop(),
+            manifest,
+        )
+        .await
+        .unwrap();
+        let before = inner.state.read().clone();
+        write_wal_sst(
+            provider.wal_store(),
+            1,
+            vec![RowEntry::new_value(b"new-key", b"new-value", 1)],
+        )
+        .await
+        .unwrap();
+        inner.maybe_replay_new_wals().await.unwrap();
+        let after = inner.state.read().clone();
+        assert!(!Arc::ptr_eq(&before, &after));
+        assert!(Arc::ptr_eq(
+            before.snapshot_lease.as_ref().unwrap(),
+            after.snapshot_lease.as_ref().unwrap()
+        ));
+        let initial_expiration = before
+            .snapshot_lease
+            .as_ref()
+            .unwrap()
+            .checkpoint()
+            .expire_time;
+        clock.advance(Duration::from_millis(500)).await;
+        inner.retention.as_ref().unwrap().maintain().await.unwrap();
+        assert!(
+            before
+                .snapshot_lease
+                .as_ref()
+                .unwrap()
+                .checkpoint()
+                .expire_time
+                > initial_expiration
+        );
+        assert_eq!(
+            before
+                .snapshot_lease
+                .as_ref()
+                .unwrap()
+                .checkpoint()
+                .expire_time,
+            after
+                .snapshot_lease
+                .as_ref()
+                .unwrap()
+                .checkpoint()
+                .expire_time
+        );
+        assert_eq!(
+            inner
+                .get_with_options(b"new-key", &crate::config::ReadOptions::default())
+                .await
+                .unwrap(),
+            Some(Bytes::from_static(b"new-value"))
+        );
+    }
+    #[rstest]
+    #[case::uncached(None)]
+    #[cfg_attr(
+        feature = "foyer",
+        case::foyer(Some(Arc::new(crate::db_cache::foyer::FoyerCache::new()) as Arc<dyn crate::db_cache::DbCache>))
+    )]
+    #[tokio::test]
+    async fn managed_scan_drop_cancels_blocked_fetch_and_retires_old_checkpoint(
+        #[case] cache: Option<Arc<dyn crate::db_cache::DbCache>>,
+    ) {
+        let (reader, gated, clock) = gated_managed_reader_with_cache(cache).await;
+        let old_id = reader
+            .inner
+            .state
+            .read()
+            .snapshot_lease
+            .as_ref()
+            .unwrap()
+            .checkpoint()
+            .id;
+        let mut scan = reader
+            .scan_with_options(
+                ..,
+                &crate::config::ScanOptions {
+                    cache_blocks: true,
+                    max_fetch_tasks: 1,
+                    read_ahead_bytes: 1,
+                    ..crate::config::ScanOptions::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert!(scan.next().await.unwrap().is_some());
+        let mut manifest = StoredManifest::load(reader.inner.manifest_store.clone(), clock)
+            .await
+            .unwrap();
+        let mut dirty = manifest.prepare_dirty().unwrap();
+        dirty.value.core.last_l0_seq = 2;
+        manifest.update(dirty).await.unwrap();
+        ManifestPoller {
+            inner: reader.inner.clone(),
+        }
+        .handle(DbReaderMessage::PollManifest)
+        .await
+        .unwrap();
+        assert_ne!(
+            old_id,
+            reader
+                .inner
+                .state
+                .read()
+                .snapshot_lease
+                .as_ref()
+                .unwrap()
+                .checkpoint()
+                .id
+        );
+
+        let arrivals = gated.get_opts_gate.arrivals();
+        gated.get_opts_gate.close();
+        let mut pending = Box::pin(async {
+            while scan.next().await?.is_some() {}
+            Ok::<_, crate::Error>(())
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while gated.get_opts_gate.arrivals() == arrivals {
+                assert!(futures::poll!(&mut pending).is_pending());
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(futures::poll!(&mut pending).is_pending());
+        drop(pending);
+        drop(scan);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                reader
+                    .inner
+                    .retention
+                    .as_ref()
+                    .unwrap()
+                    .maintain()
+                    .await
+                    .unwrap();
+                let latest = reader
+                    .inner
+                    .manifest_store
+                    .read_latest_manifest()
+                    .await
+                    .unwrap();
+                if latest.manifest.core.find_checkpoint(old_id).is_none() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        reader.inner.check_closed().unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while gated.get_opts_gate.active_calls() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        gated.get_opts_gate.release();
+        assert_eq!(
+            reader.get(b"key-127").await.unwrap(),
+            Some(Bytes::from(vec![b'x'; 512]))
+        );
+        reader.close().await.unwrap();
+    }
 }
+
+#[cfg(test)]
+mod retention_tests;

--- a/slatedb/src/db_reader/retention_tests.rs
+++ b/slatedb/src/db_reader/retention_tests.rs
@@ -1,0 +1,948 @@
+use super::{DbReader, DbReaderMessage, DbReaderMode, ManifestPoller};
+use crate::{
+    block_cache_policy::BlockCachePolicy,
+    compactions_store::{CompactionsStore, StoredCompactions},
+    compactor_state::{Compaction, CompactionSpec, SourceId},
+    config::{
+        CompactionWorkerOptions, CompactorOptions, DbReaderOptions, FlushOptions, FlushType,
+        GarbageCollectorDirectoryOptions, GarbageCollectorOptions, ScanOptions, Settings,
+    },
+    db::builder::CompactorBuilder,
+    db_state::{SsTableHandle, SsTableId, SsTableView},
+    dispatcher::MessageHandler,
+    format::sst::SsTableFormat,
+    garbage_collector::GarbageCollector,
+    manifest::{
+        store::{ManifestStore, StoredManifest},
+        ManifestCore,
+    },
+    tablestore::{TableStore, TableStoreKind},
+    test_utils::{OnDemandCompactionSchedulerSupplier, RecordingObjectStore},
+    types::RowEntry,
+    wal::slatedb::store::WalTableStore,
+    Db,
+};
+use bytes::Bytes;
+use object_store::{memory::InMemory, path::Path, ObjectStore};
+use slatedb_common::{
+    clock::{DefaultSystemClock, SystemClock},
+    metrics::MetricsRecorderHelper,
+    DbRand, MockSystemClock,
+};
+use std::{
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+use ulid::Ulid;
+
+async fn write_rows(table_store: &Arc<TableStore>, id: SsTableId, value: &[u8]) -> SsTableHandle {
+    let mut builder = table_store.table_builder();
+    for index in 0..64 {
+        let key = Bytes::from(format!("key-{index:03}"));
+        let mut row_value = Vec::from(value);
+        row_value.resize(96, b'x');
+        builder
+            .add(RowEntry::new_value(key.as_ref(), &row_value, 1))
+            .await
+            .unwrap();
+    }
+    let table = builder.build().await.unwrap();
+    table_store
+        .write_sst(&id, &table, Some(Bytes::new()))
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn managed_scan_retains_ssts_across_refresh_and_gc() {
+    let raw_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let reader_recording = Arc::new(RecordingObjectStore::new(Arc::clone(&raw_store)));
+    let reader_store: Arc<dyn ObjectStore> = reader_recording.clone();
+    let root = Path::from("reader-retention-regression");
+    let clock = Arc::new(MockSystemClock::with_time(10_000));
+    let format = SsTableFormat {
+        block_size: 128,
+        ..SsTableFormat::default()
+    };
+
+    let writer_tables = Arc::new(TableStore::new(
+        Arc::clone(&raw_store),
+        format.clone(),
+        root.clone(),
+        None,
+        TableStoreKind::Main,
+        BlockCachePolicy::default(),
+    ));
+    let reader_tables = Arc::new(TableStore::new(
+        Arc::clone(&reader_store),
+        format.clone(),
+        root.clone(),
+        None,
+        TableStoreKind::Reader,
+        BlockCachePolicy::default(),
+    ));
+    let gc_tables = Arc::new(TableStore::new(
+        Arc::clone(&raw_store),
+        format.clone(),
+        root.clone(),
+        None,
+        TableStoreKind::GC,
+        BlockCachePolicy::default(),
+    ));
+    let manifest_store = Arc::new(ManifestStore::new(&root, Arc::clone(&raw_store)));
+    let reader_manifest_store = Arc::new(ManifestStore::new(&root, Arc::clone(&reader_store)));
+    let compactions_store = Arc::new(CompactionsStore::new(&root, Arc::clone(&raw_store)));
+    let wal_store = Arc::new(WalTableStore::new(
+        Arc::clone(&raw_store),
+        format,
+        root.clone(),
+        TableStoreKind::Reader,
+    ));
+
+    let old_id = SsTableId::from(Ulid::from_parts(1_000, 0));
+    let control_id = SsTableId::from(Ulid::from_parts(2_000, 0));
+    let replacement_id = SsTableId::from(Ulid::from_parts(8_000, 0));
+    let old_handle = write_rows(&writer_tables, old_id, b"old-value").await;
+    let _control_handle = write_rows(&writer_tables, control_id, b"control").await;
+    let replacement_handle = write_rows(&writer_tables, replacement_id, b"new-value").await;
+
+    let mut stored_manifest = StoredManifest::create_new_db(
+        Arc::clone(&manifest_store),
+        ManifestCore::new(),
+        clock.clone(),
+    )
+    .await
+    .unwrap();
+    let mut dirty = stored_manifest.prepare_dirty().unwrap();
+    Arc::make_mut(&mut dirty.value.core.tree)
+        .l0
+        .push_front(SsTableView::identity(old_handle));
+    dirty.value.core.last_l0_seq = 1;
+    stored_manifest.update(dirty).await.unwrap();
+
+    let reader = DbReader::open_internal(
+        Arc::clone(&reader_manifest_store),
+        Arc::clone(&reader_tables),
+        Arc::clone(&wal_store),
+        DbReaderMode::ManagedCheckpoint,
+        None,
+        None,
+        None,
+        DbReaderOptions {
+            manifest_poll_interval: Duration::from_secs(10),
+            checkpoint_lifetime: Duration::from_secs(60),
+            skip_wal_replay: true,
+            object_store_max_retries: Some(0),
+            ..DbReaderOptions::default()
+        },
+        clock.clone(),
+        Arc::new(DbRand::default()),
+        MetricsRecorderHelper::noop(),
+    )
+    .await
+    .unwrap();
+
+    let mut scan = reader
+        .scan_with_options(
+            ..,
+            &ScanOptions {
+                cache_blocks: false,
+                max_fetch_tasks: 1,
+                read_ahead_bytes: 1,
+                ..ScanOptions::default()
+            },
+        )
+        .await
+        .unwrap();
+    let first = scan.next().await.unwrap().unwrap();
+    assert_eq!(first.key, Bytes::from_static(b"key-000"));
+    assert!(first.value.starts_with(b"old-value"));
+
+    let mut stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
+        .await
+        .unwrap();
+    let mut dirty = stored_manifest.prepare_dirty().unwrap();
+    let tree = Arc::make_mut(&mut dirty.value.core.tree);
+    tree.l0.clear();
+    tree.l0
+        .push_front(SsTableView::identity(replacement_handle));
+    dirty.value.core.last_l0_seq = 2;
+    stored_manifest.update(dirty).await.unwrap();
+
+    let mut poller = ManifestPoller {
+        inner: Arc::clone(&reader.inner),
+    };
+    poller.handle(DbReaderMessage::PollManifest).await.unwrap();
+    let new_value = reader.get(b"key-060").await.unwrap().unwrap();
+    assert!(new_value.starts_with(b"new-value"));
+
+    let mut stored_compactions = StoredCompactions::create(
+        Arc::clone(&compactions_store),
+        stored_manifest.manifest().compactor_epoch,
+    )
+    .await
+    .unwrap();
+    let mut dirty = stored_compactions.prepare_dirty().unwrap();
+    dirty.value.insert(Compaction::new(
+        Ulid::from_parts(9_000, 0),
+        CompactionSpec::new(vec![SourceId::SortedRun(0)], 0),
+    ));
+    stored_compactions.update(dirty).await.unwrap();
+
+    let gc = GarbageCollector::new(
+        Arc::clone(&manifest_store),
+        compactions_store,
+        gc_tables,
+        wal_store,
+        Arc::clone(&raw_store),
+        GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: None,
+            wal_fence_options: None,
+            compacted_options: Some(GarbageCollectorDirectoryOptions {
+                interval: None,
+                min_age: Duration::from_secs(1),
+                dry_run: false,
+            }),
+            compactions_options: None,
+            detach_options: None,
+            metric_level: None,
+            boundary_files_enabled: true,
+            object_store_max_retries: Some(0),
+        },
+        &MetricsRecorderHelper::noop(),
+        clock,
+        None,
+        None,
+    );
+    gc.run_gc_once().await;
+
+    let remaining_ids = writer_tables
+        .list_compacted_ssts(..)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|metadata| metadata.id)
+        .collect::<HashSet<_>>();
+    let old_sst_present = remaining_ids.contains(&old_id);
+    assert!(
+        !remaining_ids.contains(&control_id),
+        "GC did not delete the eligible control SST"
+    );
+
+    reader_recording.clear();
+    let seek_result = scan.seek(b"key-060").await;
+    let reader_gets_after_gc = reader_recording
+        .get_kinds(false)
+        .into_iter()
+        .filter(|kind| *kind == Some(TableStoreKind::Reader))
+        .count();
+    assert!(
+        reader_gets_after_gc > 0,
+        "later seek did not read from the backing object store"
+    );
+    assert!(
+        old_sst_present,
+        "managed scan lost its backing SST after checkpoint refresh and GC; seek result: {seek_result:?}; reader GET count: {reader_gets_after_gc}"
+    );
+    seek_result.unwrap();
+    let later = scan.next().await.unwrap().unwrap();
+    assert_eq!(later.key, Bytes::from_static(b"key-060"));
+    assert!(later.value.starts_with(b"old-value"));
+    drop(scan);
+    reader.close().await.unwrap();
+}
+
+fn expected_rows(value: &[u8]) -> Vec<(Bytes, Bytes)> {
+    (0..64)
+        .map(|index| {
+            let key = Bytes::from(format!("key-{index:03}"));
+            let mut row_value = Vec::from(value);
+            row_value.resize(96, b'x');
+            (key, Bytes::from(row_value))
+        })
+        .collect()
+}
+
+async fn collect_rows(scan: &mut crate::DbIterator) -> Vec<(Bytes, Bytes)> {
+    let mut rows = Vec::new();
+    while let Some(row) = scan.next().await.unwrap() {
+        rows.push((row.key, row.value));
+    }
+    rows
+}
+
+async fn publish_generation(
+    manifest_store: &Arc<ManifestStore>,
+    clock: &Arc<MockSystemClock>,
+    handle: SsTableHandle,
+    last_l0_seq: u64,
+) {
+    let mut stored_manifest = StoredManifest::load(Arc::clone(manifest_store), clock.clone())
+        .await
+        .unwrap();
+    let mut dirty = stored_manifest.prepare_dirty().unwrap();
+    let tree = Arc::make_mut(&mut dirty.value.core.tree);
+    tree.l0.clear();
+    tree.l0.push_front(SsTableView::identity(handle));
+    dirty.value.core.last_l0_seq = last_l0_seq;
+    stored_manifest.update(dirty).await.unwrap();
+}
+
+async fn checkpoint_count(
+    manifest_store: &Arc<ManifestStore>,
+    clock: &Arc<MockSystemClock>,
+) -> usize {
+    StoredManifest::load(Arc::clone(manifest_store), clock.clone())
+        .await
+        .unwrap()
+        .manifest()
+        .core
+        .checkpoints
+        .len()
+}
+
+#[tokio::test]
+async fn managed_scans_keep_multiple_generations_until_final_release() {
+    let raw_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let reader_recording = Arc::new(RecordingObjectStore::new(Arc::clone(&raw_store)));
+    let reader_store: Arc<dyn ObjectStore> = reader_recording.clone();
+    let root = Path::from("reader-retention-generations");
+    let clock = Arc::new(MockSystemClock::with_time(10_000));
+    let format = SsTableFormat {
+        block_size: 128,
+        ..SsTableFormat::default()
+    };
+    let writer_tables = Arc::new(TableStore::new(
+        Arc::clone(&raw_store),
+        format.clone(),
+        root.clone(),
+        None,
+        TableStoreKind::Main,
+        BlockCachePolicy::default(),
+    ));
+    let reader_tables = Arc::new(TableStore::new(
+        Arc::clone(&reader_store),
+        format.clone(),
+        root.clone(),
+        None,
+        TableStoreKind::Reader,
+        BlockCachePolicy::default(),
+    ));
+    let gc_tables = Arc::new(TableStore::new(
+        Arc::clone(&raw_store),
+        format.clone(),
+        root.clone(),
+        None,
+        TableStoreKind::GC,
+        BlockCachePolicy::default(),
+    ));
+    let manifest_store = Arc::new(ManifestStore::new(&root, Arc::clone(&raw_store)));
+    let reader_manifest_store = Arc::new(ManifestStore::new(&root, Arc::clone(&reader_store)));
+    let compactions_store = Arc::new(CompactionsStore::new(&root, Arc::clone(&raw_store)));
+    let wal_store = Arc::new(WalTableStore::new(
+        Arc::clone(&raw_store),
+        format,
+        root.clone(),
+        TableStoreKind::Reader,
+    ));
+
+    let old_id = SsTableId::from(Ulid::from_parts(1_000, 0));
+    let control_id = SsTableId::from(Ulid::from_parts(2_000, 0));
+    let middle_id = SsTableId::from(Ulid::from_parts(7_000, 0));
+    let latest_id = SsTableId::from(Ulid::from_parts(8_500, 0));
+    let old_handle = write_rows(&writer_tables, old_id, b"old-value").await;
+    let _control_handle = write_rows(&writer_tables, control_id, b"control").await;
+    let middle_handle = write_rows(&writer_tables, middle_id, b"middle-value").await;
+    let latest_handle = write_rows(&writer_tables, latest_id, b"latest-value").await;
+
+    let mut stored_manifest = StoredManifest::create_new_db(
+        Arc::clone(&manifest_store),
+        ManifestCore::new(),
+        clock.clone(),
+    )
+    .await
+    .unwrap();
+    let mut dirty = stored_manifest.prepare_dirty().unwrap();
+    Arc::make_mut(&mut dirty.value.core.tree)
+        .l0
+        .push_front(SsTableView::identity(old_handle));
+    dirty.value.core.last_l0_seq = 1;
+    stored_manifest.update(dirty).await.unwrap();
+
+    let reader = DbReader::open_internal(
+        Arc::clone(&reader_manifest_store),
+        Arc::clone(&reader_tables),
+        Arc::clone(&wal_store),
+        DbReaderMode::ManagedCheckpoint,
+        None,
+        None,
+        None,
+        DbReaderOptions {
+            manifest_poll_interval: Duration::from_secs(10),
+            checkpoint_lifetime: Duration::from_secs(60),
+            skip_wal_replay: true,
+            object_store_max_retries: Some(0),
+            ..DbReaderOptions::default()
+        },
+        clock.clone(),
+        Arc::new(DbRand::default()),
+        MetricsRecorderHelper::noop(),
+    )
+    .await
+    .unwrap();
+    let scan_options = ScanOptions {
+        cache_blocks: false,
+        max_fetch_tasks: 1,
+        read_ahead_bytes: 1,
+        ..ScanOptions::default()
+    };
+
+    reader_recording.clear();
+    let mut old_scan = reader.scan_with_options(.., &scan_options).await.unwrap();
+    let mut old_peer = reader.scan_with_options(.., &scan_options).await.unwrap();
+    for _ in 0..32 {
+        let mut short_scan = reader.scan_with_options(.., &scan_options).await.unwrap();
+        assert!(short_scan.next().await.unwrap().is_some());
+    }
+    assert!(reader_recording.write_kinds().is_empty());
+    assert_eq!(checkpoint_count(&manifest_store, &clock).await, 1);
+    let first = old_scan.next().await.unwrap().unwrap();
+    assert_eq!(first.key, Bytes::from_static(b"key-000"));
+    assert!(first.value.starts_with(b"old-value"));
+
+    publish_generation(&manifest_store, &clock, middle_handle, 2).await;
+    let mut poller = ManifestPoller {
+        inner: Arc::clone(&reader.inner),
+    };
+    poller.handle(DbReaderMessage::PollManifest).await.unwrap();
+    let mut middle_scan = reader.scan_with_options(.., &scan_options).await.unwrap();
+    assert_eq!(checkpoint_count(&manifest_store, &clock).await, 2);
+
+    publish_generation(&manifest_store, &clock, latest_handle, 3).await;
+    poller.handle(DbReaderMessage::PollManifest).await.unwrap();
+    assert_eq!(checkpoint_count(&manifest_store, &clock).await, 3);
+    let latest_value = reader.get(b"key-060").await.unwrap().unwrap();
+    assert!(latest_value.starts_with(b"latest-value"));
+
+    clock.set(41_000);
+    reader
+        .inner
+        .retention
+        .as_ref()
+        .unwrap()
+        .maintain()
+        .await
+        .unwrap();
+    clock.set(72_000);
+    reader
+        .inner
+        .retention
+        .as_ref()
+        .unwrap()
+        .maintain()
+        .await
+        .unwrap();
+    let manifest_after_renewal = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
+        .await
+        .unwrap();
+    assert_eq!(manifest_after_renewal.manifest().core.checkpoints.len(), 3);
+    assert!(manifest_after_renewal
+        .manifest()
+        .core
+        .checkpoints
+        .iter()
+        .all(|checkpoint| checkpoint
+            .expire_time
+            .is_some_and(|expiry| expiry > clock.now())));
+
+    let mut stored_compactions = StoredCompactions::create(
+        Arc::clone(&compactions_store),
+        stored_manifest.manifest().compactor_epoch,
+    )
+    .await
+    .unwrap();
+    let mut dirty = stored_compactions.prepare_dirty().unwrap();
+    dirty.value.insert(Compaction::new(
+        Ulid::from_parts(90_000, 0),
+        CompactionSpec::new(vec![SourceId::SortedRun(0)], 0),
+    ));
+    stored_compactions.update(dirty).await.unwrap();
+    let gc = GarbageCollector::new(
+        Arc::clone(&manifest_store),
+        compactions_store,
+        gc_tables,
+        wal_store,
+        Arc::clone(&raw_store),
+        GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: None,
+            wal_fence_options: None,
+            compacted_options: Some(GarbageCollectorDirectoryOptions {
+                interval: None,
+                min_age: Duration::from_secs(1),
+                dry_run: false,
+            }),
+            compactions_options: None,
+            detach_options: None,
+            metric_level: None,
+            boundary_files_enabled: true,
+            object_store_max_retries: Some(0),
+        },
+        &MetricsRecorderHelper::noop(),
+        clock.clone(),
+        None,
+        None,
+    );
+    gc.run_gc_once().await;
+
+    let retained_ids = writer_tables
+        .list_compacted_ssts(..)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|metadata| metadata.id)
+        .collect::<HashSet<_>>();
+    assert!(!retained_ids.contains(&control_id));
+    assert!(retained_ids.contains(&old_id));
+    assert!(retained_ids.contains(&middle_id));
+    assert!(retained_ids.contains(&latest_id));
+
+    reader_recording.clear();
+    old_scan.seek(b"key-060").await.unwrap();
+    let later = old_scan.next().await.unwrap().unwrap();
+    assert_eq!(later.key, Bytes::from_static(b"key-060"));
+    assert!(later.value.starts_with(b"old-value"));
+    drop(old_scan);
+    reader
+        .inner
+        .retention
+        .as_ref()
+        .unwrap()
+        .maintain()
+        .await
+        .unwrap();
+    gc.run_gc_once().await;
+    assert!(writer_tables
+        .list_compacted_ssts(..)
+        .await
+        .unwrap()
+        .into_iter()
+        .any(|metadata| metadata.id == old_id));
+    assert_eq!(
+        collect_rows(&mut old_peer).await,
+        expected_rows(b"old-value")
+    );
+    assert_eq!(
+        collect_rows(&mut middle_scan).await,
+        expected_rows(b"middle-value")
+    );
+    assert!(reader_recording
+        .get_kinds(false)
+        .into_iter()
+        .any(|kind| kind == Some(TableStoreKind::Reader)));
+
+    drop(old_peer);
+    drop(middle_scan);
+    for _ in 0..20 {
+        reader
+            .inner
+            .retention
+            .as_ref()
+            .unwrap()
+            .maintain()
+            .await
+            .unwrap();
+        if checkpoint_count(&manifest_store, &clock).await == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(checkpoint_count(&manifest_store, &clock).await, 1);
+    gc.run_gc_once().await;
+    let reclaimed_ids = writer_tables
+        .list_compacted_ssts(..)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|metadata| metadata.id)
+        .collect::<HashSet<_>>();
+    assert!(!reclaimed_ids.contains(&old_id));
+    assert!(!reclaimed_ids.contains(&middle_id));
+    assert_eq!(reclaimed_ids, HashSet::from([latest_id]));
+    reader.close().await.unwrap();
+}
+
+async fn wait_for_manifest(
+    manifest_id: u64,
+    manifest: impl Fn() -> crate::manifest::VersionedManifest,
+) {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if manifest().id() >= manifest_id {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("manifest did not refresh before the timeout");
+}
+
+async fn wait_for_last_l0_seq(
+    last_l0_seq: u64,
+    manifest: impl Fn() -> crate::manifest::VersionedManifest,
+) -> crate::manifest::VersionedManifest {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let manifest = manifest();
+            if manifest.manifest.core.last_l0_seq >= last_l0_seq {
+                return manifest;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("flushed sequence did not become visible before the timeout")
+}
+
+async fn wait_for_checkpoint_expiration_after(
+    manifest_store: &Arc<ManifestStore>,
+    clock: &Arc<DefaultSystemClock>,
+    checkpoint_id: uuid::Uuid,
+    previous_expiration: chrono::DateTime<chrono::Utc>,
+) -> chrono::DateTime<chrono::Utc> {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let stored_manifest = StoredManifest::load(Arc::clone(manifest_store), clock.clone())
+                .await
+                .unwrap();
+            let expiration = stored_manifest
+                .manifest()
+                .core
+                .checkpoints
+                .iter()
+                .find(|checkpoint| checkpoint.id == checkpoint_id)
+                .and_then(|checkpoint| checkpoint.expire_time);
+            if expiration.is_some_and(|expiration| expiration > previous_expiration) {
+                return expiration.unwrap();
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("background lease renewal did not finish before the timeout")
+}
+
+fn manifest_sst_ids(manifest: &crate::manifest::Manifest) -> HashSet<SsTableId> {
+    manifest
+        .core
+        .all_sst_views()
+        .map(|view| view.sst.id)
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn managed_scan_survives_real_compaction_background_refresh_and_gc() {
+    let raw_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let reader_recording = Arc::new(RecordingObjectStore::new(Arc::clone(&raw_store)));
+    let reader_store: Arc<dyn ObjectStore> = reader_recording.clone();
+    let root = Path::from("reader-retention-real-compaction");
+    let clock = Arc::new(DefaultSystemClock::new());
+    let compact = Arc::new(AtomicBool::new(false));
+    let compact_for_scheduler = Arc::clone(&compact);
+    let scheduler = Arc::new(OnDemandCompactionSchedulerSupplier::new(Arc::new(
+        move |_| compact_for_scheduler.swap(false, Ordering::SeqCst),
+    )));
+    let compactor_options = CompactorOptions {
+        poll_interval: Duration::from_millis(20),
+        max_concurrent_compactions: 1,
+        commit_compacted_interval: Duration::from_millis(10),
+        checkpoint_lifetime: Duration::from_millis(250),
+        worker: Some(CompactionWorkerOptions {
+            compactions_poll_interval: Duration::from_millis(20),
+            ..CompactionWorkerOptions::default()
+        }),
+        object_store_max_retries: Some(0),
+        ..CompactorOptions::default()
+    };
+    let db = Db::builder(root.clone(), Arc::clone(&raw_store))
+        .with_settings(Settings {
+            flush_interval: None,
+            manifest_poll_interval: Duration::from_millis(20),
+            l0_sst_size_bytes: 1024 * 1024,
+            compactor_options: None,
+            garbage_collector_options: None,
+            object_store_max_retries: Some(0),
+            ..Settings::default()
+        })
+        .with_compactor_builder(
+            CompactorBuilder::new(root.clone(), Arc::clone(&raw_store))
+                .with_system_clock(clock.clone())
+                .with_options(compactor_options)
+                .with_scheduler_supplier(scheduler),
+        )
+        .with_system_clock(clock.clone())
+        .build()
+        .await
+        .unwrap();
+
+    for (key, value) in expected_rows(b"old-value") {
+        db.put(key, value).await.unwrap();
+    }
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .unwrap();
+    let initial_manifest = wait_for_last_l0_seq(1, || db.manifest()).await;
+    let old_sst_ids = initial_manifest
+        .l0()
+        .iter()
+        .map(|view| view.sst.id)
+        .collect::<HashSet<_>>();
+    assert!(!old_sst_ids.is_empty());
+
+    let reader = DbReader::builder(root.clone(), Arc::clone(&reader_store))
+        .with_options(DbReaderOptions {
+            manifest_poll_interval: Duration::from_millis(20),
+            checkpoint_lifetime: Duration::from_secs(1),
+            skip_wal_replay: true,
+            object_store_max_retries: Some(0),
+            ..DbReaderOptions::default()
+        })
+        .with_db_cache_disabled()
+        .build()
+        .await
+        .unwrap();
+    let old_checkpoint = reader
+        .inner
+        .state
+        .read()
+        .snapshot_lease
+        .as_ref()
+        .unwrap()
+        .checkpoint();
+    let old_checkpoint_id = old_checkpoint.id;
+    let old_checkpoint_initial_expiration = old_checkpoint.expire_time.unwrap();
+    let scan_options = ScanOptions {
+        cache_blocks: false,
+        max_fetch_tasks: 1,
+        read_ahead_bytes: 1,
+        ..ScanOptions::default()
+    };
+    let mut old_scan = reader.scan_with_options(.., &scan_options).await.unwrap();
+    let first = old_scan.next().await.unwrap().unwrap();
+    assert_eq!(first.key, Bytes::from_static(b"key-000"));
+    assert!(first.value.starts_with(b"old-value"));
+
+    compact.store(true, Ordering::SeqCst);
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let manifest = db.manifest();
+            if manifest.l0().is_empty() && !manifest.compacted().is_empty() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("compaction did not finish before the timeout");
+    let compacted_manifest = db.manifest();
+    assert!(old_sst_ids.is_disjoint(&manifest_sst_ids(&compacted_manifest.manifest)));
+    let compacted_manifest_id = compacted_manifest.id();
+    wait_for_manifest(compacted_manifest_id, || reader.manifest()).await;
+
+    for (key, value) in expected_rows(b"new-value") {
+        db.put(key, value).await.unwrap();
+    }
+    db.flush_with_options(FlushOptions {
+        flush_type: FlushType::MemTable,
+    })
+    .await
+    .unwrap();
+    let updated_manifest =
+        wait_for_last_l0_seq(compacted_manifest.manifest.core.last_l0_seq + 1, || {
+            db.manifest()
+        })
+        .await;
+    wait_for_last_l0_seq(updated_manifest.manifest.core.last_l0_seq, || {
+        reader.manifest()
+    })
+    .await;
+    let fresh_value = reader.get(b"key-060").await.unwrap().unwrap();
+    assert!(fresh_value.starts_with(b"new-value"));
+
+    let control_id = SsTableId::from(Ulid::from_parts(
+        (clock.now().timestamp_millis() - 10_000) as u64,
+        0,
+    ));
+    let control_tables = Arc::new(TableStore::new(
+        Arc::clone(&raw_store),
+        SsTableFormat::default(),
+        root.clone(),
+        None,
+        TableStoreKind::Main,
+        BlockCachePolicy::default(),
+    ));
+    let _control_handle = write_rows(&control_tables, control_id, b"control").await;
+
+    let manifest_store = Arc::new(ManifestStore::new(&root, Arc::clone(&raw_store)));
+    let first_renewed_expiration = wait_for_checkpoint_expiration_after(
+        &manifest_store,
+        &clock,
+        old_checkpoint_id,
+        old_checkpoint_initial_expiration,
+    )
+    .await;
+    let second_renewed_expiration = wait_for_checkpoint_expiration_after(
+        &manifest_store,
+        &clock,
+        old_checkpoint_id,
+        first_renewed_expiration,
+    )
+    .await;
+    let past_first_renewal =
+        first_renewed_expiration + chrono::Duration::milliseconds(10) - clock.now();
+    if let Ok(wait) = past_first_renewal.to_std() {
+        tokio::time::sleep(wait).await;
+    }
+    assert!(clock.now() > old_checkpoint_initial_expiration);
+    assert!(clock.now() > first_renewed_expiration);
+    assert!(second_renewed_expiration > first_renewed_expiration);
+
+    let compactions_store = Arc::new(CompactionsStore::new(&root, Arc::clone(&raw_store)));
+    let gc_tables = Arc::new(TableStore::new(
+        Arc::clone(&raw_store),
+        SsTableFormat::default(),
+        root.clone(),
+        None,
+        TableStoreKind::GC,
+        BlockCachePolicy::default(),
+    ));
+    let wal_store = Arc::new(WalTableStore::new(
+        Arc::clone(&raw_store),
+        SsTableFormat::default(),
+        root.clone(),
+        TableStoreKind::GC,
+    ));
+    let gc = GarbageCollector::new(
+        Arc::clone(&manifest_store),
+        compactions_store,
+        Arc::clone(&gc_tables),
+        wal_store,
+        Arc::clone(&raw_store),
+        GarbageCollectorOptions {
+            manifest_options: None,
+            wal_options: None,
+            wal_fence_options: None,
+            compacted_options: Some(GarbageCollectorDirectoryOptions {
+                interval: None,
+                min_age: Duration::from_millis(100),
+                dry_run: false,
+            }),
+            compactions_options: None,
+            detach_options: None,
+            metric_level: None,
+            boundary_files_enabled: true,
+            object_store_max_retries: Some(0),
+        },
+        &MetricsRecorderHelper::noop(),
+        clock.clone(),
+        None,
+        None,
+    );
+    gc.run_gc_once().await;
+
+    let stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
+        .await
+        .unwrap();
+    assert!(stored_manifest
+        .manifest()
+        .core
+        .checkpoints
+        .iter()
+        .any(|checkpoint| checkpoint.id == old_checkpoint_id));
+    assert!(stored_manifest
+        .manifest()
+        .core
+        .checkpoints
+        .iter()
+        .all(|checkpoint| checkpoint
+            .expire_time
+            .is_none_or(|expiry| expiry > clock.now())));
+    for checkpoint in &stored_manifest.manifest().core.checkpoints {
+        let checkpoint_manifest = manifest_store
+            .read_manifest(checkpoint.manifest_id)
+            .await
+            .unwrap();
+        if !old_sst_ids.is_disjoint(&manifest_sst_ids(&checkpoint_manifest)) {
+            assert_eq!(checkpoint.id, old_checkpoint_id);
+        }
+    }
+    let retained_ids = gc_tables
+        .list_compacted_ssts(..)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|metadata| metadata.id)
+        .collect::<HashSet<_>>();
+    assert!(!retained_ids.contains(&control_id));
+    assert!(old_sst_ids.is_subset(&retained_ids));
+
+    reader_recording.clear();
+    let mut old_rows = vec![(first.key, first.value)];
+    old_rows.extend(collect_rows(&mut old_scan).await);
+    assert_eq!(old_rows, expected_rows(b"old-value"));
+    assert!(reader_recording
+        .get_kinds(false)
+        .into_iter()
+        .any(|kind| kind == Some(TableStoreKind::Reader)));
+    let mut fresh_scan = reader.scan_with_options(.., &scan_options).await.unwrap();
+    assert_eq!(
+        collect_rows(&mut fresh_scan).await,
+        expected_rows(b"new-value")
+    );
+
+    drop(old_scan);
+    drop(fresh_scan);
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let stored_manifest = StoredManifest::load(Arc::clone(&manifest_store), clock.clone())
+                .await
+                .unwrap();
+            if stored_manifest
+                .manifest()
+                .core
+                .find_checkpoint(old_checkpoint_id)
+                .is_none()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("released checkpoint was not retired before the timeout");
+    gc.run_gc_once().await;
+    let reclaimed_ids = gc_tables
+        .list_compacted_ssts(..)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|metadata| metadata.id)
+        .collect::<HashSet<_>>();
+    assert!(old_sst_ids.is_disjoint(&reclaimed_ids));
+    let mut fresh_scan = reader.scan_with_options(.., &scan_options).await.unwrap();
+    assert_eq!(
+        collect_rows(&mut fresh_scan).await,
+        expected_rows(b"new-value")
+    );
+    drop(fresh_scan);
+    reader.close().await.unwrap();
+    db.close().await.unwrap();
+}

--- a/slatedb/src/error.rs
+++ b/slatedb/src/error.rs
@@ -192,6 +192,14 @@ pub(crate) enum SlateDBError {
     CheckpointMissing(Uuid),
 
     #[error(
+        "checkpoint protection ended. checkpoint_id=`{checkpoint_id}`, manifest_id=`{manifest_id}`"
+    )]
+    SnapshotLeaseLost {
+        checkpoint_id: Uuid,
+        manifest_id: u64,
+    },
+
+    #[error(
         "unsupported {format_name} format version. supported_versions=`{supported_versions:?}`, actual_version=`{actual_version}`"
     )]
     InvalidVersion {
@@ -712,6 +720,7 @@ impl From<SlateDBError> for Error {
             SlateDBError::BlockTransformError => Error::data(msg),
             SlateDBError::InvalidRowFlags { .. } => Error::data(msg),
             SlateDBError::CheckpointMissing(_) => Error::data(msg),
+            SlateDBError::SnapshotLeaseLost { .. } => Error::data(msg),
             SlateDBError::InvalidVersion { .. } => Error::data(msg),
             SlateDBError::ManifestMissing(_) => Error::data(msg),
             LatestTransactionalObjectVersionMissing => Error::data(msg),

--- a/slatedb/src/lib.rs
+++ b/slatedb/src/lib.rs
@@ -159,6 +159,7 @@ mod retention_iterator;
 mod retrying_object_store;
 mod segment_iterator;
 mod single_flight;
+mod snapshot_lease;
 mod snapshot_manager;
 mod sorted_run_iterator;
 mod sst_builder;

--- a/slatedb/src/manifest/store.rs
+++ b/slatedb/src/manifest/store.rs
@@ -267,7 +267,7 @@ impl StoredManifest {
         Ok(self.inner.refresh().await?)
     }
 
-    fn new_checkpoint(
+    pub(crate) fn new_checkpoint(
         manifest: &Manifest,
         current_id: u64,
         clock: &dyn SystemClock,
@@ -350,77 +350,6 @@ impl StoredManifest {
                 result
             })
             .await?)
-    }
-
-    /// Replace an existing checkpoint with a new checkpoint. If the old checkpoint
-    /// is missing, the new checkpoint will still be added. This helps avoid
-    /// issuing two manifest updates when creating a new checkpoint.
-    pub(crate) async fn replace_checkpoint(
-        &mut self,
-        old_checkpoint_id: Uuid,
-        new_checkpoint_id: Uuid,
-        new_checkpoint_options: &CheckpointOptions,
-    ) -> Result<Checkpoint, SlateDBError> {
-        let clock = Arc::clone(&self.clock);
-        self.inner
-            .maybe_apply_update(|sr| {
-                let mut new_val = sr.object().clone();
-                // compute new checkpoint
-                let checkpoint = Self::new_checkpoint(
-                    &new_val,
-                    sr.id().into(),
-                    clock.as_ref(),
-                    new_checkpoint_id,
-                    new_checkpoint_options,
-                )?;
-                new_val
-                    .core
-                    .checkpoints
-                    .retain(|cp| cp.id != old_checkpoint_id);
-                new_val.core.checkpoints.push(checkpoint);
-                let mut dirty = sr.prepare_dirty()?;
-                dirty.value = new_val;
-                let result: Result<Option<DirtyObject<Manifest>>, SlateDBError> = Ok(Some(dirty));
-                result
-            })
-            .await?;
-        let new_checkpoint = self
-            .db_state()
-            .find_checkpoint(new_checkpoint_id)
-            .expect("update applied but checkpoint not found")
-            .clone();
-        Ok(new_checkpoint)
-    }
-
-    pub(crate) async fn refresh_checkpoint(
-        &mut self,
-        checkpoint_id: Uuid,
-        new_lifetime: Duration,
-    ) -> Result<Checkpoint, SlateDBError> {
-        let clock = Arc::clone(&self.clock);
-        self.inner
-            .maybe_apply_update(|sr| {
-                let mut new_val = sr.object().clone();
-                let Some(cp) = new_val
-                    .core
-                    .checkpoints
-                    .iter_mut()
-                    .find(|c| c.id == checkpoint_id)
-                else {
-                    return Err(CheckpointMissing(checkpoint_id));
-                };
-                cp.expire_time = Some(clock.now() + new_lifetime);
-                let mut dirty = sr.prepare_dirty()?;
-                dirty.value = new_val;
-                Ok(Some(dirty))
-            })
-            .await?;
-        let checkpoint = self
-            .db_state()
-            .find_checkpoint(checkpoint_id)
-            .expect("update applied but checkpoint not found")
-            .clone();
-        Ok(checkpoint)
     }
 
     pub(crate) async fn update(
@@ -1324,127 +1253,6 @@ mod tests {
             ms.delete_manifest(checkpoint1.manifest_id).await,
             Err(SlateDBError::InvalidDeletion)
         ));
-    }
-
-    #[tokio::test]
-    async fn should_refresh_checkpoint() {
-        let ms = new_memory_manifest_store();
-        let state = ManifestCore::new();
-        let mut sm = StoredManifest::create_new_db(
-            ms.clone(),
-            state.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        )
-        .await
-        .unwrap();
-
-        let options = CheckpointOptions {
-            lifetime: Some(Duration::from_secs(100)),
-            ..CheckpointOptions::default()
-        };
-
-        let checkpoint = sm
-            .write_checkpoint(uuid::Uuid::new_v4(), &options)
-            .await
-            .unwrap();
-        let expire_time = checkpoint.expire_time.unwrap();
-
-        let refreshed_checkpoint = sm
-            .refresh_checkpoint(checkpoint.id, Duration::from_secs(500))
-            .await
-            .unwrap();
-        let refreshed_expire_time = refreshed_checkpoint.expire_time.unwrap();
-        assert!(refreshed_expire_time > expire_time);
-
-        assert_eq!(
-            Some(&refreshed_checkpoint),
-            sm.manifest().core.find_checkpoint(checkpoint.id)
-        );
-    }
-
-    #[tokio::test]
-    async fn should_fail_refresh_if_checkpoint_missing() {
-        let ms = new_memory_manifest_store();
-        let state = ManifestCore::new();
-        let mut sm = StoredManifest::create_new_db(
-            ms.clone(),
-            state.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        )
-        .await
-        .unwrap();
-
-        let checkpoint_id = uuid::Uuid::new_v4();
-        let result = sm
-            .refresh_checkpoint(checkpoint_id, Duration::from_secs(100))
-            .await;
-
-        if let Err(SlateDBError::CheckpointMissing(missing_id)) = result {
-            assert_eq!(checkpoint_id, missing_id);
-        } else {
-            panic!("Unexpected result {result:?}")
-        }
-    }
-
-    #[tokio::test]
-    async fn should_replace_checkpoint() {
-        let ms = new_memory_manifest_store();
-        let state = ManifestCore::new();
-        let mut sm = StoredManifest::create_new_db(
-            ms.clone(),
-            state.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        )
-        .await
-        .unwrap();
-
-        let checkpoint = sm
-            .write_checkpoint(uuid::Uuid::new_v4(), &CheckpointOptions::default())
-            .await
-            .unwrap();
-
-        let replaced_checkpoint = sm
-            .replace_checkpoint(
-                checkpoint.id,
-                uuid::Uuid::new_v4(),
-                &CheckpointOptions::default(),
-            )
-            .await
-            .unwrap();
-        assert_ne!(checkpoint.id, replaced_checkpoint.id);
-        assert_eq!(None, sm.manifest().core.find_checkpoint(checkpoint.id));
-        assert_eq!(
-            Some(&replaced_checkpoint),
-            sm.manifest().core.find_checkpoint(replaced_checkpoint.id),
-        );
-    }
-
-    #[tokio::test]
-    async fn should_ignore_missing_checkpoint_if_replacing() {
-        let ms = new_memory_manifest_store();
-        let state = ManifestCore::new();
-        let mut sm = StoredManifest::create_new_db(
-            ms.clone(),
-            state.clone(),
-            Arc::new(DefaultSystemClock::new()),
-        )
-        .await
-        .unwrap();
-
-        let missing_checkpoint_id = uuid::Uuid::new_v4();
-        let replaced_checkpoint = sm
-            .replace_checkpoint(
-                uuid::Uuid::new_v4(),
-                missing_checkpoint_id,
-                &CheckpointOptions::default(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            Some(&replaced_checkpoint),
-            sm.manifest().core.find_checkpoint(replaced_checkpoint.id),
-        );
     }
 
     #[tokio::test]

--- a/slatedb/src/reader.rs
+++ b/slatedb/src/reader.rs
@@ -10,6 +10,7 @@ use crate::mem_table::{ImmutableMemtable, KVTable};
 use crate::merge_operator::{instrument_merge_operator, MergeOperatorType};
 use crate::oracle::Oracle;
 use crate::segment_iterator::{build_segment_iter, SegmentScanContext};
+use crate::snapshot_lease::SnapshotLease;
 use crate::sorted_run_iterator::SortedRunIterator;
 use crate::sst_iter::{SstIterator, SstIteratorOptions};
 use crate::tablestore::TableStore;
@@ -25,6 +26,9 @@ pub(crate) trait DbStateReader {
     fn memtable(&self) -> Arc<KVTable>;
     fn imm_memtable(&self) -> &VecDeque<Arc<ImmutableMemtable>>;
     fn core(&self) -> &ManifestCore;
+    fn snapshot_lease(&self) -> Option<Arc<SnapshotLease>> {
+        None
+    }
 }
 
 struct IteratorSources {
@@ -271,7 +275,11 @@ impl Reader {
             max_seq,
             read_trace.clone(),
         );
-        read.instrument(read_trace.read_span()).await
+        SnapshotLease::protect(
+            db_state.snapshot_lease(),
+            read.instrument(read_trace.read_span()),
+        )
+        .await
     }
 
     async fn get_key_value_with_options_inner<K: AsRef<[u8]>>(
@@ -290,6 +298,7 @@ impl Reader {
 
         let sst_iter_options = SstIteratorOptions {
             cache_blocks: options.cache_blocks,
+            snapshot_lease: db_state.snapshot_lease(),
             eager_spawn: true,
             filter_context: options.filter_context.clone(),
             ..SstIteratorOptions::default()
@@ -320,6 +329,7 @@ impl Reader {
             self.read_merge_operator.clone(),
             sst_iter_options.order,
             read_trace,
+            db_state.snapshot_lease(),
         )
         .await?;
 
@@ -356,8 +366,9 @@ impl Reader {
         ctx: ScanContext<'_>,
     ) -> Result<DbIterator, SlateDBError> {
         let read_trace = Self::read_trace(options.tracing_options.as_ref());
+        let lease = ctx.db_state.snapshot_lease();
         let read = self.scan_with_options_inner(range, options, ctx, read_trace.clone());
-        read.instrument(read_trace.read_span()).await
+        SnapshotLease::protect(lease, read.instrument(read_trace.read_span())).await
     }
 
     async fn scan_with_options_inner(
@@ -371,6 +382,7 @@ impl Reader {
         let max_seq = self.prepare_max_seq(ctx.max_seq, options.durability_filter, options.dirty);
 
         let sst_iter_options = SstIteratorOptions {
+            snapshot_lease: ctx.db_state.snapshot_lease(),
             max_fetch_tasks: options.max_fetch_tasks,
             target_bytes_to_fetch: options.read_ahead_bytes,
             cache_blocks: options.cache_blocks,
@@ -409,6 +421,7 @@ impl Reader {
             self.read_merge_operator.clone(),
             options.order,
             read_trace,
+            ctx.db_state.snapshot_lease(),
         )
         .await
     }
@@ -455,6 +468,7 @@ impl Reader {
 
         let range = BytesRange::from_prefix(prefix.as_ref());
         let sst_iter_options = SstIteratorOptions {
+            snapshot_lease: None,
             max_fetch_tasks: options.max_fetch_tasks,
             target_bytes_to_fetch: options.read_ahead_bytes,
             cache_blocks: options.cache_blocks,

--- a/slatedb/src/snapshot_lease.rs
+++ b/slatedb/src/snapshot_lease.rs
@@ -1,0 +1,782 @@
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::{Arc, Weak};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use parking_lot::Mutex;
+use slatedb_common::clock::SystemClock;
+use slatedb_txn_obj::TransactionalObject;
+use tokio::runtime::Handle;
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use uuid::Uuid;
+
+use crate::config::CheckpointOptions;
+use crate::dispatcher::{MessageHandler, MessageHandlerExecutor, MessageTickerDef};
+use crate::error::SlateDBError;
+use crate::manifest::store::{ManifestStore, StoredManifest};
+use crate::Checkpoint;
+
+pub(crate) const SNAPSHOT_LEASE_TASK_NAME: &str = "snapshot_leases";
+
+#[derive(Debug)]
+struct LeaseState {
+    checkpoint: Checkpoint,
+    provisional: bool,
+    error: Option<SlateDBError>,
+}
+
+/// Shared ownership of one managed checkpoint generation.
+#[derive(Debug)]
+pub(crate) struct SnapshotLease {
+    state: Mutex<LeaseState>,
+    clock: Arc<dyn SystemClock>,
+    lifetime: Duration,
+    changed: Notify,
+    cancelled: CancellationToken,
+    tasks: TaskTracker,
+    released: async_channel::Sender<()>,
+}
+
+impl SnapshotLease {
+    pub(crate) fn checkpoint(&self) -> Checkpoint {
+        self.state.lock().checkpoint.clone()
+    }
+
+    fn lost(state: &LeaseState) -> SlateDBError {
+        SlateDBError::SnapshotLeaseLost {
+            checkpoint_id: state.checkpoint.id,
+            manifest_id: state.checkpoint.manifest_id,
+        }
+    }
+
+    fn deadline(&self, state: &LeaseState) -> DateTime<Utc> {
+        // Keep one eighth of the lifetime as a margin before durable expiration.
+        state
+            .checkpoint
+            .expire_time
+            .expect("managed checkpoint expiration")
+            - self.lifetime / 8
+    }
+
+    fn check_state(&self, state: &mut LeaseState) -> Result<(), SlateDBError> {
+        if state.error.is_none() && self.clock.now() >= self.deadline(state) {
+            state.error = Some(Self::lost(state));
+            self.cancelled.cancel();
+            self.tasks.close();
+        }
+        match &state.error {
+            Some(error) => Err(error.clone()),
+            None => Ok(()),
+        }
+    }
+
+    pub(crate) fn check(&self) -> Result<(), SlateDBError> {
+        self.check_state(&mut self.state.lock())
+    }
+
+    pub(crate) fn invalidate(&self, error: SlateDBError) {
+        let mut state = self.state.lock();
+        if state.error.is_none() {
+            state.error = Some(error);
+        }
+        self.cancelled.cancel();
+        self.tasks.close();
+    }
+
+    pub(crate) fn invalidate_missing(&self) {
+        let error = Self::lost(&self.state.lock());
+        self.invalidate(error);
+    }
+
+    fn acknowledge(&self, checkpoint: Checkpoint) -> Result<(), SlateDBError> {
+        let mut state = self.state.lock();
+        self.check_state(&mut state)?;
+        state.checkpoint = checkpoint;
+        state.provisional = false;
+        self.changed.notify_waiters();
+        self.check_state(&mut state)
+    }
+
+    async fn invalidated(&self) -> SlateDBError {
+        loop {
+            let changed = self.changed.notified();
+            let duration = {
+                let mut state = self.state.lock();
+                if let Err(error) = self.check_state(&mut state) {
+                    return error;
+                }
+                (self.deadline(&state) - self.clock.now())
+                    .to_std()
+                    .unwrap_or_default()
+            };
+            tokio::select! {
+                _ = self.cancelled.cancelled() => {},
+                _ = changed => {},
+                _ = self.clock.sleep(duration) => {},
+            }
+        }
+    }
+
+    pub(crate) async fn protect<F, T>(
+        lease: Option<Arc<Self>>,
+        future: F,
+    ) -> Result<T, SlateDBError>
+    where
+        F: Future<Output = Result<T, SlateDBError>>,
+    {
+        match lease {
+            Some(lease) => tokio::select! {
+                biased;
+                error = lease.invalidated() => Err(error),
+                result = future => {
+                    lease.check()?;
+                    result
+                }
+            },
+            None => future.await,
+        }
+    }
+
+    /// Register child tasks before spawning, under the invalidation lock.
+    pub(crate) fn protect_task<F, T>(
+        lease: Option<Arc<Self>>,
+        future: F,
+    ) -> impl Future<Output = Result<T, SlateDBError>>
+    where
+        F: Future<Output = Result<T, SlateDBError>>,
+    {
+        let registration = lease
+            .as_ref()
+            .map(|lease| {
+                let mut state = lease.state.lock();
+                lease.check_state(&mut state)?;
+                Ok::<_, SlateDBError>(lease.tasks.token())
+            })
+            .transpose();
+        async move {
+            let _registration = registration?;
+            Self::protect(lease, future).await
+        }
+    }
+}
+
+impl Drop for SnapshotLease {
+    fn drop(&mut self) {
+        let _ = self.released.try_send(());
+    }
+}
+
+#[derive(Default)]
+struct Registry {
+    leases: BTreeMap<Uuid, Weak<SnapshotLease>>,
+    closed: Option<SlateDBError>,
+}
+
+pub(crate) struct SnapshotLeaseManager {
+    registry: Mutex<Registry>,
+    store: Arc<ManifestStore>,
+    clock: Arc<dyn SystemClock>,
+    lifetime: Duration,
+    pub(crate) stopped: CancellationToken,
+    released: async_channel::Sender<()>,
+    receiver: async_channel::Receiver<()>,
+}
+
+impl SnapshotLeaseManager {
+    pub(crate) fn new(
+        store: Arc<ManifestStore>,
+        clock: Arc<dyn SystemClock>,
+        lifetime: Duration,
+    ) -> Arc<Self> {
+        let (released, receiver) = async_channel::bounded(1);
+        Arc::new(Self {
+            registry: Mutex::new(Registry::default()),
+            store,
+            clock,
+            lifetime,
+            stopped: CancellationToken::new(),
+            released,
+            receiver,
+        })
+    }
+
+    fn expiration(&self) -> DateTime<Utc> {
+        let expiration = self.clock.now() + self.lifetime;
+        let nanos = expiration.timestamp_subsec_nanos();
+        // The manifest stores whole seconds. Round upward before the write.
+        if nanos == 0 {
+            expiration
+        } else {
+            expiration + Duration::from_nanos(u64::from(1_000_000_000 - nanos))
+        }
+    }
+
+    pub(crate) async fn create(
+        &self,
+        manifest: &mut StoredManifest,
+        id: Uuid,
+    ) -> Result<Arc<SnapshotLease>, SlateDBError> {
+        let lease = Arc::new(SnapshotLease {
+            state: Mutex::new(LeaseState {
+                checkpoint: Checkpoint {
+                    id,
+                    manifest_id: manifest.id() + 1,
+                    expire_time: Some(self.expiration()),
+                    create_time: self.clock.now(),
+                    name: None,
+                },
+                provisional: true,
+                error: None,
+            }),
+            clock: self.clock.clone(),
+            lifetime: self.lifetime,
+            changed: Notify::new(),
+            cancelled: CancellationToken::new(),
+            tasks: TaskTracker::new(),
+            released: self.released.clone(),
+        });
+        {
+            let mut registry = self.registry.lock();
+            if let Some(error) = &registry.closed {
+                return Err(error.clone());
+            }
+            registry.leases.insert(id, Arc::downgrade(&lease));
+        }
+        let options = CheckpointOptions {
+            lifetime: Some(self.lifetime),
+            ..CheckpointOptions::default()
+        };
+        SnapshotLease::protect(
+            Some(lease.clone()),
+            manifest.maybe_apply_update(|stored| {
+                lease.check()?;
+                let mut dirty = stored.prepare_dirty()?;
+                let mut checkpoint = StoredManifest::new_checkpoint(
+                    stored.object(),
+                    stored.id().into(),
+                    self.clock.as_ref(),
+                    id,
+                    &options,
+                )?;
+                checkpoint.expire_time = Some(self.expiration());
+                dirty.value.core.checkpoints.push(checkpoint);
+                Ok(Some(dirty))
+            }),
+        )
+        .await?;
+        let checkpoint = manifest
+            .db_state()
+            .find_checkpoint(id)
+            .expect("created checkpoint")
+            .clone();
+        lease.acknowledge(checkpoint)?;
+        Ok(lease)
+    }
+
+    pub(crate) fn spawn(
+        self: &Arc<Self>,
+        executor: &MessageHandlerExecutor,
+    ) -> Result<(), SlateDBError> {
+        executor.add_handler(
+            SNAPSHOT_LEASE_TASK_NAME.into(),
+            Box::new(LeaseMaintenance(self.clone())),
+            self.receiver.clone(),
+            &Handle::current(),
+        )
+    }
+
+    pub(crate) fn stop(&self, error: SlateDBError) {
+        let mut registry = self.registry.lock();
+        if registry.closed.is_none() {
+            registry.closed = Some(error.clone());
+        }
+        for lease in registry.leases.values().filter_map(Weak::upgrade) {
+            lease.invalidate(error.clone());
+        }
+        self.stopped.cancel();
+    }
+
+    pub(crate) async fn maintain(&self) -> Result<(), SlateDBError> {
+        let (live, retired): (Vec<_>, Vec<_>) = {
+            let registry = self.registry.lock();
+            if registry.closed.is_some() {
+                return Ok(());
+            }
+            let mut live = Vec::new();
+            let mut retired = Vec::new();
+            for (id, owner) in &registry.leases {
+                match owner.upgrade() {
+                    Some(lease) => live.push(lease),
+                    None => retired.push(*id),
+                }
+            }
+            (live, retired)
+        };
+        let due = live
+            .iter()
+            .filter(|lease| {
+                let mut state = lease.state.lock();
+                lease.check_state(&mut state).is_ok()
+                    && !state.provisional
+                    && self.clock.now()
+                        >= state
+                            .checkpoint
+                            .expire_time
+                            .expect("managed checkpoint expiration")
+                            - self.lifetime / 2
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        if due.is_empty() && retired.is_empty() {
+            return Ok(());
+        }
+        let timeout = live
+            .iter()
+            .filter_map(|lease| {
+                let mut state = lease.state.lock();
+                lease.check_state(&mut state).ok().map(|_| {
+                    (lease.deadline(&state) - self.clock.now())
+                        .to_std()
+                        .unwrap_or_default()
+                })
+            })
+            .min()
+            .unwrap_or(self.lifetime / 4);
+        let update = async {
+            let mut manifest = StoredManifest::load(self.store.clone(), self.clock.clone()).await?;
+            manifest
+                .maybe_apply_update(|stored| {
+                    let mut dirty = stored.prepare_dirty()?;
+                    let checkpoints = &mut dirty.value.core.checkpoints;
+                    checkpoints.retain(|checkpoint| !retired.contains(&checkpoint.id));
+                    // Fence prepared creates before forgetting their retired IDs,
+                    // including writes whose outcome was unknown after cancellation.
+                    let mut changed = !retired.is_empty();
+                    for lease in &due {
+                        let mut state = lease.state.lock();
+                        if lease.check_state(&mut state).is_err() {
+                            continue;
+                        }
+                        let Some(checkpoint) = checkpoints
+                            .iter_mut()
+                            .find(|checkpoint| checkpoint.id == state.checkpoint.id)
+                        else {
+                            drop(state);
+                            lease.invalidate_missing();
+                            continue;
+                        };
+                        if checkpoint
+                            .expire_time
+                            .is_none_or(|expiration| expiration <= self.clock.now())
+                        {
+                            drop(state);
+                            lease.invalidate_missing();
+                            continue;
+                        }
+                        checkpoint.expire_time = Some(self.expiration());
+                        changed = true;
+                    }
+                    Ok(changed.then_some(dirty))
+                })
+                .await?;
+            for lease in &due {
+                if let Some(checkpoint) = manifest.db_state().find_checkpoint(lease.checkpoint().id)
+                {
+                    let _ = lease.acknowledge(checkpoint.clone());
+                }
+            }
+            self.registry
+                .lock()
+                .leases
+                .retain(|id, _| !retired.contains(id));
+            Ok(())
+        };
+        tokio::select! {
+            biased;
+            _ = self.stopped.cancelled() => Ok(()),
+            _ = self.clock.sleep(timeout) => {
+                for lease in &live { let _ = lease.check(); }
+                Ok(())
+            },
+            result = update => result,
+        }
+    }
+
+    async fn cleanup(&self, result: Result<(), SlateDBError>) -> Result<(), SlateDBError> {
+        self.stop(result.err().unwrap_or(SlateDBError::Closed));
+        let (ids, live): (Vec<_>, Vec<_>) = {
+            let registry = self.registry.lock();
+            (
+                registry.leases.keys().copied().collect(),
+                registry.leases.values().filter_map(Weak::upgrade).collect(),
+            )
+        };
+        for lease in live {
+            lease.tasks.wait().await;
+        }
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let remove = async {
+            let mut manifest = StoredManifest::load(self.store.clone(), self.clock.clone()).await?;
+            manifest
+                .maybe_apply_update(|stored| {
+                    let mut dirty = stored.prepare_dirty()?;
+                    let checkpoints = &mut dirty.value.core.checkpoints;
+                    checkpoints.retain(|checkpoint| !ids.contains(&checkpoint.id));
+                    // Advance the manifest even when a registered checkpoint is absent.
+                    // A prepared create must conflict if it completes after cleanup.
+                    Ok(Some(dirty))
+                })
+                .await
+        };
+        tokio::select! {
+            result = remove => result,
+            _ = self.clock.sleep(self.lifetime / 4) => Ok(()),
+        }
+    }
+}
+
+struct LeaseMaintenance(Arc<SnapshotLeaseManager>);
+
+#[async_trait]
+impl MessageHandler<()> for LeaseMaintenance {
+    fn tickers(&mut self) -> Vec<MessageTickerDef<()>> {
+        vec![MessageTickerDef::new(self.0.lifetime / 4, Box::new(|| ()))]
+    }
+
+    async fn handle(&mut self, _: ()) -> Result<(), SlateDBError> {
+        self.0.maintain().await
+    }
+
+    async fn cleanup(
+        &mut self,
+        _: BoxStream<'async_trait, ()>,
+        result: Result<(), SlateDBError>,
+    ) -> Result<(), SlateDBError> {
+        self.0.cleanup(result).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::ManifestCore;
+    use crate::test_utils::GatedObjectStore;
+    use object_store::{memory::InMemory, path::Path, ObjectStore};
+    use slatedb_common::clock::MockSystemClock;
+
+    async fn fixture() -> (
+        Arc<SnapshotLeaseManager>,
+        StoredManifest,
+        Arc<MockSystemClock>,
+        Arc<GatedObjectStore>,
+    ) {
+        let clock = Arc::new(MockSystemClock::new());
+        let object_store = Arc::new(GatedObjectStore::new(Arc::new(InMemory::new())));
+        let store: Arc<dyn ObjectStore> = object_store.clone();
+        let store = Arc::new(ManifestStore::new(&Path::from("lease-tests"), store));
+        let manifest =
+            StoredManifest::create_new_db(store.clone(), ManifestCore::new(), clock.clone())
+                .await
+                .unwrap();
+        let manager = SnapshotLeaseManager::new(store, clock.clone(), Duration::from_secs(1));
+        (manager, manifest, clock, object_store)
+    }
+
+    #[tokio::test]
+    async fn renews_live_generations_at_half_lifetime_and_retires_final_owner() {
+        let (manager, mut manifest, clock, _) = fixture().await;
+        let old = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        let other_owner = old.clone();
+        let current = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        let before = manager.store.list_manifests(..).await.unwrap().len();
+        clock.advance(Duration::from_millis(499)).await;
+        manager.maintain().await.unwrap();
+        assert_eq!(
+            before,
+            manager.store.list_manifests(..).await.unwrap().len()
+        );
+        clock.advance(Duration::from_millis(1)).await;
+        manager.maintain().await.unwrap();
+        assert_eq!(
+            before + 1,
+            manager.store.list_manifests(..).await.unwrap().len()
+        );
+        assert_eq!(
+            old.checkpoint().expire_time,
+            current.checkpoint().expire_time
+        );
+        assert_eq!(
+            old.checkpoint().expire_time.unwrap().timestamp_millis(),
+            2000
+        );
+        let durable = manager.store.read_latest_manifest().await.unwrap();
+        assert_eq!(
+            durable
+                .manifest
+                .core
+                .find_checkpoint(old.checkpoint().id)
+                .unwrap()
+                .expire_time,
+            old.checkpoint().expire_time
+        );
+        for _ in 0..4 {
+            clock.advance(Duration::from_millis(500)).await;
+            manager.maintain().await.unwrap();
+            old.check().unwrap();
+        }
+        let old_id = old.checkpoint().id;
+        drop(old);
+        manager.maintain().await.unwrap();
+        assert!(manager
+            .store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core
+            .find_checkpoint(old_id)
+            .is_some());
+        drop(other_owner);
+        manager.maintain().await.unwrap();
+        let latest = manager.store.read_latest_manifest().await.unwrap();
+        assert!(latest.manifest.core.find_checkpoint(old_id).is_none());
+        assert!(latest
+            .manifest
+            .core
+            .find_checkpoint(current.checkpoint().id)
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn expiration_is_terminal_at_the_safe_deadline() {
+        let (manager, mut manifest, clock, _) = fixture().await;
+        let lease = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        clock.advance(Duration::from_millis(874)).await;
+        lease.check().unwrap();
+        clock.advance(Duration::from_millis(1)).await;
+        assert!(matches!(
+            lease.check(),
+            Err(SlateDBError::SnapshotLeaseLost { .. })
+        ));
+        let mut late = lease.checkpoint();
+        late.expire_time = Some(clock.now() + Duration::from_secs(10));
+        assert!(lease.acknowledge(late).is_err());
+        manager.maintain().await.unwrap();
+        assert!(lease.check().is_err());
+        assert_eq!(
+            lease.checkpoint().expire_time.unwrap().timestamp_millis(),
+            1000
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_checkpoint_invalidates_only_its_generation() {
+        let (manager, mut manifest, clock, _) = fixture().await;
+        let old = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        let current = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        manifest
+            .delete_checkpoint(old.checkpoint().id)
+            .await
+            .unwrap();
+        clock.advance(Duration::from_millis(500)).await;
+        manager.maintain().await.unwrap();
+        assert!(matches!(
+            old.check(),
+            Err(SlateDBError::SnapshotLeaseLost { .. })
+        ));
+        current.check().unwrap();
+    }
+
+    #[tokio::test]
+    async fn blocked_renewal_stops_at_the_deadline() {
+        let (manager, mut manifest, clock, object_store) = fixture().await;
+        let lease = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        clock.advance(Duration::from_millis(500)).await;
+        object_store.put_opts_gate.close();
+        let maintenance = manager.maintain();
+        tokio::pin!(maintenance);
+        assert!(futures::poll!(&mut maintenance).is_pending());
+        clock.advance(Duration::from_millis(375)).await;
+        maintenance.await.unwrap();
+        assert!(matches!(
+            lease.check(),
+            Err(SlateDBError::SnapshotLeaseLost { .. })
+        ));
+        object_store.put_opts_gate.release();
+        assert_eq!(
+            lease.checkpoint().expire_time.unwrap().timestamp_millis(),
+            1000
+        );
+    }
+
+    #[tokio::test]
+    async fn close_cancels_children_without_waiting_for_retained_caller_futures() {
+        let (manager, mut manifest, _, _) = fixture().await;
+        let lease = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        let retained = SnapshotLease::protect(
+            Some(lease.clone()),
+            std::future::pending::<Result<(), SlateDBError>>(),
+        );
+        tokio::pin!(retained);
+        assert!(futures::poll!(&mut retained).is_pending());
+        let child = tokio::spawn(SnapshotLease::protect_task(
+            Some(lease.clone()),
+            std::future::pending::<Result<(), SlateDBError>>(),
+        ));
+        manager.cleanup(Ok(())).await.unwrap();
+        assert!(matches!(child.await.unwrap(), Err(SlateDBError::Closed)));
+        assert!(matches!(retained.await, Err(SlateDBError::Closed)));
+        assert!(matches!(
+            SnapshotLease::protect_task(Some(lease), async { Ok(()) }).await,
+            Err(SlateDBError::Closed)
+        ));
+        assert!(manager
+            .store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core
+            .checkpoints
+            .is_empty());
+    }
+    #[tokio::test]
+    async fn fractional_creation_and_conflict_retry_acknowledge_durable_seconds() {
+        let (manager, mut stale, clock, _) = fixture().await;
+        let mut concurrent = StoredManifest::load(manager.store.clone(), clock.clone())
+            .await
+            .unwrap();
+        concurrent
+            .write_checkpoint(Uuid::new_v4(), &CheckpointOptions::default())
+            .await
+            .unwrap();
+        clock.advance(Duration::from_millis(123)).await;
+        let lease = manager.create(&mut stale, Uuid::new_v4()).await.unwrap();
+        assert_eq!(lease.checkpoint().manifest_id, concurrent.id() + 1);
+        for now in [123, 1500, 2500, 3500] {
+            clock.set(now);
+            manager.maintain().await.unwrap();
+            lease.check().unwrap();
+            let durable = manager.store.read_latest_manifest().await.unwrap();
+            let durable = durable
+                .manifest
+                .core
+                .find_checkpoint(lease.checkpoint().id)
+                .unwrap();
+            assert_eq!(durable.expire_time, lease.checkpoint().expire_time);
+            assert_eq!(durable.expire_time.unwrap().timestamp_subsec_nanos(), 0);
+            assert!(durable.expire_time.unwrap() > clock.now());
+        }
+    }
+
+    #[tokio::test]
+    async fn renewal_retry_does_not_restore_a_removed_checkpoint() {
+        let clock = Arc::new(MockSystemClock::new());
+        let raw: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let gated = Arc::new(GatedObjectStore::new(raw.clone()));
+        let path = Path::from("renewal-conflict");
+        let store = Arc::new(ManifestStore::new(&path, gated.clone()));
+        let direct = Arc::new(ManifestStore::new(&path, raw));
+        let mut manifest =
+            StoredManifest::create_new_db(store.clone(), ManifestCore::new(), clock.clone())
+                .await
+                .unwrap();
+        let manager = SnapshotLeaseManager::new(store, clock.clone(), Duration::from_secs(1));
+        let lease = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        clock.advance(Duration::from_millis(500)).await;
+        let arrivals = gated.put_opts_gate.arrivals();
+        gated.put_opts_gate.close();
+        let renewal = manager.maintain();
+        tokio::pin!(renewal);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::select! {
+                result = &mut renewal => panic!("renewal completed before the gate: {result:?}"),
+                _ = gated.put_opts_gate.wait_for_arrivals(arrivals + 1) => {},
+            }
+        })
+        .await
+        .unwrap();
+        let mut concurrent = StoredManifest::load(direct, clock).await.unwrap();
+        concurrent
+            .delete_checkpoint(lease.checkpoint().id)
+            .await
+            .unwrap();
+        gated.put_opts_gate.release();
+        renewal.await.unwrap();
+        assert!(matches!(
+            lease.check(),
+            Err(SlateDBError::SnapshotLeaseLost { .. })
+        ));
+        assert!(manager
+            .store
+            .read_latest_manifest()
+            .await
+            .unwrap()
+            .manifest
+            .core
+            .find_checkpoint(lease.checkpoint().id)
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn exhausted_storage_error_remains_the_terminal_error() {
+        let (manager, mut manifest, clock, store) = fixture().await;
+        let lease = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        clock.advance(Duration::from_millis(500)).await;
+        store
+            .put_opts_gate
+            .set_error(|| object_store::Error::Generic {
+                store: "lease-test",
+                source: Box::new(std::io::Error::other("renewal failed")),
+            });
+        let error = manager.maintain().await.unwrap_err();
+        assert!(matches!(error, SlateDBError::ObjectStoreError(_)));
+        store.put_opts_gate.clear_error();
+        manager.cleanup(Err(error.clone())).await.unwrap();
+        assert_eq!(lease.check().unwrap_err().to_string(), error.to_string());
+    }
+
+    #[rstest::rstest]
+    #[case::cleanup(false)]
+    #[case::retirement(true)]
+    #[tokio::test]
+    async fn cleanup_fences_prepared_checkpoint_write_when_registered_id_is_absent(
+        #[case] retire_before_cleanup: bool,
+    ) {
+        let (manager, mut manifest, clock, _) = fixture().await;
+        let lease = manager.create(&mut manifest, Uuid::new_v4()).await.unwrap();
+        let checkpoint = lease.checkpoint();
+        manifest.delete_checkpoint(checkpoint.id).await.unwrap();
+
+        let mut late = StoredManifest::load(manager.store.clone(), clock)
+            .await
+            .unwrap();
+        let mut dirty = late.prepare_dirty().unwrap();
+        dirty.value.core.checkpoints.push(checkpoint.clone());
+
+        if retire_before_cleanup {
+            drop(lease);
+            manager.maintain().await.unwrap();
+        } else {
+            manager.cleanup(Ok(())).await.unwrap();
+        }
+        let late_result = late.update(dirty).await;
+        let latest = manager.store.read_latest_manifest().await.unwrap();
+        assert!(
+            late_result.is_err() && latest.manifest.core.find_checkpoint(checkpoint.id).is_none(),
+            "lease retirement did not fence a prepared checkpoint write; retired before cleanup: {retire_before_cleanup}; late result: {late_result:?}; checkpoint present: {}",
+            latest
+                .manifest
+                .core
+                .find_checkpoint(checkpoint.id)
+                .is_some()
+        );
+    }
+}

--- a/slatedb/src/sst_iter.rs
+++ b/slatedb/src/sst_iter.rs
@@ -1,3 +1,4 @@
+use crate::snapshot_lease::SnapshotLease;
 use async_trait::async_trait;
 use bytes::Bytes;
 use log::error;
@@ -6,7 +7,7 @@ use std::collections::VecDeque;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, Range, RangeBounds};
 use std::sync::Arc;
-use tokio::task::JoinHandle;
+use tokio_util::task::AbortOnDropHandle;
 
 use crate::block_iterator::DataBlockIterator;
 use crate::bytes_range::BytesRange;
@@ -25,12 +26,13 @@ use crate::{
 };
 
 enum FetchTask {
-    InFlight(JoinHandle<Result<VecDeque<Arc<Block>>, SlateDBError>>),
+    InFlight(AbortOnDropHandle<Result<VecDeque<Arc<Block>>, SlateDBError>>),
     Finished(VecDeque<Arc<Block>>),
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct SstIteratorOptions {
+    pub(crate) snapshot_lease: Option<Arc<SnapshotLease>>,
     pub(crate) max_fetch_tasks: usize,
     pub(crate) target_bytes_to_fetch: usize,
     pub(crate) cache_blocks: bool,
@@ -45,6 +47,7 @@ pub(crate) struct SstIteratorOptions {
 impl Default for SstIteratorOptions {
     fn default() -> Self {
         SstIteratorOptions {
+            snapshot_lease: None,
             max_fetch_tasks: 1,
             target_bytes_to_fetch: 1,
             cache_blocks: true,
@@ -427,17 +430,22 @@ impl<'a> InternalSstIterator<'a> {
                     let segment = self.options.segment.clone();
                     let blocks_end = blocks.end;
                     self.fetch_tasks
-                        .push_back(FetchTask::InFlight(tokio::spawn(async move {
-                            table_store
-                                .read_blocks_using_index(
-                                    &table,
-                                    index,
-                                    blocks,
-                                    cache_blocks,
-                                    segment,
-                                )
-                                .await
-                        })));
+                        .push_back(FetchTask::InFlight(AbortOnDropHandle::new(tokio::spawn(
+                            SnapshotLease::protect_task(
+                                self.options.snapshot_lease.clone(),
+                                async move {
+                                    table_store
+                                        .read_blocks_using_index(
+                                            &table,
+                                            index,
+                                            blocks,
+                                            cache_blocks,
+                                            segment,
+                                        )
+                                        .await
+                                },
+                            ),
+                        ))));
                     self.next_block_idx_to_fetch = blocks_end;
                 }
             }
@@ -461,17 +469,22 @@ impl<'a> InternalSstIterator<'a> {
                     let segment = self.options.segment.clone();
                     let blocks_start = blocks.start;
                     self.fetch_tasks
-                        .push_back(FetchTask::InFlight(tokio::spawn(async move {
-                            table_store
-                                .read_blocks_using_index(
-                                    &table,
-                                    index,
-                                    blocks,
-                                    cache_blocks,
-                                    segment,
-                                )
-                                .await
-                        })));
+                        .push_back(FetchTask::InFlight(AbortOnDropHandle::new(tokio::spawn(
+                            SnapshotLease::protect_task(
+                                self.options.snapshot_lease.clone(),
+                                async move {
+                                    table_store
+                                        .read_blocks_using_index(
+                                            &table,
+                                            index,
+                                            blocks,
+                                            cache_blocks,
+                                            segment,
+                                        )
+                                        .await
+                                },
+                            ),
+                        ))));
                     self.next_block_idx_to_fetch = blocks_start;
                 }
             }
@@ -1990,6 +2003,7 @@ mod tests {
             &sst,
             table_store.clone(),
             SstIteratorOptions {
+                snapshot_lease: None,
                 max_fetch_tasks: 32,
                 target_bytes_to_fetch: 256 * 128,
                 cache_blocks: true,
@@ -2010,6 +2024,7 @@ mod tests {
             &sst,
             table_store.clone(),
             SstIteratorOptions {
+                snapshot_lease: None,
                 max_fetch_tasks: 1,
                 target_bytes_to_fetch: 1,
                 cache_blocks: true,
@@ -2633,6 +2648,7 @@ mod tests {
         let end_key = b"key079";
 
         let sst_iter_options = SstIteratorOptions {
+            snapshot_lease: None,
             max_fetch_tasks: 3,
             target_bytes_to_fetch: 3 * 128,
             cache_blocks: true,
@@ -2933,6 +2949,7 @@ mod tests {
             &sst,
             table_store.clone(),
             SstIteratorOptions {
+                snapshot_lease: None,
                 max_fetch_tasks: 1,
                 target_bytes_to_fetch: 1,
                 cache_blocks: true,

--- a/slatedb/src/tablestore.rs
+++ b/slatedb/src/tablestore.rs
@@ -1,4 +1,5 @@
 use std::collections::VecDeque;
+use std::future::Future;
 use std::ops::{Range, RangeBounds};
 use std::sync::Arc;
 
@@ -33,6 +34,34 @@ use crate::sst_io::MAX_VALIDATION_RETRIES;
 use crate::sst_io::{read_obj, read_with_validation_retry, ReadOnlyObject};
 use crate::sst_stats::SstStats;
 use crate::types::RowEntry;
+
+/// Keep object-store loads inside the requesting future. Some cache implementations
+/// spawn their loader and keep it running after the request is dropped. The proxy
+/// can outlive this call, but cancellation drops the actual read with its caller's
+/// snapshot lease. Other cache waiters receive an error and use their own direct read.
+async fn fetch_cached<F, Fut>(loader: CacheLoader, fetch: F) -> Result<CachedEntry, crate::Error>
+where
+    F: FnOnce(CacheLoader) -> Fut,
+    Fut: Future<Output = Result<CachedEntry, crate::Error>>,
+{
+    let (request, requested) = tokio::sync::oneshot::channel();
+    let (result, response) = tokio::sync::oneshot::channel();
+    let proxy: CacheLoader = Box::new(move || {
+        let _ = request.send(());
+        Box::pin(async move { response.await.map_err(SlateDBError::from)? })
+    });
+    let fetch = fetch(proxy);
+    tokio::pin!(fetch);
+    let load = async move {
+        if requested.await.is_ok() {
+            let _ = result.send(loader().await);
+        }
+    };
+    tokio::select! {
+        result = &mut fetch => result,
+        () = load => fetch.await,
+    }
+}
 
 pub(crate) struct TableStore {
     object_store: Arc<dyn ObjectStore>,
@@ -403,13 +432,12 @@ impl TableStore {
             // always the smuggled loader error (so the direct retry will also fail),
             // and on the rare foyer-machinery error an insert would likely fail too.
             let entry = if cache_blocks {
-                cache
-                    .fetch_filter(
-                        cache_key.clone(),
-                        self.read_loader(handle, CacheTarget::Filters, segment.clone()),
-                    )
-                    .await
-                    .ok()
+                fetch_cached(
+                    self.read_loader(handle, CacheTarget::Filters, segment.clone()),
+                    |loader| cache.fetch_filter(cache_key.clone(), loader),
+                )
+                .await
+                .ok()
             } else {
                 cache.get_filter(&cache_key).await.unwrap_or(None)
             };
@@ -456,13 +484,12 @@ impl TableStore {
         if let Some(cache) = self.cache_for_reads() {
             // See `read_filters` for the rationale on the fall-through path.
             let entry = if cache_blocks {
-                cache
-                    .fetch_stats(
-                        cache_key,
-                        self.read_loader(handle, CacheTarget::Stats, segment.clone()),
-                    )
-                    .await
-                    .ok()
+                fetch_cached(
+                    self.read_loader(handle, CacheTarget::Stats, segment.clone()),
+                    |loader| cache.fetch_stats(cache_key, loader),
+                )
+                .await
+                .ok()
             } else {
                 cache.get_stats(&cache_key).await.unwrap_or(None)
             };
@@ -496,13 +523,12 @@ impl TableStore {
         if let Some(cache) = self.cache_for_reads() {
             // See `read_filters` for the rationale on the fall-through path.
             let entry = if cache_blocks {
-                cache
-                    .fetch_index(
-                        cache_key,
-                        self.read_loader(handle, CacheTarget::Index, segment.clone()),
-                    )
-                    .await
-                    .ok()
+                fetch_cached(
+                    self.read_loader(handle, CacheTarget::Index, segment.clone()),
+                    |loader| cache.fetch_index(cache_key, loader),
+                )
+                .await
+                .ok()
             } else {
                 cache.get_index(&cache_key).await.unwrap_or(None)
             };
@@ -734,7 +760,9 @@ impl TableStore {
                 let offset = index.borrow().block_meta().get(block_num).offset();
                 let cache_key: CachedKey = (handle.id, offset).into();
                 let loader = self.block_loader(handle, index.clone(), block_num, segment.clone());
-                if let Ok(entry) = cache.fetch_block(cache_key, loader).await {
+                if let Ok(entry) =
+                    fetch_cached(loader, |loader| cache.fetch_block(cache_key, loader)).await
+                {
                     if let Some(block) = entry.block() {
                         let mut result = VecDeque::with_capacity(1);
                         result.push_back(block);
@@ -2387,14 +2415,17 @@ mod tests {
     ///
     /// 1. The first range-bounded `get_opts` call to the wrapped object store signals
     ///    `first_read_started` and parks on `release`. Once we see that signal we
-    ///    know task A's load is in flight inside foyer's spawned loader task.
+    ///    know task A's load has reached the object store.
     /// 2. `tokio::join!(task_b, release_task)` polls members in source order. Task
     ///    B's first poll synchronously joins foyer's in-flight fetch (no second
     ///    object-store call); the release fires only after B has registered as a
     ///    waiter.
     #[cfg(feature = "foyer")]
+    #[rstest]
+    #[case::completed(false)]
+    #[case::cancelled(true)]
     #[tokio::test]
-    async fn dedups_concurrent_reads_through_object_store() {
+    async fn dedups_concurrent_reads_through_object_store(#[case] cancel_first: bool) {
         use crate::db_cache::foyer::FoyerCache;
         use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
         use tokio::sync::Notify;
@@ -2456,8 +2487,13 @@ mod tests {
             async move { reader.read_index(&handle, true, Some(Bytes::new())).await }
         });
 
-        // wait until A's read has reached the object store and is paused
-        first_read_started.notified().await;
+        // Wait until A's read has reached the object store and is paused.
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            first_read_started.notified(),
+        )
+        .await
+        .unwrap();
         assert_eq!(
             counting.get_range_count.load(Ordering::SeqCst),
             1,
@@ -2473,21 +2509,33 @@ mod tests {
         };
         let release_task = {
             let release = release.clone();
+            let abort = handle_a.abort_handle();
             async move {
                 tokio::task::yield_now().await;
-                release.notify_one();
+                if cancel_first {
+                    abort.abort();
+                } else {
+                    release.notify_one();
+                }
             }
         };
-        let (b_result, _) = tokio::join!(task_b, release_task);
+        let (b_result, _) = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            tokio::join!(task_b, release_task)
+        })
+        .await
+        .unwrap();
 
-        // then: both callers got an index, and exactly one object-store read happened
-        let a_result = handle_a.await.expect("task A panicked");
-        assert!(a_result.is_ok(), "task A failed: {:?}", a_result.err());
+        let a_result = handle_a.await;
+        if cancel_first {
+            assert!(matches!(a_result, Err(error) if error.is_cancelled()));
+        } else {
+            assert!(a_result.unwrap().is_ok());
+        }
         assert!(b_result.is_ok(), "task B failed: {:?}", b_result.err());
         assert_eq!(
             counting.get_range_count.load(Ordering::SeqCst),
-            1,
-            "concurrent index reads must dedup into a single object-store read"
+            if cancel_first { 2 } else { 1 },
+            "only cancellation should require a second object-store read"
         );
     }
 

--- a/slatedb/src/test_utils.rs
+++ b/slatedb/src/test_utils.rs
@@ -985,6 +985,7 @@ pub(crate) struct Gate {
     /// (see [`admit`](Self::admit)).
     permits: AtomicUsize,
     arrival_count: AtomicUsize,
+    active_count: AtomicUsize,
     /// If `Some`, callers receive the produced error after the gate opens.
     error_fn: std::sync::Mutex<Option<Box<dyn Fn() -> object_store::Error + Send + Sync>>>,
 }
@@ -1005,6 +1006,7 @@ impl Default for Gate {
             open: std::sync::atomic::AtomicBool::new(true),
             permits: AtomicUsize::new(0),
             arrival_count: AtomicUsize::new(0),
+            active_count: AtomicUsize::new(0),
             error_fn: std::sync::Mutex::new(None),
         }
     }
@@ -1064,9 +1066,23 @@ impl Gate {
         self.arrival_count.load(Ordering::Acquire)
     }
 
+    /// How many callers are currently waiting at the gate.
+    pub(crate) fn active_calls(&self) -> usize {
+        self.active_count.load(Ordering::Acquire)
+    }
+
     /// Block at this gate until released or admitted. Returns the configured
     /// error (if any) or `Ok(())` to let the caller proceed to the inner store.
     async fn wait(&self) -> object_store::Result<()> {
+        struct ActiveCall<'a>(&'a AtomicUsize);
+        impl Drop for ActiveCall<'_> {
+            fn drop(&mut self) {
+                self.0.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+        self.active_count.fetch_add(1, Ordering::AcqRel);
+        let _active = ActiveCall(&self.active_count);
+
         // Signal arrival.
         self.arrival_count.fetch_add(1, Ordering::AcqRel);
 


### PR DESCRIPTION
## Summary

Checkpoint replacement lets garbage collection erase files that an active managed `DbReader` scan still needs.

## Changes

Share and renew a checkpoint lease per live snapshot generation. Stop storage reads on lease loss or reader close. Keep cache loads in the caller future.

Related: #2073. This change covers managed `DbReader` scans only.

## Verification

The original regression failed on unchanged production code and passes with the fix. On commit `3876c9c`, 2,444 workspace tests and 61 documentation tests pass. One workspace test was skipped, and seven documentation tests were ignored. Three crates do not support documentation tests for their crate types. Formatting, all-target Clippy, and both 30-configuration feature matrices pass. CI for this commit is pending.

## AI Assistance

| Model | Effort |
| --- | --- |
| GPT-6 Codex | Not exposed by the earlier session |
| GPT-6 Astra | high |
| GPT-6 Astra | medium |
| GPT-5.6 Sol | high |
| GPT-5.6 Luna | max |

## Notes for Reviewers

Keep the reader open until its scans finish. Reader close invalidates its managed scans. Please examine the shared-generation choice against the per-scan time-limit discussion in #2073.

Proposed split plan:

- Submit caller-owned cache reads and SST task cancellation with their tests.
- Submit the managed checkpoint lifecycle and retention tests after that prerequisite.

## Checklist

- [x] Initially opened as Draft with a split plan for more than 500 production lines.
- [x] Linked the related issue.
- [x] Reviewed the diff and comments.
- [x] Added tests that pass locally.
- [x] Completed local formatting, Clippy, and Nextest checks.
- [x] Described the reader-close behavior change.
- [x] Considered checkpoint writes and cache cancellation costs.
