### PR TITLE
Fix pause ordering in writer fencing test

### DIFF
--- a/slatedb/src/fence.rs
+++ b/slatedb/src/fence.rs
@@ -487,11 +487,9 @@ mod tests {
             .replay_after_wal_id;
         h.run_gc(replay_after_wal_id).await;
 
-        // resume the fencer. re-issuing "pause" wakes the current pause and
-        // keeps the action set to "pause" so the next toggled event also
-        // pauses.
-        fail_parallel::cfg(h.fp_registry.clone(), "LoadEmptyWalId", "pause").unwrap();
-        fail_parallel::cfg(h.fp_registry.clone(), case.pause_event, "pause").unwrap();
+        // Resume the fencer, but keep the case's pause active until the new writer takes ownership.
+        // Setting "pause" again can release the fencer if it already reached that pause.
+        fail_parallel::cfg(h.fp_registry.clone(), "LoadEmptyWalId", "off").unwrap();
 
         // wait for the case's pause event. fp_notify sends an event for every
         // failpoint regardless of whether it pauses, so drain intermediate
@@ -528,7 +526,6 @@ mod tests {
         }
 
         // resume the fencer
-        fail_parallel::cfg(h.fp_registry.clone(), "LoadEmptyWalId", "off").unwrap();
         fail_parallel::cfg(h.fp_registry.clone(), case.pause_event, "off").unwrap();
 
         // validate that its fenced — the fencer's manifest.refresh sees the new db's


### PR DESCRIPTION
## Summary

The writer ownership test can release both pauses before the competing writer starts and fail with `expected Fenced, got Ok(())`.
The test now releases only `LoadEmptyWalId` and keeps the second pause active until the competing writer takes ownership.

## Changes

Set `LoadEmptyWalId` to `off` and remove the second pause reset.
Remove redundant cleanup of the first pause.

## AI Assistance

| Model | Effort |
| --- | --- |
| GPT-6 (Codex) | xhigh |

## Notes for Reviewers

The failure occurred in [this GitHub Actions job](https://github.com/slatedb/slatedb/actions/runs/34415060892/job/102678005311).
The same timing sequence also fails on parent commit `b7ce7418271f40b36f1d94e4449bd6f15fa066cb`, before #2064.
This change affects test coordination only.

Local validation passed:

- Formatting: `cargo fmt --all -- --check`.
- All 8 fencing tests: `cargo nextest run --locked --offline -p slatedb --all-features --lib --profile ci-cross --no-fail-fast -E 'test(fence::tests)'`.
- All 40 repeated executions with forced timing delays across the four affected test variants.

The forced timing runs used two optional 50 ms delays in a temporary copy.
Each run confirmed that the writer remained paused before the competing writer started.
The final checkout passed the 8 fencing tests after a fresh build without diagnostic code.
Clippy and the full test suite were not run locally.

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [ ] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [x] Called out any breaking changes and provided migration notes
- [x] Considered performance impact; added notes or benchmarks if relevant
