### PR TITLE
fix clippy issues when no cache feature enabled

### DIFF
--- a/slatedb/Cargo.toml
+++ b/slatedb/Cargo.toml
@@ -144,6 +144,7 @@ harness = false
 [[bench]]
 name = "scan_prefix_bench"
 harness = false
+required-features = ["foyer"]
 
 [[bench]]
 name = "scan_prefix_large_sorted_run_bench"
@@ -165,3 +166,7 @@ harness = false
 
 [lints]
 workspace = true
+
+[[test]]
+name = "foyer_cache_flush"
+required-features = ["foyer"]

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -1294,6 +1294,8 @@ mod tests {
     use crate::format::sst::{EncodedSsTable, SsTableFormat};
     use crate::test_utils::build_test_sst;
     use crate::types::{RowEntry, ValueDeletable};
+    #[cfg(feature = "foyer")]
+    use foyer::HybridCacheBuilder;
     use rstest::{fixture, rstest};
     use slatedb_common::metrics::{
         lookup_metric_with_labels, DefaultMetricsRecorder, MetricLevel, MetricsRecorderHelper,
@@ -1415,7 +1417,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_lookup_outcomes() {
-        let mut caches: Vec<(Arc<dyn DbCache>, bool)> = vec![
+        let caches: Vec<(Arc<dyn DbCache>, bool)> = vec![
             (Arc::new(TestCache::new()), true),
             (Arc::new(SplitCache::new()), false),
             (
@@ -1427,11 +1429,43 @@ mod tests {
                 true,
             ),
         ];
-        #[cfg(feature = "foyer")]
-        caches.push((Arc::new(super::foyer::FoyerCache::new()), true));
-        #[cfg(feature = "moka")]
-        caches.push((Arc::new(super::moka::MokaCache::new()), true));
 
+        verify_fetch_lookup_outcomes(caches).await;
+    }
+
+    #[cfg(feature = "foyer")]
+    #[tokio::test]
+    async fn test_fetch_lookup_outcomes_foyer() {
+        let caches: Vec<(Arc<dyn DbCache>, bool)> =
+            vec![(Arc::new(super::foyer::FoyerCache::new()), true)];
+        verify_fetch_lookup_outcomes(caches).await;
+    }
+
+    #[cfg(feature = "foyer")]
+    #[tokio::test]
+    async fn test_fetch_lookup_outcomes_foyer_hybrid() {
+        let cache = HybridCacheBuilder::new()
+            .memory(1024 * 1024)
+            .storage()
+            .build()
+            .await
+            .unwrap();
+        let caches: Vec<(Arc<dyn DbCache>, bool)> = vec![(
+            Arc::new(super::foyer_hybrid::FoyerHybridCache::new_with_cache(cache)),
+            true,
+        )];
+        verify_fetch_lookup_outcomes(caches).await;
+    }
+
+    #[cfg(feature = "moka")]
+    #[tokio::test]
+    async fn test_fetch_lookup_outcomes_moka() {
+        let caches: Vec<(Arc<dyn DbCache>, bool)> =
+            vec![(Arc::new(super::moka::MokaCache::new()), true)];
+        verify_fetch_lookup_outcomes(caches).await;
+    }
+
+    async fn verify_fetch_lookup_outcomes(caches: Vec<(Arc<dyn DbCache>, bool)>) {
         for (cache, retains_entries) in caches {
             for (offset, method) in ["data_block", "index", "filter", "stats"]
                 .into_iter()

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -1422,25 +1422,33 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Arc::new(TestCache::new()), true)]
-    #[case(Arc::new(SplitCache::new()), false)]
-    #[case(Arc::new(SplitCache::new()
-            .with_block_cache(Some(Arc::new(TestCache::new())))
-            .with_meta_cache(Some(Arc::new(TestCache::new())))),
-        true)]
-    #[cfg(feature = "foyer")]
-    #[case(Arc::new(FoyerCache::new()), true)]
-    #[cfg(feature = "foyer")]
-    #[case(Arc::new(FoyerHybridCache::new_with_cache(
-        HybridCacheBuilder::new()
-            .memory(1024 * 1024)
-            .storage()
-            .build()
-            .await
-            .unwrap())),
-        true)]
-    #[cfg(feature = "moka")]
-    #[case(Arc::new(MokaCache::new()), true)]
+    #[case::test_cache(Arc::new(TestCache::new()), true)]
+    #[case::split_cache(Arc::new(SplitCache::new()), false)]
+    #[case::split_cache_with_delegates(
+        Arc::new(
+            SplitCache::new()
+                .with_block_cache(Some(Arc::new(TestCache::new())))
+                .with_meta_cache(Some(Arc::new(TestCache::new())))
+        ),
+        true
+    )]
+    #[cfg_attr(feature = "foyer", case::foyer(Arc::new(FoyerCache::new()), true))]
+    #[cfg_attr(
+        feature = "foyer",
+        case::foyer_hybrid(
+            Arc::new(FoyerHybridCache::new_with_cache(
+                HybridCacheBuilder::new()
+                    .memory(1024 * 1024)
+                    .with_weighter(|_, v: &CachedEntry| v.size())
+                    .storage()
+                    .build()
+                    .await
+                    .unwrap()
+            )),
+            true
+        )
+    )]
+    #[cfg_attr(feature = "moka", case::moka(Arc::new(MokaCache::new()), true))]
     #[tokio::test]
     async fn test_fetch_lookup_outcomes(
         #[case] cache: Arc<dyn DbCache>,

--- a/slatedb/src/db_cache/mod.rs
+++ b/slatedb/src/db_cache/mod.rs
@@ -5,7 +5,7 @@
 //!
 //! There are currently two built-in cache implementations:
 //! - [Foyer](crate::db_cache::foyer::FoyerCache): Requires the `foyer` feature flag. (Enabled by default)
-//! - [Moka](crate::db_cache::moka::MokaCache): Requires the `moka` feature flag. (Enabled by default)
+//! - [Moka](crate::db_cache::moka::MokaCache): Requires the `moka` feature flag.
 //!
 //! ## Usage
 //!
@@ -1290,6 +1290,12 @@ mod tests {
 
     use crate::flatbuffer_types::test_utils::assert_index_clamped;
 
+    #[cfg(feature = "foyer")]
+    use super::foyer::FoyerCache;
+    #[cfg(feature = "foyer")]
+    use super::foyer_hybrid::FoyerHybridCache;
+    #[cfg(feature = "moka")]
+    use super::moka::MokaCache;
     use crate::db_cache::test_utils::TestCache;
     use crate::format::sst::{EncodedSsTable, SsTableFormat};
     use crate::test_utils::build_test_sst;
@@ -1415,89 +1421,61 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_fetch_lookup_outcomes() {
-        let caches: Vec<(Arc<dyn DbCache>, bool)> = vec![
-            (Arc::new(TestCache::new()), true),
-            (Arc::new(SplitCache::new()), false),
-            (
-                Arc::new(
-                    SplitCache::new()
-                        .with_block_cache(Some(Arc::new(TestCache::new())))
-                        .with_meta_cache(Some(Arc::new(TestCache::new()))),
-                ),
-                true,
-            ),
-        ];
-
-        verify_fetch_lookup_outcomes(caches).await;
-    }
-
+    #[rstest]
+    #[case(Arc::new(TestCache::new()), true)]
+    #[case(Arc::new(SplitCache::new()), false)]
+    #[case(Arc::new(SplitCache::new()
+            .with_block_cache(Some(Arc::new(TestCache::new())))
+            .with_meta_cache(Some(Arc::new(TestCache::new())))),
+        true)]
     #[cfg(feature = "foyer")]
-    #[tokio::test]
-    async fn test_fetch_lookup_outcomes_foyer() {
-        let caches: Vec<(Arc<dyn DbCache>, bool)> =
-            vec![(Arc::new(super::foyer::FoyerCache::new()), true)];
-        verify_fetch_lookup_outcomes(caches).await;
-    }
-
+    #[case(Arc::new(FoyerCache::new()), true)]
     #[cfg(feature = "foyer")]
-    #[tokio::test]
-    async fn test_fetch_lookup_outcomes_foyer_hybrid() {
-        let cache = HybridCacheBuilder::new()
+    #[case(Arc::new(FoyerHybridCache::new_with_cache(
+        HybridCacheBuilder::new()
             .memory(1024 * 1024)
             .storage()
             .build()
             .await
-            .unwrap();
-        let caches: Vec<(Arc<dyn DbCache>, bool)> = vec![(
-            Arc::new(super::foyer_hybrid::FoyerHybridCache::new_with_cache(cache)),
-            true,
-        )];
-        verify_fetch_lookup_outcomes(caches).await;
-    }
-
+            .unwrap())),
+        true)]
     #[cfg(feature = "moka")]
+    #[case(Arc::new(MokaCache::new()), true)]
     #[tokio::test]
-    async fn test_fetch_lookup_outcomes_moka() {
-        let caches: Vec<(Arc<dyn DbCache>, bool)> =
-            vec![(Arc::new(super::moka::MokaCache::new()), true)];
-        verify_fetch_lookup_outcomes(caches).await;
-    }
-
-    async fn verify_fetch_lookup_outcomes(caches: Vec<(Arc<dyn DbCache>, bool)>) {
-        for (cache, retains_entries) in caches {
-            for (offset, method) in ["data_block", "index", "filter", "stats"]
-                .into_iter()
-                .enumerate()
-            {
-                let key = CachedKey::from((SST_ID, offset as u64));
-                let mut builder = BlockBuilder::new_latest(4096);
-                assert!(builder
-                    .add(RowEntry::new_value(b"key", b"value", 0))
-                    .unwrap());
-                let block = Arc::new(builder.build().unwrap());
-                for attempt in 0..2 {
-                    let entry = CachedEntry::with_block(block.clone());
-                    let loader: CacheLoader = Box::new(move || Box::pin(async move { Ok(entry) }));
-                    let fetch = match method {
-                        "data_block" => cache.fetch_block(key.clone(), loader).await,
-                        "index" => cache.fetch_index(key.clone(), loader).await,
-                        "filter" => cache.fetch_filter(key.clone(), loader).await,
-                        "stats" => cache.fetch_stats(key.clone(), loader).await,
-                        _ => unreachable!(),
-                    }
-                    .unwrap();
-                    assert_eq!(
-                        fetch.lookup,
-                        if attempt == 0 || !retains_entries {
-                            CacheLookup::Miss
-                        } else {
-                            CacheLookup::Hit
-                        }
-                    );
-                    assert_eq!(fetch.entry.block().unwrap().size(), block.size());
+    async fn test_fetch_lookup_outcomes(
+        #[case] cache: Arc<dyn DbCache>,
+        #[case] retains_entries: bool,
+    ) {
+        for (offset, method) in ["data_block", "index", "filter", "stats"]
+            .into_iter()
+            .enumerate()
+        {
+            let key = CachedKey::from((SST_ID, offset as u64));
+            let mut builder = BlockBuilder::new_latest(4096);
+            assert!(builder
+                .add(RowEntry::new_value(b"key", b"value", 0))
+                .unwrap());
+            let block = Arc::new(builder.build().unwrap());
+            for attempt in 0..2 {
+                let entry = CachedEntry::with_block(block.clone());
+                let loader: CacheLoader = Box::new(move || Box::pin(async move { Ok(entry) }));
+                let fetch = match method {
+                    "data_block" => cache.fetch_block(key.clone(), loader).await,
+                    "index" => cache.fetch_index(key.clone(), loader).await,
+                    "filter" => cache.fetch_filter(key.clone(), loader).await,
+                    "stats" => cache.fetch_stats(key.clone(), loader).await,
+                    _ => unreachable!(),
                 }
+                .unwrap();
+                assert_eq!(
+                    fetch.lookup,
+                    if attempt == 0 || !retains_entries {
+                        CacheLookup::Miss
+                    } else {
+                        CacheLookup::Hit
+                    }
+                );
+                assert_eq!(fetch.entry.block().unwrap().size(), block.size());
             }
         }
     }
@@ -1505,7 +1483,7 @@ mod tests {
     #[cfg(feature = "foyer")]
     #[tokio::test]
     async fn test_concurrent_fetch_lookup() {
-        let cache = super::foyer::FoyerCache::new();
+        let cache = FoyerCache::new();
         let key = CachedKey::from((SST_ID, 0));
         let loader_started = Arc::new(tokio::sync::Notify::new());
         let release_loader = Arc::new(tokio::sync::Notify::new());

--- a/slatedb/tests/foyer_cache_flush.rs
+++ b/slatedb/tests/foyer_cache_flush.rs
@@ -19,8 +19,6 @@
 //! through to object storage (a GET), which is the externally-observable
 //! signal the whole feature is trying to produce.
 
-#![cfg(feature = "foyer")]
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 

--- a/slatedb/tests/foyer_cache_flush.rs
+++ b/slatedb/tests/foyer_cache_flush.rs
@@ -19,6 +19,8 @@
 //! through to object storage (a GET), which is the externally-observable
 //! signal the whole feature is trying to produce.
 
+#![cfg(feature = "foyer")]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

The following clippy command is not successful:
```
cargo clippy -p slatedb --no-default-features --tests -- -Dwarnings
```
The reason is that a mutable vector in `db_cache/mod.rs::test_fetch_lookup_outcomes()` does not need to be mutable if the `foyer` and `moka` features are disabled.

Additionally, the entire test file `foyer_cache_flush.rs` breaks the build if the `foyer` feature is disabled.

This PR fixes those issues. 

## Changes

- Split test `test_fetch_lookup_outcomes()` by feature with rstest and gate them by a feature flag.
- Require feature `foyer` for test `foyer_cache_flush.rs`.
- Require feature `foyer` for bench `scan_prefix_bench`.

## AI Assistance

| Model | Effort | Task |
| --- | --- | --- |
| gpt-6-astra | low | research and verification |
| Fable | high | review |

## Notes for Reviewers

Nothing special

## Checklist

- [x] Small, scoped PR (< 500 total lines excluding tests); or opened as Draft with a plan on how to break it into smaller pieces
- [x] Linked related issue(s) or added context in the description
- [x] Self-reviewed the diff; added comments for tricky parts
- [x] Tests added/updated and passing locally
- [x] Ran `cargo fmt`, `cargo clippy --all-targets --all-features`, and `cargo nextest run --all-features`
- [ ] Called out any breaking changes and provided migration notes
- [ ] Considered performance impact; added notes or benchmarks if relevant

Thank you for the review! 🙏
